### PR TITLE
[BugFix] Re-record per-partition coordinator claim on every sender's open

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -82,6 +82,11 @@ public:
     Status incremental_open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* result,
                             std::shared_ptr<OlapTableSchemaParam> schema) override;
 
+    // Re-applied non-incremental open: only re-records the per-partition
+    // coordinator claim. See base class comment for the rationale and
+    // `_record_coordinator_claims` for what is recorded.
+    void update_open(const PTabletWriterOpenRequest& params) override { _record_coordinator_claims(params); }
+
     void cancel(const std::string& reason) override;
 
     void abort() override;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -172,6 +172,19 @@ void LoadChannel::open(const LoadChannelOpenContext& open_context) {
             COUNTER_UPDATE(_index_num, 1);
         } else if (request.is_incremental()) {
             st = it->second->incremental_open(request, response, _schema);
+        } else {
+            // Channel already created by another sender's non-incremental open.
+            // We must still apply this sender's open params so that per-sender
+            // state derived from open (e.g. the lake per-partition coordinator
+            // claim) reflects every sender, not just the first opener.
+            // Without this, `LakeTabletsChannel::_partition_coordinator` only
+            // records the first opener on each storage BE, causing
+            // `_should_enter_collect_path(sender_id)` to return false for the
+            // other senders' EOS handlers — their EOS responses then carry no
+            // txn_logs back to the FE-coord OlapTableSink, and the combined
+            // txn_log file ends up missing the contributions from whichever
+            // NodeChannel was not coordinated by sender 0.
+            it->second->update_open(request);
         }
     }
     LOG_IF(WARNING, !st.ok()) << "Fail to open index " << key << " of load " << _load_id << ": " << st.to_string();

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -60,6 +60,16 @@ public:
     virtual Status incremental_open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* result,
                                     std::shared_ptr<OlapTableSchemaParam> schema) = 0;
 
+    // Re-apply the open request to an already-opened channel for a different
+    // sender. The first sender to arrive runs `open()`/`incremental_open()`;
+    // every subsequent non-incremental open for the same `TabletsChannelKey`
+    // would otherwise silently no-op in `LoadChannel::open`, which is fine
+    // for sender accounting but is NOT fine for per-sender state populated
+    // from open params (notably the lake per-partition coordinator claim).
+    // Override this in subclasses that depend on every sender's open being
+    // observed. Default is no-op so non-lake channels are unaffected.
+    virtual void update_open(const PTabletWriterOpenRequest& params) {}
+
     virtual void add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
                            PTabletWriterAddBatchResult* response, bool* close_channel_ptr) = 0;
 

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -1580,4 +1580,126 @@ TEST_F(LakeTabletsChannelPerPartitionCoordinatorTest, test_two_senders_split_par
     // claimed by its opener.
     EXPECT_EQ(orphan_before, m->lake_txn_log_collect_orphan_partition_total.value());
 }
