### PR TITLE
[BugFix] avoid stale-ref overwrite of committed txn in abortTransaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -627,6 +627,25 @@ public class DatabaseTransactionMgr {
         transactionState.writeLock();
         TransactionState copiedState = null;
         try {
+            // Re-fetch the latest TransactionState under writeLock. Between releasing
+            // readLock above and acquiring writeLock here, a concurrent commit path may
+            // have COW'd a new TransactionState object and replaced the map entry via
+            // unprotectUpsertTransactionState. The local `transactionState` reference
+            // would then point at a stale snapshot whose status is still PREPARED, even
+            // though the canonical map entry has already advanced to COMMITTED. Without
+            // this re-fetch, unprotectAbortTransaction's status-guard reads from the
+            // stale copy, the abort proceeds, and the freshly committed map entry gets
+            // overwritten with an ABORTED state carrying version=-1.
+            TransactionState latest;
+            readLock();
+            try {
+                latest = unprotectedGetTransactionState(transactionId);
+            } finally {
+                readUnlock();
+            }
+            if (latest != null && latest != transactionState) {
+                transactionState = latest;
+            }
             // COW
             copiedState = new TransactionState(transactionState);
             // before state transform

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -624,7 +624,14 @@ public class DatabaseTransactionMgr {
             transactionState.setTxnCommitAttachment(txnCommitAttachment);
         }
 
-        transactionState.writeLock();
+        // Keep a stable reference to the object whose writeLock we actually acquire,
+        // so the finally block always unlocks the same object. The local
+        // `transactionState` reference may be reassigned to `latest` below when a
+        // concurrent commit has replaced the map entry; unlocking that reassigned
+        // object (which this thread never locked) would throw IllegalMonitorStateException
+        // and leak the lock on the original object.
+        final TransactionState lockedState = transactionState;
+        lockedState.writeLock();
         TransactionState copiedState = null;
         try {
             // Re-fetch the latest TransactionState under writeLock. Between releasing
@@ -671,7 +678,7 @@ public class DatabaseTransactionMgr {
                 LOG.warn("transaction after state transform failed: {}", transactionState, t);
             }
         } finally {
-            transactionState.writeUnlock();
+            lockedState.writeUnlock();
         }
 
         if (copiedState.getTransactionStatus() != TransactionStatus.ABORTED) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -1096,8 +1096,10 @@ public class DatabaseTransactionMgrTest {
         // brand-new COMMITTED state object into the running map before abort
         // acquires the per-txn writeLock and reads from its stale local ref.
         // The mock signature must match the original (no `throws InterruptedException`)
-        // — wrap the latch wait in unchecked Exception.
-        MockUp<TransactionState> abortLockMock = new MockUp<TransactionState>() {
+        // — wrap the latch wait in unchecked Exception. Maven surefire runs each
+        // test class in its own JVM (reuseForks=false), so MockUp lifetime is
+        // bounded by the JVM and does not leak to other classes.
+        new MockUp<TransactionState>() {
             @Mock
             public void writeLock(Invocation inv) {
                 TransactionState ts = (TransactionState) inv.getInvokedInstance();
@@ -1186,7 +1188,6 @@ public class DatabaseTransactionMgrTest {
             // Ensure no thread is left waiting on the latch if the test errored.
             commitCompleted.countDown();
             abortThread.join(5_000);
-            abortLockMock.tearDown();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -1095,15 +1095,24 @@ public class DatabaseTransactionMgrTest {
         // the racing txn id, so the test can let the commit thread upsert a
         // brand-new COMMITTED state object into the running map before abort
         // acquires the per-txn writeLock and reads from its stale local ref.
-        new MockUp<TransactionState>() {
+        // The mock signature must match the original (no `throws InterruptedException`)
+        // — wrap the latch wait in unchecked Exception.
+        MockUp<TransactionState> abortLockMock = new MockUp<TransactionState>() {
             @Mock
-            public void writeLock(Invocation inv) throws InterruptedException {
+            public void writeLock(Invocation inv) {
                 TransactionState ts = (TransactionState) inv.getInvokedInstance();
                 if (Thread.currentThread() == abortThreadRef.get()
                         && ts.getTransactionId() == raceTxnId
                         && abortPastWriteLock.compareAndSet(false, true)) {
                     abortReachedWriteLock.countDown();
-                    assertTrue(commitCompleted.await(10, TimeUnit.SECONDS));
+                    try {
+                        if (!commitCompleted.await(10, TimeUnit.SECONDS)) {
+                            throw new RuntimeException("commit did not complete within 10s");
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
+                    }
                 }
                 inv.proceed();
             }
@@ -1119,58 +1128,65 @@ public class DatabaseTransactionMgrTest {
             }
         }, "abort-race-thread");
         abortThreadRef.set(abortThread);
-        abortThread.start();
+        try {
+            abortThread.start();
 
-        // Wait until abort thread has captured the local stale ref to object A
-        // (after readUnlock at the top of abortTransaction) and is parked just
-        // before transactionState.writeLock().
-        assertTrue(abortReachedWriteLock.await(10, TimeUnit.SECONDS),
-                "abort thread did not reach writeLock in time");
+            // Wait until abort thread has captured the local stale ref to object A
+            // (after readUnlock at the top of abortTransaction) and is parked just
+            // before transactionState.writeLock().
+            assertTrue(abortReachedWriteLock.await(10, TimeUnit.SECONDS),
+                    "abort thread did not reach writeLock in time");
 
-        // Run commit to completion on the main thread. After this returns,
-        // idToRunningTransactionState[raceTxnId] holds a brand-new
-        // TransactionState (status=COMMITTED), not the object A captured above.
-        masterTransMgr.commitPreparedTransaction(db, raceTxnId, 1000L);
+            // Run commit to completion on the main thread. After this returns,
+            // idToRunningTransactionState[raceTxnId] holds a brand-new
+            // TransactionState (status=COMMITTED), not the object A captured above.
+            masterTransMgr.commitPreparedTransaction(db, raceTxnId, 1000L);
 
-        TransactionState mapEntryAfterCommit = masterDbTransMgr.getTransactionState(raceTxnId);
-        assertNotNull(mapEntryAfterCommit);
-        assertEquals(TransactionStatus.COMMITTED, mapEntryAfterCommit.getTransactionStatus());
-        Assertions.assertNotSame(objectA, mapEntryAfterCommit,
-                "commit should have upserted a new TransactionState object into the running map");
+            TransactionState mapEntryAfterCommit = masterDbTransMgr.getTransactionState(raceTxnId);
+            assertNotNull(mapEntryAfterCommit);
+            assertEquals(TransactionStatus.COMMITTED, mapEntryAfterCommit.getTransactionStatus());
+            Assertions.assertNotSame(objectA, mapEntryAfterCommit,
+                    "commit should have upserted a new TransactionState object into the running map");
 
-        // Release abort: it will now acquire the writeLock and either
-        //   (fixed)   re-read idToRunningTransactionState, see COMMITTED, and
-        //             refuse to abort (throwing TransactionAlreadyCommitException), or
-        //   (buggy)   COW from the stale object A (status=PREPARED), flip to
-        //             ABORTED, and overwrite the committed map entry.
-        commitCompleted.countDown();
-        abortThread.join(10_000);
-        Assertions.assertFalse(abortThread.isAlive(), "abort thread should have terminated");
+            // Release abort: it will now acquire the writeLock and either
+            //   (fixed)   re-read idToRunningTransactionState, see COMMITTED, and
+            //             refuse to abort (throwing TransactionAlreadyCommitException), or
+            //   (buggy)   COW from the stale object A (status=PREPARED), flip to
+            //             ABORTED, and overwrite the committed map entry.
+            commitCompleted.countDown();
+            abortThread.join(10_000);
+            Assertions.assertFalse(abortThread.isAlive(), "abort thread should have terminated");
 
-        if (abortError[0] != null) {
-            Throwable cause = abortError[0];
-            while (cause != null && !(cause instanceof TransactionAlreadyCommitException)) {
-                cause = cause.getCause();
+            if (abortError[0] != null) {
+                Throwable cause = abortError[0];
+                while (cause != null && !(cause instanceof TransactionAlreadyCommitException)) {
+                    cause = cause.getCause();
+                }
+                assertNotNull(cause, "abort error must be (caused by) TransactionAlreadyCommitException, got "
+                        + abortError[0]);
             }
-            assertNotNull(cause, "abort error must be (caused by) TransactionAlreadyCommitException, got "
-                    + abortError[0]);
-        }
 
-        // The committed map entry MUST NOT have been overwritten with ABORTED,
-        // and the partition commit version produced by commit MUST survive.
-        TransactionState finalState = masterDbTransMgr.getTransactionState(raceTxnId);
-        assertNotNull(finalState);
-        assertEquals(TransactionStatus.COMMITTED, finalState.getTransactionStatus(),
-                "stale-ref race must not overwrite the committed entry with ABORTED");
+            // The committed map entry MUST NOT have been overwritten with ABORTED,
+            // and the partition commit version produced by commit MUST survive.
+            TransactionState finalState = masterDbTransMgr.getTransactionState(raceTxnId);
+            assertNotNull(finalState);
+            assertEquals(TransactionStatus.COMMITTED, finalState.getTransactionStatus(),
+                    "stale-ref race must not overwrite the committed entry with ABORTED");
 
-        TableCommitInfo tci = finalState.getIdToTableCommitInfos().get(GlobalStateMgrTestUtil.testTableId1);
-        assertNotNull(tci, "committed state must keep its table commit info");
-        Assertions.assertFalse(tci.getIdToPartitionCommitInfo().isEmpty(),
-                "committed state must keep at least one partition commit info");
-        for (PartitionCommitInfo pci : tci.getIdToPartitionCommitInfo().values()) {
-            Assertions.assertTrue(pci.getVersion() > 0,
-                    "committed partition version must remain positive (not -1 from abort COW), got "
-                            + pci.getVersion());
+            TableCommitInfo tci = finalState.getIdToTableCommitInfos().get(GlobalStateMgrTestUtil.testTableId1);
+            assertNotNull(tci, "committed state must keep its table commit info");
+            Assertions.assertFalse(tci.getIdToPartitionCommitInfo().isEmpty(),
+                    "committed state must keep at least one partition commit info");
+            for (PartitionCommitInfo pci : tci.getIdToPartitionCommitInfo().values()) {
+                Assertions.assertTrue(pci.getVersion() > 0,
+                        "committed partition version must remain positive (not -1 from abort COW), got "
+                                + pci.getVersion());
+            }
+        } finally {
+            // Ensure no thread is left waiting on the latch if the test errored.
+            commitCompleted.countDown();
+            abortThread.join(5_000);
+            abortLockMock.tearDown();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -80,6 +80,7 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
@@ -96,6 +97,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1055,6 +1057,120 @@ public class DatabaseTransactionMgrTest {
             assertTrue(transactionState2.getCommitTime() > maxCommitTsBefore);
         } finally {
             releasePersist.countDown();
+        }
+    }
+
+    // Race between commitPreparedTransaction and abortTransaction: abort holds a
+    // local reference to the original (PREPARED) TransactionState that it read
+    // outside the per-txn writeLock; if a concurrent commit upserts a fresh
+    // TransactionState object into idToRunningTransactionState before abort
+    // acquires the writeLock, abort must NOT proceed to COW from the stale
+    // local reference and overwrite the committed map entry with an ABORTED
+    // state carrying version=-1. See lake-mode-commit-abort race report.
+    @Test
+    public void testAbortRaceWithConcurrentCommitDoesNotOverwriteCommittedState() throws Exception {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        Database db = masterGlobalStateMgr.getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDbId1);
+        DatabaseTransactionMgr masterDbTransMgr =
+                masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+
+        long raceTxnId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                "test_commit_abort_race_" + System.nanoTime(),
+                transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, raceTxnId, -1,
+                buildTabletCommitInfoList(), Lists.newArrayList(), null);
+
+        TransactionState objectA = masterDbTransMgr.getTransactionState(raceTxnId);
+        assertNotNull(objectA);
+        assertEquals(TransactionStatus.PREPARED, objectA.getTransactionStatus());
+
+        CountDownLatch abortReachedWriteLock = new CountDownLatch(1);
+        CountDownLatch commitCompleted = new CountDownLatch(1);
+        AtomicReference<Thread> abortThreadRef = new AtomicReference<>();
+        AtomicBoolean abortPastWriteLock = new AtomicBoolean(false);
+
+        // Intercept TransactionState.writeLock() only for the abort thread on
+        // the racing txn id, so the test can let the commit thread upsert a
+        // brand-new COMMITTED state object into the running map before abort
+        // acquires the per-txn writeLock and reads from its stale local ref.
+        new MockUp<TransactionState>() {
+            @Mock
+            public void writeLock(Invocation inv) throws InterruptedException {
+                TransactionState ts = (TransactionState) inv.getInvokedInstance();
+                if (Thread.currentThread() == abortThreadRef.get()
+                        && ts.getTransactionId() == raceTxnId
+                        && abortPastWriteLock.compareAndSet(false, true)) {
+                    abortReachedWriteLock.countDown();
+                    assertTrue(commitCompleted.await(10, TimeUnit.SECONDS));
+                }
+                inv.proceed();
+            }
+        };
+
+        Throwable[] abortError = new Throwable[1];
+        Thread abortThread = new Thread(() -> {
+            try {
+                masterDbTransMgr.abortTransaction(raceTxnId, true, "race-fake-timeout", null,
+                        Lists.newArrayList(), Lists.newArrayList());
+            } catch (Throwable t) {
+                abortError[0] = t;
+            }
+        }, "abort-race-thread");
+        abortThreadRef.set(abortThread);
+        abortThread.start();
+
+        // Wait until abort thread has captured the local stale ref to object A
+        // (after readUnlock at the top of abortTransaction) and is parked just
+        // before transactionState.writeLock().
+        assertTrue(abortReachedWriteLock.await(10, TimeUnit.SECONDS),
+                "abort thread did not reach writeLock in time");
+
+        // Run commit to completion on the main thread. After this returns,
+        // idToRunningTransactionState[raceTxnId] holds a brand-new
+        // TransactionState (status=COMMITTED), not the object A captured above.
+        masterTransMgr.commitPreparedTransaction(db, raceTxnId, 1000L);
+
+        TransactionState mapEntryAfterCommit = masterDbTransMgr.getTransactionState(raceTxnId);
+        assertNotNull(mapEntryAfterCommit);
+        assertEquals(TransactionStatus.COMMITTED, mapEntryAfterCommit.getTransactionStatus());
+        Assertions.assertNotSame(objectA, mapEntryAfterCommit,
+                "commit should have upserted a new TransactionState object into the running map");
+
+        // Release abort: it will now acquire the writeLock and either
+        //   (fixed)   re-read idToRunningTransactionState, see COMMITTED, and
+        //             refuse to abort (throwing TransactionAlreadyCommitException), or
+        //   (buggy)   COW from the stale object A (status=PREPARED), flip to
+        //             ABORTED, and overwrite the committed map entry.
+        commitCompleted.countDown();
+        abortThread.join(10_000);
+        Assertions.assertFalse(abortThread.isAlive(), "abort thread should have terminated");
+
+        if (abortError[0] != null) {
+            Throwable cause = abortError[0];
+            while (cause != null && !(cause instanceof TransactionAlreadyCommitException)) {
+                cause = cause.getCause();
+            }
+            assertNotNull(cause, "abort error must be (caused by) TransactionAlreadyCommitException, got "
+                    + abortError[0]);
+        }
+
+        // The committed map entry MUST NOT have been overwritten with ABORTED,
+        // and the partition commit version produced by commit MUST survive.
+        TransactionState finalState = masterDbTransMgr.getTransactionState(raceTxnId);
+        assertNotNull(finalState);
+        assertEquals(TransactionStatus.COMMITTED, finalState.getTransactionStatus(),
+                "stale-ref race must not overwrite the committed entry with ABORTED");
+
+        TableCommitInfo tci = finalState.getIdToTableCommitInfos().get(GlobalStateMgrTestUtil.testTableId1);
+        assertNotNull(tci, "committed state must keep its table commit info");
+        Assertions.assertFalse(tci.getIdToPartitionCommitInfo().isEmpty(),
+                "committed state must keep at least one partition commit info");
+        for (PartitionCommitInfo pci : tci.getIdToPartitionCommitInfo().values()) {
+            Assertions.assertTrue(pci.getVersion() > 0,
+                    "committed partition version must remain positive (not -1 from abort COW), got "
+                            + pci.getVersion());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -1142,7 +1142,16 @@ public class DatabaseTransactionMgrTest {
             // Run commit to completion on the main thread. After this returns,
             // idToRunningTransactionState[raceTxnId] holds a brand-new
             // TransactionState (status=COMMITTED), not the object A captured above.
-            masterTransMgr.commitPreparedTransaction(db, raceTxnId, 1000L);
+            // commitPreparedTransaction upserts the COMMITTED state into the running
+            // map before it waits for publish; in UT there is no publish daemon, so
+            // the publish-wait always times out with a "publish timeout" StarRocksException.
+            // That timeout is expected and harmless here — the COMMITTED map entry is
+            // already in place — so tolerate it exactly like the sibling commit-race test.
+            try {
+                masterTransMgr.commitPreparedTransaction(db, raceTxnId, 1000L);
+            } catch (Throwable t) {
+                assertPublishTimeoutOrNull(t);
+            }
 
             TransactionState mapEntryAfterCommit = masterDbTransMgr.getTransactionState(raceTxnId);
             assertNotNull(mapEntryAfterCommit);


### PR DESCRIPTION




## Why I'm doing:
abortTransaction() snapshots a local reference to the running TransactionState outside the per-txn writeLock, then COWs and upserts from that snapshot. If a concurrent commitPreparedTransaction replaces the map entry with a fresh COMMITTED state object between the readUnlock and the writeLock acquisition, the abort's status guard runs against the stale (still-PREPARED) object, flips it to ABORTED and overwrites the committed map entry. The result on a lake-mode partition: FE meta has status=ABORTED with partition_commit_info.version=-1 while BE has already applied the committed version — the partition becomes permanently stuck and every subsequent publish times out with "txn has not sent publish tasks yet".

## What I'm doing:
Fix: under the per-txn writeLock, re-read idToRunningTransactionState so the status check and the COW source see the canonical map entry. The shared txnLock guarantees the re-read observes whatever the concurrent commit just upserted.

Adds a concurrent FE UT that deterministically reproduces the race by parking abort just before writeLock(), letting commit upsert the new COMMITTED state object, then releasing abort. Before the fix the test ends with status=ABORTED and version=-1; after the fix abort throws TransactionAlreadyCommitException and the committed entry is preserved.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
