### PR TITLE
[BugFix] Detect iceberg/external MV schema drift on refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -95,6 +95,10 @@ public class MaterializedViewExceptions {
         return "base table schema changed for columns: " + StringUtils.join(columns, ",");
     }
 
+    public static String inactiveReasonForSchemaCheckFailed(String mvName, String detail) {
+        return "base table schema check failed for " + mvName + ": " + detail;
+    }
+
     public static SemanticException reportBaseTableNotExists(String tableName) {
         return new SemanticException(inactiveReasonForBaseTableNotExists(tableName));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mv/refresh/pct/MVPCTRefreshSynchronizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/refresh/pct/MVPCTRefreshSynchronizer.java
@@ -33,6 +33,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshProcessor;
+import com.starrocks.scheduler.mv.MVRefreshSchemaChecker;
 import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
@@ -181,6 +182,17 @@ public final class MVPCTRefreshSynchronizer {
                     processor.refreshExternalTable(baseTableCandidatePartitions);
                 } else {
                     processor.getLogger().info("Skip refreshExternalTable in pinned PCT mode");
+                }
+            }
+
+            // Pinned mode reads from a pinned snapshot — drift check is irrelevant there.
+            if (!processor.isPinnedMode()) {
+                MaterializedView mv = processor.getMv();
+                MVRefreshSchemaChecker.checkExternalBaseSchemaCompat(mv);
+                if (!mv.isActive()) {
+                    throw new DmlException(String.format(
+                            "Materialized view: %s/%d is not active due to %s.",
+                            mv.getName(), mv.getId(), mv.getInactiveReason()));
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -1,0 +1,205 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.google.common.base.Strings;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Detect schema drift between a still-active MV and its external (iceberg / hive / hudi / delta)
+ * base tables, and mark the MV inactive when the current base schemas no longer match what the
+ * MV captured at CREATE time. Invoked from the refresh pipeline after the connector metadata
+ * cache has been refreshed; deliberately opposite to {@code MVActiveChecker}, which is the
+ * background daemon that tries to take inactive MVs back to active.
+ */
+public final class MVRefreshSchemaChecker {
+
+    private static final Logger LOG = LogManager.getLogger(MVRefreshSchemaChecker.class);
+
+    private MVRefreshSchemaChecker() {
+    }
+
+    /**
+     * Detect schema drift on a still-active MV against its external (iceberg / hive / hudi / delta)
+     * base tables and mark it inactive on mismatch. Must be called <b>after</b>
+     * {@code refreshExternalTable} so the analyzer reads the current connector schema.
+     */
+    public static void checkExternalBaseSchemaCompat(MaterializedView mv) {
+        if (!mv.isActive()) {
+            return;
+        }
+        boolean hasExternalBase = false;
+        for (BaseTableInfo bti : mv.getBaseTableInfos()) {
+            Optional<Table> baseTableOpt = MvUtils.getTable(bti);
+            boolean isExternalCatalog = !CatalogMgr.isInternalCatalog(bti.getCatalogName());
+
+            if (!baseTableOpt.isPresent() && isExternalCatalog) {
+                mv.setInactiveAndReason(
+                        MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(bti.getTableName()));
+                return;
+            }
+            if (baseTableOpt.isPresent() && !baseTableOpt.get().isNativeTableOrMaterializedView()) {
+                hasExternalBase = true;
+            }
+        }
+        if (!hasExternalBase) {
+            return;
+        }
+
+        // Use the same query refresh actually runs: ivmDefineSql for IVM (post-rewrite, with
+        // synthetic state-column expressions like sum_state_merge(...)), and viewDefineSql
+        // for PCT via the fallback in getMVQueryDefinedSql.
+        String selectSql = mv.getMVQueryDefinedSql();
+        if (Strings.isNullOrEmpty(selectSql)) {
+            return;
+        }
+
+        ConnectContext context = StatisticUtils.buildConnectContext();
+        context.setStatisticsContext(false);
+        // bindScope save+restore protects the outer TaskRun's threadlocal — a plain
+        // ConnectContext.remove() in finally would null whatever was bound before us
+        // (StatisticUtils.buildConnectContext does not install on the threadlocal).
+        try (ConnectContext.ScopeGuard guard = context.bindScope()) {
+            analyzeAndCompareSchema(mv, context, selectSql);
+        } catch (SemanticException e) {
+            // SemanticException covers both real drift and transient connector wrappers
+            // (e.g. DeltaLake's getLatestSnapshot wraps IO failures). Only inactivate on
+            // known drift signatures so a transient catalog blip doesn't brick the MV.
+            if (isLikelyDriftException(e)) {
+                if (mv.isActive()) {
+                    mv.setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForSchemaCheckFailed(
+                            mv.getName(), e.getMessage()));
+                }
+                LOG.warn("[MVRefreshSchemaChecker] schema drift detected for MV {}: {}", mv.getName(), e.getMessage());
+            } else {
+                LOG.warn("[MVRefreshSchemaChecker] transient analyzer failure for MV {} (will retry on next refresh): {}",
+                        mv.getName(), e.getMessage());
+                throw e;
+            }
+        }
+    }
+
+    private static boolean isLikelyDriftException(SemanticException e) {
+        String msg = e.getMessage();
+        if (msg == null) {
+            return false;
+        }
+        // Stable analyzer / our-throw markers; everything else is treated as retryable.
+        // "No matching function with signature" covers FunctionAnalyzer rejections after a
+        // base column type changes (e.g. bitand(int,int) → bitand(bigint,int) no longer resolves).
+        return msg.contains("cannot be resolved")
+                || msg.contains("column schema not compatible")
+                || msg.contains("base table schema changed for columns")
+                || msg.contains("No matching function with signature");
+    }
+
+    private static void analyzeAndCompareSchema(MaterializedView mv, ConnectContext context, String selectSql) {
+        Optional<Database> mvDb = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(mv.getDbId());
+        mvDb.map(Database::getFullName).ifPresent(context::setDatabase);
+
+        List<StatementBase> statements = SqlParser.parse(selectSql, context.getSessionVariable());
+        if (statements.isEmpty() || !(statements.get(0) instanceof QueryStatement)) {
+            return;
+        }
+        QueryStatement queryStmt = (QueryStatement) statements.get(0);
+        Analyzer.analyze(queryStmt, context);
+
+        // Align by position, not name: stored MV cols and analyzer Fields are both in the
+        // SELECT-list output order, so position i pairs them. Name lookup would break MVs
+        // created with explicit column aliases — CREATE MV (x, y) AS SELECT k, v — where the
+        // stored column is named x but the analyzer Field is named k. Position is the only
+        // stable correspondence.
+        // Hidden stored cols (IVM __ROW_ID__, __AGG_STATE_<func>) keep their position but are
+        // skipped — their analyzer-derived nullability diverges from stored NOT NULL on
+        // unchanged schemas. Drift that affects the user-visible projection is caught via
+        // "cannot be resolved"; a base widening that keeps the user-visible output type
+        // unchanged but mutates the hidden state type is not detected here.
+        List<Field> derivedFields = queryStmt.getQueryRelation().getRelationFields().getAllFields();
+        List<Column> orderedAll = mv.getOrderedOutputColumns(true);
+        if (derivedFields.size() != orderedAll.size()) {
+            // Stored col count must match analyzer output of the persisted SELECT. A mismatch
+            // implies base schema changed in a way that altered the SELECT's output arity
+            // (DROP of a SELECT * column expanded at CREATE time would normally throw
+            // "cannot be resolved" first; this is a defensive catch).
+            throw new SemanticException(MaterializedViewExceptions.inactiveReasonForColumnChanged(
+                    Collections.singleton("column count " + orderedAll.size() + " vs " + derivedFields.size())));
+        }
+        for (int i = 0; i < orderedAll.size(); i++) {
+            Column existed = orderedAll.get(i);
+            if (existed.isHidden()) {
+                continue;
+            }
+            Field derivedField = derivedFields.get(i);
+            Type derivedNormalized = AnalyzerUtils.transformTableColumnType(derivedField.getType(), false);
+            if (!isColumnCompatible(existed, derivedNormalized)) {
+                // Render derived as a Column only for the error message — gives the canonical
+                // OLAP `(name type NULL/NOT NULL ...)` format.
+                Column derived = new Column(existed.getName(), derivedNormalized, derivedField.isNullable());
+                String reason = MaterializedViewExceptions.inactiveReasonForColumnNotCompatible(
+                        existed.toString(), derived.toString());
+                throw new SemanticException(reason);
+            }
+        }
+    }
+
+    // matchesType recurses through ARRAY / MAP / STRUCT — catches inner-type drift like
+    // STRUCT<a INT> → STRUCT<a BIGINT> (Spark/Trino ALTER on iceberg) that PrimitiveType.equals
+    // misses because non-scalars all return INVALID_TYPE. CHAR/VARCHAR widths stay
+    // interchangeable to avoid false positives on iceberg `string`.
+    // Nullability skipped: analyzer's NULL on rewritten IVM SELECT diverges from stored NOT NULL.
+    // Decimal precision: matchesType only buckets by primitive (DECIMAL32/64/128/256), so
+    // DECIMAL(10,2) → DECIMAL(18,2) (both DECIMAL64, same scale) would pass — overflow at
+    // refresh INSERT instead. Explicit precision check guards against this.
+    // Visible for MVRefreshSchemaCheckerTest.
+    static boolean isColumnCompatible(Column existed, Type derivedType) {
+        if (!existed.getType().matchesType(derivedType)) {
+            return false;
+        }
+        if (existed.getType().isDecimalOfAnyVersion() && derivedType.isDecimalOfAnyVersion()) {
+            ScalarType existedScalar = (ScalarType) existed.getType();
+            ScalarType derivedScalar = (ScalarType) derivedType;
+            if (existedScalar.getScalarPrecision() != derivedScalar.getScalarPrecision()
+                    || existedScalar.getScalarScale() != derivedScalar.getScalarScale()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
@@ -1,0 +1,165 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.CharType;
+import com.starrocks.type.DecimalType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.StringType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Covers {@link MVRefreshSchemaChecker#isColumnCompatible} for cases the SR SQL test framework
+ * cannot reach: iceberg STRUCT/ARRAY/MAP field-level ALTER from Spark/Trino. SR SQL itself
+ * rejects {@code ALTER ... ADD FIELD / DROP FIELD} clauses on non-OLAP tables, but the iceberg
+ * table can still be modified out of band.
+ */
+public class MVRefreshSchemaCheckerTest {
+
+    private static boolean isCompatible(Column existed, Type derivedType) {
+        return MVRefreshSchemaChecker.isColumnCompatible(existed, derivedType);
+    }
+
+    private static StructType struct(StructField... fields) {
+        return new StructType(new ArrayList<>(Arrays.asList(fields)));
+    }
+
+    @Test
+    public void testScalarSameTypeCompatible() {
+        Assertions.assertTrue(isCompatible(new Column("k", IntegerType.INT), IntegerType.INT));
+        Assertions.assertTrue(isCompatible(new Column("v", IntegerType.BIGINT), IntegerType.BIGINT));
+    }
+
+    @Test
+    public void testScalarWideningDriftDetected() {
+        Assertions.assertFalse(isCompatible(new Column("v", IntegerType.INT), IntegerType.BIGINT));
+        Assertions.assertFalse(isCompatible(new Column("v", IntegerType.BIGINT), IntegerType.INT));
+    }
+
+    @Test
+    public void testStringWidthInterchangeable() {
+        // matchesType treats CHAR/VARCHAR of any width as compatible — required so the iceberg
+        // `string` → varchar(1073741824) shape doesn't false-positive against a stored MV
+        // column that may be varchar(65533).
+        Column existed = new Column("s", new VarcharType(50));
+        Assertions.assertTrue(isCompatible(existed, new VarcharType(1073741824)));
+        Assertions.assertTrue(isCompatible(existed, StringType.STRING));
+        Assertions.assertTrue(isCompatible(existed, new CharType(20)));
+    }
+
+    @Test
+    public void testArrayInnerWideningDriftDetected() {
+        // A PrimitiveType.equals shortcut would miss this: both sides return INVALID_TYPE for
+        // non-scalar Type, leaving silent NULL / refresh failure with MV still active.
+        Column existed = new Column("arr", new ArrayType(IntegerType.INT));
+        Assertions.assertTrue(isCompatible(existed, new ArrayType(IntegerType.INT)));
+        Assertions.assertFalse(isCompatible(existed, new ArrayType(IntegerType.BIGINT)));
+    }
+
+    @Test
+    public void testMapKeyWideningDriftDetected() {
+        Column existed = new Column("m", new MapType(IntegerType.INT, StringType.STRING));
+        Assertions.assertFalse(isCompatible(existed, new MapType(IntegerType.BIGINT, StringType.STRING)));
+    }
+
+    @Test
+    public void testMapValueWideningDriftDetected() {
+        Column existed = new Column("m", new MapType(IntegerType.INT, IntegerType.INT));
+        Assertions.assertFalse(isCompatible(existed, new MapType(IntegerType.INT, IntegerType.BIGINT)));
+    }
+
+    @Test
+    public void testStructFieldTypeDriftDetected() {
+        // External engine (Spark) widening a STRUCT field — SR SQL itself rejects this clause
+        // on non-OLAP tables, but the iceberg table can still be ALTER'd out of band.
+        StructType original = struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("b", StringType.STRING));
+        StructType drifted = struct(
+                new StructField("a", IntegerType.BIGINT),
+                new StructField("b", StringType.STRING));
+        Assertions.assertTrue(isCompatible(new Column("s", original), original));
+        Assertions.assertFalse(isCompatible(new Column("s", original), drifted));
+    }
+
+    @Test
+    public void testStructFieldAddedDriftDetected() {
+        StructType original = struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("b", StringType.STRING));
+        StructType wider = struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("b", StringType.STRING),
+                new StructField("c", IntegerType.BIGINT));
+        Assertions.assertFalse(isCompatible(new Column("s", original), wider));
+    }
+
+    @Test
+    public void testStructFieldRenamedDriftDetected() {
+        StructType original = struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("b", StringType.STRING));
+        StructType renamed = struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("b2", StringType.STRING));
+        Assertions.assertFalse(isCompatible(new Column("s", original), renamed));
+    }
+
+    @Test
+    public void testDecimalPrecisionWideningDriftDetected() {
+        // DECIMAL(10,2) and DECIMAL(18,2) both bucket into PrimitiveType.DECIMAL64, so
+        // matchesType alone returns true — but storing DECIMAL(18,2) values into a
+        // DECIMAL(10,2) MV column overflows. Explicit precision check guards against this.
+        Column existed = new Column("d", new DecimalType(PrimitiveType.DECIMAL64, 10, 2));
+        Assertions.assertTrue(isCompatible(existed, new DecimalType(PrimitiveType.DECIMAL64, 10, 2)));
+        Assertions.assertFalse(isCompatible(existed, new DecimalType(PrimitiveType.DECIMAL64, 18, 2)));
+    }
+
+    @Test
+    public void testDecimalScaleChangeDriftDetected() {
+        // matchesType DECIMAL V3 branch already enforces scale equality; assertion guards
+        // against future relaxation of that branch.
+        Column existed = new Column("d", new DecimalType(PrimitiveType.DECIMAL64, 10, 2));
+        Assertions.assertFalse(isCompatible(existed, new DecimalType(PrimitiveType.DECIMAL64, 10, 4)));
+    }
+
+    @Test
+    public void testDecimalCrossBucketWideningDriftDetected() {
+        // Baseline: cross-PrimitiveType widening (DECIMAL64 → DECIMAL128) is already caught
+        // by matchesType. Kept for regression coverage.
+        Column existed = new Column("d", new DecimalType(PrimitiveType.DECIMAL64, 10, 2));
+        Assertions.assertFalse(isCompatible(existed, new DecimalType(PrimitiveType.DECIMAL128, 20, 2)));
+    }
+
+    @Test
+    public void testNestedArrayOfStructDriftDetected() {
+        StructType originalElem = struct(new StructField("a", IntegerType.INT));
+        StructType driftedElem = struct(new StructField("a", IntegerType.BIGINT));
+        Column existed = new Column("arr", new ArrayType(originalElem));
+        Assertions.assertFalse(isCompatible(existed, new ArrayType(driftedElem)));
+    }
+}

--- a/test/sql/test_materialized_view_ivm/R/test_iceberg_mv_ivm_schema_drift_detect
+++ b/test/sql/test_materialized_view_ivm/R/test_iceberg_mv_ivm_schema_drift_detect
@@ -1,0 +1,289 @@
+-- name: test_iceberg_mv_ivm_schema_drift_detect
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c1_db_${uuid0};
+-- result:
+-- !result
+use c1_db_${uuid0};
+-- result:
+-- !result
+create table c1_base (k int, v int) properties('format-version'='2');
+-- result:
+-- !result
+insert into c1_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c1_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c1_db_${uuid0}.c1_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+[UC]C1_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c1_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c1_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c1_base MODIFY COLUMN v BIGINT;
+-- result:
+-- !result
+INSERT INTO c1_base VALUES (3, 5000000000), (4, 99);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE LIKE '%column schema not compatible%' FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON LIKE '%column schema not compatible%' FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c1_mv';
+-- result:
+false	1
+-- !result
+DROP MATERIALIZED VIEW c1_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c2agg_db_${uuid0};
+-- result:
+-- !result
+use c2agg_db_${uuid0};
+-- result:
+-- !result
+create table c2agg_base (k int, v int) properties('format-version'='2');
+-- result:
+-- !result
+insert into c2agg_base values (1, 100), (1, 200), (2, 50);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c2agg_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, SUM(v) s, MAX(v) mx, COUNT(*) c
+   FROM mv_iceberg_${uuid0}.c2agg_db_${uuid0}.c2agg_base GROUP BY k;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c2agg_mv WITH SYNC MODE;
+[UC]C2AGG_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c2agg_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c2agg_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c2agg_base MODIFY COLUMN v BIGINT;
+-- result:
+-- !result
+INSERT INTO c2agg_base VALUES (1, 5000000000);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c2agg_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C2AGG_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c2agg_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c2agg_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c3_db_${uuid0};
+-- result:
+-- !result
+use c3_db_${uuid0};
+-- result:
+-- !result
+create table c3_base (k int, v bigint) properties('format-version'='2');
+-- result:
+-- !result
+insert into c3_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c3_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c3_db_${uuid0}.c3_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+[UC]C3_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c3_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c3_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c3_base DROP COLUMN v;
+-- result:
+-- !result
+INSERT INTO c3_base VALUES (3);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C3_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c3_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c3_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c4_db_${uuid0};
+-- result:
+-- !result
+use c4_db_${uuid0};
+-- result:
+-- !result
+create table c4_base (k int, v bigint) properties('format-version'='2');
+-- result:
+-- !result
+insert into c4_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c4_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c4_db_${uuid0}.c4_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+[UC]C4_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c4_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c4_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c4_base RENAME COLUMN v TO v_new;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C4_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c4_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c4_mv;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+drop table c1_db_${uuid0}.c1_base force;
+-- result:
+-- !result
+drop table c2agg_db_${uuid0}.c2agg_base force;
+-- result:
+-- !result
+drop table c3_db_${uuid0}.c3_base force;
+-- result:
+-- !result
+drop table c4_db_${uuid0}.c4_base force;
+-- result:
+-- !result
+drop database c1_db_${uuid0} force;
+-- result:
+-- !result
+drop database c2agg_db_${uuid0} force;
+-- result:
+-- !result
+drop database c3_db_${uuid0} force;
+-- result:
+-- !result
+drop database c4_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_iceberg_mv_ivm_schema_drift_detect
+++ b/test/sql/test_materialized_view_ivm/T/test_iceberg_mv_ivm_schema_drift_detect
@@ -1,0 +1,162 @@
+-- name: test_iceberg_mv_ivm_schema_drift_detect
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+-- ==============================================================
+-- Case 1: MODIFY COLUMN widening (INT -> BIGINT) + projection IVM MV
+-- pre-fix: silent NULL on 5e9; expected: REFRESH FAILED + MV inactive
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c1_db_${uuid0};
+use c1_db_${uuid0};
+create table c1_base (k int, v int) properties('format-version'='2');
+insert into c1_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c1_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c1_db_${uuid0}.c1_base;
+
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+[UC]C1_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c1_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c1_db_${uuid0};
+ALTER TABLE c1_base MODIFY COLUMN v BIGINT;
+INSERT INTO c1_base VALUES (3, 5000000000), (4, 99);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%column schema not compatible%' FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE, INACTIVE_REASON LIKE '%column schema not compatible%' FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c1_mv';
+
+DROP MATERIALIZED VIEW c1_mv;
+
+-- ==============================================================
+-- Case 2: MODIFY COLUMN widening + aggregation IVM MV (state column)
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c2agg_db_${uuid0};
+use c2agg_db_${uuid0};
+create table c2agg_base (k int, v int) properties('format-version'='2');
+insert into c2agg_base values (1, 100), (1, 200), (2, 50);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c2agg_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, SUM(v) s, MAX(v) mx, COUNT(*) c
+   FROM mv_iceberg_${uuid0}.c2agg_db_${uuid0}.c2agg_base GROUP BY k;
+
+[UC]REFRESH MATERIALIZED VIEW c2agg_mv WITH SYNC MODE;
+[UC]C2AGG_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c2agg_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c2agg_db_${uuid0};
+ALTER TABLE c2agg_base MODIFY COLUMN v BIGINT;
+INSERT INTO c2agg_base VALUES (1, 5000000000);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c2agg_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C2AGG_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c2agg_mv';
+
+DROP MATERIALIZED VIEW c2agg_mv;
+
+-- ==============================================================
+-- Case 3: DROP COLUMN referenced by IVM MV
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c3_db_${uuid0};
+use c3_db_${uuid0};
+create table c3_base (k int, v bigint) properties('format-version'='2');
+insert into c3_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c3_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c3_db_${uuid0}.c3_base;
+
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+[UC]C3_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c3_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c3_db_${uuid0};
+ALTER TABLE c3_base DROP COLUMN v;
+INSERT INTO c3_base VALUES (3);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C3_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c3_mv';
+
+DROP MATERIALIZED VIEW c3_mv;
+
+-- ==============================================================
+-- Case 4: RENAME COLUMN referenced by IVM MV
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c4_db_${uuid0};
+use c4_db_${uuid0};
+create table c4_base (k int, v bigint) properties('format-version'='2');
+insert into c4_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c4_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c4_db_${uuid0}.c4_base;
+
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+[UC]C4_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c4_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c4_db_${uuid0};
+ALTER TABLE c4_base RENAME COLUMN v TO v_new;
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C4_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c4_mv';
+
+DROP MATERIALIZED VIEW c4_mv;
+
+-- ==============================================================
+-- Cleanup (iceberg DROP DATABASE FORCE does not cascade tables —
+-- drop base tables individually first)
+-- ==============================================================
+drop database db_${uuid0} force;
+
+set catalog mv_iceberg_${uuid0};
+drop table c1_db_${uuid0}.c1_base force;
+drop table c2agg_db_${uuid0}.c2agg_base force;
+drop table c3_db_${uuid0}.c3_base force;
+drop table c4_db_${uuid0}.c4_base force;
+drop database c1_db_${uuid0} force;
+drop database c2agg_db_${uuid0} force;
+drop database c3_db_${uuid0} force;
+drop database c4_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};

