### PR TITLE
[Enhancement] Alter light_weight_tablet_creation + skip CreateReplicaTask in schema change/rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -471,6 +471,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -66,9 +66,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.validation.constraints.NotNull;
 
@@ -200,10 +202,12 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         long numTablets = 0;
         AgentBatchTask batchTask = new AgentBatchTask();
         MarkedCountDownLatch<Long, Long> countDownLatch;
+        boolean lightWeight;
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.ROLLUP);
+            lightWeight = table.isLightWeightTabletCreation();
 
             // disable tablet creation optimaization to avoid overwriting files with the same name.
             if (table.isFileBundling()) {
@@ -218,7 +222,13 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             countDownLatch = new MarkedCountDownLatch<>((int) numTablets);
 
             long gtid = getNextGtid();
-            for (Map.Entry<Long, MaterializedIndex> entry : this.physicalPartitionIdToRollupIndex.entrySet()) {
+            // Light-weight tablet creation skips CreateReplicaTask; the rollup tablet's
+            // version 1 metadata is materialized on demand by the CN-side fallback when
+            // the first read or publish hits it.
+            Set<Map.Entry<Long, MaterializedIndex>> rollupEntries = lightWeight
+                    ? Collections.<Map.Entry<Long, MaterializedIndex>>emptySet()
+                    : this.physicalPartitionIdToRollupIndex.entrySet();
+            for (Map.Entry<Long, MaterializedIndex> entry : rollupEntries) {
                 long partitionId = entry.getKey();
                 PhysicalPartition partition = table.getPhysicalPartition(partitionId);
                 if (partition == null) {
@@ -293,7 +303,9 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             }
         }
 
-        sendAgentTaskAndWait(batchTask, countDownLatch, Config.tablet_create_timeout_second * numTablets);
+        if (!lightWeight) {
+            sendAgentTaskAndWait(batchTask, countDownLatch, Config.tablet_create_timeout_second * numTablets);
+        }
 
         // Add shadow indexes to table.
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -95,6 +95,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -400,9 +401,11 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         long numTablets = 0;
         AgentBatchTask batchTask = new AgentBatchTask();
         MarkedCountDownLatch<Long, Long> countDownLatch;
+        boolean lightWeight;
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
+            lightWeight = table.isLightWeightTabletCreation();
 
             // disable tablet creation optimaization to avoid overwriting files with the same name.
             if (table.isFileBundling()) {
@@ -419,7 +422,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             long baseIndexMetaId = table.getBaseIndexMetaId();
             long gtid = getNextGtid();
             final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            // Light-weight tablet creation skips CreateReplicaTask; the shadow tablet's
+            // version 1 metadata is materialized on demand by the CN-side fallback when
+            // the first read or publish hits it.
+            Set<Long> shadowPhysicalPartitionIds = lightWeight
+                    ? Collections.<Long>emptySet()
+                    : physicalPartitionIndexMap.rowKeySet();
+            for (long physicalPartitionId : shadowPhysicalPartitionIds) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                 Preconditions.checkState(physicalPartition != null);
                 TStorageMedium storageMedium = table.getPartitionInfo()
@@ -498,8 +507,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             throw new AlterCancelException(e.getMessage());
         }
 
-        sendAgentTaskAndWait(batchTask, countDownLatch, Config.tablet_create_timeout_second * numTablets,
-                             waitingCreatingReplica, isCancelling);
+        if (!lightWeight) {
+            sendAgentTaskAndWait(batchTask, countDownLatch, Config.tablet_create_timeout_second * numTablets,
+                                 waitingCreatingReplica, isCancelling);
+        }
 
         // Add shadow indexes to table.
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2366,6 +2366,23 @@ public class SchemaChangeHandler extends AlterHandler {
                 LOG.info("updated table: {} lake_compaction_max_parallel from {} to {}",
                         olapTable.getName(), oldMaxParallel, maxParallel);
                 return null;
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION)) {
+                // light_weight_tablet_creation is a pure FE property: it gates whether FE
+                // dispatches CreateReplicaTask in CREATE TABLE / ADD PARTITION / schema change /
+                // rollup paths. No CN-side state to flip. Use properties.get() (not
+                // analyzeBooleanProp) so the key remains in the map for alterTableProperties
+                // to dispatch on.
+                boolean newValue = Boolean.parseBoolean(
+                        properties.get(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION));
+                if (newValue == olapTable.isLightWeightTabletCreation()) {
+                    LOG.info("table: {} light_weight_tablet_creation is {}, nothing need to do",
+                            olapTable.getName(), newValue);
+                    return null;
+                }
+                GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                LOG.info("updated table: {} light_weight_tablet_creation to {}",
+                        olapTable.getName(), newValue);
+                return null;
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
                 return processAlterCloudNativeFastSchemaEvolutionV2Property(db, olapTable, properties).orElse(null);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -506,6 +506,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildEnableStatisticCollectOnFirstLoad();
                 buildCloudNativeFastSchemaEvolutionV2();
                 buildLakeCompactionMaxParallel();
+                buildLightWeightTabletCreation();
                 buildTableQueryTimeout();
                 buildDataCacheEnable();
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4132,6 +4132,26 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    private void alterLightWeightTabletCreation(OlapTable table,
+                                                Map<String, String> properties,
+                                                List<Runnable> appliers) throws DdlException {
+        if (!table.isCloudNativeTable()) {
+            throw new DdlException("Property " + PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION +
+                    " can only be set for cloud native tables");
+        }
+        // Strict validation: AlterTableClauseAnalyzer matches at most one branch in its
+        // else-if chain, so if light_weight_tablet_creation comes after another recognized
+        // property in a multi-property ALTER, its analyzer branch is skipped. Validate
+        // here as well to ensure invalid values are always rejected.
+        String value = properties.remove(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION);
+        if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+            throw new DdlException("Property " + PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION +
+                    " must be bool type(false/true)");
+        }
+        boolean newValue = Boolean.parseBoolean(value);
+        appliers.add(() -> table.setLightWeightTabletCreation(newValue));
+    }
+
     private void alterTableQueryTimeout(OlapTable table,
                                        Map<String, String> properties,
                                        List<Runnable> appliers) throws DdlException {
@@ -4232,6 +4252,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)) {
             alterLakeCompactionMaxParallel(table, properties, appliers);
+        }
+        if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION)) {
+            alterLightWeightTabletCreation(table, properties, appliers);
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
             alterTableQueryTimeout(table, properties, appliers);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -500,6 +500,18 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                         "Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE +
                                 " must be bool type(false/true)");
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION)) {
+            String value = properties.get(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION);
+            if (!value.equalsIgnoreCase("true") && !value.equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION +
+                                " must be bool type(false/true)");
+            }
+            if (!table.isCloudNativeTable()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION +
+                                " can only be set for cloud native tables");
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -378,4 +378,42 @@ public class LakeRollupJobTest {
         Assertions.assertTrue(exception.getMessage().contains("No alive backend"));
         Assertions.assertEquals(AlterJobV2.JobState.PENDING, lakeRollupJob3.getJobState());
     }
