### PR TITLE
[BugFix] Transcode PK .del files on lake-to-lake V1→V2 replication

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -253,14 +253,16 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     std::vector<std::string> files_to_delete;
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
 
-    // src_tablet_meta->has_schema() is guaranteed by the early Corruption return above.
-    RETURN_IF_ERROR(check_pk_encoding_compat(src_tablet_id, target_tablet_id, *src_tablet_meta, *target_tablet_meta));
+    // Compute PK encoding transcode context for .del files. prepare_del_transcode_context
+    // validates PK column count/type match and rejects V2→V1 on byte-incompatible PK shapes.
+    // For V1→V2, it returns the transcode context so build_file_converters can wire up
+    // DelFileStreamConverter for .del files.
+    ASSIGN_OR_RETURN(auto del_transcode_ctx,
+                     lake::ReplicationTxnManager::prepare_del_transcode_context(*target_tablet_meta, source_schema_pb));
 
-    // PK transcoding is gated above; pass nullptr/NONE so the converter never enters the .del
-    // transcode branch in this code path.
     auto file_converters = lake::ReplicationTxnManager::build_file_converters(
-            _tablet_manager, request, filename_map, column_unique_id_map, files_to_delete, /*pkey_schema=*/nullptr,
-            PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE, PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE);
+            _tablet_manager, request, filename_map, column_unique_id_map, files_to_delete,
+            del_transcode_ctx.pkey_schema, del_transcode_ctx.source_encoding, del_transcode_ctx.target_encoding);
 
     // Track which segments have size changes
     std::unordered_map<std::string, size_t> segment_size_changes;
@@ -305,6 +307,9 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
             src_file_size = size_it->second;
         }
         bool is_seg = is_segment(src_file_name);
