### PR TITLE
[BugFix] Recreate pipe_file_list when _statistics_ is dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -44,11 +44,12 @@ public class RepoCreator {
                 LOG.warn("database not exists: " + FileListTableRepo.FILE_LIST_DB_NAME);
                 return;
             }
-            if (!checkTableExists()) {
+            tableExists = checkTableExists();
+            if (!tableExists) {
                 createTable();
+                tableExists = true;
                 LOG.info("table created: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
             }
-            tableExists = true;
             correctTable();
         } catch (Exception e) {
             LOG.error("error happens in RepoCreator: ", e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -29,27 +29,26 @@ public class RepoCreator {
     private static final Logger LOG = LogManager.getLogger(RepoCreator.class);
     private static final RepoCreator INSTANCE = new RepoCreator();
 
-    private static boolean databaseExists = false;
-    private static boolean tableExists = false;
+    private static volatile boolean databaseExists = false;
+    private static volatile boolean tableExists = false;
 
     public static RepoCreator getInstance() {
         return INSTANCE;
     }
 
-    public void run() {
+    public synchronized void run() {
         try {
+            databaseExists = checkDatabaseExists();
             if (!databaseExists) {
-                databaseExists = checkDatabaseExists();
-                if (!databaseExists) {
-                    LOG.warn("database not exists: " + FileListTableRepo.FILE_LIST_DB_NAME);
-                    return;
-                }
+                tableExists = false;
+                LOG.warn("database not exists: " + FileListTableRepo.FILE_LIST_DB_NAME);
+                return;
             }
-            if (!tableExists) {
+            if (!checkTableExists()) {
                 createTable();
                 LOG.info("table created: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
-                tableExists = true;
             }
+            tableExists = true;
             correctTable();
         } catch (Exception e) {
             LOG.error("error happens in RepoCreator: ", e);
@@ -58,6 +57,12 @@ public class RepoCreator {
 
     public boolean checkDatabaseExists() {
         return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(FileListTableRepo.FILE_LIST_DB_NAME) != null;
+    }
+
+    public boolean checkTableExists() {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .mayGetTable(FileListTableRepo.FILE_LIST_DB_NAME, FileListTableRepo.FILE_LIST_TABLE_NAME)
+                .isPresent();
     }
 
     public static void createTable() throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -29,25 +29,18 @@ public class RepoCreator {
     private static final Logger LOG = LogManager.getLogger(RepoCreator.class);
     private static final RepoCreator INSTANCE = new RepoCreator();
 
-    private static volatile boolean databaseExists = false;
-    private static volatile boolean tableExists = false;
-
     public static RepoCreator getInstance() {
         return INSTANCE;
     }
 
     public synchronized void run() {
         try {
-            databaseExists = checkDatabaseExists();
-            if (!databaseExists) {
-                tableExists = false;
+            if (!checkDatabaseExists()) {
                 LOG.warn("database not exists: " + FileListTableRepo.FILE_LIST_DB_NAME);
                 return;
             }
-            tableExists = checkTableExists();
-            if (!tableExists) {
+            if (!checkTableExists()) {
                 createTable();
-                tableExists = true;
                 LOG.info("table created: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
             }
             correctTable();
@@ -75,13 +68,5 @@ public class RepoCreator {
 
     public static boolean correctTable() {
         return StatisticUtils.alterSystemTableReplicationNumIfNecessary(FileListTableRepo.FILE_LIST_TABLE_NAME);
-    }
-
-    public boolean isDatabaseExists() {
-        return databaseExists;
-    }
-
-    public boolean isTableExists() {
-        return tableExists;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -248,8 +248,8 @@ public class FileListRepoTest {
             }
         };
         creator.run();
-        Assertions.assertTrue(creator.isDatabaseExists());
-        Assertions.assertFalse(creator.isTableExists());
+        Assertions.assertTrue(creator.checkDatabaseExists());
+        Assertions.assertFalse(creator.checkTableExists());
 
         // create with 1 replica
         new MockUp<SystemInfoService>() {
@@ -267,7 +267,7 @@ public class FileListRepoTest {
             }
         };
         creator.run();
-        Assertions.assertTrue(creator.isTableExists());
+        Assertions.assertTrue(creator.checkTableExists());
         Assertions.assertEquals(1, changed.get());
 
         // be corrected to 3 replicas
@@ -279,8 +279,8 @@ public class FileListRepoTest {
         };
 
         creator.run();
-        Assertions.assertTrue(creator.isDatabaseExists());
-        Assertions.assertTrue(creator.isTableExists());
+        Assertions.assertTrue(creator.checkDatabaseExists());
+        Assertions.assertTrue(creator.checkTableExists());
         Assertions.assertEquals(2, changed.get());
     }
 
@@ -319,24 +319,24 @@ public class FileListRepoTest {
         // Steady state: database and table both exist; run() should be a no-op
         // for table creation (correctTable is a no-op because replicas already match).
         creator.run();
-        Assertions.assertTrue(creator.isDatabaseExists());
-        Assertions.assertTrue(creator.isTableExists());
+        Assertions.assertTrue(creator.checkDatabaseExists());
+        Assertions.assertTrue(creator.checkTableExists());
         int baseline = ddlCount.get();
 
         // Simulate user `DROP DATABASE _statistics_`: both database and table disappear.
         databasePresent.set(false);
         tablePresent.set(false);
         creator.run();
-        Assertions.assertFalse(creator.isDatabaseExists());
-        Assertions.assertFalse(creator.isTableExists());
+        Assertions.assertFalse(creator.checkDatabaseExists());
+        Assertions.assertFalse(creator.checkTableExists());
 
         // StatisticsMetaManager re-creates the database; the table is still missing.
         databasePresent.set(true);
         creator.run();
         // RepoCreator must observe the missing table and recreate it instead of
         // skipping due to a stale cached `tableExists=true` flag.
-        Assertions.assertTrue(creator.isDatabaseExists());
-        Assertions.assertTrue(creator.isTableExists());
+        Assertions.assertTrue(creator.checkDatabaseExists());
+        Assertions.assertTrue(creator.checkTableExists());
         Assertions.assertEquals(baseline + 1, ddlCount.get());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.starrocks.load.pipe.PipeFileRecord.JSON_FIELD_ERROR_MESSAGE;
@@ -224,10 +225,16 @@ public class FileListRepoTest {
     @Test
     public void testCreator() throws RuntimeException, StarRocksException {
         mockExecutor();
+        AtomicBoolean tablePresentInMetastore = new AtomicBoolean(false);
         new MockUp<RepoCreator>() {
             @Mock
             public boolean checkDatabaseExists() {
                 return true;
+            }
+
+            @Mock
+            public boolean checkTableExists() {
+                return tablePresentInMetastore.get();
             }
         };
         SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
@@ -256,6 +263,7 @@ public class FileListRepoTest {
             @Mock
             public void executeDDL(String sql) {
                 changed.addAndGet(1);
+                tablePresentInMetastore.set(true);
             }
         };
         creator.run();
@@ -274,6 +282,62 @@ public class FileListRepoTest {
         Assertions.assertTrue(creator.isDatabaseExists());
         Assertions.assertTrue(creator.isTableExists());
         Assertions.assertEquals(2, changed.get());
+    }
+
+    @Test
+    public void testRecreateAfterDrop() throws RuntimeException, StarRocksException {
+        AtomicBoolean databasePresent = new AtomicBoolean(true);
+        AtomicBoolean tablePresent = new AtomicBoolean(true);
+        new MockUp<RepoCreator>() {
+            @Mock
+            public boolean checkDatabaseExists() {
+                return databasePresent.get();
+            }
+
+            @Mock
+            public boolean checkTableExists() {
+                return tablePresent.get();
+            }
+        };
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getSystemTableExpectedReplicationNum() {
+                return 1;
+            }
+        };
+        AtomicInteger ddlCount = new AtomicInteger(0);
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public void executeDDL(String sql) {
+                ddlCount.addAndGet(1);
+                tablePresent.set(true);
+            }
+        };
+
+        RepoCreator creator = RepoCreator.getInstance();
+
+        // Steady state: database and table both exist; run() should be a no-op
+        // for table creation (correctTable is a no-op because replicas already match).
+        creator.run();
+        Assertions.assertTrue(creator.isDatabaseExists());
+        Assertions.assertTrue(creator.isTableExists());
+        int baseline = ddlCount.get();
+
+        // Simulate user `DROP DATABASE _statistics_`: both database and table disappear.
+        databasePresent.set(false);
+        tablePresent.set(false);
+        creator.run();
+        Assertions.assertFalse(creator.isDatabaseExists());
+        Assertions.assertFalse(creator.isTableExists());
+
+        // StatisticsMetaManager re-creates the database; the table is still missing.
+        databasePresent.set(true);
+        creator.run();
+        // RepoCreator must observe the missing table and recreate it instead of
+        // skipping due to a stale cached `tableExists=true` flag.
+        Assertions.assertTrue(creator.isDatabaseExists());
+        Assertions.assertTrue(creator.isTableExists());
+        Assertions.assertEquals(baseline + 1, ddlCount.get());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`RepoCreator` (the daemon that owns `_statistics_.pipe_file_list`) caches
`databaseExists` and `tableExists` in `static` fields and only flips them from
`false` to `true`. Once both are `true`, every subsequent `run()` short-circuits
without re-checking the metastore.

That means after any of the following the table is never re-created until the
FE leader restarts:

- `DROP DATABASE _statistics_`
- `DROP TABLE _statistics_.pipe_file_list`
- The table being lost for any other reason (e.g. shared-data storage volume
  failure during a schema change on `column_statistics`)

For users who actively use PIPE this is dangerous: `pipe_file_list` is the
ledger of already-loaded files. If it is missing, active PIPEs may re-ingest
files that were already loaded.

## What I'm doing:

Live-check existence from the metastore on every `run()`, mirroring the
pattern in `TableKeeper`:

- Always call `checkDatabaseExists()` / `checkTableExists()` instead of trusting
  the cached flags.
- Reset `tableExists` when the database is gone.
- Set `tableExists = true` only after either observing the table or completing
  `createTable()` successfully.
- `synchronized run()` and `volatile` flags to keep the accessor reads honest.

The new `checkTableExists()` uses `LocalMetastore.mayGetTable(...)` — the same
helper `TableKeeper` uses.

Added `testRecreateAfterDrop` to cover the drop / restore / recreate cycle.
The existing `testCreator` was updated to mock `checkTableExists` since the
mock-table state now needs to be visible to the daemon between iterations.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
