### PR TITLE
[Refactor] Extract AWS SDK init/shutdown into AwsSdkGuard RAII

### DIFF
--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -49,6 +49,7 @@ set(EXEC_FILES
     credential/cloud_configuration_factory.cpp
     hdfs/fs_hdfs.cpp
     hdfs/hdfs_fs_cache.cpp
+    s3/aws_sdk_guard.cpp
     s3/poco_http_client_factory.cpp
     s3/poco_http_client.cpp
     s3/poco_common.cpp

--- a/be/src/fs/s3/aws_sdk_guard.cpp
+++ b/be/src/fs/s3/aws_sdk_guard.cpp
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __APPLE__
+#include "fs/s3/aws_sdk_guard.h"
+
+#include <aws/core/utils/logging/LogLevel.h>
+#include <boost/algorithm/string.hpp>
+
+#include <iostream>
+#include <memory>
+
+#include "common/configbase.h"
+#include "fs/s3/poco_http_client_factory.h"
+
+namespace starrocks {
+
+namespace {
+
+Aws::Utils::Logging::LogLevel parse_aws_sdk_log_level(const std::string& s) {
+    Aws::Utils::Logging::LogLevel levels[] = {
+            Aws::Utils::Logging::LogLevel::Off,   Aws::Utils::Logging::LogLevel::Fatal,
+            Aws::Utils::Logging::LogLevel::Error, Aws::Utils::Logging::LogLevel::Warn,
+            Aws::Utils::Logging::LogLevel::Info,  Aws::Utils::Logging::LogLevel::Debug,
+            Aws::Utils::Logging::LogLevel::Trace,
+    };
+    std::string slevel = boost::algorithm::to_upper_copy(s);
+    Aws::Utils::Logging::LogLevel level = Aws::Utils::Logging::LogLevel::Warn;
+    for (auto& idx : levels) {
+        auto name = Aws::Utils::Logging::GetLogLevelName(idx);
+        if (name == slevel) {
+            level = idx;
+            break;
+        }
+    }
+    return level;
+}
+
+} // namespace
+
+AwsSdkGuard::AwsSdkGuard() {
+    // libcurl is already initialized beforehand.
+    _options.httpOptions.initAndCleanupCurl = false;
+    if (config::aws_sdk_logging_trace_enabled) {
+        auto level = parse_aws_sdk_log_level(config::aws_sdk_logging_trace_level);
+        std::cerr << "enable aws sdk logging trace. log level = " << Aws::Utils::Logging::GetLogLevelName(level)
+                  << "\n";
+        _options.loggingOptions.logLevel = level;
+    }
+    if (config::aws_sdk_enable_compliant_rfc3986_encoding) {
+        _options.httpOptions.compliantRfc3986Encoding = true;
+    }
+    Aws::InitAPI(_options);
+    if (config::enable_poco_client_for_aws_sdk) {
+        Aws::Http::SetHttpClientFactory(std::make_shared<poco::PocoHttpClientFactory>());
+    }
+}
+
+AwsSdkGuard::~AwsSdkGuard() {
+    Aws::ShutdownAPI(_options);
+}
+
+} // namespace starrocks
+#endif

--- a/be/src/fs/s3/aws_sdk_guard.cpp
+++ b/be/src/fs/s3/aws_sdk_guard.cpp
@@ -16,8 +16,8 @@
 #include "fs/s3/aws_sdk_guard.h"
 
 #include <aws/core/utils/logging/LogLevel.h>
-#include <boost/algorithm/string.hpp>
 
+#include <boost/algorithm/string.hpp>
 #include <iostream>
 #include <memory>
 

--- a/be/src/fs/s3/aws_sdk_guard.cpp
+++ b/be/src/fs/s3/aws_sdk_guard.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <memory>
 
+#include "common/config_object_storage_fwd.h"
 #include "common/configbase.h"
 #include "fs/s3/poco_http_client_factory.h"
 

--- a/be/src/fs/s3/aws_sdk_guard.h
+++ b/be/src/fs/s3/aws_sdk_guard.h
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef __APPLE__
+#include <aws/core/Aws.h>
+
+namespace starrocks {
+
+class AwsSdkGuard {
+public:
+    AwsSdkGuard();
+    ~AwsSdkGuard();
+
+    AwsSdkGuard(const AwsSdkGuard&) = delete;
+    AwsSdkGuard& operator=(const AwsSdkGuard&) = delete;
+    AwsSdkGuard(AwsSdkGuard&&) = delete;
+    AwsSdkGuard& operator=(AwsSdkGuard&&) = delete;
+
+private:
+    Aws::SDKOptions _options;
+};
+
+} // namespace starrocks
+#endif

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -44,12 +44,8 @@
 #include <thrift/TOutput.h>
 
 #ifndef __APPLE__
-#include <aws/core/Aws.h>
-
-#include "fs/s3/poco_http_client_factory.h"
+#include "fs/s3/aws_sdk_guard.h"
 #endif
-
-#include <boost/algorithm/string.hpp>
 
 #include "agent/agent_server.h"
 #include "agent/heartbeat_server.h"
@@ -100,27 +96,6 @@ static void thrift_output(const char* x) {
     LOG(WARNING) << "thrift internal message: " << x;
 }
 } // namespace starrocks