+        // Segments and .del files go through download_lake_file_with_converter + file_converters,
+        // which routes .del files through DelFileStreamConverter when V1→V2 transcoding is needed.
+        bool use_converter = is_seg || is_del(src_file_name);
         const auto& target_file_name = pair.second.first;
         FileEncryptionInfo encryption_info;
         if (config::enable_transparent_data_encryption) {
@@ -312,7 +317,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         }
 
         tasks.emplace_back([&, src_file_name, src_file_location, target_file_location, target_file_name, src_file_size,
-                            is_seg, encryption_info]() -> Status {
+                            is_seg, use_converter, encryption_info]() -> Status {
             // Fast cancel: check right before each file copy starts.
             if (txn_id < get_master_info().min_active_txn_id) {
                 LOG(WARNING) << "Lake replication task cancelled before file copy, transaction is aborted"
@@ -328,15 +333,15 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
 
             size_t final_file_size = 0;
             auto start_ts = butil::gettimeofday_us();
-            if (is_seg) {
+            if (use_converter) {
                 TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_task::download_segment",
                                          &final_file_size);
                 if (final_file_size == 0) {
-                    RETURN_IF_ERROR(ReplicationUtils::download_lake_segment_file(
+                    RETURN_IF_ERROR(ReplicationUtils::download_lake_file_with_converter(
                             src_file_location, src_file_name, src_file_size, shared_src_fs, active_file_converters,
                             &final_file_size));
                 }
-                if (final_file_size > 0 && final_file_size != src_file_size) {
+                if (is_seg && final_file_size > 0 && final_file_size != src_file_size) {
                     if (shared_mutex != nullptr) {
                         std::lock_guard lock(*shared_mutex);
                         segment_size_changes[target_file_name] = final_file_size;
@@ -462,38 +467,6 @@ bool LakeReplicationTxnManager::should_use_parallel_copy(size_t file_count, cons
         return false;
     }
     return thread_pool->num_queued_tasks() <= num_threads * kParallelCopyMaxQueuePerThread;
-}
-
-Status LakeReplicationTxnManager::check_pk_encoding_compat(int64_t src_tablet_id, int64_t target_tablet_id,
-                                                           const TabletMetadata& src_tablet_meta,
-                                                           const TabletMetadata& target_tablet_meta) {
-    if (!is_primary_key(target_tablet_meta)) {
-        return Status::OK();
-    }
-    // Lake-to-lake replication routes .del files through copy_non_segment_file_with_retry (a raw
-    // byte copy), not through file_converters. So if source/target use different PK encodings in
-    // a way that produces non-byte-compatible .del bytes (single non-string fixed-length PK +
-    // V1<->V2), the byte copy would silently corrupt the target. Reject explicitly until .del
-    // is routed through a transcoding converter on this path as well.
-    //
-    // V1 source vs V2 target shows up when the source tablet is from a pre-#69939 cloud-native
-    // cluster (V1 default) and the target is post-#69939 (V2 default for new cloud-native tables).
-    TabletSchema source_schema(src_tablet_meta.schema());
-    TabletSchema target_schema(target_tablet_meta.schema());
-    ASSIGN_OR_RETURN(auto source_encoding, source_schema.primary_key_encoding_type_or_error());
-    ASSIGN_OR_RETURN(auto target_encoding, target_schema.primary_key_encoding_type_or_error());
-    if (source_encoding != target_encoding && is_single_fixed_length_non_string_primary_key(target_schema)) {
-        LOG(WARNING) << "Lake-to-lake replication with PK encoding mismatch is not supported, src_tablet: "
-                     << src_tablet_id << ", target_tablet: " << target_tablet_id
-                     << ", source_encoding: " << static_cast<int>(source_encoding)
-                     << ", target_encoding: " << static_cast<int>(target_encoding)
-                     << ", pk_logical_type: " << logical_type_to_string(target_schema.column(0).type());
-        return Status::NotSupported(
-                "Lake-to-lake replication with V1<->V2 primary-key encoding change on a single "
-                "non-string fixed-length PK column is not supported; .del files in this path "
-                "are byte-copied without re-encoding and would fail to apply on the target.");
-    }
-    return Status::OK();
 }
 
 StatusOr<size_t> LakeReplicationTxnManager::copy_non_segment_file_with_retry(

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -106,15 +106,6 @@ public:
                                                              const std::string& target_file_location,
                                                              const WritableFileOptions& opts, int max_retry);
 
-    // Returns Status::NotSupported if the source/target PK encoding combination would produce
-    // byte-incompatible .del file copies in the lake-to-lake path (which raw-copies .del files
-    // without re-encoding). Specifically rejects either direction of V1<->V2 on a single
-    // non-string fixed-length PK column. Returns Status::OK for safe combinations and for
-    // non-PK target tablets.
-    static Status check_pk_encoding_compat(int64_t src_tablet_id, int64_t target_tablet_id,
-                                           const TabletMetadata& src_tablet_meta,
-                                           const TabletMetadata& target_tablet_meta);
-
     // Decide whether to use parallel copy for current tablet files.
     static bool should_use_parallel_copy(size_t file_count, const ThreadPool* thread_pool);
 

--- a/be/src/storage/replication_utils.cpp
+++ b/be/src/storage/replication_utils.cpp
@@ -342,12 +342,13 @@ StatusOr<std::string> ReplicationUtils::download_remote_snapshot_file(
 #endif
 }
 
-Status ReplicationUtils::download_lake_segment_file(const std::string& src_file_path, const std::string& src_file_name,
-                                                    size_t src_file_size, const std::shared_ptr<FileSystem>& src_fs,
-                                                    const FileConverterCreatorFunc& file_converters,
-                                                    size_t* final_file_size) {
+Status ReplicationUtils::download_lake_file_with_converter(const std::string& src_file_path,
+                                                           const std::string& src_file_name, size_t src_file_size,
+                                                           const std::shared_ptr<FileSystem>& src_fs,
+                                                           const FileConverterCreatorFunc& file_converters,
+                                                           size_t* final_file_size) {
     TRACE_COUNTER_SCOPE_LATENCY_US("lake_replication_download_segment_cost_us");
-    TRACE("Start download_lake_segment_file, src_file: $0", src_file_path);
+    TRACE("Start download_lake_file_with_converter, src_file: $0", src_file_path);
 
     ASSIGN_OR_RETURN(auto src_file, src_fs->new_random_access_file(src_file_path));
     if (src_file_size == 0) {
@@ -403,7 +404,7 @@ Status ReplicationUtils::download_lake_segment_file(const std::string& src_file_
         *final_file_size = output_size;
     }
 
-    TRACE("Finish download_lake_segment_file, read_count: $0, final_size: $1", read_count, output_size);
+    TRACE("Finish download_lake_file_with_converter, read_count: $0, final_size: $1", read_count, output_size);
 
     return Status::OK();
 }

--- a/be/src/storage/replication_utils.h
+++ b/be/src/storage/replication_utils.h
@@ -47,10 +47,10 @@ public:
                                                                TSchemaHash remote_schema_hash,
                                                                const std::string& file_name, uint64_t timeout_sec);
 
-    static Status download_lake_segment_file(const std::string& src_file_path, const std::string& src_file_name,
-                                             size_t src_file_size, const std::shared_ptr<FileSystem>& src_fs,
-                                             const FileConverterCreatorFunc& file_converters,
-                                             size_t* final_file_size = nullptr);
+    static Status download_lake_file_with_converter(const std::string& src_file_path, const std::string& src_file_name,
+                                                    size_t src_file_size, const std::shared_ptr<FileSystem>& src_fs,
+                                                    const FileConverterCreatorFunc& file_converters,
+                                                    size_t* final_file_size = nullptr);
 
     static constexpr uint32_t kFakeColumnUniqueId = INT_MAX;
 

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1365,7 +1365,7 @@ TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_error_handling) {
 
     (void)update_master_info(original_master_info);
 
-    // Parallel copy should fail because download_lake_segment_file fails with mock FS
+    // Parallel copy should fail because download_lake_file_with_converter fails with mock FS
     EXPECT_FALSE(status.ok());
     pool->shutdown();
 }

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -32,6 +32,7 @@
 #include "platform/store_path.h"
 #include "runtime/exec_env.h"
 #include "storage/chunk_helper.h"
+#include "storage/del_file_stream_converter.h"
 #include "storage/delta_column_group.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -887,54 +888,95 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_c
     ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
 }
 
-// check_pk_encoding_compat: non-PK target -> OK.
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_non_pk) {
-    auto src = make_non_pk_tablet_metadata(1);
-    auto tgt = make_non_pk_tablet_metadata(2);
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
-    EXPECT_TRUE(st.ok()) << st;
+// build_file_converters: V1→V2 on single INT PK produces DelFileStreamConverter for .del files,
+// plain FileStreamConverter for .dat files, and returns nullptr for unknown files.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_del_transcode_v1_to_v2) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
+    auto& ctx = ctx_or.value();
+    ASSERT_NE(nullptr, ctx.pkey_schema);
+
+    // Set up minimal environment for build_file_converters
+    std::string test_dir = config::storage_root_path + "/build_file_converters_test";
+    auto location_provider = std::make_shared<lake::FixedLocationProvider>(test_dir);
+    ASSERT_TRUE(FileSystem::Default()->create_dir_recursive(location_provider->segment_root_location(1)).ok());
+    auto update_manager = std::make_unique<lake::UpdateManager>(location_provider, nullptr);
+    auto tablet_manager = std::make_unique<lake::TabletManager>(location_provider, update_manager.get(), 16384);
+
+    TReplicateSnapshotRequest request;
+    request.tablet_id = 1;
+    request.transaction_id = 100;
+    request.src_visible_version = 2;
+
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+    filename_map["src_0.del"] = {lake::gen_del_filename(100), FileEncryptionPair()};
+    filename_map["src_0.dat"] = {lake::gen_segment_filename(100), FileEncryptionPair()};
+
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    std::vector<std::string> files_to_delete;
+
+    auto converters = lake::ReplicationTxnManager::build_file_converters(
+            tablet_manager.get(), request, filename_map, column_unique_id_map, files_to_delete, ctx.pkey_schema,
+            ctx.source_encoding, ctx.target_encoding);
+
+    // .del file should produce a DelFileStreamConverter
+    auto del_converter_or = converters("src_0.del", 100);
+    ASSERT_TRUE(del_converter_or.ok()) << del_converter_or.status();
+    ASSERT_NE(nullptr, del_converter_or.value());
+    EXPECT_NE(nullptr, dynamic_cast<DelFileStreamConverter*>(del_converter_or.value().get()));
+
+    // .dat file (no column_unique_id_map) should produce a plain FileStreamConverter
+    auto seg_converter_or = converters("src_0.dat", 200);
+    ASSERT_TRUE(seg_converter_or.ok()) << seg_converter_or.status();
+    ASSERT_NE(nullptr, seg_converter_or.value());
+    EXPECT_EQ(nullptr, dynamic_cast<DelFileStreamConverter*>(seg_converter_or.value().get()));
+
+    // Unknown file should return nullptr
+    auto unknown_or = converters("unknown.sst", 50);
+    ASSERT_TRUE(unknown_or.ok());
+    EXPECT_EQ(nullptr, unknown_or.value());
+
+    (void)fs::remove_all(test_dir);
 }
 
-// check_pk_encoding_compat: matching V2 encoding -> OK.
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_same_encoding) {
-    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
-    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
-    EXPECT_TRUE(st.ok()) << st;
-}
+// build_file_converters: same encoding produces plain FileStreamConverter for .del files (no transcode).
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_del_no_transcode_same_encoding) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
+    auto& ctx = ctx_or.value();
 
-// check_pk_encoding_compat: V1 -> V2 on single fixed PK -> NotSupported.
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_v1_to_v2_rejected) {
-    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"BIGINT"});
-    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"BIGINT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
-    ASSERT_FALSE(st.ok());
-    EXPECT_TRUE(st.is_not_supported()) << st;
-}
+    std::string test_dir = config::storage_root_path + "/build_file_converters_test2";
+    auto location_provider = std::make_shared<lake::FixedLocationProvider>(test_dir);
+    ASSERT_TRUE(FileSystem::Default()->create_dir_recursive(location_provider->segment_root_location(1)).ok());
+    auto update_manager = std::make_unique<lake::UpdateManager>(location_provider, nullptr);
+    auto tablet_manager = std::make_unique<lake::TabletManager>(location_provider, update_manager.get(), 16384);
 
-// check_pk_encoding_compat: V2 -> V1 on single fixed PK -> NotSupported.
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_v2_to_v1_rejected) {
-    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
-    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
-    ASSERT_FALSE(st.ok());
-    EXPECT_TRUE(st.is_not_supported()) << st;
-}
+    TReplicateSnapshotRequest request;
+    request.tablet_id = 1;
+    request.transaction_id = 100;
+    request.src_visible_version = 2;
 
