### PR TITLE
[Enhancement] Add HTTP authentication framework gated by enable_http_auth

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -749,6 +749,11 @@ CONF_String(flamegraph_tool_dir, "${STARROCKS_HOME}/bin/flamegraph");
 // to forward compatibility, will be removed later
 CONF_mBool(enable_token_check, "true");
 
+// Whether to require Basic Auth for external BE HTTP endpoints. Internal endpoints
+// (BE-to-BE clone, internal load download, health probe, Prometheus metrics) are always
+// exempt. Default false for backward compatibility.
+CONF_mBool(enable_http_auth, "false");
+
 // to open/close system metrics
 CONF_Bool(enable_system_metrics, "true");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -462,7 +462,8 @@
         "max_download_speed_kbps",
         "download_low_speed_limit_kbps",
         "download_low_speed_time",
-        "enable_token_check"
+        "enable_token_check",
+        "enable_http_auth"
       ]
     },
     {

--- a/be/src/common/config_http_fwd.h
+++ b/be/src/common/config_http_fwd.h
@@ -32,4 +32,9 @@ CONF_mInt32(download_low_speed_time, "300");
 // to forward compatibility, will be removed later
 CONF_mBool(enable_token_check, "true");
 
+// Whether to require Basic Auth for external BE HTTP endpoints. Internal endpoints
+// (BE-to-BE clone, internal load download, health probe, Prometheus metrics) are always
+// exempt. Default false for backward compatibility.
+CONF_mBool(enable_http_auth, "false");
+
 } // namespace starrocks::config

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -49,6 +49,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     const GlobalEnv& _global_env;
 

--- a/be/src/http/action/compact_rocksdb_meta_action.h
+++ b/be/src/http/action/compact_rocksdb_meta_action.h
@@ -33,6 +33,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _compact(HttpRequest* req);
 

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -59,6 +59,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     Status _handle_show_compaction(HttpRequest* req, std::string* json_result);
     Status _handle_compaction(HttpRequest* req, std::string* json_result);

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -39,6 +39,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     bool _check_request(HttpRequest* req);
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);

--- a/be/src/http/action/greplog_action.h
+++ b/be/src/http/action/greplog_action.h
@@ -28,6 +28,8 @@ public:
     ~GrepLogAction() override = default;
 
     void handle(HttpRequest* req) override;
+
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
 };
 
 } // namespace starrocks

--- a/be/src/http/action/health_action.h
+++ b/be/src/http/action/health_action.h
@@ -49,6 +49,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override { return false; }
+
 private:
     [[maybe_unused]] ExecEnv* _exec_env;
 };

--- a/be/src/http/action/jit_cache_action.h
+++ b/be/src/http/action/jit_cache_action.h
@@ -34,6 +34,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     void _handle_stat(HttpRequest* req);

--- a/be/src/http/action/lake/dump_tablet_metadata_action.h
+++ b/be/src/http/action/lake/dump_tablet_metadata_action.h
@@ -33,6 +33,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     ExecEnv* _exec_env;
 };

--- a/be/src/http/action/memory_metrics_action.h
+++ b/be/src/http/action/memory_metrics_action.h
@@ -54,6 +54,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override { return false; }
+
 private:
     const GlobalEnv& _global_env;
 

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -54,6 +54,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     static Status _handle_header(HttpRequest* req, std::string* json_header);
 

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -60,6 +60,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override { return false; }
+
 private:
     void _collect_table_metrics(starrocks::MetricsVisitor* visitor);
 

--- a/be/src/http/action/pipeline_blocking_drivers_action.h
+++ b/be/src/http/action/pipeline_blocking_drivers_action.h
@@ -36,6 +36,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     // Returns information about the blocking drivers with the following format:

