### PR TITLE
[Enhancement] Optimize DATETIME/DATE to string cast — eliminate per-row heap allocations

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1454,6 +1454,42 @@ DEFINE_INT_CAST_TO_STRING(TYPE_SMALLINT, TYPE_VARCHAR);
 DEFINE_INT_CAST_TO_STRING(TYPE_INT, TYPE_VARCHAR);
 DEFINE_INT_CAST_TO_STRING(TYPE_BIGINT, TYPE_VARCHAR);
 
+// Specialized temporal-to-string: writes directly into the bytes buffer via to_string(char*, n),
+// avoiding per-row std::string allocation + copy that the generic StringUnaryFunction path does.
+#define DEFINE_TEMPORAL_CAST_TO_STRING(FROM_TYPE, TO_TYPE, MAX_LEN)                                         \
+    template <>                                                                                             \
+    template <>                                                                                             \
+    inline ColumnPtr StringUnaryFunction<CastToString>::evaluate<FROM_TYPE, TO_TYPE>(const ColumnPtr& v1) { \
+        const auto& r1 = ColumnHelper::cast_to_raw<FROM_TYPE>(v1)->get_data();                              \
+        auto result = RunTimeColumnType<TO_TYPE>::create();                                                 \
+        int size = v1->size();                                                                              \
+        auto& offset = result->get_offset();                                                                \
+        offset.resize(size + 1);                                                                            \
+        auto& bytes = result->get_bytes();                                                                  \
+        bytes.resize(static_cast<size_t>(MAX_LEN) * size);                                                  \
+        char* dst = reinterpret_cast<char*>(bytes.data());                                                  \
+        size_t off = 0;                                                                                     \
+        if constexpr (FROM_TYPE == TYPE_DATE) {                                                             \
+            /* DateValue::to_string always writes MAX_LEN when n >= MAX_LEN */                              \
+            for (int i = 0; i < size; ++i) {                                                                \
+                r1[i].to_string(dst + off, MAX_LEN);                                                        \
+                off += MAX_LEN;                                                                             \
+                offset[i + 1] = static_cast<uint32_t>(off);                                                 \
+            }                                                                                               \
+        } else {                                                                                            \
+            for (int i = 0; i < size; ++i) {                                                                \
+                int len = r1[i].to_string(dst + off, MAX_LEN);                                              \
+                if (LIKELY(len > 0)) off += len;                                                            \
+                offset[i + 1] = static_cast<uint32_t>(off);                                                 \
+            }                                                                                               \
+        }                                                                                                   \
+        bytes.resize(off);                                                                                  \
+        return result;                                                                                      \
+    }
+
+DEFINE_TEMPORAL_CAST_TO_STRING(TYPE_DATETIME, TYPE_VARCHAR, 26);
+DEFINE_TEMPORAL_CAST_TO_STRING(TYPE_DATE, TYPE_VARCHAR, 10);
+
 // Cast SQL type to JSON
 CUSTOMIZE_FN_CAST(TYPE_NULL, TYPE_JSON, cast_to_json_fn);
 CUSTOMIZE_FN_CAST(TYPE_INT, TYPE_JSON, cast_to_json_fn);

--- a/be/src/types/date_value.cpp
+++ b/be/src/types/date_value.cpp
@@ -205,4 +205,12 @@ std::string DateValue::to_string() const {
     return date::to_string(_julian);
 }
 
+int DateValue::to_string(char* s, size_t n) const {
+    if (n < 10) return -1;
+    int year, month, day;
+    date::to_date_with_cache(_julian, &year, &month, &day);
+    date::to_string(year, month, day, s);
+    return 10;
+}
+
 } // namespace starrocks

--- a/be/src/types/date_value.h
+++ b/be/src/types/date_value.h
@@ -101,6 +101,12 @@ public:
 
     std::string to_string() const;
 
+    // Formats into the provided buffer as "YYYY-MM-DD" (10 chars).
+    // Returns the number of characters written (always 10) or -1 on error.
+    int to_string(char* s, size_t n) const;
+
+    static constexpr int max_string_length() { return 10; }
+
     JulianDate julian() const { return _julian; }
 
     // Convert to C++20 chrono sys_days for time arithmetic

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -736,6 +736,63 @@ TEST_F(VectorizedCastExprTest, timestmapCastString) {
     }
 }
 
