### PR TITLE
[Enhancement] account collecting aggregates' off-pool heap in agg-state memory

### DIFF
--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -96,8 +96,20 @@ struct ArrayAggAggregateState {
         set.clear();
     }
 
-    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
-    int64_t mem_usage() const { return data_column.memory_usage(); }
+    // Off-pool heap charged into the operator's agg-state memory so it shows in
+    // Aggregator::memory_usage(): the value column, plus (distinct mode) the dedup hash set,
+    // approximated from its slot count (phmap exposes no exact byte count). For string keys the
+    // key bytes live in the operator mem pool (counted there); only the set's slots/control
+    // bytes are added here, so there is no double counting. Distinct mode materializes the set
+    // into the value column lazily at output (get_data_column); that transient copy is not charged
+    // here -- only the build-time set drives sizing, and the query MemTracker still sees it.
+    int64_t mem_usage() const {
+        int64_t usage = data_column.memory_usage();
+        if constexpr (is_distinct) {
+            usage += static_cast<int64_t>(set.capacity()) * (sizeof(typename MyHashSet::value_type) + 1);
+        }
+        return usage;
+    }
 
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;
@@ -183,8 +195,20 @@ struct ArrayAggAggregateState<PT, is_distinct, MyHashSet, StringOrBinaryGuard<PT
         set.clear();
     }
 
-    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
-    int64_t mem_usage() const { return data_column.memory_usage(); }
+    // Off-pool heap charged into the operator's agg-state memory so it shows in
+    // Aggregator::memory_usage(): the value column, plus (distinct mode) the dedup hash set,
+    // approximated from its slot count (phmap exposes no exact byte count). For string keys the
+    // key bytes live in the operator mem pool (counted there); only the set's slots/control
+    // bytes are added here, so there is no double counting. Distinct mode materializes the set
+    // into the value column lazily at output (get_data_column); that transient copy is not charged
+    // here -- only the build-time set drives sizing, and the query MemTracker still sees it.
+    int64_t mem_usage() const {
+        int64_t usage = data_column.memory_usage();
+        if constexpr (is_distinct) {
+            usage += static_cast<int64_t>(set.capacity()) * (sizeof(typename MyHashSet::value_type) + 1);
+        }
+        return usage;
+    }
 
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -96,6 +96,9 @@ struct ArrayAggAggregateState {
         set.clear();
     }
 
+    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
+    int64_t mem_usage() const { return data_column.memory_usage(); }
+
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;
     MyHashSet set;
@@ -180,6 +183,9 @@ struct ArrayAggAggregateState<PT, is_distinct, MyHashSet, StringOrBinaryGuard<PT
         set.clear();
     }
 
+    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
+    int64_t mem_usage() const { return data_column.memory_usage(); }
+
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;
     MyHashSet set;
@@ -230,7 +236,9 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         // TODO: update is random access, so we could not pre-reserve memory for State, which is the bottleneck
+        int64_t prev_memory = this->data(state).mem_usage();
         this->data(state).update(ctx->mem_pool(), *columns[0], row_num, 1);
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void process_null(FunctionContext* ctx, AggDataPtr __restrict state) const override {
@@ -247,9 +255,11 @@ public:
         size_t element_null_count = array_element.null_count(offset_size.first, offset_size.second);
         DCHECK_LE(element_null_count, offset_size.second);
 
+        int64_t prev_memory = this->data(state).mem_usage();
         this->data(state).update(ctx->mem_pool(), *element_data_column, offset_size.first,
                                  offset_size.second - element_null_count);
         this->data(state).append_null(element_null_count);
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -285,7 +295,9 @@ public:
     }
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        int64_t prev_memory = this->data(state).mem_usage();
         this->data(state).reset();
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -390,6 +390,17 @@ struct ArrayAggAggregateStateV2 {
 
     void reset(FunctionContext* ctx) { data_columns.clear(); }
 
+    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
+    int64_t mem_usage() const {
+        int64_t usage = 0;
+        for (const auto& col : data_columns) {
+            if (col != nullptr) {
+                usage += col->memory_usage();
+            }
+        }
+        return usage;
+    }
+
     // using pointer rather than vector to avoid variadic size
     // array_agg(a order by b, c, d), the a,b,c,d are put into data_columns in order.
     mutable MutableColumns data_columns;
@@ -425,6 +436,9 @@ public:
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
+        int64_t prev_memory = this->data(state).mem_usage();
+        // DeferOp so the delta is reported on every early-return path below.
+        auto defer = DeferOp([&]() { ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory); });
         for (auto i = 0; i < ctx->get_num_args(); ++i) {
             if (UNLIKELY(columns[i]->size() <= row_num)) {
                 ctx->set_error(std::string(get_name() + "'s update row number overflow").c_str(), false);
@@ -448,6 +462,7 @@ public:
 
     // struct and array elements aren't be null, as they consist from several columns
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        int64_t prev_memory = this->data(state).mem_usage();
         const auto input_columns = down_cast<const StructColumn*>(ColumnHelper::get_data_column(column))->fields();
         for (auto i = 0; i < input_columns.size(); ++i) {
             auto array_column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(input_columns[i].get()));
@@ -455,6 +470,7 @@ public:
             this->data(state).update(array_column->elements(), i, offsets[row_num],
                                      offsets[row_num + 1] - offsets[row_num]);
         }
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     // serialize each state->column to a [nullable] array in a [nullable] struct
@@ -637,7 +653,9 @@ public:
     }
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        int64_t prev_memory = this->data(state).mem_usage();
         this->data(state).reset(ctx);
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,