--- a/be/src/http/action/pprof_actions.h
+++ b/be/src/http/action/pprof_actions.h
@@ -38,7 +38,13 @@
 
 namespace starrocks {
 
-class HeapAction : public HttpHandler {
+// Shared base for pprof/profile handlers: requires System OPERATE privilege on top of identity AuthN.
+class PprofBaseHandler : public HttpHandler {
+public:
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+};
+
+class HeapAction : public PprofBaseHandler {
 public:
     HeapAction() = default;
     ~HeapAction() override = default;
@@ -46,7 +52,7 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class GrowthAction : public HttpHandler {
+class GrowthAction : public PprofBaseHandler {
 public:
     GrowthAction() = default;
     ~GrowthAction() override = default;
@@ -54,7 +60,7 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class ProfileAction : public HttpHandler {
+class ProfileAction : public PprofBaseHandler {
 public:
     ProfileAction() = default;
     ~ProfileAction() override = default;
@@ -62,7 +68,7 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class IOProfileAction : public HttpHandler {
+class IOProfileAction : public PprofBaseHandler {
 public:
     IOProfileAction() = default;
     ~IOProfileAction() override = default;
@@ -70,14 +76,14 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class PmuProfileAction : public HttpHandler {
+class PmuProfileAction : public PprofBaseHandler {
 public:
     PmuProfileAction() = default;
     ~PmuProfileAction() override = default;
     void handle(HttpRequest* req) override {}
 };
 
-class ContentionAction : public HttpHandler {
+class ContentionAction : public PprofBaseHandler {
 public:
     ContentionAction() = default;
     ~ContentionAction() override = default;
@@ -85,14 +91,14 @@ public:
     void handle(HttpRequest* req) override {}
 };
 
-class CmdlineAction : public HttpHandler {
+class CmdlineAction : public PprofBaseHandler {
 public:
     CmdlineAction() = default;
     ~CmdlineAction() override = default;
     void handle(HttpRequest* req) override;
 };
 
-class SymbolAction : public HttpHandler {
+class SymbolAction : public PprofBaseHandler {
 public:
     SymbolAction() = default;
     ~SymbolAction() override = default;

--- a/be/src/http/action/proc_profile_action.h
+++ b/be/src/http/action/proc_profile_action.h
@@ -33,6 +33,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle_list(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);

--- a/be/src/http/action/proc_profile_file_action.h
+++ b/be/src/http/action/proc_profile_file_action.h
@@ -32,6 +32,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     bool is_valid_filename(const std::string& filename);
     void serve_gzipped_html(HttpRequest* req, const std::string& file_path);

--- a/be/src/http/action/query_cache_action.h
+++ b/be/src/http/action/query_cache_action.h
@@ -36,6 +36,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     void _handle_stat(HttpRequest* req);

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -49,6 +49,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void reload(const std::string& path, int64_t tablet_id, int32_t schema_hash, HttpRequest* req);
 

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -53,6 +53,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     Status _handle(HttpRequest* req);
 

--- a/be/src/http/action/runtime_filter_cache_action.h
+++ b/be/src/http/action/runtime_filter_cache_action.h
@@ -37,6 +37,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     void _handle_stat(HttpRequest* req);

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -36,6 +36,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     int64_t make_snapshot(int64_t tablet_id, int schema_hash, std::string* snapshot_path);
 

--- a/be/src/http/action/stop_be_action.h
+++ b/be/src/http/action/stop_be_action.h
@@ -31,6 +31,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::NODE; }
+
 private:
     [[maybe_unused]] ExecEnv* _exec_env;
 

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -64,6 +64,11 @@ public:
     void on_chunk_data(HttpRequest* req) override;
     void free_handler_ctx(void* ctx) override;
 
+    // Auth (identity + table-level INSERT priv) is performed by FE as part of the
+    // loadTxnBegin/streamLoadPut RPC flow; skip the framework-level pre-check to
+    // avoid an extra FE round-trip per stream-load request.
+    bool need_auth() const override { return false; }
+
 private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);
     Status _handle(StreamLoadContext* ctx);

--- a/be/src/http/action/transaction_stream_load.h
+++ b/be/src/http/action/transaction_stream_load.h
@@ -36,6 +36,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    // Framework-level Basic is skipped: this endpoint uses a label-bound session
+    // model where begin parses Basic and stashes credentials into StreamLoadContext,
+    // and subsequent commit/rollback look up the ctx by label. Identity + INSERT
+    // are validated inside the begin/commit/rollback RPCs on FE.
+    bool need_auth() const override { return false; }
+
 private:
     void _send_error_reply(HttpRequest* req, const Status& st);
 
@@ -56,6 +62,11 @@ public:
     void on_chunk_data(HttpRequest* req) override;
 
     void free_handler_ctx(void* ctx) override;
+
+    // Framework-level Basic is skipped: this endpoint looks up the
+    // StreamLoadContext by label and inherits the credentials captured at begin.
+    // Identity + INSERT are validated by FE during the streamLoadPut RPC flow.
+    bool need_auth() const override { return false; }
 
 private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);

--- a/be/src/http/action/update_config_action.h
+++ b/be/src/http/action/update_config_action.h
@@ -45,6 +45,8 @@ public:
     ~UpdateConfigAction() override = default;
 
     void handle(HttpRequest* req) override;
+
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
 };
 
 } // namespace starrocks

--- a/be/src/http/download_action.h
+++ b/be/src/http/download_action.h
@@ -41,6 +41,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override {
+        // NORMAL (BE-to-BE tablet clone, internal load file download) is internal and
+        // already gated by a shared token; only ERROR_LOG is user-facing.
+        return _download_type == ERROR_LOG;
+    }
+
 private:
     enum DOWNLOAD_TYPE {
         NORMAL = 1,

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -191,6 +191,12 @@ EvHttpServer::~EvHttpServer() {
 }
 
 Status EvHttpServer::start() {
+    // Mark the server as started so `set_auth_verifier` will DCHECK if called
+    // late. Setting before _bind() means even a failed start can't be "fixed
+    // up" by retroactively wiring a verifier between attempts — but that's
+    // intentional: re-using a partially-started instance isn't supported.
+    _started = true;
+
     // bind to
     RETURN_IF_ERROR(_bind());
 
@@ -430,6 +436,24 @@ int EvHttpServer::on_header(struct evhttp_request* ev_req) {
         HttpChannel::send_reply(request.get(), HttpStatus::NOT_FOUND, "Not Found");
         return 0;
     }
+
+    // Basic-Auth check (gated by `config::enable_http_auth` inside the injected verifier).
+    // Done before handler->on_header so handlers don't get a chance to read the body.
+    // HttpCore stays format-agnostic: the verifier shapes the failure response (status,
+    // headers, body) and HttpCore just dispatches it.
+    if (handler->need_auth() && _auth_verifier) {
+        auto failure = _auth_verifier(request.get(), handler->required_privilege());
+        if (failure.has_value()) {
+            evhttp_remove_header(evhttp_request_get_input_headers(ev_req), HttpHeaders::EXPECT);
+            if (!failure->www_authenticate.empty()) {
+                evhttp_add_header(evhttp_request_get_output_headers(ev_req), "WWW-Authenticate",
+                                  failure->www_authenticate.c_str());
+            }
+            HttpChannel::send_reply_json(request.get(), failure->http_status, failure->body);
+            return 0;
+        }
+    }
+
     // set handler before call on_header, because handler_ctx will set in on_header
     request->set_handler(handler);
     res = handler->on_header(request.get());

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -19,21 +19,43 @@
 
 #include <event2/event.h>
 
+#include <functional>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "base/path/path_trie.hpp"
 #include "common/status.h"
+#include "http/http_handler.h"
 #include "http/http_method.h"
+#include "http/http_status.h"
 
 namespace starrocks {
 
-class HttpHandler;
 class HttpRequest;
 
 class EvHttpServer {
 public:
+    // Result returned by an AuthVerifier when authentication or authorization fails.
+    // The verifier (injected by the service layer) is responsible for shaping the
+    // response body — HttpCore stays format-agnostic.
+    struct AuthVerifyFailure {
+        HttpStatus http_status = HttpStatus::UNAUTHORIZED;
+        // Value for the response's `WWW-Authenticate` header. Empty means the server
+        // will not add the header (e.g. for 403 where the header is semantically wrong).
+        std::string www_authenticate;
+        // Pre-serialized response body sent to the client as-is (Content-Type: application/json).
+        std::string body;
+    };
+
+    // Callback used to verify Basic Auth credentials (plus an optional role/privilege
+    // requirement) carried by an HTTP request. Returning std::nullopt means OK and the
+    // server proceeds to dispatch to the handler; returning a populated AuthVerifyFailure
+    // causes the server to short-circuit with that response. Service layer injects an
+    // implementation that talks to FE.
+    using AuthVerifier = std::function<std::optional<AuthVerifyFailure>(HttpRequest*, HttpHandler::RequiredPrivilege)>;
+
     EvHttpServer(int port, int num_workers = 1);
     EvHttpServer(std::string host, int port, int num_workers = 1);
     ~EvHttpServer();
@@ -42,6 +64,15 @@ public:
     bool register_handler(const HttpMethod& method, const std::string& path, HttpHandler* handler);
 
     void register_static_file_handler(HttpHandler* handler);
+
+    // Wire a Basic-Auth verifier. When set, EvHttpServer invokes it before dispatching
+    // any request whose handler reports `need_auth() == true`.
+    // Must be called BEFORE `start()`; not thread-safe to change after worker threads
+    // begin reading `_auth_verifier`.
+    void set_auth_verifier(AuthVerifier verifier) {
+        DCHECK(!_started) << "set_auth_verifier must be called before start()";
+        _auth_verifier = std::move(verifier);
+    }
 
     Status start();
     void stop();
@@ -87,6 +118,10 @@ private:
     PathTrie<HttpHandler*> _options_handlers;
     std::vector<struct event_base*> _event_bases;
     std::vector<struct evhttp*> _https;
+    AuthVerifier _auth_verifier;
+    // Set true once `start()` begins; gates `set_auth_verifier` so the verifier
+    // can't be swapped after worker threads start reading it.
+    bool _started = false;
 };
 
 } // namespace starrocks

--- a/be/src/http/http_handler.h
+++ b/be/src/http/http_handler.h
@@ -38,6 +38,22 @@ public:
 
     virtual void on_chunk_data(HttpRequest* req) {}
     virtual void free_handler_ctx(void* handler_ctx) {}
+
+    // Whether this handler requires Basic Auth when `config::enable_http_auth` is on.
+    // Default true. Internal endpoints (BE-to-BE clone, internal load download,
+    // health probe, Prometheus metrics) should override and return false.
+    virtual bool need_auth() const { return true; }
+
+    // Additional role/privilege required on top of identity AuthN, evaluated by FE
+    // via the `required_privilege` field of the checkAuth RPC. Mirrors the thrift
+    // `TPrivilegeRequirement` enum without dragging the thrift header into this base.
+    // Default NONE: identity-only auth.
+    enum class RequiredPrivilege {
+        NONE,
+        OPERATE, // user must hold System OPERATE privilege
+        NODE,    // user must hold System NODE privilege
+    };
+    virtual RequiredPrivilege required_privilege() const { return RequiredPrivilege::NONE; }
 };
 
 } // namespace starrocks

--- a/be/src/http/http_request.h
+++ b/be/src/http/http_request.h
@@ -52,6 +52,11 @@ public:
 
     const std::string& header(const std::string& key) const;
 
+    // Set an input request header. Production code populates `_headers` via
+    // `init_from_evhttp()` reading from libevent; this setter lets tests
+    // synthesize headers on an HttpRequest that wasn't fed through libevent.
+    void set_header(const std::string& key, const std::string& value) { _headers[key] = value; }
+
     void add_param(const std::string& key, const std::string& value) { _params.emplace(key, value); }
     const std::string& param(const std::string& key) const;
 

--- a/be/src/http/web_page_handler.h
+++ b/be/src/http/web_page_handler.h
@@ -44,6 +44,11 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    // BE Web UI pages (/, /varz, /memz, /mem_tracker, /logs, /proc_profile) plus
+    // the static-file fallback (/static/*). Operator-debug surface: callers need
+    // SYSTEM OPERATE privilege, matching the pprof and ioprofile policy.
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
     // Register a route 'path' to be rendered via template.
     // The appropriate template to use is determined by 'path'.
     // If 'is_on_nav_bar' is true, a link to the page will be placed on the navbar

--- a/be/src/service/service_be/CMakeLists.txt
+++ b/be/src/service/service_be/CMakeLists.txt
@@ -20,6 +20,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/service_be")
 set(SERVICE_BE_FILES
     backend_service.cpp
     config_update_hooks.cpp
+    http_auth_response.cpp
     http_service.cpp
     internal_service.cpp
     starrocks_be.cpp

--- a/be/src/service/service_be/http_auth_response.cpp
+++ b/be/src/service/service_be/http_auth_response.cpp
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service/service_be/http_auth_response.h"
+
+#include <fmt/format.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include "common/config_http_fwd.h"
+#include "common/config_rpc_client_fwd.h"
+#include "common/logging.h"
+#include "common/system/master_info.h"
+#include "gen_cpp/FrontendService.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "http/http_auth.h"
+#include "http/http_request.h"
+#include "platform/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+std::string build_auth_failure_body(std::string_view message) {
+    rapidjson::Document doc;
+    doc.SetObject();
+    auto& alloc = doc.GetAllocator();
+    doc.AddMember("status", rapidjson::Value("FAILED", alloc), alloc);
+    doc.AddMember("code", rapidjson::Value("1", alloc), alloc);
+    doc.AddMember("message", rapidjson::Value(message.data(), message.size(), alloc), alloc);
+    rapidjson::StringBuffer buf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    doc.Accept(writer);
+    return std::string(buf.GetString(), buf.GetSize());
+}
+
+EvHttpServer::AuthVerifyFailure make_unauthorized(std::string_view message) {
+    return EvHttpServer::AuthVerifyFailure{
+            .http_status = HttpStatus::UNAUTHORIZED,
+            .www_authenticate = "Basic realm=\"\"",
+            .body = build_auth_failure_body(message),
+    };
+}
+
+EvHttpServer::AuthVerifyFailure make_server_error(HttpStatus http_status, std::string_view message) {
+    return EvHttpServer::AuthVerifyFailure{
+            .http_status = http_status,
+            .www_authenticate = {}, // no Basic challenge — re-auth won't help
+            .body = build_auth_failure_body(message),
+    };
+}
+
+std::optional<EvHttpServer::AuthVerifyFailure> auth_failure_from_fe_status(const Status& fe_status) {
+    // FE's checkAuth distinguishes credential failure (NOT_AUTHORIZED) from
+    // internal problems (INTERNAL_ERROR — e.g. an unknown TPrivilegeRequirement
+    // enum value from a newer BE talking to an older FE). The two have different
+    // remedies, so map them to different HTTP status classes. The 401 body comes
+    // from FE (already scrubbed to "Access denied for user@host" there); the 500
+    // body is generic so we don't echo internal error strings to the client.
+    if (fe_status.is_not_authorized()) {
+        return make_unauthorized(fe_status.message());
+    }
+    if (!fe_status.ok()) {
+        LOG(WARNING) << "checkAuth FE returned non-OK status: " << fe_status;
+        return make_server_error(HttpStatus::INTERNAL_SERVER_ERROR, "auth verification failed");
+    }
+    return std::nullopt;
+}
+
+TPrivilegeRequirement::type to_thrift_privilege(HttpHandler::RequiredPrivilege priv) {
+    switch (priv) {
+    case HttpHandler::RequiredPrivilege::NONE:
+        return TPrivilegeRequirement::NONE;
+    case HttpHandler::RequiredPrivilege::OPERATE:
+        return TPrivilegeRequirement::OPERATE;
+    case HttpHandler::RequiredPrivilege::NODE:
+        return TPrivilegeRequirement::NODE;
+    }
+    LOG(ERROR) << "to_thrift_privilege: unknown RequiredPrivilege value " << static_cast<int>(priv)
+               << ", failing closed as OPERATE";
+    return TPrivilegeRequirement::OPERATE;
+}
+
+std::optional<EvHttpServer::AuthVerifyFailure> verify_http_basic_auth(
+        HttpRequest* req, HttpHandler::RequiredPrivilege required_privilege) {
+    if (!config::enable_http_auth) {
+        return std::nullopt;
+    }
+
+    AuthInfo auth;
+    if (!parse_basic_auth(*req, &auth)) {
+        return make_unauthorized("missing Basic authorization");
+    }
+
+    TAuthenticateParams params;
+    params.__set_user(auth.user);
+    params.__set_passwd(auth.passwd);
+    params.__set_host(auth.user_ip);
+    if (required_privilege != HttpHandler::RequiredPrivilege::NONE) {
+        params.__set_required_privilege(to_thrift_privilege(required_privilege));
+    }
+
+    TNetworkAddress master = get_master_address();
+    if (master.hostname.empty() || master.port == 0) {
+        LOG(WARNING) << "checkAuth: FE master address is not yet known on this BE";
+        return make_server_error(HttpStatus::SERVICE_UNAVAILABLE,
+                                 "auth verification failed: FE master address unknown");
+    }
+    TFeResult result;
+    Status rpc_st = ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master.hostname, master.port,
+            [&result, &params](FrontendServiceConnection& client) { client->checkAuth(result, params); },
+            config::thrift_rpc_timeout_ms, /*retry_times=*/1);
+    if (!rpc_st.ok()) {
+        LOG(WARNING) << "checkAuth RPC to FE failed: " << rpc_st;
+        return make_server_error(HttpStatus::SERVICE_UNAVAILABLE, "auth verification failed");
+    }
+    return auth_failure_from_fe_status(Status(result.status));
+}
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_auth_response.h
+++ b/be/src/service/service_be/http_auth_response.h
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "common/status.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "http/ev_http_server.h"
+#include "http/http_handler.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+class HttpRequest;
+
+// Helpers for shaping `AuthVerifyFailure` responses returned by the BE-side
+// AuthVerifier. Extracted from http_service.cpp so the FE-Status-to-HTTP-status
+// mapping can be unit-tested without spinning up a real server / FE.
+
+// Renders the JSON body sent on auth failure: mirrors FE's RestBaseResult
+// (FAILED case) shape: {status, code, message}.
+std::string build_auth_failure_body(std::string_view message);
+
+// 401 + WWW-Authenticate. Use for genuine credential / authorization failures
+// where the client can fix the issue by re-authenticating.
+EvHttpServer::AuthVerifyFailure make_unauthorized(std::string_view message);
+
+// 5xx, no WWW-Authenticate. Use for server-side problems (FE unreachable, FE
+// returned an internal error). The client's credentials may be valid; sending
+// 401 would mislead them into retrying the same creds and burning retries on a
+// server-side fault.
+EvHttpServer::AuthVerifyFailure make_server_error(HttpStatus http_status, std::string_view message);
+
+// Maps the FE-side `checkAuth` Status to an AuthVerifyFailure (or nullopt on
+// success). NOT_AUTHORIZED is the only status that maps to 401; any other
+// non-OK status is treated as an internal server problem (e.g. unknown
+// TPrivilegeRequirement enum value from a newer BE talking to an older FE)
+// and surfaced as 500. Pure function — safe to test directly.
+std::optional<EvHttpServer::AuthVerifyFailure> auth_failure_from_fe_status(const Status& fe_status);
+
+// Maps the BE-side `RequiredPrivilege` enum to its thrift twin. Listing every
+// case (no `default`) makes the compiler flag missing entries when the enum
+// grows; the unreachable fallback returns OPERATE so an unmapped value still
+// rejects non-operator callers without unnecessarily locking out legitimate
+// db_admin holders.
+TPrivilegeRequirement::type to_thrift_privilege(HttpHandler::RequiredPrivilege priv);
+
+// The full BE auth-verifier hook. Returns `nullopt` when authentication +
+// authorization both succeed (or when `enable_http_auth=false`), otherwise an
+// `AuthVerifyFailure` the EvHttpServer wraps into the HTTP response. Order of
+// checks: flag gate → Basic-Auth header → FE master address known → FE
+// checkAuth RPC. Anything before the RPC is unit-testable; the RPC itself is
+// covered by the end-to-end smoke test.
+std::optional<EvHttpServer::AuthVerifyFailure> verify_http_basic_auth(
+        HttpRequest* req, HttpHandler::RequiredPrivilege required_privilege);
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -34,11 +34,18 @@
 
 #include "http_service.h"
 
+#include <fmt/format.h>
+
+#include <optional>
+
 #include "cache/datacache.h"
+#include "common/config_http_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_path_fwd.h"
 #include "common/config_update_registry.h"
+#include "common/utils.h"
 #include "fs/fs_util.h"
+#include "gen_cpp/HeartbeatService_types.h"
 #include "gutil/stl_util.h"
 #include "http/action/checksum_action.h"
 #include "http/action/compact_rocksdb_meta_action.h"
@@ -71,12 +78,14 @@
 #include "http/download_action.h"
 #include "http/ev_http_server.h"
 #include "http/http_method.h"
+#include "http/utils.h"
 #include "http/web_page_handler.h"
 #include "platform/store_path.h"
 #include "runtime/base_load_path_mgr.h"
 #include "runtime/env/global_env.h"
 #include "runtime/exec_env.h"
 #include "service/service_be/config_update_hooks.h"
+#include "service/service_be/http_auth_response.h"
 
 namespace starrocks {
 
@@ -109,6 +118,8 @@ Status HttpServiceBE::start() {
     ConfigUpdateRegistry::instance()->set_ready();
 
     add_default_path_handlers(_web_page_handler.get(), _global_env);
+
+    _ev_http_server->set_auth_verifier(&verify_http_basic_auth);
 
     // register load
     auto* stream_load_action = new StreamLoadAction(_env, _http_concurrent_limiter.get());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -253,6 +253,7 @@ set(EXEC_FILES
         ./formats/disk_range_test.cpp
         ./http/default_path_handlers_test.cpp
         ./http/ev_http_server_test.cpp
+        ./http/handler_required_privilege_test.cpp
         ./http/http_core_test.cpp
         ./http/http_metrics_test.cpp
         ./http/http_client_test.cpp
@@ -327,6 +328,7 @@ set(EXEC_FILES
         ./service/mem_hook_test.cpp
         ./service/service_metrics_test.cpp
         ./service/service_be/arrow_flight_call_header_utils_test.cpp
+        ./service/service_be/http_auth_response_test.cpp
         ./service/service_be/internal_service_test.cpp
         ./udf/python/env_test.cpp
         ./udf/java/java_native_method_test.cpp

--- a/be/test/http/ev_http_server_test.cpp
+++ b/be/test/http/ev_http_server_test.cpp
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -190,6 +191,150 @@ TEST_F(EvHttpServerTest, concurrent_connections_multi_worker) {
     for (auto& th : clients) th.join();
     EXPECT_EQ(N_THREADS * REQS_PER_THREAD, ok_count.load());
     EXPECT_EQ(N_THREADS * REQS_PER_THREAD, _handler->served_count.load());
+
+    server->stop();
+    server->join();
+}
+
+// --------- AuthVerifier wiring (added with the HTTP-auth framework) ---------
+//
+// The auth tests use a dedicated handler that records invocations and a
+// configurable need_auth() so we can exercise the four interesting paths:
+//   1) verifier returns nullopt          -> handler is invoked
+//   2) verifier returns AuthVerifyFailure -> handler is NOT invoked, response
+//      carries the verifier-supplied status/headers/body verbatim
+//   3) handler->need_auth() == false      -> verifier is bypassed entirely
+//   4) no verifier wired                  -> handler runs unconditionally
+class AuthProbeHandler : public HttpHandler {
+public:
+    explicit AuthProbeHandler(bool need_auth) : _need_auth(need_auth) {}
+    void handle(HttpRequest* req) override {
+        ++invocations;
+        HttpChannel::send_reply(req, "handler-ok");
+    }
+    bool need_auth() const override { return _need_auth; }
+
+    std::atomic<int> invocations{0};
+
+private:
+    bool _need_auth;
+};
+
+TEST(EvHttpServerAuthTest, verifier_returns_nullopt_dispatches_handler) {
+    auto handler = std::make_unique<AuthProbeHandler>(true);
+    auto server = std::make_unique<EvHttpServer>(0, 1);
+    server->register_handler(GET, "/probe", handler.get());
+
+    std::atomic<int> verifier_calls{0};
+    server->set_auth_verifier(
+            [&](HttpRequest*, HttpHandler::RequiredPrivilege) -> std::optional<EvHttpServer::AuthVerifyFailure> {
+                ++verifier_calls;
+                return std::nullopt;
+            });
+
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    std::string url = "http://127.0.0.1:" + std::to_string(port) + "/probe";
+
+    HttpClient client;
+    ASSERT_OK(client.init(url));
+    client.set_method(GET);
+    std::string resp;
+    ASSERT_OK(client.execute(&resp));
+    EXPECT_EQ("handler-ok", resp);
+    EXPECT_EQ(1, verifier_calls.load());
+    EXPECT_EQ(1, handler->invocations.load());
+
+    server->stop();
+    server->join();
+}
+
+TEST(EvHttpServerAuthTest, verifier_returns_failure_short_circuits_handler) {
+    auto handler = std::make_unique<AuthProbeHandler>(true);
+    auto server = std::make_unique<EvHttpServer>(0, 1);
+    server->register_handler(GET, "/probe", handler.get());
+
+    std::atomic<int> verifier_calls{0};
+    server->set_auth_verifier(
+            [&](HttpRequest*, HttpHandler::RequiredPrivilege) -> std::optional<EvHttpServer::AuthVerifyFailure> {
+                ++verifier_calls;
+                EvHttpServer::AuthVerifyFailure f;
+                f.http_status = HttpStatus::UNAUTHORIZED;
+                f.www_authenticate = "Basic realm=\"\"";
+                f.body = "{\"status\":\"FAILED\",\"code\":\"1\",\"message\":\"denied\"}";
+                return f;
+            });
+
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    std::string url = "http://127.0.0.1:" + std::to_string(port) + "/probe";
+
+    HttpClient client;
+    ASSERT_OK(client.init(url));
+    client.set_method(GET);
+    client.set_fail_on_error(false);
+    std::string resp;
+    ASSERT_OK(client.execute(&resp));
+    EXPECT_EQ("{\"status\":\"FAILED\",\"code\":\"1\",\"message\":\"denied\"}", resp);
+    EXPECT_EQ("application/json", client.get_response_content_type());
+    EXPECT_EQ(1, verifier_calls.load());
+    EXPECT_EQ(0, handler->invocations.load());
+
+    server->stop();
+    server->join();
+}
+
+TEST(EvHttpServerAuthTest, handler_need_auth_false_bypasses_verifier) {
+    auto handler = std::make_unique<AuthProbeHandler>(false);
+    auto server = std::make_unique<EvHttpServer>(0, 1);
+    server->register_handler(GET, "/probe", handler.get());
+
+    std::atomic<int> verifier_calls{0};
+    server->set_auth_verifier(
+            [&](HttpRequest*, HttpHandler::RequiredPrivilege) -> std::optional<EvHttpServer::AuthVerifyFailure> {
+                ++verifier_calls;
+                // Verifier would reject if it ran, so seeing the handler run
+                // is a strong signal that the verifier was bypassed.
+                EvHttpServer::AuthVerifyFailure f;
+                f.http_status = HttpStatus::UNAUTHORIZED;
+                f.body = "should not be sent";
+                return f;
+            });
+
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    std::string url = "http://127.0.0.1:" + std::to_string(port) + "/probe";
+
+    HttpClient client;
+    ASSERT_OK(client.init(url));
+    client.set_method(GET);
+    std::string resp;
+    ASSERT_OK(client.execute(&resp));
+    EXPECT_EQ("handler-ok", resp);
+    EXPECT_EQ(0, verifier_calls.load());
+    EXPECT_EQ(1, handler->invocations.load());
+
+    server->stop();
+    server->join();
+}
+
+TEST(EvHttpServerAuthTest, no_verifier_wired_runs_handler) {
+    auto handler = std::make_unique<AuthProbeHandler>(true);
+    auto server = std::make_unique<EvHttpServer>(0, 1);
+    server->register_handler(GET, "/probe", handler.get());
+    // intentionally no set_auth_verifier()
+
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    std::string url = "http://127.0.0.1:" + std::to_string(port) + "/probe";
+
+    HttpClient client;
+    ASSERT_OK(client.init(url));
+    client.set_method(GET);
+    std::string resp;
+    ASSERT_OK(client.execute(&resp));
+    EXPECT_EQ("handler-ok", resp);
+    EXPECT_EQ(1, handler->invocations.load());
 
     server->stop();
     server->join();

--- a/be/test/http/handler_required_privilege_test.cpp
+++ b/be/test/http/handler_required_privilege_test.cpp
@@ -1,0 +1,225 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pins the priv-level overrides on BE HTTP handlers that were chosen with the
+// http_auth feature. Each override is a one-line virtual return, so the failure
+// mode is silent demotion/promotion in a future refactor (e.g. demoting NODE to
+// OPERATE for a node-mgmt endpoint, or promoting OPERATE to ADMIN for a
+// query-debug endpoint). Locking the values here keeps the SQL-aligned policy
+// from drifting.
+
+#include <gtest/gtest.h>
+
+#include "http/action/checksum_action.h"
+#include "http/action/compact_rocksdb_meta_action.h"
+#include "http/action/compaction_action.h"
+#include "http/action/datacache_action.h"
+#include "http/action/greplog_action.h"
+#include "http/action/health_action.h"
+#include "http/action/lake/dump_tablet_metadata_action.h"
+#include "http/action/memory_metrics_action.h"
+#include "http/action/meta_action.h"
+#include "http/action/metrics_action.h"
+#include "http/action/pipeline_blocking_drivers_action.h"
+#include "http/action/pprof_actions.h"
+#include "http/action/proc_profile_action.h"
+#include "http/action/proc_profile_file_action.h"
+#include "http/action/query_cache_action.h"
+#include "http/action/reload_tablet_action.h"
+#include "http/action/restore_tablet_action.h"
+#include "http/action/runtime_filter_cache_action.h"
+#include "http/action/snapshot_action.h"
+#include "http/action/stop_be_action.h"
+#include "http/action/stream_load.h"
+#include "http/action/transaction_stream_load.h"
+#include "http/action/update_config_action.h"
+#include "http/download_action.h"
+#include "http/ev_http_server.h"
+#include "http/http_handler.h"
+#include "http/web_page_handler.h"
+#include "runtime/env/global_env.h"
+
+#ifdef STARROCKS_JIT_ENABLE
+#include "http/action/jit_cache_action.h"
+#endif
+
+namespace starrocks {
+
+// Tests only call required_privilege() / need_auth() — const lookups that don't
+// touch the stored GlobalEnv&. The process-wide singleton is the cheapest valid
+// reference that won't crash if a future override accidentally dereferences it.
+static const GlobalEnv& fake_global_env() {
+    return *GlobalEnv::GetInstance();
+}
+
+using Priv = HttpHandler::RequiredPrivilege;
+
+// --------- NODE (cluster_admin domain) ---------
+// Matches SQL `DROP BACKEND` policy. db_admin / security_admin must NOT be
+// able to stop BEs through this endpoint.
+TEST(BeHandlerPrivilegeTest, stop_be_requires_NODE) {
+    StopBeAction h(nullptr);
+    EXPECT_EQ(Priv::NODE, h.required_privilege());
+}
+
+// --------- OPERATE (DB / data / execution operate) ---------
+// Matches SQL `ADMIN SET BACKEND CONFIG` / `ADMIN COMPACT` policy.
+TEST(BeHandlerPrivilegeTest, update_config_requires_OPERATE) {
+    UpdateConfigAction h;
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, compaction_requires_OPERATE_all_subtypes) {
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SHOW_INFO).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::RUN_COMPACTION).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SHOW_REPAIR).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SUBMIT_REPAIR).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SHOW_RUNNING_TASK).required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, checksum_requires_OPERATE) {
+    ChecksumAction h(fake_global_env());
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, reload_tablet_requires_OPERATE) {
+    ReloadTabletAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, restore_tablet_requires_OPERATE) {
+    RestoreTabletAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, snapshot_requires_OPERATE) {
+    SnapshotAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, meta_requires_OPERATE) {
+    MetaAction h(META_TYPE::HEADER);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, dump_tablet_metadata_requires_OPERATE) {
+    lake::DumpTabletMetadataAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, compact_rocksdb_meta_requires_OPERATE) {
+    CompactRocksDbMetaAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, datacache_requires_OPERATE) {
+    DataCacheAction h(nullptr, nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, query_cache_requires_OPERATE) {
+    QueryCacheAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, runtime_filter_cache_requires_OPERATE) {
+    RuntimeFilterCacheAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+#ifdef STARROCKS_JIT_ENABLE
+TEST(BeHandlerPrivilegeTest, jit_cache_requires_OPERATE) {
+    JITCacheAction h;
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+#endif
+
+TEST(BeHandlerPrivilegeTest, pipeline_blocking_drivers_requires_OPERATE) {
+    PipelineBlockingDriversAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+// --------- OPERATE (process profiling / log diagnostics) ---------
+// DB operators (db_admin → OPERATE) inspect profiles to diagnose hot queries
+// running on the BE. cluster_admin holders can pick up OPERATE explicitly when
+// they need pprof access.
+TEST(BeHandlerPrivilegeTest, pprof_handlers_require_OPERATE) {
+    EXPECT_EQ(Priv::OPERATE, HeapAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, GrowthAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, ProfileAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, IOProfileAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, PmuProfileAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, ContentionAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CmdlineAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, SymbolAction().required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, proc_profile_requires_OPERATE) {
+    ProcProfileAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, proc_profile_file_requires_OPERATE) {
+    ProcProfileFileAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, greplog_requires_OPERATE) {
+    GrepLogAction h;
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+// --------- DownloadAction: dynamic need_auth() based on download type ---------
+// NORMAL (BE-to-BE tablet clone, internal load file download): token-gated,
+// framework Basic is skipped (`need_auth() == false`).
+// ERROR_LOG (user-facing load-failure log): framework Basic required.
+TEST(BeHandlerNeedAuthTest, download_action_normal_skips_framework_auth) {
+    DownloadAction normal(nullptr, std::vector<std::string>{});
+    EXPECT_FALSE(normal.need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, download_action_error_log_requires_framework_auth) {
+    DownloadAction error_log(nullptr, std::string{});
+    EXPECT_TRUE(error_log.need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, probe_and_prometheus_endpoints_skip_framework_auth) {
+    EXPECT_FALSE(HealthAction(nullptr).need_auth());
+    EXPECT_FALSE(MetricsAction(nullptr).need_auth());
+    EXPECT_FALSE(MemoryMetricsAction(fake_global_env()).need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, stream_load_uses_builtin_fe_auth_flow) {
+    StreamLoadAction action(nullptr, nullptr);
+    EXPECT_FALSE(action.need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, transaction_endpoints_skip_framework_auth) {
+    // Both transaction-management endpoints opt out of the framework Basic-Auth
+    // gate — they use a label-bound session model (begin parses Basic, later ops
+    // look up the StreamLoadContext by label).
+    TransactionManagerAction txn_mgr(nullptr);
+    EXPECT_FALSE(txn_mgr.need_auth());
+    TransactionStreamLoadAction txn_load(nullptr);
+    EXPECT_FALSE(txn_load.need_auth());
+}
+
+TEST(BeHandlerPrivilegeTest, web_page_handler_requires_OPERATE) {
+    // BE Web UI is operator-debug surface — same policy as pprof / ioprofile.
+    EvHttpServer server(/*port=*/0, /*num_workers=*/1);
+    WebPageHandler handler(&server);
+    EXPECT_EQ(Priv::OPERATE, handler.required_privilege());
+}
+
+} // namespace starrocks

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -27,10 +27,12 @@
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
+#include "common/brpc/brpc_stub_cache.h"
 #include "common/config_ingest_fwd.h"
 #include "common/system/cpu_info.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
+#include "http/download_action.h"
 #include "http/http_channel.h"
 #include "http/http_common.h"
 #include "http/http_request.h"
@@ -111,6 +113,10 @@ protected:
     MetricRegistry _metrics{"transaction_stream_load_action_test"};
     bool _owns_platform_env = false;
 };
+
+// `need_auth() == false` for both handlers is pinned in handler_required_privilege_test.cpp
+// (BeHandlerNeedAuthTest.transaction_endpoints_skip_framework_auth). This file focuses on
+// the txn dispatch semantics under various auth/label combinations below.
 
 TEST_F(TransactionStreamLoadActionTest, txn_begin_no_auth) {
     TransactionManagerAction txn_action(&_env);

--- a/be/test/service/service_be/http_auth_response_test.cpp
+++ b/be/test/service/service_be/http_auth_response_test.cpp
@@ -1,0 +1,221 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service/service_be/http_auth_response.h"
+
+#include <event2/buffer.h>
+#include <event2/http.h>
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "common/config_http_fwd.h"
+#include "common/status.h"
+#include "common/system/master_info.h"
+#include "http/ev_http_server.h"
+#include "http/http_handler.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+// `auth_failure_from_fe_status` is the pure mapping that decides what HTTP
+// response a BE returns based on what FE's checkAuth came back with. The
+// classes are intentionally distinct because each suggests a different
+// remedy to the client:
+//
+//   NOT_AUTHORIZED (401 + WWW-Authenticate): fix your credentials
+//   INTERNAL_ERROR (500): a bug on the FE — operator must investigate
+//   network/RPC failure: 503, handled by caller (not this helper)
+//
+// Regression here is silent (e.g. someone collapses the switch and lumps
+// all non-OK into 401), so the cases are pinned explicitly.
+
+TEST(AuthFailureFromFeStatusTest, ok_returns_nullopt) {
+    auto result = auth_failure_from_fe_status(Status::OK());
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(AuthFailureFromFeStatusTest, not_authorized_maps_to_401_with_basic_challenge) {
+    auto result = auth_failure_from_fe_status(Status::NotAuthorized("bad password"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, result->http_status);
+    EXPECT_EQ("Basic realm=\"\"", result->www_authenticate);
+    // Body shape mirrors FE RestBaseResult — verify message round-trips into JSON.
+    EXPECT_NE(std::string::npos, result->body.find("FAILED"));
+    EXPECT_NE(std::string::npos, result->body.find("bad password"));
+}
+
+TEST(AuthFailureFromFeStatusTest, internal_error_maps_to_500_without_basic_challenge) {
+    // FE might return InternalError for unknown TPrivilegeRequirement enum
+    // values (cross-version mismatch). Client retrying with the same creds
+    // would never help, so we must NOT emit a Basic challenge. The body is
+    // a generic "auth verification failed" — internal error strings stay
+    // server-side (logged at WARNING), never echoed to the HTTP client.
+    auto result = auth_failure_from_fe_status(Status::InternalError("unknown required_privilege: 999"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::INTERNAL_SERVER_ERROR, result->http_status);
+    EXPECT_TRUE(result->www_authenticate.empty());
+    EXPECT_NE(std::string::npos, result->body.find("auth verification failed"));
+    EXPECT_EQ(std::string::npos, result->body.find("unknown required_privilege"));
+}
+
+TEST(AuthFailureFromFeStatusTest, other_non_ok_maps_to_500) {
+    // Defensive: any non-OK that isn't NOT_AUTHORIZED is treated as server-side.
+    // Pick a status that's neither — Aborted is a reasonable stand-in for
+    // "something unexpected came back from FE".
+    auto result = auth_failure_from_fe_status(Status::Aborted("aborted"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::INTERNAL_SERVER_ERROR, result->http_status);
+    EXPECT_TRUE(result->www_authenticate.empty());
+}
+
+TEST(MakeUnauthorizedTest, has_401_and_basic_realm) {
+    auto failure = make_unauthorized("missing Basic");
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, failure.http_status);
+    EXPECT_EQ("Basic realm=\"\"", failure.www_authenticate);
+    EXPECT_NE(std::string::npos, failure.body.find("missing Basic"));
+}
+
+TEST(MakeServerErrorTest, respects_caller_supplied_status_and_omits_www_authenticate) {
+    auto failure = make_server_error(HttpStatus::SERVICE_UNAVAILABLE, "FE unreachable");
+    EXPECT_EQ(HttpStatus::SERVICE_UNAVAILABLE, failure.http_status);
+    EXPECT_TRUE(failure.www_authenticate.empty());
+    EXPECT_NE(std::string::npos, failure.body.find("FE unreachable"));
+}
+
+TEST(BuildAuthFailureBodyTest, contains_failed_status_code_and_message) {
+    std::string body = build_auth_failure_body("denied: bad pw");
+    // Shape mirrors FE's RestBaseResult — must be parseable JSON with the three
+    // expected keys (status / code / message).
+    EXPECT_NE(std::string::npos, body.find("\"status\":\"FAILED\""));
+    EXPECT_NE(std::string::npos, body.find("\"code\":\"1\""));
+    EXPECT_NE(std::string::npos, body.find("\"message\":\"denied: bad pw\""));
+}
+
+TEST(BuildAuthFailureBodyTest, escapes_quotes_in_message) {
+    // rapidjson must escape user-controlled strings to keep the body parseable.
+    std::string body = build_auth_failure_body("he said \"hi\"");
+    EXPECT_NE(std::string::npos, body.find("he said \\\"hi\\\""));
+}
+
+// --------- to_thrift_privilege ---------
+// Every enum value must round-trip to its thrift twin; missing cases trip
+// `-Wswitch` at compile time. The unreachable fallback is what catches a future
+// enum value that someone adds to the C++ side but forgets to map — pin its
+// "fail closed as OPERATE" behavior so we don't silently regress to NONE.
+
+TEST(ToThriftPrivilegeTest, maps_each_enum_value) {
+    EXPECT_EQ(TPrivilegeRequirement::NONE, to_thrift_privilege(HttpHandler::RequiredPrivilege::NONE));
+    EXPECT_EQ(TPrivilegeRequirement::OPERATE, to_thrift_privilege(HttpHandler::RequiredPrivilege::OPERATE));
+    EXPECT_EQ(TPrivilegeRequirement::NODE, to_thrift_privilege(HttpHandler::RequiredPrivilege::NODE));
+}
+
+TEST(ToThriftPrivilegeTest, unknown_enum_value_fails_closed_as_operate) {
+    // Synthesize an out-of-range RequiredPrivilege to simulate a future enum
+    // addition that didn't get a switch case. Fail-closed = OPERATE (still
+    // rejects non-operator callers; previously the default branch silently
+    // returned NONE, which would have downgraded authorization to AuthN-only).
+    auto bogus = static_cast<HttpHandler::RequiredPrivilege>(99);
+    EXPECT_EQ(TPrivilegeRequirement::OPERATE, to_thrift_privilege(bogus));
+}
+
+// --------- verify_http_basic_auth ---------
+// The verifier does flag-gate → Basic-Auth parse → FE master check → RPC.
+// Everything up to the RPC is unit-testable. The RPC + result handling are
+// covered end-to-end by summary/http_auth/http_auth_smoke_test.py (a real
+// cluster is needed to exercise FE's checkAuth).
+
+class VerifyHttpBasicAuthTest : public testing::Test {
+public:
+    void SetUp() override {
+        _saved_flag = config::enable_http_auth;
+        _saved_master_info = get_master_info();
+        _ev_req = evhttp_request_new(nullptr, nullptr);
+        ASSERT_NE(nullptr, _ev_req);
+    }
+    void TearDown() override {
+        config::enable_http_auth = _saved_flag;
+        // Restore master_info so later tests in this binary aren't affected.
+        // master_info refuses lower-or-equal epoch updates; bump just one above
+        // whatever the current epoch is so later tests can still apply their
+        // own updates (previously we used int64_max here, which poisoned every
+        // subsequent update_master_info call).
+        TMasterInfo restored = _saved_master_info;
+        restored.epoch = get_master_info().epoch + 1;
+        (void)update_master_info(restored);
+        if (_ev_req != nullptr) {
+            evhttp_request_free(_ev_req);
+            _ev_req = nullptr;
+        }
+    }
+
+protected:
+    bool _saved_flag = false;
+    TMasterInfo _saved_master_info;
+    evhttp_request* _ev_req = nullptr;
+};
+
+TEST_F(VerifyHttpBasicAuthTest, flag_off_skips_verification) {
+    config::enable_http_auth = false;
+    HttpRequest req(_ev_req);
+    // No headers populated, no FE configured. With the flag off, none of that
+    // matters — must return nullopt unconditionally.
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::OPERATE);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(VerifyHttpBasicAuthTest, missing_authorization_header_returns_401) {
+    config::enable_http_auth = true;
+    HttpRequest req(_ev_req);
+    // No Authorization header → parse_basic_auth fails → 401 with Basic challenge.
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::NONE);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, result->http_status);
+    EXPECT_EQ("Basic realm=\"\"", result->www_authenticate);
+}
+
+TEST_F(VerifyHttpBasicAuthTest, malformed_authorization_returns_401) {
+    config::enable_http_auth = true;
+    HttpRequest req(_ev_req);
+    // "Bearer" instead of "Basic" — parse_basic_auth rejects it.
+    req.set_header(HttpHeaders::AUTHORIZATION, "Bearer not-a-basic-token");
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::NONE);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, result->http_status);
+}
+
+TEST_F(VerifyHttpBasicAuthTest, unknown_fe_master_returns_503) {
+    config::enable_http_auth = true;
+    // Overwrite master info with an empty endpoint. Use a high epoch so we win
+    // against any state a prior test in this binary may have stored (the
+    // master-info store ignores updates with a lower-or-equal epoch).
+    TMasterInfo empty;
+    empty.network_address.hostname = "";
+    empty.network_address.port = 0;
+    empty.epoch = 999999999;
+    EXPECT_TRUE(update_master_info(empty));
+
+    HttpRequest req(_ev_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo="); // root:
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::OPERATE);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::SERVICE_UNAVAILABLE, result->http_status);
+    // Service-side failure ⇒ no WWW-Authenticate (the client's creds may be fine).
+    EXPECT_TRUE(result->www_authenticate.empty());
+    EXPECT_NE(std::string::npos, result->body.find("FE master address unknown"));
+}
+
+} // namespace starrocks

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -196,6 +196,20 @@ This topic introduces the following types of BE configurations:
 - Description: The BE HTTP server port.
 - Introduced in: -
 
+### enable_http_auth
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Introduced in: -
+- Description: When true, most external BE HTTP endpoints require HTTP Basic Auth. Credentials are verified by RPC to the FE leader using the `checkAuth` Thrift method, so the user/password store on the FE side (including LDAP / security-integration) is the source of truth. The following are exempt:
+  - Public probes / observability: `/api/health`, `/metrics`, `/metrics/memory`.
+  - Token-gated internal transport (used by FE/BE for tablet clone and load-error file fetch): `/api/_tablet/_download`, `/api/_download_load`. These remain protected by their own token check; setting `enable_http_auth=true` does **not** compensate for `enable_token_check=false`.
+  - Stream Load and transaction endpoints that authenticate inside the handler using the load label + table grants: `/api/{db}/{table}/_stream_load`, `/api/transaction/{txn_op}`, `/api/transaction/load`.
+
+  Privileged endpoints additionally require a SYSTEM-level RBAC privilege (`OPERATE` or `NODE`) that is **active** in the session — use `SET DEFAULT ROLE <roles> TO <user>;` or set `activate_all_roles_on_login=true` if the role is granted but not default. LDAP / security-integration group → role mappings activate automatically.
+
 ### be_port
 
 - Default: 9060

--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -768,6 +768,20 @@ This topic introduces the following types of FE configurations:
 - Description: The port on which the HTTP server in the FE node listens.
 - Introduced in: -
 
+### `enable_http_auth`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Introduced in: -
+- Description: When true, most external FE HTTP endpoints require HTTP Basic Auth. Credentials are validated against the user store via `AuthenticationHandler.authenticate()`, so LDAP / security-integration login works on the HTTP path the same way it does for the MySQL protocol. The following are exempt:
+  - Public probes / observability: `/api/health`, `/api/bootstrap`, `/api/idle_status`, `/api/v2/feature`, `/metrics`, `/api/oauth2`.
+  - Peer-FE / control-plane paths that are IP-whitelisted or token-gated inside the handler: `/image`, `/check`, `/journal_id`, `/info`, `/role`, `/dump`, `/dump_starmgr`, `/service_id`, `/static`, `/api/_meta_replay_state`, `/api/get_small_file`.
+  - Stream Load planner endpoints that resolve identity from the load label + table grants: `/api/{db}/_load_info`, `/api/{db}/{table}/_stream_load_meta`, `/api/{db}/{table}/_schema`, `/api/{db}/{table}/_count`.
+
+  Privileged endpoints additionally require a SYSTEM-level RBAC privilege (`OPERATE` or `NODE`) that is **active** in the caller's session. If the granting role is not the user's default, run `SET DEFAULT ROLE <roles> TO <user>;` or set the global variable `activate_all_roles_on_login=true` so the roles activate at login. LDAP / security-integration group → role mappings activate automatically.
+
 ### `http_web_page_display_hardware`
 
 - Default: true

--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -778,7 +778,6 @@ This topic introduces the following types of FE configurations:
 - Description: When true, most external FE HTTP endpoints require HTTP Basic Auth. Credentials are validated against the user store via `AuthenticationHandler.authenticate()`, so LDAP / security-integration login works on the HTTP path the same way it does for the MySQL protocol. The following are exempt:
   - Public probes / observability: `/api/health`, `/api/bootstrap`, `/api/idle_status`, `/api/v2/feature`, `/metrics`, `/api/oauth2`.
   - Peer-FE / control-plane paths that are IP-whitelisted or token-gated inside the handler: `/image`, `/check`, `/journal_id`, `/info`, `/role`, `/dump`, `/dump_starmgr`, `/service_id`, `/static`, `/api/_meta_replay_state`, `/api/get_small_file`.
-  - Stream Load planner endpoints that resolve identity from the load label + table grants: `/api/{db}/_load_info`, `/api/{db}/{table}/_stream_load_meta`, `/api/{db}/{table}/_schema`, `/api/{db}/{table}/_count`.
 
   Privileged endpoints additionally require a SYSTEM-level RBAC privilege (`OPERATE` or `NODE`) that is **active** in the caller's session. If the granting role is not the user's default, run `SET DEFAULT ROLE <roles> TO <user>;` or set the global variable `activate_all_roles_on_login=true` so the roles activate at login. LDAP / security-integration group → role mappings activate automatically.
 

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -168,6 +168,20 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: BE HTTP サーバーポート。
 - 導入バージョン: -
 
+### enable_http_auth
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 導入時期: -
+- 説明: true の場合、ほとんどの外部 BE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は Thrift `checkAuth` RPC で FE Leader に転送されて検証され、ユーザー名/パスワードは FE 側の認証システム（LDAP / security integration を含む）を正としています。次のエンドポイントは常に除外されます：
+  - 公開プローブ / 可観測性: `/api/health`、`/metrics`、`/metrics/memory`。
+  - トークン認証の内部転送（FE/BE 間の tablet clone と load エラーファイル取得に使用）: `/api/_tablet/_download`、`/api/_download_load`。これらは各自の token チェックで保護されており、`enable_http_auth=true` を有効にしても `enable_token_check=false` の影響を補うことはできません。
+  - ハンドラ内でロードラベル + テーブル権限から認証する Stream Load / transaction エンドポイント: `/api/{db}/{table}/_stream_load`、`/api/transaction/{txn_op}`、`/api/transaction/load`。
+
+  特権エンドポイントでは追加でセッション内に**有効化された** SYSTEM レベル RBAC 権限（`OPERATE` / `NODE`）が必要です。付与済みでデフォルトに設定されていない場合は `SET DEFAULT ROLE <roles> TO <user>;` または `activate_all_roles_on_login=true` を利用してください。LDAP / security integration のグループ → ロールマッピングは自動的に有効化されます。
+
 ### be_port
 
 - デフォルト: 9060

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -758,6 +758,20 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：FE ノードの HTTP サーバーがリッスンするポート。
 - 導入時期：-
 
+### `enable_http_auth`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 導入時期：-
+- 説明：true の場合、ほとんどの外部 FE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は `AuthenticationHandler.authenticate()` を介してユーザーストアと照合されるため、LDAP / security integration による認証も MySQL プロトコルと同様に HTTP 経路で機能します。次のエンドポイントは常に除外されます：
+  - 公開プローブ / 可観測性：`/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
+  - ハンドラ内で IP ホワイトリストまたはトークンで認証する FE 間 / コントロールプレーン経路：`/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。
+  - ロードラベル + テーブル権限から ID を解決する Stream Load プランナエンドポイント：`/api/{db}/_load_info`、`/api/{db}/{table}/_stream_load_meta`、`/api/{db}/{table}/_schema`、`/api/{db}/{table}/_count`。
+
+  特権エンドポイントでは追加でセッション内に**有効化された** SYSTEM レベル RBAC 権限（`OPERATE` / `NODE`）が必要です。付与済みでデフォルトに設定されていないロールを使う場合は `SET DEFAULT ROLE <roles> TO <user>;` を実行するか、グローバル変数 `activate_all_roles_on_login=true` を設定してログイン時に有効化してください。LDAP / security integration のグループ → ロールマッピングは自動的に有効化されます。
+
 ### `http_web_page_display_hardware`
 
 - デフォルト：true

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -768,7 +768,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：true の場合、ほとんどの外部 FE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は `AuthenticationHandler.authenticate()` を介してユーザーストアと照合されるため、LDAP / security integration による認証も MySQL プロトコルと同様に HTTP 経路で機能します。次のエンドポイントは常に除外されます：
   - 公開プローブ / 可観測性：`/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
   - ハンドラ内で IP ホワイトリストまたはトークンで認証する FE 間 / コントロールプレーン経路：`/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。
-  - ロードラベル + テーブル権限から ID を解決する Stream Load プランナエンドポイント：`/api/{db}/_load_info`、`/api/{db}/{table}/_stream_load_meta`、`/api/{db}/{table}/_schema`、`/api/{db}/{table}/_count`。
 
   特権エンドポイントでは追加でセッション内に**有効化された** SYSTEM レベル RBAC 権限（`OPERATE` / `NODE`）が必要です。付与済みでデフォルトに設定されていないロールを使う場合は `SET DEFAULT ROLE <roles> TO <user>;` を実行するか、グローバル変数 `activate_all_roles_on_login=true` を設定してログイン時に有効化してください。LDAP / security integration のグループ → ロールマッピングは自動的に有効化されます。
 

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -183,6 +183,20 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE HTTP Server 端口。
 - 引入版本：-
 
+### enable_http_auth
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 引入版本：-
+- 描述：是否对大部分外部 BE HTTP 接口启用 Basic Auth。凭证通过 Thrift `checkAuth` RPC 转发到 FE Leader 校验，用户/密码以 FE 端的认证体系（含 LDAP / security integration）为准。以下接口始终豁免：
+  - 公开探针 / 可观测性：`/api/health`、`/metrics`、`/metrics/memory`。
+  - Token 鉴权的内部传输（FE/BE 用于 tablet clone 和 load 错误文件拉取）：`/api/_tablet/_download`、`/api/_download_load`。这些接口仍由各自的 token 检查保护；开启 `enable_http_auth=true` **不**能弥补 `enable_token_check=false` 带来的安全损失。
+  - Stream Load 及 transaction 接口，由 handler 内基于 load label + 表级授权识别身份：`/api/{db}/{table}/_stream_load`、`/api/transaction/{txn_op}`、`/api/transaction/load`。
+
+  特权接口还要求会话中**当前激活**了 SYSTEM 级 RBAC 权限（`OPERATE` 或 `NODE`）——若已 GRANT 但未设为默认角色，需 `SET DEFAULT ROLE <roles> TO <user>;` 或将 `activate_all_roles_on_login` 设为 `true`。LDAP / security integration 的组 → 角色映射会自动激活。
+
 ### be_port
 
 - 默认值：9060

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -776,7 +776,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否对大部分外部 FE HTTP 接口启用 Basic Auth。凭证通过 `AuthenticationHandler.authenticate()` 校验，因此 LDAP / security integration 在 HTTP 路径上的工作方式与 MySQL 协议一致。以下接口始终豁免:
   - 公开探针 / 可观测性: `/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
   - 由 handler 自行通过 IP 白名单或 token 鉴权的对等 FE / 控制面端点: `/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。
-  - Stream Load 规划端点，通过 load label + 表级授权识别身份: `/api/{db}/_load_info`、`/api/{db}/{table}/_stream_load_meta`、`/api/{db}/{table}/_schema`、`/api/{db}/{table}/_count`。
 
   特权接口还要求会话中**当前激活**了 SYSTEM 级 RBAC 权限（`OPERATE` 或 `NODE`）。若用户已 GRANT 但未设为默认角色，需 `SET DEFAULT ROLE <roles> TO <user>;`，或将全局变量 `activate_all_roles_on_login` 设为 `true` 让角色登录时自动激活。LDAP / security integration 的组 → 角色映射会自动激活。
 

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -766,6 +766,20 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: FE 节点中 HTTP 服务器监听的端口。
 - 引入版本: -
 
+### `enable_http_auth`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 引入版本: -
+- 描述: 是否对大部分外部 FE HTTP 接口启用 Basic Auth。凭证通过 `AuthenticationHandler.authenticate()` 校验，因此 LDAP / security integration 在 HTTP 路径上的工作方式与 MySQL 协议一致。以下接口始终豁免:
+  - 公开探针 / 可观测性: `/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
+  - 由 handler 自行通过 IP 白名单或 token 鉴权的对等 FE / 控制面端点: `/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。
+  - Stream Load 规划端点，通过 load label + 表级授权识别身份: `/api/{db}/_load_info`、`/api/{db}/{table}/_stream_load_meta`、`/api/{db}/{table}/_schema`、`/api/{db}/{table}/_count`。
+
+  特权接口还要求会话中**当前激活**了 SYSTEM 级 RBAC 权限（`OPERATE` 或 `NODE`）。若用户已 GRANT 但未设为默认角色，需 `SET DEFAULT ROLE <roles> TO <user>;`，或将全局变量 `activate_all_roles_on_login` 设为 `true` 让角色登录时自动激活。LDAP / security integration 的组 → 角色映射会自动激活。
+
 ### `http_web_page_display_hardware`
 
 - 默认值: true

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -852,6 +852,11 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_port = 8030;
 
+    @ConfField(mutable = true, comment = "Whether to require Basic Auth for external HTTP endpoints. " +
+            "Internal endpoints (FE meta sync, health/metrics probes, OAuth2 callback) are always exempt. " +
+            "Default false for backward compatibility.")
+    public static boolean enable_http_auth = false;
+
     /**
      * Fe https port
      * Currently, all FEs' https port must be the same.

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
@@ -70,8 +70,16 @@ public class BootstrapFinishAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/bootstrap", new BootstrapFinishAction(controller));
     }
 
+    // FE bootstrap probe; intentionally unauthenticated. Caller can pass the cluster
+    // token to unlock additional fields (journal id / ports / version), but the endpoint
+    // itself accepts anonymous requests for readiness checks.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) throws DdlException {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
         boolean isReady = GlobalStateMgr.getCurrentState().isReady();
 
         // to json response

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoadAction.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
@@ -57,7 +58,8 @@ public class CancelStreamLoadAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response)
+            throws DdlException, AccessDeniedException {
 
         if (redirectToLeader(request, response)) {
             return;
@@ -73,8 +75,11 @@ public class CancelStreamLoadAction extends RestBaseAction {
             throw new DdlException("No label selected.");
         }
 
-        // FIXME(cmy)
-        // checkWritePriv(authInfo.fullUserName, fullDbName);
+        // The actual cancel is keyed by (dbId, label) and ignores the {table} segment in the URL,
+        // so a URL-table-based INSERT check would be a confused-deputy gate (any INSERT user on
+        // some allowed table could cancel a load against a different table in the same db).
+        // Use db-level INSERT instead — consistent with GetStreamLoadState which is also dbId+label.
+        requireDbInsertIfHttpAuthEnabled(dbName);
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ConnectionAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ConnectionAction.java
@@ -34,6 +34,8 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -56,8 +58,16 @@ public class ConnectionAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/connection", new ConnectionAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String connStr = request.getSingleParameter("connection_id");
         if (connStr == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
@@ -32,8 +32,14 @@ public class FeatureAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/v2/feature", new FeatureAction(controller));
     }
 
+    // Public endpoint: returns server version + feature flag list, no sensitive data.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         response.setContentType("application/json");
 
         RestResult result = new RestResult();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetClusterSnapshotRestoreStateAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetClusterSnapshotRestoreStateAction.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -32,8 +34,16 @@ public class GetClusterSnapshotRestoreStateAction extends RestBaseAction {
                 new GetClusterSnapshotRestoreStateAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         response.setContentType("application/json");
 
         RestResult result = new RestResult();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetSmallFileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetSmallFileAction.java
@@ -58,8 +58,15 @@ public class GetSmallFileAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/get_small_file", new GetSmallFileAction(controller));
     }
 
+    // Internal BE-to-FE small-file download; gated by the cluster-shared token check below.
+    // Callers (BEs) don't carry user credentials, so we must not require Basic Auth here.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         String token = request.getSingleParameter("token");
         String fileIdStr = request.getSingleParameter("file_id");
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
@@ -58,7 +59,7 @@ public class GetStreamLoadState extends RestBaseAction {
 
     @Override
     public void executeWithoutPassword(BaseRequest request, BaseResponse response)
-            throws DdlException {
+            throws DdlException, AccessDeniedException {
 
         if (redirectToLeader(request, response)) {
             return;
@@ -74,8 +75,7 @@ public class GetStreamLoadState extends RestBaseAction {
             throw new DdlException("No label selected.");
         }
 
-        // FIXME(cmy)
-        // checkReadPriv(authInfo.fullUserName, fullDbName);
+        requireDbInsertIfHttpAuthEnabled(dbName);
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
@@ -53,8 +53,14 @@ public class HealthAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/health", new HealthAction(controller));
     }
 
+    // Liveness probe; intentionally unauthenticated.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         if (GracefulExitFlag.isGracefulExit()) {
             sendResult(request, response, HttpResponseStatus.INTERNAL_SERVER_ERROR);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
@@ -49,8 +49,14 @@ public class IdleAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/idle_status", new IdleAction(controller));
     }
 
+    // K8s idle probe; intentionally unauthenticated.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         String showDetails = request.getSingleParameter("show_details");
         if (Config.warehouse_idle_check_enable) {
             IdleStatus idleStatus = GlobalStateMgr.getCurrentState().getWarehouseIdleChecker()

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MemoryUsageAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MemoryUsageAction.java
@@ -16,6 +16,8 @@ package com.starrocks.http.rest;
 
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -38,8 +40,17 @@ public class MemoryUsageAction extends RestBaseAction {
                 new MemoryUsageAction(controller));
     }
 
+    // Historically anonymous (host-restricted to 127.0.0.1 below); gated for backward
+    // compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         if (!"127.0.0.1".equals(request.getHostString())) {
             response.appendContent("only allow access from 127.0.0.1");
             writeResponse(request, response, HttpResponseStatus.FORBIDDEN);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -123,8 +123,16 @@ public class MetricsAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, API_PATH, new MetricsAction(controller));
     }
 
+    // Prometheus-style metrics; intentionally unauthenticated by default. Per-table /
+    // per-MV / per-user-connection breakdowns do their own admin check inside
+    // parseRequestParams() and gracefully fall back when unauthenticated.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) throws DdlException {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
         // parse visitor type
         String type = request.getSingleParameter(TYPE_PARAM);
         MetricVisitor visitor = null;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -69,8 +69,14 @@ public class OAuth2Action extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/oauth2", new OAuth2Action(controller));
     }
 
+    // OAuth2 callback endpoint is itself the auth handshake; cannot require Basic.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         String authorizationCode = getSingleParameter(request, "code", r -> r);
         String connectionIdStr = getSingleParameter(request, "state", r -> r);
         long connectionId = Long.parseLong(connectionIdStr);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ProfileAction.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -57,7 +58,9 @@ public class ProfileAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String queryId = request.getSingleParameter("query_id");
         if (queryId == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDetailAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDetailAction.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.rest;
 
 import com.google.gson.Gson;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -57,7 +58,9 @@ public class QueryDetailAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String eventTimeStr = request.getSingleParameter("event_time");
         if (eventTimeStr == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
@@ -54,7 +55,9 @@ public class QueryDumpAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException, AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         ConnectContext context = ConnectContext.get();
         String catalogDbName = request.getSingleParameter(DB);
         boolean enableMock = request.getSingleParameter(MOCK) == null ||

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
@@ -34,6 +34,8 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.QueryProgressUtils;
 import com.starrocks.http.ActionController;
@@ -57,8 +59,16 @@ public class QueryProgressAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/query/progress", new QueryProgressAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String queryId = request.getSingleParameter("query_id");
         if (queryId == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -39,8 +39,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.starrocks.authentication.AuthenticationException;
+import com.starrocks.authentication.AuthenticationHandler;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.AuthorizationMgr;
+import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -60,6 +63,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -73,6 +77,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -103,6 +108,25 @@ public class RestBaseAction extends BaseAction {
 
     public RestBaseAction(ActionController controller) {
         super(controller);
+    }
+
+    /**
+     * Whether this action requires HTTP Basic Auth. {@code true} by default — auth is
+     * performed by {@link #execute(BaseRequest, BaseResponse)} before dispatching to
+     * {@link #executeWithoutPassword(BaseRequest, BaseResponse)}. Subclasses may override
+     * {@code execute} for pre-dispatch bypasses (see {@code LoadAction#tryInternalTokenBypass});
+     * the normal path must still call {@code super.execute(...)} so the auth pipeline runs.
+     * <p>
+     * Subclasses opt out by returning {@code false}:
+     * <ul>
+     *   <li>Probes / OAuth callback / internal token-protected endpoints — always {@code false}.</li>
+     *   <li>Endpoints that historically accepted anonymous requests and are gated for backward
+     *       compatibility — return {@link Config#enable_http_auth} so they require Basic only when
+     *       the operator opts in.</li>
+     * </ul>
+     */
+    public boolean needAuth() {
+        return true;
     }
 
     @Override
@@ -150,31 +174,59 @@ public class RestBaseAction extends BaseAction {
         }
     }
 
+    // Subclasses may override execute to short-circuit before auth runs (see
+    // LoadAction#tryInternalTokenBypass), but if a subclass falls through to
+    // the normal Basic-auth path it MUST call super.execute(...) — do not
+    // reimplement auth/ctx population, otherwise group-derived roles will be
+    // lost and requireXxxIfHttpAuthEnabled() helpers will deny legitimate users.
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException, AccessDeniedException {
-        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-        // check password
-        UserIdentity currentUser = checkPassword(authInfo);
-
         HttpConnectContext ctx = request.getConnectContext();
 
-        // Change user for ConnectContext if necessary
-        UserIdentity prevUserIdentity = ctx.getCurrentUserIdentity();
-        Set<Long> prevRoleIds = ctx.getCurrentRoleIds();
-        String prevUserName = ctx.getQualifiedUser();
+        if (needAuth()) {
+            ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
 
-        ctx.setCurrentUserIdentity(currentUser);
-        ctx.setCurrentRoleIds(currentUser);
-        ctx.setQualifiedUser(authInfo.fullUserName);
+            // Authenticate via a temporary ConnectContext so AuthenticationHandler can populate
+            // identity *and* group-derived roles on it. The legacy BaseAction.checkPassword(authInfo)
+            // overload drops the temp ctx and only returns UserIdentity, which means group roles
+            // (e.g. db_admin granted via LDAP group mapping) would be lost on the real ctx and
+            // requireXxxIfHttpAuthEnabled() helpers would wrongly deny access.
+            ConnectContext authCtx = new ConnectContext();
+            UserIdentity currentUser;
+            Set<Long> currentRoleIds;
+            Set<String> currentGroups;
+            try {
+                AuthenticationHandler.authenticate(authCtx, authInfo.fullUserName,
+                        authInfo.remoteIp, authInfo.password.getBytes(StandardCharsets.UTF_8));
+                currentUser = authCtx.getCurrentUserIdentity();
+                currentRoleIds = authCtx.getCurrentRoleIds();
+                currentGroups = authCtx.getGroups();
+            } catch (AuthenticationException e) {
+                throw new AccessDeniedException("Access denied for " + authInfo.fullUserName + "@" + authInfo.remoteIp);
+            }
 
-        if (ctx.isRegistered() && prevUserName != null && !prevUserName.equals(authInfo.fullUserName)) {
-            ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
-            Pair<Boolean, String> userChangeRes = connectScheduler.onUserChanged(ctx, prevUserName, ctx.getQualifiedUser());
-            if (!userChangeRes.first) {
-                ctx.setCurrentUserIdentity(prevUserIdentity);
-                ctx.setCurrentRoleIds(prevRoleIds);
-                ctx.setQualifiedUser(prevUserName);
-                throw new StarRocksHttpException(SERVICE_UNAVAILABLE, userChangeRes.second);
+            // Change user for ConnectContext if necessary
+            UserIdentity prevUserIdentity = ctx.getCurrentUserIdentity();
+            Set<Long> prevRoleIds = ctx.getCurrentRoleIds();
+            String prevUserName = ctx.getQualifiedUser();
+            Set<String> prevGroups = ctx.getGroups();
+
+            ctx.setCurrentUserIdentity(currentUser);
+            ctx.setCurrentRoleIds(currentRoleIds);
+            ctx.setGroups(currentGroups);
+            ctx.setQualifiedUser(authInfo.fullUserName);
+
+            if (ctx.isRegistered() && prevUserName != null && !prevUserName.equals(authInfo.fullUserName)) {
+                ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+                Pair<Boolean, String> userChangeRes =
+                        connectScheduler.onUserChanged(ctx, prevUserName, ctx.getQualifiedUser());
+                if (!userChangeRes.first) {
+                    ctx.setCurrentUserIdentity(prevUserIdentity);
+                    ctx.setCurrentRoleIds(prevRoleIds);
+                    ctx.setGroups(prevGroups);
+                    ctx.setQualifiedUser(prevUserName);
+                    throw new StarRocksHttpException(SERVICE_UNAVAILABLE, userChangeRes.second);
+                }
             }
         }
 
@@ -182,17 +234,40 @@ public class RestBaseAction extends BaseAction {
         ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         ctx.setNettyChannel(request.getContext());
         ctx.setQueryId(UUIDUtil.genUUID());
-        ctx.setRemoteIP(authInfo.remoteIp);
+        ctx.setRemoteIP(request.getHostString());
         try (var scope = ctx.bindScope()) {
             executeWithoutPassword(request, response);
         }
     }
 
-    // If user password should be checked, the derived class should implement this method, NOT 'execute()',
-    // otherwise, override 'execute()' directly
+    // Subclasses implement this. Auth + ConnectContext setup are already done by the final
+    // {@link #execute(BaseRequest, BaseResponse)} above; if {@link #needAuth()} returns false,
+    // the user-identity fields on ctx are left unset.
     protected void executeWithoutPassword(BaseRequest request, BaseResponse response)
             throws DdlException, AccessDeniedException {
         throw new DdlException("Not implemented");
+    }
+
+    // ---------- privilege helpers, gated by Config.enable_http_auth ----------
+    // Endpoints historically accepted anonymous (or any-authenticated) callers and we
+    // can't tighten them by default without breaking running scripts. These helpers
+    // let the subclass declare the intended privilege; the check actually runs only
+    // when the operator opts in via `enable_http_auth=true`.
+
+    /** Require INSERT on any table within the given db. */
+    protected void requireDbInsertIfHttpAuthEnabled(String dbName) throws AccessDeniedException {
+        if (!Config.enable_http_auth) {
+            return;
+        }
+        Authorizer.checkActionInDb(ConnectContext.get(), dbName, PrivilegeType.INSERT);
+    }
+
+    /** Require SYSTEM.OPERATE — for db/data/query operations. */
+    protected void requireOperateIfHttpAuthEnabled() throws AccessDeniedException {
+        if (!Config.enable_http_auth) {
+            return;
+        }
+        Authorizer.checkSystemAction(ConnectContext.get(), PrivilegeType.OPERATE);
     }
 
     public void sendResult(BaseRequest request, BaseResponse response, RestBaseResult result) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowDataAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowDataAction.java
@@ -34,9 +34,11 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.ActionController;
@@ -62,6 +64,12 @@ public class ShowDataAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.GET, "/api/show_data", new ShowDataAction(controller));
+    }
+
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
+    @Override
+    public boolean needAuth() {
+        return Config.enable_http_auth;
     }
 
     public long getDataSizeOfDatabase(Database db) {
@@ -100,7 +108,9 @@ public class ShowDataAction extends RestBaseAction {
     }
 
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String dbName = request.getSingleParameter("db");
         ConcurrentHashMap<String, Database> fullNameToDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getFullNameToDb();
         long totalSize = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -37,12 +37,14 @@ package com.starrocks.http.rest;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.ha.HAProtocol;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -92,8 +94,16 @@ public class ShowMetaInfoAction extends RestBaseAction {
                 new ShowMetaInfoAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String action = request.getSingleParameter("action");
         // check param empty
         if (Strings.isNullOrEmpty(action)) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowRuntimeInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowRuntimeInfoAction.java
@@ -35,6 +35,8 @@
 package com.starrocks.http.rest;
 
 import com.google.gson.Gson;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -57,8 +59,16 @@ public class ShowRuntimeInfoAction extends RestBaseAction {
                 new ShowRuntimeInfoAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         HashMap<String, String> feInfo = new HashMap<String, String>();
 
         // Get memory info

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TriggerAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TriggerAction.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.clone.DynamicPartitionScheduler;
@@ -52,7 +53,9 @@ public class TriggerAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String triggerType = request.getSingleParameter("type");
 
         if (Strings.isNullOrEmpty(triggerType)) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/BackendActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/BackendActionV2.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -39,7 +40,9 @@ public class BackendActionV2 extends RestBaseAction {
     }
 
     @Override
-    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         List<BackendNodeInfo> backendNodeInfos = new ArrayList<>();
         ImmutableMap<Long, Backend> backendMap =
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ClusterSummaryActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ClusterSummaryActionV2.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -62,7 +63,9 @@ public class ClusterSummaryActionV2 extends RestBaseAction {
     }
 
     @Override
-    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         LocalMetastore infoService = GlobalStateMgr.getCurrentState().getLocalMetastore();
 
         GlobalStateMgr globalState = GlobalStateMgr.getCurrentState();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ComputeNodeActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ComputeNodeActionV2.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -42,7 +43,9 @@ public class ComputeNodeActionV2 extends RestBaseAction {
     }
 
     @Override
-    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         List<ComputeNodeInfo> backendNodeInfos = new ArrayList<>();
         ImmutableMap<Long, ComputeNode> backendMap =
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdComputeNode();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.gson.reflect.TypeToken;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -43,7 +44,9 @@ public class ProfileActionV2 extends RestBaseAction {
     }
 
     @Override
-    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String authorization = request.getAuthorizationHeader();
         String queryId = request.getSingleParameter("query_id");
         String isRequestAllStr = request.getSingleParameter("is_request_all_frontend", "false");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/QueryDetailActionV2.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.gson.reflect.TypeToken;
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -44,7 +45,9 @@ public class QueryDetailActionV2 extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String authorization = request.getAuthorizationHeader();
         String eventTimeStr = request.getSingleParameter("event_time");
         String user = request.getSingleParameter("user");

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -350,6 +350,7 @@ import com.starrocks.thrift.TOlapTableTablet;
 import com.starrocks.thrift.TPartitionMeta;
 import com.starrocks.thrift.TPartitionMetaRequest;
 import com.starrocks.thrift.TPartitionMetaResponse;
+import com.starrocks.thrift.TPrivilegeRequirement;
 import com.starrocks.thrift.TQueryStatisticsInfo;
 import com.starrocks.thrift.TRefreshConnectionsRequest;
 import com.starrocks.thrift.TRefreshConnectionsResponse;
@@ -1103,6 +1104,72 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             default:
                 status.setStatus_code(NOT_IMPLEMENTED_ERROR);
                 break;
+        }
+        return result;
+    }
+
+    @Override
+    public TFeResult checkAuth(TAuthenticateParams request) throws TException {
+        TStatus status = new TStatus(TStatusCode.OK);
+        TFeResult result = new TFeResult(FrontendServiceVersion.V1, status);
+        if (request == null || !request.isSetUser() || !request.isSetPasswd()) {
+            status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
+            status.addToError_msgs("missing authentication parameters");
+            return result;
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("checkAuth request user={} host={} requiredPriv={}",
+                    request.getUser(),
+                    request.isSetHost() ? request.getHost() : null,
+                    request.isSetRequired_privilege() ? request.getRequired_privilege() : null);
+        }
+
+        String host = request.isSetHost() ? request.getHost() : "";
+        try {
+            ConnectContext ctx = new ConnectContext();
+            // authenticate() populates ctx.currentUserIdentity + currentRoleIds (with group-derived roles),
+            // so we MUST NOT overwrite them afterward; doing so would drop LDAP/security-integration groups
+            // and the OPERATE/NODE checks below would falsely reject privileged callers.
+            AuthenticationHandler.authenticate(ctx, request.getUser(), host,
+                    request.getPasswd().getBytes(StandardCharsets.UTF_8));
+
+            // getRequired_privilege() can return null when a newer BE sends an enum value
+            // this FE doesn't know (TPrivilegeRequirement.findByValue returns null); guard
+            // before the switch so we reject cleanly instead of throwing NPE.
+            TPrivilegeRequirement requiredPriv = request.isSetRequired_privilege()
+                    ? request.getRequired_privilege() : TPrivilegeRequirement.NONE;
+            if (requiredPriv == null) {
+                LOG.warn("checkAuth received unknown required_privilege (enum int) from BE for user={}",
+                        request.getUser());
+                status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                status.addToError_msgs("auth verification failed");
+                return result;
+            }
+            switch (requiredPriv) {
+                case NONE:
+                    break;
+                case OPERATE:
+                    Authorizer.checkSystemAction(ctx, PrivilegeType.OPERATE);
+                    break;
+                case NODE:
+                    Authorizer.checkSystemAction(ctx, PrivilegeType.NODE);
+                    break;
+                default:
+                    LOG.warn("checkAuth hit default switch arm for required_privilege={} (FE enum out of sync)",
+                            requiredPriv);
+                    status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                    status.addToError_msgs("auth verification failed");
+                    return result;
+            }
+        } catch (AuthenticationException e) {
+            LOG.warn("checkAuth authentication failed for user={}: {}", request.getUser(), e.getMessage());
+            status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
+            status.addToError_msgs("Access denied for " + request.getUser() + "@" + host);
+        } catch (AccessDeniedException e) {
+            LOG.warn("checkAuth privilege check failed for user={}: {}", request.getUser(), e.getMessage());
+            status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
+            status.addToError_msgs("Access denied for " + request.getUser() + "@" + host);
         }
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
@@ -56,4 +56,5 @@ public class BasicActionTest {
         result = WebUtils.sanitizeHttpReqUri(uri);
         Assertions.assertEquals(uri, result);
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -15,13 +15,41 @@
 package com.starrocks.http;
 
 import com.google.common.collect.Lists;
+import com.starrocks.authentication.AuthenticationException;
+import com.starrocks.authentication.AuthenticationHandler;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.http.rest.BootstrapFinishAction;
+import com.starrocks.http.rest.ConnectionAction;
+import com.starrocks.http.rest.FeatureAction;
+import com.starrocks.http.rest.GetClusterSnapshotRestoreStateAction;
+import com.starrocks.http.rest.GetSmallFileAction;
+import com.starrocks.http.rest.HealthAction;
+import com.starrocks.http.rest.IdleAction;
+import com.starrocks.http.rest.MemoryUsageAction;
+import com.starrocks.http.rest.MetricsAction;
+import com.starrocks.http.rest.OAuth2Action;
+import com.starrocks.http.rest.QueryProgressAction;
 import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.http.rest.ShowDataAction;
+import com.starrocks.http.rest.ShowMetaInfoAction;
+import com.starrocks.http.rest.ShowRuntimeInfoAction;
+import com.starrocks.http.rest.v2.BackendActionV2;
+import com.starrocks.http.rest.v2.ClusterSummaryActionV2;
+import com.starrocks.http.rest.v2.ComputeNodeActionV2;
+import com.starrocks.http.rest.v2.ProfileActionV2;
+import com.starrocks.http.rest.v2.QueryDetailActionV2;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -32,15 +60,24 @@ import io.netty.handler.codec.http.HttpVersion;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
+import java.util.Set;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,8 +90,44 @@ public class RestBaseActionTest {
     private TNetworkAddress mockAddr;
 
     static class TestableRestBaseAction extends RestBaseAction {
+        boolean executed;
+        UserIdentity observedUser;
+        Set<Long> observedRoleIds;
+        Set<String> observedGroups;
+        String observedQualifiedUser;
+        String observedRemoteIp;
+
         public TestableRestBaseAction() {
             super(null);
+        }
+
+        @Override
+        protected void executeWithoutPassword(BaseRequest request, BaseResponse response)
+                throws DdlException, AccessDeniedException {
+            executed = true;
+            ConnectContext ctx = ConnectContext.get();
+            observedUser = ctx.getCurrentUserIdentity();
+            observedRoleIds = ctx.getCurrentRoleIds();
+            observedGroups = ctx.getGroups();
+            observedQualifiedUser = ctx.getQualifiedUser();
+            observedRemoteIp = ctx.getRemoteIP();
+        }
+
+        // Expose the protected enable_http_auth-gated helpers so tests in this package
+        // can call them without reflection.
+        public void callRequireOperate() throws AccessDeniedException {
+            requireOperateIfHttpAuthEnabled();
+        }
+
+        public void callRequireDbInsert(String db) throws AccessDeniedException {
+            requireDbInsertIfHttpAuthEnabled(db);
+        }
+    }
+
+    static class NoAuthRestBaseAction extends TestableRestBaseAction {
+        @Override
+        public boolean needAuth() {
+            return false;
         }
     }
 
@@ -172,4 +245,249 @@ public class RestBaseActionTest {
         Assertions.assertEquals(frontend.getHost(), result.get(0).first);
         Assertions.assertEquals(Config.http_port, result.get(0).second);
     }
+
+    private static String basicAuth(String user, String password) {
+        String raw = user + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static BaseRequest mockExecutableRequest(String authHeader, HttpConnectContext connectContext) {
+        BaseRequest request = mock(BaseRequest.class);
+        HttpRequest httpRequest = mock(HttpRequest.class);
+        when(httpRequest.uri()).thenReturn("/api/auth_probe");
+        when(request.getRequest()).thenReturn(httpRequest);
+        when(request.getAuthorizationHeader()).thenReturn(authHeader);
+        when(request.getHostString()).thenReturn("10.4.5.6");
+        when(request.getConnectContext()).thenReturn(connectContext);
+
+        ChannelHandlerContext channelContext = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        when(channel.remoteAddress()).thenReturn(new InetSocketAddress("10.4.5.6", 9030));
+        when(channelContext.channel()).thenReturn(channel);
+        when(request.getContext()).thenReturn(channelContext);
+        return request;
+    }
+
+    @Test
+    public void testExecuteWithBasicAuthCopiesAuthenticatedContext() throws Exception {
+        TestableRestBaseAction action = new TestableRestBaseAction();
+        HttpConnectContext connectContext = new HttpConnectContext();
+        BaseRequest request = mockExecutableRequest(basicAuth("ldap_user", "secret"), connectContext);
+        UserIdentity authenticatedUser = UserIdentity.createAnalyzedUserIdentWithIp("ldap_user", "%");
+        Set<Long> roleIds = Set.of(10L, 20L);
+        Set<String> groups = Set.of("ldap_admins", "ldap_ops");
+
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            mocked.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class),
+                            eq("ldap_user"), eq("10.4.5.6"), any(byte[].class)))
+                    .thenAnswer(invocation -> {
+                        ConnectContext authCtx = invocation.getArgument(0);
+                        byte[] passwordBytes = invocation.getArgument(3);
+                        Assertions.assertArrayEquals("secret".getBytes(StandardCharsets.UTF_8), passwordBytes);
+                        authCtx.setCurrentUserIdentity(authenticatedUser);
+                        authCtx.setCurrentRoleIds(roleIds);
+                        authCtx.setGroups(groups);
+                        return authenticatedUser;
+                    });
+
+            action.execute(request, new BaseResponse());
+        }
+
+        Assertions.assertTrue(action.executed);
+        Assertions.assertEquals(authenticatedUser, action.observedUser);
+        Assertions.assertEquals(roleIds, action.observedRoleIds);
+        Assertions.assertEquals(groups, action.observedGroups);
+        Assertions.assertEquals("ldap_user", action.observedQualifiedUser);
+        Assertions.assertEquals("10.4.5.6", action.observedRemoteIp);
+    }
+
+    @Test
+    public void testExecuteWithAuthDisabledByActionBypassesAuthenticationHandler() throws Exception {
+        NoAuthRestBaseAction action = new NoAuthRestBaseAction();
+        BaseRequest request = mockExecutableRequest(null, new HttpConnectContext());
+
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            action.execute(request, new BaseResponse());
+            mocked.verifyNoInteractions();
+        }
+
+        Assertions.assertTrue(action.executed);
+        Assertions.assertNull(action.observedUser);
+    }
+
+    @Test
+    public void testExecuteWithInvalidCredentialsThrowsAccessDeniedBeforeDispatch() throws Exception {
+        TestableRestBaseAction action = new TestableRestBaseAction();
+        BaseRequest request = mockExecutableRequest(basicAuth("bad_user", "bad_pwd"), new HttpConnectContext());
+
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            mocked.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class),
+                            eq("bad_user"), eq("10.4.5.6"), any(byte[].class)))
+                    .thenThrow(new AuthenticationException("bad credentials"));
+
+            Assertions.assertThrows(AccessDeniedException.class, () -> action.execute(request, new BaseResponse()));
+        }
+
+        Assertions.assertFalse(action.executed);
+    }
+
+    @Test
+    public void testAlwaysAnonymousRestActionsBypassBasicAuth() {
+        Config.enable_http_auth = true;
+        Assertions.assertFalse(new BootstrapFinishAction(null).needAuth());
+        Assertions.assertFalse(new FeatureAction(null).needAuth());
+        Assertions.assertFalse(new HealthAction(null).needAuth());
+        Assertions.assertFalse(new GetSmallFileAction(null).needAuth());
+        Assertions.assertFalse(new OAuth2Action(null).needAuth());
+        Assertions.assertFalse(new IdleAction(null).needAuth());
+        Assertions.assertFalse(new MetricsAction(null).needAuth());
+    }
+
+    @Test
+    public void testCompatibilityGatedRestActionsFollowHttpAuthFlag() {
+        Config.enable_http_auth = false;
+        Assertions.assertFalse(new ConnectionAction(null).needAuth());
+        Assertions.assertFalse(new ShowDataAction(null).needAuth());
+        Assertions.assertFalse(new GetClusterSnapshotRestoreStateAction(null).needAuth());
+        Assertions.assertFalse(new MemoryUsageAction(null).needAuth());
+        Assertions.assertFalse(new QueryProgressAction(null).needAuth());
+        Assertions.assertFalse(new ShowMetaInfoAction(null).needAuth());
+        Assertions.assertFalse(new ShowRuntimeInfoAction(null).needAuth());
+
+        Config.enable_http_auth = true;
+        Assertions.assertTrue(new ConnectionAction(null).needAuth());
+        Assertions.assertTrue(new ShowDataAction(null).needAuth());
+        Assertions.assertTrue(new GetClusterSnapshotRestoreStateAction(null).needAuth());
+        Assertions.assertTrue(new MemoryUsageAction(null).needAuth());
+        Assertions.assertTrue(new QueryProgressAction(null).needAuth());
+        Assertions.assertTrue(new ShowMetaInfoAction(null).needAuth());
+        Assertions.assertTrue(new ShowRuntimeInfoAction(null).needAuth());
+    }
+
+    @Test
+    public void testSensitiveV2RestActionsKeepDefaultBasicAuth() {
+        Assertions.assertTrue(new BackendActionV2(null).needAuth());
+        Assertions.assertTrue(new ClusterSummaryActionV2(null).needAuth());
+        Assertions.assertTrue(new ComputeNodeActionV2(null).needAuth());
+        Assertions.assertTrue(new ProfileActionV2(null).needAuth());
+        Assertions.assertTrue(new QueryDetailActionV2(null).needAuth());
+    }
+
+    // -------- enable_http_auth-gated helpers --------
+
+    private boolean savedEnableHttpAuth;
+    private ConnectContext savedCtx;
+
+    @BeforeEach
+    public void saveHttpAuthFlag() {
+        savedEnableHttpAuth = Config.enable_http_auth;
+        savedCtx = ConnectContext.get();
+    }
+
+    @AfterEach
+    public void restoreHttpAuthFlag() {
+        Config.enable_http_auth = savedEnableHttpAuth;
+        if (savedCtx == null) {
+            ConnectContext.remove();
+        } else {
+            savedCtx.setThreadLocalInfo();
+        }
+    }
+
+    private TestableRestBaseAction newTestableAction() {
+        return new TestableRestBaseAction();
+    }
+
+    @Test
+    public void testRequireOperate_disabled_isNoop() throws Exception {
+        Config.enable_http_auth = false;
+        ConnectContext.remove();
+        newTestableAction().callRequireOperate();
+    }
+
+    @Test
+    public void testRequireDbInsert_disabled_isNoop() throws Exception {
+        Config.enable_http_auth = false;
+        ConnectContext.remove();
+        newTestableAction().callRequireDbInsert("any_db");
+    }
+
+    @Test
+    public void testRequireOperate_enabled_callsAuthorizer() throws Exception {
+        Config.enable_http_auth = true;
+        new ConnectContext().setThreadLocalInfo();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            // default no-throw = authorized
+            newTestableAction().callRequireOperate();
+            mocked.verify(() -> Authorizer.checkSystemAction(any(ConnectContext.class),
+                    org.mockito.ArgumentMatchers.eq(PrivilegeType.OPERATE)));
+        }
+    }
+
+    @Test
+    public void testRequireOperate_enabled_denied_propagatesAccessDenied() throws Exception {
+        Config.enable_http_auth = true;
+        new ConnectContext().setThreadLocalInfo();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            mocked.when(() -> Authorizer.checkSystemAction(any(ConnectContext.class),
+                            org.mockito.ArgumentMatchers.eq(PrivilegeType.OPERATE)))
+                    .thenThrow(new AccessDeniedException("operate denied"));
+
+            Assertions.assertThrows(AccessDeniedException.class,
+                    () -> newTestableAction().callRequireOperate());
+        }
+    }
+
+    @Test
+    public void testRequireDbInsert_enabled_denied_propagatesAccessDenied() throws Exception {
+        Config.enable_http_auth = true;
+        new ConnectContext().setThreadLocalInfo();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            mocked.when(() -> Authorizer.checkActionInDb(any(ConnectContext.class),
+                            org.mockito.ArgumentMatchers.eq("test_db"),
+                            org.mockito.ArgumentMatchers.eq(PrivilegeType.INSERT)))
+                    .thenThrow(new AccessDeniedException("db insert denied"));
+
+            Assertions.assertThrows(AccessDeniedException.class,
+                    () -> newTestableAction().callRequireDbInsert("test_db"));
+        }
+    }
+
+    @Test
+    public void testRequireOperate_enabled_checksOperateOnly() throws Exception {
+        // Asserts requireOperateIfHttpAuthEnabled checks SYSTEM.OPERATE and
+        // nothing else — in particular, the helper must not also try NODE as
+        // a fallback. The NODE-denied stub would surface any such regression.
+        Config.enable_http_auth = true;
+        new ConnectContext().setThreadLocalInfo();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            mocked.when(() -> Authorizer.checkSystemAction(any(ConnectContext.class),
+                            org.mockito.ArgumentMatchers.eq(PrivilegeType.NODE)))
+                    .thenThrow(new AccessDeniedException("must not be called"));
+
+            newTestableAction().callRequireOperate();
+            mocked.verify(() -> Authorizer.checkSystemAction(any(ConnectContext.class),
+                    org.mockito.ArgumentMatchers.eq(PrivilegeType.OPERATE)));
+            mocked.verify(() -> Authorizer.checkSystemAction(any(ConnectContext.class),
+                    org.mockito.ArgumentMatchers.eq(PrivilegeType.NODE)), never());
+        }
+    }
+
+    @Test
+    public void testRequireDbInsert_enabled_callsCheckActionInDb() throws Exception {
+        Config.enable_http_auth = true;
+        new ConnectContext().setThreadLocalInfo();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            newTestableAction().callRequireDbInsert("test_db");
+            mocked.verify(() -> Authorizer.checkActionInDb(any(ConnectContext.class),
+                    org.mockito.ArgumentMatchers.eq("test_db"),
+                    org.mockito.ArgumentMatchers.eq(PrivilegeType.INSERT)));
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -15,6 +15,10 @@
 package com.starrocks.service;
 
 import com.google.common.collect.Lists;
+import com.starrocks.authentication.AuthenticationException;
+import com.starrocks.authentication.AuthenticationHandler;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.MaterializedIndex;
@@ -48,11 +52,13 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.MVTaskType;
 import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBatchGetTableSchemaRequest;
 import com.starrocks.thrift.TBatchGetTableSchemaResponse;
 import com.starrocks.thrift.TColumnDef;
@@ -61,6 +67,7 @@ import com.starrocks.thrift.TCreatePartitionResult;
 import com.starrocks.thrift.TDescribeTableParams;
 import com.starrocks.thrift.TDescribeTableResult;
 import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TFeResult;
 import com.starrocks.thrift.TFileType;
 import com.starrocks.thrift.TGetDictQueryParamRequest;
 import com.starrocks.thrift.TGetDictQueryParamResponse;
@@ -99,6 +106,7 @@ import com.starrocks.thrift.TPartitionMeta;
 import com.starrocks.thrift.TPartitionMetaRequest;
 import com.starrocks.thrift.TPartitionMetaResponse;
 import com.starrocks.thrift.TPlanFragmentExecParams;
+import com.starrocks.thrift.TPrivilegeRequirement;
 import com.starrocks.thrift.TRefreshConnectionsRequest;
 import com.starrocks.thrift.TRefreshConnectionsResponse;
 import com.starrocks.thrift.TResourceUsage;
@@ -152,6 +160,7 @@ import static com.starrocks.thrift.TFileType.FILE_STREAM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -201,6 +210,174 @@ public class FrontendServiceImplTest {
 
         TMVReportEpochResponse response = impl.mvReport(request);
         Assertions.assertNotNull(response);
+    }
+
+    @Test
+    public void testCheckAuthRejectsMissingCredentials() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        TFeResult nullRequestResult = impl.checkAuth(null);
+        Assertions.assertEquals(TStatusCode.NOT_AUTHORIZED, nullRequestResult.getStatus().getStatus_code());
+
+        TFeResult emptyRequestResult = impl.checkAuth(new TAuthenticateParams());
+        Assertions.assertEquals(TStatusCode.NOT_AUTHORIZED, emptyRequestResult.getStatus().getStatus_code());
+
+        TAuthenticateParams missingPasswordRequest = new TAuthenticateParams();
+        missingPasswordRequest.setUser("root");
+        TFeResult missingPasswordResult = impl.checkAuth(missingPasswordRequest);
+        Assertions.assertEquals(TStatusCode.NOT_AUTHORIZED, missingPasswordResult.getStatus().getStatus_code());
+    }
+
+    private static TAuthenticateParams buildAuthParams(TPrivilegeRequirement priv) {
+        TAuthenticateParams params = new TAuthenticateParams();
+        params.setUser("ut_user");
+        params.setPasswd("ut_pwd");
+        if (priv != null) {
+            params.setRequired_privilege(priv);
+        }
+        return params;
+    }
+
+    @Test
+    public void testCheckAuth_None_validCredentials_succeeds() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            mocked.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+
+            TFeResult result = impl.checkAuth(buildAuthParams(null));
+            Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
+        }
+    }
+
+    @Test
+    public void testCheckAuth_Operate_authorized_succeeds() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        try (MockedStatic<AuthenticationHandler> mockedAuth = mockStatic(AuthenticationHandler.class);
+                MockedStatic<Authorizer> mockedAuthz = mockStatic(Authorizer.class)) {
+            mockedAuth.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+            // checkSystemAction is void; default mock = no-op (i.e. authorized)
+
+            TFeResult result = impl.checkAuth(buildAuthParams(TPrivilegeRequirement.OPERATE));
+            Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
+            mockedAuthz.verify(
+                    () -> Authorizer.checkSystemAction(any(ConnectContext.class), eq(PrivilegeType.OPERATE)));
+        }
+    }
+
+    @Test
+    public void testCheckAuth_Operate_denied_returnsNotAuthorized() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        try (MockedStatic<AuthenticationHandler> mockedAuth = mockStatic(AuthenticationHandler.class);
+                MockedStatic<Authorizer> mockedAuthz = mockStatic(Authorizer.class)) {
+            mockedAuth.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+            mockedAuthz.when(() -> Authorizer.checkSystemAction(any(ConnectContext.class), eq(PrivilegeType.OPERATE)))
+                    .thenThrow(new AccessDeniedException("internal denial reason — operator only"));
+
+            TFeResult result = impl.checkAuth(buildAuthParams(TPrivilegeRequirement.OPERATE));
+            Assertions.assertEquals(TStatusCode.NOT_AUTHORIZED, result.getStatus().getStatus_code());
+            // The internal denial reason MUST NOT leak to the HTTP client; only a
+            // generic "Access denied for user@host" is exposed.
+            String errMsg = String.join(";", result.getStatus().getError_msgs());
+            Assertions.assertFalse(errMsg.contains("internal denial reason"));
+            Assertions.assertTrue(errMsg.startsWith("Access denied for"));
+        }
+    }
+
+    @Test
+    public void testCheckAuth_Node_authorized_succeeds() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        try (MockedStatic<AuthenticationHandler> mockedAuth = mockStatic(AuthenticationHandler.class);
+                MockedStatic<Authorizer> mockedAuthz = mockStatic(Authorizer.class)) {
+            mockedAuth.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+
+            TFeResult result = impl.checkAuth(buildAuthParams(TPrivilegeRequirement.NODE));
+            Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
+            mockedAuthz.verify(
+                    () -> Authorizer.checkSystemAction(any(ConnectContext.class), eq(PrivilegeType.NODE)));
+        }
+    }
+
+    @Test
+    public void testCheckAuth_Node_denied_returnsNotAuthorized() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        try (MockedStatic<AuthenticationHandler> mockedAuth = mockStatic(AuthenticationHandler.class);
+                MockedStatic<Authorizer> mockedAuthz = mockStatic(Authorizer.class)) {
+            mockedAuth.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+            mockedAuthz.when(() -> Authorizer.checkSystemAction(any(ConnectContext.class), eq(PrivilegeType.NODE)))
+                    .thenThrow(new AccessDeniedException("denied"));
+
+            TFeResult result = impl.checkAuth(buildAuthParams(TPrivilegeRequirement.NODE));
+            Assertions.assertEquals(TStatusCode.NOT_AUTHORIZED, result.getStatus().getStatus_code());
+        }
+    }
+
+    @Test
+    public void testCheckAuth_AuthenticationException_returnsNotAuthorized() throws TException {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            mocked.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenThrow(new AuthenticationException("wrong password"));
+
+            TFeResult result = impl.checkAuth(buildAuthParams(TPrivilegeRequirement.OPERATE));
+            Assertions.assertEquals(TStatusCode.NOT_AUTHORIZED, result.getStatus().getStatus_code());
+        }
+    }
+
+    @Test
+    public void testCheckAuth_nullRequiredPrivilege_returnsInternalError() throws TException {
+        // A newer BE may send a thrift enum value this FE does not know.
+        // TPrivilegeRequirement.findByValue would return null in the generated thrift
+        // accessor, but isSetRequired_privilege() would still report true. Spy on a
+        // real request to reproduce that combination and verify the pre-switch
+        // null-guard rejects cleanly instead of throwing NPE on switch(null).
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TAuthenticateParams real = buildAuthParams(TPrivilegeRequirement.OPERATE);
+        TAuthenticateParams spy = Mockito.spy(real);
+        Mockito.doReturn(true).when(spy).isSetRequired_privilege();
+        Mockito.doReturn(null).when(spy).getRequired_privilege();
+
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            mocked.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+
+            TFeResult result = impl.checkAuth(spy);
+            Assertions.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
+        }
+    }
+
+    @Test
+    public void testCheckAuth_debugLogEnabled_doesNotCrash() throws TException {
+        // Flip the FrontendServiceImpl logger to DEBUG so the isDebugEnabled() guard
+        // fires and the LOG.debug(...) format call executes. Asserts the call doesn't
+        // NPE when host / required_privilege are unset.
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        org.apache.logging.log4j.core.config.Configurator.setLevel(
+                FrontendServiceImpl.class.getName(), org.apache.logging.log4j.Level.DEBUG);
+        try (MockedStatic<AuthenticationHandler> mocked = mockStatic(AuthenticationHandler.class)) {
+            mocked.when(() -> AuthenticationHandler.authenticate(any(ConnectContext.class), any(), any(), any()))
+                    .thenReturn(UserIdentity.ROOT);
+            TAuthenticateParams params = new TAuthenticateParams();
+            params.setUser("ut_user");
+            params.setPasswd("ut_pwd");
+            // intentionally leave host + required_privilege unset to exercise the
+            // ternaries in the debug log.
+            TFeResult result = impl.checkAuth(params);
+            Assertions.assertNotNull(result.getStatus());
+        } finally {
+            org.apache.logging.log4j.core.config.Configurator.setLevel(
+                    FrontendServiceImpl.class.getName(), org.apache.logging.log4j.Level.INFO);
+        }
     }
 
     private static ConnectContext connectContext;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -58,12 +58,27 @@ struct TSetSessionParams {
     1: required string user
 }
 
