### PR TITLE
[Enhancement] Add Darwin fallbacks for procfs lookups

### DIFF
--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -36,6 +36,13 @@
 
 #include <gperftools/profiler.h>
 
+#ifdef __APPLE__
+#include <stdlib.h>
+#endif
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <mutex>
@@ -153,6 +160,14 @@ void IOProfileAction::handle(HttpRequest* req) {
 }
 
 void CmdlineAction::handle(HttpRequest* req) {
+#ifdef __APPLE__
+    const char* prog_name = getprogname();
+    if (prog_name == nullptr || prog_name[0] == '\0') {
+        HttpChannel::send_reply(req, "read cmdline failed");
+        return;
+    }
+    HttpChannel::send_reply(req, prog_name);
+#else
     FILE* fp = fopen("/proc/self/cmdline", "r");
     if (fp == nullptr) {
         std::string str = "Unable to open file: /proc/self/cmdline";
@@ -168,6 +183,7 @@ void CmdlineAction::handle(HttpRequest* req) {
     std::string str = buf;
 
     HttpChannel::send_reply(req, str);
+#endif
 }
 
 void SymbolAction::handle(HttpRequest* req) {

--- a/be/src/udf/python/env.cpp
+++ b/be/src/udf/python/env.cpp
@@ -102,7 +102,11 @@ Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process
     }
     posix_spawn_file_actions_addclose(&actions, pipefd[0]);
 
+#ifdef __APPLE__
+    DIR* dir = opendir("/dev/fd");
+#else
     DIR* dir = opendir("/proc/self/fd");
+#endif
     auto defer = DeferOp([&dir]() {
         if (dir != nullptr) {
             closedir(dir);
@@ -110,7 +114,11 @@ Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process
     });
 
     if (dir == nullptr) {
+#ifdef __APPLE__
+        return Status::InternalError(fmt::format("open /dev/fd error {}", std::strerror(errno)));
+#else
         return Status::InternalError(fmt::format("open /proc/self/fd error {}", std::strerror(errno)));
+#endif
     }
 
     {
@@ -122,12 +130,19 @@ Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process
 
     struct dirent* entry;
     while ((entry = readdir(dir)) != nullptr) {
-        if (entry->d_type == DT_LNK) {
+#ifdef __APPLE__
+        int fd = atoi(entry->d_name);
+        if (fd >= 3 && fd != pipefd[0] && fd != pipefd[1]) {
+            posix_spawn_file_actions_addclose(&actions, fd);
+        }
+#else
+        if (entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN) {
             int fd = atoi(entry->d_name);
-            if (fd > 3 && fd != pipefd[0] && fd != pipefd[1]) {
+            if (fd >= 3 && fd != pipefd[0] && fd != pipefd[1]) {
                 posix_spawn_file_actions_addclose(&actions, fd);
             }
         }
+#endif
     }
 
     std::string script = PyWorkerManager::bootstrap();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -261,6 +261,7 @@ set(EXEC_FILES
         ./http/metrics_action_test.cpp
         ./http/stream_load_test.cpp
         ./http/transaction_stream_load_test.cpp
+        ./http/action/pprof_actions_test.cpp
         ./http/action/proc_profile_e2e_test.cpp
         ./io/compressed_input_stream_test.cpp
         ./io/s3_output_stream_test.cpp
@@ -326,6 +327,7 @@ set(EXEC_FILES
         ./service/service_metrics_test.cpp
         ./service/service_be/arrow_flight_call_header_utils_test.cpp
         ./service/service_be/internal_service_test.cpp
+        ./udf/python/env_test.cpp
         ./udf/java/java_native_method_test.cpp
         ./udf/java/java_data_converter_test.cpp
         ./udf/java/java_udf_test.cpp

--- a/be/test/http/action/pprof_actions_test.cpp
+++ b/be/test/http/action/pprof_actions_test.cpp
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/pprof_actions.h"
+
+#include <event2/http.h>
+#include <gtest/gtest.h>
+
+#include "http/http_channel.h"
+#include "http/http_request.h"
+
+namespace starrocks {
+
+extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, std::string_view);
+
+namespace {
+std::string k_response;
+
+void inject_send_reply(HttpRequest* request, HttpStatus status, std::string_view content) {
+    (void)request;
+    (void)status;
+    k_response = content;
+}
+} // namespace
+
+class PprofActionsTest : public testing::Test {
+public:
+    static void SetUpTestSuite() { s_injected_send_reply = inject_send_reply; }
+    static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
+
+    void SetUp() override {
+        k_response.clear();
+        _evhttp_req = evhttp_request_new(nullptr, nullptr);
+    }
+
+    void TearDown() override {
+        if (_evhttp_req != nullptr) {
+            evhttp_request_free(_evhttp_req);
+        }
+    }
+
+protected:
+    evhttp_request* _evhttp_req = nullptr;
+};
+
+TEST_F(PprofActionsTest, cmdline_returns_process_name) {
+    CmdlineAction action;
+    HttpRequest request(_evhttp_req);
+
+    action.handle(&request);
+
+    EXPECT_FALSE(k_response.empty());
+    EXPECT_NE(std::string("read cmdline failed"), k_response);
+#ifndef __APPLE__
+    EXPECT_NE(std::string("Unable to open file: /proc/self/cmdline"), k_response);
+#endif
+}
+
+} // namespace starrocks

--- a/be/test/udf/python/env_test.cpp
+++ b/be/test/udf/python/env_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "udf/python/env.h"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "base/testutil/assert.h"
+#include "common/config_path_fwd.h"
+#include "common/config_udf_fwd.h"
+#include "platform/python/env.h"
+
+namespace starrocks {
+
+class PyWorkerManagerEnvTest : public testing::Test {
+public:
+    void SetUp() override {
+        _test_dir = std::filesystem::current_path() / ("test_py_worker_env_" + std::to_string(getpid()));
+        std::filesystem::remove_all(_test_dir);
+        std::filesystem::create_directories(_test_dir);
+
+        auto& registry = global_python_env_registry();
+        _saved_envs = registry._envs;
+        registry._envs.clear();
+
+        if (const char* starrocks_home = std::getenv("STARROCKS_HOME"); starrocks_home != nullptr) {
+            _saved_starrocks_home = starrocks_home;
+        }
+        _saved_local_library_dir = config::local_library_dir;
+        _saved_create_child_worker_timeout_ms = config::create_child_worker_timeout_ms;
+        _saved_report_python_worker_error = config::report_python_worker_error;
+
+        _starrocks_home = _test_dir / "starrocks_home";
+        config::local_library_dir = (_test_dir / "local_library_dir").string();
+        config::create_child_worker_timeout_ms = 5000;
+        config::report_python_worker_error = true;
+        std::filesystem::create_directories(_starrocks_home / "lib/py-packages");
+        std::filesystem::create_directories(config::local_library_dir);
+        setenv("STARROCKS_HOME", _starrocks_home.c_str(), 1);
+    }
+
+    void TearDown() override {
+        auto& registry = global_python_env_registry();
+        registry._envs = _saved_envs;
+
+        config::local_library_dir = _saved_local_library_dir;
+        config::create_child_worker_timeout_ms = _saved_create_child_worker_timeout_ms;
+        config::report_python_worker_error = _saved_report_python_worker_error;
+
+        if (_saved_starrocks_home.has_value()) {
+            setenv("STARROCKS_HOME", _saved_starrocks_home->c_str(), 1);
+        } else {
+            unsetenv("STARROCKS_HOME");
+        }
+
+        if (_leaked_fd >= 0) {
+            close(_leaked_fd);
+        }
+        std::filesystem::remove_all(_test_dir);
+    }
+
+protected:
+    void create_fake_python_env() {
+        _python_env = _test_dir / "python_env";
+        auto bin_dir = _python_env / "bin";
+        std::filesystem::create_directories(bin_dir);
+        auto python_path = bin_dir / "python3";
+
+        std::ofstream python(python_path);
+        python << "#!/bin/sh\n"
+               << "if [ -e /proc/self/fd/" << _leaked_fd << " ] || [ -e /dev/fd/" << _leaked_fd << " ]; then\n"
+               << "  printf 'leaked fd " << _leaked_fd << "'\n"
+               << "else\n"
+               << "  printf 'Pywork start success'\n"
+               << "fi\n"
+               << "/bin/sleep 30\n";
+        python.close();
+
+        std::filesystem::permissions(python_path,
+                                     std::filesystem::perms::owner_exec | std::filesystem::perms::group_exec |
+                                             std::filesystem::perms::others_exec,
+                                     std::filesystem::perm_options::add);
+        ASSERT_OK(global_python_env_registry().init({_python_env.string()}));
+    }
+
+    std::filesystem::path _test_dir;
+    std::filesystem::path _starrocks_home;
+    std::filesystem::path _python_env;
+    std::unordered_map<std::string, PythonEnv> _saved_envs;
+    std::optional<std::string> _saved_starrocks_home;
+    std::string _saved_local_library_dir;
+    int32_t _saved_create_child_worker_timeout_ms = 0;
+    bool _saved_report_python_worker_error = false;
+    int _leaked_fd = -1;
+};
+
+TEST_F(PyWorkerManagerEnvTest, fork_py_worker_closes_inherited_descriptors) {
+    auto leaked_file = _test_dir / "leaked_fd";
+    int fd = open(leaked_file.c_str(), O_CREAT | O_RDWR, 0600);
+    ASSERT_GE(fd, 0);
+    _leaked_fd = fcntl(fd, F_DUPFD, 100);
+    close(fd);
+    ASSERT_GE(_leaked_fd, 100);
+    ASSERT_NO_FATAL_FAILURE(create_fake_python_env());
+
+    std::unique_ptr<PyWorker> child_process;
+    ASSERT_OK(PyWorkerManager::getInstance()._fork_py_worker(&child_process));
+    ASSERT_NE(nullptr, child_process);
+    child_process->terminate_and_wait();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

StarRocks has a few backend runtime paths that assume Linux procfs. Those paths block native Apple Silicon development, including the Nix development environment in #74009.

## What I'm doing:

- Use `/dev/fd` on Darwin when closing inherited Python worker file descriptors.
- On Darwin, close numeric `/dev/fd` entries regardless of `d_type`; devfs does not reliably report them as links.
- Keep the Linux `/proc/self/fd` path and also accept `DT_UNKNOWN` fd entries.
- Use `getprogname()` for `/pprof/cmdline` on Darwin instead of `/proc/self/cmdline`.
- Add BE unit coverage for the `/pprof/cmdline` action.

Fixes #issue

N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: native Darwin compatibility for existing backend helper paths

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5