+
+// Regression test for the bug where a non-first-opener's non-incremental open
+// was silently no-op'd by LoadChannel::open, leaving its partition claim out of
+// `_partition_coordinator`. The repro: sender 1 arrives at the storage BE
+// first and is recorded as the partition's only coordinator; sender 0 arrives
+// second but its claim was being dropped, so the post-wait election picked
+// sender 1 even though sender 0 has the smaller id — txn_logs were returned
+// to OlapTableSink 1's NC instead of OlapTableSink 0's, and concurrent writes
+// from multiple OlapTableSinks raced to write a partial combined_txn_log on
+// shared-data OSS.
+//
+// With the fix, LoadChannel::open's new else branch invokes
+// `LakeTabletsChannel::update_open` for the late-arriving sender, which
+// re-runs `_record_coordinator_claims`. This test exercises that path
+// directly: simulate sender 1 opening first, then call `update_open` with
+// sender 0's params, and assert that sender 0 ends up the coordinator
+// (collects all logs) and sender 1 collects nothing.
+TEST_F(LakeTabletsChannelPerPartitionCoordinatorTest,
+       test_late_arriving_sender_0_open_claims_via_update_open) {
+    auto* m = RuntimeMetrics::instance();
+    int64_t per_partition_before = m->lake_txn_log_collect_per_partition_total.value();
+    int64_t orphan_before = m->lake_txn_log_collect_orphan_partition_total.value();
+
+    constexpr int kChunkSize = 128;
+    auto chunk = generate_data(kChunkSize);
+
+    // Both senders cover the SAME tablet set across two partitions — this
+    // mirrors how multiple OlapTableSink instances (different sender_ids) on
+    // one FE-coord BE each open all of the storage BE's tablets.
+    auto make_open = [&](int32_t sender_id) {
+        PTabletWriterOpenRequest req;
+        req.mutable_id()->CopyFrom(_open_request.id());
+        req.set_index_id(kIndexId);
+        req.set_txn_id(kTxnId);
+        req.set_num_senders(2);
+        req.set_sender_id(sender_id);
+        req.set_need_gen_rollup(false);
+        req.set_load_channel_timeout_s(10);
+        req.set_is_vectorized(true);
+        req.mutable_schema()->CopyFrom(_open_request.schema());
+        for (auto& [pid, tid] : std::vector<std::pair<int64_t, int64_t>>{
+                     {10, 10086}, {10, 10087}, {11, 10088}, {11, 10089}}) {
+            auto* t = req.add_tablets();
+            t->set_partition_id(pid);
+            t->set_tablet_id(tid);
+        }
+        req.mutable_lake_tablet_params()->set_write_txn_log(false);
+        req.mutable_lake_tablet_params()->set_enable_per_partition_coordinator(true);
+        return req;
+    };
+
+    // Sender 1 wins the race to create the channel (simulates the bug
+    // trigger: a non-zero sender_id arriving first on this storage BE).
+    PTabletWriterOpenResult open_resp;
+    ASSERT_OK(_tablets_channel->open(make_open(1), &open_resp, _schema_param, false));
+
+    // Sender 0's non-incremental open arrives second. LoadChannel::open's new
+    // else branch funnels it through update_open() so the claim is recorded.
+    // Calling update_open directly here is what that else branch boils down to.
+    _tablets_channel->update_open(make_open(0));
+
+    std::atomic<int> close_channel_count{0};
+    std::atomic<int> sender_0_logs{-1};
+    std::atomic<int> sender_1_logs{-1};
+
+    auto sender_task = [&](int sender_id) {
+        PTabletWriterAddChunkRequest add_req;
+        PTabletWriterAddBatchResult add_resp;
+        add_req.set_index_id(kIndexId);
+        add_req.set_sender_id(sender_id);
+        add_req.set_eos(false);
+        add_req.set_packet_seq(0);
+        add_req.set_timeout_ms(30 * 1000);
+        for (int i = 0; i < kChunkSize; i++) {
+            int64_t tablet_id = 10086 + (i % 4);
+            add_req.add_tablet_ids(tablet_id);
+            add_req.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+        }
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_req.mutable_chunk()->Swap(&chunk_pb);
+        bool close_channel = false;
+        _tablets_channel->add_chunk(&chunk, add_req, &add_resp, &close_channel);
+        ASSERT_EQ(TStatusCode::OK, add_resp.status().status_code()) << add_resp.status().error_msgs(0);
+
+        PTabletWriterAddChunkRequest fin_req;
+        PTabletWriterAddBatchResult fin_resp;
+        fin_req.set_index_id(kIndexId);
+        fin_req.set_sender_id(sender_id);
+        fin_req.set_eos(true);
+        fin_req.set_packet_seq(1);
+        fin_req.add_partition_ids(10);
+        fin_req.add_partition_ids(11);
+        fin_req.set_timeout_ms(30 * 1000);
+        _tablets_channel->add_chunk(nullptr, fin_req, &fin_resp, &close_channel);
+        ASSERT_EQ(TStatusCode::OK, fin_resp.status().status_code()) << fin_resp.status().error_msgs(0);
+        if (close_channel) {
+            close_channel_count.fetch_add(1);
+        }
+        int logs = fin_resp.lake_tablet_data().txn_logs_size();
+        (sender_id == 0 ? sender_0_logs : sender_1_logs).store(logs);
+    };
+
+    auto bids = std::vector<bthread_t>{};
+    ASSIGN_OR_ABORT(auto b0, bthreads::start_bthread([&] { sender_task(0); }));
+    bids.push_back(b0);
+    ASSIGN_OR_ABORT(auto b1, bthreads::start_bthread([&] { sender_task(1); }));
+    bids.push_back(b1);
+    for (auto b : bids) (void)bthread_join(b, nullptr);
+
+    ASSERT_EQ(1, close_channel_count.load());
+
+    // Smallest sender_id wins after update_open recorded sender 0's claim.
+    // Sender 0 must collect ALL 4 tablet logs; sender 1 must collect none.
+    // Without the fix, sender 0_logs would be 0 (claim never recorded) and
+    // sender 1 would be the one returning logs, which is the bug.
+    EXPECT_EQ(4, sender_0_logs.load());
+    EXPECT_EQ(0, sender_1_logs.load());
+
+    // Exactly one coordinator (sender 0) fired the collect path.
+    EXPECT_EQ(per_partition_before + 1, m->lake_txn_log_collect_per_partition_total.value());
+    EXPECT_EQ(orphan_before, m->lake_txn_log_collect_orphan_partition_total.value());
+}
 } // namespace starrocks

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -1597,8 +1597,7 @@ TEST_F(LakeTabletsChannelPerPartitionCoordinatorTest, test_two_senders_split_par
 // directly: simulate sender 1 opening first, then call `update_open` with
 // sender 0's params, and assert that sender 0 ends up the coordinator
 // (collects all logs) and sender 1 collects nothing.
-TEST_F(LakeTabletsChannelPerPartitionCoordinatorTest,
-       test_late_arriving_sender_0_open_claims_via_update_open) {
+TEST_F(LakeTabletsChannelPerPartitionCoordinatorTest, test_late_arriving_sender_0_open_claims_via_update_open) {
     auto* m = RuntimeMetrics::instance();
     int64_t per_partition_before = m->lake_txn_log_collect_per_partition_total.value();
     int64_t orphan_before = m->lake_txn_log_collect_orphan_partition_total.value();
@@ -1620,8 +1619,8 @@ TEST_F(LakeTabletsChannelPerPartitionCoordinatorTest,
         req.set_load_channel_timeout_s(10);
         req.set_is_vectorized(true);
         req.mutable_schema()->CopyFrom(_open_request.schema());
-        for (auto& [pid, tid] : std::vector<std::pair<int64_t, int64_t>>{
-                     {10, 10086}, {10, 10087}, {11, 10088}, {11, 10089}}) {
+        for (auto& [pid, tid] :
+             std::vector<std::pair<int64_t, int64_t>>{{10, 10086}, {10, 10087}, {11, 10088}, {11, 10089}}) {
             auto* t = req.add_tablets();
             t->set_partition_id(pid);
             t->set_tablet_id(tid);


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, the lake per-partition coordinator added in #71992 elects the smallest `sender_id` whose open RPC recorded a claim for a given partition (`LakeTabletsChannel::_partition_coordinator`). Only the elected coordinator returns `txn_logs` in its EOS response, and the FE-coord `OlapTableSink` of that sender writes the partition's `combined_txn_log` file to OSS.

The election only works if **every** sender's claim makes it into `_partition_coordinator`. It doesn't today: `LoadChannel::open` (`be/src/runtime/load_channel.cpp`) creates the `LakeTabletsChannel` and calls `channel->open(...)` for the **first** sender that lands on a given `TabletsChannelKey`; every subsequent non-incremental open finds the channel already in `_tablets_channels` and falls into the no-op default branch — so `_record_coordinator_claims` never sees those senders' params.

For a non-partitioned shared-data PK table with pipeline parallelism N, all N senders share the same `TabletsChannelKey` (only the doubleWrite optimize-table path sets non-zero `sink_id`). So on each storage BE only the first sender to arrive is recorded. When that first opener is not sender 0 — which happens whenever RPC scheduling reorders opens, even on the local NodeChannel — `_should_enter_collect_path(0)` returns false at EOS time, and that BE's `txn_logs` get returned in the response of whichever sender did win the race. Across the storage BEs of one load, multiple `OlapTableSink` instances end up with different subsets of the partition's logs and all of them race to write the same shared-data OSS `combined_txn_log` path under `CREATE_OR_OPEN_WITH_TRUNCATE`. The last writer wins and the file ends up missing every losing sink's NodeChannel-worth of tablets.

Downstream, the `aggregate_publish_version` for that partition then trips `txn log list does not contain txn log of tablet` (transactions.cpp:158), `publish_version` returns InternalError, and the partition retries forever:

```
ERROR PublishVersionDaemon.publishPartitionBatch
  Fail to publish partition <pid> ... error msg: txn log list does not contain txn log of tablet <tid>
```

I observed this on a 4.0.10 cluster after the cherry-pick of #71992: ~3% of `.logs` files in one partition were missing 1–10 NodeChannels' worth of tablet entries, with the lost groups exactly matching the 2-tablet-per-BE assignment.

## What I'm doing:

Add a virtual `TabletsChannel::update_open(const PTabletWriterOpenRequest&)` with a no-op default. Override it on `LakeTabletsChannel` to invoke `_record_coordinator_claims(params)`. In `LoadChannel::open`'s `else-if (is_incremental)` chain, when the channel already exists and the request is *not* incremental, call `update_open` so the late-arriving sender's partition claim still lands in `_partition_coordinator`. Smallest-sender-id-wins election then converges to sender 0 across all storage BEs, all `txn_logs` flow back to a single `OlapTableSink`, and there is exactly one writer of the partition's `combined_txn_log`.

The change is shared-data-only by construction: `LocalTabletsChannel` inherits the no-op base implementation.

A regression test (`LakeTabletsChannelPerPartitionCoordinatorTest.test_late_arriving_sender_0_open_claims_via_update_open`) simulates sender 1 opening first via `channel->open` and sender 0 arriving via `channel->update_open` (what `LoadChannel::open`'s new else branch funnels into), then drives both senders through `add_chunk` + EOS and asserts sender 0 (smallest id) returns all 4 tablet logs while sender 1 returns 0.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: every sender's non-incremental open is now applied to the lake per-partition coordinator map (previously only the first opener's)
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5