+// Exercises DEFINE_TEMPORAL_CAST_TO_STRING(TYPE_DATETIME, ...) with non-zero microseconds,
+// i.e. the 26-char branch of timestamp::to_string(_, buf, n).
+TEST_F(VectorizedCastExprTest, timestampCastStringWithMicros) {
+    expr_node.child_type = TPrimitiveType::DATETIME;
+    expr_node.type = gen_type_desc(TPrimitiveType::VARCHAR);
+    expr_node.type.types[0].scalar_type.__set_len(26);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_DATETIME> col1(expr_node, 5, TimestampValue::create(2020, 2, 3, 1, 23, 45, 123456));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        ASSERT_TRUE(ptr->is_binary());
+
+        auto v = BinaryColumn::static_pointer_cast(ptr);
+        ASSERT_EQ(5, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_EQ(std::string("2020-02-03 01:23:45.123456"), v->get_slice(j));
+        }
+    }
+}
+
+// Exercises DEFINE_TEMPORAL_CAST_TO_STRING(TYPE_DATE, ...).
+TEST_F(VectorizedCastExprTest, dateCastString) {
+    expr_node.child_type = TPrimitiveType::DATE;
+    expr_node.type = gen_type_desc(TPrimitiveType::VARCHAR);
+    expr_node.type.types[0].scalar_type.__set_len(10);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_DATE> col1(expr_node, 10, DateValue::create(2020, 2, 3));
+
+    expr->_children.push_back(&col1);
+
+    {
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+
+        ASSERT_TRUE(ptr->is_binary());
+
+        auto v = BinaryColumn::static_pointer_cast(ptr);
+        ASSERT_EQ(10, v->size());
+
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_EQ(std::string("2020-02-03"), v->get_slice(j));
+        }
+
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
+    }
+}
+
 TEST_F(VectorizedCastExprTest, stringCastInt) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::INT);

--- a/be/test/types/date_value_test.cpp
+++ b/be/test/types/date_value_test.cpp
@@ -17,6 +17,7 @@
 
 #define private public
 
+#include <cstring>
 #include <type_traits>
 
 #include "types/date_value.h"
@@ -321,6 +322,52 @@ TEST(DateValueTest, test_trunc_to_quarter) {
         ASSERT_EQ(month_to_quarter[month0], month1);
         ASSERT_EQ(1, day1);
     }
+}
+
+TEST(DateValueTest, to_string_buffer) {
+    DateValue dv;
+    dv.from_date(2020, 2, 3);
+
+    // Buffer exactly the required size: writes 10 chars, no null terminator.
+    char buf[16];
+    std::memset(buf, '#', sizeof(buf));
+    int len = dv.to_string(buf, 10);
+    ASSERT_EQ(10, len);
+    ASSERT_EQ(std::string("2020-02-03"), std::string(buf, len));
+    // Bytes beyond the written range must be untouched.
+    ASSERT_EQ('#', buf[10]);
+
+    // Larger buffer still writes exactly 10 chars.
+    std::memset(buf, '#', sizeof(buf));
+    len = dv.to_string(buf, sizeof(buf));
+    ASSERT_EQ(10, len);
+    ASSERT_EQ(std::string("2020-02-03"), std::string(buf, len));
+    ASSERT_EQ('#', buf[10]);
+
+    // Single-digit month/day are zero-padded.
+    dv.from_date(1, 1, 1);
+    len = dv.to_string(buf, 10);
+    ASSERT_EQ(10, len);
+    ASSERT_EQ(std::string("0001-01-01"), std::string(buf, len));
+
+    dv.from_date(9999, 12, 31);
+    len = dv.to_string(buf, 10);
+    ASSERT_EQ(10, len);
+    ASSERT_EQ(std::string("9999-12-31"), std::string(buf, len));
+
+    // Matches the std::string overload.
+    dv.from_date(2020, 2, 3);
+    len = dv.to_string(buf, 10);
+    ASSERT_EQ(std::string(buf, len), dv.to_string());
+
+    // Undersized buffer returns -1 and does not write.
+    std::memset(buf, '#', sizeof(buf));
+    ASSERT_EQ(-1, dv.to_string(buf, 9));
+    ASSERT_EQ('#', buf[0]);
+    ASSERT_EQ(-1, dv.to_string(buf, 0));
+    ASSERT_EQ('#', buf[0]);
+
+    ASSERT_EQ(10, DateValue::max_string_length());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
Add specialized StringUnaryFunction templates for TYPE_DATETIME and TYPE_DATE that write directly into the output bytes buffer via to_string(char*, n), bypassing the generic path which creates a temporary std::string per row.

- Pre-allocate bytes.reserve(max_len * size) before the loop
- Write dirrectly into column buffer
- Add DateValue::to_string(char*, size_t) buffer overload (was missing)

For N rows this eliminates N heap allocations + 2*N string copies that the generic CastToString path performed.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