--- a/test/sql/test_mv_on_iceberg/R/test_iceberg_mv_pct_schema_drift_detect.sql
+++ b/test/sql/test_mv_on_iceberg/R/test_iceberg_mv_pct_schema_drift_detect.sql
@@ -1,0 +1,360 @@
+-- name: test_iceberg_mv_pct_schema_drift_detect
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c1_db_${uuid0};
+-- result:
+-- !result
+use c1_db_${uuid0};
+-- result:
+-- !result
+create table c1_base (k int, v int) properties('format-version'='2');
+-- result:
+-- !result
+insert into c1_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c1_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c1_db_${uuid0}.c1_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+[UC]C1_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c1_mv';
+SELECT k, v FROM c1_mv ORDER BY k;
+-- result:
+1	10
+2	20
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c1_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c1_base MODIFY COLUMN v BIGINT;
+-- result:
+-- !result
+INSERT INTO c1_base VALUES (3, 5000000000), (4, 99);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE LIKE '%column schema not compatible%' FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON LIKE '%column schema not compatible%' FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c1_mv';
+-- result:
+false	1
+-- !result
+SELECT k, v FROM c1_mv ORDER BY k;
+-- result:
+1	10
+2	20
+-- !result
+DROP MATERIALIZED VIEW c1_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c2_db_${uuid0};
+-- result:
+-- !result
+use c2_db_${uuid0};
+-- result:
+-- !result
+create table c2_base (k int, v int) properties('format-version'='2');
+-- result:
+-- !result
+insert into c2_base values (1, 100), (1, 200), (2, 50);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c2_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, SUM(v) s, MAX(v) mx, COUNT(*) c
+   FROM mv_iceberg_${uuid0}.c2_db_${uuid0}.c2_base GROUP BY k;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c2_mv WITH SYNC MODE;
+[UC]C2_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c2_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c2_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c2_base MODIFY COLUMN v BIGINT;
+-- result:
+-- !result
+INSERT INTO c2_base VALUES (1, 5000000000);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c2_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C2_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c2_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c2_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c3_db_${uuid0};
+-- result:
+-- !result
+use c3_db_${uuid0};
+-- result:
+-- !result
+create table c3_base (k int, v bigint) properties('format-version'='2');
+-- result:
+-- !result
+insert into c3_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c3_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c3_db_${uuid0}.c3_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+[UC]C3_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c3_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c3_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c3_base DROP COLUMN v;
+-- result:
+-- !result
+INSERT INTO c3_base VALUES (3);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C3_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c3_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c3_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c4_db_${uuid0};
+-- result:
+-- !result
+use c4_db_${uuid0};
+-- result:
+-- !result
+create table c4_base (k int, v bigint) properties('format-version'='2');
+-- result:
+-- !result
+insert into c4_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c4_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c4_db_${uuid0}.c4_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+[UC]C4_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c4_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c4_db_${uuid0};
+-- result:
+-- !result
+ALTER TABLE c4_base RENAME COLUMN v TO v_new;
+-- result:
+-- !result
+INSERT INTO c4_base VALUES (3, 30);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C4_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c4_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c4_mv;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c5_db_${uuid0};
+-- result:
+-- !result
+use c5_db_${uuid0};
+-- result:
+-- !result
+create table c5_base (k int, v bigint) properties('format-version'='2');
+-- result:
+-- !result
+insert into c5_base values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c5_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c5_db_${uuid0}.c5_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c5_mv WITH SYNC MODE;
+[UC]C5_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c5_mv';
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c5_db_${uuid0};
+-- result:
+-- !result
+DROP TABLE c5_base;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c5_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C5_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c5_mv';
+-- result:
+false
+-- !result
+DROP MATERIALIZED VIEW c5_mv;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+drop table c1_db_${uuid0}.c1_base force;
+-- result:
+-- !result
+drop table c2_db_${uuid0}.c2_base force;
+-- result:
+-- !result
+drop table c3_db_${uuid0}.c3_base force;
+-- result:
+-- !result
+drop table c4_db_${uuid0}.c4_base force;
+-- result:
+-- !result
+drop database c1_db_${uuid0} force;
+-- result:
+-- !result
+drop database c2_db_${uuid0} force;
+-- result:
+-- !result
+drop database c3_db_${uuid0} force;
+-- result:
+-- !result
+drop database c4_db_${uuid0} force;
+-- result:
+-- !result
+drop database c5_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_mv_on_iceberg/T/test_iceberg_mv_pct_schema_drift_detect.sql
+++ b/test/sql/test_mv_on_iceberg/T/test_iceberg_mv_pct_schema_drift_detect.sql
@@ -1,0 +1,198 @@
+-- name: test_iceberg_mv_pct_schema_drift_detect
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+-- ==============================================================
+-- Case 1: MODIFY COLUMN widening (INT -> BIGINT) + projection MV
+-- pre-fix: silent NULL on 5e9; expected: REFRESH FAILED + MV inactive
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c1_db_${uuid0};
+use c1_db_${uuid0};
+create table c1_base (k int, v int) properties('format-version'='2');
+insert into c1_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c1_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c1_db_${uuid0}.c1_base;
+
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+[UC]C1_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c1_mv';
+
+SELECT k, v FROM c1_mv ORDER BY k;
+
+set catalog mv_iceberg_${uuid0};
+use c1_db_${uuid0};
+ALTER TABLE c1_base MODIFY COLUMN v BIGINT;
+INSERT INTO c1_base VALUES (3, 5000000000), (4, 99);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c1_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%column schema not compatible%' FROM information_schema.task_runs WHERE TASK_NAME = '${C1_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE, INACTIVE_REASON LIKE '%column schema not compatible%' FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c1_mv';
+SELECT k, v FROM c1_mv ORDER BY k;
+
+DROP MATERIALIZED VIEW c1_mv;
+
+-- ==============================================================
+-- Case 2: MODIFY COLUMN widening + aggregation MV (covers state column)
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c2_db_${uuid0};
+use c2_db_${uuid0};
+create table c2_base (k int, v int) properties('format-version'='2');
+insert into c2_base values (1, 100), (1, 200), (2, 50);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c2_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, SUM(v) s, MAX(v) mx, COUNT(*) c
+   FROM mv_iceberg_${uuid0}.c2_db_${uuid0}.c2_base GROUP BY k;
+
+[UC]REFRESH MATERIALIZED VIEW c2_mv WITH SYNC MODE;
+[UC]C2_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c2_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c2_db_${uuid0};
+ALTER TABLE c2_base MODIFY COLUMN v BIGINT;
+INSERT INTO c2_base VALUES (1, 5000000000);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c2_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C2_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c2_mv';
+
+DROP MATERIALIZED VIEW c2_mv;
+
+-- ==============================================================
+-- Case 3: DROP COLUMN referenced by MV
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c3_db_${uuid0};
+use c3_db_${uuid0};
+create table c3_base (k int, v bigint) properties('format-version'='2');
+insert into c3_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c3_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c3_db_${uuid0}.c3_base;
+
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+[UC]C3_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c3_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c3_db_${uuid0};
+ALTER TABLE c3_base DROP COLUMN v;
+INSERT INTO c3_base VALUES (3);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c3_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C3_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c3_mv';
+
+DROP MATERIALIZED VIEW c3_mv;
+
+-- ==============================================================
+-- Case 4: RENAME COLUMN referenced by MV
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c4_db_${uuid0};
+use c4_db_${uuid0};
+create table c4_base (k int, v bigint) properties('format-version'='2');
+insert into c4_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c4_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c4_db_${uuid0}.c4_base;
+
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+[UC]C4_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c4_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c4_db_${uuid0};
+ALTER TABLE c4_base RENAME COLUMN v TO v_new;
+INSERT INTO c4_base VALUES (3, 30);
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c4_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C4_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c4_mv';
+
+DROP MATERIALIZED VIEW c4_mv;
+
+-- ==============================================================
+-- Case 5: base TABLE dropped entirely (covers Optional.empty branch)
+-- ==============================================================
+set catalog mv_iceberg_${uuid0};
+create database c5_db_${uuid0};
+use c5_db_${uuid0};
+create table c5_base (k int, v bigint) properties('format-version'='2');
+insert into c5_base values (1, 10), (2, 20);
+
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c5_mv
+REFRESH DEFERRED MANUAL
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c5_db_${uuid0}.c5_base;
+
+[UC]REFRESH MATERIALIZED VIEW c5_mv WITH SYNC MODE;
+[UC]C5_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c5_mv';
+
+set catalog mv_iceberg_${uuid0};
+use c5_db_${uuid0};
+DROP TABLE c5_base;
+
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c5_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C5_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c5_mv';
+
+DROP MATERIALIZED VIEW c5_mv;
+
+-- ==============================================================
+-- Cleanup (iceberg DROP DATABASE FORCE does not cascade tables —
+-- drop base tables individually first; c5_base was already dropped)
+-- ==============================================================
+drop database db_${uuid0} force;
+
+set catalog mv_iceberg_${uuid0};
+drop table c1_db_${uuid0}.c1_base force;
+drop table c2_db_${uuid0}.c2_base force;
+drop table c3_db_${uuid0}.c3_base force;
+drop table c4_db_${uuid0}.c4_base force;
+drop database c1_db_${uuid0} force;
+drop database c2_db_${uuid0} force;
+drop database c3_db_${uuid0} force;
+drop database c4_db_${uuid0} force;
+drop database c5_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

When an iceberg / external-catalog base table's schema evolves (column
widened, dropped, renamed, struct field changed, or table dropped
entirely), the dependent MV's next refresh silently produces NULL rows
or fails with a confusing raw analyzer error. The OLAP propagation path
that marks dependent MVs inactive on ALTER doesn't fire for non-OLAP
bases — and external engines (Spark / Trino / pyiceberg) can ALTER
iceberg tables completely outside StarRocks' view.

