### PR TITLE
[Refactor] Move Python env registry initialization to RuntimeEnv

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -193,8 +193,8 @@ Format-oriented output stream primitives above RuntimeCore, FSCore, and Types.
 ### RuntimeEnv (`runtimeenv`)
 Process-scoped runtime environment resources below full Runtime and above RuntimeCore.
 - Targets: `RuntimeEnv`
-- Allowed internal include prefixes: `runtime/env/`, `runtime/`, `types/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
-- Allowed target deps: `RuntimeCore`, `Types`, `Common`, `Base`, `Gutil`, `StarRocksGen`
+- Allowed internal include prefixes: `runtime/env/`, `runtime/`, `platform/`, `types/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
+- Allowed target deps: `Platform`, `RuntimeCore`, `Types`, `Common`, `Base`, `Gutil`, `StarRocksGen`
 - Core tests: `runtime_env_test`
 - Remediation: Keep RuntimeEnv limited to process-scoped runtime environment resources; move query execution, storage, service, connector, and UDF integration upward.
 

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -371,12 +371,12 @@
       "summary": "Process-scoped runtime environment resources below full Runtime and above RuntimeCore.",
       "owned_targets": ["RuntimeEnv"],
       "owned_roots": ["be/src/runtime/env"],
-      "allowed_include_prefixes": ["runtime/env/", "runtime/", "types/", "common/", "base/", "gutil/", "gen_cpp/"],
+      "allowed_include_prefixes": ["runtime/env/", "runtime/", "platform/", "types/", "common/", "base/", "gutil/", "gen_cpp/"],
       "forbidden_include_prefixes": ["exec/", "storage/", "service/", "connector/", "udf/"],
       "forbidden_includes": ["runtime/exec_env.h"],
