### PR TITLE
[BugFix] Avoid set_thread_name race on data dir load threads

### DIFF
--- a/be/src/common/thread/thread.cpp
+++ b/be/src/common/thread/thread.cpp
@@ -282,44 +282,24 @@ int64_t Thread::current_thread_id() {
 
 void Thread::set_thread_name(pthread_t t, const std::string& name) {
     // pthread_setname_np's length is restricted to 16 bytes, including the terminating null byte ('\0')
-    int ret;
-    if (name.length() < 16) {
+    std::string truncated = name.length() >= 16 ? name.substr(0, 15) : name;
 #ifdef __APPLE__
-        (void)t;
-        ret = pthread_setname_np(name.data());
+    (void)t;
+    int ret = pthread_setname_np(truncated.c_str());
 #else
-        ret = pthread_setname_np(t, name.data());
+    int ret = pthread_setname_np(t, truncated.c_str());
 #endif
-    } else {
-        std::string str = name;
-        str.at(15) = '\0';
-#ifdef __APPLE__
-        (void)t;
-        ret = pthread_setname_np(str.data());
-#else
-        ret = pthread_setname_np(t, str.data());
-#endif
-    }
     if (ret) {
-        LOG(WARNING) << "failed to set thread name: " << name;
+        LOG(WARNING) << "failed to set thread name, ret=" << ret << ", name: " << truncated;
     }
 }
 
 void Thread::set_thread_name(std::thread& t, std::string name) {
-    // pthread_setname_np's length is restricted to 16 bytes, including the terminating null byte ('\0')
-    if (name.length() >= 16) {
-        name.at(15) = '\0';
-    }
-    int ret;
 #ifdef __APPLE__
-    (void)t;
-    ret = pthread_setname_np(name.data());
+    set_thread_name(pthread_t{}, name);
 #else
-    ret = pthread_setname_np(t.native_handle(), name.data());
+    set_thread_name(t.native_handle(), name);
 #endif
-    if (ret) {
-        LOG(WARNING) << "failed to set thread name: " << name;
-    }
 }
 
 int64_t Thread::wait_for_tid() const {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -170,10 +170,13 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
     std::vector<std::thread> threads;
     threads.reserve(data_dirs.size());
     for (auto data_dir : data_dirs) {
-        threads.emplace_back([data_dir] { (void)data_dir->load(); });
-        Thread::set_thread_name(threads.back(), "load_data_dir");
+        threads.emplace_back([data_dir] {
+            Thread::set_thread_name(pthread_self(), "load_data_dir");
+            data_dir->load();
+        });
 
         threads.emplace_back([data_dir] {
+            Thread::set_thread_name(pthread_self(), "compact_data_dir");
             if (config::manual_compact_before_data_dir_load) {
                 uint64_t live_sst_files_size_before = 0;
                 if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_before)) {
@@ -194,7 +197,6 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
                 }
             }
         });
-        Thread::set_thread_name(threads.back(), "compact_data_dir");
     }
     for (auto& thread : threads) {
         DCHECK(thread.joinable());


### PR DESCRIPTION
## Why I'm doing:

On every BE startup, `load_data_dirs` printed a noisy warning per data dir, e.g.:

```
W20260518 14:43:15.781343 thread.cpp:321] failed to set thread name: compact_data_di^@
```

`storage_engine.cpp::load_data_dirs` spawned `std::thread`s and then, from the
**main thread**, called `Thread::set_thread_name(threads.back(), "compact_data_dir")`.
For non-self threads glibc implements `pthread_setname_np` via
`open + write("/proc/self/task/<tid>/comm")`. When the lambda body finished
quickly (most commonly when `config::manual_compact_before_data_dir_load=false`
makes the body a near no-op), the pthread had already exited by the time the
main thread reached `write`, and the kernel returned `ESRCH(3)`.
The real errno was hidden in the log because `Thread::set_thread_name`'s
"truncation" was `name.at(15) = '\0'`, which only wrote a NUL into the buffer
but kept `std::string::size() == 16`. Logging `<< name` then emitted an embedded
NUL, and terminals/log viewers truncated at it — swallowing any text that came
after `name`.

## What I'm doing:

Avoid set_thread_name race on data dir load threads

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