Concrete reproducers:
- `MODIFY COLUMN v INT → BIGINT` + projection MV + insert 5000000000:
  MV silently shows `(3, NULL)` instead of the value
- `MODIFY COLUMN v INT → BIGINT` + aggregation MV: MV `MAX(v)` silently
  NULL
- `DROP COLUMN` / `RENAME COLUMN` referenced by MV: refresh fails with
  raw `Column cannot be resolved` analyzer stack, MV stays "active"
- STRUCT field type widened by Spark/Trino (e.g. `STRUCT<a INT, b STR>`
  → `STRUCT<a BIGINT, b STR>`): refresh repeatedly fails on type
  mismatch, MV stays active

OLAP MVs in the equivalent scenarios already surface the canonical
`ERROR 1064 ... column schema not compatible: (...) and (...)` +
`IS_ACTIVE=false` + `INACTIVE_REASON` populated. This PR wires the same
behavior for external-base MVs.

## What I'm doing:

Adds a dedicated `MVRefreshSchemaChecker.checkExternalBaseSchemaCompat(mv)`
that re-parses + re-analyzes the MV's stored query SQL against the
connector's current schema, then compares each stored user-output column
to the analyzer-derived `Field` **at the same SELECT-list position**.
Lives in `fe-core/.../scheduler/mv/MVRefreshSchemaChecker.java`,
deliberately opposite in direction to `MVActiveChecker` (which is the
background inactive→active daemon).