--- a/be/src/exprs/agg/array_union_agg.h
+++ b/be/src/exprs/agg/array_union_agg.h
@@ -98,8 +98,20 @@ struct ArrayUnionAggAggregateState {
         return &data_column;
     }
 
-    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
-    int64_t mem_usage() const { return data_column.memory_usage(); }
+    // Off-pool heap charged into the operator's agg-state memory so it shows in
+    // Aggregator::memory_usage(): the value column, plus (distinct mode) the dedup hash set,
+    // approximated from its slot count (phmap exposes no exact byte count). For string keys the
+    // key bytes live in the operator mem pool (counted there); only the set's slots/control
+    // bytes are added here, so there is no double counting. Distinct mode materializes the set
+    // into the value column lazily at output (get_data_column); that transient copy is not charged
+    // here -- only the build-time set drives sizing, and the query MemTracker still sees it.
+    int64_t mem_usage() const {
+        int64_t usage = data_column.memory_usage();
+        if constexpr (is_distinct) {
+            usage += static_cast<int64_t>(set.capacity()) * (sizeof(typename MyHashSet::value_type) + 1);
+        }
+        return usage;
+    }
 
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;

--- a/be/src/exprs/agg/array_union_agg.h
+++ b/be/src/exprs/agg/array_union_agg.h
@@ -98,6 +98,9 @@ struct ArrayUnionAggAggregateState {
         return &data_column;
     }
 
+    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
+    int64_t mem_usage() const { return data_column.memory_usage(); }
+
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;
     MyHashSet set;
@@ -112,6 +115,7 @@ public:
 
     void update_state(FunctionContext* ctx, const ArrayColumn* input_column, AggDataPtr __restrict state,
                       size_t row_num) const {
+        int64_t prev_memory = this->data(state).mem_usage();
         // Array element is nullable, so we need to extract the data from nullable column first
         auto offset_size = input_column->get_element_offset_size(row_num);
         auto& array_element = down_cast<const NullableColumn&>(input_column->elements());
@@ -130,6 +134,7 @@ public:
         }
 
         this->data(state).append_null(element_null_count);
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -39,6 +39,15 @@ struct GroupConcatAggregateState {
     std::string intermediate_string{};
     // is initial
     bool initial{};
+
+    // Off-pool heap charged into the operator's agg-state memory so it shows in
+    // Aggregator::memory_usage(). Ignore the small-string-optimization inline buffer (it lives in
+    // the state struct, counted in the mem pool); only a heap-allocated buffer is off-pool.
+    int64_t mem_usage() const {
+        static const size_t sso_capacity = std::string().capacity();
+        const size_t cap = intermediate_string.capacity();
+        return cap > sso_capacity ? static_cast<int64_t>(cap) : 0;
+    }
 };
 
 template <LogicalType LT, typename T = RunTimeCppType<LT>, LogicalType ResultLT = GroupConcatResultLT<LT>,
