### PR TITLE
[Enhancement] Extend IVM aggregate-function whitelist to MIN/MAX(DECIMAL)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -106,13 +106,13 @@ public class IVMAnalyzer {
                     // preserves the typed AggStateDesc on the state_union scalar so the
                     // intermediate (sum, count) tuple keeps its DECIMAL precision/scale.
                     .put(FunctionSet.AVG,                    args -> isFixedOrFloat(args[0]) || args[0].isDecimalV3())
-                    // min/max: numeric, temporal, and string. VARCHAR was unblocked by #73095
-                    // which relaxed state_union's strict type-equality precondition to accept
-                    // compatible string types (VARCHAR(N) vs catalog-normalized VARCHAR(65533)).
+                    // min/max: numeric (incl. DECIMAL), temporal, string. DECIMAL is safe
+                    // because MIN/MAX state is the value itself — no composite (sum, count)
+                    // intermediate like AVG that would need precision-preserving plumbing.
                     .put(FunctionSet.MIN,                    args -> isFixedOrFloat(args[0]) || isTemporal(args[0])
-                                                                    || args[0].isStringType())
+                                                                    || args[0].isStringType() || args[0].isDecimalV3())
                     .put(FunctionSet.MAX,                    args -> isFixedOrFloat(args[0]) || isTemporal(args[0])
-                                                                    || args[0].isStringType())
+                                                                    || args[0].isStringType() || args[0].isDecimalV3())
                     // array_agg: accept single-arg only. ORDER BY in the source query inlines extra
                     // children via FunctionAnalyzer.getAdjustedAnalyzedAggregateFunction, so args.length
                     // exceeds 1 for `array_agg(col ORDER BY key)`. IVM state_union is unordered, so

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -220,6 +220,22 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                         + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id");
     }
 
+    /** {@code MIN(DECIMAL)} — MIN/MAX state is the value itself; no AVG-style (sum, count) plumbing. */
+    @Test
+    public void testWhitelistAcceptsMinDecimal() throws Exception {
+        assertWhitelistAccepts(
+                "SELECT id, MIN(CAST(c1 AS DECIMAL(10, 2))) "
+                        + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id");
+    }
+
+    /** {@code MAX(DECIMAL)} — symmetric to MIN(DECIMAL). */
+    @Test
+    public void testWhitelistAcceptsMaxDecimal() throws Exception {
+        assertWhitelistAccepts(
+                "SELECT id, MAX(CAST(c1 AS DECIMAL(10, 2))) "
+                        + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id");
+    }
+
     /** {@code ARRAY_AGG(col)} (single arg) — newly whitelisted entry. */
     @Test
     public void testWhitelistAcceptsArrayAggSingleArg() throws Exception {

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
@@ -2,6 +2,7 @@
 -- Verifies the widened IVM aggregate-function whitelist:
 --   * MIN/MAX(VARCHAR) — enabled by #73095 (state_union accepts compatible string types)
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)
+--   * MIN/MAX(DECIMAL) — state is the value itself; no AVG-style (sum, count) plumbing
 --   * ARRAY_AGG(arg)   — single-arg accepted; ORDER BY variant rejected
 -- HLL_UNION / BITMAP_UNION remain rejected (Column.type singleton mutation bug
 -- in the underlying combinator path; deferred to a separate PR).
@@ -77,6 +78,20 @@ SELECT k, dt, avg_d FROM mv_avg_dec ORDER BY k, dt;
 -- result:
 1	2023-12-01	15.62500000
 2	2023-12-02	35.12500000
+-- !result
+CREATE MATERIALIZED VIEW mv_minmax_dec PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, MIN(d_dec) AS min_d, MAX(d_dec) AS max_d
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_minmax_dec WITH SYNC MODE;
+SELECT k, dt, min_d, max_d FROM mv_minmax_dec ORDER BY k, dt;
+-- result:
+1	2023-12-01	10.50	20.75
+2	2023-12-02	30.00	40.25
 -- !result
 CREATE MATERIALIZED VIEW mv_array_agg PARTITION BY dt
 REFRESH DEFERRED MANUAL

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
@@ -2,6 +2,7 @@
 -- Verifies the widened IVM aggregate-function whitelist:
 --   * MIN/MAX(VARCHAR) — enabled by #73095 (state_union accepts compatible string types)
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)
+--   * MIN/MAX(DECIMAL) — state is the value itself; no AVG-style (sum, count) plumbing
 --   * ARRAY_AGG(arg)   — single-arg accepted; ORDER BY variant rejected
 -- HLL_UNION / BITMAP_UNION remain rejected (Column.type singleton mutation bug
 -- in the underlying combinator path; deferred to a separate PR).
@@ -58,6 +59,18 @@ AS SELECT k, dt, AVG(d_dec) AS avg_d
    GROUP BY k, dt;
 [UC]REFRESH MATERIALIZED VIEW mv_avg_dec WITH SYNC MODE;
 SELECT k, dt, avg_d FROM mv_avg_dec ORDER BY k, dt;
+
+-- ============================================================
+-- POSITIVE: MIN/MAX(DECIMAL) IVM MV
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_minmax_dec PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, MIN(d_dec) AS min_d, MAX(d_dec) AS max_d
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+[UC]REFRESH MATERIALIZED VIEW mv_minmax_dec WITH SYNC MODE;
+SELECT k, dt, min_d, max_d FROM mv_minmax_dec ORDER BY k, dt;
 
 -- ============================================================
 -- POSITIVE: ARRAY_AGG(single arg) IVM MV


### PR DESCRIPTION
## Why I'm doing:

PR #73146 widened the IVM aggregate-function whitelist to include MIN/MAX(VARCHAR), AVG(DECIMAL), and ARRAY_AGG but inadvertently left MIN/MAX(DECIMAL) out. The omission was a test-coverage gap rather than a technical constraint:

- AVG(DECIMAL) needed #73012 to preserve the typed `AggStateDesc` across the `(sum, count)` intermediate tuple on `state_union`.
- MIN/MAX state is the scalar value itself — no composite intermediate — so DECIMAL precision and scale flow through `state_union` unchanged with no FE/BE plumbing required.

Today, creating an IVM materialized view with `MIN(decimal_col)` or `MAX(decimal_col)` fails at CREATE time even though the BE `state_union` path handles DECIMAL MIN/MAX correctly.

## What I'm doing:

- `IVMAnalyzer.java`: add `args[0].isDecimalV3()` to the `MIN` / `MAX` predicates in `IVM_SUPPORTED_AGG_FUNCTIONS`; update the inline comment to document why DECIMAL needs no special handling for MIN/MAX (contrast with AVG/#73012).
- `IVMAnalyzerTest.java`: add `testWhitelistAcceptsMinDecimal` / `testWhitelistAcceptsMaxDecimal`, mirroring the existing `testWhitelistAcceptsAvgDecimal` shape (CAST trick because the mocked Iceberg tables only expose integer numeric columns).
- `test_ivm_whitelist_widening` (T + R): extend with a CREATE + REFRESH + value-check on a `DECIMAL(10, 2)` Iceberg column.

DECIMAL_V2 is intentionally not added: the Iceberg `ColumnTypeConverter` always emits `DECIMAL_V3`, and IVM only supports Iceberg base tables today, so V2 is unreachable in IVM scope.

Local verification: `mvn checkstyle:check -pl fe-core` passes; `mvn test -pl fe-core -Dtest=IVMAnalyzerTest` runs 25/25 tests passing (was 23 before).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5