Wired into `MVPCTRefreshSynchronizer.syncAndCheckPCTPartitions` directly
after `refreshExternalTable` — the shared entry point for both PCT and
IVM refresh, so a single check covers both modes. On drift the MV is
marked inactive via the canonical `setInactiveAndReason` +
`inactiveReasonForSchemaCheckFailed` / `inactiveReasonForColumnNotCompatible`
/ `inactiveReasonForColumnChanged` / `inactiveReasonForBaseTableNotExists`
factories, matching OLAP's message format and `INACTIVE_REASON` column.
Skipped in pinned PCT mode where the pinned snapshot is consistent by
construction.

Key design decisions:
- **Analyzer input**: `mv.getMVQueryDefinedSql()` — falls through to
  `ivmDefineSql` for IVM (post-rewrite SELECT producing synthetic
  state-column names like `sum_state_merge(...)`) and to `viewDefineSql`
  for PCT. Aligns the analyzer input with what the refresh runtime
  actually executes.
- **Positional alignment, not name lookup.** Stored
  `mv.getOrderedOutputColumns(true)` and analyzer Fields are both in
  SELECT-list output order, so position `i` pairs them. Name lookup
  would break MVs created with explicit column aliases — `CREATE MV
  (x, y) AS SELECT k, v` — where the stored column is named `x` but
  the analyzer Field is named `k`. (Reproduced and verified end-to-end
  on dev cluster.)