-
-#ifndef __APPLE__
-static Aws::Utils::Logging::LogLevel parse_aws_sdk_log_level(const std::string& s) {
-    Aws::Utils::Logging::LogLevel levels[] = {
-            Aws::Utils::Logging::LogLevel::Off,   Aws::Utils::Logging::LogLevel::Fatal,
-            Aws::Utils::Logging::LogLevel::Error, Aws::Utils::Logging::LogLevel::Warn,
-            Aws::Utils::Logging::LogLevel::Info,  Aws::Utils::Logging::LogLevel::Debug,
-            Aws::Utils::Logging::LogLevel::Trace,
-    };
-    std::string slevel = boost::algorithm::to_upper_copy(s);
-    Aws::Utils::Logging::LogLevel level = Aws::Utils::Logging::LogLevel::Warn;
-    for (auto& idx : levels) {
-        auto s = Aws::Utils::Logging::GetLogLevelName(idx);
-        if (s == slevel) {
-            level = idx;
-            break;
-        }
-    }
-    return level;
-}
-#endif
 
 extern int meta_tool_main(int argc, char** argv);
 
@@ -225,22 +200,7 @@ int main(int argc, char** argv) {
     }
 
 #ifndef __APPLE__
-    Aws::SDKOptions aws_sdk_options;
-    // it is already initialized beforehead
-    aws_sdk_options.httpOptions.initAndCleanupCurl = false;
-    if (starrocks::config::aws_sdk_logging_trace_enabled) {
-        auto level = parse_aws_sdk_log_level(starrocks::config::aws_sdk_logging_trace_level);
-        std::cerr << "enable aws sdk logging trace. log level = " << Aws::Utils::Logging::GetLogLevelName(level)
-                  << "\n";
-        aws_sdk_options.loggingOptions.logLevel = level;
-    }
-    if (starrocks::config::aws_sdk_enable_compliant_rfc3986_encoding) {
-        aws_sdk_options.httpOptions.compliantRfc3986Encoding = true;
-    }
-    Aws::InitAPI(aws_sdk_options);
-    if (starrocks::config::enable_poco_client_for_aws_sdk) {
-        Aws::Http::SetHttpClientFactory(std::make_shared<starrocks::poco::PocoHttpClientFactory>());
-    }
+    starrocks::AwsSdkGuard aws_sdk_guard;
 #endif
 
     EXIT_IF_ERROR(starrocks::fs::install_builtin_file_system_providers());
@@ -289,10 +249,6 @@ int main(int argc, char** argv) {
         LOG(INFO) << "BE is shutting down, will exit quickly";
         exit(0);
     }
-
-#ifndef __APPLE__
-    Aws::ShutdownAPI(aws_sdk_options);
-#endif
 
     return 0;
 }


### PR DESCRIPTION
## Why I'm doing:

Move the AWS SDK init and shutdown logic out of starrocks_main into a dedicated AwsSdkGuard class under fs/s3, so a single stack-allocated guard manages the SDK lifetime instead of paired InitAPI/ShutdownAPI calls around main.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
