### PR TITLE
[Enhancement] Add avrocpp-based Avro scanner for routine load

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -17,6 +17,7 @@
 #include "connector/file_scan_metrics.h"
 #include "exec/file_scanner/avro_cpp_scanner.h"
 #include "exec/file_scanner/avro_scanner.h"
+#include "exec/file_scanner/avro_stream_scanner.h"
 #include "exec/file_scanner/csv_scanner.h"
 #include "exec/file_scanner/json_scanner.h"
 #include "exec/file_scanner/orc_scanner.h"
@@ -104,8 +105,18 @@ Status FileDataSource::_create_scanner() {
              _scan_range.params.file_scan_type == TFileScanType::FILES_QUERY)) {
             _scanner = std::make_unique<AvroCppScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
         } else {
-            // avro routine load
-            _scanner = std::make_unique<AvroScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+            // avro routine load. FE resolves the per-job `avro.use_native_reader` property against its
+            // own default and sets use_native_avro_reader on every scan range, so the choice is uniform
+            // across BE nodes. Unset (older FE) falls back to the legacy scanner.
+            bool use_native =
+                    _scan_range.params.__isset.use_native_avro_reader && _scan_range.params.use_native_avro_reader;
+            if (use_native) {
+                // avrocpp stack (STRUCT/MAP support)
+                _scanner =
+                        std::make_unique<AvroStreamScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+            } else {
+                _scanner = std::make_unique<AvroScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+            }
         }
     } else {
         _scanner = std::make_unique<CSVScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -418,7 +418,10 @@ set(EXEC_NON_PIPELINE_FILES
     hdfs_scanner/hdfs_scanner.cpp
     hdfs_scanner/jni_scanner.cpp
     file_scanner/avro_cpp_scanner.cpp
+    file_scanner/avro_datum_path.cpp
     file_scanner/avro_scanner.cpp
+    file_scanner/avro_stream_scanner.cpp
+    file_scanner/confluent_avro_decoder.cpp
     file_scanner/csv_scanner.cpp
     file_scanner/file_scanner.cpp
     file_scanner/json_scanner.cpp

--- a/be/src/exec/file_scanner/avro_datum_path.cpp
+++ b/be/src/exec/file_scanner/avro_datum_path.cpp
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/avro_datum_path.h"
+
+#include <avrocpp/GenericDatum.hh>
+#include <avrocpp/Types.hh>
+
+#include "common/status.h"
+#include "gutil/strings/substitute.h"
+
+namespace starrocks {
+
+static void replace_all(std::string& str, const std::string& from, const std::string& to) {
+    size_t pos = 0;
+    while ((pos = str.find(from, pos)) != std::string::npos) {
+        str.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+}
+
+std::string avro_preprocess_jsonpaths(std::string jsonpaths) {
+    replace_all(jsonpaths, ".*.", ".");
+    replace_all(jsonpaths, ".*", "");
+    return jsonpaths;
+}
+
+// A nullable Avro field is encoded as a union; the decoded GenericDatum holds the selected branch.
+// Peel unions until a non-union (possibly null) branch is reached. Avro forbids unions of unions, so
+// the loop normally runs at most once; it stays a loop only for defensiveness.
+static const avro::GenericDatum* unwrap_union(const avro::GenericDatum* datum) {
+    while (datum->type() == avro::AVRO_UNION) {
+        datum = &datum->value<avro::GenericUnion>().datum();
+    }
+    return datum;
+}
+
+static StatusOr<const avro::GenericDatum*> array_element(const avro::GenericDatum* datum, int idx) {
+    const auto& elements = datum->value<avro::GenericArray>().value();
+    // idx < 0 covers the wildcard [*] (idx == -2), which is intentionally unsupported.
+    if (idx < 0 || static_cast<size_t>(idx) >= elements.size()) {
+        return Status::InternalError(
+                strings::Substitute("array index $0 out of range (size $1)", idx, elements.size()));
+    }
+    return &elements[idx];
+}
+
+// Looks up `key` in a record (by field name) or a map (linear scan of key/value pairs). avrocpp's
+// GenericMap has no by-key accessor, hence the linear scan; map lookups via jsonpath are rare.
+static StatusOr<const avro::GenericDatum*> lookup(const avro::GenericDatum* datum, const std::string& key) {
+    if (datum->type() == avro::AVRO_RECORD) {
+        const auto& record = datum->value<avro::GenericRecord>();
+        if (!record.hasField(key)) {
+            return Status::NotFound(strings::Substitute("field not found: $0", key));
+        }
+        return &record.field(key);
+    }
+    // AVRO_MAP
+    for (const auto& entry : datum->value<avro::GenericMap>().value()) {
+        if (entry.first == key) {
+            return &entry.second;
+        }
+    }
+    return Status::NotFound(strings::Substitute("map key not found: $0", key));
+}
+
+StatusOr<const avro::GenericDatum*> avro_extract_field(const avro::GenericDatum& root,
+                                                       const std::vector<SimpleJsonPath>& path) {
+    const avro::GenericDatum* cur = &root;
+
+    // Whole-datum selector "$": return it (after peeling a top-level union).
+    if (path.size() == 1 && path[0].key == "$" && path[0].idx == -1) {
+        return unwrap_union(cur);
+    }
+
+    // Peel a top-level union before the root checks, so a nullable top-level array still takes the
+    // root-index branch below; a null root value makes every path NULL.
+    cur = unwrap_union(cur);
+    if (cur->type() == avro::AVRO_NULL) {
+        return cur;
+    }
+
+    if (cur->type() == avro::AVRO_ARRAY) {
+        // Root is an array: only $[i] selects into it.
+        if (path[0].key != "$" || path[0].idx < 0) {
+            return Status::InternalError("the avro root type is an array, select a specific array element");
+        }
+        ASSIGN_OR_RETURN(cur, array_element(cur, path[0].idx));
+    } else if (path[0].idx != -1) {
+        // Deliberate divergence from the legacy reader, which silently ignores a root array index on
+        // a non-array root and returns the whole datum (e.g. $[0] on a record yields the record).
+        return Status::InternalError("jsonpath has a root array index but the avro root value is not an array");
+    }
+
+    // path[0] is "$"; descend through the remaining segments.
+    for (size_t i = 1; i < path.size(); ++i) {
+        cur = unwrap_union(cur);
+        if (cur->type() == avro::AVRO_NULL) {
+            return cur;
+        }
+        const auto type = cur->type();
+        if (type != avro::AVRO_RECORD && type != avro::AVRO_MAP) {
+            // Deliberate divergence from the legacy AvroScanner::_extract_field, which on the LAST
+            // segment returns the scalar itself (e.g. $.id.x on a long `id` silently yields `id`).
+            // The native reader is opt-in, so a path that overshoots a leaf fails loudly instead of
+            // loading the parent value into the wrong column.
+            return Status::InternalError(strings::Substitute(
+                    "jsonpath segment '$0' descends into a non-record/map avro value", path[i].key));
+        }
+        ASSIGN_OR_RETURN(cur, lookup(cur, path[i].key));
+
+        if (path[i].idx != -1) {
+            cur = unwrap_union(cur);
+            if (cur->type() == avro::AVRO_NULL) {
+                return cur;
+            }
+            if (cur->type() != avro::AVRO_ARRAY) {
+                return Status::InternalError("a non-array type was found where an array index was expected");
+            }
+            ASSIGN_OR_RETURN(cur, array_element(cur, path[i].idx));
+        }
+    }
+
+    return unwrap_union(cur);
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/avro_datum_path.h
+++ b/be/src/exec/file_scanner/avro_datum_path.h
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <avrocpp/Generic.hh>
+#include <vector>
+
+#include "common/statusor.h"
+#include "exprs/json_functions.h" // SimpleJsonPath
+
+namespace starrocks {
+
+// Rewrites a jsonpaths string for the avrocpp navigator: ".*." -> "." and a trailing ".*" -> "",
+// so paths written for the old union-tag style (e.g. "$.*.id") resolve as "$.id". Must run before
+// JsonFunctions::parse_json_paths.
+std::string avro_preprocess_jsonpaths(std::string jsonpaths);
+
+// Navigates a decoded Avro datum along a parsed jsonpath (the same SimpleJsonPath vector produced by
+// JsonFunctions::parse_json_paths) and returns a pointer to the selected sub-datum. The pointer is
+// valid only as long as `root` is alive and unmodified.
+//
+// Returns NotFound when a record/map key along the path is absent, so the caller can append a null.
+// Returns InternalError on a structural mismatch (e.g. indexing a non-array). Wildcard `[*]`
+// (idx == -2) is intentionally unsupported and reported as an error.
+StatusOr<const avro::GenericDatum*> avro_extract_field(const avro::GenericDatum& root,
+                                                       const std::vector<SimpleJsonPath>& path);
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/avro_stream_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_stream_scanner.cpp
@@ -1,0 +1,257 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/avro_stream_scanner.h"
+
+#include <fmt/format.h>
+
+#include <avrocpp/Exception.hh>
+#include <avrocpp/GenericDatum.hh>
+#include <avrocpp/Types.hh>
+
+#include "base/time/timezone_utils.h"
+#include "column/adaptive_nullable_column.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "common/runtime_profile.h"
+#include "exec/file_scanner/json_scanner.h" // JsonScanner::parse_json_paths
+#include "fs/fs.h"
+#include "gutil/casts.h"
+#include "runtime/runtime_state.h"
+#include "runtime/runtime_state_helper.h"
+#include "runtime/stream_load/stream_load_pipe.h"
+#include "util/byte_buffer.h"
+
+namespace starrocks {
+
+AvroStreamScanner::AvroStreamScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                                     ScannerCounter* counter)
+        : FileScanner(state, profile, scan_range.params, counter),
+          _scan_range(scan_range),
+          _max_chunk_size(state->chunk_size()) {
+    _file_format_str = "avro";
+}
+
+AvroStreamScanner::~AvroStreamScanner() = default;
+
+Status AvroStreamScanner::open() {
+    RETURN_IF_ERROR(FileScanner::open());
+    if (_scan_range.ranges.empty()) {
+        return Status::OK();
+    }
+
+    if (!TimezoneUtils::find_cctz_time_zone(_state->timezone(), _timezone)) {
+        return Status::InvalidArgument(fmt::format("can not find cctz time zone {}", _state->timezone()));
+    }
+
+    const TBrokerRangeDesc& range_desc = _scan_range.ranges[0];
+
+    if (!_scan_range.params.__isset.confluent_schema_registry_url) {
+        return Status::InternalError("'confluent_schema_registry_url' not set");
+    }
+    _decoder = std::make_unique<ConfluentAvroDecoder>(_scan_range.params.confluent_schema_registry_url);
+    RETURN_IF_ERROR(_decoder->init());
+
+    if (range_desc.__isset.jsonpaths) {
+        std::string jsonpaths = avro_preprocess_jsonpaths(range_desc.jsonpaths);
+        RETURN_IF_ERROR(JsonScanner::parse_json_paths(jsonpaths, &_json_paths));
+    }
+
+    RETURN_IF_ERROR(create_column_readers());
+    RETURN_IF_ERROR(create_sequential_file(range_desc, _scan_range.broker_addresses[0], _scan_range.params, &_file));
+    ++_counter->num_files_read;
+    return Status::OK();
+}
+
+Status AvroStreamScanner::create_column_readers() {
+    _column_readers.resize(_src_slot_descriptors.size());
+    _field_names.resize(_src_slot_descriptors.size());
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        auto* slot_desc = _src_slot_descriptors[i];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        _column_readers[i] = avrocpp::ColumnReader::get_nullable_column_reader(slot_desc->col_name(), slot_desc->type(),
+                                                                               _timezone, !_strict_mode);
+        // Materialize the avro field name once; fill_row() reuses it per message instead of rebuilding a
+        // std::string from the pmr-backed col_name() string_view for every cell.
+        _field_names[i] = slot_desc->col_name();
+    }
+    return Status::OK();
+}
+
+Status AvroStreamScanner::create_src_chunk(ChunkPtr* chunk) {
+    SCOPED_RAW_TIMER(&_counter->init_chunk_ns);
+    *chunk = std::make_shared<Chunk>();
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        auto* slot_desc = _src_slot_descriptors[i];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        auto column = ColumnHelper::create_column(slot_desc->type(), true, false, 0, true);
+        (*chunk)->append_column(std::move(column), slot_desc->id());
+    }
+    return Status::OK();
+}
+
+Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk) {
+    const bool use_jsonpath = !_json_paths.empty();
+
+    const avro::GenericRecord* record = nullptr;
+    if (!use_jsonpath) {
+        const avro::GenericDatum* d = &datum;
+        while (d->type() == avro::AVRO_UNION) {
+            d = &d->value<avro::GenericUnion>().datum();
+        }
+        if (d->type() != avro::AVRO_RECORD) {
+            return Status::InternalError("avro message top-level value is not a record");
+        }
+        record = &d->value<avro::GenericRecord>();
+    }
+
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        auto* slot_desc = _src_slot_descriptors[i];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        auto* column = down_cast<AdaptiveNullableColumn*>(chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()));
+
+        if (use_jsonpath) {
+            if (i >= _json_paths.size()) {
+                column->append_nulls(1);
+                continue;
+            }
+            auto extracted = avro_extract_field(datum, _json_paths[i]);
+            if (extracted.status().is_not_found()) {
+                column->append_nulls(1);
+                continue;
+            }
+            RETURN_IF_ERROR(extracted.status());
+            RETURN_IF_ERROR(_column_readers[i]->read_datum_for_adaptive_column(*extracted.value(), column));
+        } else {
+            // GenericRecord::hasField/field take const std::string&; reuse the name materialized once in
+            // create_column_readers() (col_name() is a pmr-backed std::string_view).
+            const std::string& field_name = _field_names[i];
+            if (record->hasField(field_name)) {
+                RETURN_IF_ERROR(_column_readers[i]->read_datum_for_adaptive_column(record->field(field_name), column));
+            } else {
+                column->append_nulls(1);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status AvroStreamScanner::parse_one_message(const uint8_t* data, size_t size, Chunk* chunk) {
+    const size_t rows_before = chunk->num_rows();
+
+    Status st = _decoder->decode(data, size, &_datum);
+    if (!st.ok()) {
+        _counter->num_rows_filtered++;
+        RuntimeStateHelper::append_error_msg_to_file(_state, "", st.to_string());
+        return st;
+    }
+
+    // decode() converts avrocpp exceptions to Status itself; the readers below it do not, and a datum
+    // shape the guards don't anticipate must cost one filtered row, never the BE.
+    try {
+        st = fill_row(_datum, chunk);
+    } catch (const avro::Exception& e) {
+        st = Status::DataQualityError(fmt::format("avro read failed: {}", e.what()));
+    }
+    if (!st.ok()) {
+        if (_counter->num_rows_filtered++ < MAX_ERROR_LINES_IN_FILE) {
+            RuntimeStateHelper::append_error_msg_to_file(_state, "", st.to_string());
+        }
+        chunk->set_num_rows(rows_before);
+        return st;
+    }
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> AvroStreamScanner::get_next() {
+    SCOPED_RAW_TIMER(&_counter->total_ns);
+    // open() succeeds without initializing _file when the scan range carries no ranges.
+    if (_file == nullptr) {
+        return Status::EndOfFile("no avro ranges to read");
+    }
+    ChunkPtr src_chunk;
+    RETURN_IF_ERROR(create_src_chunk(&src_chunk));
+
+    auto* stream = down_cast<StreamLoadPipeInputStream*>(_file->stream().get());
+
+    Status st = Status::OK();
+    while (src_chunk->num_rows() < static_cast<size_t>(_max_chunk_size)) {
+        ByteBufferPtr buf;
+        {
+            ++_counter->file_read_count;
+            SCOPED_RAW_TIMER(&_counter->file_read_ns);
+            auto res = stream->pipe()->read();
+            if (!res.ok()) {
+                st = res.status();
+                break;
+            }
+            buf = std::move(res.value());
+        }
+        if (buf == nullptr || buf->remaining() == 0) {
+            continue;
+        }
+        // Confluent framing requires one message per buffer; StreamLoadPipe::read() returns the whole
+        // buffer that KafkaConsumerPipe::append_json enqueued, so each buffer is exactly one message.
+        RETURN_IF_ERROR(
+                parse_one_message(reinterpret_cast<const uint8_t*>(buf->ptr), buf->remaining(), src_chunk.get()));
+    }
+
+    // A non-timeout/non-EOF read error (cancel/abort/internal) is fatal regardless of how many rows
+    // were already filled, matching the legacy AvroScanner. Otherwise it would be deferred to the next
+    // get_next(), or lost entirely if the caller stops after consuming this chunk.
+    if (!st.ok() && !st.is_time_out() && !st.is_end_of_file()) {
+        return st;
+    }
+
+    if (src_chunk->num_rows() == 0) {
+        if (st.is_end_of_file()) {
+            return Status::EndOfFile("EOF of reading avro stream, nothing read");
+        }
+        // Timeout with nothing read yet: surface it so the task retries; with rows already filled we
+        // fall through and materialize what we have (legacy behavior).
+        if (st.is_time_out()) {
+            return st;
+        }
+    }
+
+    materialize_src_chunk_adaptive_nullable_column(src_chunk);
+    return materialize(src_chunk, src_chunk);
+}
+
+void AvroStreamScanner::materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk) {
+    chunk->materialized_nullable();
+    for (int i = 0; i < chunk->num_columns(); i++) {
+        auto* adaptive_column = down_cast<AdaptiveNullableColumn*>(chunk->get_column_raw_ptr_by_index(i));
+        chunk->update_column_by_index(NullableColumn::create(adaptive_column->materialized_raw_data_column(),
+                                                             adaptive_column->materialized_raw_null_column()),
+                                      i);
+    }
+}
+
+void AvroStreamScanner::close() {
+    if (!_closed) {
+        _file.reset();
+        _closed = true;
+    }
+    FileScanner::close();
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/avro_stream_scanner.h
+++ b/be/src/exec/file_scanner/avro_stream_scanner.h
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <avrocpp/Generic.hh>
+
+#include "exec/file_scanner/avro_datum_path.h"
+#include "exec/file_scanner/confluent_avro_decoder.h"
+#include "exec/file_scanner/file_scanner.h"
+#include "formats/avro/cpp/column_reader.h"
+
+namespace starrocks {
+
+class SequentialFile;
+
+// Routine-load (Kafka) Avro scanner on the avrocpp stack. Reads one Confluent-framed message per pipe
+// buffer, decodes it to an avro::GenericDatum, and fills columns through the avrocpp column readers
+// (which support STRUCT/MAP/ARRAY). Selected per job via the thrift use_native_avro_reader flag, which
+// the FE resolves at job creation (defaulting to the FE config enable_routine_load_native_avro_reader).
+// Pulsar avro never reaches here: PulsarTaskInfo sends every non-json format to the BE as CSV_PLAIN.
+class AvroStreamScanner final : public FileScanner {
+public:
+    AvroStreamScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                      ScannerCounter* counter);
+    ~AvroStreamScanner() override;
+
+    Status open() override;
+    StatusOr<ChunkPtr> get_next() override;
+    void close() override;
+
+private:
+    Status create_column_readers();
+    Status create_src_chunk(ChunkPtr* chunk);
+    // Decodes one message and appends one row; per-field "not found" becomes null, while decode and
+    // structural failures return an error and fail the task.
+    Status parse_one_message(const uint8_t* data, size_t size, Chunk* chunk);
+    Status fill_row(const avro::GenericDatum& datum, Chunk* chunk);
+    void materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk);
+
+    const TBrokerScanRange& _scan_range;
+    const int _max_chunk_size;
+    cctz::time_zone _timezone;
+    std::unique_ptr<ConfluentAvroDecoder> _decoder;
+    std::vector<avrocpp::ColumnReaderUniquePtr> _column_readers;
+    // Avro field name per source slot (parallel to _column_readers), materialized once in
+    // create_column_readers() so the non-jsonpath fill_row() does not rebuild a std::string per cell.
+    std::vector<std::string> _field_names;
+    std::vector<std::vector<SimpleJsonPath>> _json_paths;
+    std::shared_ptr<SequentialFile> _file;
+    // Reused across messages; the GenericDatum from the previous message is overwritten on each decode.
+    avro::GenericDatum _datum;
+    bool _closed = false;
+};
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/confluent_avro_decoder.cpp
+++ b/be/src/exec/file_scanner/confluent_avro_decoder.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/confluent_avro_decoder.h"
+
+#include <fmt/format.h>
+
+#include <avrocpp/Compiler.hh>
+#include <avrocpp/Decoder.hh>
+#include <avrocpp/Exception.hh>
+#include <avrocpp/Stream.hh>
+
+namespace starrocks {
+
+ConfluentAvroDecoder::ConfluentAvroDecoder(std::string schema_registry_url)
+        : _test_mode(false), _registry_url(std::move(schema_registry_url)) {}
+
+ConfluentAvroDecoder::ConfluentAvroDecoder(avro::ValidSchema test_schema)
+        : _test_mode(true), _test_schema(std::move(test_schema)) {}
+
+ConfluentAvroDecoder::~ConfluentAvroDecoder() {
+    if (_serdes != nullptr) {
+        serdes_destroy(_serdes);
+        _serdes = nullptr;
+    }
+}
+
+Status ConfluentAvroDecoder::init() {
+    if (_test_mode) {
+        return Status::OK();
+    }
+    // serdes_new takes ownership of the conf object.
+    serdes_conf_t* conf = serdes_conf_new(nullptr, 0, "schema.registry.url", _registry_url.c_str(), NULL);
+    _serdes = serdes_new(conf, _err_buf, sizeof(_err_buf));
+    if (_serdes == nullptr) {
+        return Status::InternalError(fmt::format("failed to create serdes handle: {}", _err_buf));
+    }
+    return Status::OK();
+}
+
+StatusOr<const avro::ValidSchema*> ConfluentAvroDecoder::_resolve(int32_t schema_id, serdes_schema_t* serdes_schema) {
+    if (auto it = _schema_cache.find(schema_id); it != _schema_cache.end()) {
+        return &it->second;
+    }
+    const char* definition = serdes_schema_definition(serdes_schema);
+    if (definition == nullptr) {
+        return Status::InternalError(fmt::format("empty schema definition for schema id {}", schema_id));
+    }
+    // compileJsonSchemaFromString may throw avro::Exception on malformed JSON; decode() catches it.
+    avro::ValidSchema valid_schema = avro::compileJsonSchemaFromString(definition);
+    auto [it, _] = _schema_cache.emplace(schema_id, std::move(valid_schema));
+    return &it->second;
+}
+
+Status ConfluentAvroDecoder::decode(const uint8_t* data, size_t size, avro::GenericDatum* datum) {
+    try {
+        const avro::ValidSchema* schema = nullptr;
+        const uint8_t* payload = data;
+        size_t payload_size = size;
+
+        if (_test_mode) {
+            // Input is a raw Avro datum without Confluent framing.
+            schema = &_test_schema;
+        } else {
+            // serdes_framing_read strips the Confluent framing per the serdes config, advances the
+            // payload pointer/length past it, and resolves the writer schema (registry-cached).
+            const void* p = data;
+            size_t sz = size;
+            serdes_schema_t* serdes_schema = nullptr;
+            ssize_t framing = serdes_framing_read(_serdes, &p, &sz, &serdes_schema, _err_buf, sizeof(_err_buf));
+            if (framing == -1 || serdes_schema == nullptr) {
+                return Status::InternalError(fmt::format("confluent framing/schema resolve failed: {}", _err_buf));
+            }
+            payload = static_cast<const uint8_t*>(p);
+            payload_size = sz;
+            ASSIGN_OR_RETURN(schema, _resolve(serdes_schema_id(serdes_schema), serdes_schema));
+        }
+
+        auto input = avro::memoryInputStream(payload, payload_size);
+        avro::DecoderPtr decoder = avro::binaryDecoder();
+        decoder->init(*input);
+        avro::GenericReader::read(*decoder, *datum, *schema);
+        return Status::OK();
+    } catch (const avro::Exception& e) {
+        return Status::InternalError(fmt::format("avro decode failed: {}", e.what()));
+    }
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/confluent_avro_decoder.h
+++ b/be/src/exec/file_scanner/confluent_avro_decoder.h
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <avrocpp/Generic.hh>
+#include <avrocpp/ValidSchema.hh>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "common/status.h"
+#include "common/statusor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "libserdes/serdes.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+// Decodes one Confluent-wire-format Avro message (magic byte 0x00 + 4-byte big-endian schema id +
+// raw Avro datum) into an avro::GenericDatum, resolving the writer schema by id from the Confluent
+// Schema Registry via libserdes.
+//
+// The compiled ValidSchema is cached per schema id. Schema ids are immutable, so the cache never
+// needs invalidation. libserdes already caches the raw registry schema; the only thing cached here
+// is the JSON->ValidSchema compilation.
+class ConfluentAvroDecoder {
+public:
+    // Production: resolve schemas from the Confluent Schema Registry at `schema_registry_url`.
+    // init() must be called before decode().
+    explicit ConfluentAvroDecoder(std::string schema_registry_url);
+
+    // Test: a single fixed writer schema, no registry/serdes. decode() then treats the input as a
+    // raw Avro datum without Confluent framing.
+    explicit ConfluentAvroDecoder(avro::ValidSchema test_schema);
+
+    ~ConfluentAvroDecoder();
+
+    ConfluentAvroDecoder(const ConfluentAvroDecoder&) = delete;
+    ConfluentAvroDecoder& operator=(const ConfluentAvroDecoder&) = delete;
+
+    // Creates the serdes handle (production mode); no-op in test mode.
+    Status init();
+
+    // Decodes one message into `datum`. `datum` may be reused across calls by the caller.
+    // Any framing/registry/decode failure returns InternalError.
+    Status decode(const uint8_t* data, size_t size, avro::GenericDatum* datum);
+
+private:
+    // Returns the compiled ValidSchema for `schema_id`, compiling+caching it from `serdes_schema`
+    // on first use. May throw avro::Exception on malformed schema JSON (caught by decode()).
+    StatusOr<const avro::ValidSchema*> _resolve(int32_t schema_id, serdes_schema_t* serdes_schema);
+
+    const bool _test_mode;
+    std::string _registry_url;
+    serdes_t* _serdes = nullptr;
+    std::unordered_map<int32_t, avro::ValidSchema> _schema_cache;
+    avro::ValidSchema _test_schema;
+    char _err_buf[512];
+};
+
+} // namespace starrocks

--- a/be/src/formats/avro/cpp/complex_column_reader.cpp
+++ b/be/src/formats/avro/cpp/complex_column_reader.cpp
@@ -29,7 +29,12 @@ StructColumnReader::StructColumnReader(std::string_view col_name, const TypeDesc
 }
 
 Status StructColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    DCHECK_EQ(datum.type(), avro::AVRO_RECORD);
+    // The reader is built from the table column type while the datum carries whatever the writer sent,
+    // so a kind mismatch is reachable data, not a programming error: value<T>() on it would crash.
+    if (UNLIKELY(datum.type() != avro::AVRO_RECORD)) {
+        return Status::DataQualityError(
+                fmt::format("Unsupported avro type {} to struct. column: {}", avro::toString(datum.type()), _col_name));
+    }
 
     auto struct_column = down_cast<StructColumn*>(column);
     const auto& record = datum.value<avro::GenericRecord>();
@@ -52,7 +57,10 @@ Status StructColumnReader::read_datum(const avro::GenericDatum& datum, Column* c
 }
 
 Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    DCHECK_EQ(datum.type(), avro::AVRO_ARRAY);
+    if (UNLIKELY(datum.type() != avro::AVRO_ARRAY)) {
+        return Status::DataQualityError(
+                fmt::format("Unsupported avro type {} to array. column: {}", avro::toString(datum.type()), _col_name));
+    }
 
     auto array_column = down_cast<ArrayColumn*>(column);
     auto* elements_column = array_column->elements_column_raw_ptr();
@@ -78,12 +86,23 @@ Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* co
 }
 
 Status MapColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    DCHECK_EQ(datum.type(), avro::AVRO_MAP);
+    if (UNLIKELY(datum.type() != avro::AVRO_MAP)) {
+        return Status::DataQualityError(
+                fmt::format("Unsupported avro type {} to map. column: {}", avro::toString(datum.type()), _col_name));
+    }
 
     auto map_column = down_cast<MapColumn*>(column);
     auto keys_column = down_cast<NullableColumn*>(map_column->keys_column_raw_ptr());
     auto* values_column = map_column->values_column_raw_ptr();
     auto* offsets_column = map_column->offsets_column_raw_ptr();
+
+    // Avro map keys are always strings, and the key path below appends raw bytes into a binary key
+    // column. FILES() always types the key column VARCHAR (inferred schema), but routine load types it
+    // straight from the table, so e.g. MAP<INT,...> reaches here: reject it instead of corrupting it.
+    if (_key_reader != nullptr && UNLIKELY(!keys_column->data_column_raw_ptr()->is_binary())) {
+        return Status::DataQualityError(
+                fmt::format("avro map keys are strings; the key type of map column '{}' cannot hold them", _col_name));
+    }
 
     const auto& map = datum.value<avro::GenericMap>();
     const auto& map_values = map.value();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -125,7 +125,10 @@ set(EXEC_FILES
         ./exec/table_function_node_test.cpp
         ./exec/olap_scan_prepare_test.cpp
         ./exec/file_scanner/avro_cpp_scanner_test.cpp
+        ./exec/file_scanner/avro_datum_path_test.cpp
         ./exec/file_scanner/avro_scanner_test.cpp
+        ./exec/file_scanner/avro_struct_map_test.cpp
+        ./exec/file_scanner/confluent_avro_decoder_test.cpp
         ./exec/file_scanner/csv_scanner_test.cpp
         ./exec/file_scanner/file_scanner_test.cpp
         ./exec/file_scanner/json_scanner_test.cpp

--- a/be/test/exec/file_scanner/avro_datum_path_test.cpp
+++ b/be/test/exec/file_scanner/avro_datum_path_test.cpp
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/avro_datum_path.h"
+
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <vector>
+
+#include "exec/file_scanner/confluent_avro_decoder.h"
+#include "exprs/json_functions.h"
+
+namespace starrocks {
+
+// Builds one decoded GenericDatum from a fixed schema and hand-encoded Avro binary, then exercises
+// the jsonpath navigator against it (record descent, array index, nullable-union, missing field).
+class AvroDatumPathTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        static const char* kJson = R"({
+            "type": "record",
+            "name": "r",
+            "fields": [
+                {"name": "id", "type": "long"},
+                {"name": "nested", "type": {"type": "record", "name": "n",
+                                            "fields": [{"name": "x", "type": "long"}]}},
+                {"name": "arr", "type": {"type": "array", "items": "long"}},
+                {"name": "opt", "type": ["null", "long"]}
+            ]
+        })";
+        _decoder = std::make_unique<ConfluentAvroDecoder>(avro::compileJsonSchemaFromString(kJson));
+        ASSERT_TRUE(_decoder->init().ok());
+
+        // {id: 5, nested: {x: 7}, arr: [1, 2], opt: null}
+        //   id        long 5  -> zigzag 10 -> 0x0A
+        //   nested.x  long 7  -> zigzag 14 -> 0x0E
+        //   arr       block count 2 (0x04), items 1 (0x02) 2 (0x04), end block 0 (0x00)
+        //   opt       union branch 0 (null) -> 0x00
+        const std::vector<uint8_t> bytes = {0x0A, 0x0E, 0x04, 0x02, 0x04, 0x00, 0x00};
+        ASSERT_TRUE(_decoder->decode(bytes.data(), bytes.size(), &_datum).ok());
+    }
+
+    std::vector<SimpleJsonPath> path(const std::string& p) {
+        std::vector<SimpleJsonPath> parsed;
+        CHECK(JsonFunctions::parse_json_paths(p, &parsed).ok());
+        return parsed;
+    }
+
+    std::unique_ptr<ConfluentAvroDecoder> _decoder;
+    avro::GenericDatum _datum;
+};
+
+TEST_F(AvroDatumPathTest, top_level_field) {
+    auto r = avro_extract_field(_datum, path("$.id"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{5}, r.value()->value<int64_t>());
+}
+
+TEST_F(AvroDatumPathTest, nested_record) {
+    auto r = avro_extract_field(_datum, path("$.nested.x"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{7}, r.value()->value<int64_t>());
+}
+
+TEST_F(AvroDatumPathTest, array_index) {
+    auto r = avro_extract_field(_datum, path("$.arr[1]"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{2}, r.value()->value<int64_t>());
+}
+
+TEST_F(AvroDatumPathTest, array_index_out_of_range_errors) {
+    auto r = avro_extract_field(_datum, path("$.arr[9]"));
+    EXPECT_FALSE(r.ok());
+    EXPECT_FALSE(r.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, nullable_union_null_branch) {
+    auto r = avro_extract_field(_datum, path("$.opt"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(avro::AVRO_NULL, r.value()->type());
+}
+
+TEST_F(AvroDatumPathTest, path_through_scalar_leaf_errors) {
+    // $.id.x on a long `id`: the legacy reader silently returns `id`; the native reader rejects it.
+    auto r = avro_extract_field(_datum, path("$.id.x"));
+    EXPECT_FALSE(r.ok());
+    EXPECT_FALSE(r.status().is_not_found());
+
+    auto deep = avro_extract_field(_datum, path("$.nested.x.y"));
+    EXPECT_FALSE(deep.ok());
+    EXPECT_FALSE(deep.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, missing_field_is_not_found) {
+    auto r = avro_extract_field(_datum, path("$.missing"));
+    EXPECT_TRUE(r.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, whole_datum) {
+    auto r = avro_extract_field(_datum, path("$"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(avro::AVRO_RECORD, r.value()->type());
+}
+
+TEST_F(AvroDatumPathTest, root_index_on_non_array_errors) {
+    // $[0] on a record root: the legacy reader silently ignores the index and returns the whole
+    // record; the native reader rejects it.
+    auto r = avro_extract_field(_datum, path("$[0]"));
+    EXPECT_FALSE(r.ok());
+    EXPECT_FALSE(r.status().is_not_found());
+
+    auto deep = avro_extract_field(_datum, path("$[0].id"));
+    EXPECT_FALSE(deep.ok());
+    EXPECT_FALSE(deep.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, array_root) {
+    ConfluentAvroDecoder decoder(avro::compileJsonSchemaFromString(R"({"type":"array","items":"long"})"));
+    ASSERT_TRUE(decoder.init().ok());
+    // [7, 9]: block count 2 (0x04), items 7 (0x0E) 9 (0x12), end block 0 (0x00)
+    const std::vector<uint8_t> bytes = {0x04, 0x0E, 0x12, 0x00};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(bytes.data(), bytes.size(), &datum).ok());
+
+    auto r = avro_extract_field(datum, path("$[1]"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{9}, r.value()->value<int64_t>());
+
+    // A field selector on an array root is invalid.
+    auto bad = avro_extract_field(datum, path("$.x"));
+    EXPECT_FALSE(bad.ok());
+    EXPECT_FALSE(bad.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, nullable_array_root) {
+    // ["null", array<long>] top-level union: the root union is peeled before the root-array branch,
+    // so $[i] still indexes a nullable array, and a null root yields NULL for any path.
+    ConfluentAvroDecoder decoder(avro::compileJsonSchemaFromString(R"(["null", {"type":"array","items":"long"}])"));
+    ASSERT_TRUE(decoder.init().ok());
+
+    // union branch 1 (0x02), array [5]: count 1 (0x02), item 5 (0x0A), end block 0 (0x00)
+    const std::vector<uint8_t> bytes = {0x02, 0x02, 0x0A, 0x00};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(bytes.data(), bytes.size(), &datum).ok());
+    auto r = avro_extract_field(datum, path("$[0]"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{5}, r.value()->value<int64_t>());
+
+    // union branch 0 (null)
+    const std::vector<uint8_t> null_bytes = {0x00};
+    avro::GenericDatum null_datum;
+    ASSERT_TRUE(decoder.decode(null_bytes.data(), null_bytes.size(), &null_datum).ok());
+    auto n = avro_extract_field(null_datum, path("$[0]"));
+    ASSERT_TRUE(n.ok());
+    EXPECT_EQ(avro::AVRO_NULL, n.value()->type());
+}
+
+TEST_F(AvroDatumPathTest, preprocess_jsonpaths_rewrites_union_star) {
+    EXPECT_EQ("$.id", avro_preprocess_jsonpaths("$.*.id"));
+    EXPECT_EQ("$.a.b", avro_preprocess_jsonpaths("$.a.*.b"));
+    EXPECT_EQ("$.a", avro_preprocess_jsonpaths("$.a.*"));
+}
+
+} // namespace starrocks

--- a/be/test/exec/file_scanner/avro_struct_map_test.cpp
+++ b/be/test/exec/file_scanner/avro_struct_map_test.cpp
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cctz/time_zone.h>
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <vector>
+
+#include "column/column_helper.h"
+#include "exec/file_scanner/confluent_avro_decoder.h"
+#include "formats/avro/cpp/column_reader.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+// Proves STRUCT and MAP end-to-end on the routine-load decode path: decode a message into a
+// GenericDatum (ConfluentAvroDecoder), then fill columns with the same avrocpp column readers the
+// scanner uses, and check the rendered values. No pipe/scanner needed.
+class AvroStructMapTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        static const char* kJson = R"({
+            "type": "record",
+            "name": "r",
+            "fields": [
+                {"name": "s", "type": {"type": "record", "name": "inner",
+                                       "fields": [{"name": "a", "type": "long"},
+                                                  {"name": "b", "type": "string"}]}},
+                {"name": "m", "type": {"type": "map", "values": "long"}}
+            ]
+        })";
+        _decoder = std::make_unique<ConfluentAvroDecoder>(avro::compileJsonSchemaFromString(kJson));
+        ASSERT_TRUE(_decoder->init().ok());
+
+        // {s: {a: 1, b: "x"}, m: {"k1": 10, "k2": 20}}
+        //   s.a   long 1     -> 0x02
+        //   s.b   string "x" -> len 1 (0x02) + 'x' (0x78)
+        //   m     map block count 2 (0x04),
+        //           "k1" (len 2 -> 0x04) 'k'(0x6B)'1'(0x31), value 10 (0x14),
+        //           "k2" (len 2 -> 0x04) 'k'(0x6B)'2'(0x32), value 20 (0x28),
+        //         end block 0 (0x00)
+        const std::vector<uint8_t> bytes = {0x02, 0x02, 0x78, 0x04, 0x04, 0x6B, 0x31,
+                                            0x14, 0x04, 0x6B, 0x32, 0x28, 0x00};
+        ASSERT_TRUE(_decoder->decode(bytes.data(), bytes.size(), &_datum).ok());
+        _tz = cctz::utc_time_zone();
+    }
+
+    std::unique_ptr<ConfluentAvroDecoder> _decoder;
+    avro::GenericDatum _datum;
+    cctz::time_zone _tz;
+};
+
+TEST_F(AvroStructMapTest, struct_field) {
+    auto type = TypeDescriptor::create_struct_type(
+            {"a", "b"}, {TypeDescriptor(TYPE_BIGINT), TypeDescriptor::create_varchar_type(16)});
+    auto reader = avrocpp::ColumnReader::get_nullable_column_reader("s", type, _tz, /*invalid_as_null=*/true);
+    auto column = ColumnHelper::create_column(type, true);
+
+    const auto& field = _datum.value<avro::GenericRecord>().field("s");
+    ASSERT_TRUE(reader->read_datum(field, column.get()).ok());
+    EXPECT_EQ("{a:1,b:'x'}", column->debug_item(0));
+}
+
+TEST_F(AvroStructMapTest, map_field) {
+    auto type = TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(16), TypeDescriptor(TYPE_BIGINT));
+    auto reader = avrocpp::ColumnReader::get_nullable_column_reader("m", type, _tz, /*invalid_as_null=*/true);
+    auto column = ColumnHelper::create_column(type, true);
+
+    const auto& field = _datum.value<avro::GenericRecord>().field("m");
+    ASSERT_TRUE(reader->read_datum(field, column.get()).ok());
+    EXPECT_EQ("{'k1':10,'k2':20}", column->debug_item(0));
+}
+
+TEST_F(AvroStructMapTest, map_with_non_string_key_column_is_rejected) {
+    // Avro map keys are always strings; a MAP<INT,...> column must yield a data error (NULL in
+    // non-strict mode), not raw string bytes appended into the integer key column.
+    auto type = TypeDescriptor::create_map_type(TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_BIGINT));
+    const auto& field = _datum.value<avro::GenericRecord>().field("m");
+
+    auto strict_reader = avrocpp::ColumnReader::get_nullable_column_reader("m", type, _tz, /*invalid_as_null=*/false);
+    auto column = ColumnHelper::create_column(type, true);
+    auto st = strict_reader->read_datum(field, column.get());
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_data_quality_error());
+
+    auto lax_reader = avrocpp::ColumnReader::get_nullable_column_reader("m", type, _tz, /*invalid_as_null=*/true);
+    auto lax_column = ColumnHelper::create_column(type, true);
+    ASSERT_TRUE(lax_reader->read_datum(field, lax_column.get()).ok());
+    EXPECT_EQ("NULL", lax_column->debug_item(0));
+}
+
+TEST_F(AvroStructMapTest, kind_mismatched_datum_is_rejected) {
+    // The reader is built from the table column type while the datum carries whatever the writer
+    // sent: a scalar datum routed into a STRUCT/MAP/ARRAY column must yield a data error (NULL in
+    // non-strict mode), not a crashing value<T>() cast.
+    const auto& scalar = _datum.value<avro::GenericRecord>().field("s").value<avro::GenericRecord>().field("a");
+    const std::vector<TypeDescriptor> types = {
+            TypeDescriptor::create_struct_type({"a"}, {TypeDescriptor(TYPE_BIGINT)}),
+            TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(16), TypeDescriptor(TYPE_BIGINT)),
+            TypeDescriptor::create_array_type(TypeDescriptor(TYPE_BIGINT)),
+    };
+    for (const auto& type : types) {
+        auto strict_reader =
+                avrocpp::ColumnReader::get_nullable_column_reader("c", type, _tz, /*invalid_as_null=*/false);
+        auto column = ColumnHelper::create_column(type, true);
+        auto st = strict_reader->read_datum(scalar, column.get());
+        ASSERT_FALSE(st.ok()) << type.debug_string();
+        EXPECT_TRUE(st.is_data_quality_error()) << type.debug_string();
+
+        auto lax_reader = avrocpp::ColumnReader::get_nullable_column_reader("c", type, _tz, /*invalid_as_null=*/true);
+        auto lax_column = ColumnHelper::create_column(type, true);
+        ASSERT_TRUE(lax_reader->read_datum(scalar, lax_column.get()).ok()) << type.debug_string();
+        EXPECT_EQ("NULL", lax_column->debug_item(0)) << type.debug_string();
+    }
+}
+
+// The decoder must preserve the Avro logicalType so DateColumnReader interprets a logical `date`
+// (int days since epoch) as a DATE, rather than the raw day count the legacy reader would yield.
+TEST_F(AvroStructMapTest, logical_date) {
+    auto schema = avro::compileJsonSchemaFromString(R"({
+        "type": "record",
+        "name": "r",
+        "fields": [{"name": "d", "type": {"type": "int", "logicalType": "date"}}]
+    })");
+    ConfluentAvroDecoder decoder(schema);
+    ASSERT_TRUE(decoder.init().ok());
+
+    // date = 5 days since epoch -> 1970-01-06; int 5 -> zigzag 10 -> 0x0A
+    const std::vector<uint8_t> bytes = {0x0A};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(bytes.data(), bytes.size(), &datum).ok());
+
+    auto type = TypeDescriptor(TYPE_DATE);
+    auto reader = avrocpp::ColumnReader::get_nullable_column_reader("d", type, _tz, /*invalid_as_null=*/true);
+    auto column = ColumnHelper::create_column(type, true);
+    ASSERT_TRUE(reader->read_datum(datum.value<avro::GenericRecord>().field("d"), column.get()).ok());
+    EXPECT_EQ("1970-01-06", column->debug_item(0));
+}
+
+} // namespace starrocks

--- a/be/test/exec/file_scanner/confluent_avro_decoder_test.cpp
+++ b/be/test/exec/file_scanner/confluent_avro_decoder_test.cpp
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/confluent_avro_decoder.h"
+
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <vector>
+
+namespace starrocks {
+
+// Schema-injection mode treats input as a raw Avro datum without Confluent framing, so these tests
+// run compile-schema -> GenericReader::read -> GenericDatum without a schema registry.
+class ConfluentAvroDecoderTest : public ::testing::Test {
+protected:
+    static avro::ValidSchema record_schema() {
+        // record { long id; string name }
+        static const char* kJson = R"({
+            "type": "record",
+            "name": "r",
+            "fields": [
+                {"name": "id", "type": "long"},
+                {"name": "name", "type": "string"}
+            ]
+        })";
+        return avro::compileJsonSchemaFromString(kJson);
+    }
+};
+
+TEST_F(ConfluentAvroDecoderTest, decode_raw_datum) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    // Hand-encoded Avro binary for {id: 27, name: "hi"}:
+    //   id   = long 27   -> zigzag(27)=54 -> varint 0x36
+    //   name = string    -> length 2 -> zigzag(2)=4 -> 0x04, then UTF-8 'h'(0x68) 'i'(0x69)
+    const std::vector<uint8_t> payload = {0x36, 0x04, 0x68, 0x69};
+
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(payload.data(), payload.size(), &datum).ok());
+
+    ASSERT_EQ(avro::AVRO_RECORD, datum.type());
+    const auto& record = datum.value<avro::GenericRecord>();
+    EXPECT_EQ(int64_t{27}, record.field("id").value<int64_t>());
+    EXPECT_EQ("hi", record.field("name").value<std::string>());
+}
+
+TEST_F(ConfluentAvroDecoderTest, decode_reuses_datum_across_calls) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    avro::GenericDatum datum;
+    const std::vector<uint8_t> first = {0x02, 0x02, 0x61};  // id=1, name="a"
+    const std::vector<uint8_t> second = {0x04, 0x02, 0x62}; // id=2, name="b"
+
+    ASSERT_TRUE(decoder.decode(first.data(), first.size(), &datum).ok());
+    EXPECT_EQ(int64_t{1}, datum.value<avro::GenericRecord>().field("id").value<int64_t>());
+
+    ASSERT_TRUE(decoder.decode(second.data(), second.size(), &datum).ok());
+    EXPECT_EQ(int64_t{2}, datum.value<avro::GenericRecord>().field("id").value<int64_t>());
+    EXPECT_EQ("b", datum.value<avro::GenericRecord>().field("name").value<std::string>());
+}
+
+TEST_F(ConfluentAvroDecoderTest, truncated_payload_returns_error) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    // Only the long field is present; reading the string runs past the buffer -> avro::Exception
+    // -> InternalError (decode never lets the exception escape).
+    const std::vector<uint8_t> truncated = {0x36};
+
+    avro::GenericDatum datum;
+    EXPECT_FALSE(decoder.decode(truncated.data(), truncated.size(), &datum).ok());
+}
+
+} // namespace starrocks

