### PR TITLE
[BugFix] Fix BACKUP ON (ALL FUNCTION) / (ALL EXTERNAL CATALOGS) failures

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -517,24 +517,22 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
                 stmt.getTimeoutMs(), globalStateMgr, repository.getId());
         List<Function> allFunctions = Lists.newArrayList();
 
-        if (!stmt.containsExternalCatalog()) {
-            if (!stmt.withOnClause() || stmt.allFunction()) {
-                for (Map.Entry<String, List<Function>> entry : db.getNameToFunction().entrySet()) {
-                    List<Function> fns = entry.getValue();
-                    allFunctions.addAll(fns);
-                }
-            } else {
-                for (FunctionRef fnRef : stmt.getFnRefs()) {
-                    String functionName = fnRef.getFunctionName();
+        if (!stmt.containsExternalCatalog() && (!stmt.withOnClause() || stmt.allFunction())) {
+            for (Map.Entry<String, List<Function>> entry : db.getNameToFunction().entrySet()) {
+                List<Function> fns = entry.getValue();
+                allFunctions.addAll(fns);
+            }
+        } else if (!stmt.containsExternalCatalog()) {
+            for (FunctionRef fnRef : stmt.getFnRefs()) {
+                String functionName = fnRef.getFunctionName();
 
-                    List<Function> functionList = db.getFunctionsByName(functionName);
-                    if (functionList.isEmpty()) {
-                        ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
-                                "Invalid backup function(s), function name: " + functionName);
-                    }
-
-                    allFunctions.addAll(functionList);
+                List<Function> functionList = db.getFunctionsByName(functionName);
+                if (functionList.isEmpty()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                            "Invalid backup function(s), function name: " + functionName);
                 }
+
+                allFunctions.addAll(functionList);
             }
         }
         backupJob.setBackupFunctions(allFunctions);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -517,22 +517,24 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
                 stmt.getTimeoutMs(), globalStateMgr, repository.getId());
         List<Function> allFunctions = Lists.newArrayList();
 
-        if (!stmt.withOnClause() || stmt.allFunction()) {
-            for (Map.Entry<String, List<Function>> entry : db.getNameToFunction().entrySet()) {
-                List<Function> fns = entry.getValue();
-                allFunctions.addAll(fns);
-            }
-        } else {
-            for (FunctionRef fnRef : stmt.getFnRefs()) {
-                String functionName = fnRef.getFunctionName();
-
-                List<Function> functionList = db.getFunctionsByName(functionName);
-                if (functionList.isEmpty()) {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
-                            "Invalid backup function(s), function name: " + functionName);
+        if (!stmt.containsExternalCatalog()) {
+            if (!stmt.withOnClause() || stmt.allFunction()) {
+                for (Map.Entry<String, List<Function>> entry : db.getNameToFunction().entrySet()) {
+                    List<Function> fns = entry.getValue();
+                    allFunctions.addAll(fns);
                 }
+            } else {
+                for (FunctionRef fnRef : stmt.getFnRefs()) {
+                    String functionName = fnRef.getFunctionName();
 
-                allFunctions.addAll(functionList);
+                    List<Function> functionList = db.getFunctionsByName(functionName);
+                    if (functionList.isEmpty()) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                                "Invalid backup function(s), function name: " + functionName);
+                    }
+
+                    allFunctions.addAll(functionList);
+                }
             }
         }
         backupJob.setBackupFunctions(allFunctions);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2587,6 +2587,19 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
                     }
                 }
             });