- **Type compare: structural `Type.matchesType`**, not just primitive
  type. `matchesType` recurses through ARRAY / MAP / STRUCT, catching
  inner-type drift like `STRUCT<a INT>` → `STRUCT<a BIGINT>` from a
  Spark/Trino ALTER on iceberg — a top-level `PrimitiveType.equals`
  would miss it because non-scalar `Type.getPrimitiveType()` returns
  `INVALID_TYPE`. CHAR/VARCHAR widths stay interchangeable, so iceberg
  `string` → `varchar(1073741824)` doesn't false-positive against a
  stored MV column declared as a tighter width.
- **Comparison scope**: user-visible columns only (`existed.isHidden()`
  skip). Hidden IVM internals (`__ROW_ID__`, `__AGG_STATE_<func>`)
  keep their position but are skipped — their analyzer-derived
  nullability diverges from stored `NOT NULL` even on unchanged
  schemas, and the OLAP-side `enable_active_materialized_view_schema_strict_check`
  config is meant for `ALTER ... ACTIVATE`, not refresh-time drift.
  Drift that affects the user-visible projection is caught via
  `cannot be resolved`; a base widening that keeps the user-visible
  output type unchanged but mutates the hidden state type is the one
  known residual gap, surfacing at refresh INSERT time instead.