--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -889,6 +889,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to collect Routine Load Kafka partition offset lag metrics. Please note that set this item to `true` will call the Kafka API to get the partition's latest offset.
 - Introduced in: -
 
+### `enable_routine_load_native_avro_reader`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: The default Avro reader for Routine Load jobs that do not set the `avro.use_native_reader` property. When `true`, such jobs use the native (avrocpp) reader, which loads Avro `record`/`map` fields as `STRUCT`/`MAP` columns and interprets Avro logical types (`date` → DATE, `timestamp` → DATETIME, `decimal` → DECIMAL); when `false`, the legacy reader is used. The reader choice is resolved when a job is created, so changing this item only affects newly created jobs, not existing ones.
+- Introduced in: -
+
 ### `enable_sync_publish`
 
 - Default: true

--- a/docs/en/loading/RoutineLoad.md
+++ b/docs/en/loading/RoutineLoad.md
@@ -383,6 +383,69 @@ FROM KAFKA
   >
   > You do not need to specify the `COLUMNS` parameter if the names and number of the fields in the Avro record completely match those of columns in the StarRocks table.
 
+- Native Avro reader (`STRUCT`/`MAP` and logical types)
+
+  By default, Routine Load uses the legacy Avro reader, which loads `record`/`map` fields as JSON strings and reads Avro logical types (`date`, `timestamp`, `decimal`) as raw integers/bytes.
+
+  Set `"avro.use_native_reader" = "true"` in `PROPERTIES` to use the native reader instead:
+
+  - `record` is loaded into a `STRUCT` column and `map` into a `MAP` column (instead of JSON).
+  - Avro logical types are interpreted: `date` → `DATE`, `timestamp-millis`/`timestamp-micros` → `DATETIME` (converted with the job time zone), and `decimal(precision, scale)` → `DECIMAL(precision, scale)`.
+
+  The property is set per job. When it is not specified, the FE configuration item `enable_routine_load_native_avro_reader` (default `false`) decides which reader to use. The reader choice is fixed when the job is created, so changing the configuration item later affects only newly created jobs — existing jobs keep their reader.
+
+  For example, given the following Avro schema with a nested `record` field `event`, a `map` field `tags`, a logical `date` field `d`, and a logical `decimal` field `amount`:
+
+  ```JSON
+  {
+      "type": "record",
+      "name": "Event",
+      "fields": [
+          {"name": "id", "type": "long"},
+          {"name": "event", "type": {
+              "type": "record",
+              "name": "EventInfo",
+              "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "code", "type": "int"}
+              ]
+          }},
+          {"name": "tags", "type": {"type": "map", "values": "long"}},
+          {"name": "d", "type": {"type": "int", "logicalType": "date"}},
+          {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}}
+      ]
+  }
+  ```
+
+  Create a matching table and load it with the native reader:
+
+  ```SQL
+  CREATE TABLE example_db.events (
+      id           BIGINT,
+      event        STRUCT<name VARCHAR(64), code INT>,
+      tags         MAP<VARCHAR(64), BIGINT>,
+      d            DATE,
+      amount       DECIMAL(18, 4)
+  )
+  ENGINE = OLAP
+  DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id);
+
+  CREATE ROUTINE LOAD example_db.events_load_job ON events
+  PROPERTIES
+  (
+      "format" = "avro",
+      "avro.use_native_reader" = "true"
+  )
+  FROM KAFKA
+  (
+      "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+      "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+      "kafka_topic" = "topic_events",
+      "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+  );
+  ```
+
 After submitting the load job, you can execute the [SHOW ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md) statement to check the status of the load job.
 
 #### Data types mapping
