### PR TITLE
[Tool] Upgrade thirdparty LLVM from 16.0.6 to 18.1.8

### DIFF
--- a/be/cmake_modules/FindLLVM.cmake
+++ b/be/cmake_modules/FindLLVM.cmake
@@ -14,8 +14,8 @@
 
 if (ENABLE_MULTI_DYNAMIC_LIBS)
     add_library(LLVM SHARED IMPORTED)
-    set_target_properties(LLVM PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/llvm/lib/libLLVM-16.so)
-    install(FILES ${THIRDPARTY_DIR}/llvm/lib/libLLVM-16.so DESTINATION ${OUTPUT_DIR}/lib)
+    set_target_properties(LLVM PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/llvm/lib/libLLVM-18.so)
+    install(FILES ${THIRDPARTY_DIR}/llvm/lib/libLLVM-18.so DESTINATION ${OUTPUT_DIR}/lib)
     set (LLVM_LIBRARIES LLVM)
 else()
     set (LLVM_LIBRARIES
@@ -65,6 +65,14 @@ else()
         LLVMSelectionDAG
         LLVMMCParser
         LLVMSupport
+        # LLVM 18 OrcJIT pulls in COFFVCRuntimeBootstrapper which references
+        # llvm::findVCToolChain* defined in LLVMWindowsDriver. The COFF code
+        # is unreachable on Linux but the symbols must still resolve at link.
+        LLVMWindowsDriver
+        # LLVM 18 split these out of LLVMCodeGen / LLVMipo / pass plugins:
+        LLVMCodeGenTypes
+        LLVMFrontendOffloading
+        LLVMHipStdPar
     )
 
     if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86_64")

--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -160,8 +160,7 @@ StatusOr<llvm::orc::JITTargetMachineBuilder> make_target_machine_builder() {
 
 void add_absolute_symbol(llvm::orc::LLJIT& lljit, const std::string& name, void* function_ptr) {
     llvm::orc::MangleAndInterner mangle(lljit.getExecutionSession(), lljit.getDataLayout());
-    llvm::orc::ExecutorSymbolDef symbol(llvm::orc::ExecutorAddr::fromPtr(function_ptr),
-                                        llvm::JITSymbolFlags::Exported);
+    llvm::orc::ExecutorSymbolDef symbol(llvm::orc::ExecutorAddr::fromPtr(function_ptr), llvm::JITSymbolFlags::Exported);
     auto error = lljit.getMainJITDylib().define(llvm::orc::absoluteSymbols({{mangle(name), symbol}}));
     llvm::cantFail(std::move(error));
 }

--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -30,18 +30,16 @@
 #include <llvm/IR/PassManager.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Linker/Linker.h>
-#include <llvm/MC/SubtargetFeature.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Passes/PassPlugin.h>
 #include <llvm/Support/Error.h>
-#include <llvm/Support/Host.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/TargetParser/Host.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/GlobalOpt.h>
-#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Transforms/InstCombine/InstCombine.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
@@ -50,7 +48,6 @@
 #include <llvm/Transforms/Utils.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/Mem2Reg.h>
-#include <llvm/Transforms/Vectorize.h>
 #include <llvm/Transforms/Vectorize/LoopVectorize.h>
 #include <llvm/Transforms/Vectorize/SLPVectorizer.h>
 
@@ -79,9 +76,9 @@ static inline Status generate_scalar_function_ir(ExprContext* context, llvm::Mod
     /// Create function type.
     auto* size_type = b.getInt64Ty();
     // Same with JITColumn.
-    auto* data_type = llvm::StructType::get(b.getInt8PtrTy(), b.getInt8PtrTy());
+    auto* data_type = llvm::StructType::get(b.getPtrTy(), b.getPtrTy());
     // Same with JITScalarFunction.
-    auto* func_type = llvm::FunctionType::get(b.getVoidTy(), {size_type, data_type->getPointerTo()}, false);
+    auto* func_type = llvm::FunctionType::get(b.getVoidTy(), {size_type, b.getPtrTy()}, false);
 
     /// Create function in module.
     // Pseudo code: void "expr->jit_expr_name"(int64_t rows_count, JITColumn* columns);
@@ -156,15 +153,15 @@ StatusOr<T> as_JIT_result(llvm::Expected<T>& expected, const std::string& error_
 
 StatusOr<llvm::orc::JITTargetMachineBuilder> make_target_machine_builder() {
     llvm::orc::JITTargetMachineBuilder jtmb((llvm::Triple(llvm::sys::getDefaultTargetTriple())));
-    auto const opt_level = llvm::CodeGenOpt::Aggressive; // or llvm::CodeGenOpt::None;
+    auto const opt_level = llvm::CodeGenOptLevel::Aggressive; // or llvm::CodeGenOptLevel::None;
     jtmb.setCodeGenOptLevel(opt_level);
     return jtmb;
 }
 
 void add_absolute_symbol(llvm::orc::LLJIT& lljit, const std::string& name, void* function_ptr) {
     llvm::orc::MangleAndInterner mangle(lljit.getExecutionSession(), lljit.getDataLayout());
-    llvm::JITEvaluatedSymbol symbol(reinterpret_cast<llvm::JITTargetAddress>(function_ptr),
-                                    llvm::JITSymbolFlags::Exported);
+    llvm::orc::ExecutorSymbolDef symbol(llvm::orc::ExecutorAddr::fromPtr(function_ptr),
+                                        llvm::JITSymbolFlags::Exported);
     auto error = lljit.getMainJITDylib().define(llvm::orc::absoluteSymbols({{mangle(name), symbol}}));
     llvm::cantFail(std::move(error));
 }
@@ -233,29 +230,6 @@ Status use_JIT_link(llvm::orc::LLJITBuilder& jit_builder, llvm::jitlink::JITLink
         return std::make_unique<llvm::orc::ObjectLinkingLayer>(ES, memory_manager);
     });
     return Status::OK();
-}
-
-StatusOr<std::unique_ptr<llvm::orc::LLJIT>> build_JIT(llvm::orc::JITTargetMachineBuilder jtmb,
-                                                      JITObjectCache& object_cache,
-                                                      llvm::jitlink::JITLinkMemoryManager& memory_manager) {
-    llvm::orc::LLJITBuilder jit_builder;
-    RETURN_IF_ERROR(use_JIT_link(jit_builder, memory_manager));
-    jit_builder.setJITTargetMachineBuilder(std::move(jtmb));
-    jit_builder.setCompileFunctionCreator(
-            [&object_cache](llvm::orc::JITTargetMachineBuilder JTMB)
-                    -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
-                auto target_machine = JTMB.createTargetMachine();
-                if (!target_machine) {
-                    return target_machine.takeError();
-                }
-                // after compilation, the object code will be stored into the given object cache
-                return std::make_unique<llvm::orc::TMOwningSimpleCompiler>(std::move(*target_machine), &object_cache);
-            });
-
-    auto maybe_jit = jit_builder.create();
-    ASSIGN_OR_RETURN(auto jit, as_JIT_result(maybe_jit, "Could not create LLJIT instance: "));
-    add_process_symbol(*jit);
-    return std::move(jit);
 }
 
 static inline void optimize_module(llvm::Module& module, llvm::TargetIRAnalysis target_analysis) {
@@ -350,6 +324,29 @@ public:
 private:
     ShardedLRUCache _cache;
 };
