### PR TITLE
[BugFix] fix NullableColumnUnaryFunction lose decimal's scale when all null

### DIFF
--- a/be/src/exprs/unary_function.h
+++ b/be/src/exprs/unary_function.h
@@ -182,7 +182,12 @@ public:
             auto col = ColumnHelper::as_raw_column<NullableColumn>(v1);
 
             if (v1->size() == ColumnHelper::count_nulls(v1)) {
-                auto data = RunTimeColumnType<ResultType>::create(std::forward<Args>(args)...);
+                typename RunTimeColumnType<ResultType>::MutablePtr data;
+                if constexpr (lt_is_decimal<ResultType>) {
+                    data = RunTimeColumnType<ResultType>::create(std::forward<Args>(args)...);
+                } else {
+                    data = RunTimeColumnType<ResultType>::create();
+                }
                 data->resize(v1->size());
                 auto nul = NullColumn::create();
                 nul->append(*col->null_column(), 0, col->null_column()->size());

--- a/be/src/exprs/unary_function.h
+++ b/be/src/exprs/unary_function.h
@@ -182,7 +182,7 @@ public:
             auto col = ColumnHelper::as_raw_column<NullableColumn>(v1);
 
             if (v1->size() == ColumnHelper::count_nulls(v1)) {
-                auto data = RunTimeColumnType<ResultType>::create();
+                auto data = RunTimeColumnType<ResultType>::create(std::forward<Args>(args)...);
                 data->resize(v1->size());
                 auto nul = NullColumn::create();
                 nul->append(*col->null_column(), 0, col->null_column()->size());

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -1289,6 +1289,40 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
     }
 }
 
+TEST_F(VecMathFunctionsTest, AbsDecimalNullableAllNullPreservesScale) {
+    constexpr int precision = 38;
+    constexpr int input_scale = 8;
+    constexpr int result_scale = 12;
+
+    auto data_column = DecimalV3Column<int128_t>::create(precision, input_scale);
+    data_column->append_default(2);
+
+    auto null_column = NullColumn::create();
+    null_column->append(1);
+    null_column->append(1);
+
+    Columns columns;
+    columns.emplace_back(NullableColumn::create(std::move(data_column), std::move(null_column)));
+
+    FunctionContext::TypeDesc return_type;
+    return_type.type = TYPE_DECIMAL128;
+    return_type.precision = precision;
+    return_type.scale = result_scale;
+    std::unique_ptr<FunctionContext> ctx(
+            FunctionContext::create_test_context(std::vector<FunctionContext::TypeDesc>(), return_type));
+
+    ColumnPtr result = MathFunctions::abs_decimal128(ctx.get(), columns).value();
+    ASSERT_TRUE(result->is_nullable());
+    ASSERT_EQ(2, result->size());
+    ASSERT_TRUE(result->is_null(0));
+    ASSERT_TRUE(result->is_null(1));
+
+    auto result_data =
+            ColumnHelper::cast_to<TYPE_DECIMAL128>(FunctionHelper::get_data_column_of_nullable(result)).get();
+    EXPECT_EQ(precision, result_data->precision());
+    EXPECT_EQ(result_scale, result_data->scale());
+}
+
 TEST_F(VecMathFunctionsTest, CotTest) {
     {
         Columns columns;


### PR DESCRIPTION
## Why I'm doing:
NullableColumnUnaryFunction may lose decimal's scale when all null
and such column may passed by exchange passthrough, and accumulate in result sink's chunk accumulator, cause other data lose scale 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
