### PR TITLE
[BugFix] relax db read locks to intensive table locks in InformationSchemaDataSource

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -257,45 +257,57 @@ public class InformationSchemaDataSource {
 
         for (String dbName : result.authorizedDbs) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
-            if (db != null) {
-                Locker locker = new Locker();
-                locker.lockDatabase(db.getId(), LockType.READ);
-                try {
-                    List<Table> allTables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
-                    for (Table table : allTables) {
-                        if (tableMatcher != null && !tableMatcher.match(table.getName())) {
-                            continue;
-                        }
-
-                        try {
-                            ConnectContext context = result.buildConnectContext();
-                            Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
-                        } catch (AccessDeniedException e) {
-                            LOG.warn("failed to check db: {} table: {} authorization", dbName, table, e);
-                            continue;
-                        }
-
-                        TTableConfigInfo tableConfigInfo = new TTableConfigInfo();
-                        tableConfigInfo.setTable_schema(dbName);
-                        tableConfigInfo.setTable_name(table.getName());
-
-                        if (table.isNativeTableOrMaterializedView() || table.isOlapExternalTable()) {
-                            // OLAP (done)
-                            // OLAP_EXTERNAL (done)
-                            // MATERIALIZED_VIEW (done)
-                            // LAKE (done)
-                            // LAKE_MATERIALIZED_VIEW (done)
-                            genNormalTableConfigInfo(table, tableConfigInfo);
-                        } else if (table.isView()) {
-                            // VIEW (done)
-                            tableConfigInfo.setTable_engine(table.getType().toString());
-                        }
-                        // TODO(cjs): other table type (HIVE, MYSQL, ICEBERG, HUDI, JDBC, ELASTICSEARCH)
-                        tList.add(tableConfigInfo);
-                    }
-                } finally {
-                    locker.unLockDatabase(db.getId(), LockType.READ);
+            if (db == null) {
+                continue;
+            }
+            // Snapshot the table list (getTables returns a concurrent copy), then lock
+            // each table individually instead of holding a DB-wide READ for the whole
+            // walk, so DDL/ALTER on tables not currently being read is not blocked.
+            List<Table> allTables = db.getTables();
+            for (Table table : allTables) {
+                if (tableMatcher != null && !tableMatcher.match(table.getName())) {
+                    continue;
                 }
+
+                try {
+                    ConnectContext context = result.buildConnectContext();
+                    Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
+                } catch (AccessDeniedException e) {
+                    LOG.info("failed to check db: {} table: {} authorization", dbName, table, e);
+                    continue;
+                }
+
+                TTableConfigInfo tableConfigInfo = new TTableConfigInfo();
+                tableConfigInfo.setTable_schema(dbName);
+                tableConfigInfo.setTable_name(table.getName());
+
+                if (table.isNativeTableOrMaterializedView() || table.isOlapExternalTable()) {
+                    // OLAP (done)
+                    // OLAP_EXTERNAL (done)
+                    // MATERIALIZED_VIEW (done)
+                    // LAKE (done)
+                    // LAKE_MATERIALIZED_VIEW (done)
+                    // genNormalTableConfigInfo reads per-table internal state, so take a
+                    // table READ (IS-on-db + READ-on-table) only for these types.
+                    Locker locker = new Locker();
+                    locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                    try {
+                        // The list above was snapshotted unlocked; skip if a concurrent
+                        // DROP removed the table before we acquired the lock.
+                        if (GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getId(), table.getId()) == null) {
+                            continue;
+                        }
+                        genNormalTableConfigInfo(table, tableConfigInfo);
+                    } finally {
+                        locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                    }
+                } else if (table.isView()) {
+                    // VIEW (done)
+                    tableConfigInfo.setTable_engine(table.getType().toString());
+                }
+                // TODO(cjs): other table type (HIVE, MYSQL, ICEBERG, HUDI, JDBC, ELASTICSEARCH)
+                tList.add(tableConfigInfo);
             }
         }
         resp.tables_config_infos = tList;
@@ -412,10 +424,18 @@ public class InformationSchemaDataSource {
             }
             // only olap table/mv or cloud table/mv will reach here;
             // use the same lock level with `SHOW PARTITIONS FROM XXX` to ensure other modification to
-            // partition does not trigger crash
+            // partition does not trigger crash. A table READ (IS-on-db + READ-on-table) is enough:
+            // only this one table's partitions are read.
             Locker locker = new Locker();
-            locker.lockDatabase(ele.dbId, LockType.READ);
+            locker.lockTableWithIntensiveDbLock(ele.dbId, table.getId(), LockType.READ);
             try {
+                // The table was snapshotted without a lock above. Once the intensive lock is
+                // held a concurrent DROP (DB WRITE) is blocked, but it may already have run;
+                // reading partitions of a dropped table is exactly the crash this lock guards
+                // against, so skip it if it is gone.
+                if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(ele.dbId, table.getId()) == null) {
+                    continue;
+                }
                 OlapTable olapTable = (OlapTable) table;
                 PartitionInfo tblPartitionInfo = olapTable.getPartitionInfo();
                 // normal partition
@@ -445,7 +465,7 @@ public class InformationSchemaDataSource {
                     break;
                 }
             } finally {
-                locker.unLockDatabase(ele.dbId, LockType.READ);
+                locker.unLockTableWithIntensiveDbLock(ele.dbId, table.getId(), LockType.READ);
             }
         }
         resp.partitions_meta_infos = pList;
