### PR TITLE
[Refactor] Extract libcurl global init/cleanup into CurlGlobalGuard RAII

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -39,7 +39,6 @@
 #include <sanitizer/lsan_interface.h>
 #endif
 
-#include <curl/curl.h>
 #include <gflags/gflags.h>
 #include <thrift/TOutput.h>
 
@@ -75,6 +74,7 @@
 #include "service/daemon.h"
 #include "service/service.h"
 #include "storage/storage_engine.h"
+#include "util/curl_global_guard.h"
 #include "util/logging.h"
 
 #if !defined(__clang__) && defined(__GNUC__) && !_GLIBCXX_USE_CXX11_ABI
@@ -193,8 +193,8 @@ int main(int argc, char** argv) {
     starrocks::Status::access_directory_of_inject();
 #endif
     // Initialize libcurl here to avoid concurrent initialization.
-    auto curl_ret = curl_global_init(CURL_GLOBAL_ALL);
-    if (curl_ret != 0) {
+    starrocks::CurlGlobalGuard curl_guard;
+    if (auto curl_ret = curl_guard.init(); curl_ret != 0) {
         LOG(FATAL) << "fail to initialize libcurl, curl_ret=" << curl_ret;
         exit(-1);
     }

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -31,6 +31,7 @@ set(UTIL_FILES
   debug/query_trace_impl.cpp
   memory_lock.cpp
   byte_buffer.cpp
+  curl_global_guard.cpp
   hdfs_util.cpp
   jvm_metrics.cpp
   llm_cache.cpp

--- a/be/src/util/curl_global_guard.cpp
+++ b/be/src/util/curl_global_guard.cpp
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/curl_global_guard.h"
+
+#include <curl/curl.h>
+
+namespace starrocks {
+
+int CurlGlobalGuard::init() {
+    auto ret = curl_global_init(CURL_GLOBAL_ALL);
+    _initialized = (ret == CURLE_OK);
+    return ret;
+}
+
+CurlGlobalGuard::~CurlGlobalGuard() {
+    if (_initialized) {
+        curl_global_cleanup();
+    }
+}
+
+} // namespace starrocks

--- a/be/src/util/curl_global_guard.h
+++ b/be/src/util/curl_global_guard.h
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks {
+
+// RAII guard around curl_global_init / curl_global_cleanup. Call init() once
+// at process startup; failure to initialize is reported via the return code so
+// the caller can choose how to fail. The destructor runs curl_global_cleanup
+// only if init() succeeded.
+class CurlGlobalGuard {
+public:
+    CurlGlobalGuard() = default;
+    ~CurlGlobalGuard();
+
+    CurlGlobalGuard(const CurlGlobalGuard&) = delete;
+    CurlGlobalGuard& operator=(const CurlGlobalGuard&) = delete;
+    CurlGlobalGuard(CurlGlobalGuard&&) = delete;
+    CurlGlobalGuard& operator=(CurlGlobalGuard&&) = delete;
+
+    // Returns the underlying CURLcode (0 on success).
+    int init();
+
+private:
+    bool _initialized = false;
+};
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

curl_global_init was called in main without a matching curl_global_cleanup; wrap it in a stack-allocated RAII guard so cleanup runs on normal shutdown and the init/cleanup pair lives in one place. Mirrors the AwsSdkGuard approach already used for the AWS SDK.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
