### PR TITLE
[Enhancement] Resolve cherry-pick conflict for #73512 backport of #73204

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -508,10 +508,6 @@ service LakeService {
     rpc drop_tablet_cache(DropTabletCacheRequest) returns (DropTabletCacheResponse);
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
     rpc repair_tablet_metadata(RepairTabletMetadataRequest) returns (RepairTabletMetadataResponse);
-<<<<<<< HEAD
-=======
     // Placeholder for external cluster snapshot feature.
     rpc upload_snapshot_files(UploadSnapshotFilesRequestPB) returns (UploadSnapshotFilesResponsePB);
-    rpc build_vector_index(BuildVectorIndexRequest) returns (BuildVectorIndexResponse);
->>>>>>> 52ee60cd64 ([Enhancement] Reserve proto/thrift fields for external cluster snapshot feature (#73204))
 }


### PR DESCRIPTION
## Why I'm doing:

The Mergify auto-backport for #73204 to \`branch-4.1\` (PR #73512) failed
with a cherry-pick conflict in \`gensrc/proto/lake_service.proto\` and was
pushed with unresolved \`<<<<<<<\` / \`=======\` / \`>>>>>>>\` markers at the
end of the \`LakeService\` definition.

The conflict block additionally pulled in an unrelated
\`build_vector_index\` RPC whose \`BuildVectorIndexRequest\` /
\`BuildVectorIndexResponse\` types are not defined on \`branch-4.1\` —
keeping it would break the proto compile.

## What I'm doing:

- Remove the conflict markers in \`gensrc/proto/lake_service.proto\`.
- Keep only the RPC introduced by #73204
  (\`upload_snapshot_files(UploadSnapshotFilesRequestPB)\`).
- Drop the unrelated \`build_vector_index\` RPC.

The new placeholder messages (\`TabletDataSnapshotPB\`,
\`UploadSnapshotFilesRequestPB\`, \`UploadSnapshotFilesResponsePB\`) and the
other four files (\`lake_types.proto\`, \`AgentService.thrift\`,
\`MasterService.thrift\`, \`Types.thrift\`) were applied cleanly by mergify
and are preserved unchanged.

Merging this PR into \`mergify/bp/branch-4.1/pr-73204\` unblocks #73512.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] This is a backport pr