@@ -595,12 +615,14 @@ public class InformationSchemaDataSource {
 
             for (BasicTable table : tables) {
                 Locker tableLocker = new Locker();
+                // Acquire before the try so a failed acquire does not trigger an unlock of an
+                // unheld lock in the finally block.
+                boolean nativeOrMv = table.isNativeTableOrMaterializedView();
+                if (nativeOrMv) {
+                    tableLocker.lockTablesWithIntensiveDbLock(db.getId(),
+                            Lists.newArrayList(((OlapTable) table).getId()), LockType.READ);
+                }
                 try {
-                    if (table.isNativeTableOrMaterializedView()) {
-                        tableLocker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(((OlapTable) table).getId()),
-                                LockType.READ);
-                    }
-
                     TTableInfo info = new TTableInfo();
 
                     // refer to https://dev.mysql.com/doc/refman/8.0/en/information-schema-tables-table.html
@@ -642,7 +664,7 @@ public class InformationSchemaDataSource {
                     }
                     infos.add(info);
                 } finally {
-                    if (table.isNativeTableOrMaterializedView()) {
+                    if (nativeOrMv) {
                         tableLocker.unLockTablesWithIntensiveDbLock(db.getId(),
                                 Lists.newArrayList(((OlapTable) table).getId()), LockType.READ);
                     }
@@ -732,8 +754,11 @@ public class InformationSchemaDataSource {
             Database db = metadataMgr.getDb(databaseId);
             if (db != null) {
                 Map<Long, UUID> tableMap = allTables.row(databaseId);
+                // Bounded set of temp tables for this db: lock exactly those tables
+                // (IS-on-db + READ-on-table) instead of a DB-wide READ.
+                List<Long> tableIds = new ArrayList<>(tableMap.keySet());
                 Locker locker = new Locker();
-                locker.lockDatabase(db.getId(), LockType.READ);
+                locker.lockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.READ);
                 try {
                     for (Map.Entry<Long, UUID> entry : tableMap.entrySet()) {
                         UUID sessionId = entry.getValue();
@@ -775,7 +800,7 @@ public class InformationSchemaDataSource {
                         break;
                     }
                 } finally {
-                    locker.unLockDatabase(db.getId(), LockType.READ);
+                    locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.READ);
                 }
             }
         }


### PR DESCRIPTION
Four metadata RPC handlers held a full-database READ lock while reading per-table state. Narrow each to the intensive table path (IS on the db plus READ on the specific tables) so DDL/ALTER on unrelated tables in the same db is no longer blocked:

- generateTablesConfigResponse: snapshot the table list, then take a per-table READ only for native/MV tables (views and other types need no lock).
- generatePartitionsMetaResponse: read one table's partitions under a single table READ.
- generateTemporaryTablesInfoResponse: lock the bounded set of temp-table ids with the intensive path.

generateTablesConfigResponse and generatePartitionsMetaResponse obtain the Table from an unlocked snapshot, so after acquiring the table lock they revalidate the table still exists by id and skip it otherwise, closing the window in which a concurrent DROP removes it.

generateTablesInfoResponse already used the intensive path; acquire its lock before the try block so a failed acquire cannot unlock an unheld lock in the finally.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