@@ -406,12 +469,22 @@ The data type mapping between the Avro data fields you want to load and the Star
 
 | Avro           | StarRocks                                                    |
 | -------------- | ------------------------------------------------------------ |
-| record         | Load the entire RECORD or its subfields into StarRocks as JSON. |
+| record         | Legacy reader: the entire RECORD or its subfields as JSON. Native reader (`avro.use_native_reader = true`): `STRUCT`. |
 | enums          | STRING                                                       |
 | arrays         | ARRAY                                                        |
-| maps           | JSON                                                         |
+| maps           | Legacy reader: JSON. Native reader: `MAP`.                  |
 | union(T, null) | NULLABLE(T)                                                  |
 | fixed          | STRING                                                       |
+
+##### Logical types
+
+The native reader (`avro.use_native_reader = true`) also interprets Avro logical types. The legacy reader loads them as their underlying primitive (raw int/long/bytes).
+
+| Avro logical type            | StarRocks (native reader) |
+| ---------------------------- | ------------------------- |
+| date                         | DATE                      |
+| timestamp-millis / -micros   | DATETIME                  |
+| decimal(precision, scale)    | DECIMAL(precision, scale) |
 
 #### Limits
 

--- a/docs/ja/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/management/FE_parameters/user_query_loading.md
@@ -889,6 +889,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：ルーチンロード Kafka パーティションオフセットラグメトリックを収集するかどうか。この項目を `true` に設定すると、Kafka API が呼び出されてパーティションの最新オフセットが取得されることに注意してください。
 - 導入時期：-
 