+
+    @Test
+    public void testLightWeightTabletCreationSkipsSendTask() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_table_lw\n" +
+                "(\n" +
+                "    k1 date,\n" +
+                "    k2 int,\n" +
+                "    k3 int\n" +
+                ")\n" +
+                "PARTITION BY RANGE(k1)\n" +
+                "(\n" +
+                "    PARTITION p1 values [('2022-02-01'),('2022-02-16'))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('light_weight_tablet_creation' = 'true');");
+
+        LakeRollupJob job = createJob(
+                "create materialized view mv_lw as select k2, k1 from base_table_lw order by k2;");
+        OlapTable lwTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb(DB).getTable("base_table_lw");
+        Assertions.assertTrue(lwTable.isLightWeightTabletCreation());
+
+        java.util.concurrent.atomic.AtomicBoolean sendCalled =
+                new java.util.concurrent.atomic.AtomicBoolean(false);
+        new MockUp<LakeRollupJob>() {
+            @Mock
+            public void sendAgentTaskAndWait(AgentBatchTask batchTask,
+                                             com.starrocks.common.util.concurrent.MarkedCountDownLatch<Long, Long> latch,
+                                             long timeoutSeconds) {
+                sendCalled.set(true);
+            }
+        };
+
+        job.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        Assertions.assertFalse(sendCalled.get(),
+                "sendAgentTaskAndWait must not be invoked when light_weight_tablet_creation is enabled");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -248,6 +248,35 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
+    public void testLightWeightTabletCreationSkipsSendTask() throws Exception {
+        // Flip the table to light-weight tablet creation; the schema-change PENDING phase
+        // must skip CreateReplicaTask building and sendAgentTaskAndWait while still
+        // advancing the job to WAITING_TXN.
+        alterTable(connectContext,
+                "ALTER TABLE t0 SET ('light_weight_tablet_creation' = 'true')");
+        Assertions.assertTrue(table.isLightWeightTabletCreation());
+
+        AtomicBoolean sendCalled = new AtomicBoolean(false);
+        new MockUp<LakeTableSchemaChangeJob>() {
+            @Mock
+            public void sendAgentTaskAndWait(AgentBatchTask batchTask, MarkedCountDownLatch<Long, Long> countDownLatch,
+                                             long timeoutSeconds, AtomicBoolean waitingCreatingReplica,
+                                             AtomicBoolean isCancelling) throws AlterCancelException {
+                sendCalled.set(true);
+            }
+        };
+
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
+        schemaChangeJob.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
+        Assertions.assertFalse(sendCalled.get(),
+                "sendAgentTaskAndWait must not be invoked when light_weight_tablet_creation is enabled");
+
+        schemaChangeJob.cancel("test");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
+    }
+
+    @Test
     public void testPreviousTxnNotFinished() throws Exception {
         LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -36,6 +36,7 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
@@ -84,6 +85,11 @@ public class CreateLakeTableTest {
     private static void createTable(String sql) throws Exception {
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+    }
+
+    private static void alterTable(String sql) throws Exception {
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, alterTableStmt);
     }
 
     private void checkLakeTable(String dbName, String tableName) {
@@ -860,5 +866,33 @@ public class CreateLakeTableTest {
         } finally {
             Config.lake_enable_light_weight_tablet_creation = saved;
         }
+    }
+
+    @Test
+    public void testAlterLightWeightTabletCreation() throws Exception {
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.alter_lw (c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2\n" +
+                        "properties('light_weight_tablet_creation' = 'false')"));
+        LakeTable table = getLakeTable("lake_test", "alter_lw");
+        Assertions.assertFalse(table.isLightWeightTabletCreation());
+
+        // false -> true
+        alterTable("alter table lake_test.alter_lw set ('light_weight_tablet_creation' = 'true')");
+        Assertions.assertTrue(table.isLightWeightTabletCreation());
+
+        // true -> false
+        alterTable("alter table lake_test.alter_lw set ('light_weight_tablet_creation' = 'false')");
+        Assertions.assertFalse(table.isLightWeightTabletCreation());
+
+        // No-op (same value) is a successful no-op, not an error.
+        ExceptionChecker.expectThrowsNoException(() -> alterTable(
+                "alter table lake_test.alter_lw set ('light_weight_tablet_creation' = 'false')"));
+        Assertions.assertFalse(table.isLightWeightTabletCreation());
+
+        // Invalid value rejected by analyzer.
+        ExceptionChecker.expectThrowsWithMsg(Exception.class, "must be bool type", () -> alterTable(
+                "alter table lake_test.alter_lw set ('light_weight_tablet_creation' = 'maybe')"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Build on the table property and CREATE TABLE skip from #73422 by wiring up the ALTER path and the corresponding CreateReplicaTask skip for shadow tablets in lake schema change / rollup jobs. The shadow tablet's version 1 metadata is materialized on demand by the CN-side fallback (already on main, see #72270 and #72364) when the first read or publish hits it.

## What I'm doing:

**ALTER TABLE property change**
* `AlterTableClauseAnalyzer` validates the value (true/false) and rejects the property on non-cloud-native tables.
* `AlterJobExecutor.visitModifyTablePropertiesClause` now routes the property through `SchemaChangeHandler.processLakeTableAlterMeta` so the cloud-native dispatch picks it up.
* `SchemaChangeHandler.createAlterMetaJob` handles `light_weight_tablet_creation` as a pure FE property (mirrors `lake_compaction_max_parallel`): no-op when the value is unchanged, otherwise routes to `LocalMetastore.alterTableProperties`.
* `LocalMetastore.alterLightWeightTabletCreation` appends an applier that calls `OlapTable.setLightWeightTabletCreation`. The change is persisted by the existing `ModifyTablePropertyOperationLog` under `OP_ALTER_TABLE_PROPERTIES`.
* `TableProperty.buildProperty(OP_ALTER_TABLE_PROPERTIES)` now invokes `buildLightWeightTabletCreation` so replay on follower / FE restart syncs the typed field from the properties map.

**Schema change / rollup skip**
* `LakeTableSchemaChangeJob.runPendingJob` and `LakeRollupJob.runPendingJob` snapshot `table.isLightWeightTabletCreation()` and skip `CreateReplicaTask` construction plus `sendAgentTaskAndWait` when enabled. The job still advances through `addShadowIndexToCatalog`, `watershedTxnId` allocation, and `persistStateChange(WAITING_TXN)`.

**Tests**
* `CreateLakeTableTest.testAlterLightWeightTabletCreation`: toggle on/off/no-op + invalid value rejection.
* `LakeTableSchemaChangeJobTest.testLightWeightTabletCreationSkipsSendTask`: light-weight schema change advances to `WAITING_TXN` without invoking `sendAgentTaskAndWait`.
* `LakeRollupJobTest.testLightWeightTabletCreationSkipsSendTask`: same expectation for `ADD ROLLUP`.

Pre-downgrade backfill (writing v1 metadata + schema file when `light_weight_tablet_creation` is set to `false`) lands in a follow-up PR.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: ALTER for an opt-in property; behavior only changes for tables that opt in via the property added in #73422.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4