### PR TITLE
[Refactor] Move format output streams to FormatsIO

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -182,6 +182,14 @@ Core runtime building blocks without full Runtime/Exec/Storage coupling.
 - Core tests: `runtime_core_test`
 - Remediation: Keep RuntimeCore restricted to core runtime infrastructure; move service/storage/stream-load/integration code into Runtime.
 
+### FormatsIO (`formatsio`)
+Format-oriented output stream primitives above RuntimeCore, FSCore, and Types.
+- Targets: `FormatsIO`
+- Allowed internal include prefixes: `formats/io/`, `runtime/`, `fs/`, `types/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
+- Allowed target deps: `RuntimeCore`, `FSCore`, `Types`, `Common`, `Base`, `Gutil`, `StarRocksGen`
+- Core tests: `formats_io_test`
+- Remediation: Keep FormatsIO limited to reusable format output stream primitives; move connector orchestration and higher execution policy upward.
+
 ### RuntimeEnv (`runtimeenv`)
 Process-scoped runtime environment resources below full Runtime and above RuntimeCore.
 - Targets: `RuntimeEnv`

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -547,6 +547,7 @@ set(STARROCKS_LINK_LIBS
     ${WL_WHOLE_ARCHIVE_PREFIX} Exprs ${WL_WHOLE_ARCHIVE_SUFFIX}
     FileSystem
     Formats
+    FormatsIO
     IO
     Storage
     Rowset

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -352,6 +352,18 @@
       "remediation": "Keep RuntimeCore restricted to core runtime infrastructure; move service/storage/stream-load/integration code into Runtime."
     },
     {
+      "id": "formatsio",
+      "doc_label": "FormatsIO",
+      "summary": "Format-oriented output stream primitives above RuntimeCore, FSCore, and Types.",
+      "owned_targets": ["FormatsIO"],
+      "owned_globs": ["be/src/formats/io/**"],
+      "allowed_include_prefixes": ["formats/io/", "runtime/", "fs/", "types/", "common/", "base/", "gutil/", "gen_cpp/"],
+      "allowed_target_deps": ["RuntimeCore", "FSCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "allowed_test_targets": ["formats_io_test"],
+      "allowed_test_link_deps": ["FormatsIO", "RuntimeCore", "FSCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "remediation": "Keep FormatsIO limited to reusable format output stream primitives; move connector orchestration and higher execution policy upward."
+    },
+    {
       "id": "runtimeenv",
       "doc_label": "RuntimeEnv",
       "summary": "Process-scoped runtime environment resources below full Runtime and above RuntimeCore.",

--- a/be/src/connector/async_flush_stream_poller.h
+++ b/be/src/connector/async_flush_stream_poller.h
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
+#include <deque>
 #include <future>
-#include <queue>
 
 #include "common/status.h"
+#include "formats/io/async_flush_output_stream.h"
 #include "formats/utils.h"
-#include "io/async_flush_output_stream.h"
-
-#pragma once
 
 namespace starrocks::connector {
 
-/// own a FIFO queue of `io::AsyncFlushOutputStream`
+/// own a FIFO queue of `formats::AsyncFlushOutputStream`
 /// client periodically poll the state of async io operations via `poll()`
-/// each `io::AsyncFlushOutputStream` will be destroyed once its async status is ready and fetched
+/// each `formats::AsyncFlushOutputStream` will be destroyed once its async status is ready and fetched
 class AsyncFlushStreamPoller {
 public:
-    using Stream = io::AsyncFlushOutputStream;
+    using Stream = formats::AsyncFlushOutputStream;
 
     AsyncFlushStreamPoller() = default;
 

--- a/be/src/connector/partition_chunk_writer.h
+++ b/be/src/connector/partition_chunk_writer.h
@@ -98,7 +98,7 @@ public:
 
     std::shared_ptr<formats::FileWriter> file_writer() { return _file_writer; }
 
-    std::shared_ptr<io::AsyncFlushOutputStream> out_stream() { return _out_stream; }
+    std::shared_ptr<formats::AsyncFlushOutputStream> out_stream() { return _out_stream; }
 
     void set_io_poller(AsyncFlushStreamPoller* io_poller) { _io_poller = io_poller; }
 
@@ -125,7 +125,7 @@ protected:
     // Therefore, we must ensure _file_writer is destroyed first, followed by _out_stream.
     // Failing to do so will result in a use-after-free error for _out_stream.
     // TODO: Refactor the file writer and output stream to make them more robust and user-friendly.
-    std::shared_ptr<io::AsyncFlushOutputStream> _out_stream;
+    std::shared_ptr<formats::AsyncFlushOutputStream> _out_stream;
     std::shared_ptr<formats::FileWriter> _file_writer;
     CommitFunc _commit_callback;
     std::string _commit_extra_data;

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -570,4 +570,4 @@ ADD_BE_LIB(Exec
 )
 
 target_link_libraries(Exec PUBLIC ExecPrimitive ExecSinkCore SpillCore ExecSchemaScannerCore ExecSchemaScanners ExecSortingCore ExecJoinCore RuntimeEnv)
-target_link_libraries(Exec PRIVATE Platform)
+target_link_libraries(Exec PRIVATE FormatsIO Platform)

--- a/be/src/exec/data_sinks/export_sink.h
+++ b/be/src/exec/data_sinks/export_sink.h
@@ -39,8 +39,8 @@
 #include "common/runtime_profile.h"
 #include "exec/data_sink.h"
 #include "formats/csv/converter.h"
+#include "formats/io/formatted_output_stream_file.h"
 #include "fs/fs.h"
-#include "io/formatted_output_stream_file.h"
 
 namespace starrocks {
 

--- a/be/src/exec/data_sinks/file_result_writer.cpp
+++ b/be/src/exec/data_sinks/file_result_writer.cpp
@@ -44,10 +44,10 @@
 #include "exec/parquet_builder.h"
 #include "exec/plain_text_builder.h"
 #include "formats/csv/converter.h"
+#include "formats/io/formatted_output_stream.h"
 #include "fs/fs_broker.h"
 #include "fs/fs_factory.h"
 #include "gutil/strings/substitute.h"
-#include "io/formatted_output_stream.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {

--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -25,9 +25,9 @@
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
 #include "formats/csv/converter.h"
+#include "formats/io/formatted_output_stream.h"
 #include "fs/fs_broker.h"
 #include "fs/fs_factory.h"
-#include "io/formatted_output_stream.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {

--- a/be/src/exec/plain_text_builder.cpp
+++ b/be/src/exec/plain_text_builder.cpp
@@ -10,9 +10,9 @@
 #include "exprs/expr_context.h"
 #include "formats/csv/converter.h"
 #include "formats/csv/csv_escape.h"
+#include "formats/io/formatted_output_stream.h"
+#include "formats/io/formatted_output_stream_file.h"
 #include "gutil/strings/substitute.h"
-#include "io/formatted_output_stream.h"
-#include "io/formatted_output_stream_file.h"
 
 namespace starrocks {
 
@@ -22,8 +22,8 @@ PlainTextBuilder::PlainTextBuilder(PlainTextBuilderOptions options, std::unique_
                                    const std::vector<ExprContext*>& output_expr_ctxs)
         : _options(std::move(options)),
           _output_expr_ctxs(output_expr_ctxs),
-          _output_stream(std::make_unique<io::FormattedOutputStreamFile>(std::move(writable_file),
-                                                                         OUTSTREAM_BUFFER_SIZE_BYTES)) {}
+          _output_stream(std::make_unique<formats::FormattedOutputStreamFile>(std::move(writable_file),
+                                                                              OUTSTREAM_BUFFER_SIZE_BYTES)) {}
 
 PlainTextBuilder::~PlainTextBuilder() = default;
 

--- a/be/src/exec/plain_text_builder.h
+++ b/be/src/exec/plain_text_builder.h
@@ -29,9 +29,9 @@ namespace csv {
 class Converter;
 } // namespace csv
 
-namespace io {
+namespace formats {
 class FormattedOutputStream;
-} // namespace io
+} // namespace formats
 
 class ExprContext;
 class FileWriter;
@@ -59,7 +59,7 @@ private:
     const static size_t OUTSTREAM_BUFFER_SIZE_BYTES;
     const PlainTextBuilderOptions _options;
     const std::vector<ExprContext*>& _output_expr_ctxs;
-    std::unique_ptr<io::FormattedOutputStream> _output_stream;
+    std::unique_ptr<formats::FormattedOutputStream> _output_stream;
     std::vector<std::unique_ptr<csv::Converter>> _converters;
     bool _init{false};
 

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -14,6 +14,21 @@
 
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/formats")
 
+ADD_BE_LIB(FormatsIO
+        io/async_flush_output_stream.cpp
+        io/formatted_output_stream_file.cpp
+        )
+
+target_link_libraries(FormatsIO PUBLIC
+        RuntimeCore
+        FSCore
+        Types
+        Common
+        Base
+        Gutil
+        StarRocksGen
+)
+
 ADD_BE_LIB(Formats
         csv/array_converter.cpp
         csv/array_reader.cpp
@@ -97,5 +112,7 @@ ADD_BE_LIB(Formats
         disk_range.hpp
         file_writer.cpp
         )
+
+target_link_libraries(Formats PUBLIC FormatsIO)
 
 add_subdirectory(orc/apache-orc)

--- a/be/src/formats/csv/array_converter.cpp
+++ b/be/src/formats/csv/array_converter.cpp
@@ -19,7 +19,7 @@
 
 namespace starrocks::csv {
 
-Status ArrayConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status ArrayConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                     const Options& options) const {
     const auto* array = down_cast<const ArrayColumn*>(&column);
     const auto& offsets = array->offsets();
@@ -58,7 +58,7 @@ Status ArrayConverter::write_string(io::FormattedOutputStream* os, const Column&
     return os->write(']');
 }
 
-Status ArrayConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status ArrayConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                            const Options& options) const {
     return write_string(os, column, row_num, options);
 }

--- a/be/src/formats/csv/array_converter.h
+++ b/be/src/formats/csv/array_converter.h
@@ -24,9 +24,9 @@ public:
     explicit ArrayConverter(std::unique_ptr<Converter> elem_converter)
             : _element_converter(std::move(elem_converter)) {}
 
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/boolean_converter.cpp
+++ b/be/src/formats/csv/boolean_converter.cpp
@@ -20,7 +20,7 @@
 
 namespace starrocks::csv {
 
-Status BooleanConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status BooleanConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                       const Options& options) const {
     const static Slice kTrue("true");
     const static Slice kFalse("false");
@@ -33,7 +33,7 @@ Status BooleanConverter::write_string(io::FormattedOutputStream* os, const Colum
     }
 }
 
-Status BooleanConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status BooleanConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                              const Options& options) const {
     return write_string(os, column, row_num, options);
 }

--- a/be/src/formats/csv/boolean_converter.h
+++ b/be/src/formats/csv/boolean_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class BooleanConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/converter.h
+++ b/be/src/formats/csv/converter.h
@@ -25,7 +25,7 @@
 #include "base/container/raw_container.h"
 #include "base/string/slice.h"
 #include "common/status.h"
-#include "io/formatted_output_stream.h"
+#include "formats/io/formatted_output_stream.h"
 #include "types/date_value.h"
 #include "types/decimalv2_value.h"
 #include "types/time_types.h"
@@ -87,10 +87,10 @@ public:
 
     virtual ~Converter() = default;
 
-    virtual Status write_string(io::FormattedOutputStream* buff, const Column& column, size_t row_num,
+    virtual Status write_string(formats::FormattedOutputStream* buff, const Column& column, size_t row_num,
                                 const Options& options) const = 0;
 
-    virtual Status write_quoted_string(io::FormattedOutputStream* buff, const Column& column, size_t row_num,
+    virtual Status write_quoted_string(formats::FormattedOutputStream* buff, const Column& column, size_t row_num,
                                        const Options& options) const = 0;
 
     virtual bool read_string_for_adaptive_null_column(Column* column, Slice s, const Options& options) const {

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -24,14 +24,14 @@
 #include "exec/hdfs_scanner/hdfs_scanner_text.h"
 #include "formats/column_evaluator.h"
 #include "formats/csv/csv_escape.h"
+#include "formats/io/formatted_output_stream_file.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "formats/utils.h"
-#include "io/formatted_output_stream_file.h"
-#include "io/formatted_output_stream_string.h"
 #include "runtime/current_thread.h"
 
 namespace starrocks::formats {
 
-CSVFileWriter::CSVFileWriter(std::string location, std::shared_ptr<io::FormattedOutputStream> output_stream,
+CSVFileWriter::CSVFileWriter(std::string location, std::shared_ptr<FormattedOutputStream> output_stream,
                              std::vector<std::string> column_names, std::vector<TypeDescriptor> types,
                              std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                              std::shared_ptr<CSVWriterOptions> writer_options, std::function<void()> rollback_action)
@@ -217,7 +217,7 @@ Status CSVFileWriter::_write_enclosed_field(csv::Converter* converter, const Col
                                             const csv::Converter::Options& options) {
     // Write the field content into a temporary in-memory string buffer, then scan
     // and escape via _write_enclosed_string.
-    io::FormattedOutputStreamString field_buf(256);
+    formats::FormattedOutputStreamString field_buf(256);
     RETURN_IF_ERROR(converter->write_string(&field_buf, column, row_num, options));
     RETURN_IF_ERROR(field_buf.finalize()); // flush internal buffer to string
     return _write_enclosed_string(field_buf.as_string());
@@ -302,20 +302,21 @@ StatusOr<WriterAndStream> CSVFileWriterFactory::create(const std::string& path) 
     auto column_evaluators = ColumnEvaluator::clone(_column_evaluators);
     auto types = ColumnEvaluator::types(_column_evaluators);
     auto async_output_stream =
-            std::make_unique<io::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
 
     // Create base async output stream
-    auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_output_stream.get(), 1024 * 1024);
+    auto base_stream =
+            std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_output_stream.get(), 1024 * 1024);
 
     // Wrap with compression if enabled (decorator pattern)
-    std::shared_ptr<io::FormattedOutputStream> csv_output_stream;
+    std::shared_ptr<FormattedOutputStream> csv_output_stream;
     CompressionTypePB compression_pb = CompressionUtils::to_compression_pb(_compression_type);
     // Only use compression if it's a valid, recognized compression type
     // (not UNKNOWN_COMPRESSION which is returned for AUTO, DEFAULT_COMPRESSION, etc.)
     if (compression_pb != CompressionTypePB::NO_COMPRESSION &&
         compression_pb != CompressionTypePB::UNKNOWN_COMPRESSION) {
         ASSIGN_OR_RETURN(csv_output_stream,
-                         io::CompressedFormattedOutputStream::create(base_stream, compression_pb, 1024 * 1024));
+                         formats::CompressedFormattedOutputStream::create(base_stream, compression_pb, 1024 * 1024));
     } else {
         csv_output_stream = base_stream;
     }

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -16,8 +16,8 @@
 
 #include "formats/csv/converter.h"
 #include "formats/file_writer.h"
+#include "formats/io/formatted_output_stream.h"
 #include "gen_cpp/Types_types.h"
-#include "io/formatted_output_stream.h"
 
 namespace starrocks {
 class ColumnEvaluator;
@@ -54,7 +54,7 @@ struct CSVWriterOptions : FileWriterOptions {
 // TODO(letian-jiang): support escaping
 class CSVFileWriter final : public FileWriter {
 public:
-    CSVFileWriter(std::string location, std::shared_ptr<io::FormattedOutputStream> output_stream,
+    CSVFileWriter(std::string location, std::shared_ptr<FormattedOutputStream> output_stream,
                   std::vector<std::string> column_names, std::vector<TypeDescriptor> types,
                   std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                   std::shared_ptr<CSVWriterOptions> writer_options, std::function<void()> rollback_action);
@@ -75,7 +75,7 @@ public:
 
 private:
     const std::string _location;
-    std::shared_ptr<io::FormattedOutputStream> _output_stream;
+    std::shared_ptr<FormattedOutputStream> _output_stream;
     const std::vector<std::string> _column_names;
     const std::vector<TypeDescriptor> _types;
     std::vector<std::unique_ptr<ColumnEvaluator>> _column_evaluators;

--- a/be/src/formats/csv/date_converter.cpp
+++ b/be/src/formats/csv/date_converter.cpp
@@ -21,13 +21,13 @@
 
 namespace starrocks::csv {
 
-Status DateConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DateConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                    const Options& options) const {
     auto date_column = down_cast<const FixedLengthColumn<DateValue>*>(&column);
     return os->write(date_column->immutable_data()[row_num]);
 }
 
-Status DateConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DateConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                           const Options& options) const {
     RETURN_IF_ERROR(os->write('"'));
     RETURN_IF_ERROR(write_string(os, column, row_num, options));

--- a/be/src/formats/csv/date_converter.h
+++ b/be/src/formats/csv/date_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class DateConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/datetime_converter.cpp
+++ b/be/src/formats/csv/datetime_converter.cpp
@@ -21,13 +21,13 @@
 
 namespace starrocks::csv {
 
-Status DatetimeConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DatetimeConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                        const Options& options) const {
     auto datetime_column = down_cast<const FixedLengthColumn<TimestampValue>*>(&column);
     return os->write(datetime_column->immutable_data()[row_num]);
 }
 
-Status DatetimeConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DatetimeConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                               const Options& options) const {
     RETURN_IF_ERROR(os->write('"'));
     RETURN_IF_ERROR(write_string(os, column, row_num, options));

--- a/be/src/formats/csv/datetime_converter.h
+++ b/be/src/formats/csv/datetime_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class DatetimeConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/decimalv2_converter.cpp
+++ b/be/src/formats/csv/decimalv2_converter.cpp
@@ -21,13 +21,13 @@
 
 namespace starrocks::csv {
 
-Status DecimalV2Converter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DecimalV2Converter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                         const Options& options) const {
     auto decimal_column = down_cast<const FixedLengthColumn<DecimalV2Value>*>(&column);
     return os->write(decimal_column->immutable_data()[row_num]);
 }
 
-Status DecimalV2Converter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DecimalV2Converter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                                const Options& options) const {
     return write_string(os, column, row_num, options);
 }

--- a/be/src/formats/csv/decimalv2_converter.h
+++ b/be/src/formats/csv/decimalv2_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class DecimalV2Converter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/decimalv3_converter.cpp
+++ b/be/src/formats/csv/decimalv3_converter.cpp
@@ -21,7 +21,7 @@
 namespace starrocks::csv {
 
 template <typename T>
-Status DecimalV3Converter<T>::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DecimalV3Converter<T>::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                            const Options& options) const {
     auto decimalv3_column = down_cast<const DecimalV3Column<T>*>(&column);
     const auto immutable_data = decimalv3_column->immutable_data();
@@ -31,8 +31,8 @@ Status DecimalV3Converter<T>::write_string(io::FormattedOutputStream* os, const 
 }
 
 template <typename T>
-Status DecimalV3Converter<T>::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
-                                                  const Options& options) const {
+Status DecimalV3Converter<T>::write_quoted_string(formats::FormattedOutputStream* os, const Column& column,
+                                                  size_t row_num, const Options& options) const {
     return write_string(os, column, row_num, options);
 }
 

--- a/be/src/formats/csv/decimalv3_converter.h
+++ b/be/src/formats/csv/decimalv3_converter.h
@@ -26,9 +26,9 @@ class DecimalV3Converter final : public Converter {
 public:
     DecimalV3Converter(int precision, int scale) : _precision(precision), _scale(scale) {}
 
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/default_value_converter.cpp
+++ b/be/src/formats/csv/default_value_converter.cpp
@@ -31,12 +31,12 @@ bool DefaultValueConverter::read_string(Column* column, const Slice& s, const Op
     return read_quoted_string(column, s, options);
 }
 
-Status DefaultValueConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
-                                                  const Options& options) const {
+Status DefaultValueConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column,
+                                                  size_t row_num, const Options& options) const {
     return Status::InternalError("Csv DefaultValueConverter only support for read, not write");
 }
 
-Status DefaultValueConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status DefaultValueConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                            const Options& options) const {
     return write_quoted_string(os, column, row_num, options);
 }

--- a/be/src/formats/csv/default_value_converter.h
+++ b/be/src/formats/csv/default_value_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class DefaultValueConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/float_converter.cpp
+++ b/be/src/formats/csv/float_converter.cpp
@@ -21,14 +21,14 @@
 namespace starrocks::csv {
 
 template <typename T>
-Status FloatConverter<T>::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status FloatConverter<T>::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                        const Options& options) const {
     auto float_column = down_cast<const FixedLengthColumn<DataType>*>(&column);
     return os->write(float_column->immutable_data()[row_num]);
 }
 
 template <typename T>
-Status FloatConverter<T>::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status FloatConverter<T>::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                               const Options& options) const {
     return write_string(os, column, row_num, options);
 }

--- a/be/src/formats/csv/float_converter.h
+++ b/be/src/formats/csv/float_converter.h
@@ -25,9 +25,9 @@ class FloatConverter final : public Converter {
 public:
     using DataType = T;
 
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/json_converter.cpp
+++ b/be/src/formats/csv/json_converter.cpp
@@ -21,7 +21,7 @@
 
 namespace starrocks::csv {
 
-Status JsonConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status JsonConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                    const Options& options) const {
     auto data_column = down_cast<const JsonColumn*>(&column);
     auto json_value = data_column->get_object(row_num);
@@ -29,7 +29,7 @@ Status JsonConverter::write_string(io::FormattedOutputStream* os, const Column& 
     return os->write(json_str);
 }
 
-Status JsonConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status JsonConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                           const Options& options) const {
     RETURN_IF_ERROR(os->write('"'));
     RETURN_IF_ERROR(write_string(os, column, row_num, options));

--- a/be/src/formats/csv/json_converter.h
+++ b/be/src/formats/csv/json_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class JsonConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/map_converter.cpp
+++ b/be/src/formats/csv/map_converter.cpp
@@ -19,7 +19,7 @@
 
 namespace starrocks::csv {
 
-Status MapConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status MapConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                   const Options& options) const {
     auto* map = down_cast<const MapColumn*>(&column);
     auto& offsets = map->offsets();
@@ -43,7 +43,7 @@ Status MapConverter::write_string(io::FormattedOutputStream* os, const Column& c
     return os->write('}');
 }
 
-Status MapConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status MapConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                          const Options& options) const {
     return write_string(os, column, row_num, options);
 }

--- a/be/src/formats/csv/map_converter.h
+++ b/be/src/formats/csv/map_converter.h
@@ -23,9 +23,9 @@ public:
     explicit MapConverter(std::unique_ptr<Converter> key_converter, std::unique_ptr<Converter> value_converter)
             : _key_converter(std::move(key_converter)), _value_converter(std::move(value_converter)) {}
 
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/nullable_converter.cpp
+++ b/be/src/formats/csv/nullable_converter.cpp
@@ -20,7 +20,7 @@
 
 namespace starrocks::csv {
 
-Status NullableConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status NullableConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                        const Options& options) const {
     if (column.is_nullable()) {
         auto nullable_column = down_cast<const NullableColumn*>(&column);
@@ -36,7 +36,7 @@ Status NullableConverter::write_string(io::FormattedOutputStream* os, const Colu
     }
 }
 
-Status NullableConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status NullableConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                               const Options& options) const {
     if (column.is_nullable()) {
         auto nullable_column = down_cast<const NullableColumn*>(&column);

--- a/be/src/formats/csv/nullable_converter.h
+++ b/be/src/formats/csv/nullable_converter.h
@@ -23,9 +23,9 @@ public:
     explicit NullableConverter(std::unique_ptr<Converter> base_converter)
             : _base_converter(std::move(base_converter)) {}
 
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string_for_adaptive_null_column(Column* column, Slice s, const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/numeric_converter.cpp
+++ b/be/src/formats/csv/numeric_converter.cpp
@@ -20,7 +20,7 @@
 namespace starrocks::csv {
 
 template <typename T>
-Status NumericConverter<T>::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status NumericConverter<T>::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                          const Options& options) const {
     auto numeric_column = down_cast<const FixedLengthColumn<DataType>*>(&column);
     const auto idata = numeric_column->immutable_data();
@@ -32,8 +32,8 @@ Status NumericConverter<T>::write_string(io::FormattedOutputStream* os, const Co
 }
 
 template <typename T>
-Status NumericConverter<T>::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
-                                                const Options& options) const {
+Status NumericConverter<T>::write_quoted_string(formats::FormattedOutputStream* os, const Column& column,
+                                                size_t row_num, const Options& options) const {
     return write_string(os, column, row_num, options);
 }
 

--- a/be/src/formats/csv/numeric_converter.h
+++ b/be/src/formats/csv/numeric_converter.h
@@ -25,9 +25,9 @@ class NumericConverter final : public Converter {
 public:
     using DataType = T;
 
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -22,7 +22,7 @@
 
 namespace starrocks::csv {
 
-Status StringConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status StringConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                      const Options& options) const {
     auto* binary = down_cast<const BinaryColumn*>(&column);
     auto bytes = binary->get_immutable_bytes();
@@ -33,7 +33,7 @@ Status StringConverter::write_string(io::FormattedOutputStream* os, const Column
     return os->write(s);
 }
 
-Status StringConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status StringConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                             const Options& options) const {
     auto* binary = down_cast<const BinaryColumn*>(&column);
     auto bytes = binary->get_immutable_bytes();

--- a/be/src/formats/csv/string_converter.h
+++ b/be/src/formats/csv/string_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class StringConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/csv/varbinary_converter.cpp
+++ b/be/src/formats/csv/varbinary_converter.cpp
@@ -27,7 +27,7 @@
 
 namespace starrocks::csv {
 
-Status VarBinaryConverter::write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status VarBinaryConverter::write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                         const Options& options) const {
     auto* binary = down_cast<const BinaryColumn*>(&column);
     auto& bytes = binary->get_immutable_bytes();
@@ -45,7 +45,7 @@ Status VarBinaryConverter::write_string(io::FormattedOutputStream* os, const Col
     return os->write(Slice(buf, encoded_len));
 }
 
-Status VarBinaryConverter::write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+Status VarBinaryConverter::write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                                const Options& options) const {
     RETURN_IF_ERROR(os->write('"'));
     RETURN_IF_ERROR(write_string(os, column, row_num, options));

--- a/be/src/formats/csv/varbinary_converter.h
+++ b/be/src/formats/csv/varbinary_converter.h
@@ -20,9 +20,9 @@ namespace starrocks::csv {
 
 class VarBinaryConverter final : public Converter {
 public:
-    Status write_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                         const Options& options) const override;
-    Status write_quoted_string(io::FormattedOutputStream* os, const Column& column, size_t row_num,
+    Status write_quoted_string(formats::FormattedOutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string(Column* column, const Slice& s, const Options& options) const override;
     bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;

--- a/be/src/formats/file_writer.cpp
+++ b/be/src/formats/file_writer.cpp
@@ -18,7 +18,7 @@
 
 #include <utility>
 
-#include "io/async_flush_output_stream.h"
+#include "formats/io/async_flush_output_stream.h"
 
 namespace starrocks::formats {
 

--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -25,10 +25,9 @@
 #include "common/status.h"
 #include "common/statusor.h"
 
-namespace starrocks::io {
-class AsyncFlushOutputStream;
-}
 namespace starrocks::formats {
+
+class AsyncFlushOutputStream;
 
 struct FileWriterOptions {
     virtual ~FileWriterOptions() = default;
@@ -69,7 +68,7 @@ public:
 };
 
 struct WriterAndStream {
-    std::unique_ptr<io::AsyncFlushOutputStream> stream;
+    std::unique_ptr<AsyncFlushOutputStream> stream;
     std::unique_ptr<FileWriter> writer;
 };
 

--- a/be/src/formats/io/async_flush_output_stream.cpp
+++ b/be/src/formats/io/async_flush_output_stream.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "io/async_flush_output_stream.h"
+#include "formats/io/async_flush_output_stream.h"
 
 #include "base/failpoint/fail_point.h"
 #include "common/thread/priority_thread_pool.hpp"
@@ -20,7 +20,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 
-namespace starrocks::io {
+namespace starrocks::formats {
 
 DEFINE_FAIL_POINT(async_flush_output_stream_sleep);
 
@@ -188,4 +188,4 @@ void AsyncFlushOutputStream::enqueue_tasks_and_maybe_submit_task(std::vector<Tas
         _io_status.update(Status::ResourceBusy("fail to submit io task"));
     }
 }
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/src/formats/io/async_flush_output_stream.h
+++ b/be/src/formats/io/async_flush_output_stream.h
@@ -14,8 +14,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+#include <deque>
+#include <functional>
 #include <future>
+#include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
 #include <vector>
@@ -29,7 +34,7 @@ class PriorityThreadPool;
 class RuntimeState;
 } // namespace starrocks
 
-namespace starrocks::io {
+namespace starrocks::formats {
 
 // NOT thread-safe
 class AsyncFlushOutputStream {
@@ -94,4 +99,4 @@ private:
     Status _io_status;
 };
 
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/src/formats/io/formatted_output_stream.h
+++ b/be/src/formats/io/formatted_output_stream.h
@@ -16,13 +16,20 @@
 
 #include <ryu/ryu.h>
 
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "base/string/slice.h"
 #include "base/utility/mysql_global.h"
+#include "common/status.h"
 #include "fmt/compile.h"
 #include "types/date_value.h"
 #include "types/decimalv2_value.h"
 #include "types/timestamp_value.h"
 
-namespace starrocks::io {
+namespace starrocks::formats {
 
 class FormattedOutputStream {
 public:
@@ -142,4 +149,4 @@ private:
     char* _end;
 };
 
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/src/formats/io/formatted_output_stream_file.cpp
+++ b/be/src/formats/io/formatted_output_stream_file.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "io/formatted_output_stream_file.h"
+#include "formats/io/formatted_output_stream_file.h"
 
 #include <algorithm>
 #include <cstring>
@@ -21,7 +21,7 @@
 #include "base/compression/compression_headers.h"
 #include "fmt/format.h"
 
-namespace starrocks::io {
+namespace starrocks::formats {
 
 static bool is_block_compression(CompressionTypePB compression_type) {
     return compression_type == CompressionTypePB::SNAPPY || compression_type == CompressionTypePB::LZ4;
@@ -262,4 +262,4 @@ std::size_t BlockCompressedFormattedOutputStream::size() {
     return _compressed_bytes_written + pending_estimate;
 }
 
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/src/formats/io/formatted_output_stream_file.h
+++ b/be/src/formats/io/formatted_output_stream_file.h
@@ -16,15 +16,17 @@
 
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include "base/compression/stream_compressor.h"
 #include "base/container/raw_container.h"
+#include "common/statusor.h"
+#include "formats/io/async_flush_output_stream.h"
+#include "formats/io/formatted_output_stream.h"
 #include "fs/fs.h"
 #include "gen_cpp/segment.pb.h"
-#include "io/async_flush_output_stream.h"
-#include "io/formatted_output_stream.h"
 
-namespace starrocks::io {
+namespace starrocks::formats {
 
 class FormattedOutputStreamFile final : public FormattedOutputStream {
 public:
@@ -47,7 +49,7 @@ private:
 
 class AsyncFormattedOutputStreamFile final : public FormattedOutputStream {
 public:
-    AsyncFormattedOutputStreamFile(io::AsyncFlushOutputStream* stream, size_t buff_size)
+    AsyncFormattedOutputStreamFile(AsyncFlushOutputStream* stream, size_t buff_size)
             : FormattedOutputStream(buff_size), _stream(stream) {}
 
     Status finalize() override {
@@ -64,7 +66,7 @@ protected:
     }
 
 private:
-    io::AsyncFlushOutputStream* _stream;
+    AsyncFlushOutputStream* _stream;
 };
 
 // CompressedFormattedOutputStream is an abstract base class for compressed output streams.
@@ -158,4 +160,4 @@ private:
     raw::RawVector<uint8_t> _block_buffer;
 };
 
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/src/formats/io/formatted_output_stream_string.h
+++ b/be/src/formats/io/formatted_output_stream_string.h
@@ -14,9 +14,11 @@
 
 #pragma once
 
-#include "io/formatted_output_stream.h"
+#include <string>
 
-namespace starrocks::io {
+#include "formats/io/formatted_output_stream.h"
+
+namespace starrocks::formats {
 
 class FormattedOutputStreamString final : public FormattedOutputStream {
 public:
@@ -34,4 +36,4 @@ private:
     std::string _str;
 };
 
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -25,16 +25,16 @@
 #include "common/http/content_type.h"
 #include "common/util/debug_util.h"
 #include "formats/column_evaluator.h"
+#include "formats/io/async_flush_output_stream.h"
 #include "formats/orc/orc_memory_pool.h"
 #include "formats/orc/utils.h"
 #include "formats/utils.h"
 #include "fs/fs.h"
-#include "io/async_flush_output_stream.h"
 #include "runtime/current_thread.h"
 
 namespace starrocks::formats {
 
-AsyncOrcOutputStream::AsyncOrcOutputStream(io::AsyncFlushOutputStream* stream) : _stream(stream) {}
+AsyncOrcOutputStream::AsyncOrcOutputStream(formats::AsyncFlushOutputStream* stream) : _stream(stream) {}
 
 uint64_t AsyncOrcOutputStream::getLength() const {
     return _stream->tell();
@@ -507,7 +507,7 @@ StatusOr<WriterAndStream> ORCFileWriterFactory::create(const string& path) const
     auto column_evaluators = ColumnEvaluator::clone(_column_evaluators);
     auto types = ColumnEvaluator::types(_column_evaluators);
     auto async_output_stream =
-            std::make_unique<io::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
     auto orc_output_stream = std::make_shared<AsyncOrcOutputStream>(async_output_stream.get());
     auto writer =
             std::make_unique<ORCFileWriter>(path, orc_output_stream, _column_names, types, std::move(column_evaluators),

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -35,7 +35,7 @@ namespace starrocks::formats {
 
 class AsyncOrcOutputStream : public orc::OutputStream {
 public:
-    AsyncOrcOutputStream(io::AsyncFlushOutputStream* _stream);
+    AsyncOrcOutputStream(formats::AsyncFlushOutputStream* _stream);
 
     ~AsyncOrcOutputStream() override = default;
 
@@ -50,7 +50,7 @@ public:
     const std::string& getName() const override;
 
 private:
-    io::AsyncFlushOutputStream* _stream;
+    formats::AsyncFlushOutputStream* _stream;
     bool _is_closed = false;
 };
 

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -108,7 +108,7 @@ arrow::Status ParquetOutputStream::Close() {
     return arrow::Status::OK();
 }
 
-AsyncParquetOutputStream::AsyncParquetOutputStream(io::AsyncFlushOutputStream* stream) : _stream(stream) {
+AsyncParquetOutputStream::AsyncParquetOutputStream(formats::AsyncFlushOutputStream* stream) : _stream(stream) {
     set_mode(arrow::io::FileMode::WRITE);
 }
 

--- a/be/src/formats/parquet/file_writer.h
+++ b/be/src/formats/parquet/file_writer.h
@@ -51,10 +51,10 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "common/thread/priority_thread_pool.hpp"
+#include "formats/io/async_flush_output_stream.h"
 #include "formats/parquet/chunk_writer.h"
 #include "fs/fs_fwd.h"
 #include "gen_cpp/Types_types.h"
-#include "io/async_flush_output_stream.h"
 #include "runtime/runtime_fwd.h"
 #include "types/type_descriptor.h"
 
@@ -104,7 +104,7 @@ private:
 
 class AsyncParquetOutputStream : public arrow::io::OutputStream {
 public:
-    AsyncParquetOutputStream(io::AsyncFlushOutputStream* stream);
+    AsyncParquetOutputStream(formats::AsyncFlushOutputStream* stream);
 
     ~AsyncParquetOutputStream() override = default;
 
@@ -119,7 +119,7 @@ public:
     bool closed() const override { return _is_closed; };
 
 private:
-    io::AsyncFlushOutputStream* _stream;
+    formats::AsyncFlushOutputStream* _stream;
     bool _is_closed = false;
 };
 

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -375,7 +375,7 @@ StatusOr<WriterAndStream> ParquetFileWriterFactory::create(const std::string& pa
     auto column_evaluators = ColumnEvaluator::clone(*_column_evaluators);
     auto types = ColumnEvaluator::types(*_column_evaluators);
     auto async_output_stream =
-            std::make_unique<io::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
     auto parquet_output_stream = std::make_shared<parquet::AsyncParquetOutputStream>(async_output_stream.get());
     auto writer = std::make_unique<ParquetFileWriter>(path, parquet_output_stream, _column_names, types,
                                                       std::move(column_evaluators), _compression_type, _parsed_options,

--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -35,9 +35,7 @@ ADD_BE_LIB(IO
         cache_input_stream.cpp
         cache_select_input_stream.hpp
         shared_buffered_input_stream.cpp
-        async_flush_output_stream.cpp
         direct_s3_output_stream.cpp
-        formatted_output_stream_file.cpp
 )
 
 target_link_libraries(IO PUBLIC IOCore)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -30,7 +30,7 @@ set(EXEC_FILES
         ./connector_sink/iceberg_chunk_sink_test.cpp
         ./connector_sink/file_chunk_sink_test.cpp
         ./connector_sink/partition_chunk_writer_test.cpp
-        ./connector_sink/async_flush_output_stream_test.cpp
+        ./connector_sink/async_flush_stream_poller_test.cpp
         ./connector_sink/iceberg_table_sink_test.cpp
         ./connector_sink/iceberg_delete_sink_test.cpp
         ./connector_sink/iceberg_row_delta_sink_test.cpp
@@ -263,7 +263,6 @@ set(EXEC_FILES
         ./http/transaction_stream_load_test.cpp
         ./http/action/proc_profile_e2e_test.cpp
         ./io/compressed_input_stream_test.cpp
-        ./io/formatted_output_stream_file_test.cpp
         ./io/s3_output_stream_test.cpp
         ./io/s3_input_stream_test.cpp
         ./io/shared_buffered_input_stream_test.cpp
@@ -372,6 +371,7 @@ add_subdirectory(column)
 add_subdirectory(types)
 add_subdirectory(exec)
 add_subdirectory(connector)
+add_subdirectory(formats)
 add_subdirectory(runtime)
 add_subdirectory(exprs)
 add_subdirectory(io)

--- a/be/test/connector_sink/async_flush_stream_poller_test.cpp
+++ b/be/test/connector_sink/async_flush_stream_poller_test.cpp
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/async_flush_stream_poller.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "common/object_pool.h"
+#include "common/thread/priority_thread_pool.hpp"
+#include "exec/pipeline/fragment_context.h"
+#include "formats/io/async_flush_output_stream.h"
+#include "fs/fs_memory.h"
+#include "runtime/exec_env.h"
+
+namespace starrocks::connector {
+namespace {
+
+class AsyncFlushStreamPollerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _fragment_context = std::make_shared<pipeline::FragmentContext>();
+        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>());
+        _runtime_state = _fragment_context->runtime_state();
+        auto* exec_env = ExecEnv::GetInstance();
+        _runtime_state->set_exec_env(exec_env);
+        _runtime_state->set_query_execution_services(&exec_env->query_execution_services());
+        _io_executor = _pool.add(new PriorityThreadPool("test", 1, 100));
+        _file = _fs.new_writable_file("/test.out").value();
+    }
+
+    ObjectPool _pool;
+    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
+    RuntimeState* _runtime_state;
+    PriorityThreadPool* _io_executor;
+    MemoryFileSystem _fs;
+    std::unique_ptr<WritableFile> _file;
+};
+
+TEST_F(AsyncFlushStreamPollerTest, poll_until_async_status_ready) {
+    auto stream = std::make_shared<formats::AsyncFlushOutputStream>(std::move(_file), _io_executor, _runtime_state);
+    auto* raw_stream = stream.get();
+    AsyncFlushStreamPoller poller;
+    poller.enqueue(std::move(stream));
+    EXPECT_EQ(poller.releasable_memory(), 0);
+
+    auto [initial_status, initial_done] = poller.poll();
+    EXPECT_OK(initial_status);
+    EXPECT_FALSE(initial_done);
+
+    const int N = 1000'000;
+    const int M = 100;
+    std::vector<uint8_t> data(N, 'a');
+    for (int i = 0; i < M; i++) {
+        EXPECT_OK(raw_stream->write(data.data(), data.size()));
+    }
+    EXPECT_OK(raw_stream->close());
+
+    using namespace std::chrono_literals;
+    while (true) {
+        auto [status, done] = poller.poll();
+        EXPECT_OK(status);
+        if (done) {
+            break;
+        }
+        std::this_thread::sleep_for(10ms);
+    }
+}
+
+} // namespace
+} // namespace starrocks::connector

--- a/be/test/connector_sink/iceberg_chunk_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_chunk_sink_test.cpp
@@ -39,7 +39,7 @@ namespace {
 
 using CommitResult = formats::FileWriter::CommitResult;
 using WriterAndStream = formats::WriterAndStream;
-using Stream = io::AsyncFlushOutputStream;
+using Stream = formats::AsyncFlushOutputStream;
 using ::testing::Return;
 using ::testing::ByMove;
 using ::testing::_;

--- a/be/test/connector_sink/partition_chunk_writer_test.cpp
+++ b/be/test/connector_sink/partition_chunk_writer_test.cpp
@@ -42,7 +42,7 @@ namespace {
 
 using CommitResult = formats::FileWriter::CommitResult;
 using WriterAndStream = formats::WriterAndStream;
-using Stream = io::AsyncFlushOutputStream;
+using Stream = formats::AsyncFlushOutputStream;
 using ::testing::Return;
 using ::testing::ByMove;
 using ::testing::_;

--- a/be/test/connector_sink/sink_memory_manager_test.cpp
+++ b/be/test/connector_sink/sink_memory_manager_test.cpp
@@ -34,7 +34,7 @@
 namespace starrocks::connector {
 namespace {
 
-using Stream = io::AsyncFlushOutputStream;
+using Stream = formats::AsyncFlushOutputStream;
 
 class SinkMemoryManagerTest : public ::testing::Test {
 protected:

--- a/be/test/exec/sink/connector_sink_operator_test.cpp
+++ b/be/test/exec/sink/connector_sink_operator_test.cpp
@@ -27,8 +27,8 @@
 #include "connector/connector_chunk_sink.h"
 #include "connector/hive_chunk_sink.h"
 #include "connector/sink_memory_manager.h"
+#include "formats/io/async_flush_output_stream.h"
 #include "formats/utils.h"
-#include "io/async_flush_output_stream.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 
@@ -36,7 +36,7 @@ namespace starrocks::pipeline {
 namespace {
 
 using CommitResult = formats::FileWriter::CommitResult;
-using Stream = io::AsyncFlushOutputStream;
+using Stream = formats::AsyncFlushOutputStream;
 
 class NoopWritableFile : public WritableFile {
 public:

--- a/be/test/formats/CMakeLists.txt
+++ b/be/test/formats/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(FORMATS_IO_TEST_FILES
+    ../base/cxa_throw_wrap.cpp
+    io/async_flush_output_stream_test.cpp
+    io/formatted_output_stream_file_test.cpp
+)
+
+set(FORMATS_IO_TEST_LINK_LIBS
+    FormatsIO
+    RuntimeCore
+    FSCore
+    Types
+    Common
+    Base
+    Gutil
+    StarRocksGen
+    ${STARROCKS_DEPENDENCIES}
+    ${STARROCKS_STATIC_LINK_LIBS}
+    ${WL_LINK_DYNAMIC} ${STARROCKS_SYSTEM_LINK_LIBS} ${WRAP_LINKER_FLAGS}
+    ${WL_START_GROUP}
+    gmock
+    gtest
+    ${WL_END_GROUP}
+)
+
+add_library(starrocks_formats_io_test_objs OBJECT ${FORMATS_IO_TEST_FILES})
+target_link_libraries(starrocks_formats_io_test_objs PRIVATE StarRocksPCH)
+set_target_properties(starrocks_formats_io_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
+add_executable(formats_io_test $<TARGET_OBJECTS:starrocks_formats_io_test_objs>)
+target_link_libraries(formats_io_test ${FORMATS_IO_TEST_LINK_LIBS} gtest_main)

--- a/be/test/formats/csv/array_converter_test.cpp
+++ b/be/test/formats/csv/array_converter_test.cpp
@@ -18,7 +18,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -461,7 +461,7 @@ TEST(ArrayConverterTest, test_write_string) {
     auto conv = csv::get_converter(t, false);
     auto col = ColumnHelper::create_column(t, false);
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     col->append_datum(DatumArray{});
     col->append_datum(DatumArray{Datum()}); // [NULL]
     col->append_datum(DatumArray{DateValue::create(1999, 9, 1)});
@@ -474,7 +474,7 @@ TEST(ArrayConverterTest, test_write_string) {
     ASSERT_TRUE(buff.finalize().ok());
     ASSERT_EQ("[][null][\"1999-09-01\"][\"2000-09-01\",\"2001-09-01\"]", buff.as_string());
 
-    io::FormattedOutputStreamString buff2;
+    formats::FormattedOutputStreamString buff2;
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 2, Converter::Options()).ok());

--- a/be/test/formats/csv/boolean_converter_test.cpp
+++ b/be/test/formats/csv/boolean_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -141,7 +141,7 @@ TEST(BooleanConverterTest, test_write_string_as_integral_value) {
     col->append_datum(true);
     col->append_datum(false);
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, opts).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, opts).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 2, opts).ok());
@@ -168,7 +168,7 @@ TEST(BooleanConverterTest, test_write_string_as_textual_value) {
     col->append_datum(true);
     col->append_datum(false);
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, opts).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, opts).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 2, opts).ok());

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -31,9 +31,9 @@
 #include "common/object_pool.h"
 #include "common/thread/priority_thread_pool.hpp"
 #include "formats/column_evaluator.h"
+#include "formats/io/formatted_output_stream_file.h"
 #include "fs/fs_memory.h"
 #include "io/compression_test_utils.h"
-#include "io/formatted_output_stream_file.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -73,7 +73,7 @@ TEST_F(CSVFileWriterTest, TestWriteIntergers) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -129,7 +129,7 @@ TEST_F(CSVFileWriterTest, TestWriteBoolean) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -169,7 +169,7 @@ TEST_F(CSVFileWriterTest, TestWriteFloat) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -210,7 +210,7 @@ TEST_F(CSVFileWriterTest, TestWriteDouble) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -251,7 +251,7 @@ TEST_F(CSVFileWriterTest, TestWriteDate) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -301,7 +301,7 @@ TEST_F(CSVFileWriterTest, TestWriteDatetime) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -350,7 +350,7 @@ TEST_F(CSVFileWriterTest, TestWriteVarchar) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -399,7 +399,7 @@ TEST_F(CSVFileWriterTest, TestWriteArrayInt) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -465,7 +465,7 @@ TEST_F(CSVFileWriterTest, TestWriteArrayBigInt) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -522,7 +522,7 @@ TEST_F(CSVFileWriterTest, TestWriteArrayWithNull) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -584,7 +584,7 @@ TEST_F(CSVFileWriterTest, TestWriteHiveArray) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->is_hive = true;
@@ -654,7 +654,7 @@ TEST_F(CSVFileWriterTest, TestWriteMap) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -677,7 +677,7 @@ TEST_F(CSVFileWriterTest, TestWriteNestedArray) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     auto writer =
@@ -740,13 +740,13 @@ TEST_F(CSVFileWriterTest, TestUnknownCompression) {
 
     auto column_names = _make_type_names(type_descs);
     auto output_file = _fs.new_writable_file(_file_path).value();
-    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, nullptr);
+    auto async_stream = std::make_unique<formats::AsyncFlushOutputStream>(std::move(output_file), nullptr, nullptr);
 
     // UNKNOWN_COMPRESSION should fail when creating CompressedOutputStream
     // We expect this to return an error status
-    auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024);
+    auto base_stream = std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024);
     auto result =
-            io::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::UNKNOWN_COMPRESSION, 1024);
+            formats::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::UNKNOWN_COMPRESSION, 1024);
     ASSERT_FALSE(result.ok());
 }
 
@@ -798,7 +798,7 @@ TEST_F(CSVFileWriterTest, TestWriteWithHeader) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
@@ -844,7 +844,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderOnly) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
@@ -875,7 +875,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderWithSpecialChars) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
@@ -904,7 +904,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderWithCustomDelimiter) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
@@ -935,7 +935,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderEscapeCustomDelimiter) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
@@ -962,7 +962,7 @@ TEST_F(CSVFileWriterTest, TestWriteWithoutHeader) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = false; // explicitly false
@@ -1004,10 +1004,11 @@ TEST_F(CSVFileWriterTest, TestWriteIntegersWithGzipCompression) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
-    auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto async_stream =
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
     auto csv_output_stream_result =
-            io::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+            formats::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
     ASSERT_OK(csv_output_stream_result.status());
     auto csv_output_stream = std::move(csv_output_stream_result.value());
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
@@ -1070,10 +1071,11 @@ TEST_F(CSVFileWriterTest, TestWriteVarcharWithGzipCompression) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
-    auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto async_stream =
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
     auto csv_output_stream_result =
-            io::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+            formats::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
     ASSERT_OK(csv_output_stream_result.status());
     auto csv_output_stream = std::move(csv_output_stream_result.value());
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
@@ -1122,10 +1124,11 @@ TEST_F(CSVFileWriterTest, TestWriteLargeDataWithGzipCompression) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
-    auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto async_stream =
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
     auto csv_output_stream_result =
-            io::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+            formats::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
     ASSERT_OK(csv_output_stream_result.status());
     auto csv_output_stream = std::move(csv_output_stream_result.value());
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
@@ -1199,10 +1202,10 @@ TEST_F(CSVFileWriterTest, TestCompressionRatio) {
         EXPECT_OK(maybe_output_file.status());
         auto output_file = std::move(maybe_output_file.value());
         auto async_stream =
-                std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
-        auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
+                std::make_unique<formats::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+        auto base_stream = std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
         auto csv_output_stream_result =
-                io::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+                formats::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
         ASSERT_OK(csv_output_stream_result.status());
         auto csv_output_stream = std::move(csv_output_stream_result.value());
         auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
@@ -1337,7 +1340,7 @@ TEST_F(CSVFileWriterTest, TestEncloseEscapeRFC4180) {
     };
     std::vector<std::string> column_names = {"id", "name", "val"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1384,7 +1387,7 @@ TEST_F(CSVFileWriterTest, TestEncloseEscapeBackslash) {
     };
     std::vector<std::string> column_names = {"id", "name", "val"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1427,7 +1430,7 @@ TEST_F(CSVFileWriterTest, TestEncloseWithoutEscape) {
     std::vector<TypeDescriptor> type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
     std::vector<std::string> column_names = {"name"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1467,7 +1470,7 @@ TEST_F(CSVFileWriterTest, TestEncloseWithHeader) {
     // Column name with enclose char inside
     std::vector<std::string> column_names = {"id", "my\"col"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1510,7 +1513,7 @@ TEST_F(CSVFileWriterTest, TestEncloseDisabled) {
     };
     std::vector<std::string> column_names = {"id", "name"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1555,7 +1558,7 @@ TEST_F(CSVFileWriterTest, TestEncloseConstNullableColumn) {
     };
     std::vector<std::string> column_names = {"id", "const_col"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1609,7 +1612,7 @@ TEST_F(CSVFileWriterTest, TestConstColumnWithoutEnclose) {
     };
     std::vector<std::string> column_names = {"id", "const_str"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1656,7 +1659,7 @@ TEST_F(CSVFileWriterTest, TestEncloseConstStringColumn) {
     };
     std::vector<std::string> column_names = {"id", "const_str"};
     auto output_file = std::move(_fs.new_writable_file(_file_path).value());
-    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto output_stream = std::make_unique<formats::FormattedOutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
 
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
@@ -1725,10 +1728,11 @@ TEST_F(CSVFileWriterTest, TestCompressionWithCustomDelimiters) {
     auto maybe_output_file = _fs.new_writable_file(_file_path);
     EXPECT_OK(maybe_output_file.status());
     auto output_file = std::move(maybe_output_file.value());
-    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
-    auto base_stream = std::make_shared<io::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto async_stream =
+            std::make_unique<formats::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<formats::AsyncFormattedOutputStreamFile>(async_stream.get(), 1024 * 1024);
     auto csv_output_stream_result =
-            io::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+            formats::CompressedFormattedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
     ASSERT_OK(csv_output_stream_result.status());
     auto csv_output_stream = std::move(csv_output_stream_result.value());
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);

--- a/be/test/formats/csv/date_converter_test.cpp
+++ b/be/test/formats/csv/date_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -88,7 +88,7 @@ TEST_F(DateConverterTest, test_read_quoted_string_invalid_value) {
 TEST_F(DateConverterTest, test_write_string) {
     auto conv = csv::get_converter(_type, false);
     auto col = ColumnHelper::create_column(_type, false);
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
 
     col->append_datum(DateValue::create(1999, 1, 1));
     col->append_datum(DateValue::create(2000, 11, 20));

--- a/be/test/formats/csv/datetime_converter_test.cpp
+++ b/be/test/formats/csv/datetime_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -88,7 +88,7 @@ TEST_F(DatetimeConverterTest, test_read_quoted_string_invalid_value) {
 TEST_F(DatetimeConverterTest, test_write_string) {
     auto conv = csv::get_converter(_type, false);
     auto col = ColumnHelper::create_column(_type, false);
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
 
     col->append_datum(TimestampValue::create(1999, 1, 1, 10, 9, 8));
     col->append_datum(TimestampValue::create(2000, 11, 20, 10, 9, 8));

--- a/be/test/formats/csv/decimalv2_converter_test.cpp
+++ b/be/test/formats/csv/decimalv2_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -82,14 +82,14 @@ TEST_F(DecimalV2ConverterTest, test_write_string) {
     col->append_datum(DecimalV2Value("-0.00000001"));
     col->append_datum(DecimalV2Value("99999999999999999.00000001"));
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 2, Converter::Options()).ok());
     ASSERT_TRUE(buff.finalize().ok());
     ASSERT_EQ("0.00000001-0.0000000199999999999999999.00000001", buff.as_string());
 
-    io::FormattedOutputStreamString buff2;
+    formats::FormattedOutputStreamString buff2;
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 2, Converter::Options()).ok());

--- a/be/test/formats/csv/float_converter_test.cpp
+++ b/be/test/formats/csv/float_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/logical_type.h"
 #include "types/type_descriptor.h"
 
@@ -94,7 +94,7 @@ TEST_F(FloatConverterTest, test_double_write_string) {
     col->append_datum((double)1.1);
     col->append_datum((double)-0.1);
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff, *col, 0, Converter::Options()).ok());
@@ -102,7 +102,7 @@ TEST_F(FloatConverterTest, test_double_write_string) {
     ASSERT_TRUE(buff.finalize().ok());
     ASSERT_EQ("1.1-0.11.1-0.1", buff.as_string());
 
-    io::FormattedOutputStreamString buff2;
+    formats::FormattedOutputStreamString buff2;
     auto col2 = ColumnHelper::create_column(_type, false);
     col2->append_datum((double)1.12345678901234e+18);
     ASSERT_TRUE(conv->write_string(&buff2, *col2, 0, Converter::Options()).ok());
@@ -115,7 +115,7 @@ TEST_F(FloatConverterTest, test_float_write_string) {
     auto conv = csv::get_converter(type, false);
     auto col = ColumnHelper::create_column(type, false);
     col->append_datum((float)7.092579e+08);
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(buff.finalize().ok());
     ASSERT_EQ("7.092579e+08", buff.as_string());

--- a/be/test/formats/csv/json_converter_test.cpp
+++ b/be/test/formats/csv/json_converter_test.cpp
@@ -17,7 +17,7 @@
 #include "column/column_helper.h"
 #include "column/json_column.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/json_value.h"
 #include "types/type_descriptor.h"
 
@@ -77,14 +77,14 @@ TEST_F(JsonConverterTest, test_write_string) {
     json = JsonValue::parse(R"({"name": "name", "num": 3, "sites": [ "Google", "Runoob", "Taobao" ]})");
     json_column->append(&json.value());
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *json_column, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *json_column, 1, Converter::Options()).ok());
     ASSERT_TRUE(buff.finalize().ok());
     ASSERT_EQ("{\"a\": 1, \"b\": 2}{\"name\": \"name\", \"num\": 3, \"sites\": [\"Google\", \"Runoob\", \"Taobao\"]}",
               buff.as_string());
 
-    io::FormattedOutputStreamString buff2;
+    formats::FormattedOutputStreamString buff2;
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *json_column, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *json_column, 1, Converter::Options()).ok());
     ASSERT_TRUE(buff2.finalize().ok());

--- a/be/test/formats/csv/map_converter_test.cpp
+++ b/be/test/formats/csv/map_converter_test.cpp
@@ -18,7 +18,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -53,7 +53,7 @@ TEST(MapConverterTest, test_read_write_map_int_string) {
     EXPECT_EQ("{2:NULL,1:NULL}", col->debug_item(3));
 
     // write
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 2, Converter::Options()).ok());
@@ -102,7 +102,7 @@ TEST(MapConverterTest, test_read_write_nest_map) {
     EXPECT_EQ("{11:{2:NULL,1:NULL},22:{2:'unique'}}", col->debug_item(5));
 
     // write
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 2, Converter::Options()).ok());

--- a/be/test/formats/csv/nullable_converter_test.cpp
+++ b/be/test/formats/csv/nullable_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -104,7 +104,7 @@ TEST_F(NullableConverterTest, test_write_string_nullable_column) {
     col->append_datum(Datum()); // null
     col->append_datum((int32_t)10);
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff, *col, 0, Converter::Options()).ok());
@@ -120,7 +120,7 @@ TEST_F(NullableConverterTest, test_write_string_not_nullable_column) {
     col->append_datum((int32_t)1);
     col->append_datum((int32_t)10);
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff, *col, 0, Converter::Options()).ok());

--- a/be/test/formats/csv/numeric_converter_test.cpp
+++ b/be/test/formats/csv/numeric_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -182,7 +182,7 @@ TEST_F(NumericConverterTest, test_write_string) {
     col->append_datum((int16_t)11);
     col->append_datum((int16_t)32767);
 
-    io::FormattedOutputStreamString buff(64);
+    formats::FormattedOutputStreamString buff(64);
 
     /// write_string
 

--- a/be/test/formats/csv/string_converter_test.cpp
+++ b/be/test/formats/csv/string_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -202,7 +202,7 @@ TEST_F(StringConverterTest, test_write_string) {
     std::vector<Slice> strings = {"aaaaaaaaaaaa", "bbbbbbbb", "\"\"", "ccccc"};
     (void)col->append_strings(strings.data(), strings.size());
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_string(&buff, *col, 2, Converter::Options()).ok());
@@ -210,7 +210,7 @@ TEST_F(StringConverterTest, test_write_string) {
     ASSERT_TRUE(buff.finalize().ok());
     ASSERT_EQ("aaaaaaaaaaaabbbbbbbb\"\"ccccc", buff.as_string());
 
-    io::FormattedOutputStreamString buff2;
+    formats::FormattedOutputStreamString buff2;
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 0, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 1, Converter::Options()).ok());
     ASSERT_TRUE(conv->write_quoted_string(&buff2, *col, 2, Converter::Options()).ok());

--- a/be/test/formats/csv/varbinary_converter_test.cpp
+++ b/be/test/formats/csv/varbinary_converter_test.cpp
@@ -20,7 +20,7 @@
 
 #include "column/column_helper.h"
 #include "formats/csv/converter.h"
-#include "io/formatted_output_stream_string.h"
+#include "formats/io/formatted_output_stream_string.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::csv {
@@ -102,7 +102,7 @@ TEST_F(VarBinaryConverterTest, test_write_string) {
     auto col = ColumnHelper::create_column(_type, false);
     (void)col->append_strings(std::vector<Slice>{"aaaaaaaaaaaa", "bbbbbbbb", "", "ccccc"});
 
-    io::FormattedOutputStreamString buff;
+    formats::FormattedOutputStreamString buff;
     EXPECT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());
     EXPECT_TRUE(conv->write_string(&buff, *col, 1, Converter::Options()).ok());
     EXPECT_TRUE(conv->write_string(&buff, *col, 2, Converter::Options()).ok());
@@ -110,7 +110,7 @@ TEST_F(VarBinaryConverterTest, test_write_string) {
     EXPECT_TRUE(buff.finalize().ok());
     EXPECT_EQ("YWFhYWFhYWFhYWFhYmJiYmJiYmI=Y2NjY2M=", buff.as_string());
 
-    io::FormattedOutputStreamString buff2;
+    formats::FormattedOutputStreamString buff2;
     EXPECT_TRUE(conv->write_quoted_string(&buff2, *col, 0, Converter::Options()).ok());
     EXPECT_TRUE(conv->write_quoted_string(&buff2, *col, 1, Converter::Options()).ok());
     EXPECT_TRUE(conv->write_quoted_string(&buff2, *col, 2, Converter::Options()).ok());

--- a/be/test/formats/io/async_flush_output_stream_test.cpp
+++ b/be/test/formats/io/async_flush_output_stream_test.cpp
@@ -12,36 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "io/async_flush_output_stream.h"
+#include "formats/io/async_flush_output_stream.h"
 
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
-#include <thread>
-
 #include "base/testutil/assert.h"
-#include "base/utility/defer_op.h"
+#include "common/object_pool.h"
 #include "common/thread/priority_thread_pool.hpp"
-#include "connector/async_flush_stream_poller.h"
-#include "exec/pipeline/fragment_context.h"
 #include "formats/utils.h"
 #include "fs/fs_memory.h"
-#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
 
-namespace starrocks::connector {
+namespace starrocks::formats {
 namespace {
 
-using Stream = io::AsyncFlushOutputStream;
+using Stream = AsyncFlushOutputStream;
 
 class AsyncFlushOutputStreamTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        _fragment_context = std::make_shared<pipeline::FragmentContext>();
-        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>());
-        _runtime_state = _fragment_context->runtime_state();
-        auto* exec_env = ExecEnv::GetInstance();
-        _runtime_state->set_exec_env(exec_env);
-        _runtime_state->set_query_execution_services(&exec_env->query_execution_services());
+        _runtime_state = _pool.add(new RuntimeState(TQueryGlobals()));
+        _runtime_state->init_instance_mem_tracker();
         _io_executor = _pool.add(new PriorityThreadPool("test", 1, 100));
         _file = _fs.new_writable_file("/test.out").value();
     }
@@ -49,7 +41,6 @@ protected:
     void TearDown() override {}
 
     ObjectPool _pool;
-    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
     RuntimeState* _runtime_state;
     PriorityThreadPool* _io_executor;
     MemoryFileSystem _fs;
@@ -94,39 +85,5 @@ TEST_F(AsyncFlushOutputStreamTest, test_append_repeated) {
     EXPECT_EQ(stream.tell(), N * M);
 }
 
-TEST_F(AsyncFlushOutputStreamTest, test_poller) {
-    auto stream = std::make_unique<Stream>(std::move(_file), _io_executor, _runtime_state);
-    auto ptr = stream.get();
-    AsyncFlushStreamPoller poller;
-    poller.enqueue(std::move(stream));
-    EXPECT_EQ(poller.releasable_memory(), 0);
-    {
-        auto [s, done] = poller.poll();
-        EXPECT_OK(s);
-        EXPECT_FALSE(done);
-    }
-
-    {
-        const int N = 1000'000;
-        const int M = 100;
-        std::vector<uint8> data(N, 'a');
-        for (int i = 0; i < M; i++) {
-            EXPECT_OK(ptr->write(data.data(), data.size()));
-        }
-        EXPECT_OK(ptr->close());
-    }
-
-    {
-        using namespace std::chrono_literals;
-        while (true) {
-            auto [s, done] = poller.poll();
-            if (done) {
-                break;
-            }
-            std::this_thread::sleep_for(10ms);
-        }
-    }
-}
-
 } // namespace
-} // namespace starrocks::connector
+} // namespace starrocks::formats

--- a/be/test/formats/io/formatted_output_stream_file_test.cpp
+++ b/be/test/formats/io/formatted_output_stream_file_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "io/formatted_output_stream_file.h"
+#include "formats/io/formatted_output_stream_file.h"
 
 #include <gtest/gtest.h>
 
@@ -21,29 +21,24 @@
 
 #include "base/testutil/assert.h"
 #include "common/object_pool.h"
-#include "compression_test_utils.h"
-#include "exec/pipeline/fragment_context.h"
+#include "formats/io/async_flush_output_stream.h"
 #include "fs/fs_memory.h"
-#include "io/async_flush_output_stream.h"
-#include "runtime/exec_env.h"
+#include "io/compression_test_utils.h"
+#include "runtime/runtime_state.h"
 
-namespace starrocks::io {
+namespace starrocks::formats {
 
 class FormattedOutputStreamFileTest : public testing::Test {
 public:
     void SetUp() override {
-        _fragment_context = std::make_shared<pipeline::FragmentContext>();
-        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>());
-        _runtime_state = _fragment_context->runtime_state();
-        auto* exec_env = ExecEnv::GetInstance();
-        _runtime_state->set_exec_env(exec_env);
-        _runtime_state->set_query_execution_services(&exec_env->query_execution_services());
+        _runtime_state = _pool.add(new RuntimeState(TQueryGlobals()));
+        _runtime_state->init_instance_mem_tracker();
     }
 
     void TearDown() override {}
 
 protected:
-    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
+    ObjectPool _pool;
     RuntimeState* _runtime_state;
     MemoryFileSystem _fs;
 };
@@ -689,4 +684,4 @@ TEST_F(FormattedOutputStreamFileTest, TestAllCompressionTypesLargeData) {
     }
 }
 
-} // namespace starrocks::io
+} // namespace starrocks::formats

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -25,11 +25,11 @@
 #include "common/config_exec_fwd.h"
 #include "common/object_pool.h"
 #include "formats/column_evaluator.h"
+#include "formats/io/async_flush_output_stream.h"
 #include "formats/orc/orc_chunk_reader.h"
 #include "fs/fs_memory.h"
 #include "fs/fs_posix.h"
 #include "gen_cpp/Exprs_types.h"
-#include "io/async_flush_output_stream.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -67,7 +67,7 @@ public:
         _fs = new_fs_posix();
         ASSERT_OK(ignore_not_found(_fs->delete_file(_file_path)));
         _file = _fs->new_writable_file(_file_path).value();
-        _stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(_file), nullptr, _runtime_state.get());
+        _stream = std::make_unique<formats::AsyncFlushOutputStream>(std::move(_file), nullptr, _runtime_state.get());
         _orc_stream = std::make_unique<AsyncOrcOutputStream>(_stream.get());
         _write_options = std::make_shared<formats::ORCWriterOptions>();
     };
@@ -137,7 +137,7 @@ protected:
     ObjectPool _pool;
     std::shared_ptr<RuntimeState> _runtime_state;
     std::unique_ptr<WritableFile> _file;
-    std::unique_ptr<io::AsyncFlushOutputStream> _stream;
+    std::unique_ptr<formats::AsyncFlushOutputStream> _stream;
     std::unique_ptr<AsyncOrcOutputStream> _orc_stream;
     std::shared_ptr<formats::ORCWriterOptions> _write_options;
 };


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
