### PR TITLE
[BugFix] Fast-path skip empty input in TabletInvertedIndex.deleteTablets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -186,6 +186,9 @@ public class TabletInvertedIndex implements MemoryTrackable {
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
         }
+        if (tabletIds.isEmpty()) {
+            return;
+        }
         mutationLock.lock();
         try {
             for (long tabletId : tabletIds) {


### PR DESCRIPTION
Avoid acquiring lock when the tabletIds collection is empty.

* for new partition creation, mostly the orphan tablets are empty, `TabletInvertedIndex.deleteTablets()` can be skipped in fast path.
```
  "java.base@17.0.18/java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(ReentrantReadWriteLock.java:959)",
  "app//com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock.exclusiveLock(QueryableReentrantReadWriteLock.java:126)",
  "app//com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock.lockDetectingSlowLock(QueryableReentrantReadWriteLock.java:108)",
  "app//com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock.exclusiveLockDetectingSlowLock(QueryableReentrantReadWriteLock.java:81)",
  "app//com.starrocks.catalog.TabletInvertedIndex.writeLock(TabletInvertedIndex.java:106)",
  "app//com.starrocks.catalog.TabletInvertedIndex.deleteTablets(TabletInvertedIndex.java:256)",
  "app//com.starrocks.server.LocalMetastore.cleanExistPartitionNameSet(LocalMetastore.java:1201)",
  "app//com.starrocks.server.LocalMetastore.addPartitions(LocalMetastore.java:1311)",
  "app//com.starrocks.server.LocalMetastore.addPartitions(LocalMetastore.java:880)",
  "app//com.starrocks.service.FrontendServiceImpl.createPartitionProcess(FrontendServiceImpl.java:2305)",
  "app//com.starrocks.service.FrontendServiceImpl.createPartition(FrontendServiceImpl.java:2146)",
  "app//com.starrocks.thrift.FrontendService$Processor$createPartition.getResult(FrontendService.java:6861)",
  "app//com.starrocks.thrift.FrontendService$Processor$createPartition.getResult(FrontendService.java:6838)",
  "app//org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)",
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