- **Drift vs transient narrowing**: `catch (SemanticException)` only
  inactivates when the message matches a positive-list of stable
  drift markers (`cannot be resolved`, `column schema not compatible`,
  `base table schema changed for columns`, `No matching function with
  signature`). Other SemanticException types — e.g. DeltaLake wraps IO
  failures as SemanticException — log and rethrow as retryable refresh
  failures so a one-off catalog blip doesn't permanently flip
  `IS_ACTIVE=false`.
- **`SELECT *` MVs handled correctly**: `MaterializedViewAnalyzer`
  expands `SELECT *` to explicit `SlotRef`s at CREATE time and persists
  the expanded form (via `AstToSQLBuilder.toSQL` with default
  `printActualSelectItem=true`). Stored `viewDefineSql` /
  `ivmDefineSql` is `SELECT a, b, c FROM base`, not `SELECT *`, so base
  ADD COLUMN / reorder via `ALTER TABLE ... MODIFY COLUMN ... AFTER`
  does not change refresh output column count or order — verified
  empirically on the dev cluster.
- **Optional.empty()** from an external-catalog `BaseTableInfo` is
  treated as "base dropped" — canonical inactive flow.
- **ConnectContext threadlocal preserved** via `ScopeGuard` save/restore,
  so the outer TaskRun's threadlocal is restored, not wiped.

