### PR TITLE
[Tool] auto-attach AI-recommended reviewer + rename step for honesty

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Skills synced to $SKILL_DEST:"
           ls -1 "$SKILL_DEST"
 
-      - name: Assign PR Reviewer
+      - name: Recommend Reviewer (AI)
         run: |
           echo "=== DEBUG ==="
           echo "PR: ${{ github.event.number }}"
@@ -60,13 +60,48 @@ jobs:
           echo "CLAUDE_CODE_OAUTH_TOKEN length: ${#CLAUDE_CODE_OAUTH_TOKEN}"
           echo "GITHUB_TOKEN length: ${#GITHUB_TOKEN}"
           echo "=== RUN ==="
-          # tee captures the skill's stdout for the Notify Slack step to parse
+          # Runs inside claude-cli docker; produces only "Recommended reviewer: <login>"
+          # output. The host-side "Apply Reviewer" step below actually attaches it
+          # (gh is not available inside the container).
+          # tee captures the skill's stdout for the downstream steps to parse.
           docker exec -i -u claudeuser \
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
             -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" \
             2>&1 | tee "${RUNNER_TEMP}/ai_output.txt" || true
+
+      - name: Apply Reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The skill runs inside claude-cli docker where `gh` is unavailable,
+          # so it can only print "Recommended reviewer: <login>" and asks for
+          # manual assignment. Host runner has `gh` + GITHUB_TOKEN, so attach
+          # the reviewer here instead. Idempotent: gh ignores duplicates.
+          ai_output="${RUNNER_TEMP}/ai_output.txt"
+          if [ ! -f "$ai_output" ]; then
+            echo "no ai_output, skip"
+            exit 0
+          fi
+          reviewer=$(grep -iE '^\**Recommended reviewer:' "$ai_output" | tail -1 \
+            | sed -E 's/^\**[Rr]ecommended reviewer:\**[[:space:]]*//' \
+            | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1 || true)
+          if [ -z "$reviewer" ] || [ "$reviewer" = "none" ]; then
+            echo "no reviewer extracted, skip"
+            exit 0
+          fi
+          # Self-review guard: GitHub rejects request-review from the PR author.
+          author=$(gh pr view "$PR" -R "$REPO" --json author -q '.author.login' 2>/dev/null || true)
+          if [ -n "$author" ] && [ "$reviewer" = "$author" ]; then
+            echo "skip: recommended reviewer ($reviewer) is the PR author"
+            exit 0
+          fi
+          echo "Assigning reviewer: $reviewer"
+          gh pr edit "$PR" -R "$REPO" --add-reviewer "$reviewer" \
+            || echo "WARN: gh pr edit --add-reviewer failed (permissions, already a reviewer, or transient API error)"
 
       - name: Notify Slack
         env:


### PR DESCRIPTION
## Why I'm doing:
The previous `Assign PR Reviewer` step was misleading. It runs the Claude skill inside the `claude-cli` docker container, where `gh` is **not available**, so the skill only prints `Recommended reviewer: <login>` and asks for manual assignment. The PR's reviewer list was never updated, while Slack notifications still fired for the recommendation — recipients had no idea the assignment hadn't actually happened.

Concrete example: [run #26389136185](https://github.com/StarRocks/starrocks/actions/runs/26389136185/job/77674380486) — skill logged `The gh command is unavailable in this environment (session-env error). Please assign manually.` then `Recommended reviewer: trueeyu`. Slack notified `trueeyu`, but PR #73800's reviewer list stayed empty.

## What I'm doing:
1. **Rename** `Assign PR Reviewer` → `Recommend Reviewer (AI)` so the step name matches what it actually does (produces a recommendation, no side effect on the PR).
2. **Add a new host-side step** `Apply Reviewer` between the skill and the Slack notification. The host runner has `gh` and `GITHUB_TOKEN`. It:
   - Reuses the same `Recommended reviewer:` parsing as the Slack step.
   - Guards against self-review (skips if the recommended login equals the PR author).
   - Calls `gh pr edit "$PR" --add-reviewer "$reviewer"`. The call is idempotent — `gh` ignores duplicates.
   - On any gh failure (permissions, transient API error, etc.) logs a warning and continues; never fails the job.

After this PR, reviewers recommended by the AI skill will land on the PR's reviewer list automatically.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4