### PR TITLE
[Enhancement] Make BE thread names fit Linux 15-char limit for stack analysis

### DIFF
--- a/be/src/cache/disk_space_monitor.cpp
+++ b/be/src/cache/disk_space_monitor.cpp
@@ -272,7 +272,7 @@ void DiskSpaceMonitor::start() {
     }
     _stopped.store(false, std::memory_order_release);
     _adjust_datacache_thread = std::thread([this] { _adjust_datacache_callback(); });
-    Thread::set_thread_name(_adjust_datacache_thread, "adjust_disk_cache");
+    Thread::set_thread_name(_adjust_datacache_thread, "adj_disk_cache");
 }
 
 void DiskSpaceMonitor::stop() {

--- a/be/src/cache/mem_space_monitor.cpp
+++ b/be/src/cache/mem_space_monitor.cpp
@@ -27,7 +27,7 @@ namespace starrocks {
 
 void MemSpaceMonitor::start() {
     _adjust_datacache_thread = std::thread([this] { _adjust_datacache_callback(); });
-    Thread::set_thread_name(_adjust_datacache_thread, "adjust_mem_cache");
+    Thread::set_thread_name(_adjust_datacache_thread, "adj_mem_cache");
 }
 
 void MemSpaceMonitor::stop() {

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -177,7 +177,7 @@ Status ExecStateReporter::report_exec_status(const TReportExecStatusParams& para
 
 ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateReporterMetrics* metrics) {
     int exec_state_report_threads = std::max(1, config::exec_state_report_max_threads);
-    auto status = ThreadPoolBuilder("exec_state_report") // exec state reporter
+    auto status = ThreadPoolBuilder("exec_st_report") // exec state reporter
                           .set_min_threads(1)
                           .set_max_threads(exec_state_report_threads)
                           .set_max_queue_size(1000)
@@ -189,7 +189,7 @@ ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateRep
     }
 
     int priority_exec_state_report_threads = std::max(1, config::priority_exec_state_report_max_threads);
-    status = ThreadPoolBuilder("priority_exec_state_report") // priority exec state reporter with infinite queue
+    status = ThreadPoolBuilder("prio_st_report") // priority exec state reporter with infinite queue
                      .set_min_threads(1)
                      .set_max_threads(priority_exec_state_report_threads)
                      .set_idle_timeout(MonoDelta::FromMilliseconds(2000))

--- a/be/src/runtime/env/global_thread_pools.cpp
+++ b/be/src/runtime/env/global_thread_pools.cpp
@@ -65,7 +65,7 @@ Status GlobalThreadPools::init_execution_thread_pools(MetricRegistry* metrics) {
 
     int automatic_partition_thread_num = config::automatic_partition_thread_pool_thread_num;
     int automatic_partition_queue_size = automatic_partition_thread_num * 10;
-    RETURN_IF_ERROR(ThreadPoolBuilder("automatic_partition")
+    RETURN_IF_ERROR(ThreadPoolBuilder("auto_partition")
                             .set_min_threads(0)
                             .set_max_threads(automatic_partition_thread_num)
                             .set_max_queue_size(automatic_partition_queue_size)
@@ -116,7 +116,7 @@ Status GlobalThreadPools::init_execution_thread_pools(MetricRegistry* metrics) {
                             .build(&_load_rpc_pool));
     REGISTER_GAUGE_RUNTIME_METRIC(metrics, load_rpc_threadpool_size, [this]() { return _load_rpc_pool->num_threads(); })
 
-    RETURN_IF_ERROR(ThreadPoolBuilder("dictionary_cache")
+    RETURN_IF_ERROR(ThreadPoolBuilder("dict_cache")
                             .set_min_threads(1)
                             .set_max_threads(config::dictionary_cache_refresh_threadpool_size)
                             .set_max_queue_size(INT32_MAX)
@@ -131,7 +131,7 @@ Status GlobalThreadPools::init_execution_thread_pools(MetricRegistry* metrics) {
     LOG(INFO) << strings::Substitute("[PIPELINE] Exec thread pool: thread_num=$0", _max_executor_threads);
 
     RETURN_IF_ERROR(
-            ThreadPoolBuilder("load_rowset_pool")
+            ThreadPoolBuilder("load_rowset")
                     .set_min_threads(0)
                     .set_max_threads(config::load_segment_thread_pool_num_max)
                     .set_max_queue_size(config::load_segment_thread_pool_queue_size)
@@ -139,14 +139,14 @@ Status GlobalThreadPools::init_execution_thread_pools(MetricRegistry* metrics) {
                     .build(&_load_rowset_thread_pool));
 
     RETURN_IF_ERROR(
-            ThreadPoolBuilder("load_segment_pool")
+            ThreadPoolBuilder("load_segment")
                     .set_min_threads(0)
                     .set_max_threads(config::load_segment_thread_pool_num_max)
                     .set_max_queue_size(config::load_segment_thread_pool_queue_size)
                     .set_idle_timeout(MonoDelta::FromMilliseconds(config::streaming_load_thread_pool_idle_time_ms))
                     .build(&_load_segment_thread_pool));
 
-    RETURN_IF_ERROR(ThreadPoolBuilder("put_combined_txn_log_thread_pool")
+    RETURN_IF_ERROR(ThreadPoolBuilder("put_cmb_txnlog")
                             .set_min_threads(0)
                             .set_max_threads(config::put_combined_txn_log_thread_pool_num_max)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(500))
@@ -165,7 +165,7 @@ Status GlobalThreadPools::init_lake_thread_pools(MetricRegistry* metrics) {
     if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores();
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("put_aggregate_metadata")
+    RETURN_IF_ERROR(ThreadPoolBuilder("put_agg_meta")
                             .set_min_threads(1)
                             .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(std::numeric_limits<int>::max())
@@ -176,7 +176,7 @@ Status GlobalThreadPools::init_lake_thread_pools(MetricRegistry* metrics) {
     if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores() / 2;
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_execution")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_pkidx_exec")
                             .set_min_threads(1)
                             .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(config::pk_index_parallel_execution_threadpool_size)
@@ -187,7 +187,7 @@ Status GlobalThreadPools::init_lake_thread_pools(MetricRegistry* metrics) {
     if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores() / 2;
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_memtable_flush")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_pidx_flush")
                             .set_min_threads(1)
                             .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(config::pk_index_memtable_flush_threadpool_size)
@@ -199,36 +199,36 @@ Status GlobalThreadPools::init_lake_thread_pools(MetricRegistry* metrics) {
     if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores() / 2;
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_part_upd")
                             .set_min_threads(0)
                             .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(config::lake_partial_update_thread_pool_queue_size)
                             .build(&_lake_partial_update_thread_pool));
     REGISTER_THREAD_POOL_RUNTIME_METRICS(metrics, lake_partial_update, _lake_partial_update_thread_pool);
 #elif defined(BE_TEST)
-    RETURN_IF_ERROR(ThreadPoolBuilder("put_aggregate_metadata_pool")
+    RETURN_IF_ERROR(ThreadPoolBuilder("put_agg_meta")
                             .set_min_threads(1)
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_put_aggregate_metadata_thread_pool));
-    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_execution")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_pkidx_exec")
                             .set_min_threads(1)
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_execution_thread_pool));
-    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_memtable_flush")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_pidx_flush")
                             .set_min_threads(1)
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_memtable_flush_thread_pool));
-    RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_part_upd")
                             .set_min_threads(0)
                             .set_max_threads(4)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_lake_partial_update_thread_pool));
 #endif
 
-    RETURN_IF_ERROR(ThreadPoolBuilder("lake_metadata_fetch")
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_meta_fetch")
                             .set_min_threads(0)
                             .set_max_threads(std::max(1, static_cast<int>(config::lake_metadata_fetch_thread_count)))
                             .set_max_queue_size(std::numeric_limits<int>::max())

--- a/be/src/runtime/stream_load/transaction_mgr.cpp
+++ b/be/src/runtime/stream_load/transaction_mgr.cpp
@@ -77,7 +77,7 @@ TransactionMgr::TransactionMgr(ExecEnv* exec_env) : _exec_env(exec_env) {
             nap_sleep(interval, [this] { return _is_stopped.load(); });
         }
     });
-    Thread::set_thread_name(_transaction_clean_thread, "transaction_clean");
+    Thread::set_thread_name(_transaction_clean_thread, "txn_clean");
 }
 
 TransactionMgr::~TransactionMgr() {

--- a/be/src/service/daemon.cpp
+++ b/be/src/service/daemon.cpp
@@ -389,7 +389,7 @@ void Daemon::init(bool as_cn, const std::vector<StorePath>& paths, ProcessMetric
 
     if (config::enable_jemalloc_memory_tracker) {
         std::thread jemalloc_tracker_thread(jemalloc_tracker_daemon, this);
-        Thread::set_thread_name(jemalloc_tracker_thread, "jemalloc_tracker_daemon");
+        Thread::set_thread_name(jemalloc_tracker_thread, "jemalloc_track");
         _daemon_threads.emplace_back(std::move(jemalloc_tracker_thread));
     }
 #endif

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -72,7 +72,7 @@ void CompactionManager::schedule() {
     DCHECK(st.ok());
 
     _dispatch_update_candidate_thread = std::thread([this] { _dispatch_worker(); });
-    Thread::set_thread_name(_dispatch_update_candidate_thread, "dispatch_candidate");
+    Thread::set_thread_name(_dispatch_update_candidate_thread, "disp_upd_cand");
 
     st = ThreadPoolBuilder("compact_pool")
                  .set_min_threads(1)

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -225,7 +225,7 @@ CompactionScheduler::CompactionScheduler(TabletManager* tablet_mgr)
           _contexts(),
           _task_queues(config::compact_threads) {
     CHECK_GT(_task_queues.task_queue_size(), 0);
-    auto st = ThreadPoolBuilder("cloud_native_compact")
+    auto st = ThreadPoolBuilder("lake_compact")
                       .set_min_threads(0)
                       .set_max_threads(INT_MAX)
                       .set_max_queue_size(INT_MAX)

--- a/be/src/storage/load_spill_block_manager.cpp
+++ b/be/src/storage/load_spill_block_manager.cpp
@@ -49,13 +49,13 @@ static int calc_max_merge_blocks_thread() {
 }
 
 Status LoadSpillBlockMergeExecutor::init() {
-    RETURN_IF_ERROR(ThreadPoolBuilder("load_spill_block_merge")
+    RETURN_IF_ERROR(ThreadPoolBuilder("ld_spill_merge")
                             .set_min_threads(1)
                             .set_max_threads(calc_max_merge_blocks_thread())
                             .set_max_queue_size(40960 /*a random chosen number that should big enough*/)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
                             .build(&_merge_pool));
-    RETURN_IF_ERROR(ThreadPoolBuilder("tablet_internal_parallel_merge")
+    RETURN_IF_ERROR(ThreadPoolBuilder("tablet_par_mrg")
                             .set_min_threads(1)
                             .set_max_threads(calc_max_merge_blocks_thread())
                             .set_max_queue_size(40960 /*a random chosen number that should big enough*/)

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -199,7 +199,7 @@ Status MemTableFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {
 // Used in shared-data mode
 Status MemTableFlushExecutor::init_for_lake_table(const std::vector<DataDir*>& data_dirs) {
     int max_threads = calc_max_threads_for_lake_table(data_dirs);
-    return ThreadPoolBuilder("lake_memtable_flush") // mem table flush
+    return ThreadPoolBuilder("lake_mt_flush") // mem table flush
             .set_min_threads(0)
             .set_max_threads(max_threads)
             .build(&_flush_pool);

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -90,7 +90,7 @@ Status StorageEngine::start_bg_threads() {
     Thread::set_thread_name(_update_cache_expire_thread, "cache_expire");
 
     _update_cache_evict_thread = std::thread([this] { _update_cache_evict_thread_callback(nullptr); });
-    Thread::set_thread_name(_update_cache_evict_thread, "evict_update_cache");
+    Thread::set_thread_name(_update_cache_evict_thread, "evict_upd_cache");
 
     _unused_rowset_monitor_thread = std::thread([this] { _unused_rowset_monitor_thread_callback(nullptr); });
     Thread::set_thread_name(_unused_rowset_monitor_thread, "rowset_monitor");
@@ -104,7 +104,7 @@ Status StorageEngine::start_bg_threads() {
     Thread::set_thread_name(_disk_stat_monitor_thread, "disk_monitor");
 
     _pk_index_major_compaction_thread = std::thread([this] { _pk_index_major_compaction_thread_callback(nullptr); });
-    Thread::set_thread_name(_pk_index_major_compaction_thread, "pk_index_compaction_scheduler");
+    Thread::set_thread_name(_pk_index_major_compaction_thread, "pk_idx_cmpt_sch");
 
     _pk_dump_thread = std::thread([this] { _pk_dump_thread_callback(nullptr); });
     Thread::set_thread_name(_pk_dump_thread, "pk_dump");
@@ -112,12 +112,12 @@ Status StorageEngine::start_bg_threads() {
 #ifdef USE_STAROS
     _local_pk_index_shared_data_gc_evict_thread =
             std::thread([this] { _local_pk_index_shared_data_gc_evict_thread_callback(nullptr); });
-    Thread::set_thread_name(_local_pk_index_shared_data_gc_evict_thread, "pk_index_shared_data_gc_evict");
+    Thread::set_thread_name(_local_pk_index_shared_data_gc_evict_thread, "pindex_gc_evict");
 #endif
 
     // start thread for check finish publish version
     _finish_publish_version_thread = std::thread([this] { _finish_publish_version_thread_callback(nullptr); });
-    Thread::set_thread_name(_finish_publish_version_thread, "finish_publish_version");
+    Thread::set_thread_name(_finish_publish_version_thread, "finish_pub_ver");
 
     // convert store map to vector
     std::vector<DataDir*> data_dirs;
@@ -240,7 +240,7 @@ Status StorageEngine::start_bg_threads() {
 
     _clear_expired_replcation_snapshots_thread =
             std::thread([this]() { _clear_expired_replication_snapshots_callback(nullptr); });
-    Thread::set_thread_name(_clear_expired_replcation_snapshots_thread, "clear_expired_replication_snapshots");
+    Thread::set_thread_name(_clear_expired_replcation_snapshots_thread, "clr_exp_repsnap");
 
     start_schedule_apply_thread();
 

--- a/be/src/storage/persistent_index_compaction_manager.cpp
+++ b/be/src/storage/persistent_index_compaction_manager.cpp
@@ -43,7 +43,7 @@ Status PersistentIndexCompactionManager::init() {
             config::pindex_major_compaction_num_threads > 0
                     ? config::pindex_major_compaction_num_threads
                     : std::max((size_t)1, StorageEngine::instance()->get_store_num() * 2);
-    RETURN_IF_ERROR(ThreadPoolBuilder("pk_index_compaction_worker")
+    RETURN_IF_ERROR(ThreadPoolBuilder("pkidx_cmpt_wkr")
                             .set_min_threads(1)
                             .set_max_threads(max_pk_index_compaction_thread_cnt)
                             .build(&_worker_thread_pool));

--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -31,7 +31,7 @@ Status PublishVersionManager::init() {
         max_thread_count = CpuInfo::num_cores();
     }
     max_thread_count = std::max(max_thread_count, MIN_FINISH_PUBLISH_WORKER_COUNT);
-    RETURN_IF_ERROR(ThreadPoolBuilder("finish_publish_version")
+    RETURN_IF_ERROR(ThreadPoolBuilder("finish_pub_ver")
                             .set_min_threads(MIN_FINISH_PUBLISH_WORKER_COUNT)
                             .set_max_threads(max_thread_count)
                             .build(&_finish_publish_version_thread_pool));

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -432,7 +432,7 @@ Status SegmentReplicateExecutor::init(const std::vector<DataDir*>& data_dirs) {
     int data_dir_num = static_cast<int>(data_dirs.size());
     int min_threads = std::max<int>(1, config::flush_thread_num_per_store);
     int max_threads = std::max(data_dir_num * min_threads, min_threads);
-    return ThreadPoolBuilder("segment_replicate")
+    return ThreadPoolBuilder("seg_replicate")
             .set_min_threads(min_threads)
             .set_max_threads(max_threads)
             .build(&_replicate_pool);

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -176,7 +176,7 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
         });
 
         threads.emplace_back([data_dir] {
-            Thread::set_thread_name(pthread_self(), "compact_data_dir");
+            Thread::set_thread_name(pthread_self(), "cmpt_data_dir");
             if (config::manual_compact_before_data_dir_load) {
                 uint64_t live_sst_files_size_before = 0;
                 if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_before)) {

--- a/be/test/agent/agent_metrics_test.cpp
+++ b/be/test/agent/agent_metrics_test.cpp
@@ -101,7 +101,7 @@ TEST(AgentMetricsTest, RegisterThreadPoolMetrics) {
     MetricRegistry registry("test_registry");
     metrics.install(&registry);
 
-    auto status = ThreadPoolBuilder("agent_metrics_test")
+    auto status = ThreadPoolBuilder("agent_met_test")
                           .set_min_threads(0)
                           .set_max_threads(3)
                           .set_max_queue_size(5)
@@ -118,7 +118,7 @@ TEST(AgentMetricsTest, RegisterThreadPoolMetrics) {
 TEST(AgentMetricsTest, RegisterThreadPoolMetricsBeforeInstall) {
     std::unique_ptr<ThreadPool> threadpool;
     AgentMetrics metrics;
-    auto status = ThreadPoolBuilder("agent_metrics_test")
+    auto status = ThreadPoolBuilder("agent_met_test")
                           .set_min_threads(0)
                           .set_max_threads(3)
                           .set_max_queue_size(5)

--- a/be/test/runtime/batch_write/batch_write_mgr_test.cpp
+++ b/be/test/runtime/batch_write/batch_write_mgr_test.cpp
@@ -41,7 +41,7 @@ public:
         config::merge_commit_trace_log_enable = true;
         _exec_env = ExecEnv::GetInstance();
         std::unique_ptr<ThreadPool> thread_pool;
-        ASSERT_OK(ThreadPoolBuilder("BatchWriteMgrTest")
+        ASSERT_OK(ThreadPoolBuilder("BatchWrMgrTest")
                           .set_min_threads(0)
                           .set_max_threads(4)
                           .set_max_queue_size(2048)

--- a/be/test/runtime/batch_write/isomorphic_batch_write_test.cpp
+++ b/be/test/runtime/batch_write/isomorphic_batch_write_test.cpp
@@ -38,7 +38,7 @@ public:
         config::merge_commit_trace_log_enable = true;
         _exec_env = ExecEnv::GetInstance();
         std::unique_ptr<ThreadPool> thread_pool;
-        ASSERT_OK(ThreadPoolBuilder("IsomorphicBatchWriteTest")
+        ASSERT_OK(ThreadPoolBuilder("IsoBatchWrTest")
                           .set_min_threads(0)
                           .set_max_threads(1)
                           .set_max_queue_size(2048)

--- a/be/test/runtime/batch_write/txn_state_cache_test.cpp
+++ b/be/test/runtime/batch_write/txn_state_cache_test.cpp
@@ -32,7 +32,7 @@ public:
         _db = "test_db";
         _tbl = "test_tbl";
         _auth = {"test_user", "test_password"};
-        ASSERT_OK(ThreadPoolBuilder("IsomorphicBatchWriteTest")
+        ASSERT_OK(ThreadPoolBuilder("IsoBatchWrTest")
                           .set_min_threads(0)
                           .set_max_threads(1)
                           .set_max_queue_size(2048)

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -519,11 +519,8 @@ TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_can_disable_by
     config::lake_replication_parallel_copy_min_file_count = 0;
 
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_par_dis")
-                      .set_min_threads(1)
-                      .set_max_threads(1)
-                      .set_max_queue_size(8)
-                      .build(&pool));
+    ASSERT_OK(
+            ThreadPoolBuilder("lake_par_dis").set_min_threads(1).set_max_threads(1).set_max_queue_size(8).build(&pool));
 
     EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(100, pool.get()));
     pool->shutdown();

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -482,7 +482,7 @@ TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_basic_gate) {
     EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(2, nullptr));
 
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_gate")
+    ASSERT_OK(ThreadPoolBuilder("lake_par_gate")
                       .set_min_threads(1)
                       .set_max_threads(1)
                       .set_max_queue_size(8)
@@ -496,7 +496,7 @@ TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_queue_overload
     Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
     config::lake_replication_parallel_copy_min_file_count = 2;
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_overload")
+    ASSERT_OK(ThreadPoolBuilder("lake_par_overld")
                       .set_min_threads(1)
                       .set_max_threads(1)
                       .set_max_queue_size(32)
@@ -519,7 +519,7 @@ TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_can_disable_by
     config::lake_replication_parallel_copy_min_file_count = 0;
 
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_disable")
+    ASSERT_OK(ThreadPoolBuilder("lake_par_dis")
                       .set_min_threads(1)
                       .set_max_threads(1)
                       .set_max_queue_size(8)
@@ -1310,7 +1310,7 @@ TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_with_mocked_file_ope
 
     // Create thread pool and pass it to replication manager
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_repl_test_pool")
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_test")
                       .set_min_threads(2)
                       .set_max_threads(4)
                       .set_max_queue_size(16)
@@ -1361,7 +1361,7 @@ TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_error_handling) {
     config::lake_replication_parallel_copy_min_file_count = 2;
 
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_repl_test_err_pool")
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_err")
                       .set_min_threads(2)
                       .set_max_threads(4)
                       .set_max_queue_size(16)

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -6950,7 +6950,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
     auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
 
     std::unique_ptr<ThreadPool> pool;
-    ThreadPoolBuilder("range_split_test_pool").set_max_threads(4).build(&pool);
+    ThreadPoolBuilder("rng_split_test").set_max_threads(4).build(&pool);
 
     auto st = _manager->create_parallel_tasks(
             tablet_id, txn_id, version, pconfig, callback, false, pool.get(), []() { return true; }, [](bool) {});

--- a/be/test/storage/publish_version_manager_test.cpp
+++ b/be/test/storage/publish_version_manager_test.cpp
@@ -50,7 +50,7 @@ public:
     void SetUp() override {
         _publish_version_manager = starrocks::StorageEngine::instance()->publish_version_manager();
         _finish_publish_version_thread = std::thread([this] { _finish_publish_version_thread_callback(nullptr); });
-        Thread::set_thread_name(_finish_publish_version_thread, "finish_publish_version");
+        Thread::set_thread_name(_finish_publish_version_thread, "finish_pub_ver");
     }
 
     void TearDown() override {

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -442,7 +442,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version_cancellation) {
 
     // Build a dedicated thread pool with a single worker
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_TRUE(ThreadPoolBuilder("publish-cancel-test")
+    ASSERT_TRUE(ThreadPoolBuilder("pub-cancel-test")
                         .set_min_threads(1)
                         .set_max_threads(1)
                         .set_max_queue_size(128)
@@ -634,7 +634,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version_submit_failure) {
 
     // Build a dedicated pool and shut it down to force submit() to fail
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_TRUE(ThreadPoolBuilder("publish-submit-fail-test").set_min_threads(1).set_max_threads(1).build(&pool).ok());
+    ASSERT_TRUE(ThreadPoolBuilder("pub-submit-fail").set_min_threads(1).set_max_threads(1).build(&pool).ok());
     auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     pool->shutdown();
 

--- a/be/test/storage/rowset/unique_rowset_id_generator_test.cpp
+++ b/be/test/storage/rowset/unique_rowset_id_generator_test.cpp
@@ -109,10 +109,8 @@ TEST_F(UniqueRowsetIdGeneratorTest, GenerateIdBenchmark) {
     UniqueId backend_uid = UniqueId::gen_uid();
     UniqueRowsetIdGenerator id_generator(backend_uid);
     std::unique_ptr<ThreadPool> pool;
-    Status s = ThreadPoolBuilder("GenIdBenchmark")
-                       .set_min_threads(kNumThreads)
-                       .set_max_threads(kNumThreads)
-                       .build(&pool);
+    Status s =
+            ThreadPoolBuilder("GenIdBenchmark").set_min_threads(kNumThreads).set_max_threads(kNumThreads).build(&pool);
     ASSERT_TRUE(s.ok()) << s.to_string();
 
     int64_t cost_ns = 0;

--- a/be/test/storage/rowset/unique_rowset_id_generator_test.cpp
+++ b/be/test/storage/rowset/unique_rowset_id_generator_test.cpp
@@ -109,7 +109,7 @@ TEST_F(UniqueRowsetIdGeneratorTest, GenerateIdBenchmark) {
     UniqueId backend_uid = UniqueId::gen_uid();
     UniqueRowsetIdGenerator id_generator(backend_uid);
     std::unique_ptr<ThreadPool> pool;
-    Status s = ThreadPoolBuilder("GenerateIdBenchmark")
+    Status s = ThreadPoolBuilder("GenIdBenchmark")
                        .set_min_threads(kNumThreads)
                        .set_max_threads(kNumThreads)
                        .build(&pool);

--- a/be/test/storage/storage_metrics_test.cpp
+++ b/be/test/storage/storage_metrics_test.cpp
@@ -209,7 +209,7 @@ TEST(StorageMetricsTest, RegisterGaugeHooksBeforeInstall) {
 
 TEST(StorageMetricsTest, RegisterThreadPoolMetricsBeforeInstall) {
     std::unique_ptr<ThreadPool> threadpool;
-    auto status = ThreadPoolBuilder("storage_metrics_test")
+    auto status = ThreadPoolBuilder("stor_metric_tst")
                           .set_min_threads(0)
                           .set_max_threads(3)
                           .set_max_queue_size(5)


### PR DESCRIPTION
## Why I'm doing:

 Linux's pthread_setname_np truncates thread names to 15 characters (16 bytes including \0). Many BE thread / thread-pool names exceed this limit — e.g., clear_expired_replication_snapshots (35) gets truncated to clear_expired_r,
  which is unrecognizable in a stack trace.

  This directly hurts debuggability:
  
  - On-call engineers reading pstack / gdb output can't identify what each thread is doing.
  - AI-assisted diagnosis (which groups threads by name from stack traces) loses critical context after truncation.
  - Distinct long names collide after truncation. For example, pk_index_compaction_scheduler and pk_index_shared_data_gc_evict both become pk_index_compac / pk_index_shared, making them indistinguishable

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