@@ -51,13 +60,16 @@ public:
     using ResultColumnType = InputColumnType;
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+        int64_t prev_memory = this->data(state).mem_usage();
         this->data(state).intermediate_string = {};
         this->data(state).initial = false;
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         DCHECK(columns[0]->is_binary() || columns[0]->is_large_binary());
+        int64_t prev_memory = this->data(state).mem_usage();
         if (ctx->get_num_args() > 1) {
             if (!ctx->is_notnull_constant_column(1)) {
                 const auto val = GetContainer<LT>::get_data(columns[0], row_num);
@@ -112,11 +124,15 @@ public:
                 result.append(", ").append(val.get_data(), val.get_size());
             }
         }
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         auto val_bytes = GetContainer<TYPE_VARCHAR>::get_data(columns[0]).immutable_bytes_size();
+        // Account the up-front reserve here; the per-row update() below only sees the
+        // post-reserve capacity, so it would otherwise miss this whole buffer.
+        int64_t prev_memory = this->data(state).mem_usage();
         if (ctx->get_num_args() > 1) {
             if (!ctx->is_notnull_constant_column(1)) {
                 auto sep_bytes = GetContainer<TYPE_VARCHAR>::get_data(columns[1]).immutable_bytes_size();
@@ -129,6 +145,7 @@ public:
         } else {
             this->data(state).intermediate_string.reserve(val_bytes + 2 * chunk_size);
         }
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
 
         for (size_t i = 0; i < chunk_size; ++i) {
             update(ctx, columns, state, i);
@@ -144,6 +161,7 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        int64_t prev_memory = this->data(state).mem_usage();
         Slice slice = column->get(row_num).get_slice();
         char* data = slice.data;
         uint32_t size_value = *reinterpret_cast<uint32_t*>(data);
@@ -157,6 +175,7 @@ public:
 
             this->data(state).intermediate_string.append(data, size_value - sizeof(uint32_t));
         }
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -17,6 +17,7 @@
 #include <cmath>
 
 #include "base/string/utf8.h"
+#include "base/utility/defer_op.h"
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
@@ -334,6 +335,20 @@ struct GroupConcatAggregateStateV2 {
         data_columns->resize(output_col_num + 1);
     }
 
+    // Off-pool heap charged into the operator's agg-state memory so it shows in Aggregator::memory_usage().
+    int64_t mem_usage() const {
+        if (data_columns == nullptr) {
+            return 0;
+        }
+        int64_t usage = 0;
+        for (const auto& col : *data_columns) {
+            if (col != nullptr) {
+                usage += col->memory_usage();
+            }
+        }
+        return usage;
+    }
+
     // using pointer rather than vector to avoid variadic size
     // group_concat(a, b order by c, d), the a,b,',',c,d are put into data_columns in order, and reject null for
     // output columns a and b.
@@ -381,11 +396,13 @@ public:
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         auto& state_impl = this->data(state);
+        int64_t prev_memory = state_impl.mem_usage();
         if (state_impl.data_columns != nullptr) {
             for (auto& col : *state_impl.data_columns) {
                 col->resize(0);
             }
         }
+        ctx->add_mem_usage(state_impl.mem_usage() - prev_memory);
     }
 
     // reject null for output columns, but non-output columns may be null
@@ -393,6 +410,9 @@ public:
                 size_t row_num) const override {
         auto num = ctx->get_num_args();
         auto& state_impl = this->data(state);
+        int64_t prev_memory = state_impl.mem_usage();
+        // DeferOp so the delta is reported on every early-return path below.
+        auto defer = DeferOp([&]() { ctx->add_mem_usage(state_impl.mem_usage() - prev_memory); });
         if (state_impl.data_columns == nullptr) {
             create_impl(ctx, state_impl);
         }
@@ -464,6 +484,9 @@ public:
         }
         const auto& input_columns = down_cast<const StructColumn*>(ColumnHelper::get_data_column(column))->fields();
         auto& state_impl = this->data(state);
+        int64_t prev_memory = state_impl.mem_usage();
+        // DeferOp so the delta is reported on every early-return path below.
+        auto defer = DeferOp([&]() { ctx->add_mem_usage(state_impl.mem_usage() - prev_memory); });
         if (state_impl.data_columns == nullptr) {
             create_impl(ctx, state_impl);
         }

--- a/be/src/exprs/agg/map_agg.h
+++ b/be/src/exprs/agg/map_agg.h
@@ -66,6 +66,19 @@ struct MapAggAggregateFunctionState : public AggregateFunctionEmptyState {
             }
         }
     }
