### PR TITLE
[UT] Drop trailing strict-check restore in test_alter_mv to stop leaking =true

### DIFF
--- a/test/sql/test_alter_mv/R/test_alter_mv
+++ b/test/sql/test_alter_mv/R/test_alter_mv
@@ -118,6 +118,6 @@ SELECT * FROM test_mv1 ORDER BY k1;
 DROP TABLE t1;
 -- result:
 -- !result
-admin set frontend config("enable_active_materialized_view_schema_strict_check"="true");
+admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");
 -- result:
 -- !result

--- a/test/sql/test_alter_mv/R/test_alter_mv
+++ b/test/sql/test_alter_mv/R/test_alter_mv
@@ -61,6 +61,9 @@ REFRESH DEFERRED MANUAL
 AS SELECT k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13 FROM t1;
 -- result:
 -- !result
+admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");
+-- result:
+-- !result
 ALTER TABLE t1 MODIFY COLUMN k13 decimal(32, 10);
 -- result:
 -- !result

--- a/test/sql/test_alter_mv/R/test_alter_mv
+++ b/test/sql/test_alter_mv/R/test_alter_mv
@@ -61,9 +61,6 @@ REFRESH DEFERRED MANUAL
 AS SELECT k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13 FROM t1;
 -- result:
 -- !result
-admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");
--- result:
--- !result
 ALTER TABLE t1 MODIFY COLUMN k13 decimal(32, 10);
 -- result:
 -- !result
@@ -116,8 +113,5 @@ SELECT * FROM test_mv1 ORDER BY k1;
 2020-10-24	2020-10-25 12:12:12	k3	k4	0	1	2	3	4	5	1.1	1.12	2.889000000
 -- !result
 DROP TABLE t1;
--- result:
--- !result
-admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");
 -- result:
 -- !result

--- a/test/sql/test_alter_mv/T/test_alter_mv
+++ b/test/sql/test_alter_mv/T/test_alter_mv
@@ -36,8 +36,6 @@ CREATE MATERIALIZED VIEW test_mv1
 REFRESH DEFERRED MANUAL 
 AS SELECT k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13 FROM t1;
 
-admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");
-
 -- alter column: k13
 ALTER TABLE t1 MODIFY COLUMN k13 decimal(32, 10);
 function: wait_alter_table_finish()
@@ -57,4 +55,3 @@ INSERT INTO t1 VALUES
 SELECT * FROM test_mv1 ORDER BY k1;
 
 DROP TABLE t1;
-admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");

--- a/test/sql/test_alter_mv/T/test_alter_mv
+++ b/test/sql/test_alter_mv/T/test_alter_mv
@@ -36,6 +36,8 @@ CREATE MATERIALIZED VIEW test_mv1
 REFRESH DEFERRED MANUAL 
 AS SELECT k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13 FROM t1;
 
+admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");
+
 -- alter column: k13
 ALTER TABLE t1 MODIFY COLUMN k13 decimal(32, 10);
 function: wait_alter_table_finish()

--- a/test/sql/test_alter_mv/T/test_alter_mv
+++ b/test/sql/test_alter_mv/T/test_alter_mv
@@ -57,4 +57,4 @@ INSERT INTO t1 VALUES
 SELECT * FROM test_mv1 ORDER BY k1;
 
 DROP TABLE t1;
-admin set frontend config("enable_active_materialized_view_schema_strict_check"="true");
+admin set frontend config("enable_active_materialized_view_schema_strict_check"="false");


### PR DESCRIPTION
## Why I'm doing:

`test/sql/test_alter_mv/T/test_alter_mv` ends with

```sql
admin set frontend config("enable_active_materialized_view_schema_strict_check"="true");
```

`enable_active_materialized_view_schema_strict_check` is a global FE config. Once `test_alter_mv` flips it to `true`, every subsequent test running on the same FE in the same CI batch inherits `true` — silently changing the behavior of `ALTER MATERIALIZED VIEW ... ACTIVE` for any test that relies on the documented default.

History: #50869 introduced this config with default `true`, and the test's final `="true"` was the correct "restore to original" at that time. A later change flipped the default to `false` (`Config.java:3904`), but this test's cleanup line was never updated, so it now leaks `=true` across tests.

I hit this while developing the iceberg-MV schema-drift detector: my external-base check fires through `MaterializedViewExceptions.inactiveReasonForBaseTableActiveCheckFailed`, which is only consulted when `enable_active_materialized_view_schema_strict_check` is `true`. After `test_alter_mv` ran ahead of an iceberg-MV test in CI, the config stayed `=true` and a follow-up MV test would suddenly inactivate base tables it had no business inactivating.

## What I'm doing:

Delete the trailing `admin set ...="true"` line in both `T/test_alter_mv` and `R/test_alter_mv`. The opening `admin set ...="false"` at line 39 stays untouched — it is empirically load-bearing (the test body relies on the loose schema check for the DECIMAL(27,9) → DECIMAL(32,10) MODIFY COLUMN at line 42, and on the dev cluster the test fails fast with an empty MV if line 39 is missing, even when `admin show frontend config` reports the runtime value is already `false`).

After this PR, the test ends with the FE config at `false` (line 39's set), which matches the current default and no longer leaks into subsequent tests.

Verification: `cdsql test sql/test_alter_mv` against the dev cluster on this branch — flaky harness reports `passed 3 out of the required 3 times`, ran 1 test in 177.854 s, `OK`.

Fixes #issue: N/A — internal-only CI hygiene fix surfaced during #73770 / #73938 development.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5