### PR TITLE
[Enhancement] fix too heavy SpinLock, replace with lock-free parallel map

### DIFF
--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -253,31 +253,22 @@ void QueryStatistics::merge_pb(const PQueryStatistics& statistics) {
 }
 
 void QueryStatisticsRecvr::insert(const PQueryStatistics& statistics, int sender_id) {
-    std::lock_guard<SpinLock> l(_lock);
     QueryStatistics* query_statistics = nullptr;
-    auto iter = _query_statistics.find(sender_id);
-    if (iter == _query_statistics.end()) {
-        query_statistics = new QueryStatistics;
-        _query_statistics[sender_id] = query_statistics;
-    } else {
-        query_statistics = iter->second;
-    }
+    _query_statistics.lazy_emplace_l(
+            sender_id, [&](QueryStatistics* const& existing) { query_statistics = existing; },
+            [&](const auto& ctor) {
+                query_statistics = new QueryStatistics;
+                ctor(sender_id, query_statistics);
+            });
     query_statistics->merge_pb(statistics);
 }
 
 void QueryStatisticsRecvr::aggregate(QueryStatistics* statistics) {
-    std::lock_guard<SpinLock> l(_lock);
-    for (auto& pair : _query_statistics) {
-        statistics->merge(pair.first, *pair.second);
-    }
+    _query_statistics.for_each([&statistics](const auto& pair) { statistics->merge(pair.first, *pair.second); });
 }
 
 QueryStatisticsRecvr::~QueryStatisticsRecvr() {
-    // It is unnecessary to lock here, because the destructor will be
-    // called alter DataStreamRecvr's close in ExchangeNode.
-    for (auto& pair : _query_statistics) {
-        delete pair.second;
-    }
+    _query_statistics.for_each_m([](auto& pair) { delete pair.second; });
     _query_statistics.clear();
 }
 

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -34,9 +34,10 @@
 
 #pragma once
 
-#include <mutex>
+#include <shared_mutex>
 
 #include "base/concurrency/spinlock.h"
+#include "base/phmap/phmap.h"
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/data.pb.h"
 
@@ -135,8 +136,9 @@ public:
     void aggregate(QueryStatistics* statistics);
 
 private:
-    std::map<int, QueryStatistics*> _query_statistics;
-    SpinLock _lock;
+    phmap::parallel_flat_hash_map<int, QueryStatistics*, phmap::Hash<int>, phmap::EqualTo<int>,
+                                  phmap::Allocator<phmap::Pair<const int, QueryStatistics*>>, 4, std::shared_mutex>
+            _query_statistics;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
merge_pb itself is thread-safe
QueryStatistics::merge_pb use only atomics value and have internal locks for operations over maps/vectors/etc

at the same time in medium sized clusters (50+ machines x 255 cpu) when we need to send intermediate/final statistics from workers `SpinLock` consume 10-16% cpu on `perf` profile

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