+enum TPrivilegeRequirement {
+    // Identity-only authentication, no role/privilege check beyond AuthN.
+    NONE = 0,
+    // Caller must hold System-level OPERATE privilege.
+    // Maps to Authorizer.checkSystemAction(OPERATE) on the FE side.
+    OPERATE = 1,
+    // Caller must hold System-level NODE privilege.
+    // Maps to Authorizer.checkSystemAction(NODE) on the FE side.
+    NODE = 2,
+}
+
 struct TAuthenticateParams {
     1: required string user
     2: required string passwd
     3: optional string host
     4: optional string db_name
     5: optional list<string> table_names;
+    // Required role/privilege the caller must have, in addition to identity AuthN.
+    // Used by FE.checkAuth on the BE HTTP auth path so BE handlers can demand
+    // admin/operate-level checks without round-tripping the role check themselves.
+    6: optional TPrivilegeRequirement required_privilege;
 }
 
 struct TColumnDesc {
@@ -2532,4 +2547,9 @@ service FrontendService {
     TBatchGetTableSchemaResponse getTableSchema(1: TBatchGetTableSchemaRequest request)
 
     TBatchGetTabletMetadataResponse getTabletMetadata(1: optional TBatchGetTabletMetadataRequest request)
+
+    // Verify Basic Auth credentials. Used by BE to authenticate external HTTP requests
+    // when `enable_http_auth` is on. Returns OK status when the user/password pair is
+    // valid for the given host, or an error status otherwise.
+    TFeResult checkAuth(1: optional TAuthenticateParams request)
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

## Summary

 Wire authentication and RBAC enforcement onto every external HTTP endpoint on
 FE and BE, controlled by a new global flag `enable_http_auth` so the change
 ships dark and can be ramped per deployment.

 - **FE**: `RestBaseAction` routes requests through a new
   `requireXxxIfHttpAuthEnabled` helper family that short-circuits when the
   flag is off, preserving today's `main`-branch behavior on upgrade. Each
   REST action declares its required privilege (operate / node /
   db_insert, or `token` / `label-context` for handler-internal checks) at
   the helper call site; legacy main-only priv checks stay untouched.
   `FrontendServiceImpl.checkAuth` becomes the BE → FE entry point: it runs
   `AuthenticationHandler.authenticate` to populate the `ConnectContext`, then
   dispatches on `TPrivilegeRequirement` to `Authorizer.checkSystemAction`. The
   two priv values (`OPERATE`, `NODE`) check the active role set so LDAP /
   security-integration group mappings are honored exactly like SQL. We
   deliberately did **not** add an `ADMIN` value backed by the
   legacy `BaseAction.checkUserOwnsAdminRole` helper — every endpoint declares
   a concrete RBAC privilege instead.
 - **BE**: `HttpHandler` grows a virtual `required_privilege()` returning a
   new `RequiredPrivilege` enum that mirrors the thrift contract; concrete
   handlers override it (e.g. `WebPageHandler → OPERATE`,
   `PprofBaseHandler → OPERATE`, `StopBeAction → NODE`,
   `ChecksumAction → OPERATE`,
   `StreamLoad → NONE` since it does its own label-scoped check inside the
   handler).
   `ev_http_server` invokes `verify_http_basic_auth` before dispatch when the
   flag is on; the helper parses the Authorization header and calls
   `FrontendService.checkAuth` over thrift with the handler's declared
   privilege. A new `http_auth_response` helper centralizes the 401 /
   `WWW-Authenticate` response so handlers don't reimplement it.
 - **thrift**: Extend `TAuthenticateParams` with a new optional
   `TPrivilegeRequirement` enum (`NONE / OPERATE / NODE`)
   so BE can express the handler-level requirement without leaking BE enums.

 ### Exempt endpoints (anonymous access stays allowed even with the flag on)

 - FE public probes / observability: `/api/health`, `/api/bootstrap`,
   `/api/idle_status`, `/api/v2/feature`, `/metrics`, `/api/oauth2`
 - BE public probes / observability: `/api/health`, `/metrics`,
   `/metrics/memory`

 ### Endpoints that bypass Basic Auth because they enforce their own identity / authorization

 - FE peer / control-plane (IP-whitelisted or token-gated): `/image`,
   `/check`, `/journal_id`, `/info`, `/role`, `/dump`, `/dump_starmgr`,
   `/service_id`, `/static`, `/api/_meta_replay_state`,
   `/api/get_small_file`
 - BE internal transport (token-gated, used by FE/BE for tablet clone and
   load-error file fetch): `/api/_tablet/_download`, `/api/_download_load`
 - BE Stream Load and transaction endpoints that authenticate inside the
   handler using the load label + table grants:
   `/api/{db}/{table}/_stream_load`, `/api/transaction/{txn_op}`,
   `/api/transaction/load`

 ## Endpoints overview (114 total)

 | Group | Count | Behavior when `enable_http_auth=on` |
 |---|---|---|
 | FE flag-gated (new Basic + new priv)              | 7  | both AuthN and AuthZ kick in |
 | FE always-Basic, priv flag-gated                  | 11 | new priv check on top of existing Basic |
 | FE legacy ADMIN priv (unchanged)                  | 9  | no behavior change |
 | FE Stream Load / SQL table-scope (unchanged)      | 8  | no behavior change |
 | FE Web UI pages (always-on)                       | 10 | unchanged, NODE_OR_ADMIN |
 | FE legacy admin pages / meta-sync (unchanged)     | 16 | unchanged |
 | FE handler-internal (IP-whitelist / token)        | 2  | unchanged |
 | FE exempt                                         | 6  | always anonymous |
 | **BE flag-gated admin / data-plane**              | 15 | new Basic + new priv |
 | BE flag-gated cache stat                          | 4  | new Basic + new priv |
 | BE flag-gated profiling                           | 11 | new Basic + new priv |
 | BE flag-gated Web UI pages                        | 6  | new Basic + OPERATE |
 | BE Stream Load (AuthN flag-gated)                 | 1  | adds Basic; priv stays in handler |
 | BE AuthN-only flag-gated (`_load_error_log`)      | 1  | new Basic only |
 | BE handler-internal (token / label-context)       | 4  | unchanged |
 | BE exempt                                         | 3  | always anonymous |

 - **New AuthN added** (Basic-Auth required when flag on): **45 endpoints**
 - **New priv checks added** (via BE→FE `checkAuth`): **54 endpoints**
   (43 of those are also in "New AuthN added"; the other 11 ride on always-on Basic Auth)
 - Always-on / legacy / Web UI preserved: 43 endpoints
 - Exempt / handler-internal preserved: 15 endpoints

 <details>
 <summary><b>Full endpoint list — expand to see every API</b></summary>

 #### Legend

 `AuthN` column — when the flag is on:
 - `Basic` — HTTP Basic Authorization header required; verified against the user store
 - `Token` — handler-internal token check (BE→BE / BE→FE)
 - `Label` — Stream Load label + table-grant context check
 - `IP-whitelist` — peer-FE only, rejected from external IPs
 - `Exempt` — anonymous access stays allowed

 `Privilege` column — what the FE `checkAuth` (or the in-handler check for `webui` pages) demands. All values map to `Authorizer.checkSystemAction`, which honors the **active** role set on the session (so LDAP / security-integration group mappings work the same as for SQL):
 - `OPERATE` = `SYSTEM.OPERATE`
 - `NODE` = `SYSTEM.NODE` (granted via `cluster_admin` role)
 - `NODE_OR_ADMIN` = legacy WebBaseAction policy (NODE or db_admin+user_admin), used only by FE Web UI pages that retain main's pre-PR semantics
 - `INSERT(*)` = `INSERT` on the target table / any table in the target db

 `Flag-gated` means: privilege only enforced when `enable_http_auth=true`.
 `Always-on` means: privilege enforced regardless of the flag (legacy behavior preserved).

 ---

 #### FE — REST endpoints, flag-gated (7)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/api/connection`                            | Basic | OPERATE         |
 | GET | `/api/query/progress`                        | Basic | OPERATE         |
 | GET | `/api/show_data`                             | Basic | OPERATE         |
 | GET | `/api/show_meta_info`                        | Basic | OPERATE         |
 | GET | `/api/show_runtime_info`                     | Basic | OPERATE |
 | GET | `/api/v2/get_cluster_snapshot_restore_state` | Basic | OPERATE |
 | GET | `/api/memory_usage`                          | Basic | OPERATE |

 #### FE — REST endpoints, always Basic-Auth, additional priv check flag-gated (11)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET  | `/api/profile`              | Basic (always) | OPERATE         |
 | GET  | `/api/v2/profile`           | Basic (always) | OPERATE         |
 | GET  | `/api/query_detail`         | Basic (always) | OPERATE         |
 | GET  | `/api/v2/query_detail`      | Basic (always) | OPERATE         |
 | POST | `/api/query_dump`           | Basic (always) | OPERATE         |
 | GET  | `/api/trigger`              | Basic (always) | OPERATE         |
 | POST | `/api/{db}/{table}/_cancel` | Basic (always) | INSERT(db)      |
 | GET  | `/api/{db}/get_load_state`  | Basic (always) | INSERT(any in db) |
 | GET  | `/api/v2/backend`           | Basic (always) | OPERATE |
 | GET  | `/api/v2/computeNode`       | Basic (always) | OPERATE |
 | GET  | `/api/v2/cluster_summary`   | Basic (always) | OPERATE |

 #### FE — REST endpoints with legacy/main-line privilege (always-on, unchanged) (9)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET  | `/api/show_proc`               | Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/colocate`                | Basic | ADMIN (legacy, always-on) |
 | POST | `/api/global_dict/table/enable`| Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/{db}/{table}/_sync_meta` | Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/_set_config`             | Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/_check_storagetype`      | Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/_get_ddl`                | Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/_migration`              | Basic | ADMIN (legacy, always-on) |
 | GET  | `/api/rowcount`                | Basic | ADMIN (legacy, always-on) |

 #### FE — Stream Load and SQL endpoints (table-scoped auth, unchanged) (8)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | PUT  | `/api/{db}/{table}/_stream_load`                                            | Basic | INSERT(table) |
 | POST | `/api/transaction/{txn_op}`                                                 | Basic | INSERT(table) |
 | PUT  | `/api/transaction/load`                                                     | Basic | INSERT(table) |
 | GET  | `/api/{db}/{table}/_query_plan`                                             | Basic | (handler-internal) |
 | POST | `/api/v1/catalogs/{catalog}/sql`                                            | Basic | (handler-internal) |
 | POST | `/api/v1/catalogs/{catalog}/databases/{db}/sql`                             | Basic | (handler-internal) |
 | GET  | `/api/v2/catalogs/{catalog}/databases/{db}/tables/{table}/schema`           | Basic | (handler-internal) |
 | GET  | `/api/v2/catalogs/{catalog}/databases/{db}/tables/{table}/partition`        | Basic | (handler-internal) |

 #### FE — Web UI pages (WebBaseAction, always-on AuthN + AuthZ) (10)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/system`        | Basic | NODE_OR_ADMIN |
 | GET | `/backend`       | Basic | NODE_OR_ADMIN |
 | GET | `/log`           | Basic | NODE_OR_ADMIN |
 | GET | `/session`       | Basic | NODE_OR_ADMIN |
 | GET | `/variable`      | Basic | NODE_OR_ADMIN |
 | GET | `/ha`            | Basic | NODE_OR_ADMIN |
 | GET | `/query`         | Basic | NODE_OR_ADMIN |
 | GET | `/query_profile` | Basic | NODE_OR_ADMIN |
 | GET | `/proc_profile`  | Basic | NODE_OR_ADMIN |
 | GET | `/index`         | Basic | NODE_OR_ADMIN |

 #### FE — Legacy admin pages and meta-sync routes (legacy, always-on) (16)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/image`                              | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/check`                              | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/journal_id`                         | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/info`                               | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/role`                               | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/dump`                               | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/dump_starmgr`                       | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/service_id`                         | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/static`                             | Basic | NODE_OR_ADMIN (legacy) |
 | GET | `/api/{db}/_load_info`                | Basic | INSERT(any in db) (legacy) |
 | GET | `/api/{db}/{table}/_stream_load_meta` | Basic | (handler-internal) |
 | GET | `/api/{db}/{table}/_schema`           | Basic | (handler-internal) |
 | GET | `/api/{db}/{table}/_count`            | Basic | (handler-internal) |
 | GET | `/api/colocate/group_stable`          | Basic | ADMIN (legacy) |
 | GET | `/api/check_decommission`             | Basic | ADMIN (legacy) |
 | GET | `/api/get_log_file`                   | Basic | ADMIN (legacy) |

 #### FE — Handler-internal auth (unchanged) (2)

 | Method | Path | AuthN | Notes |
 |---|---|---|---|
 | GET | `/api/_meta_replay_state` | IP-whitelist | peer-FE only |
 | GET | `/api/get_small_file`     | Token        | BE → FE internal |

 #### FE — Exempt (anonymous, regardless of flag) (6)

 | Method | Path | Reason |
 |---|---|---|
 | GET | `/api/health`      | health probe |
 | GET | `/api/bootstrap`   | bootstrap probe |
 | GET | `/api/idle_status` | idle probe |
 | GET | `/api/v2/feature`  | feature flag query |
 | GET | `/metrics`         | Prometheus scrape |
 | GET | `/api/oauth2`      | OAuth callback (third-party) |

 ---

 #### BE — Admin / data-plane endpoints, flag-gated (15)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET  | `/api/_stop_be`                              | Basic | NODE    |
 | POST | `/api/update_config`                         | Basic | OPERATE |
 | POST | `/api/compact`                               | Basic | OPERATE |
 | GET  | `/api/compaction/show`                       | Basic | OPERATE |
 | GET  | `/api/compaction/show_repair`                | Basic | OPERATE |
 | GET  | `/api/compaction/running`                    | Basic | OPERATE |
 | PUT  | `/api/compaction/submit_repair`              | Basic | OPERATE |
 | GET  | `/api/checksum`                              | Basic | OPERATE |
 | GET  | `/api/reload_tablet`                         | Basic | OPERATE |
 | POST | `/api/restore_tablet`                        | Basic | OPERATE |
 | GET  | `/api/snapshot`                              | Basic | OPERATE |
 | GET  | `/api/meta/header/{tablet_id}`               | Basic | OPERATE |
 | POST | `/api/compact_rocksdb_meta`                  | Basic | OPERATE |
 | GET  | `/api/cloudnative/dump_tablet_metadata/{id}` | Basic | OPERATE |
 | GET  | `/api/runtime_filter_cache/stat`             | Basic | OPERATE |

 #### BE — Cache stat endpoints, flag-gated (4)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/api/query_cache/stat`               | Basic | OPERATE |
 | GET | `/api/jit_cache/stat`                 | Basic | OPERATE |
 | GET | `/api/datacache/stat`                 | Basic | OPERATE |
 | GET | `/api/pipeline_blocking_drivers/stat` | Basic | OPERATE |

 #### BE — Profiling endpoints, flag-gated (11)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/pprof/heap`            | Basic | OPERATE |
 | GET | `/pprof/growth`          | Basic | OPERATE |
 | GET | `/pprof/profile`         | Basic | OPERATE |
 | GET | `/pprof/pmuprofile`      | Basic | OPERATE |
 | GET | `/pprof/contention`      | Basic | OPERATE |
 | GET | `/pprof/cmdline`         | Basic | OPERATE |
 | GET | `/pprof/symbol`          | Basic | OPERATE |
 | GET | `/ioprofile`             | Basic | OPERATE |
 | GET | `/greplog`               | Basic | OPERATE |
 | GET | `/api/proc_profile/list` | Basic | OPERATE |
 | GET | `/proc_profile/file`     | Basic | OPERATE |

 #### BE — Web UI pages, flag-gated (6)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/`             | Basic | OPERATE |
 | GET | `/varz`         | Basic | OPERATE |
 | GET | `/memz`         | Basic | OPERATE |
 | GET | `/mem_tracker`  | Basic | OPERATE |
 | GET | `/logs`         | Basic | OPERATE |
 | GET | `/proc_profile` | Basic | OPERATE |

 #### BE — Stream Load (flag-gated AuthN, priv in handler) (1)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | PUT | `/api/{db}/{table}/_stream_load` | Basic | INSERT(table) (in-handler) |

 #### BE — Other flag-gated AuthN, no priv check (1)

 | Method | Path | AuthN | Privilege |
 |---|---|---|---|
 | GET | `/api/_load_error_log` | Basic | — |

 #### BE — Handler-internal auth (unchanged) (4)

 | Method | Path | AuthN | Notes |
 |---|---|---|---|
 | POST | `/api/transaction/{txn_op}` | Label-context | Stream Load label + table grants |
 | PUT  | `/api/transaction/load`     | Label-context | Stream Load label + table grants |
 | GET  | `/api/_tablet/_download`    | Token         | BE-to-BE tablet clone |
 | GET  | `/api/_download_load`       | Token         | internal load file fetch |

 #### BE — Exempt (anonymous, regardless of flag) (3)

 | Method | Path | Reason |
 |---|---|---|
 | GET | `/api/health`     | health probe |
 | GET | `/metrics`        | Prometheus scrape |
 | GET | `/metrics/memory` | Prometheus scrape (memory) |

 </details>


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