+
+StatusOr<std::unique_ptr<llvm::orc::LLJIT>> build_JIT(llvm::orc::JITTargetMachineBuilder jtmb,
+                                                      JITObjectCache& object_cache,
+                                                      llvm::jitlink::JITLinkMemoryManager& memory_manager) {
+    llvm::orc::LLJITBuilder jit_builder;
+    RETURN_IF_ERROR(use_JIT_link(jit_builder, memory_manager));
+    jit_builder.setJITTargetMachineBuilder(std::move(jtmb));
+    jit_builder.setCompileFunctionCreator(
+            [&object_cache](llvm::orc::JITTargetMachineBuilder JTMB)
+                    -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
+                auto target_machine = JTMB.createTargetMachine();
+                if (!target_machine) {
+                    return target_machine.takeError();
+                }
+                // after compilation, the object code will be stored into the given object cache
+                return std::make_unique<llvm::orc::TMOwningSimpleCompiler>(std::move(*target_machine), &object_cache);
+            });
+
+    auto maybe_jit = jit_builder.create();
+    ASSIGN_OR_RETURN(auto jit, as_JIT_result(maybe_jit, "Could not create LLJIT instance: "));
+    add_process_symbol(*jit);
+    return std::move(jit);
+}
 
 size_t JITCallable::getSize() {
     return _mem_mgr->getSize();

--- a/be/src/exprs/jit/jit_engine.h
+++ b/be/src/exprs/jit/jit_engine.h
@@ -19,7 +19,6 @@
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #include <llvm/IR/IRBuilder.h>
-#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
 #include <cstdint>
 #include <memory>

--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -19,7 +19,7 @@ ARG prebuild_maven=false
 # value: true | false
 # default: false
 ARG predownload_thirdparty=false
-ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20250731.tar
+ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20260526.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
 ARG starlet_tag=v4.2-rc1

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -457,6 +457,14 @@ build_llvm() {
         "LLVMSelectionDAG"
         "LLVMMCParser"
         "LLVMSupport"
+        # LLVM 18 OrcJIT references llvm::findVCToolChain* defined in
+        # WindowsDriver (via COFFVCRuntimeBootstrapper). Required to link
+        # libstarrocks_be even on Linux.
+        "LLVMWindowsDriver"
+        # LLVM 18 split these out of LLVMCodeGen / LLVMipo / pass plugins.
+        "LLVMCodeGenTypes"
+        "LLVMFrontendOffloading"
+        "LLVMHipStdPar"
     )
     if [ "${LLVM_TARGET}" == "X86" ]; then
         LLVM_TARGETS_TO_BUILD+=("LLVMX86Info" "LLVMX86Desc" "LLVMX86CodeGen" "LLVMX86AsmParser" "LLVMX86Disassembler")

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -404,10 +404,10 @@ LIBDEFLATE_SOURCE="libdeflate-1.18"
 LIBDEFLATE_MD5SUM="1ec42dfe7d777929ade295281560d750"
 
 # llvm
-LLVM_DOWNLOAD="https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/llvm-project-16.0.6.src.tar.xz"
-LLVM_NAME="llvm-project-16.0.6.src.tar.xz"
-LLVM_SOURCE="llvm-project-16.0.6.src"
-LLVM_MD5SUM="dc13938a604f70379d3b38d09031de98"
+LLVM_DOWNLOAD="https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz"
+LLVM_NAME="llvm-project-18.1.8.src.tar.xz"
+LLVM_SOURCE="llvm-project-18.1.8.src"
+LLVM_MD5SUM="81cd0be5ae6f1ad8961746116d426a96"
 
 #clucene
 CLUCENE_DOWNLOAD="https://github.com/StarRocks/clucene/archive/refs/tags/starrocks-2026.04.09.tar.gz"


### PR DESCRIPTION
LLVM 16's APFloat.h is incompatible with clang + libstdc++ 14 + -std=gnu++23: DoubleAPFloat's in-class operator= odr-uses ~unique_ptr<APFloat[]>(), and libstdc++ 14 ships a static_assert(sizeof(_Tp)>0) in default_delete<T[]>, which fires while APFloat is still an incomplete forward declaration. Upstream LLVM commit 687bd77e2c26 ("[ADT][NFC] Fix compilation of headers under C++23", D149854) fixes this by moving DoubleAPFloat's operator= and getFirst/getSecond out of the class definition. The fix landed in llvmorg-17.0.0; the latest 18.x release is 18.1.8. (https://github.com/llvm/llvm-project/issues/58206)

thirdparty:
  - Bump LLVM_DOWNLOAD/NAME/SOURCE/MD5SUM to llvm-project-18.1.8.
  - Add LLVMWindowsDriver, LLVMCodeGenTypes, LLVMFrontendOffloading, and LLVMHipStdPar to LLVM_TARGETS_TO_BUILD. WindowsDriver is pulled in via OrcJIT's COFFVCRuntimeBootstrapper (findVCToolChain* symbols) and the other three were split out of LLVMCodeGen / LLVMipo in v18.

be/cmake_modules/FindLLVM.cmake:
  - libLLVM-16.so -> libLLVM-18.so for the dyld variant.
  - Same four new components added to the static-link list.

be/src/exprs/jit/jit_engine.{h,cpp}: LLVM 17/18 API migration.
  - Drop removed legacy headers <llvm/Support/Host.h>, <llvm/MC/SubtargetFeature.h>, <llvm/Transforms/IPO/PassManagerBuilder.h>, <llvm/Transforms/Vectorize.h>; include <llvm/TargetParser/Host.h> for getDefaultTargetTriple().
  - CodeGenOpt::Aggressive -> CodeGenOptLevel::Aggressive.
  - Opaque pointer migration: getInt8PtrTy() -> getPtrTy(), drop StructType::getPointerTo().
  - JITEvaluatedSymbol -> orc::ExecutorSymbolDef constructed with ExecutorAddr::fromPtr() for absoluteSymbols(SymbolMap).
  - Reorder build_JIT past the full JITObjectCache definition so the JITObjectCache* -> llvm::ObjectCache* upcast inside make_unique<TMOwningSimpleCompiler> instantiates against a complete derived type (C++23 constexpr make_unique eagerly instantiates the body, which is what surfaced this).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
