### PR TITLE
[BugFix] aggregator spill: account off-pool state in revocable and mem-table sizing

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -49,8 +49,22 @@
 
 namespace starrocks {
 
+// percentile_approx* return SQL NULL on empty / all-rejected state (zero total
+// weight) via PercentileApproxAggEmptyPred. The predicate lives in the
+// nullable wrapper, so the resolver must select the nullable mapping even when
+// all arguments are non-nullable; otherwise the raw aggregate path would
+// finalize the empty digest to NaN.
 static const std::unordered_set<std::string> ALWAYS_NULLABLE_RESULT_AGG_FUNCS = {
-        "variance_samp", "var_samp", "stddev_samp", "covar_samp", "corr", "max_by_v2", "min_by_v2"};
+        "variance_samp",
+        "var_samp",
+        "stddev_samp",
+        "covar_samp",
+        "corr",
+        "max_by_v2",
+        "min_by_v2",
+        "percentile_approx",
+        "percentile_approx_weighted",
+};
 
 static const std::string FUNCTION_COUNT = "count";
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -129,7 +129,7 @@ Status SpillableAggregateBlockingSinkOperator::push_chunk(RuntimeState* state, c
 
     if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         RETURN_IF_ERROR(AggregateBlockingSinkOperator::push_chunk(state, chunk));
-        set_revocable_mem_bytes(_aggregator->hash_map_memory_usage());
+        set_revocable_mem_bytes(_aggregator->memory_usage());
         return Status::OK();
     }
 
@@ -152,7 +152,7 @@ Status SpillableAggregateBlockingSinkOperator::reset_state(RuntimeState* state,
 
 Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_force(RuntimeState* state, const ChunkPtr& chunk) {
     RETURN_IF_ERROR(AggregateBlockingSinkOperator::push_chunk(state, chunk));
-    set_revocable_mem_bytes(_aggregator->hash_map_memory_usage());
+    set_revocable_mem_bytes(_aggregator->memory_usage());
     return _spill_all_data(state, true);
 }
 
@@ -166,7 +166,7 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
     RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
     const auto chunk_size = chunk->num_rows();
 
-    const size_t ht_mem_usage = _aggregator->hash_map_memory_usage();
+    const size_t ht_mem_usage = _aggregator->memory_usage();
     bool ht_need_expansion = _aggregator->hash_map_variant().need_expand(chunk_size);
     const size_t max_mem_usage = state->spill_mem_table_size();
 
@@ -254,13 +254,13 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
     }
 
     // finally, check memory usage of streaming_chunks and hash table, decide whether to spill
