### PR TITLE
[BugFix] IVM MV refresh: surface strict-load errors instead of silently dropping rows

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -33,6 +33,7 @@ import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetail;
+import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshProcessor;
@@ -358,6 +359,11 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         try {
             executor.addRunningQueryDetail(insertStmt);
             executor.handleDMLStmtWithProfile(execPlan, insertStmt);
+            // StmtExecutor's filter-ratio check sets ctx.getState() to ERR without throwing;
+            // mirror InsertOverwriteJobRunner.executeInsert by rethrowing here.
+            if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                throw new DmlException(ctx.getState().getErrorMessage());
+            }
         } catch (Exception e) {
             logger.warn("[QueryId:{}] refresh mv {} failed in DML", ctx.getQueryId(), e);
             throw e;

--- a/test/sql/test_materialized_view_ivm/R/test_iceberg_mv_ivm_strict_load_on_overflow
+++ b/test/sql/test_materialized_view_ivm/R/test_iceberg_mv_ivm_strict_load_on_overflow
@@ -1,0 +1,105 @@
+-- name: test_iceberg_mv_ivm_strict_load_on_overflow
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database c5_db_${uuid0};
+-- result:
+-- !result
+use c5_db_${uuid0};
+-- result:
+-- !result
+create table c5_base (k int, v decimal(10,2)) properties('format-version'='2');
+-- result:
+-- !result
+insert into c5_base values (1, 12.34), (2, 99.99);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW c5_ivm_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c5_db_${uuid0}.c5_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c5_ivm_mv WITH SYNC MODE;
+[UC]C5_IVM_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c5_ivm_mv';
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C5_IVM_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+SUCCESS
+-- !result
+SELECT k, v FROM c5_ivm_mv ORDER BY k;
+-- result:
+1	12.34
+2	99.99
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+use c5_db_${uuid0};
+-- result:
+-- !result
+insert into c5_base values (3, 1234567890.12);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW c5_ivm_mv WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C5_IVM_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE LIKE '%Insert has filtered data%' FROM information_schema.task_runs WHERE TASK_NAME = '${C5_IVM_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c5_ivm_mv';
+-- result:
+true
+-- !result
+DROP MATERIALIZED VIEW c5_ivm_mv;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+drop table c5_db_${uuid0}.c5_base force;
+-- result:
+-- !result
+drop database c5_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_iceberg_mv_ivm_strict_load_on_overflow
+++ b/test/sql/test_materialized_view_ivm/T/test_iceberg_mv_ivm_strict_load_on_overflow
@@ -1,0 +1,62 @@
+-- name: test_iceberg_mv_ivm_strict_load_on_overflow
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+-- Base iceberg table with DECIMAL(10,2) — 8 integer digits, 2 fractional.
+set catalog mv_iceberg_${uuid0};
+create database c5_db_${uuid0};
+use c5_db_${uuid0};
+create table c5_base (k int, v decimal(10,2)) properties('format-version'='2');
+insert into c5_base values (1, 12.34), (2, 99.99);
+
+-- IVM MV (incremental refresh).
+set catalog default_catalog;
+use db_${uuid0};
+CREATE MATERIALIZED VIEW c5_ivm_mv
+REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode' = 'incremental')
+AS SELECT k, v FROM mv_iceberg_${uuid0}.c5_db_${uuid0}.c5_base;
+
+[UC]REFRESH MATERIALIZED VIEW c5_ivm_mv WITH SYNC MODE;
+[UC]C5_IVM_TASK=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='c5_ivm_mv';
+
+-- Baseline: refresh succeeds, MV has 2 rows.
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C5_IVM_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT k, v FROM c5_ivm_mv ORDER BY k;
+
+-- Insert a value that overflows DECIMAL(10,2): 1234567890.12 has 10 integer digits.
+set catalog mv_iceberg_${uuid0};
+use c5_db_${uuid0};
+insert into c5_base values (3, 1234567890.12);
+
+-- Refresh must FAIL with strict-load filter error, matching PCT behavior.
+-- Pre-fix: IVM silently dropped the overflow row and reported SUCCESS.
+set catalog default_catalog;
+use db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW c5_ivm_mv WITH SYNC MODE;
+
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${C5_IVM_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%Insert has filtered data%' FROM information_schema.task_runs WHERE TASK_NAME = '${C5_IVM_TASK}' ORDER BY CREATE_TIME DESC LIMIT 1;
+
+-- MV is NOT marked inactive — this is a refresh-time data error, not schema drift.
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'c5_ivm_mv';
+
+DROP MATERIALIZED VIEW c5_ivm_mv;
+
+-- Cleanup
+drop database db_${uuid0} force;
+set catalog mv_iceberg_${uuid0};
+drop table c5_db_${uuid0}.c5_base force;
+drop database c5_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Iceberg base table value-level overflow (e.g. inserting `1234567890.12` into a
`DECIMAL(10,2)` column — 10 integer digits exceed the type's 8-digit
capacity) makes the refresh hit the filter-ratio strict-load check in
`StmtExecutor` (`filteredRows > total * insert_max_filter_ratio` with ratio=0
by default via `Config.mv_refresh_fail_on_filter_data=true`). That check only
calls `ctx.getState().setError(FILTER_DATA_ERR)` and returns — **it does not
throw**.

PCT's `INSERT OVERWRITE` routes through `InsertOverwriteJobRunner.executeInsert`,
which checks `ctx.getState()` after `handleDMLStmt` and re-throws as a
`DmlException`. IVM's `INSERT INTO` goes through
`MVTaskRunProcessor.executePlan` directly, with no such state inspection, so
the `FILTER_DATA_ERR` signal is silently swallowed: `task_runs` reports
`SUCCESS`, the MV stays active, but rows that overflowed the target type were
dropped at the BE sink and never landed in the MV.

This is the IVM half of the original reproducer's Case 5 ("base DECIMAL
overflow: IVM silently drops rows, PCT correctly errors"). The other 4 cases (schema drift) were
handled in #73770.

## What I'm doing:

After `executor.handleDMLStmtWithProfile` in `MVTaskRunProcessor.executePlan`,
check `ctx.getState()` for `ERR` and throw a `DmlException` carrying the
error message — matching `InsertOverwriteJobRunner.executeInsert`'s contract
so both PCT and IVM refresh modes propagate strict-load failures uniformly.

The check is intentionally narrow: it only fires when the inner DML didn't
already throw but left `ctx.getState()` in `ERR`. The existing `catch
(Exception e)` block still handles every thrown failure path. For PCT going
through `executePlan` (e.g. hybrid → PCT fallback), `InsertOverwriteJobRunner`
already throws first; this new check is a no-op there.

Reproducer (verified end-to-end on dev cluster):
- `CREATE iceberg table base (k INT, v DECIMAL(10,2))` — schema stable
- `CREATE IVM MV` over base, refresh — 2 rows
- `INSERT INTO base VALUES (3, 1234567890.12)` — 10 integer digits, overflows DECIMAL(10,2)
- `REFRESH IVM MV`
  - **Before fix:** `task_runs.STATE = SUCCESS`, MV has only 2 rows (overflow row silently dropped)
  - **After fix:** `task_runs.STATE = FAILED`, `ERROR_MESSAGE` contains "Insert has filtered data", MV stays `IS_ACTIVE=true`
- Same setup with PCT MV → fails identically (unchanged from before)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous

Previously: IVM MV refresh silently dropped rows whose values overflowed the
MV's stored column type. `task_runs` reported `SUCCESS`, the MV stayed
active, the dropped rows were invisible to the user.

Now: refresh fails with `ERROR 1064 ... Insert has filtered data`,
`task_runs.STATE = FAILED`, `ERROR_MESSAGE` populated. MV stays
`IS_ACTIVE=true` (this is a data-value error, not schema drift). Behavior
matches PCT.

## Test plan

- [x] FE UT: `IVMBasedMvRefreshProcessorIcebergTest` 50/0/0,
  `PartitionBasedMvRefreshProcessorIcebergTest` 19/0/0,
  `MVRefreshSchemaCheckerTest` 13/0/0 — pass locally on the fix (no regression
  on prior happy-path coverage).
- [x] SQL regression test: new
  `test/sql/test_materialized_view_ivm/T/test_iceberg_mv_ivm_strict_load_on_overflow`
  with R file recorded on the fixed FE. Asserts:
  - `task_runs.STATE = FAILED` after the overflow INSERT
  - `ERROR_MESSAGE LIKE '%Insert has filtered data%' = 1`
  - `IS_ACTIVE = true` (no schema drift)
- [x] Manual dev-cluster verification on the fixed commit — reproducer from
  the doc returns the expected error and MV stays active.
- [x] `mvn compile -pl fe-core -am -DskipTests` clean
- [x] `mvn checkstyle:check -pl fe-core` 0 violations

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