-// check_pk_encoding_compat: V1 -> V2 on VARCHAR PK -> OK (byte-compatible).
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_varchar_pk_allowed) {
-    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"VARCHAR"});
-    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"VARCHAR"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
-    EXPECT_TRUE(st.ok()) << st;
-}
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+    filename_map["src_0.del"] = {lake::gen_del_filename(100), FileEncryptionPair()};
 
-// check_pk_encoding_compat: V1 -> V2 on composite PK -> OK (byte-compatible).
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_composite_pk_allowed) {
-    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT", "INT"});
-    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT", "INT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
-    EXPECT_TRUE(st.ok()) << st;
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    std::vector<std::string> files_to_delete;
+
+    auto converters = lake::ReplicationTxnManager::build_file_converters(
+            tablet_manager.get(), request, filename_map, column_unique_id_map, files_to_delete, ctx.pkey_schema,
+            ctx.source_encoding, ctx.target_encoding);
+
+    // Same encoding: .del file should produce a plain FileStreamConverter, not DelFileStreamConverter
+    auto del_converter_or = converters("src_0.del", 100);
+    ASSERT_TRUE(del_converter_or.ok()) << del_converter_or.status();
+    ASSERT_NE(nullptr, del_converter_or.value());
+    EXPECT_EQ(nullptr, dynamic_cast<DelFileStreamConverter*>(del_converter_or.value().get()));
+
+    (void)fs::remove_all(test_dir);
 }
 
 // Test convert_dcg_meta_for_pk: converts DeltaColumnGroupList from snapshot into DeltaColumnGroupMetadataPB

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -902,7 +902,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_d
     std::string test_dir = config::storage_root_path + "/build_file_converters_test";
     auto location_provider = std::make_shared<lake::FixedLocationProvider>(test_dir);
     ASSERT_TRUE(FileSystem::Default()->create_dir_recursive(location_provider->segment_root_location(1)).ok());
