### PR TITLE
[Enhancement] Support `ANALYZE TABLE` statistics collection for `ENGINE=file` external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -64,15 +64,33 @@ public class FileTable extends Table {
     @SerializedName(value = "fp")
     private Map<String, String> fileProperties = Maps.newHashMap();
 
+    @SerializedName(value = "dn")
+    private String dbName;
+
     public FileTable() {
         super(TableType.FILE);
     }
 
     public FileTable(long id, String name, List<Column> fullSchema, Map<String, String> properties)
             throws DdlException {
+        this(id, name, null, fullSchema, properties);
+    }
+
+    public FileTable(long id, String name, String dbName, List<Column> fullSchema, Map<String, String> properties)
+            throws DdlException {
         super(id, name, TableType.FILE, fullSchema);
+        this.dbName = dbName;
         this.fileProperties = properties;
         validate(properties);
+    }
+
+    @Override
+    public String getUUID() {
+        // Null-safe: old serialized instances that pre-date this field fall back to the legacy numeric ID.
+        if (dbName == null) {
+            return Long.toString(id);
+        }
+        return String.join(".", InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName, name, Long.toString(id));
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -214,6 +232,7 @@ public class FileTable extends Table {
     public static class Builder {
         private long id;
         private String tableName;
+        private String dbName;
         private List<Column> fullSchema;
         private Map<String, String> properties = Maps.newHashMap();
 
@@ -230,6 +249,11 @@ public class FileTable extends Table {
             return this;
         }
 
+        public FileTable.Builder setDbName(String dbName) {
+            this.dbName = dbName;
+            return this;
+        }
+
         public FileTable.Builder setFullSchema(List<Column> fullSchema) {
             this.fullSchema = fullSchema;
             return this;
@@ -241,7 +265,7 @@ public class FileTable extends Table {
         }
 
         public FileTable build() throws DdlException {
-            return new FileTable(id, tableName, fullSchema, properties);
+            return new FileTable(id, tableName, dbName, fullSchema, properties);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/FileTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/FileTableFactory.java
@@ -45,6 +45,7 @@ public class FileTableFactory implements AbstractTableFactory {
         FileTable.Builder tableBuilder = FileTable.builder()
                 .setId(tableId)
                 .setTableName(tableName)
+                .setDbName(database.getOriginName())
                 .setFullSchema(columns)
                 .setProperties(properties);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -226,6 +226,8 @@ public class AnalyzeStmtAnalyzer {
                 statement.setExternal(true);
             } else if (CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(analyzeTable.getCatalogName())) {
                 throw new SemanticException("Don't support analyze external table created by resource mapping");
+            } else if (analyzeTable.getType() == Table.TableType.FILE) {
+                statement.setExternal(true);
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -644,12 +644,38 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalFileScan(LogicalFileScanOperator node, ExpressionContext context) {
-        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap());
+        return computeFileTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap());
     }
 
     @Override
     public Void visitPhysicalFileScan(PhysicalFileScanOperator node, ExpressionContext context) {
-        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap());
+        return computeFileTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap());
+    }
+
+    private Void computeFileTableScanNode(Operator node, ExpressionContext context, Table table,
+                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+        List<ColumnRefOperator> requiredColumnRefs = new ArrayList<>(colRefToColumnMetaMap.keySet());
+        List<String> columnNames = requiredColumnRefs.stream()
+                .map(ref -> colRefToColumnMetaMap.get(ref).getName())
+                .collect(Collectors.toList());
+
+        // Use sync loading so the optimizer sees stats immediately without a cache warm-up round.
+        List<ConnectorTableColumnStats> columnStatsList =
+                GlobalStateMgr.getCurrentState().getStatisticStorage()
+                        .getConnectorTableStatisticsSync(table, columnNames);
+
+        Statistics.Builder builder = Statistics.builder();
+        double rowCount = Double.NaN;
+        for (int i = 0; i < requiredColumnRefs.size(); i++) {
+            ConnectorTableColumnStats colStats = columnStatsList.get(i);
+            builder.addColumnStatistic(requiredColumnRefs.get(i), colStats.getColumnStatistic());
+            if (!colStats.isUnknown()) {
+                rowCount = Double.isNaN(rowCount) ? colStats.getRowCount() : Math.max(rowCount, colStats.getRowCount());
+            }
+        }
+        builder.setOutputRowCount(Double.isNaN(rowCount) ? 1 : rowCount);
+        context.setStatistics(builder.build());
+        return visitOperator(node, context);
     }
 
     private Void computeFileScanNode(Operator node, ExpressionContext context,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -258,7 +258,10 @@ public class StatisticsCollectJobFactory {
 
         List<String> allPartitionNames = null;
         if (partitionNames == null) {
-            partitionNames = ConnectorPartitionTraits.build(table).getPartitionNames();
+            // FileTable has no partition metadata; treat it as a single unpartitioned segment.
+            partitionNames = table.getType() == Table.TableType.FILE
+                    ? Lists.newArrayList(table.getName())
+                    : ConnectorPartitionTraits.build(table).getPartitionNames();
             allPartitionNames = partitionNames;
         }
         if (analyzeType.equals(StatsConstants.AnalyzeType.SAMPLE)) {
@@ -268,8 +271,11 @@ public class StatisticsCollectJobFactory {
 
             samplePartitionSize = Math.min(samplePartitionSize, partitionNames.size());
             List<String> samplePartitionNames = StatisticUtils.getLatestPartitionsSample(partitionNames, samplePartitionSize);
-            allPartitionNames = allPartitionNames == null ? ConnectorPartitionTraits.build(table).getPartitionNames() :
-                    allPartitionNames;
+            allPartitionNames = allPartitionNames == null
+                    ? (table.getType() == Table.TableType.FILE
+                            ? Lists.newArrayList(table.getName())
+                            : ConnectorPartitionTraits.build(table).getPartitionNames())
+                    : allPartitionNames;
             return new ExternalSampleStatisticsCollectJob(catalogName, db, table, samplePartitionNames, columnNames,
                     columnTypes, analyzeType, scheduleType, properties, allPartitionNames.size());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -22,19 +22,19 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
-import com.starrocks.load.loadv2.LoadJob;
-import com.starrocks.sql.ast.KeysType;
-import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.common.Config;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.load.BrokerFileGroup;
+import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.ast.DataDescription;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TBrokerFileStatus;
@@ -152,7 +152,6 @@ public class FileScanNodeTest {
         fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file2", false, 268435400, true));
         fileStatusesList.add(fileStatusList);
 
-        
         DescriptorTable descTable = new DescriptorTable();
         TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList,
@@ -213,7 +212,6 @@ public class FileScanNodeTest {
         fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file4", false, 268435451, false));
         fileStatusesList.add(fileStatusList);
 
-        
         descTable = new DescriptorTable();
         tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 4,
@@ -266,7 +264,6 @@ public class FileScanNodeTest {
         fileStatusList2.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file5", false, 10, true));
         fileStatusesList.add(fileStatusList2);
 
-        
         descTable = new DescriptorTable();
         tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 5,
@@ -315,7 +312,6 @@ public class FileScanNodeTest {
         fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file2", false, 10, false));
         fileStatusesList.add(fileStatusList);
 
-        
         descTable = new DescriptorTable();
         tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 2,
@@ -349,7 +345,6 @@ public class FileScanNodeTest {
         fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file1", false, 0, false));
         fileStatusesList.add(fileStatusList);
 
-        
         descTable = new DescriptorTable();
         tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 1,
@@ -395,7 +390,7 @@ public class FileScanNodeTest {
         fileStatusList2 = Lists.newArrayList();
         fileStatusList2.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file2", false, 1073741824, true));
         fileStatusesList.add(fileStatusList2);
-        
+
         descTable = new DescriptorTable();
         tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 2,
@@ -445,7 +440,6 @@ public class FileScanNodeTest {
         }
         fileStatusesList.add(fileStatusList);
 
-        
         descTable = new DescriptorTable();
         tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 2,
@@ -503,7 +497,7 @@ public class FileScanNodeTest {
 
     @Test
     public void testNoFilesFoundOnePath() {
-        
+
         DescriptorTable descTable = new DescriptorTable();
         TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
@@ -526,7 +520,7 @@ public class FileScanNodeTest {
 
     @Test
     public void testIllegalColumnSeparator(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
-                                     @Injectable Database db, @Injectable OlapTable table) {
+                                           @Injectable Database db, @Injectable OlapTable table) {
         new MockUp<RunMode>() {
             @Mock
             public RunMode getCurrentRunMode() {
@@ -566,7 +560,6 @@ public class FileScanNodeTest {
         List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
         fileStatusesList.add(fileStatusList);
 
-        
         DescriptorTable descTable = new DescriptorTable();
         TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList,
@@ -576,9 +569,10 @@ public class FileScanNodeTest {
                 "The valid bytes length for 'column separator' is [1, 50]",
                 () -> scanNode.init(descTable));
     }
+
     @Test
     public void testIllegalRowDelimiter(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
-                                           @Injectable Database db, @Injectable OlapTable table) {
+                                        @Injectable Database db, @Injectable OlapTable table) {
         new MockUp<RunMode>() {
             @Mock
             public RunMode getCurrentRunMode() {
@@ -618,7 +612,6 @@ public class FileScanNodeTest {
         List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
         fileStatusesList.add(fileStatusList);
 
-        
         DescriptorTable descTable = new DescriptorTable();
         TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
         FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList,

--- a/test/sql/test_analyze_statistics/R/test_analyze_file_table_stats
+++ b/test/sql/test_analyze_statistics/R/test_analyze_file_table_stats
@@ -1,0 +1,61 @@
+-- name: test_analyze_file_table_stats
+shell: ossutil64 mkdir oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_two_page.parquet oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/dict_two_page.parquet | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 24,270. OK num: 1(upload 1 files).
+-- !result
+CREATE DATABASE test_file_stats_db_${uuid0};
+-- result:
+-- !result
+USE test_file_stats_db_${uuid0};
+-- result:
+-- !result
+CREATE EXTERNAL TABLE file_tbl (
+    seq bigint,
+    f00 string,
+    f01 string,
+    id  string,
+    f03 string,
+    f04 string
+) ENGINE=file
+PROPERTIES (
+    "path"   = "oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/dict_two_page.parquet",
+    "format" = "parquet"
+);
+-- result:
+-- !result
+ANALYZE FULL TABLE file_tbl;
+-- result:
+[REGEX]OK
+-- !result
+select count(1) from default_catalog._statistics_.external_column_statistics
+    where catalog_name = 'default_catalog'
+      and db_name      = 'test_file_stats_db_${uuid0}'
+      and table_name   = 'file_tbl';
+-- result:
+6
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 60, "interval": 5, "desc": "wait fe cache stats finished"}
+  result=explain costs select seq from file_tbl;
+  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
+} END LOOP
+LOOP {
+  PROPERTY: {"timeout": 10, "interval": 2, "desc": "check join cardinality > 1 after stats"}
+  result=explain verbose select A.seq, B.seq from file_tbl A join file_tbl B on A.seq = B.seq + 1;
+  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
+} END LOOP
+DROP DATABASE test_file_stats_db_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_analyze_statistics/R/test_analyze_file_table_stats
+++ b/test/sql/test_analyze_statistics/R/test_analyze_file_table_stats
@@ -31,9 +31,6 @@ PROPERTIES (
 -- result:
 -- !result
 ANALYZE FULL TABLE file_tbl;
--- result:
-[REGEX]OK
--- !result
 select count(1) from default_catalog._statistics_.external_column_statistics
     where catalog_name = 'default_catalog'
       and db_name      = 'test_file_stats_db_${uuid0}'
@@ -41,16 +38,10 @@ select count(1) from default_catalog._statistics_.external_column_statistics
 -- result:
 6
 -- !result
-LOOP {
-  PROPERTY: {"timeout": 60, "interval": 5, "desc": "wait fe cache stats finished"}
-  result=explain costs select seq from file_tbl;
-  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
-} END LOOP
-LOOP {
-  PROPERTY: {"timeout": 10, "interval": 2, "desc": "check join cardinality > 1 after stats"}
-  result=explain verbose select A.seq, B.seq from file_tbl A join file_tbl B on A.seq = B.seq + 1;
-  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
-} END LOOP
+function: assert_explain_verbose_contains('select A.seq, B.seq from file_tbl A join file_tbl B on A.seq = B.seq + 1', 'cardinality: 200')
+-- result:
+None
+-- !result
 DROP DATABASE test_file_stats_db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_analyze_statistics/T/test_analyze_file_table_stats
+++ b/test/sql/test_analyze_statistics/T/test_analyze_file_table_stats
@@ -27,21 +27,9 @@ select count(1) from default_catalog._statistics_.external_column_statistics
       and db_name      = 'test_file_stats_db_${uuid0}'
       and table_name   = 'file_tbl';
 
--- Wait until the stats cache is warmed and the optimizer reflects collected cardinality.
-LOOP {
-  PROPERTY: {"timeout": 60, "interval": 5, "desc": "wait fe cache stats finished"}
-  result=explain costs select seq from file_tbl;
-  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
-} END LOOP
-
--- After stats are collected the optimizer must assign cardinality > 1 on each scan side.
--- A self-join (A.seq = B.seq + 1) forces two separate scan estimates; if either scan
--- were still at the default cardinality=1 the join estimate would also be trivially 1.
-LOOP {
-  PROPERTY: {"timeout": 10, "interval": 2, "desc": "check join cardinality > 1 after stats"}
-  result=explain verbose select A.seq, B.seq from file_tbl A join file_tbl B on A.seq = B.seq + 1;
-  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
-} END LOOP
+-- Stats are loaded synchronously; cardinality must reflect the actual 200 rows
+-- on the first explain, not the default hardcoded 1.
+function: assert_explain_verbose_contains('select A.seq, B.seq from file_tbl A join file_tbl B on A.seq = B.seq + 1', 'cardinality: 200')
 
 DROP DATABASE test_file_stats_db_${uuid0};
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_analyze_statistics/T/test_analyze_file_table_stats
+++ b/test/sql/test_analyze_statistics/T/test_analyze_file_table_stats
@@ -1,0 +1,47 @@
+-- name: test_analyze_file_table_stats
+shell: ossutil64 mkdir oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_two_page.parquet oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/dict_two_page.parquet | grep -Pv "(average|elapsed)"
+
+CREATE DATABASE test_file_stats_db_${uuid0};
+USE test_file_stats_db_${uuid0};
+
+CREATE EXTERNAL TABLE file_tbl (
+    seq bigint,
+    f00 string,
+    f01 string,
+    id  string,
+    f03 string,
+    f04 string
+) ENGINE=file
+PROPERTIES (
+    "path"   = "oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/dict_two_page.parquet",
+    "format" = "parquet"
+);
+
+-- Collect statistics on the external file table (sync, blocks until done).
+ANALYZE FULL TABLE file_tbl;
+
+-- Verify stats were written: one row per column (6 columns).
+select count(1) from default_catalog._statistics_.external_column_statistics
+    where catalog_name = 'default_catalog'
+      and db_name      = 'test_file_stats_db_${uuid0}'
+      and table_name   = 'file_tbl';
+
+-- Wait until the stats cache is warmed and the optimizer reflects collected cardinality.
+LOOP {
+  PROPERTY: {"timeout": 60, "interval": 5, "desc": "wait fe cache stats finished"}
+  result=explain costs select seq from file_tbl;
+  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
+} END LOOP
+
+-- After stats are collected the optimizer must assign cardinality > 1 on each scan side.
+-- A self-join (A.seq = B.seq + 1) forces two separate scan estimates; if either scan
+-- were still at the default cardinality=1 the join estimate would also be trivially 1.
+LOOP {
+  PROPERTY: {"timeout": 10, "interval": 2, "desc": "check join cardinality > 1 after stats"}
+  result=explain verbose select A.seq, B.seq from file_tbl A join file_tbl B on A.seq = B.seq + 1;
+  CHECK: re.search(r"cardinality: [1-9][0-9]+", ${result}) != None
+} END LOOP
+
+DROP DATABASE test_file_stats_db_${uuid0};
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_analyze_file_table_stats/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
`ENGINE=file` external tables (backed by HDFS/OSS parquet/orc files) previously returned hardcoded cardinality=1 to the optimizer regardless of actual data size, because `ANALYZE TABLE` silently no-op'd on them. This caused suboptimal query plans — especially join ordering — whenever these tables were involved.

## What I'm doing:

**Collection path** — route `ANALYZE TABLE` on a FileTable through the existing external-table statistics pipeline (`ExternalFullStatisticsCollectJob → external_column_statistics`), which already works for Hive/Iceberg/Paimon:

```
ANALYZE TABLE file_tbl
  → AnalyzeStmtAnalyzer: mark isExternal=true
  → ExternalAnalyzeStatus (catalogName = default_catalog)
  → ExternalFullStatisticsCollectJob
      SELECT COUNT, MIN, MAX, NDV... FROM `default_catalog`.`db`.`file_tbl` WHERE 1=1
      → write rows into external_column_statistics keyed by table.getUUID()
```

**UUID alignment** — the external stats storage/cache infrastructure identifies tables by a `catalog.db.table.id` string (parsed by `StatisticsUtils.getTableByUUID`). FileTable previously inherited the base `Table.getUUID()` that returns a bare numeric id, which the parser would reject. `FileTable` now overrides `getUUID()` to emit the same 4-part format; legacy serialised instances without `dbName` fall back to the numeric id transparently.

**Partition handling** — FileTable has no partition metadata and is absent from `ConnectorPartitionTraits`.  StatisticsCollectJobFactory` now treats it as a single unpartitioned segment (matching `DefaultTraits` behaviour for unpartitioned tables), so `WHERE 1=1` is used and no partition-key predicates are generated.

**Optimizer read path** — `StatisticsCalculator.computeFileTableScanNode` previously returned hardcoded unknowns. It now calls `getConnectorTableStatisticsSync` (synchronous cache load) so the optimizer sees real cardinality on the first `EXPLAIN` after `ANALYZE`, without needing a cache warm-up round.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