+### `enable_routine_load_native_avro_reader`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：`avro.use_native_reader` プロパティが設定されていない Routine Load ジョブが既定で使用する Avro リーダー。`true` の場合、該当するジョブはネイティブ（avrocpp）リーダーを使用し、Avro の `record`/`map` フィールドを `STRUCT`/`MAP` カラムとしてロードし、Avro の論理型（`date` → DATE、`timestamp` → DATETIME、`decimal` → DECIMAL）を解釈します。`false` の場合は従来のリーダーを使用します。リーダーの選択はジョブ作成時に確定するため、この項目を変更しても新規作成されるジョブにのみ影響し、既存のジョブには影響しません。
+- 導入時期：-
+
 ### `enable_sync_publish`
 
 - デフォルト：true

--- a/docs/ja/loading/RoutineLoad.md
+++ b/docs/ja/loading/RoutineLoad.md
@@ -383,6 +383,69 @@ FROM KAFKA
   >
   > Avro レコードのフィールドの名前と数が StarRocks テーブルのカラムと完全に一致する場合、`COLUMNS` パラメータを指定する必要はありません。
 
+- ネイティブ Avro リーダー（`STRUCT`/`MAP` と論理型）
+
+  デフォルトでは、Routine Load は従来の Avro リーダーを使用し、`record`/`map` フィールドを JSON 文字列としてロードし、Avro の論理型（`date`、`timestamp`、`decimal`）を生の整数/バイトとして読み取ります。
+
+  `PROPERTIES` に `"avro.use_native_reader" = "true"` を設定すると、代わりにネイティブリーダーを使用します:
+
+  - `record` は `STRUCT` カラムに、`map` は `MAP` カラムにロードされます（JSON ではなく）。
+  - Avro の論理型が解釈されます: `date` → `DATE`、`timestamp-millis`/`timestamp-micros` → `DATETIME`（ジョブのタイムゾーンで変換）、`decimal(precision, scale)` → `DECIMAL(precision, scale)`。
+
+  このプロパティはジョブごとに設定します。指定しない場合、FE 設定項目 `enable_routine_load_native_avro_reader`（デフォルト `false`）がどちらのリーダーを使用するかを決定します。リーダーの選択はジョブ作成時に確定するため、後で設定項目を変更しても新規作成されるジョブにのみ影響し、既存のジョブは元のリーダーを使用し続けます。
+
+  例えば、ネストされた `record` フィールド `event`、`map` フィールド `tags`、論理型 `date` フィールド `d`、論理型 `decimal` フィールド `amount` を持つ次の Avro スキーマの場合:
+
+  ```JSON
+  {
+      "type": "record",
+      "name": "Event",
+      "fields": [
+          {"name": "id", "type": "long"},
+          {"name": "event", "type": {
+              "type": "record",
+              "name": "EventInfo",
+              "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "code", "type": "int"}
+              ]
+          }},
+          {"name": "tags", "type": {"type": "map", "values": "long"}},
+          {"name": "d", "type": {"type": "int", "logicalType": "date"}},
+          {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}}
+      ]
+  }
+  ```
+
+  対応するテーブルを作成し、ネイティブリーダーでロードします:
+
+  ```SQL
+  CREATE TABLE example_db.events (
+      id           BIGINT,
+      event        STRUCT<name VARCHAR(64), code INT>,
+      tags         MAP<VARCHAR(64), BIGINT>,
+      d            DATE,
+      amount       DECIMAL(18, 4)
+  )
+  ENGINE = OLAP
+  DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id);
+
+  CREATE ROUTINE LOAD example_db.events_load_job ON events
+  PROPERTIES
+  (
+      "format" = "avro",
+      "avro.use_native_reader" = "true"
+  )
+  FROM KAFKA
+  (
+      "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+      "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+      "kafka_topic" = "topic_events",
+      "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+  );
+  ```
+
 ロードジョブを送信した後、[SHOW ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md) ステートメントを実行して、ロードジョブのステータスを確認できます。
 
 #### データ型のマッピング