-    auto update_manager = std::make_unique<lake::UpdateManager>(location_provider, nullptr);
+    auto mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+    auto update_manager = std::make_unique<lake::UpdateManager>(location_provider, mem_tracker.get());
     auto tablet_manager = std::make_unique<lake::TabletManager>(location_provider, update_manager.get(), 16384);
 
     TReplicateSnapshotRequest request;
@@ -952,7 +953,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_d
     std::string test_dir = config::storage_root_path + "/build_file_converters_test2";
     auto location_provider = std::make_shared<lake::FixedLocationProvider>(test_dir);
     ASSERT_TRUE(FileSystem::Default()->create_dir_recursive(location_provider->segment_root_location(1)).ok());
-    auto update_manager = std::make_unique<lake::UpdateManager>(location_provider, nullptr);
+    auto mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+    auto update_manager = std::make_unique<lake::UpdateManager>(location_provider, mem_tracker.get());
     auto tablet_manager = std::make_unique<lake::TabletManager>(location_provider, update_manager.get(), 16384);
 
     TReplicateSnapshotRequest request;


### PR DESCRIPTION
## Why I'm doing:

This is follow-up PR for #73649 which fixed `.del` file transcoding for the **shared-nothing → shared-data (SN→CN)** snapshot replication path but left the **lake-to-lake (shared-data → shared-data)** path gated behind a `NotSupported` reject (`check_pk_encoding_compat`).

## What I'm doing:

Fixes #

Reuse the `DelFileStreamConverter` infrastructure from PR #73649 to enable V1→V2 `.del` file transcoding on the lake-to-lake path:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5