### PR TITLE
[BugFix] Disable jemalloc mem hook for macOS test startup

### DIFF
--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -14,6 +14,8 @@
 
 #include "mem_hook.h"
 
+#if STARROCKS_ENABLE_JEMALLOC_MEM_HOOK
+
 #include <iostream>
 
 #include "base/failpoint/fail_point.h"
@@ -28,6 +30,21 @@
 #ifndef BE_TEST
 #include "runtime/exec_env.h"
 #endif
+
+#endif
+
+static int64_t g_large_memory_alloc_failure_threshold = 0;
+
+namespace starrocks {
+// thread-safety is not a concern here since this is a really rare op
+int64_t set_large_memory_alloc_failure_threshold(int64_t val) {
+    int64_t old_val = g_large_memory_alloc_failure_threshold;
+    g_large_memory_alloc_failure_threshold = val;
+    return old_val;
+}
+} // namespace starrocks
+
+#if STARROCKS_ENABLE_JEMALLOC_MEM_HOOK
 
 #define ALIAS(my_fn) __attribute__((alias(#my_fn), used))
 
@@ -101,17 +118,6 @@ std::atomic<int64_t> g_mem_usage(0);
 #define SET_EXCEED_MEM_TRACKER() (void)0
 #define IS_BAD_ALLOC_CATCHED() false
 #endif
-
-static int64_t g_large_memory_alloc_failure_threshold = 0;
-
-namespace starrocks {
-// thread-safety is not a concern here since this is a really rare op
-int64_t set_large_memory_alloc_failure_threshold(int64_t val) {
-    int64_t old_val = g_large_memory_alloc_failure_threshold;
-    g_large_memory_alloc_failure_threshold = val;
-    return old_val;
-}
-} // namespace starrocks
 
 const size_t large_memory_alloc_report_threshold = 1073741824;
 inline thread_local bool skip_report = false;
@@ -484,3 +490,5 @@ void* __libc_memalign(size_t alignment, size_t size) {
 }
 #endif
 }
+
+#endif // STARROCKS_ENABLE_JEMALLOC_MEM_HOOK

--- a/be/src/service/mem_hook.h
+++ b/be/src/service/mem_hook.h
@@ -16,6 +16,15 @@
 
 #include <cstdint>
 
+// Sanitizers need to own malloc/free, and Darwin executable-level allocator
+// interposition is unsafe with allocations made inside system/third-party
+// dylibs during dyld/global initialization.
+#if defined(__APPLE__) || defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
+#define STARROCKS_ENABLE_JEMALLOC_MEM_HOOK 0
+#else
+#define STARROCKS_ENABLE_JEMALLOC_MEM_HOOK 1
+#endif
+
 namespace starrocks {
 
 int64_t set_large_memory_alloc_failure_threshold(int64_t);

--- a/be/test/service/mem_hook_test.cpp
+++ b/be/test/service/mem_hook_test.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// FIXME: The case doesn't work on ASAN case since the malloc will be hooked
-// when doing the ASAN init. Can't make it work so just disable it for now.
-#ifndef ADDRESS_SANITIZER
-
 #include "service/mem_hook.h"
+
+// Mem hook behavior is only testable when the production hook is enabled.
+#if STARROCKS_ENABLE_JEMALLOC_MEM_HOOK
 
 #include <gtest/gtest.h>
 
@@ -75,4 +74,4 @@ TEST(MemhookTest, test_calloc_mem_hook_block_without_try_catch) {
     set_large_memory_alloc_failure_threshold(0);
 }
 } // namespace starrocks
-#endif
+#endif // STARROCKS_ENABLE_JEMALLOC_MEM_HOOK

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -426,7 +426,13 @@ export CLASSPATH=${STARROCKS_HOME}/java-extensions/java-utils/target/*:$CLASSPAT
 
 # ===========================================================
 
-export ASAN_OPTIONS="abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_stack_use_after_return=1"
+asan_options="abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_stack_use_after_return=1"
+if starrocks_is_darwin && [[ "${CMAKE_BUILD_TYPE}" == "ASAN" ]]; then
+    # Apple libc++ container annotations can report false positives in static
+    # third-party initializers before gtest starts, for example RE2.
+    asan_options="${asan_options}:detect_container_overflow=0"
+fi
+export ASAN_OPTIONS="${asan_options}"
 
 if [ $WITH_AWS = "OFF" ]; then
     append_negative_case "*S3*"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
