### PR TITLE
[BugFix] Fix timeout hint for metadata collection job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1485,8 +1485,16 @@ public class ConnectContext {
                     msg = String.format("the table %s table_query_timeout is %ds, pending time:%s",
                             tableName, tableTimeout, pendingTime);
                 } else {
+                    String timeoutVariable;
+                    if (isExecLoadType()) {
+                        timeoutVariable = SessionVariable.INSERT_TIMEOUT;
+                    } else if (isMetadataContext()) {
+                        timeoutVariable = SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT;
+                    } else {
+                        timeoutVariable = SessionVariable.QUERY_TIMEOUT;
+                    }
                     msg = String.format("please increase the '%s' session variable, pending time:%s",
-                            isExecLoadType() ? SessionVariable.INSERT_TIMEOUT : SessionVariable.QUERY_TIMEOUT, pendingTime);
+                            timeoutVariable, pendingTime);
                 }
                 errMsg = ErrorCode.ERR_TIMEOUT.formatErrorMsg(getExecType(), execTimeout, msg);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1432,6 +1432,19 @@ public class ConnectContext {
     }
 
     /**
+     * Returns the session variable name that governs the timeout for the current execution context,
+     * used when building timeout-hint messages.
+     */
+    public String getTimeoutHintVariable() {
+        if (isExecLoadType()) {
+            return SessionVariable.INSERT_TIMEOUT;
+        } else if (isMetadataContext()) {
+            return SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT;
+        }
+        return SessionVariable.QUERY_TIMEOUT;
+    }
+
+    /**
      * Check the connect context is timeout or not. If true, kill the connection, otherwise, return false.
      *
      * @param now : current time in milliseconds
@@ -1485,16 +1498,8 @@ public class ConnectContext {
                     msg = String.format("the table %s table_query_timeout is %ds, pending time:%s",
                             tableName, tableTimeout, pendingTime);
                 } else {
-                    String timeoutVariable;
-                    if (isExecLoadType()) {
-                        timeoutVariable = SessionVariable.INSERT_TIMEOUT;
-                    } else if (isMetadataContext()) {
-                        timeoutVariable = SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT;
-                    } else {
-                        timeoutVariable = SessionVariable.QUERY_TIMEOUT;
-                    }
                     msg = String.format("please increase the '%s' session variable, pending time:%s",
-                            timeoutVariable, pendingTime);
+                            getTimeoutHintVariable(), pendingTime);
                 }
                 errMsg = ErrorCode.ERR_TIMEOUT.formatErrorMsg(getExecType(), execTimeout, msg);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -978,14 +978,19 @@ public class DefaultCoordinator extends Coordinator {
                         hint = null;
                     }
                     if (hint == null) {
-                        hint = String.format("please increase the '%s' session variable and retry",
-                                SessionVariable.QUERY_TIMEOUT);
+                        hint = buildSessionTimeoutHint();
                     }
                     ErrorReport.reportTimeoutException(ErrorCode.ERR_TIMEOUT, "Query", timeoutS, hint);
                 }
                 throw new StarRocksException(ec, errMsg);
             }
         }
+    }
+
+    private String buildSessionTimeoutHint() {
+        String timeoutVariable = connectContext != null && connectContext.isMetadataContext() ?
+                SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT : SessionVariable.QUERY_TIMEOUT;
+        return String.format("please increase the '%s' session variable and retry", timeoutVariable);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -988,8 +988,8 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     private String buildSessionTimeoutHint() {
-        String timeoutVariable = connectContext != null && connectContext.isMetadataContext() ?
-                SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT : SessionVariable.QUERY_TIMEOUT;
+        String timeoutVariable = connectContext != null
+                ? connectContext.getTimeoutHintVariable() : SessionVariable.QUERY_TIMEOUT;
         return String.format("please increase the '%s' session variable and retry", timeoutVariable);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -244,6 +244,48 @@ public class ConnectContextTest {
     }
 
     @Test
+    public void testQueryTimeoutErrorMessageUsesMetadataCollectQueryTimeoutForMetadataContext() {
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setCommand(MysqlCommand.COM_QUERY);
+        ctx.setThreadLocalInfo();
+        // A metadata collection job runs its inner query under a metadata context (see
+        // MetadataCollectJob.buildConnectContext), so the timeout hint must point at metadata_collect_query_timeout.
+        ctx.setMetadataContext(true);
+
+        StmtExecutor executor = new StmtExecutor(ctx, new QueryStatement(ValuesRelation.newDualRelation()));
+        ctx.setExecutor(executor);
+
+        // checkTimeout() builds the hint and passes it to executor.cancel(); capture it into the query state
+        // so we can assert on the message (mirrors testQueryTimeoutErrorMessageUsesTableQueryTimeoutHint).
+        new Expectations(executor) {
+            {
+                executor.cancel(anyString);
+                result = new Delegate<Void>() {
+                    @SuppressWarnings("unused")
+                    void cancel(String cancelledMessage) {
+                        ctx.getState().setError(cancelledMessage);
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+
+        long now = ctx.getStartTime() + ctx.getSessionVariable().getQueryTimeoutS() * 1000L + 1;
+        boolean killed = ctx.checkTimeout(now);
+
+        // For query timeouts killConnection is false, so isKilled() stays false; assert the return value instead.
+        Assertions.assertTrue(killed);
+        String errorMsg = ctx.getState().getErrorMessage();
+        Assertions.assertNotNull(errorMsg);
+        Assertions.assertTrue(errorMsg.contains(SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT));
+        // Note: METADATA_COLLECT_QUERY_TIMEOUT itself contains the substring "query_timeout", so quote the
+        // bare query_timeout hint to make sure the message is not the generic query_timeout one.
+        Assertions.assertFalse(errorMsg.contains("'" + SessionVariable.QUERY_TIMEOUT + "'"));
+
+        ctx.cleanup();
+    }
+
+    @Test
     public void testQueryTimeoutErrorMessageUsesTableQueryTimeoutHint() {
         ConnectContext ctx = new ConnectContext(connection);
         ctx.setCommand(MysqlCommand.COM_QUERY);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -185,6 +185,21 @@ public class CoordinatorTest extends PlanTestBase {
     }
 
     @Test
+    public void testTimeoutHintUsesMetadataCollectQueryTimeoutForMetadataContext() {
+        ctx.setMetadataContext(true);
+
+        JobSpec jobSpec = Deencapsulation.getField(coordinator, "jobSpec");
+        jobSpec.getQueryOptions().setQuery_timeout(300);
+
+        Status timeoutStatus = new Status(TStatusCode.TIMEOUT, "timeout");
+        com.starrocks.common.TimeoutException ex = Assertions.assertThrows(
+                com.starrocks.common.TimeoutException.class,
+                () -> Deencapsulation.invoke(coordinator, "dealStatusToTryRetry", timeoutStatus));
+        Assertions.assertTrue(ex.getMessage().contains(SessionVariable.METADATA_COLLECT_QUERY_TIMEOUT));
+        Assertions.assertFalse(ex.getMessage().contains("'" + SessionVariable.QUERY_TIMEOUT + "'"));
+    }
+
+    @Test
     public void testClearExternalResourcesOnlyOnce() {
         AtomicInteger clearCount = new AtomicInteger();
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -200,6 +200,32 @@ public class CoordinatorTest extends PlanTestBase {
     }
 
     @Test
+    public void testTimeoutHintUsesInsertTimeoutForLoad() {
+        // In practice INSERT/CTAS timeouts are intercepted FE-side in StmtExecutor (which renders a richer
+        // hint including the load timeout property). This test covers the fallback when BE returns TIMEOUT
+        // before that polling fires: dealStatusToTryRetry must still name insert_timeout, not query_timeout.
+        StmtExecutor executor = new StmtExecutor(ctx, new QueryStatement(ValuesRelation.newDualRelation()));
+        new Expectations(executor) {
+            {
+                executor.isExecLoadType();
+                result = true;
+                minTimes = 0;
+            }
+        };
+        ctx.setExecutor(executor);
+
+        JobSpec jobSpec = Deencapsulation.getField(coordinator, "jobSpec");
+        jobSpec.getQueryOptions().setQuery_timeout(300);
+
+        Status timeoutStatus = new Status(TStatusCode.TIMEOUT, "timeout");
+        com.starrocks.common.TimeoutException ex = Assertions.assertThrows(
+                com.starrocks.common.TimeoutException.class,
+                () -> Deencapsulation.invoke(coordinator, "dealStatusToTryRetry", timeoutStatus));
+        Assertions.assertTrue(ex.getMessage().contains(SessionVariable.INSERT_TIMEOUT));
+        Assertions.assertFalse(ex.getMessage().contains("'" + SessionVariable.QUERY_TIMEOUT + "'"));
+    }
+
+    @Test
     public void testClearExternalResourcesOnlyOnce() {
         AtomicInteger clearCount = new AtomicInteger();
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));


### PR DESCRIPTION
## Why I'm doing:

When an internal metadata collection job (e.g. Iceberg distributed metadata planning via `planFileTasksRemotely`) times out, the error hint advises the user to increase the `query_timeout` session variable:

```
Failed to execute metadata collection job. Query reached its timeout of N seconds, please increase the 'query_timeout' session variable and retry
```

This is misleading. The metadata collection job runs in its own internal `ConnectContext` whose timeout is governed by `metadata_collect_query_timeout` (default 60s), not `query_timeout`. Increasing `query_timeout` has no effect on the inner job, so the user is sent down the wrong path.

## What I'm doing:

In `DefaultCoordinator`, when generating the timeout hint, check whether the current `ConnectContext` is a metadata context. If so, report `metadata_collect_query_timeout` instead of `query_timeout`. Non-metadata queries keep the existing `query_timeout` hint, so their behavior is unchanged.

Added a unit test in `CoordinatorTest` verifying that a timeout under a metadata context produces a hint referencing `metadata_collect_query_timeout` and not `query_timeout`.

Fixes StarRocks/StarRocksTest#11261

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5