@@ -406,12 +469,22 @@ FROM KAFKA
 
 | Avro           | StarRocks                                                    |
 | -------------- | ------------------------------------------------------------ |
-| record         | RECORD 全体またはそのサブフィールドを JSON として StarRocks にロードします。 |
+| record         | 従来のリーダー: RECORD 全体またはそのサブフィールドを JSON として StarRocks にロードします。ネイティブリーダー（`avro.use_native_reader = true`）: `STRUCT`。 |
 | enums          | STRING                                                       |
 | arrays         | ARRAY                                                        |
-| maps           | JSON                                                         |
+| maps           | 従来のリーダー: JSON。ネイティブリーダー: `MAP`。            |
 | union(T, null) | NULLABLE(T)                                                  |
 | fixed          | STRING                                                       |
+
+##### 論理型
+
+ネイティブリーダー（`avro.use_native_reader = true`）は Avro の論理型も解釈します。従来のリーダーはそれらを基になるプリミティブ型（生の int/long/bytes）としてロードします。
+
+| Avro 論理型                  | StarRocks（ネイティブリーダー） |
+| ---------------------------- | ------------------------- |
+| date                         | DATE                      |
+| timestamp-millis / -micros   | DATETIME                  |
+| decimal(precision, scale)    | DECIMAL(precision, scale) |
 
 #### 制限事項
 

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -889,6 +889,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否收集 Routine Load Kafka 分区偏移量滞后指标。请注意，将此项设置为 `true` 将调用 Kafka API 以获取分区的最新偏移量。
 - 引入版本: -
 
