### PR TITLE
[UT] Fix flaky RefreshTableStmtTest caused by TabletChecker rac(backport #73872)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
@@ -50,18 +50,16 @@ public class RefreshTableStmtTest {
     public void testRefreshTableParserAndAnalyzer(@Mocked MetadataMgr metadataMgr,
                                                   @Mocked Table table,
                                                   @Mocked Database database) {
-        GlobalStateMgr.getCurrentState().setMetadataMgr(metadataMgr);
-        new Expectations(metadataMgr, database) {
+        new Expectations() {
             {
+                GlobalStateMgr.getCurrentState().getMetadataMgr();
+                result = metadataMgr;
+
                 metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = table;
 
                 metadataMgr.getDb((ConnectContext) any, anyString, anyString);
                 result = database;
-
-                database.isSystemDatabase();
-                result = false;
-                minTimes = 0;
             }
         };
         String sql_1 = "REFRESH EXTERNAL TABLE db1.table1";


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

  - `RefreshTableStmtTest.testRefreshTableParserAndAnalyzer` is flaky on CI: it occasionally fails with `Missing 1 invocation to Database#isSystemDatabase()` pointing at `TabletChecker.checkOneDatabase`.
  - Root cause: `@Mocked Database` mocks every `Database` instance globally. The background `TabletChecker` daemon (started by `UtFrameUtils.createMinStarRocksCluster`) calls `db.isSystemDatabase()` on a real db that JMockit has now
   intercepted. Combined with the stricter `new Expectations(metadataMgr, database)` partial-mock form and the recorded `database.isSystemDatabase()` expectation, JMockit treats that cross-instance call as a missing invocation.
  `minTimes = 0` only excuses the recorded instance, not other Database instances.
  - Align with main: drop the `isSystemDatabase` recording, switch back to the plain `new Expectations()` form, and inject `MetadataMgr` via a recorded expectation instead of `setMetadataMgr`. Unrecorded `isSystemDatabase` calls now
   return the JMockit default (`false`) and the daemon stops tripping the verifier.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