+
+            if (statement.allFunction() && db != null) {
+                for (Function fn : db.getFunctions()) {
+                    try {
+                        Authorizer.checkFunctionAction(context, db, fn, PrivilegeType.USAGE);
+                    } catch (AccessDeniedException e) {
+                        AccessDeniedException.reportAccessDenied(
+                                InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                                context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                                PrivilegeType.DROP.name(), ObjectType.FUNCTION.name(), fn.getSignature());
+                    }
+                }
+            }
         } else {
             List<CatalogRef> externalCatalogs = statement.getExternalCatalogRefs();
             externalCatalogs.forEach(externalCatalog -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2596,7 +2596,7 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
                         AccessDeniedException.reportAccessDenied(
                                 InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                                 context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                PrivilegeType.DROP.name(), ObjectType.FUNCTION.name(), fn.getSignature());
+                                PrivilegeType.USAGE.name(), ObjectType.FUNCTION.name(), fn.getSignature());
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2545,7 +2545,9 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
         if (!statement.containsExternalCatalog()) {
             List<TableRef> tableRefs = statement.getTableRefs();
             List<FunctionRef> functionRefs = statement.getFnRefs();
-            if (tableRefs.isEmpty() && functionRefs.isEmpty()) {
+            if (tableRefs.isEmpty() && functionRefs.isEmpty()
+                    && !statement.allTable() && !statement.allMV()
+                    && !statement.allView() && !statement.allFunction()) {
                 String dBName = statement.getDbName();
                 throw new SemanticException("Database: %s is empty", dBName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2552,14 +2552,15 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
                 throw new SemanticException("Database: %s is empty", dBName);
             }
 
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(statement.getDbName());
+            String resolvedDbName = statement.getDbName();
+            if (resolvedDbName == null) {
+                resolvedDbName = context.getDatabase();
+            }
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(resolvedDbName);
+            final String dbNameForRefs = resolvedDbName;
             tableRefs.forEach(tableRef -> {
-                String dbName = statement.getDbName();
-                if (dbName == null) {
-                    dbName = context.getDatabase();
-                }
                 String tblName = tableRef.getTableName();
-                TableName tableName = new TableName(context.getCurrentCatalog(), dbName, tblName);
+                TableName tableName = new TableName(context.getCurrentCatalog(), dbNameForRefs, tblName);
 
                 try {
                     Authorizer.checkTableAction(context, tableName, PrivilegeType.EXPORT);
@@ -2570,6 +2571,10 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
                             PrivilegeType.EXPORT.name(), ObjectType.TABLE.name(), tableName.getTbl());
                 }
             });
+
+            if (db == null && (!functionRefs.isEmpty() || statement.allFunction())) {
+                throw new SemanticException("Database: " + resolvedDbName + " does not exist");
+            }
 
             functionRefs.forEach(functionRef -> {
                 String functionName = functionRef.getFunctionName();
@@ -2583,12 +2588,12 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
                         AccessDeniedException.reportAccessDenied(
                                 InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                                 context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                PrivilegeType.DROP.name(), ObjectType.FUNCTION.name(), fn.getSignature());
+                                PrivilegeType.USAGE.name(), ObjectType.FUNCTION.name(), fn.getSignature());
                     }
                 }
             });
 