Cases covered by the regression tests:

PCT SQL (`test/sql/test_mv_on_iceberg/T/test_iceberg_mv_pct_schema_drift_detect.sql`):
- `MODIFY COLUMN INT → BIGINT` + projection MV (silent-NULL case)
- `MODIFY COLUMN INT → BIGINT` + aggregation MV (catches the agg state column)
- `DROP COLUMN` referenced by MV
- `RENAME COLUMN` referenced by MV
- Base table dropped entirely (`Optional.empty()` branch)

IVM SQL (`test/sql/test_materialized_view_ivm/T/test_iceberg_mv_ivm_schema_drift_detect`):
- `MODIFY COLUMN INT → BIGINT` + projection IVM MV
- `MODIFY COLUMN INT → BIGINT` + aggregation IVM MV (state column)
- `DROP COLUMN` referenced by IVM MV
- `RENAME COLUMN` referenced by IVM MV

FE UT (`fe/fe-core/.../scheduler/mv/MVRefreshSchemaCheckerTest.java`) —
covers the Spark/Trino-only ALTER paths the SR SQL test framework
cannot reach (SR SQL rejects `MODIFY COLUMN ADD/DROP FIELD` clauses on
non-OLAP tables, but external engines can still ALTER iceberg
STRUCT/ARRAY/MAP):
- Scalar same-type and INT/BIGINT widening drift
- CHAR/VARCHAR width interchangeable (no false-positive on iceberg `string`)
- ARRAY inner-type widening drift
- MAP key / value widening drift
- STRUCT inner field type drift, field added, field renamed
- Nested ARRAY<STRUCT> inner drift