+### `enable_routine_load_native_avro_reader`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 未设置 `avro.use_native_reader` 属性的 Routine Load 作业默认使用的 Avro Reader。设置为 `true` 时，此类作业使用原生（avrocpp）Reader，将 Avro `record`/`map` 字段导入为 `STRUCT`/`MAP` 列，并解析 Avro 逻辑类型（`date` → DATE，`timestamp` → DATETIME，`decimal` → DECIMAL）；设置为 `false` 时使用旧版 Reader。Reader 的选择在作业创建时确定，因此修改该配置项仅影响新创建的作业，不影响已有作业。
+- 引入版本: -
+
 ### `enable_sync_publish`
 
 - 默认值: true

--- a/docs/zh/loading/RoutineLoad.md
+++ b/docs/zh/loading/RoutineLoad.md
@@ -369,6 +369,69 @@ FROM KAFKA
   >
   > 如果一条 Avro record 中字段的名称和数量（顺序不需要对应）都能对应目标表中列，则无需配置 `COLUMNS` 。
 
+- 原生 Avro Reader（`STRUCT`/`MAP` 和逻辑类型）
+
+  默认情况下，Routine Load 使用旧版 Avro Reader，将 `record`/`map` 字段作为 JSON 字符串导入，并将 Avro 逻辑类型（`date`、`timestamp`、`decimal`）作为原始整数/字节读取。
+
+  在 `PROPERTIES` 中设置 `"avro.use_native_reader" = "true"` 可改用原生 Reader：
+
+  - `record` 导入为 `STRUCT` 列，`map` 导入为 `MAP` 列（不再是 JSON）。
+  - 解析 Avro 逻辑类型：`date` → `DATE`，`timestamp-millis`/`timestamp-micros` → `DATETIME`（按作业时区转换），`decimal(precision, scale)` → `DECIMAL(precision, scale)`。
+
+  该属性按作业设置。未指定时，由 FE 配置项 `enable_routine_load_native_avro_reader`（默认 `false`）决定使用哪个 Reader。Reader 的选择在作业创建时确定，之后修改该配置项仅影响新创建的作业，已有作业保持原有 Reader。
+
+  例如，以下 Avro schema 包含嵌套 `record` 字段 `event`、`map` 字段 `tags`、逻辑类型 `date` 字段 `d` 和逻辑类型 `decimal` 字段 `amount`：
+
+  ```JSON
+  {
+      "type": "record",
+      "name": "Event",
+      "fields": [
+          {"name": "id", "type": "long"},
+          {"name": "event", "type": {
+              "type": "record",
+              "name": "EventInfo",
+              "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "code", "type": "int"}
+              ]
+          }},
+          {"name": "tags", "type": {"type": "map", "values": "long"}},
+          {"name": "d", "type": {"type": "int", "logicalType": "date"}},
+          {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}}
+      ]
+  }
+  ```
+
+  创建对应的表，并使用原生 Reader 导入：
+
+  ```SQL
+  CREATE TABLE example_db.events (
+      id           BIGINT,
+      event        STRUCT<name VARCHAR(64), code INT>,
+      tags         MAP<VARCHAR(64), BIGINT>,
+      d            DATE,
+      amount       DECIMAL(18, 4)
+  )
+  ENGINE = OLAP
+  DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id);
+
+  CREATE ROUTINE LOAD example_db.events_load_job ON events
+  PROPERTIES
+  (
+      "format" = "avro",
+      "avro.use_native_reader" = "true"
+  )
+  FROM KAFKA
+  (
+      "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+      "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+      "kafka_topic" = "topic_events",
+      "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+  );
+  ```
+
 提交导入作业后，您可以执行 [SHOW ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md)，查看导入作业执行情况。
 
 #### 数据类型映射