+
+    // Off-pool heap charged into the operator's agg-state memory so it shows in
+    // Aggregator::memory_usage(): the value column plus an approximate size of the
+    // open-addressing hash map (slots + one control byte each; phmap exposes no exact byte
+    // count). String keys live in the operator mem pool (already counted there), so they are
+    // excluded to avoid double counting.
+    int64_t mem_usage() const {
+        int64_t usage = static_cast<int64_t>(hash_map.capacity()) * (sizeof(typename MyHashMap::value_type) + 1);
+        if (value_column != nullptr) {
+            usage += value_column->memory_usage();
+        }
+        return usage;
+    }
 };
 
 template <LogicalType KT, typename MyHashMap = std::map<int, size_t>>
@@ -86,18 +99,22 @@ public:
             return;
         }
         const auto& key_column = down_cast<const KeyColumnType&>(*ColumnHelper::get_data_column(columns[0]));
+        int64_t prev_memory = this->data(state).mem_usage();
         this->data(state).update(ctx->mem_pool(), key_column, *columns[1], row_num, 1);
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         auto map_column = down_cast<const MapColumn*>(ColumnHelper::get_data_column(column));
         auto& offsets = map_column->offsets().immutable_data();
+        int64_t prev_memory = this->data(state).mem_usage();
         if (offsets[row_num + 1] > offsets[row_num]) {
             this->data(state).update(
                     ctx->mem_pool(),
                     *down_cast<const KeyColumnType*>(ColumnHelper::get_data_column(map_column->keys_column().get())),
                     map_column->values(), offsets[row_num], offsets[row_num + 1] - offsets[row_num]);
         }
+        ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {


### PR DESCRIPTION
## Why I'm doing:

The "collecting" aggregates -- `array_agg`, `array_union_agg`, `group_concat`,
`map_agg` -- keep their per-group state off the aggregator mem pool: a `Column`
(`array_agg`/`map_agg` value column), a `std::string` (`group_concat`), or a
`phmap` hash set/map, all allocated through the **default** allocator. That heap
is visible to the query `MemTracker` (via the allocation hook) but **not** to
the operator-level agg-state counter `_agg_state_mem_usage`, which is the only
thing fed into `Aggregator::memory_usage()`.

So for these aggregates `memory_usage()` reported ~0 for the bulk of their
footprint. `memory_usage()` drives:
- **memory-limited streaming** pre-aggregation (`LimitedMemAggState::has_limited`
  compares `memory_usage()` to the limit) -- affected on `main` today;
- **spill** revocable-bytes / mem-table sizing -- affected once the spill
  operators read `memory_usage()` (see sibling PR #73758).

Either way the operator under-counted these states and could keep building a
huge in-memory hash table without the accounting reflecting it.

## What I'm doing:

Charge the off-pool heap into `_agg_state_mem_usage` via
`FunctionContext::add_mem_usage`, mirroring `percentile`/HLL/DataSketches:
capacity-based deltas around `update`/`merge`/`reset` (and the up-front
`reserve` on the single-state `group_concat` path). Three commits by mechanism:

1. **single-column** (`array_agg`/`array_union_agg` non-distinct, `group_concat`)
   -- exact `Column::memory_usage()` / `std::string::capacity()` deltas. The
   `std::string` SSO inline buffer lives in the state struct (already in the mem
   pool), so only a heap buffer is reported.
2. **container** (`map_agg`, `array_agg` V2 / `group_concat` V2 with ORDER BY) --
   sum of `data_columns` memory; for `map_agg` also an **approximate** size of
   the open-addressing hash map (`capacity * (sizeof(value_type) + 1)`; phmap
   exposes no exact byte count). `map_agg` string keys live in the mem pool
   (already counted), so they are excluded.
3. **distinct dedup set** (`array_agg(DISTINCT)`, `array_unique_agg`) --
   approximate size of the phmap set, guarded by `if constexpr (is_distinct)`.

**No double count:** this heap is not in the mem pool (`hash_map_memory_usage`)
nor the counting allocator (`allocator_memory_usage`), and `add_mem_usage` is
independent of the query `MemTracker` that catches the malloc. These are the
exact terms `Aggregator::memory_usage()` already sums.

**Deliberately out of scope:** `count(distinct)`/`sum(distinct)` already account
their set through the `AggregateStateAllocator` (-> `allocator_memory_usage`), so
they are untouched. For distinct array variants the dedup set is materialized
into the value column lazily at output; that transient copy is not separately
charged (the build-time set drives sizing, and the query `MemTracker` still sees
it) -- same as `percentile`/HLL, which don't account output materialization.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(Query results are unchanged. Only the internal memory-accounting accuracy
improves, so memory-limited streaming / spill may trigger slightly earlier and
more correctly under memory pressure.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