-      "allowed_target_deps": ["RuntimeCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "allowed_target_deps": ["Platform", "RuntimeCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
       "allowed_test_targets": ["runtime_env_test"],
-      "allowed_test_link_deps": ["RuntimeEnv", "RuntimeCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "allowed_test_link_deps": ["RuntimeEnv", "Platform", "RuntimeCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
       "remediation": "Keep RuntimeEnv limited to process-scoped runtime environment resources; move query execution, storage, service, connector, and UDF integration upward."
     },
     {

--- a/be/src/platform/CMakeLists.txt
+++ b/be/src/platform/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PLATFORM_FILES
   download_util.cpp
   platform_env.cpp
   platform_metrics.cpp
+  python/env.cpp
   store_path.cpp
   thrift_rpc_helper.cpp
   udf_downloader.cpp

--- a/be/src/platform/python/env.cpp
+++ b/be/src/platform/python/env.cpp
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "platform/python/env.h"
+
+#include <fmt/format.h>
+
+#include <filesystem>
+
+namespace starrocks {
+
+std::string PythonEnv::get_python_path() const {
+    return fmt::format("{}/bin/python3", home);
+}
+
+Status PythonEnvRegistry::init(const std::vector<std::string>& envs) {
+    for (const auto& env : envs) {
+        std::filesystem::path path = env;
+        if (!std::filesystem::is_directory(path)) {
+            return Status::InvalidArgument(fmt::format("unsupported python env: {} not a directory", env));
+        }
+
+        if (!std::filesystem::exists(path / "bin/python3")) {
+            return Status::InvalidArgument(fmt::format("unsupported python env: {} not found python", env));
+        }
+
+        PythonEnv python_env;
+        python_env.home = env;
+        _envs[env] = python_env;
+    }
+    return Status::OK();
+}
+
+StatusOr<PythonEnv> PythonEnvRegistry::getDefault() const {
+    if (_envs.empty()) {
+        return Status::InternalError("not found avaliable env");
+    }
+    return _envs.begin()->second;
+}
+
+PythonEnvRegistry& global_python_env_registry() {
+    static PythonEnvRegistry registry;
+    return registry;
+}
+
+} // namespace starrocks

--- a/be/src/platform/python/env.h
+++ b/be/src/platform/python/env.h
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common/statusor.h"
+
+namespace starrocks {
+
+struct PythonEnv {
+    std::string home;
+    std::string get_python_path() const;
+};
+
+class PythonEnvRegistry {
+public:
+    Status init(const std::vector<std::string>& envs);
+    StatusOr<PythonEnv> getDefault() const;
+
+private:
+    // readonly after init
+    std::unordered_map<std::string, PythonEnv> _envs;
+};
+
+PythonEnvRegistry& global_python_env_registry();
+
+} // namespace starrocks

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -73,6 +73,7 @@ ADD_BE_LIB(RuntimeEnv
 )
 
 target_link_libraries(RuntimeEnv PUBLIC
+    Platform
     RuntimeCore
     Types
     Common

--- a/be/src/runtime/env/global_env.cpp
+++ b/be/src/runtime/env/global_env.cpp
@@ -24,6 +24,7 @@
 #include "common/mem_chunk.h"
 #include "common/statusor.h"
 #include "common/system/mem_info.h"
+#include "platform/python/env.h"
 #include "runtime/current_thread.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/memory/mem_chunk_allocator.h"
@@ -120,6 +121,7 @@ bool GlobalEnv::is_init() {
 
 Status GlobalEnv::init(MetricRegistry* metrics) {
     RETURN_IF_ERROR(_init_mem_tracker(metrics));
+    RETURN_IF_ERROR(global_python_env_registry().init(config::python_envs));
     CurrentThread::set_mem_tracker_source(&GlobalEnv::is_init, process_mem_tracker_provider);
     _is_init = true;
     return Status::OK();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -441,7 +441,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRe
     }
 #endif
 
-    RETURN_IF_ERROR(PythonEnvManager::getInstance().init(config::python_envs));
     PythonEnvManager::getInstance().start_background_cleanup_thread();
 
     _refresh_service_contexts();

--- a/be/src/udf/CMakeLists.txt
+++ b/be/src/udf/CMakeLists.txt
@@ -31,4 +31,4 @@ set(UDF_FILES
 
 ADD_BE_LIB(Udf ${UDF_FILES})
 
-target_link_libraries(Udf PUBLIC RuntimeEnv)
+target_link_libraries(Udf PUBLIC RuntimeEnv Platform)

--- a/be/src/udf/python/env.cpp
+++ b/be/src/udf/python/env.cpp
@@ -38,6 +38,7 @@
 #include "common/config_path_fwd.h"
 #include "common/config_udf_fwd.h"
 #include "common/util/misc.h"
+#include "platform/python/env.h"
 
 namespace starrocks {
 
@@ -79,7 +80,7 @@ std::string PyWorkerManager::unix_socket_path(pid_t pid) {
 }
 
 Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process) {
-    ASSIGN_OR_RETURN(auto py_env, PythonEnvManager::getInstance().getDefault());
+    ASSIGN_OR_RETURN(auto py_env, global_python_env_registry().getDefault());
 
     std::string python_path = py_env.get_python_path();
     int pipefd[2];

--- a/be/src/udf/python/env.h
+++ b/be/src/udf/python/env.h
@@ -15,13 +15,12 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <sys/types.h>
 
 #include <atomic>
-#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -30,11 +29,6 @@
 #include "common/statusor.h"
 
 namespace starrocks {
-
-struct PythonEnv {
-    std::string home;
-    std::string get_python_path() const { return fmt::format("{}/bin/python3", home); }
-};
 
 class ArrowFlightWithRW;
 class PyFunctionDescriptor;
@@ -120,34 +114,9 @@ class PythonEnvManager {
 public:
     ~PythonEnvManager() { close(); }
 
-    Status init(const std::vector<std::string>& envs) {
-        for (const auto& env : envs) {
-            std::filesystem::path path = env;
-            if (!std::filesystem::is_directory(path)) {
-                return Status::InvalidArgument(fmt::format("unsupported python env: {} not a directory", env));
-            }
-
-            if (!std::filesystem::exists(path / "bin/python3")) {
-                return Status::InvalidArgument(fmt::format("unsupported python env: {} not found python", env));
-            }
-
-            PythonEnv python_env;
-            python_env.home = env;
-            _envs[env] = python_env;
-        }
-        return Status::OK();
-    }
-
     static PythonEnvManager& getInstance() {
         static PythonEnvManager instance;
         return instance;
-    }
-
-    StatusOr<PythonEnv> getDefault() {
-        if (_envs.empty()) {
-            return Status::InternalError("not found avaliable env");
-        }
-        return _envs.begin()->second;
     }
 
     void start_background_cleanup_thread();
@@ -156,7 +125,5 @@ public:
 private:
     bool _running = false;
     std::unique_ptr<std::thread> _cleanup_thread;
-    // readyonly after init
-    std::unordered_map<std::string, PythonEnv> _envs;
 };
 } // namespace starrocks

--- a/be/test/platform/CMakeLists.txt
+++ b/be/test/platform/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PLATFORM_TEST_FILES
     download_util_test.cpp
     platform_env_test.cpp
     platform_metrics_test.cpp
+    python_env_test.cpp
     store_path_test.cpp
     thrift_rpc_helper_test.cpp
 )

--- a/be/test/platform/python_env_test.cpp
+++ b/be/test/platform/python_env_test.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "base/testutil/assert.h"
+#include "fmt/format.h"
+#include "platform/python/env.h"
+
+namespace starrocks {
+
+class PythonEnvRegistryTest : public testing::Test {
+public:
+    void SetUp() override {
+        _test_dir = std::filesystem::current_path() / "test_python_env_registry";
+        std::filesystem::remove_all(_test_dir);
+        std::filesystem::create_directories(_test_dir);
+    }
+
+    void TearDown() override { std::filesystem::remove_all(_test_dir); }
+
+protected:
+    std::filesystem::path _test_dir;
+};
+
+TEST_F(PythonEnvRegistryTest, EmptyRegistryReturnsError) {
+    PythonEnvRegistry registry;
+    auto env = registry.getDefault();
+    ASSERT_FALSE(env.ok());
+    EXPECT_TRUE(env.status().is_internal_error()) << env.status();
+    EXPECT_EQ("not found avaliable env", env.status().message());
+}
+
+TEST_F(PythonEnvRegistryTest, RejectsNonDirectoryEnv) {
+    PythonEnvRegistry registry;
+    auto env_path = (_test_dir / "missing").string();
+
+    auto status = registry.init({env_path});
+
+    ASSERT_TRUE(status.is_invalid_argument()) << status;
+    EXPECT_EQ(fmt::format("unsupported python env: {} not a directory", env_path), status.message());
+}
+
+TEST_F(PythonEnvRegistryTest, RejectsEnvWithoutPythonBinary) {
+    PythonEnvRegistry registry;
+    auto env_path = _test_dir / "python_env";
+    std::filesystem::create_directories(env_path / "bin");
+
+    auto status = registry.init({env_path.string()});
+
+    ASSERT_TRUE(status.is_invalid_argument()) << status;
+    EXPECT_EQ(fmt::format("unsupported python env: {} not found python", env_path.string()), status.message());
+}
+
+TEST_F(PythonEnvRegistryTest, AcceptsValidEnvAndReturnsPythonPath) {
+    PythonEnvRegistry registry;
+    auto env_path = _test_dir / "python_env";
+    std::filesystem::create_directories(env_path / "bin");
+    std::ofstream(env_path / "bin/python3").close();
+
+    ASSERT_OK(registry.init({env_path.string()}));
+    auto env = registry.getDefault();
+    ASSERT_OK(env.status());
+    EXPECT_EQ(env_path.string(), env->home);
+    EXPECT_EQ((env_path / "bin/python3").string(), env->get_python_path());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