@@ -392,12 +455,22 @@ StarRocks 支持导入所有类型的 Avro 数据。导入 Avro 数据至 StarRo
 
 | Avro           |StarRocks                                        |
 | -------------- | ------------------------------------------------ |
-| record         | 将 RECORD 类型的字段或者其子字段中作为 JSON 导入 |
+| record         | 旧版 Reader：将 RECORD 类型的字段或者其子字段中作为 JSON 导入。原生 Reader（`avro.use_native_reader = true`）：`STRUCT`。 |
 | enums          | STRING                                           |
 | arrays         | ARRAY                                            |
-| maps           | JSON                                             |
+| maps           | 旧版 Reader：JSON。原生 Reader：`MAP`。          |
 | union(T, null) | NULLABE(T)                                       |
 | fixed          | STRING                                           |
+
+**逻辑类型**
+
+原生 Reader（`avro.use_native_reader = true`）还会解析 Avro 逻辑类型。旧版 Reader 将其作为底层原始类型（raw int/long/bytes）导入。
+
+| Avro 逻辑类型                | StarRocks（原生 Reader）  |
+| ---------------------------- | ------------------------- |
+| date                         | DATE                      |
+| timestamp-millis / -micros   | DATETIME                  |
+| decimal(precision, scale)    | DECIMAL(precision, scale) |
 
 #### 使用限制
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2110,6 +2110,14 @@ public class Config extends ConfigBase {
     public static long routine_load_pulsar_timeout_second = 12;
 
     /**
+     * Default for avro routine load jobs that do not set the `avro.use_native_reader` property:
+     * when true, use the avrocpp-based scanner (STRUCT/MAP support); when false, the legacy reader.
+     * Resolved on the FE so all BE nodes of a job use the same scanner.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_routine_load_native_avro_reader = false;
+
+    /**
      * it can't auto-resume routine load job as long as one of the backends is down
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -243,6 +243,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     protected long maxBatchSizeBytes = Config.max_routine_load_batch_size;
 
     private String confluentSchemaRegistryUrl;
+    // Resolved at job creation for Avro jobs (never null for them); null means a non-Avro job
+    // or a job persisted before this field existed.
+    @SerializedName("nar")
+    private Boolean useNativeAvroReader;
 
     protected int currentTaskConcurrentNum;
     @SerializedName("p")
@@ -444,6 +448,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                 jobProperties.put(CreateRoutineLoadStmt.JSONPATHS, "");
             }
             this.confluentSchemaRegistryUrl = stmt.getConfluentSchemaRegistryUrl();
+            this.useNativeAvroReader = stmt.getUseNativeAvroReader();
         } else {
             throw new StarRocksException("Invalid format type.");
         }
@@ -500,6 +505,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public Boolean getUseNativeAvroReader() {
+        return useNativeAvroReader;
     }
 
     @Override
@@ -1796,6 +1805,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
         sb.append("\"").append(CreateRoutineLoadStmt.JSONROOT).append("\"=\"");
         sb.append(getJsonRoot()).append("\",\n");
+
+        // For an Avro job persisted before this field existed (null), emit "false" rather than nothing:
+        // such a job runs the legacy reader, and replaying the shown DDL must keep doing so even if the
+        // FE-wide default config has been flipped to the native reader since.
+        if ("avro".equalsIgnoreCase(getFormat())) {
+            sb.append("\"").append(CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER).append("\"=\"");
+            sb.append(useNativeAvroReader != null ? useNativeAvroReader : Boolean.FALSE).append("\",\n");
+        }
 
         if (!Strings.isNullOrEmpty(getEnvelope())) {
             sb.append("\"").append(CreateRoutineLoadStmt.ENVELOPE).append("\"=\"");

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -90,6 +90,10 @@ public class StreamLoadInfo {
     private int loadParallelRequestNum = 0;
     private boolean enableReplicatedStorage = false;
     private String confluentSchemaRegistryUrl;
+    // null = not set; the choice is resolved on the FE (from the FE config
+    // enable_routine_load_native_avro_reader default) and carried to the BE, which falls back to the
+    // legacy avro scanner when it is unset.
+    private Boolean useNativeAvroReader;
     private long logRejectedRecordNum = 0;
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
     private ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
@@ -123,6 +127,10 @@ public class StreamLoadInfo {
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public Boolean getUseNativeAvroReader() {
+        return useNativeAvroReader;
     }
 
     public TUniqueId getId() {
@@ -473,6 +481,7 @@ public class StreamLoadInfo {
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
         }
         confluentSchemaRegistryUrl = routineLoadJob.getConfluentSchemaRegistryUrl();
+        useNativeAvroReader = routineLoadJob.getUseNativeAvroReader();
         trimSpace = routineLoadJob.isTrimspace();
         enclose = routineLoadJob.getEnclose();
         escape = routineLoadJob.getEscape();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -257,6 +257,12 @@ public class StreamLoadScanNode extends LoadScanNode {
         if (streamLoadInfo.getConfluentSchemaRegistryUrl() != null) {
             params.setConfluent_schema_registry_url(streamLoadInfo.getConfluentSchemaRegistryUrl());
         }
+        // Resolved once at job creation (CreateRoutineLoadStmt) and persisted, so it is uniform across
+        // all BE nodes and stable across FE-config changes. null = a job created before this feature
+        // (or a non-avro job) -> leave unset, BE falls back to the legacy scanner.
+        if (streamLoadInfo.getUseNativeAvroReader() != null) {
+            params.setUse_native_avro_reader(streamLoadInfo.getUseNativeAvroReader());
+        }
         initColumns();
         initWhereExpr(streamLoadInfo.getWhereExpr());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -133,6 +133,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String KAFKA_DEFAULT_OFFSETS = "kafka_default_offsets";
     // optional
     public static final String CONFLUENT_SCHEMA_REGISTRY_URL = "confluent.schema.registry.url";
+    // optional: per-job override to use the avrocpp-based reader (STRUCT/MAP support) for avro.
+    // When unset, the FE config enable_routine_load_native_avro_reader supplies the default, resolved
+    // once at job creation.
+    public static final String AVRO_USE_NATIVE_READER = "avro.use_native_reader";
 
     // pulsar type properties
     public static final String PULSAR_SERVICE_URL_PROPERTY = "pulsar_service_url";
@@ -171,6 +175,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(TASK_CONSUME_SECOND)
             .add(TASK_TIMEOUT_SECOND)
             .add(PropertyAnalyzer.PROPERTIES_WAREHOUSE)
+            .add(AVRO_USE_NATIVE_READER)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -190,6 +195,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .build();
 
     private String confluentSchemaRegistryUrl;
+    // For Avro jobs, resolved at analyze time: the job property if set, otherwise the FE config
+    // default. Stays null for non-Avro formats.
+    private Boolean useNativeAvroReader;
     private LabelName labelName;
     private final String tableName;
     private final List<ParseNode> loadPropertyList;
@@ -285,6 +293,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public Boolean getUseNativeAvroReader() {
+        return useNativeAvroReader;
     }
 
     public long getTaskConsumeSecond() {
@@ -621,6 +633,11 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             } else if (format.equalsIgnoreCase("avro")) {
                 format = "avro";
                 jsonPaths = jobProperties.get(JSONPATHS);
+                // Resolve the reader choice once, at creation time, so flipping the FE-wide default
+                // later only affects newly created jobs and never existing ones.
+                useNativeAvroReader = Util.getBooleanPropertyOrDefault(jobProperties.get(AVRO_USE_NATIVE_READER),
+                        Config.enable_routine_load_native_avro_reader,
+                        AVRO_USE_NATIVE_READER + " should be a boolean");
             } else {
                 throw new StarRocksException("Format type is invalid. format=`" + format + "`");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -584,6 +584,22 @@ public class KafkaRoutineLoadJobTest {
     }
 
     @Test
+    public void testJobPropertiesToSqlWithNativeAvroReader() {
+        RoutineLoadJob job = new KafkaRoutineLoadJob(1L, "routine_load", 1L, 1L, "127.0.0.1:9020", "topic1");
+        // Non-avro job: the property is not emitted at all.
+        Assertions.assertFalse(job.jobPropertiesToSql().contains(CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER));
+        // Avro job with the field unset (persisted by an older FE): an explicit "false", so replaying
+        // the DDL keeps the legacy reader regardless of the current FE-wide default.
+        Map<String, String> jobProperties = Deencapsulation.getField(job, "jobProperties");
+        jobProperties.put(CreateRoutineLoadStmt.FORMAT, "avro");
+        Assertions.assertTrue(job.jobPropertiesToSql()
+                .contains("\"" + CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER + "\"=\"false\""));
+        Deencapsulation.setField(job, "useNativeAvroReader", true);
+        Assertions.assertTrue(job.jobPropertiesToSql()
+                .contains("\"" + CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER + "\"=\"true\""));
+    }
+
+    @Test
     public void testGetStatistic() {
         RoutineLoadJob job = new KafkaRoutineLoadJob(1L, "routine_load", 1L, 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(job, "receivedBytes", 10);

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -303,6 +303,11 @@ struct TBrokerScanRangeParams {
     32: optional bool flexible_column_mapping
     33: optional TFileScanType file_scan_type
     34: optional bool schema_sample_types = true
+    // Per-job choice for avro routine load: use the avrocpp-based scanner (STRUCT/MAP support). The FE
+    // resolves this at job creation (from the avro.use_native_reader property, defaulting to the FE
+    // config enable_avro_routine_load_native_reader) and sets it here. If unset (e.g. an older FE), the
+    // BE falls back to the legacy avro scanner.
+    35: optional bool use_native_avro_reader
 }
 
 // Broker scan range

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -61,6 +61,7 @@ PROPERTIES
 "jsonpaths"="",
 "strip_outer_array"="false",
 "json_root"="",
+"avro.use_native_reader"="false",
 "strict_mode"="false",
 "pause_on_fatal_parse_error"="false",
 "timezone"="Asia/Shanghai",


### PR DESCRIPTION
## Why I'm doing:

Routine-load Avro (Kafka) runs on a separate legacy stack — C `libavro` + `libserdes` (`AvroScanner` + `formats/avro/{binary,numeric,nullable}_column`) — that the rest of the engine no longer uses. It has real gaps:

- **No native STRUCT/MAP** — an Avro `record` is flattened to a JSON string and a `map` to JSON, instead of `STRUCT`/`MAP` columns.
- **Avro logical types are ignored** — `date`/`timestamp`/`decimal` are read as raw int/long/bytes (the readers never inspect `logicalType`), so they don't become `DATE`/`DATETIME`/`DECIMAL`.
- **Two Avro engines to maintain** — `libavro` for routine load, `avrocpp` everywhere else (FILES()/external, `hdfs_scanner_avro`).

## What I'm doing:

Add `AvroStreamScanner`, a routine-load Avro scanner on the **`avrocpp`** stack that reuses the **same column readers** as the FILES()/external path — so routine load gets native `STRUCT`/`MAP`/`ARRAY` and correct logical types, on a single Avro engine. `libserdes` stays, used only to resolve the schema id from the Confluent Schema Registry.

- `ConfluentAvroDecoder` — strips Confluent framing, resolves the writer schema by id (cached), decodes one message into a `GenericDatum`.
- jsonpath navigation ported onto `GenericDatum` — functional parity with the legacy path, with two deliberate tightenings where the legacy reader silently loads the parent value instead: a jsonpath that overshoots a scalar leaf (`$.id.x` on a `long` `id`), and a root array index on a non-array root (`$[0]` on a record). Both now fail the row with an explicit error. Everything else (union peeling, `$`/array-index selectors, missing field → NULL) behaves identically.
- **Avro is Kafka-only.** Both decoders (legacy and native) require Confluent wire framing + a Confluent Schema Registry — a Kafka-ecosystem mechanism with no Pulsar equivalent (Pulsar's native per-topic schema is unrelated and not Confluent-framed, so it would not decode). Pulsar behavior is unchanged in this PR: `PulsarTaskInfo` still maps every non-json format (including avro) to `FORMAT_CSV_PLAIN`, as before. The native reader applies to Kafka jobs only.
- `avro.use_native_reader` is validated through `Util.getBooleanPropertyOrDefault`, consistent with the other routine-load boolean properties.

**Selection.** Per-job: the `avro.use_native_reader` property in `CREATE ROUTINE LOAD` overrides the FE-wide default `enable_routine_load_native_avro_reader` (default `false`). The choice is resolved at job creation and persisted, so it is uniform across all BE nodes and stable across config changes — flipping the FE config affects only newly created jobs; existing jobs keep their reader.

⚠️ **Behaviour change.** Enabling the native reader loads `record`/`map` as `STRUCT`/`MAP`, and `date`/`timestamp`/`decimal` as interpreted `DATE`/`DATETIME`/`DECIMAL` instead of legacy raw values. Hence default-off and per-job opt-in.

**Compatibility.** Decode/registry failure behavior kept 1:1 with legacy (filtered row + error file + task fail). jsonpaths and schema-registry URL/auth unchanged; `schema evolution` stays unsupported (same limit). Upgrade-safe: `optional` thrift field (new ordinal), persisted FE field has `@SerializedName`; new-FE/old-BE and old-FE/new-BE both fall back to the legacy scanner. Enable native only after the BE upgrade completes.

**Tests.** Unit tests: decoder round-trip, jsonpath navigation, STRUCT/MAP filling, logical-`date`. The reused logical-type/complex `avrocpp` readers are already covered on the FILES path (`avro_cpp_scanner_test`). Docs updated (`RoutineLoad.md`, FE config reference).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
