### PR TITLE
[BugFix] Fix Paimon DATE partition column with NULL value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonPartitionKey.java
@@ -19,12 +19,15 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public class PaimonPartitionKey extends PartitionKey implements NullablePartitionKey {
+    public static final List<String> PARTITION_NULL_VALUES =
+            ImmutableList.of("__DEFAULT_PARTITION__", "null");
+
     public PaimonPartitionKey() {
         super();
     }
 
     @Override
     public List<String> nullPartitionValueList() {
-        return ImmutableList.of("__DEFAULT_PARTITION__", "null");
+        return PARTITION_NULL_VALUES;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonPartitionKey.java
@@ -14,20 +14,17 @@
 
 package com.starrocks.catalog;
 
-import com.google.common.collect.ImmutableList;
+import com.starrocks.connector.paimon.PaimonMetadata;
 
 import java.util.List;
 
 public class PaimonPartitionKey extends PartitionKey implements NullablePartitionKey {
-    public static final List<String> PARTITION_NULL_VALUES =
-            ImmutableList.of("__DEFAULT_PARTITION__", "null");
-
     public PaimonPartitionKey() {
         super();
     }
 
     @Override
     public List<String> nullPartitionValueList() {
-        return PARTITION_NULL_VALUES;
+        return PaimonMetadata.PARTITION_NULL_VALUES;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -86,6 +86,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -289,11 +290,13 @@ public class PartitionUtil {
     }
 
     // partition name such like p1=1/p2=__HIVE_DEFAULT_PARTITION__, this function will convert it to
-    // p1=1/p2=NULL
-    public static String normalizePartitionName(String partitionName, List<String> partitionColumnNames, String nullValue) {
+    // p1=1/p2=NULL. A connector may use more than one placeholder for NULL (e.g. Paimon uses both
+    // "__DEFAULT_PARTITION__" and "null"), so the caller passes all of them and any match is treated as NULL.
+    public static String normalizePartitionName(String partitionName, List<String> partitionColumnNames,
+                                                Collection<String> nullValues) {
         List<String> partitionValues = Lists.newArrayList(toPartitionValues(partitionName));
         for (int i = 0; i < partitionValues.size(); ++i) {
-            if (partitionValues.get(i).equals(nullValue)) {
+            if (nullValues.contains(partitionValues.get(i))) {
                 partitionValues.set(i, "NULL");
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.PaimonPartitionKey;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PaimonView;
 import com.starrocks.catalog.PartitionKey;
@@ -241,6 +242,11 @@ public class PaimonMetadata implements ConnectorMetadata {
             }
         } catch (Catalog.TableNotExistException e) {
             LOG.error("Failed to update partition info of paimon table {}.{}.", databaseName, tableName, e);
+        } catch (Exception e) {
+            LOG.error("Failed to update partition info of paimon table {}.{}.", databaseName, tableName, e);
+            throw new StarRocksConnectorException(
+                    String.format("Failed to update partition info of paimon table %s.%s: %s",
+                            databaseName, tableName, e.getMessage()), e);
         }
     }
 
@@ -265,7 +271,8 @@ public class PaimonMetadata implements ConnectorMetadata {
         for (int i = 0; i < partitionValues.length; i++) {
             String column = partitionColumnNames.get(i);
             String value = partitionValues[i].trim();
-            if (partitionColumnTypes.get(i) instanceof DateType && partitionLegacyName) {
+            if (partitionColumnTypes.get(i) instanceof DateType && partitionLegacyName
+                    && !PaimonPartitionKey.PARTITION_NULL_VALUES.contains(value)) {
                 value = DateTimeUtils.formatDate(Integer.parseInt(value));
             }
             sb.append(column).append("=").append(value);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -242,11 +242,6 @@ public class PaimonMetadata implements ConnectorMetadata {
             }
         } catch (Catalog.TableNotExistException e) {
             LOG.error("Failed to update partition info of paimon table {}.{}.", databaseName, tableName, e);
-        } catch (Exception e) {
-            LOG.error("Failed to update partition info of paimon table {}.{}.", databaseName, tableName, e);
-            throw new StarRocksConnectorException(
-                    String.format("Failed to update partition info of paimon table %s.%s: %s",
-                            databaseName, tableName, e.getMessage()), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.PaimonPartitionKey;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PaimonView;
 import com.starrocks.catalog.PartitionKey;
@@ -126,7 +125,7 @@ import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 public class PaimonMetadata implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(PaimonMetadata.class);
 
-    public static final String PAIMON_PARTITION_NULL_VALUE = "null";
+    public static final List<String> PARTITION_NULL_VALUES = ImmutableList.of("__DEFAULT_PARTITION__", "null");
     private static final String VIEW_DIALECTS_KEY = "starrocks";
     private final Catalog paimonNativeCatalog;
     private final HdfsEnvironment hdfsEnvironment;
@@ -267,7 +266,7 @@ public class PaimonMetadata implements ConnectorMetadata {
             String column = partitionColumnNames.get(i);
             String value = partitionValues[i].trim();
             if (partitionColumnTypes.get(i) instanceof DateType && partitionLegacyName
-                    && !PaimonPartitionKey.PARTITION_NULL_VALUES.contains(value)) {
+                    && !PARTITION_NULL_VALUES.contains(value)) {
                 value = DateTimeUtils.formatDate(Integer.parseInt(value));
             }
             sb.append(column).append("=").append(value);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -64,6 +64,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -174,19 +176,19 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         String columnNameStr = StringEscapeUtils.escapeSql(columnName);
         String quoteColumnName = StatisticUtils.quoting(table, columnName);
 
-        String nullValue;
+        Collection<String> nullValues;
         if (table.isIcebergTable()) {
-            nullValue = IcebergApiConverter.PARTITION_NULL_VALUE;
+            nullValues = Collections.singleton(IcebergApiConverter.PARTITION_NULL_VALUE);
         } else if (table.isPaimonTable()) {
-            nullValue = PaimonMetadata.PAIMON_PARTITION_NULL_VALUE;
+            nullValues = PaimonMetadata.PARTITION_NULL_VALUES;
         } else {
-            nullValue = HiveMetaClient.PARTITION_NULL_VALUE;
+            nullValues = Collections.singleton(HiveMetaClient.PARTITION_NULL_VALUE);
         }
 
         context.put("version", StatsConstants.STATISTIC_EXTERNAL_VERSION);
         // all table now, partition later
         context.put("partitionNameStr", table.isIcebergTable() ? partitionName :
-                PartitionUtil.normalizePartitionName(partitionName, table.getPartitionColumnNames(), nullValue));
+                PartitionUtil.normalizePartitionName(partitionName, table.getPartitionColumnNames(), nullValues));
         context.put("columnNameStr", columnNameStr);
         context.put("dataSize", fullAnalyzeGetDataSize(quoteColumnName, columnType));
         context.put("dbName", db.getOriginName());
@@ -208,7 +210,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         if (table.isUnPartitioned()) {
             context.put("partitionPredicate", "1=1");
         } else {
-            List<String> partitionPredicate = generatePartitionPredicates(table, partitionName, nullValue);
+            List<String> partitionPredicate = generatePartitionPredicates(table, partitionName, nullValues);
             context.put("partitionPredicate", Joiner.on(" AND ").join(partitionPredicate));
         }
 
@@ -216,7 +218,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         return builder.toString();
     }
 
-    private List<String> generatePartitionPredicates(Table table, String partitionName, String nullValue) {
+    private List<String> generatePartitionPredicates(Table table, String partitionName, Collection<String> nullValues) {
         if (table.isIcebergTable()) {
             return generatePartitionPredicatesForIcebergTable((IcebergTable) table, partitionName);
         }
@@ -226,7 +228,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         for (int i = 0; i < partitionColumnNames.size(); i++) {
             String partitionColumnName = partitionColumnNames.get(i);
             String partitionValue = partitionValues.get(i);
-            if (partitionValue.equals(nullValue)) {
+            if (nullValues.contains(partitionValue)) {
                 partitionPredicate.add(StatisticUtils.quoting(partitionColumnName) + " IS NULL");
             } else {
                 partitionPredicate.add(StatisticUtils.quoting(partitionColumnName) + " = '" + partitionValue + "'");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -360,6 +360,37 @@ public class PaimonMetadataTest {
     }
 
     @Test
+    public void testListPartitionNamesWithDateNullPartition(@Mocked FileStoreTable mockPaimonTable)
+            throws Catalog.TableNotExistException {
+        List<String> partitionNames = Lists.newArrayList("dt");
+        RowType partitionRowType = new RowType(
+                Arrays.asList(new DataField(0, "dt", new org.apache.paimon.types.DateType(true))));
+        Identifier tblIdentifier = new Identifier("db1", "tbl_date_null");
+        org.apache.paimon.partition.Partition partitionDate = new Partition(
+                Map.of("dt", "19723"), 100L, 1L, 1L, 1741327322000L, true);
+        org.apache.paimon.partition.Partition partitionNull = new Partition(
+                Map.of("dt", "__DEFAULT_PARTITION__"), 50L, 1L, 1L, 1741327322000L, true);
+
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(tblIdentifier);
+                result = mockPaimonTable;
+                mockPaimonTable.partitionKeys();
+                result = partitionNames;
+                mockPaimonTable.rowType();
+                result = partitionRowType;
+                paimonNativeCatalog.listPartitions(tblIdentifier);
+                result = Arrays.asList(partitionDate, partitionNull);
+            }
+        };
+        List<String> result = metadata.listPartitionNames("db1", "tbl_date_null",
+                ConnectorMetadataRequestContext.DEFAULT);
+        assertEquals(2, result.size());
+        Assertions.assertThat(result).hasSameElementsAs(
+                Lists.newArrayList("dt=2024-01-01", "dt=__DEFAULT_PARTITION__"));
+    }
+
+    @Test
     public void testRefreshPaimonMetadata() throws Catalog.DatabaseNotExistException {
         new Expectations() {
             {


### PR DESCRIPTION
## Why I'm doing:

Querying a Paimon table whose DATE partition column contains NULL values fails on **two separate paths**:

**1. Listing partitions (`SHOW PARTITIONS` / `EXPLAIN` / MV partition tracking / `ANALYZE`)**

Paimon represents a NULL partition value with the placeholder `__DEFAULT_PARTITION__`. For a DATE partition column in legacy-name mode (`partition.generate-legacy-name=true`, the default), partition values on disk are epoch-day integers, so `PaimonMetadata.getPartition()` restores them via `DateTimeUtils.formatDate(Integer.parseInt(value))`. When the value is the NULL placeholder, `Integer.parseInt` throws `NumberFormatException`.

**2. Statistics collection (`ANALYZE TABLE`)**

`ExternalFullStatisticsCollectJob` previously treated only the literal string `"null"` as the Paimon NULL placeholder, missing Paimon's actual default `__DEFAULT_PARTITION__`. For the NULL partition, the generated stats SQL became:

```sql
SELECT ... FROM tbl WHERE dt = '__DEFAULT_PARTITION__'
```

This predicate is pushed down to Paimon. Paimon's predicate engine then compares the DATE column's internal representation (`Integer` epoch-day) against the literal (`BinaryString`) and crashes inside `BinaryString.compareTo` with:

```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class org.apache.paimon.data.BinaryString
    at org.apache.paimon.data.BinaryString.compareTo(BinaryString.java:41)
    at org.apache.paimon.predicate.Equal.test(Equal.java:43)
    at org.apache.paimon.partition.PartitionPredicate$DefaultPartitionPredicate.test(...)
    at org.apache.paimon.operation.ManifestsReader.filterManifestFileMeta(...)
    ... at com.starrocks.connector.paimon.PaimonMetadata.getRemoteFiles(...)
    ... at ExternalFullStatisticsCollectJob.collectStatisticSync(...)
```

**Why both fixes are needed.** Fix (1) alone unmasks (2): an `ANALYZE TABLE` on the same table that previously failed with `NumberFormatException` then fails with the Paimon-internal `ClassCastException`. Only with both fixes does `ANALYZE` on a NULL DATE partition actually succeed.

## What I'm doing:

- Centralize Paimon's NULL partition placeholders into `PaimonMetadata.PARTITION_NULL_VALUES = ImmutableList.of("__DEFAULT_PARTITION__", "null")` as the single source of truth. `PaimonPartitionKey.nullPartitionValueList()` now returns it.
- In `PaimonMetadata.getPartition()`, skip the epoch-day `Integer.parseInt` conversion when the value is in `PARTITION_NULL_VALUES`, keeping the placeholder as the partition value.
- Change `PartitionUtil.normalizePartitionName` to accept `Collection<String>` for the NULL placeholders so a connector with multiple placeholders (Paimon) can match any of them as NULL. Hive / Iceberg callers wrap their single placeholder in `Collections.singleton(...)`.
- Same `Collection<String>` change in `ExternalFullStatisticsCollectJob.generatePartitionPredicates`, so the stats SQL for a NULL partition becomes `dt IS NULL` (avoiding the `dt = '__DEFAULT_PARTITION__'` predicate and the Paimon predicate-engine cast).
- Add a unit test for `listPartitionNames` on a DATE partition table with a NULL partition.

Fixes https://github.com/StarRocks/starrocks/issues/73626

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5