-    size_t revocable_mem_bytes = _streaming_bytes + _aggregator->hash_map_memory_usage();
+    size_t revocable_mem_bytes = _streaming_bytes + _aggregator->memory_usage();
     set_revocable_mem_bytes(revocable_mem_bytes);
     if (revocable_mem_bytes > max_mem_usage) {
         // If the aggregation degree of HT_LOW_REDUCTION_CHUNK_LIMIT consecutive chunks is less than HT_LOW_REDUCTION_THRESHOLD,
         // it is meaningless to keep the hash table in memory, just spill it.
         bool should_spill_hash_table = _continuous_low_reduction_chunk_num >= HT_LOW_REDUCTION_CHUNK_LIMIT ||
-                                       _aggregator->hash_map_memory_usage() > max_mem_usage;
+                                       _aggregator->memory_usage() > max_mem_usage;
         if (should_spill_hash_table) {
             _continuous_low_reduction_chunk_num = 0;
         }

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
@@ -119,7 +119,7 @@ Status SpillablePartitionWiseAggregateSinkOperator::push_chunk(RuntimeState* sta
 
     if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         RETURN_IF_ERROR(_agg_op->push_chunk(state, chunk));
-        set_revocable_mem_bytes(_agg_op->aggregator()->hash_map_memory_usage());
+        set_revocable_mem_bytes(_agg_op->aggregator()->memory_usage());
         return Status::OK();
     }
 
@@ -142,7 +142,7 @@ Status SpillablePartitionWiseAggregateSinkOperator::reset_state(RuntimeState* st
 
 Status SpillablePartitionWiseAggregateSinkOperator::_try_to_spill_by_force(RuntimeState* state, const ChunkPtr& chunk) {
     RETURN_IF_ERROR(_agg_op->push_chunk(state, chunk));
-    set_revocable_mem_bytes(_agg_op->aggregator()->hash_map_memory_usage());
+    set_revocable_mem_bytes(_agg_op->aggregator()->memory_usage());
     return _spill_all_data(state, true);
 }
 
@@ -156,7 +156,7 @@ Status SpillablePartitionWiseAggregateSinkOperator::_try_to_spill_by_auto(Runtim
     RETURN_IF_ERROR(_agg_op->aggregator()->evaluate_groupby_exprs(chunk.get()));
     const auto chunk_size = chunk->num_rows();
 
-    const size_t ht_mem_usage = _agg_op->aggregator()->hash_map_memory_usage();
+    const size_t ht_mem_usage = _agg_op->aggregator()->memory_usage();
     bool ht_need_expansion = _agg_op->aggregator()->hash_map_variant().need_expand(chunk_size);
     const size_t max_mem_usage = state->spill_mem_table_size();
 
@@ -246,13 +246,13 @@ Status SpillablePartitionWiseAggregateSinkOperator::_try_to_spill_by_auto(Runtim
     }
 
     // finally, check memory usage of streaming_chunks and hash table, decide whether to spill
-    size_t revocable_mem_bytes = _streaming_bytes + _agg_op->aggregator()->hash_map_memory_usage();
+    size_t revocable_mem_bytes = _streaming_bytes + _agg_op->aggregator()->memory_usage();
     set_revocable_mem_bytes(revocable_mem_bytes);
     if (revocable_mem_bytes > max_mem_usage) {
         // If the aggregation degree of HT_LOW_REDUCTION_CHUNK_LIMIT consecutive chunks is less than HT_LOW_REDUCTION_THRESHOLD,
         // it is meaningless to keep the hash table in memory, just spill it.
         bool should_spill_hash_table = _continuous_low_reduction_chunk_num >= HT_LOW_REDUCTION_CHUNK_LIMIT ||
-                                       _agg_op->aggregator()->hash_map_memory_usage() > max_mem_usage;
+                                       _agg_op->aggregator()->memory_usage() > max_mem_usage;
         if (should_spill_hash_table) {
             _continuous_low_reduction_chunk_num = 0;
         }

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -48,29 +48,37 @@ struct LowCardPercentileDispatcher {
 };
 
 void AggregateFuncResolver::register_others() {
+    // null_pred returns SQL NULL for a state with zero total weight instead
+    // of NaN. See PercentileApproxAggEmptyPred for the sources of empty state.
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     // percentile_approx(expr, ARRAY<DOUBLE>) -> ARRAY<DOUBLE>
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     // percentile_approx_weighted(expr, weight, ARRAY<DOUBLE>) -> ARRAY<DOUBLE>
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx_weighted", false,
-            AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx_weighted", false,
-            AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileValue>(
             "percentile_union", false, AggregateFactory::MakePercentileUnionAggregateFunction());

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -158,12 +158,14 @@ public:
         // argument 1
         DCHECK(columns[1]->is_constant());
         DCHECK(!columns[1]->is_null(0));
+        // Capture before the first-update targetQuantiles push_back so that
+        // allocation is charged too (matches the merge path).
+        int64_t prev_memory = data(state).mem_usage();
         // first update
         if (UNLIKELY(data(state).targetQuantiles.empty())) {
             data(state).targetQuantiles.push_back(columns[1]->get(0).get_double());
         }
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).mem_usage();
         data(state).percentile->add(implicit_cast<float>(column_value));
         ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
@@ -242,12 +244,14 @@ public:
         // argument 2
         DCHECK(columns[2]->is_constant());
         DCHECK(!columns[2]->is_null(0));
+        // Capture before the first-update targetQuantiles push_back so that
+        // allocation is charged too (matches the merge path).
+        int64_t prev_memory = data(state).mem_usage();
         if (UNLIKELY(data(state).targetQuantiles.empty())) {
             data(state).targetQuantiles.push_back(columns[2]->get(0).get_double());
         }
 
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).mem_usage();
         // add value with weight. Reject w <= 0: a negative weight pushes
         // _processed_weight negative and yields NaN from weightedAverageSorted().
         // TDigest::add() also rejects non-positive weights as a second guard.
@@ -329,6 +333,9 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         // argument 1: array column wrapped in ConstColumn, no need to check is_null
         DCHECK(columns[1]->is_constant());
+        // Capture before the lazy-init reinit + targetQuantiles.assign so the
+        // quantile-vector allocation is charged too (matches the scalar path).
+        int64_t prev_memory = data(state).mem_usage();
         // Lazy initialization of compression factor on first update
         if (UNLIKELY(!data(state).compression_initialized)) {
             double compression = get_compression_factor(ctx);
@@ -350,7 +357,6 @@ public:
         const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
 
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).mem_usage();
         data(state).percentile->add(implicit_cast<float>(column_value));
         ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
@@ -358,6 +364,9 @@ public:
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         double compression = get_compression_factor(ctx);
+        // Capture before the lazy-init reinit + first-merge targetQuantiles.resize
+        // so both allocations are charged (matches the scalar/update paths).
+        int64_t prev_memory = data(state).mem_usage();
         // Lazy initialization of compression factor on first merge
         if (UNLIKELY(!data(state).compression_initialized)) {
             data(state).reinit_with_compression(compression);
@@ -382,7 +391,6 @@ public:
 
         // Merge into current state. See base class merge() for the singleton
         // fast-path rationale.
-        int64_t prev_memory = data(state).mem_usage();
         float singleton_mean;
         float singleton_weight;
         if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
@@ -489,6 +497,9 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         // argument 2: array column wrapped in ConstColumn, no need to check is_null
         DCHECK(columns[2]->is_constant());
+        // Capture before the lazy-init reinit + targetQuantiles.assign so the
+        // quantile-vector allocation is charged too (matches the scalar path).
+        int64_t prev_memory = data(state).mem_usage();
         // Lazy initialization of compression factor on first update
         if (UNLIKELY(!data(state).compression_initialized)) {
             double compression = get_compression_factor(ctx);
@@ -513,7 +524,6 @@ public:
         int64_t weight = columns[1]->get(real_row_num).get_int64();
 
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).mem_usage();
         // add value with weight. Reject w <= 0: a negative weight pushes
         // _processed_weight negative and yields NaN from weightedAverageSorted().
         // TDigest::add() also rejects non-positive weights as a second guard.
@@ -526,6 +536,9 @@ public:
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         double compression = get_compression_factor(ctx);
+        // Capture before the lazy-init reinit + first-merge targetQuantiles.resize
+        // so both allocations are charged (matches the scalar/update paths).
+        int64_t prev_memory = data(state).mem_usage();
         // Lazy initialization of compression factor on first merge
         if (UNLIKELY(!data(state).compression_initialized)) {
             data(state).reinit_with_compression(compression);
@@ -550,7 +563,6 @@ public:
 
         // Merge into current state. See base class merge() for the singleton
         // fast-path rationale.
-        int64_t prev_memory = data(state).mem_usage();
         float singleton_mean;
         float singleton_weight;
         if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -14,10 +14,12 @@
 
 #pragma once
 
+#include "column/array_column.h"
 #include "column/column_helper.h"
 #include "column/object_column.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
+#include "exprs/function_context.h"
 #include "gutil/casts.h"
 #include "types/percentile_value.h"
 #include "types/tdigest.h"

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -41,7 +41,10 @@ public:
         compression_initialized = true;
     }
 
-    int64_t mem_usage() const { return percentile->mem_usage(); }
+    // Heap footprint of the state. Includes the PercentileValue (capacity-
+    // based) plus the targetQuantiles vector capacity so push_back / resize
+    // of quantiles is also charged to FunctionContext::add_mem_usage.
+    int64_t mem_usage() const { return percentile->mem_usage() + targetQuantiles.capacity() * sizeof(double); }
 
     std::unique_ptr<PercentileValue> percentile;
     bool compression_initialized = false; // Flag to track if compression has been initialized from FunctionContext
@@ -82,7 +85,7 @@ public:
         PercentileApproxState src_percentile(compression);
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
 
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         // Fast-path: when convert_to_serialize_format ships a single value
         // per row (PASS_THROUGH / FORCE_STREAMING), every incoming digest is
         // a singleton. TDigest::merge() would route it through a priority
@@ -99,7 +102,7 @@ public:
         if (data(state).targetQuantiles.empty()) {
             data(state).targetQuantiles.push_back(quantile);
         }
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -160,9 +163,9 @@ public:
             data(state).targetQuantiles.push_back(columns[1]->get(0).get_double());
         }
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         data(state).percentile->add(implicit_cast<float>(column_value));
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
@@ -244,14 +247,14 @@ public:
         }
 
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         // add value with weight. Reject w <= 0: a negative weight pushes
         // _processed_weight negative and yields NaN from weightedAverageSorted().
         // TDigest::add() also rejects non-positive weights as a second guard.
         if (LIKELY(weight > 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
@@ -347,9 +350,9 @@ public:
         const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
 
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         data(state).percentile->add(implicit_cast<float>(column_value));
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
@@ -379,7 +382,7 @@ public:
 
         // Merge into current state. See base class merge() for the singleton
         // fast-path rationale.
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         float singleton_mean;
         float singleton_weight;
         if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
@@ -387,7 +390,7 @@ public:
         } else {
             data(state).percentile->merge(src_percentile.percentile.get());
         }
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     // Override serialize_to_column method, serialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
@@ -510,14 +513,14 @@ public:
         int64_t weight = columns[1]->get(real_row_num).get_int64();
 
         double column_value = data_column->immutable_data()[row_num];
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         // add value with weight. Reject w <= 0: a negative weight pushes
         // _processed_weight negative and yields NaN from weightedAverageSorted().
         // TDigest::add() also rejects non-positive weights as a second guard.
         if (LIKELY(weight > 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
@@ -547,7 +550,7 @@ public:
 
         // Merge into current state. See base class merge() for the singleton
         // fast-path rationale.
-        int64_t prev_memory = data(state).percentile->mem_usage();
+        int64_t prev_memory = data(state).mem_usage();
         float singleton_mean;
         float singleton_weight;
         if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
@@ -555,7 +558,7 @@ public:
         } else {
             data(state).percentile->merge(src_percentile.percentile.get());
         }
-        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+        ctx->add_mem_usage(data(state).mem_usage() - prev_memory);
     }
 
     // Override serialize_to_column method, serialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -47,6 +47,14 @@ public:
             targetQuantiles; // Stores target quantile(s), single value for scalar mode, multiple for array mode
 };
 
+// Null predicate for percentile_approx*. A state that received zero total
+// weight (no input rows, all inputs filtered out, all weights <= 0, all
+// values non-finite) must finalize to SQL NULL instead of NaN. Passed to
+// NullableAggregateFunctionVariadic via add_aggregate_mapping_variadic.
+struct PercentileApproxAggEmptyPred {
+    bool operator()(const PercentileApproxState& state) const { return state.percentile->is_empty(); }
+};
+
 class PercentileApproxAggregateFunctionBase
         : public AggregateFunctionBatchHelper<PercentileApproxState, PercentileApproxAggregateFunctionBase> {
 protected:
@@ -73,7 +81,19 @@ public:
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
 
         int64_t prev_memory = data(state).percentile->mem_usage();
-        data(state).percentile->merge(src_percentile.percentile.get());
+        // Fast-path: when convert_to_serialize_format ships a single value
+        // per row (PASS_THROUGH / FORCE_STREAMING), every incoming digest is
+        // a singleton. TDigest::merge() would route it through a priority
+        // queue and a batched mergeProcessed/mergeUnprocessed cycle, which
+        // is overkill for one centroid. add() pushes directly into the
+        // target's _unprocessed buffer.
+        float singleton_mean;
+        float singleton_weight;
+        if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
+            data(state).percentile->add(singleton_mean, singleton_weight);
+        } else {
+            data(state).percentile->merge(src_percentile.percentile.get());
+        }
         if (data(state).targetQuantiles.empty()) {
             data(state).targetQuantiles.push_back(quantile);
         }
@@ -82,12 +102,15 @@ public:
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         size_t size = data(state).percentile->serialize_size();
-        uint8_t result[size + sizeof(double)];
+        size_t total = size + sizeof(double);
+        // Avoid a stack VLA: a high-compression digest can serialize to tens
+        // of KB of centroids, large enough to risk stack overflow.
+        std::vector<uint8_t> result(total);
         double quantile = data(state).targetQuantiles.empty() ? 0.0 : data(state).targetQuantiles[0];
-        memcpy(result, &quantile, sizeof(double));
-        data(state).percentile->serialize(result + sizeof(double));
+        memcpy(result.data(), &quantile, sizeof(double));
+        data(state).percentile->serialize(result.data() + sizeof(double));
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, size + sizeof(double)));
+        column->append(Slice(result.data(), total));
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -105,7 +128,11 @@ public:
         double compression = DEFAULT_COMPRESSION_FACTOR;
         if (ctx->get_num_args() > 2) {
             compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
-            if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
+            // !std::isfinite catches NaN/+Inf/-Inf which the < / > comparisons
+            // below silently pass through (NaN < X and NaN > X are both false),
+            // letting std::ceil(NaN) reach processedSize()/unprocessedSize() with
+            // an undefined cast to size_t.
+            if (!std::isfinite(compression) || compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
                 LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
                              << DEFAULT_COMPRESSION_FACTOR;
                 compression = DEFAULT_COMPRESSION_FACTOR;
@@ -182,7 +209,9 @@ public:
                 if (const_col != nullptr) {
                     // Found the last constant column, this should be compression
                     compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
-                    if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
+                    // See PercentileApproxAggregateFunction::get_compression_factor for why
+                    // !std::isfinite is required in addition to the range check.
+                    if (!std::isfinite(compression) || compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
                         LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
                                      << DEFAULT_COMPRESSION_FACTOR;
                         compression = DEFAULT_COMPRESSION_FACTOR;
@@ -214,8 +243,10 @@ public:
 
         double column_value = data_column->immutable_data()[row_num];
         int64_t prev_memory = data(state).percentile->mem_usage();
-        // add value with weight
-        if (LIKELY(weight != 0)) {
+        // add value with weight. Reject w <= 0: a negative weight pushes
+        // _processed_weight negative and yields NaN from weightedAverageSorted().
+        // TDigest::add() also rejects non-positive weights as a second guard.
+        if (LIKELY(weight > 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
@@ -235,11 +266,12 @@ public:
         result->get_offset().resize(chunk_size + 1);
 
         // argument 1, weight column can be int64 or const column
-        // serialize percentile one by one
+        // serialize percentile one by one. weight <= 0 must not be added: a
+        // negative weight corrupts the digest's running weight totals.
         size_t old_size = bytes.size();
         if (src[1]->is_constant()) {
             int64_t weight = src[1]->get(0).get_int64();
-            if (LIKELY(weight != 0)) {
+            if (LIKELY(weight > 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
                     PercentileValue percentile;
                     double value = data_column->immutable_data()[i];
@@ -270,7 +302,7 @@ public:
                 int64_t weight = weight_column->immutable_data()[i];
                 PercentileValue percentile;
                 double value = data_column->immutable_data()[i];
-                if (LIKELY(weight != 0)) {
+                if (LIKELY(weight > 0)) {
                     percentile.add(implicit_cast<float>(value), weight);
                 }
                 size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
@@ -343,9 +375,16 @@ public:
         PercentileApproxState src_percentile(compression);
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
 
-        // Merge into current state
+        // Merge into current state. See base class merge() for the singleton
+        // fast-path rationale.
         int64_t prev_memory = data(state).percentile->mem_usage();
-        data(state).percentile->merge(src_percentile.percentile.get());
+        float singleton_mean;
+        float singleton_weight;
+        if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
+            data(state).percentile->add(singleton_mean, singleton_weight);
+        } else {
+            data(state).percentile->merge(src_percentile.percentile.get());
+        }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
     }
 
@@ -355,19 +394,20 @@ public:
         uint32_t count = static_cast<uint32_t>(data(state).targetQuantiles.size());
         size_t total_size = sizeof(uint32_t) + count * sizeof(double) + tdigest_size;
 
-        uint8_t result[total_size];
+        // Avoid stack VLA (see PercentileApproxAggregateFunctionBase::serialize_to_column).
+        std::vector<uint8_t> result(total_size);
 
         // Write quantile count
-        memcpy(result, &count, sizeof(uint32_t));
+        memcpy(result.data(), &count, sizeof(uint32_t));
 
         // Write all quantiles
-        memcpy(result + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
+        memcpy(result.data() + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
 
         // Write TDigest data
-        data(state).percentile->serialize(result + sizeof(uint32_t) + count * sizeof(double));
+        data(state).percentile->serialize(result.data() + sizeof(uint32_t) + count * sizeof(double));
 
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, total_size));
+        column->append(Slice(result.data(), total_size));
     }
 
     // Override finalize_to_column method, returns ARRAY<DOUBLE>
@@ -469,8 +509,10 @@ public:
 
         double column_value = data_column->immutable_data()[row_num];
         int64_t prev_memory = data(state).percentile->mem_usage();
-        // add value with weight
-        if (LIKELY(weight != 0)) {
+        // add value with weight. Reject w <= 0: a negative weight pushes
+        // _processed_weight negative and yields NaN from weightedAverageSorted().
+        // TDigest::add() also rejects non-positive weights as a second guard.
+        if (LIKELY(weight > 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
@@ -501,9 +543,16 @@ public:
         PercentileApproxState src_percentile(compression);
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
 
-        // Merge into current state
+        // Merge into current state. See base class merge() for the singleton
+        // fast-path rationale.
         int64_t prev_memory = data(state).percentile->mem_usage();
-        data(state).percentile->merge(src_percentile.percentile.get());
+        float singleton_mean;
+        float singleton_weight;
+        if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
+            data(state).percentile->add(singleton_mean, singleton_weight);
+        } else {
+            data(state).percentile->merge(src_percentile.percentile.get());
+        }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
     }
 
@@ -513,19 +562,20 @@ public:
         uint32_t count = static_cast<uint32_t>(data(state).targetQuantiles.size());
         size_t total_size = sizeof(uint32_t) + count * sizeof(double) + tdigest_size;
 
-        uint8_t result[total_size];
+        // Avoid stack VLA (see PercentileApproxAggregateFunctionBase::serialize_to_column).
+        std::vector<uint8_t> result(total_size);
 
         // Write quantile count
-        memcpy(result, &count, sizeof(uint32_t));
+        memcpy(result.data(), &count, sizeof(uint32_t));
 
         // Write all quantiles
-        memcpy(result + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
+        memcpy(result.data() + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
 
         // Write TDigest data
-        data(state).percentile->serialize(result + sizeof(uint32_t) + count * sizeof(double));
+        data(state).percentile->serialize(result.data() + sizeof(uint32_t) + count * sizeof(double));
 
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, total_size));
+        column->append(Slice(result.data(), total_size));
     }
 
     // Override finalize_to_column method, returns ARRAY<DOUBLE>
@@ -573,12 +623,13 @@ public:
         bytes.reserve(chunk_size * estimated_size_per_row);
         result->get_offset().resize(chunk_size + 1);
 
-        // argument 1, weight column can be int64 or const column
+        // argument 1, weight column can be int64 or const column. weight <= 0
+        // must not be added (see PercentileApproxWeightedAggregateFunction).
         // serialize percentile one by one
         size_t old_size = bytes.size();
         if (src[1]->is_constant()) {
             int64_t weight = src[1]->get(0).get_int64();
-            if (LIKELY(weight != 0)) {
+            if (LIKELY(weight > 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
                     PercentileValue percentile;
                     double value = data_column->immutable_data()[i];
@@ -623,7 +674,7 @@ public:
                 int64_t weight = weight_column->immutable_data()[i];
                 PercentileValue percentile;
                 double value = data_column->immutable_data()[i];
-                if (LIKELY(weight != 0)) {
+                if (LIKELY(weight > 0)) {
                     percentile.add(implicit_cast<float>(value), weight);
                 }
 

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -38,7 +38,24 @@ public:
 
     void add(float value, int64_t weight) { _tdigest.add(value, static_cast<float>(weight)); }
 
+    void add(float value, float weight) { _tdigest.add(value, weight); }
+
     void merge(const PercentileValue* other) { _tdigest.merge(&other->_tdigest); }
+
+    // Fast-path probe for the very common shape produced by
+    // PercentileApproxAggregateFunction::convert_to_serialize_format in
+    // PASS_THROUGH / streaming: one unprocessed centroid, no processed.
+    // Caller can then add(mean, weight) directly to the target and skip
+    // the priority-queue merge path in TDigest::add(iter, end).
+    bool try_extract_singleton(float* mean, float* weight) const {
+        if (!_tdigest.processed().empty() || _tdigest.unprocessed().size() != 1) {
+            return false;
+        }
+        const Centroid& c = _tdigest.unprocessed().front();
+        *mean = c.mean();
+        *weight = c.weight();
+        return true;
+    }
 
     uint64_t serialize_size() const {
         //_type 1 bytes
@@ -63,6 +80,12 @@ public:
     }
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
+
+    // True iff the digest received zero total weight. Used by the
+    // percentile_approx null predicate to return SQL NULL instead of a
+    // silent NaN when the digest is empty (e.g. weighted variant with all
+    // w <= 0, or input values rejected as non-finite by TDigest::add).
+    bool is_empty() const { return _tdigest.totalWeight() == 0; }
 
 private:
     enum PercentileDataType { TDIGEST = 0 };

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -59,7 +59,10 @@ public:
         return 1 + _tdigest.serialize_size();
     }
 
-    uint64_t mem_usage() const { return 1 + _tdigest.serialize_size(); }
+    // Heap footprint of the PercentileValue (capacity-based, so process()
+    // shrinking _unprocessed.size() does not flip the delta negative in
+    // FunctionContext::add_mem_usage).
+    uint64_t mem_usage() const { return sizeof(PercentileValue) + _tdigest.byte_size_in_memory(); }
 
     size_t serialize(uint8_t* writer) const {
         // Must not mutate _tdigest here: callers size their buffer from

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -62,10 +62,10 @@ public:
     uint64_t mem_usage() const { return 1 + _tdigest.serialize_size(); }
 
     size_t serialize(uint8_t* writer) const {
-        // Canonicalize before writing so on-disk cells carry only merged
-        // processed centroids; the now-empty unprocessed array still
-        // serializes with count=0, keeping byte layout unchanged for readers.
-        _tdigest.compress();
+        // Must not mutate _tdigest here: callers size their buffer from
+        // serialize_size() before this call, and compress() can grow the
+        // serialized footprint (rebuilds _cumulative with M+1 weights), so
+        // canonicalizing inside serialize would overflow the caller buffer.
         *(writer) = _type;
         return _tdigest.serialize(writer + 1);
     }
@@ -100,10 +100,7 @@ public:
 
 private:
     enum PercentileDataType { TDIGEST = 0 };
-    // `mutable` lets serialize() canonicalize via TDigest::compress() while
-    // staying logically const — aggregate functions reach PercentileValue
-    // through ConstAggDataPtr.
-    mutable TDigest _tdigest;
+    TDigest _tdigest;
     PercentileDataType _type;
 };
 } // namespace starrocks

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <limits>
+
+#include "common/logging.h"
 #include "types/tdigest.h"
 
 namespace starrocks {
@@ -24,14 +27,8 @@ public:
     explicit PercentileValue(double compression) : _tdigest(compression) { _type = TDIGEST; }
 
     explicit PercentileValue(const Slice& src) {
-        switch (*src.data) {
-        case PercentileDataType::TDIGEST:
-            _type = TDIGEST;
-            break;
-        default:
-            DCHECK(false);
-        }
-        _tdigest.deserialize(src.data + 1);
+        _type = TDIGEST;
+        (void)deserialize(src.data, src.size);
     }
 
     void add(float value) { _tdigest.add(value); }
@@ -65,19 +62,33 @@ public:
     uint64_t mem_usage() const { return 1 + _tdigest.serialize_size(); }
 
     size_t serialize(uint8_t* writer) const {
+        // Canonicalize before writing so on-disk cells carry only merged
+        // processed centroids; the now-empty unprocessed array still
+        // serializes with count=0, keeping byte layout unchanged for readers.
+        _tdigest.compress();
         *(writer) = _type;
         return _tdigest.serialize(writer + 1);
     }
-    void deserialize(const char* type_reader) {
-        switch (*type_reader) {
+    // Bounded entry point. Returns false on truncation or unrecognized type
+    // tag and leaves the digest in an empty state.
+    bool deserialize(const char* data, size_t size) {
+        if (size < 1) {
+            LOG(WARNING) << "PercentileValue::deserialize: missing type tag";
+            return false;
+        }
+        switch (*data) {
         case PercentileDataType::TDIGEST:
             _type = TDIGEST;
             break;
         default:
-            DCHECK(false);
+            LOG(WARNING) << "PercentileValue::deserialize: unknown type tag " << static_cast<int>(*data);
+            return false;
         }
-        _tdigest.deserialize(type_reader + 1);
+        return _tdigest.deserialize(data + 1, size - 1);
     }
+    // Legacy unsafe entry point retained for callers that do not carry the
+    // blob length; delegates with an unbounded size.
+    void deserialize(const char* type_reader) { (void)deserialize(type_reader, std::numeric_limits<size_t>::max()); }
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
 
@@ -89,7 +100,10 @@ public:
 
 private:
     enum PercentileDataType { TDIGEST = 0 };
-    TDigest _tdigest;
+    // `mutable` lets serialize() canonicalize via TDigest::compress() while
+    // staying logically const — aggregate functions reach PercentileValue
+    // through ConstAggDataPtr.
+    mutable TDigest _tdigest;
     PercentileDataType _type;
 };
 } // namespace starrocks

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -28,7 +28,10 @@ public:
 
     explicit PercentileValue(const Slice& src) {
         _type = TDIGEST;
-        (void)deserialize(src.data, src.size);
+        bool ok = deserialize(src.data, src.size);
+        // A failure here leaves an empty digest; flag it in debug so a truncated
+        // or corrupt persisted slice is not silently read as an empty value.
+        DCHECK(ok) << "PercentileValue: failed to deserialize a " << src.size << "-byte slice";
     }
 
     void add(float value) { _tdigest.add(value); }
@@ -73,7 +76,11 @@ public:
         // serialized footprint (rebuilds _cumulative with M+1 weights), so
         // canonicalizing inside serialize would overflow the caller buffer.
         *(writer) = _type;
-        return _tdigest.serialize(writer + 1);
+        // Include the 1-byte type tag so the return matches serialize_size().
+        // ObjectColumn::build_slices / serialize_batch use this value as the
+        // slice length; without the +1 each percentile slice is one byte short
+        // and bounded deserialize then rejects it as truncated.
+        return 1 + _tdigest.serialize(writer + 1);
     }
     // Bounded entry point. Returns false on truncation or unrecognized type
     // tag and leaves the digest in an empty state.

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -62,7 +62,10 @@ public:
     // Heap footprint of the PercentileValue (capacity-based, so process()
     // shrinking _unprocessed.size() does not flip the delta negative in
     // FunctionContext::add_mem_usage).
-    uint64_t mem_usage() const { return sizeof(PercentileValue) + _tdigest.byte_size_in_memory(); }
+    // byte_size_in_memory() already counts sizeof(TDigest), and since _tdigest is
+    // an inline member it is also part of sizeof(PercentileValue); subtract it
+    // once so the TDigest object is not counted twice.
+    uint64_t mem_usage() const { return sizeof(PercentileValue) + _tdigest.byte_size_in_memory() - sizeof(TDigest); }
 
     size_t serialize(uint8_t* writer) const {
         // Must not mutate _tdigest here: callers size their buffer from

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -102,7 +102,11 @@ public:
     // percentile_approx null predicate to return SQL NULL instead of a
     // silent NaN when the digest is empty (e.g. weighted variant with all
     // w <= 0, or input values rejected as non-finite by TDigest::add).
-    bool is_empty() const { return _tdigest.totalWeight() == 0; }
+    // Test the centroid vectors directly rather than TDigest::totalWeight(),
+    // which narrows the accumulated float weight to long (UB once a weighted
+    // sum exceeds the long range). A digest holds a centroid iff some w > 0
+    // was added, so emptiness == both vectors empty.
+    bool is_empty() const { return _tdigest.processed().empty() && _tdigest.unprocessed().empty(); }
 
 private:
     enum PercentileDataType { TDIGEST = 0 };

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -482,15 +482,22 @@ bool TDigest::deserialize(const char* data, size_t size) {
         _cumulative.clear();
     };
 
-    constexpr size_t kHeaderSize = sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3;
-    if (size < kHeaderSize) {
-        LOG(WARNING) << "TDigest::deserialize: blob too small for header, size=" << size;
+    // The fixed preamble is five Value fields followed by two Index fields.
+    // Three uint32_t centroid counts are interleaved with their arrays later,
+    // so the minimum legal blob is preamble + 3 * sizeof(uint32_t).
+    constexpr size_t kPreambleSize = sizeof(Value) * 5 + sizeof(Index) * 2;
+    constexpr size_t kMinBlobSize = kPreambleSize + sizeof(uint32_t) * 3;
+    if (size < kMinBlobSize) {
+        LOG(WARNING) << "TDigest::deserialize: blob too small, size=" << size;
         reset_to_empty();
         return false;
     }
 
-    const char* const end = data + size;
+    // Track remaining bytes as a counter rather than computing a past-the-end
+    // pointer. The legacy wrapper passes SIZE_MAX, and `data + SIZE_MAX` would
+    // be undefined behavior even if the value were never dereferenced.
     const char* reader = data;
+    size_t remaining = size;
 
     memcpy(&_compression, reader, sizeof(Value));
     reader += sizeof(Value);
@@ -506,22 +513,24 @@ bool TDigest::deserialize(const char* data, size_t size) {
     reader += sizeof(Value);
     memcpy(&_unprocessed_weight, reader, sizeof(Value));
     reader += sizeof(Value);
+    remaining -= kPreambleSize;
 
     auto read_centroid_array = [&](std::vector<Centroid>& dst, const char* label) -> bool {
-        if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+        if (remaining < sizeof(uint32_t)) {
             LOG(WARNING) << "TDigest::deserialize: truncated before " << label << " count";
             return false;
         }
         uint32_t count;
         memcpy(&count, reader, sizeof(uint32_t));
         reader += sizeof(uint32_t);
+        remaining -= sizeof(uint32_t);
         if (count > kMaxCentroidsDeserialize) {
             LOG(WARNING) << "TDigest::deserialize: " << label << " count " << count << " exceeds limit "
                          << kMaxCentroidsDeserialize;
             return false;
         }
         const size_t bytes = static_cast<size_t>(count) * sizeof(Centroid);
-        if (static_cast<size_t>(end - reader) < bytes) {
+        if (remaining < bytes) {
             LOG(WARNING) << "TDigest::deserialize: truncated " << label << " centroid array";
             return false;
         }
@@ -529,6 +538,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
         if (count > 0) {
             memcpy(dst.data(), reader, bytes);
             reader += bytes;
+            remaining -= bytes;
         }
         return true;
     };
@@ -542,7 +552,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
         return false;
     }
 
-    if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+    if (remaining < sizeof(uint32_t)) {
         LOG(WARNING) << "TDigest::deserialize: truncated before cumulative count";
         reset_to_empty();
         return false;
@@ -550,6 +560,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
     uint32_t cumulative_count;
     memcpy(&cumulative_count, reader, sizeof(uint32_t));
     reader += sizeof(uint32_t);
+    remaining -= sizeof(uint32_t);
     if (cumulative_count > kMaxCentroidsDeserialize) {
         LOG(WARNING) << "TDigest::deserialize: cumulative count " << cumulative_count << " exceeds limit "
                      << kMaxCentroidsDeserialize;
@@ -557,7 +568,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
         return false;
     }
     const size_t cumulative_bytes = static_cast<size_t>(cumulative_count) * sizeof(Weight);
-    if (static_cast<size_t>(end - reader) < cumulative_bytes) {
+    if (remaining < cumulative_bytes) {
         LOG(WARNING) << "TDigest::deserialize: truncated cumulative array";
         reset_to_empty();
         return false;
@@ -571,8 +582,10 @@ bool TDigest::deserialize(const char* data, size_t size) {
 
 void TDigest::deserialize(const char* type_reader) {
     // Legacy unsafe entry point retained for ctors that lack the blob length;
-    // delegates with an unbounded size, preserving pre-bounded behavior. Callers
-    // that have a Slice should prefer the (data, size) overload.
+    // delegates with SIZE_MAX. The bounded path uses a remaining-bytes
+    // counter (not a past-the-end pointer) so SIZE_MAX never participates in
+    // pointer arithmetic. Callers that have a Slice should prefer the
+    // (data, size) overload.
     (void)deserialize(type_reader, std::numeric_limits<size_t>::max());
 }
 

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -372,7 +372,12 @@ void TDigest::compress() {
 }
 
 bool TDigest::add(Value x, Weight w) {
-    if (std::isnan(x)) {
+    // Reject non-finite values (NaN, +Inf, -Inf) and non-positive weights:
+    // - NaN propagates through Centroid::add() to silently NaN mean.
+    // - Mixing +Inf and -Inf via Centroid::add() also yields NaN mean.
+    // - w <= 0 corrupts _unprocessed_weight (negative or zero total) and breaks
+    //   weightedAverageSorted() / quantile() with NaN.
+    if (!std::isfinite(x) || !(w > 0)) {
         return false;
     }
     _unprocessed.emplace_back(x, w);

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -61,13 +61,27 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <iostream>
+#include <limits>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "base/orlp/pdqsort.h"
 #include "common/logging.h"
+
+// On-disk layout invariants. Centroid is two raw floats; we memcpy it as a
+// fixed 8-byte unit in serialize/deserialize, so any padding or layout change
+// would silently corrupt the blob. The endianness check rules out big-endian
+// hosts; StarRocks only targets x86_64 and arm64.
+static_assert(sizeof(starrocks::Centroid) == 8, "Centroid must be 8 bytes (two floats) for the on-disk format");
+static_assert(std::is_trivially_copyable_v<starrocks::Centroid>,
+              "Centroid must be trivially copyable for memcpy serialization");
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
+#error "TDigest on-disk and intermediate formats assume little-endian byte order"
+#endif
 
 namespace starrocks {
 
@@ -368,7 +382,12 @@ void TDigest::add(Value x) {
 }
 
 void TDigest::compress() {
-    process();
+    // Idempotent: process() rebuilds _processed from scratch, which is
+    // wasted work (and a hot-path regression for serialize_to_column) when
+    // the digest is already canonical. Skip when there is nothing to merge.
+    if (haveUnprocessed()) {
+        process();
+    }
 }
 
 bool TDigest::add(Value x, Weight w) {
@@ -399,7 +418,10 @@ void TDigest::add(std::vector<Centroid>::const_iterator iter, std::vector<Centro
 }
 
 uint64_t TDigest::serialize_size() const {
-    return sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(size_t) * 3 + _processed.size() * sizeof(Centroid) +
+    // Three centroid-array sizes are written as uint32_t in serialize(); the
+    // header is sized to match exactly so the trailing bytes of the buffer do
+    // not leak uninitialized memory to disk.
+    return sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3 + _processed.size() * sizeof(Centroid) +
            _unprocessed.size() * sizeof(Centroid) + _cumulative.size() * sizeof(Weight);
 }
 
@@ -446,45 +468,112 @@ size_t TDigest::serialize(uint8_t* writer) const {
     return serialize_size();
 }
 
+bool TDigest::deserialize(const char* data, size_t size) {
+    auto reset_to_empty = [this]() {
+        _compression = 1000;
+        _min = std::numeric_limits<Value>::max();
+        _max = std::numeric_limits<Value>::lowest();
+        _max_processed = processedSize(0, _compression);
+        _max_unprocessed = unprocessedSize(0, _compression);
+        _processed_weight = 0;
+        _unprocessed_weight = 0;
+        _processed.clear();
+        _unprocessed.clear();
+        _cumulative.clear();
+    };
+
+    constexpr size_t kHeaderSize = sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3;
+    if (size < kHeaderSize) {
+        LOG(WARNING) << "TDigest::deserialize: blob too small for header, size=" << size;
+        reset_to_empty();
+        return false;
+    }
+
+    const char* const end = data + size;
+    const char* reader = data;
+
+    memcpy(&_compression, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_min, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_max, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_max_processed, reader, sizeof(Index));
+    reader += sizeof(Index);
+    memcpy(&_max_unprocessed, reader, sizeof(Index));
+    reader += sizeof(Index);
+    memcpy(&_processed_weight, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_unprocessed_weight, reader, sizeof(Value));
+    reader += sizeof(Value);
+
+    auto read_centroid_array = [&](std::vector<Centroid>& dst, const char* label) -> bool {
+        if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+            LOG(WARNING) << "TDigest::deserialize: truncated before " << label << " count";
+            return false;
+        }
+        uint32_t count;
+        memcpy(&count, reader, sizeof(uint32_t));
+        reader += sizeof(uint32_t);
+        if (count > kMaxCentroidsDeserialize) {
+            LOG(WARNING) << "TDigest::deserialize: " << label << " count " << count << " exceeds limit "
+                         << kMaxCentroidsDeserialize;
+            return false;
+        }
+        const size_t bytes = static_cast<size_t>(count) * sizeof(Centroid);
+        if (static_cast<size_t>(end - reader) < bytes) {
+            LOG(WARNING) << "TDigest::deserialize: truncated " << label << " centroid array";
+            return false;
+        }
+        dst.resize(count);
+        if (count > 0) {
+            memcpy(dst.data(), reader, bytes);
+            reader += bytes;
+        }
+        return true;
+    };
+
+    if (!read_centroid_array(_processed, "processed")) {
+        reset_to_empty();
+        return false;
+    }
+    if (!read_centroid_array(_unprocessed, "unprocessed")) {
+        reset_to_empty();
+        return false;
+    }
+
+    if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+        LOG(WARNING) << "TDigest::deserialize: truncated before cumulative count";
+        reset_to_empty();
+        return false;
+    }
+    uint32_t cumulative_count;
+    memcpy(&cumulative_count, reader, sizeof(uint32_t));
+    reader += sizeof(uint32_t);
+    if (cumulative_count > kMaxCentroidsDeserialize) {
+        LOG(WARNING) << "TDigest::deserialize: cumulative count " << cumulative_count << " exceeds limit "
+                     << kMaxCentroidsDeserialize;
+        reset_to_empty();
+        return false;
+    }
+    const size_t cumulative_bytes = static_cast<size_t>(cumulative_count) * sizeof(Weight);
+    if (static_cast<size_t>(end - reader) < cumulative_bytes) {
+        LOG(WARNING) << "TDigest::deserialize: truncated cumulative array";
+        reset_to_empty();
+        return false;
+    }
+    _cumulative.resize(cumulative_count);
+    if (cumulative_count > 0) {
+        memcpy(_cumulative.data(), reader, cumulative_bytes);
+    }
+    return true;
+}
+
 void TDigest::deserialize(const char* type_reader) {
-    memcpy(&_compression, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-    memcpy(&_min, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-    memcpy(&_max, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-
-    memcpy(&_max_processed, type_reader, sizeof(Index));
-    type_reader += sizeof(Index);
-    memcpy(&_max_unprocessed, type_reader, sizeof(Index));
-    type_reader += sizeof(Index);
-    memcpy(&_processed_weight, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-    memcpy(&_unprocessed_weight, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-
-    uint32_t size;
-    memcpy(&size, type_reader, sizeof(uint32_t));
-    type_reader += sizeof(uint32_t);
-    _processed.resize(size);
-    for (int i = 0; i < size; i++) {
-        memcpy(&_processed[i], type_reader, sizeof(Centroid));
-        type_reader += sizeof(Centroid);
-    }
-    memcpy(&size, type_reader, sizeof(uint32_t));
-    type_reader += sizeof(uint32_t);
-    _unprocessed.resize(size);
-    for (int i = 0; i < size; i++) {
-        memcpy(&_unprocessed[i], type_reader, sizeof(Centroid));
-        type_reader += sizeof(Centroid);
-    }
-    memcpy(&size, type_reader, sizeof(uint32_t));
-    type_reader += sizeof(uint32_t);
-    _cumulative.resize(size);
-    for (int i = 0; i < size; i++) {
-        memcpy(&_cumulative[i], type_reader, sizeof(Weight));
-        type_reader += sizeof(Weight);
-    }
+    // Legacy unsafe entry point retained for ctors that lack the blob length;
+    // delegates with an unbounded size, preserving pre-bounded behavior. Callers
+    // that have a Slice should prefer the (data, size) overload.
+    (void)deserialize(type_reader, std::numeric_limits<size_t>::max());
 }
 
 Value TDigest::mean(int i) const noexcept {

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -425,6 +425,11 @@ uint64_t TDigest::serialize_size() const {
            _unprocessed.size() * sizeof(Centroid) + _cumulative.size() * sizeof(Weight);
 }
 
+uint64_t TDigest::byte_size_in_memory() const {
+    return sizeof(TDigest) + _processed.capacity() * sizeof(Centroid) + _unprocessed.capacity() * sizeof(Centroid) +
+           _cumulative.capacity() * sizeof(Weight);
+}
+
 size_t TDigest::serialize(uint8_t* writer) const {
     memcpy(writer, &_compression, sizeof(Value));
     writer += sizeof(Value);

--- a/be/src/types/tdigest.h
+++ b/be/src/types/tdigest.h
@@ -188,6 +188,13 @@ public:
     // bounded overload at new call sites.
     void deserialize(const char* type_reader);
 
+    // Actual heap footprint, capacity-based. Distinct from serialize_size()
+    // (which only reports the logical byte length of a serialized blob);
+    // used for FunctionContext::add_mem_usage so the counter does not flip
+    // negative when process() empties _unprocessed without releasing
+    // capacity.
+    uint64_t byte_size_in_memory() const;
+
 private:
     Value _compression;
     Value _min = std::numeric_limits<Value>::max();

--- a/be/src/types/tdigest.h
+++ b/be/src/types/tdigest.h
@@ -170,10 +170,13 @@ public:
     // been reached.
     bool add(Value x, Weight w);
     void add(std::vector<Centroid>::const_iterator iter, std::vector<Centroid>::const_iterator end);
-    // Upper bound for centroid array sizes in a deserialized blob. Mirrors
-    // ClickHouse QuantileTDigest::max_centroids_deserialize and protects
+    // Upper bound for centroid array sizes in a deserialized blob. Must cover
+    // the largest legitimate intermediate state (the _unprocessed buffer
+    // before process() runs has capacity 8 * ceil(compression), and the
+    // percentile_approx MAX_COMPRESSION is 10000 → 80000 centroids). 131072
+    // = 1 << 17 gives ~60% headroom past that ceiling and still protects
     // against OOM from corrupted or truncated input.
-    static constexpr size_t kMaxCentroidsDeserialize = 65536;
+    static constexpr size_t kMaxCentroidsDeserialize = 1 << 17;
 
     uint64_t serialize_size() const;
     size_t serialize(uint8_t* writer) const;

--- a/be/src/types/tdigest.h
+++ b/be/src/types/tdigest.h
@@ -170,8 +170,19 @@ public:
     // been reached.
     bool add(Value x, Weight w);
     void add(std::vector<Centroid>::const_iterator iter, std::vector<Centroid>::const_iterator end);
+    // Upper bound for centroid array sizes in a deserialized blob. Mirrors
+    // ClickHouse QuantileTDigest::max_centroids_deserialize and protects
+    // against OOM from corrupted or truncated input.
+    static constexpr size_t kMaxCentroidsDeserialize = 65536;
+
     uint64_t serialize_size() const;
     size_t serialize(uint8_t* writer) const;
+    // Bounded variant. Returns false and resets the digest to an empty state
+    // if the blob is truncated or declares an oversized centroid array.
+    bool deserialize(const char* data, size_t size);
+    // Legacy unsafe wrapper for callers that do not carry the blob length;
+    // delegates to the bounded variant with an unbounded size. Prefer the
+    // bounded overload at new call sites.
     void deserialize(const char* type_reader);
 
 private:

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(EXEC_FILES
         ./exprs/agg/data_sketch/ds_theta_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
+        ./exprs/agg/percentile_approx_test.cpp
         ./exprs/agg/window_test.cpp
         ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/agg/agg_state_functions_test.cpp

--- a/be/test/exprs/agg/percentile_approx_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_test.cpp
@@ -27,6 +27,7 @@
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/function_context.h"
+#include "runtime/memory/counting_allocator.h"
 #include "testutil/function_utils.h"
 #include "types/logical_type.h"
 

--- a/be/test/exprs/agg/percentile_approx_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_test.cpp
@@ -27,6 +27,7 @@
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/function_context.h"
+#include "runtime/mem_pool.h"
 #include "runtime/memory/counting_allocator.h"
 #include "testutil/function_utils.h"
 #include "types/logical_type.h"
@@ -181,13 +182,13 @@ TEST_F(PercentileApproxAggTest, weighted_empty_state_finalizes_to_null) {
     auto ctx = make_ctx(arg_types, return_type, const_columns);
 
     auto values = NullableColumn::create(DoubleColumn::create(), NullColumn::create());
-    auto* values_data = down_cast<DoubleColumn*>(values->data_column().get());
+    auto* values_data = down_cast<DoubleColumn*>(values->data_column()->as_mutable_raw_ptr());
     for (auto v : {10.0, 20.0, 30.0}) {
         values_data->append(v);
         values->null_column_data().push_back(0);
     }
 
-    auto weights = NullableColumn::create(weight_const->clone_shared(), NullColumn::create(values->size(), 0));
+    auto weights = NullableColumn::create(weight_const->clone(), NullColumn::create(values->size(), 0));
 
     std::vector<const Column*> raw{values.get(), weights.get(), quantile_const.get()};
 

--- a/be/test/exprs/agg/percentile_approx_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_test.cpp
@@ -1,0 +1,243 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/agg/percentile_approx.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate_factory.h"
+#include "exprs/agg/aggregate_state_allocator.h"
+#include "exprs/function_context.h"
+#include "testutil/function_utils.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+class PercentileApproxAggTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _utils = std::make_unique<FunctionUtils>();
+        _ctx = _utils->get_fn_ctx();
+        _allocator = std::make_unique<CountingAllocatorWithHook>();
+        tls_agg_state_allocator = _allocator.get();
+    }
+    void TearDown() override {
+        tls_agg_state_allocator = nullptr;
+        _allocator.reset();
+        _utils.reset();
+    }
+
+protected:
+    std::unique_ptr<FunctionUtils> _utils;
+    FunctionContext* _ctx{};
+    std::unique_ptr<CountingAllocatorWithHook> _allocator;
+};
+
+namespace {
+
+// Build a FunctionContext that carries the const columns the aggregate
+// expects via ctx->get_constant_column(i). Used for the quantile and
+// (optionally) compression parameters.
+std::unique_ptr<FunctionContext> make_ctx(std::vector<TypeDescriptor> arg_types, TypeDescriptor return_type,
+                                          Columns const_columns) {
+    std::unique_ptr<FunctionContext> ctx(
+            FunctionContext::create_test_context(std::move(arg_types), std::move(return_type)));
+    ctx->set_constant_columns(std::move(const_columns));
+    return ctx;
+}
+
+struct ManagedState {
+    ManagedState(FunctionContext* ctx, const AggregateFunction* func) : _ctx(ctx), _func(func) {
+        _state = _mem_pool.allocate_aligned(func->size(), func->alignof_size());
+        _func->create(_ctx, _state);
+    }
+    ~ManagedState() { _func->destroy(_ctx, _state); }
+    AggDataPtr state() { return _state; }
+
+    FunctionContext* _ctx;
+    const AggregateFunction* _func;
+    MemPool _mem_pool;
+    AggDataPtr _state;
+};
+
+} // namespace
+
+// percentile_approx_weighted with a row whose weight is negative.
+// The bug: only weight == 0 was filtered, so the negative-weight row
+// entered the digest and produced an incorrect median.
+TEST_F(PercentileApproxAggTest, weighted_negative_weight_is_skipped) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx_weighted", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/false);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_BIGINT),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1),
+                          ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1), quantile_const};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = DoubleColumn::create();
+    auto weights = Int64Column::create();
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values->append(v);
+        weights->append(1);
+    }
+    values->append(100.0);
+    weights->append(-10);
+
+    std::vector<const Column*> raw{values.get(), weights.get(), quantile_const.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = DoubleColumn::create();
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    EXPECT_DOUBLE_EQ(20.0, result->get_data()[0]);
+}
+
+// percentile_approx with non-finite values in the input.
+// Bug: TDigest::add() rejected NaN but accepted +Inf / -Inf, which
+// distorted the digest and the quantile.
+TEST_F(PercentileApproxAggTest, scalar_inf_values_are_skipped) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/false);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1), quantile_const};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = DoubleColumn::create();
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values->append(v);
+    }
+    values->append(std::numeric_limits<double>::infinity());
+    values->append(-std::numeric_limits<double>::infinity());
+    values->append(std::numeric_limits<double>::quiet_NaN());
+
+    std::vector<const Column*> raw{values.get(), quantile_const.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = DoubleColumn::create();
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    const double median = result->get_data()[0];
+    EXPECT_TRUE(std::isfinite(median));
+    // T-Digest is approximate; the median of {10, 20, 30} should be near 20.
+    EXPECT_GE(median, 10.0);
+    EXPECT_LE(median, 30.0);
+}
+
+// Zero-total-weight state must finalize to SQL NULL via the nullable
+// wrapper, not NaN. Reproduces only on the is_nullable=true mapping,
+// which is what ALWAYS_NULLABLE_RESULT_AGG_FUNCS forces at runtime.
+TEST_F(PercentileApproxAggTest, weighted_empty_state_finalizes_to_null) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx_weighted", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/true);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_BIGINT),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto weight_const = ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1), weight_const, quantile_const};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = NullableColumn::create(DoubleColumn::create(), NullColumn::create());
+    auto* values_data = down_cast<DoubleColumn*>(values->data_column().get());
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values_data->append(v);
+        values->null_column_data().push_back(0);
+    }
+
+    auto weights = NullableColumn::create(weight_const->clone_shared(), NullColumn::create(values->size(), 0));
+
+    std::vector<const Column*> raw{values.get(), weights.get(), quantile_const.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = NullableColumn::create(DoubleColumn::create(), NullColumn::create());
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    EXPECT_TRUE(result->is_null(0));
+}
+
+// Non-finite compression must not propagate to TDigest sizing math.
+// FE blocks the SQL path, so we drive it directly via FunctionContext to
+// exercise the BE-side guard.
+TEST_F(PercentileApproxAggTest, non_finite_compression_falls_back_to_default) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/false);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    auto bad_compression = ColumnHelper::create_const_column<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN(), 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1), quantile_const, bad_compression};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = DoubleColumn::create();
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values->append(v);
+    }
+    std::vector<const Column*> raw{values.get(), quantile_const.get(), bad_compression.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = DoubleColumn::create();
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    const double median = result->get_data()[0];
+    EXPECT_TRUE(std::isfinite(median));
+    EXPECT_GE(median, 10.0);
+    EXPECT_LE(median, 30.0);
+}
+
+} // namespace starrocks

--- a/be/test/exprs/percentile_functions_test.cpp
+++ b/be/test/exprs/percentile_functions_test.cpp
@@ -41,7 +41,7 @@ TEST_F(PercentileFunctionsTest, percentileEmptyTest) {
 
     auto* percentile = ColumnHelper::get_const_value<TYPE_PERCENTILE>(column);
 
-    ASSERT_EQ(61, percentile->serialize_size());
+    ASSERT_EQ(49, percentile->serialize_size());
 }
 
 TEST_F(PercentileFunctionsTest, percentileHashTest) {

--- a/be/test/types/tdigest_test.cpp
+++ b/be/test/types/tdigest_test.cpp
@@ -36,7 +36,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
+#include <limits>
 #include <random>
+#include <vector>
 
 #include "common/logging.h"
 
@@ -231,6 +235,128 @@ TEST_F(TDigestTest, ExtremeQuantiles) {
     for (auto q : quantiles) {
         EXPECT_NEAR(quantile(q, values), digest.quantile(q), 0.01) << "q = " << q;
     }
+}
+
+// Regression for D1: serialize_size() must match the number of bytes
+// written by serialize(). Before the fix it over-reported by 12 B
+// (3 * (sizeof(size_t) - sizeof(uint32_t))) and the trailing space leaked
+// uninitialized memory to disk on every cell.
+TEST_F(TDigestTest, SerializeSizeMatchesSerialized) {
+    TDigest digest(1000);
+    for (int i = 0; i < 50; ++i) {
+        digest.add(static_cast<float>(i));
+    }
+    digest.compress();
+
+    const uint64_t declared = digest.serialize_size();
+    std::vector<uint8_t> buffer(declared, 0xCC);
+    const size_t written = digest.serialize(buffer.data());
+    EXPECT_EQ(declared, written);
+}
+
+TEST_F(TDigestTest, SerializeRoundTrip) {
+    TDigest source(1000);
+    for (int i = 0; i < 200; ++i) {
+        source.add(static_cast<float>(i));
+    }
+    source.compress();
+
+    std::vector<uint8_t> buffer(source.serialize_size());
+    source.serialize(buffer.data());
+
+    TDigest decoded;
+    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_NEAR(source.quantile(0.5), decoded.quantile(0.5), 0.5);
+    EXPECT_NEAR(source.quantile(0.99), decoded.quantile(0.99), 1.0);
+}
+
+// D3: serialize() canonicalizes by running compress() first, so after a
+// round-trip the unprocessed array is empty even when the source had pending
+// centroids at the time of serialization.
+TEST_F(TDigestTest, SerializeProducesCanonicalForm) {
+    TDigest source(1000);
+    for (int i = 0; i < 30; ++i) {
+        source.add(static_cast<float>(i));
+    }
+    EXPECT_FALSE(source.unprocessed().empty());
+
+    std::vector<uint8_t> buffer(source.serialize_size());
+    source.serialize(buffer.data());
+
+    TDigest decoded;
+    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_TRUE(decoded.unprocessed().empty());
+}
+
+// P15: deserialize must reject a blob whose declared header does not fit.
+TEST_F(TDigestTest, DeserializeRejectsTruncatedHeader) {
+    TDigest digest(1000);
+    digest.add(1.0f);
+    digest.compress();
+    std::vector<uint8_t> buffer(digest.serialize_size());
+    digest.serialize(buffer.data());
+
+    TDigest decoded;
+    ASSERT_FALSE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), 10));
+    EXPECT_TRUE(decoded.processed().empty());
+    EXPECT_TRUE(decoded.unprocessed().empty());
+}
+
+// P15: deserialize must reject a centroid count that exceeds the cap, which
+// previously would have done a multi-GiB resize() and OOM'd.
+TEST_F(TDigestTest, DeserializeRejectsOversizedCount) {
+    TDigest digest(1000);
+    digest.add(1.0f);
+    digest.compress();
+    std::vector<uint8_t> buffer(digest.serialize_size());
+    digest.serialize(buffer.data());
+
+    // First centroid count lives right after the fixed header.
+    constexpr size_t header_size = sizeof(float) * 5 + sizeof(size_t) * 2;
+    const uint32_t evil = TDigest::kMaxCentroidsDeserialize + 1;
+    std::memcpy(buffer.data() + header_size, &evil, sizeof(uint32_t));
+
+    TDigest decoded;
+    ASSERT_FALSE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_TRUE(decoded.processed().empty());
+}
+
+// P15: deserialize must reject when the declared count does not fit in the
+// remaining bytes.
+TEST_F(TDigestTest, DeserializeRejectsTruncatedBody) {
+    TDigest digest(1000);
+    for (int i = 0; i < 5; ++i) {
+        digest.add(static_cast<float>(i));
+    }
+    digest.compress();
+    std::vector<uint8_t> buffer(digest.serialize_size());
+    digest.serialize(buffer.data());
+
+    TDigest decoded;
+    // Chop off the last few centroid bytes.
+    const size_t truncated = buffer.size() - 4;
+    ASSERT_FALSE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), truncated));
+    EXPECT_TRUE(decoded.processed().empty());
+}
+
+// Backward compat: legacy blobs were written into a 60+body buffer where the
+// last 12 B were uninitialized. The reader only consumed 48 B of header and
+// ignored the trailing bytes. Simulate that by appending 12 B of garbage and
+// confirm deserialize still recovers the digest.
+TEST_F(TDigestTest, LegacyTrailingBytesIgnored) {
+    TDigest source(1000);
+    for (int i = 0; i < 20; ++i) {
+        source.add(static_cast<float>(i));
+    }
+    source.compress();
+    std::vector<uint8_t> buffer(source.serialize_size());
+    source.serialize(buffer.data());
+
+    buffer.insert(buffer.end(), {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, 0x01, 0x23, 0x45, 0x67});
+
+    TDigest decoded;
+    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_NEAR(source.quantile(0.5), decoded.quantile(0.5), 0.5);
 }
 
 TEST_F(TDigestTest, Montonicity) {

--- a/be/test/types/tdigest_test.cpp
+++ b/be/test/types/tdigest_test.cpp
@@ -362,6 +362,31 @@ TEST_F(TDigestTest, LegacyTrailingBytesIgnored) {
     EXPECT_NEAR(source.quantile(0.5), decoded.quantile(0.5), 0.5);
 }
 
+// P16: byte_size_in_memory tracks capacity, so it reports more than the
+// logical serialize_size once any growth has happened.
+TEST_F(TDigestTest, ByteSizeInMemoryIncludesCapacity) {
+    TDigest digest(1000);
+    for (int i = 0; i < 100; ++i) {
+        digest.add(static_cast<float>(i));
+    }
+    EXPECT_GE(digest.byte_size_in_memory(), digest.serialize_size());
+}
+
+// P16: compress() empties _unprocessed but capacity is retained, so
+// byte_size_in_memory must not drop below its pre-compress value. This is
+// the regression that the old mem_usage = serialize_size() formula caused
+// — process() would shrink serialize_size and produce a negative delta in
+// FunctionContext::add_mem_usage(curr - prev).
+TEST_F(TDigestTest, ByteSizeInMemoryStableAfterCompress) {
+    TDigest digest(1000);
+    for (int i = 0; i < 200; ++i) {
+        digest.add(static_cast<float>(i));
+    }
+    const uint64_t before = digest.byte_size_in_memory();
+    digest.compress();
+    EXPECT_GE(digest.byte_size_in_memory(), before);
+}
+
 TEST_F(TDigestTest, Montonicity) {
     TDigest digest(1000);
     std::uniform_real_distribution<> reals(0.0, 1.0);

--- a/be/test/types/tdigest_test.cpp
+++ b/be/test/types/tdigest_test.cpp
@@ -270,22 +270,25 @@ TEST_F(TDigestTest, SerializeRoundTrip) {
     EXPECT_NEAR(source.quantile(0.99), decoded.quantile(0.99), 1.0);
 }
 
-// D3: serialize() canonicalizes by running compress() first, so after a
-// round-trip the unprocessed array is empty even when the source had pending
-// centroids at the time of serialization.
-TEST_F(TDigestTest, SerializeProducesCanonicalForm) {
+// Regression: serialize() must not mutate the digest. Callers size their
+// output buffer from serialize_size() before calling serialize(); if
+// serialize() ran compress() first, the post-compress footprint
+// (rebuilt _cumulative with M+1 weights) would exceed the caller buffer
+// for unprocessed-only states and overflow the heap.
+TEST_F(TDigestTest, SerializeDoesNotGrowUnprocessedOnly) {
     TDigest source(1000);
     for (int i = 0; i < 30; ++i) {
         source.add(static_cast<float>(i));
     }
+    ASSERT_FALSE(source.unprocessed().empty());
+    ASSERT_TRUE(source.processed().empty());
+
+    const uint64_t declared = source.serialize_size();
+    std::vector<uint8_t> buffer(declared, 0xCC);
+    const size_t written = source.serialize(buffer.data());
+    EXPECT_EQ(declared, written);
     EXPECT_FALSE(source.unprocessed().empty());
-
-    std::vector<uint8_t> buffer(source.serialize_size());
-    source.serialize(buffer.data());
-
-    TDigest decoded;
-    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
-    EXPECT_TRUE(decoded.unprocessed().empty());
+    EXPECT_TRUE(source.processed().empty());
 }
 
 // P15: deserialize must reject a blob whose declared header does not fit.

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -538,8 +538,8 @@ select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighte
 -- !result
 select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, 0, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
 -- result:
-[nan,nan]
-[nan,nan]
+None
+None
 -- !result
 select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, value, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
 -- result:
@@ -586,7 +586,7 @@ select /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */ percen
 -- !result
 select /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */ percentile_approx_weighted(v2, 0, array<double>[0.1, 0.5, 0.9], 5000) from t0_convert_to_serialize_format join t1_convert_to_serialize_format group by 'a';
 -- result:
-[nan,nan,nan]
+None
 -- !result
 select /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */ percentile_approx_weighted(v2, v1, array<double>[0.1, 0.5, 0.9], 5000) from t0_convert_to_serialize_format join t1_convert_to_serialize_format group by 'a';
 -- result:


### PR DESCRIPTION
## Why I'm doing:

Spillable group-by aggregation measured the memory it can release
(`set_revocable_mem_bytes`) and sized its spill mem-table
(`_try_to_spill_by_auto`) with `hash_map_memory_usage()` — only the hash
table plus the pool-resident fixed state structs.

But the per-group state of many aggregates lives **off** the mem pool, and
the aggregator already tracks it in two other channels:

- **`agg_state_memory_usage()`** — heap charged explicitly through
  `add_mem_usage`: `percentile_approx`/`_cont`/`_union` (TDigest), HLL
  (`hll_union`/`_count`, `ndv`), DataSketches (`ds_hll`/`ds_theta`).
- **`allocator_memory_usage()`** — the counting allocator behind
  `AggregateStateAllocator` **and** the roaring memory hook, both pointed at
  the operator's allocator during update/merge: count/sum `distinct` hash
  sets, `approx_top_k` counters, and `bitmap_*` / `intersect_count` roaring
  bitmaps.

The existing composite `Aggregator::memory_usage()` already sums all three
(`hash_map + agg_state + allocator`) and is what the OOM / `has_limited()`
path uses — but the two spill sites used the pool-only number, so they were
blind to that heap:

1. **Victim selection.** The spill scheduler picks an operator by
   `revocable_mem_bytes > spill_operator_min_bytes` (default 50 MB). An
   operator holding GBs of TDigest/HLL/roaring heap reported only its
   ~tens-of-bytes-per-group pool footprint, stayed under 50 MB, and was
   **passed over** — so under memory pressure the framework reclaimed from
   lighter operators (which free little) while the operator actually holding
   the memory kept it. Result: ineffective spill and avoidable query
   memory-limit failures.
2. **Mem-table sizing.** `_try_to_spill_by_auto()` compares the footprint
   against `spill_mem_table_size`. Blind to the heap, the in-memory hash
   table grew far past the configured size before flushing, so spill
   happened in large lurches instead of bounded blocks.

The OOM trigger is **not** affected: the query MemTracker already sees this
heap via allocation hooks. The bug is purely spill scheduling using the
wrong number.

## What I'm doing:

Use the existing `Aggregator::memory_usage()` at the revocable + sizing
sites of `SpillableAggregateBlockingSinkOperator` and
`SpillablePartitionWiseAggregateSinkOperator` (no new method).

With the real footprint in `revocable_mem_bytes`, the operator that actually
holds the heap crosses `spill_operator_min_bytes`, so the scheduler selects
**it** and reclaims memory where it sits — instead of skipping it and
spilling light operators that free almost nothing. And
`_try_to_spill_by_auto()` now flushes the hash table at
`spill_mem_table_size`, producing bounded spill blocks instead of lurches.

- **No double count:** each aggregate's heap lands in exactly one channel.
  The `add_mem_usage` aggregates allocate their internal buffers with the
  default allocator (not `AggregateStateAllocator` / the roaring hook), so
  `agg_state` and `allocator` do not overlap. This is the same value
  `memory_usage()` already reports for the OOM path.
- **Now covered:** `percentile_approx`/HLL/DataSketches (via `agg_state`)
  **and** count/sum `distinct`, `approx_top_k`, `bitmap_*` /
  `intersect_count` (via `allocator`).
- **Intentionally untouched:** `estimated_memory_reserved` stays on
  `hash_map_memory_usage()` — it estimates the incremental cost of the next
  hash-table expansion, not the resident footprint. The `SELECT DISTINCT`
  dedup operators stay on `hash_set_memory_usage()` — their state is the
  pool-resident group keys, so `memory_usage()` equals
  `hash_set_memory_usage()` for them.
- **Out of scope (follow-up):** aggregates that keep their state in
  `Column`s under the default column allocator (`array_agg`, `map_agg`,
  `group_concat`) are seen only by the query MemTracker, not by any operator
  channel, so they still report ~0 to spill. Instrumenting them is separate.

Stacked on #73574 (capacity-based mem accounting), which makes
`percentile_approx`'s contribution to `agg_state_memory_usage()` correct;
the GitHub diff narrows to the spill change once #73574 merges.

Fixes #73759

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