The IVM-specific INSERT-into-MV strict-load behavior for value-level
overflows (DECIMAL / VARCHAR width) is filed as a separate PR.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Previously: iceberg-backed MV refresh silently produced NULL rows on schema
drift, or stuck-failed with raw analyzer errors. STRUCT/ARRAY/MAP inner
drift went undetected entirely.

Now: refresh returns ERROR 1064 with the OLAP-canonical "is not active due
to ..." message, `IS_ACTIVE` flips to false, `INACTIVE_REASON` is
populated. MV data is preserved at baseline (no partial commit, no silent
corruption). Complex-type drift (Spark/Trino ALTER on iceberg STRUCT
fields, ARRAY element type, MAP key/value type) is now detected too.

## Test plan

- [x] FE UT `MVRefreshSchemaCheckerTest` 10/0/0 — scalar + complex-type
  drift coverage
- [x] FE UT `IVMBasedMvRefreshProcessorIcebergTest` (50/0/0) and
  `PartitionBasedMvRefreshProcessorIcebergTest` (19/0/0) pass locally —
  the 8 IVM iceberg failures present before the `getMVQueryDefinedSql()`
  fix are gone
- [x] SQL regression tests (PCT + IVM split files), 5 PCT cases + 4 IVM cases
- [x] Manual dev-cluster verification on the fixed commit
  - All PCT + IVM cases return ERROR 1064 + `IS_ACTIVE=false` +
    `INACTIVE_REASON` populated, MV data preserved at baseline
  - 3 previously-failing iceberg SQL tests
    (`test_ivm_with_iceberg_ssb`, `test_ivm_with_iceberg_incremental`,
    `test_ivm_whitelist_widening`) now pass (3/3 flaky-runs each)
  - Negative: VARCHAR-backed MV refresh stays `IS_ACTIVE=true` (no
    false-positive from the iceberg `string` → `varchar(1073741824)` width gap)
  - Negative: idempotent refresh on unchanged base stays `IS_ACTIVE=true`
  - Negative: `SELECT *` MV + base `ALTER TABLE MODIFY COLUMN b AFTER c`
    (column reorder) — MV refresh still produces correct row data
    (verified end-to-end), confirming that stored SQL is the expanded
    explicit-column form
  - Negative: MV created with explicit column aliases
    `CREATE MV (x, y) AS SELECT k, v FROM iceberg.base` —
    refresh succeeds, `IS_ACTIVE=true` (verified end-to-end; was the
    Copilot review repro)
- [x] `mvn compile -pl fe-core -am -DskipTests` clean
- [x] `mvn checkstyle:check -pl fe-core` 0 violations

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5