### PR TITLE
[Tool] Add fail point to deterministically reproduce lake per-partition coordinator race

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -51,6 +51,7 @@
 #include "runtime/diagnose_daemon.h"
 #include "runtime/lake_tablets_channel.h"
 #include "runtime/load_channel_mgr.h"
+#include "runtime/load_fail_point.h"
 #include "runtime/local_tablets_channel.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_metrics.h"
@@ -135,6 +136,14 @@ void LoadChannel::open(const LoadChannelOpenContext& open_context) {
 
     _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
     bool is_lake_tablet = request.has_is_lake_tablet() && request.is_lake_tablet();
+
+    // Reproduction hook for the lake per-partition coordinator regression.
+    // When enabled on a storage CN, every lake open with sender_id == 0 sleeps
+    // before the find-or-create-channel step below, so sender 0 reliably loses
+    // the first-opener race to any other sender. No-op in release builds and
+    // when the fail point is disabled.
+    FAIL_POINT_TRIGGER_EXECUTE(lake_open_delay_sender_0,
+                               LAKE_OPEN_DELAY_SENDER_0_FP_ACTION(request.sender_id(), is_lake_tablet));
 
     Status st = Status::OK();
     TabletsChannelKey key(request.id(), request.sink_id(), request.index_id());

--- a/be/src/runtime/load_fail_point.cpp
+++ b/be/src/runtime/load_fail_point.cpp
@@ -17,6 +17,8 @@
 #include <fmt/format.h>
 
 #ifdef FIU_ENABLE
+#include <bthread/bthread.h>
+
 #include "base/uid_util.h"
 #include "common/system/backend_options.h"
 #include "gutil/strings/join.h"
@@ -61,6 +63,23 @@ DEFINE_FAIL_POINT(load_pk_preload);
 // Simulates failure during transaction commit at the end of loading.
 // Supported in both shared-nothing and shared-data architectures.
 DEFINE_FAIL_POINT(load_commit_txn);
+
+// ===================================== Coordination-race fail points
+
+// Deterministically reproduces the lake per-partition coordinator regression
+// by artificially delaying sender 0's processing of an open request inside
+// `LoadChannel::open`. With this point enabled on every storage CN, sender 0
+// loses the "first opener" race on every storage BE to whichever other sender
+// arrived first. Pre-fix, `_partition_coordinator` then never contains
+// sender 0, sender 0's EOS skips the collect path, txn_logs flow back to a
+// scattered set of OlapTableSinks, and concurrent writers race on the
+// shared-data OSS `combined_txn_log` path. Post-fix (LoadChannel::open's
+// non-incremental else branch invoking `update_open`), sender 0's claim is
+// recorded regardless of arrival order and the bug stays latched off.
+//
+// Only fires when the open request is for a lake tablet and sender_id == 0.
+// Shared-nothing loads are unaffected.
+DEFINE_FAIL_POINT(lake_open_delay_sender_0);
 
 #ifdef FIU_ENABLE
 
@@ -134,6 +153,20 @@ Status pk_preload_fp_action(int64_t txn_id, int64_t tablet_id) {
 Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id) {
     LOG_FP(load_commit_txn) << ", txn_id: " << txn_id << ", tablet_id: " << tablet_id;
     return Status::IOError(IO_ERROR_MSG(load_commit_txn, txn_id, tablet_id));
+}
+
+// Delay applied when the fail point fires. 50ms is large relative to any
+// realistic same-DC open-RPC scheduling jitter (typically <1ms) so it
+// reliably forces sender 0 to lose every first-opener race. Adjust only if
+// you need to defeat a different scheduling regime.
+constexpr int64_t kLakeOpenDelayMs = 50;
+
+void lake_open_delay_sender_0_fp_action(int32_t sender_id, bool is_lake_tablet) {
+    if (!is_lake_tablet || sender_id != 0) {
+        return;
+    }
+    LOG_FP(lake_open_delay_sender_0) << ", sender_id=" << sender_id << ", delay_ms=" << kLakeOpenDelayMs;
+    bthread_usleep(kLakeOpenDelayMs * 1000);
 }
 
 #endif

--- a/be/src/runtime/load_fail_point.h
+++ b/be/src/runtime/load_fail_point.h
@@ -49,6 +49,11 @@ Status segment_flush_fp_action(int64_t txn_id, int64_t tablet_id);
 Status pk_preload_fp_action(int64_t txn_id, int64_t tablet_id);
 Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id);
 
