### PR TITLE
[BugFix][CVE] bump Tomcat to 9.0.118

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -45,7 +45,7 @@ under the License.
         <zookeeper.version>3.9.5</zookeeper.version>
         <protobuf.version>3.25.5</protobuf.version>
         <thrift.version>0.23.0</thrift.version>
-        <tomcat.version>9.0.117</tomcat.version>
+        <tomcat.version>9.0.118</tomcat.version>
         <log4j.version>2.17.1</log4j.version>
         <jackson.version>2.21.1</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>


### PR DESCRIPTION
CVE-2026-41293: Apache Tomcat HTTP/2 request headers were not validated, which may have triggered unexpected application behaviour if the application assumed the header value exposed through the Servlet API would be specification compliant. Affects Tomcat 9.0.0.M1 to 9.0.117; fixed in 9.0.118.

Bumped <tomcat.version> in fs_brokers/apache_hdfs_broker/src/pom.xml from 9.0.117 to 9.0.118; covers tomcat-embed-core and tomcat-annotations-api via the existing property.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