-            if (statement.allFunction() && db != null) {
+            if (statement.allFunction()) {
                 for (Function fn : db.getFunctions()) {
                     try {
                         Authorizer.checkFunctionAction(context, db, fn, PrivilegeType.USAGE);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -332,6 +332,20 @@ public class BackupHandlerTest {
             Assertions.fail();
         }
 
+        // process BACKUP ALL EXTERNAL CATALOGS - regression: must not NPE when db is null
+        Set<AbstractBackupStmt.BackupObjectType> externalAllMarker = Sets.newHashSet();
+        externalAllMarker.add(AbstractBackupStmt.BackupObjectType.EXTERNAL_CATALOG);
+        BackupStmt backupAllCatalogsStmt = new BackupStmt(
+                new LabelName(null, "label_ext_catalog"), "repo",
+                Lists.newArrayList(), Lists.newArrayList(), null,
+                externalAllMarker, false, "", null, NodePosition.ZERO);
+        try {
+            handler.process(new ConnectContext(), backupAllCatalogsStmt);
+        } catch (DdlException e1) {
+            e1.printStackTrace();
+            Assertions.fail();
+        }
+
         // process restore
         List<TableRef> tblRefs2 = Lists.newArrayList();
         tblRefs2.add(

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -345,6 +345,13 @@ public class BackupHandlerTest {
             e1.printStackTrace();
             Assertions.fail();
         }
+        // cancel the external-catalog backup so it does not block dropRepository at the end of the test
+        try {
+            handler.cancel(new CancelBackupStmt(null, false, true));
+        } catch (DdlException e1) {
+            e1.printStackTrace();
+            Assertions.fail();
+        }
 
         // process restore
         List<TableRef> tblRefs2 = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -101,6 +101,12 @@ public class AnalyzeBackupRestoreTest {
         analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON " +
                 "( ALL FUNCTIONS, ALL TABLES, ALL VIEWS, ALL MATERIALIZED VIEWS ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( ALL FUNCTIONS ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( ALL FUNCTION ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( ALL FUNCTIONS ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP ALL EXTERNAL CATALOGS SNAPSHOT snapshot_label2 TO `repo` " +
                        "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP EXTERNAL CATALOG (catalog1) SNAPSHOT snapshot_label2 TO `repo` " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -2514,19 +2514,56 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
     @Test
     public void testBackupAllFunctionStmt() throws Exception {
         mockRepository();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        FunctionName fn = FunctionName.createFnName("db1.backup_all_fn_udf");
+        Function function = new ScalarFunction(fn,
+                Arrays.asList(StringType.STRING), StringType.STRING, false);
+        try {
+            db1.addFunction(function);
+        } catch (Throwable e) {
+            // ignore
+        }
+
         ctxToRoot();
         grantOrRevoke("grant repository on system to test");
         ctxToTestUser();
-        for (String sql : new String[] {
+
+        String[] sqls = new String[] {
                 "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');",
                 "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTION) PROPERTIES ('type' = 'full');",
                 "BACKUP DATABASE db1 SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) " +
-                        "PROPERTIES ('type' = 'full');"}) {
+                        "PROPERTIES ('type' = 'full');"};
+
+        // Without USAGE on the function the check must fail (no more "Database is empty" misfire).
+        String expectError = "Access denied; you need (at least one of) the USAGE privilege(s) on FUNCTION";
+        for (String sql : sqls) {
+            StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            try {
+                Authorizer.check(statement, starRocksAssert.getCtx());
+                Assertions.fail("expected access denied for: " + sql);
+            } catch (Exception e) {
+                logSysInfo(e.getMessage() + ", sql: " + sql);
+                Assertions.assertTrue(e.getMessage().contains(expectError), e.getMessage());
+            }
+        }
+
+        // Granting USAGE on ALL FUNCTIONS in db1 lets the check pass.
+        ctxToRoot();
+        grantOrRevoke("grant usage on ALL FUNCTIONS in database db1 to test");
+        ctxToTestUser();
+        for (String sql : sqls) {
             StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
             Authorizer.check(statement, starRocksAssert.getCtx());
         }
+
         ctxToRoot();
+        grantOrRevoke("revoke usage on ALL FUNCTIONS in database db1 from test");
         grantOrRevoke("revoke repository on system from test");
+        try {
+            db1.dropFunctionForRestore(function);
+        } catch (Throwable e) {
+            // ignore
+        }
         ctxToTestUser();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -2528,43 +2528,50 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
         grantOrRevoke("grant repository on system to test");
         ctxToTestUser();
 
-        String[] sqls = new String[] {
-                "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');",
-                "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTION) PROPERTIES ('type' = 'full');",
-                "BACKUP DATABASE db1 SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) " +
-                        "PROPERTIES ('type' = 'full');"};
-
-        // Without USAGE on the function the check must fail (no more "Database is empty" misfire).
-        String expectError = "Access denied; you need (at least one of) the USAGE privilege(s) on FUNCTION";
-        for (String sql : sqls) {
-            StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-            try {
-                Authorizer.check(statement, starRocksAssert.getCtx());
-                Assertions.fail("expected access denied for: " + sql);
-            } catch (Exception e) {
-                logSysInfo(e.getMessage() + ", sql: " + sql);
-                Assertions.assertTrue(e.getMessage().contains(expectError), e.getMessage());
-            }
-        }
-
-        // Granting USAGE on ALL FUNCTIONS in db1 lets the check pass.
-        ctxToRoot();
-        grantOrRevoke("grant usage on ALL FUNCTIONS in database db1 to test");
-        ctxToTestUser();
-        for (String sql : sqls) {
-            StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-            Authorizer.check(statement, starRocksAssert.getCtx());
-        }
-
-        ctxToRoot();
-        grantOrRevoke("revoke usage on ALL FUNCTIONS in database db1 from test");
-        grantOrRevoke("revoke repository on system from test");
         try {
-            db1.dropFunctionForRestore(function);
-        } catch (Throwable e) {
-            // ignore
+            String[] sqls = new String[] {
+                    "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');",
+                    "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTION) PROPERTIES ('type' = 'full');",
+                    "BACKUP DATABASE db1 SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) " +
+                            "PROPERTIES ('type' = 'full');"};
+
+            // Without USAGE on the function the check must fail (no more "Database is empty" misfire).
+            String expectError = "Access denied; you need (at least one of) the USAGE privilege(s) on FUNCTION";
+            for (String sql : sqls) {
+                StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+                try {
+                    Authorizer.check(statement, starRocksAssert.getCtx());
+                    Assertions.fail("expected access denied for: " + sql);
+                } catch (Exception e) {
+                    logSysInfo(e.getMessage() + ", sql: " + sql);
+                    Assertions.assertTrue(e.getMessage().contains(expectError), e.getMessage());
+                }
+            }
+
+            // Granting USAGE on ALL FUNCTIONS in db1 lets the check pass.
+            ctxToRoot();
+            grantOrRevoke("grant usage on ALL FUNCTIONS in database db1 to test");
+            ctxToTestUser();
+            try {
+                for (String sql : sqls) {
+                    StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+                    Authorizer.check(statement, starRocksAssert.getCtx());
+                }
+            } finally {
+                ctxToRoot();
+                grantOrRevoke("revoke usage on ALL FUNCTIONS in database db1 from test");
+                ctxToTestUser();
+            }
+        } finally {
+            ctxToRoot();
+            grantOrRevoke("revoke repository on system from test");
+            try {
+                db1.dropFunctionForRestore(function);
+            } catch (Throwable e) {
+                // ignore
+            }
+            ctxToTestUser();
         }
-        ctxToTestUser();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -2548,6 +2548,25 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
                 }
             }
 
+            // Regression: when the BACKUP statement has no db prefix, the session db must
+            // be resolved before the privilege check; otherwise auth would silently bypass.
+            String sqlSessionDb =
+                    "BACKUP SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');";
+            String previousDb = starRocksAssert.getCtx().getDatabase();
+            starRocksAssert.getCtx().setDatabase("db1");
+            try {
+                StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sqlSessionDb, starRocksAssert.getCtx());
+                try {
+                    Authorizer.check(statement, starRocksAssert.getCtx());
+                    Assertions.fail("expected access denied for: " + sqlSessionDb);
+                } catch (Exception e) {
+                    logSysInfo(e.getMessage() + ", sql: " + sqlSessionDb);
+                    Assertions.assertTrue(e.getMessage().contains(expectError), e.getMessage());
+                }
+            } finally {
+                starRocksAssert.getCtx().setDatabase(previousDb);
+            }
+
             // Granting USAGE on ALL FUNCTIONS in db1 lets the check pass.
             ctxToRoot();
             grantOrRevoke("grant usage on ALL FUNCTIONS in database db1 to test");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -2512,6 +2512,25 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testBackupAllFunctionStmt() throws Exception {
+        mockRepository();
+        ctxToRoot();
+        grantOrRevoke("grant repository on system to test");
+        ctxToTestUser();
+        for (String sql : new String[] {
+                "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');",
+                "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTION) PROPERTIES ('type' = 'full');",
+                "BACKUP DATABASE db1 SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) " +
+                        "PROPERTIES ('type' = 'full');"}) {
+            StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            Authorizer.check(statement, starRocksAssert.getCtx());
+        }
+        ctxToRoot();
+        grantOrRevoke("revoke repository on system from test");
+        ctxToTestUser();
+    }
+
+    @Test
     public void testShowBackupStmtInShowExecutor() throws Exception {
 
         mockAddBackupJob("db1");


### PR DESCRIPTION
## Why I'm doing:

`BACKUP ... ON (ALL FUNCTION) ...` and `BACKUP ALL EXTERNAL CATALOGS ...` both failed for distinct reasons rooted in the same area:

1. **"Database: %s is empty"** misfire on `BACKUP DATABASE <db> SNAPSHOT <sx> TO <repo> ON (ALL FUNCTION)` — even when the database contained UDFs.

   `AstBuilder` records `ALL FUNCTION` in `allMarker` without populating `fnRefs` (only individually named functions go into `fnRefs`). The analyzer correctly honors `allFunction()`, but `AuthorizerStmtVisitor` only inspected the ref lists and not `allMarker`, so the statement was rejected before the analyzer's expansion logic could run.

   `ALL TABLE` / `ALL MV` / `ALL VIEW` happened to slip past because the analyzer pre-fills `tblRefs` with all tables of the corresponding type during analysis, so the ref list was non-empty by the time the authorizer ran. `ALL FUNCTION` is expanded later in `BackupHandler`, leaving both lists empty during authorization.

2. **NPE on `BACKUP ALL EXTERNAL CATALOGS`** — `Cannot invoke "com.starrocks.catalog.Database.getNameToFunction()" because "db" is null`.

   `BackupHandler.backup()` unconditionally iterated `db.getNameToFunction()` when `withOnClause` was false. For the `ALL EXTERNAL CATALOGS` syntax, the parser sets `withOnClause=false` (the marker is not tracked as an ON clause) and `db` is intentionally null on the external-catalog path (the other db-using code paths in this method are already guarded by `!containsExternalCatalog()`).

3. **Authorization bypass on `BACKUP SNAPSHOT <label> TO <repo> ON (ALL FUNCTIONS)`** (no `<db>.` prefix, session-context db).

   `getLocalMetastore().getDb(statement.getDbName())` did no session-DB fallback; when `statement.getDbName()` was null, `getDb(null)` returned null and the `db != null` guard silently skipped the USAGE check — letting denied statements through.

4. **Wrong privilege in the access-denied error message** — both the existing specific-`FunctionRef` block and the new `allFunction()` block reported `PrivilegeType.DROP` after running `checkFunctionAction(..., USAGE)`.

## What I'm doing:

- **Authorizer (`AuthorizerStmtVisitor.visitBackupStatement`)**: extend the empty check to also consider `allTable/allMV/allView/allFunction`; resolve the session DB before the privilege check (mirroring `BackupRestoreAnalyzer.getDbName`); throw `SemanticException` if the database still cannot be resolved while a function check is required; remove the `db != null` silent guard; report `USAGE` (not `DROP`) for both `FunctionRef` paths.
- **BackupHandler (`BackupHandler.backup`)**: skip the function-collection block when `containsExternalCatalog()` is true, matching the pattern already used elsewhere in the method for db locking and `dbId`/`dbName` setup.
- **Tests**:
  - `AnalyzeBackupRestoreTest` — add analyzer coverage for `ON (ALL FUNCTIONS)` / `ON (ALL FUNCTION)` alone.
  - `PrivilegeCheckerTest.testBackupAllFunctionStmt` — exercises both the explicit-db-prefix path and the session-db-fallback regression, with the grant → pass cycle and nested try/finally cleanup.
  - `BackupHandlerTest.testCreateAndDropRepository` — regression for the `BACKUP ALL EXTERNAL CATALOGS` NPE path; cancels the external-catalog job so `dropRepository` at the end of the test does not block.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11352

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