+// Force sender_id == 0 to lose the first-opener race in `LoadChannel::open`
+// for lake (shared-data) opens. See `lake_open_delay_sender_0` in
+// `load_fail_point.cpp` for the rationale.
+void lake_open_delay_sender_0_fp_action(int32_t sender_id, bool is_lake_tablet);
+
 #define TABLET_WRITER_OPEN_FP_ACTION(remote_host, closure, request) \
     ::starrocks::load::failpoint::tablet_writer_open_fp_action(remote_host, closure, &request)
 #define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(remote_host, closure, request) \
@@ -63,6 +68,8 @@ Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id);
     return ::starrocks::load::failpoint::segment_flush_fp_action(txn_id, tablet_id)
 #define PK_PRELOAD_FP_ACTION(txn_id, tablet_id) ::starrocks::load::failpoint::pk_preload_fp_action(txn_id, tablet_id)
 #define COMMIT_TXN_FP_ACTION(txn_id, tablet_id) ::starrocks::load::failpoint::commit_txn_fp_action(txn_id, tablet_id)
+#define LAKE_OPEN_DELAY_SENDER_0_FP_ACTION(sender_id, is_lake_tablet) \
+    ::starrocks::load::failpoint::lake_open_delay_sender_0_fp_action(sender_id, is_lake_tablet)
 #else
 #define TABLET_WRITER_OPEN_FP_ACTION(remote_host, closure, request)
 #define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(remote_host, closure, request)
@@ -72,6 +79,7 @@ Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id);
 #define SEGMENT_FLUSH_FP_ACTION(txn_id, tablet_id)
 #define PK_PRELOAD_FP_ACTION(txn_id, tablet_id)
 #define COMMIT_TXN_FP_ACTION(txn_id, tablet_id)
+#define LAKE_OPEN_DELAY_SENDER_0_FP_ACTION(sender_id, is_lake_tablet)
 #endif
 
 } // namespace starrocks::load::failpoint


### PR DESCRIPTION
## Why I'm doing:

This is a **draft, deterministic-repro companion** to #73962.

#73962 fixes a shared-data regression introduced in #71992 (lake per-partition coordinator). The bug fires at ~3% rate on real workloads because it depends on which sender's `tablet_writer_open` RPC arrives first on each storage CN — that's a network/scheduling race. Verifying #73962 against a real cluster therefore needs either patience (run hundreds of small INSERTs until the bug hits) or a way to force the race.

This PR adds a fail point that **forces** the race: when enabled on a storage CN, every lake open RPC with `sender_id == 0` sleeps 50ms before the find-or-create-channel step in `LoadChannel::open`, so sender 0 always loses the first-opener race to whichever non-zero sender arrived first. Pre-fix, this turns the natural ~3% bug rate into a guaranteed reproduction on the very first INSERT. Post-fix, the same fail point is a behavioral no-op — sender 0's claim still lands in `_partition_coordinator` via the new `update_open` path.

## What I'm doing:

- Add `DEFINE_FAIL_POINT(lake_open_delay_sender_0)` in `be/src/runtime/load_fail_point.cpp` with action handler `lake_open_delay_sender_0_fp_action`.
- Hook it at the entry of `LoadChannel::open` (after `is_lake_tablet` is extracted, before the channel lookup).
- Debug-build only (`#ifdef FIU_ENABLE`), zero cost in release.

## Repro recipe (3 commands)

On a multi-CN shared-data cluster with `lake_use_combined_txn_log = true` and `lake_enable_per_partition_coordinator_txn_log = true` (FE config):

```
# 1) Enable the fail point on every CN.
for cn in $CN_HOSTS; do
  curl -s -X POST "http://${cn}:8040/api/failpoint" \
       -H 'Content-Type: application/json' \
       -d '{"name":"lake_open_delay_sender_0","behavior":{"type":"ENABLE"}}'
done

# 2) Create a non-partitioned PK table and run a single small INSERT.
mysql -e "
  CREATE TABLE repro_t (k BIGINT NOT NULL, v VARCHAR(64)) PRIMARY KEY(k)
  DISTRIBUTED BY HASH(k) BUCKETS 22;
  SET pipeline_dop = 32;
  INSERT INTO repro_t VALUES (1, 'x');
"

# 3) Watch FE.
tail -F fe.log | grep 'txn log list does not contain'
```

Without #73962, step 3 will spam `Fail to publish partition` indefinitely.
With #73962, the same INSERT commits cleanly in seconds.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] No user docs needed (debug-build-only fail point, follows existing `load_tablet_writer_open` etc. pattern)
- [ ] This is a backport pr

Companion to #73962 (BugFix).