### PR TITLE
[Enhancement] Tablet split/merge: per-segment shared optimization + uid-based identity

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -33,6 +33,7 @@
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/metacache.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_manager.h"
 #include "storage/protobuf_file.h"
 #include "storage/storage_metrics.h"
@@ -184,11 +185,16 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
             segment_meta->set_shared(false);
         }
     }
-    // The rewrite files are no longer bundled, so clear all bundle offsets once after the rewrites.
     if (!replace_segments.empty()) {
+        // The rewrite files are no longer bundled, so clear all bundle offsets once after the rewrites.
         for (auto& segment_metadata : *rowset->mutable_segment_metas()) {
             segment_metadata.clear_bundle_file_offset();
         }
+        // A rewritten segment makes this rowset's data private to this tablet, so it must not
+        // alias a cross-published sibling: mint a fresh uid. With no rewrite, the CopyFrom above
+        // preserves the op_write's write-time uid, which is identical across cross-published
+        // children.
+        tablet_reshard_helper::set_rowset_uid(rowset);
     }
 
     rowset->set_id(_tablet_meta->next_rowset_id());
@@ -1014,11 +1020,16 @@ Status MetaFileBuilder::set_final_rowset() {
             segment_meta->set_shared(false);
         }
     }
-    // The rewrite files are no longer bundled, so clear all bundle offsets once after the rewrites.
     if (!_pending_rowset_data.replace_segments.empty()) {
+        // The rewrite files are no longer bundled, so clear all bundle offsets once after the rewrites.
         for (auto& segment_metadata : *rowset->mutable_segment_metas()) {
             segment_metadata.clear_bundle_file_offset();
         }
+        // The batch-merged rowset keeps the first contributing op_write's uid (carried by the
+        // initial CopyFrom in add_rowset) so cross-published children converge on the same
+        // identity. If any segment was physically rewritten, the data is now private to this
+        // tablet and must not alias a sibling: mint a fresh uid.
+        tablet_reshard_helper::set_rowset_uid(rowset);
     }
 
     rowset->set_id(_tablet_meta->next_rowset_id());

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -73,29 +73,6 @@ bvar::Adder<int64_t> g_tablet_merge_synthesized_only_delvec_total("tablet_merge_
 bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_total("tablet_merge_legacy_sstable_rebuild_total");
 bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_dropped_entries(
         "tablet_merge_legacy_sstable_rebuild_dropped_entries");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_total("tablet_merge_legacy_sstable_fastpath_total");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_to_rebuild_total(
-        "tablet_merge_legacy_sstable_fastpath_fallback_to_rebuild_total");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_source_offset_nonzero(
-        "tablet_merge_legacy_sstable_fastpath_fallback_source_offset_nonzero");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_canonical_offset_nonzero(
-        "tablet_merge_legacy_sstable_fastpath_fallback_canonical_offset_nonzero");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_invalid_form(
-        "tablet_merge_legacy_sstable_fastpath_fallback_invalid_form");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_merged_no_range(
-        "tablet_merge_legacy_sstable_fastpath_fallback_merged_no_range");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_ranged_no_fileset_id(
-        "tablet_merge_legacy_sstable_fastpath_fallback_ranged_no_fileset_id");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction(
-        "tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_merged_delvec_nonempty(
-        "tablet_merge_legacy_sstable_fastpath_fallback_merged_delvec_nonempty");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid(
-        "tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_no_family(
-        "tablet_merge_legacy_sstable_fastpath_fallback_no_family");
-bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family(
-        "tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family");
 bvar::Adder<int64_t> g_tablet_merge_non_shared_sstable_rebuild_total("tablet_merge_non_shared_sstable_rebuild_total");
 
 } // namespace
@@ -117,28 +94,10 @@ public:
     int64_t rssid_offset() const { return _rssid_offset; }
     void set_rssid_offset(int64_t offset) { _rssid_offset = offset; }
 
-    uint32_t child_index() const { return _child_index; }
-    void set_child_index(uint32_t child_index) { _child_index = child_index; }
-
-    // The plan must outlive this ctx (typically a stack local in
-    // merge_tablet). Null on non-PK merges; map_rssid then degenerates to
-    // the shared_rssid_map → natural offset path.
-    void set_projection_plan(const detail::RssidProjectionPlan* plan) { _projection_plan = plan; }
-    const detail::RssidProjectionPlan* projection_plan() const { return _projection_plan; }
-
     // Maps an original rssid to the final output rssid. Lookup priority:
-    //   (1) RssidProjectionPlan.explicit_rssid_map keyed by (child_index,
-    //       rssid). Hit only for shared-ancestor rowsets in safe families
-    //       (PK + cloud-native gate at plan-build time).
-    //   (2) shared_rssid_map for runtime-deduped child-local mappings.
-    //   (3) natural offset (rssid + ctx.rssid_offset).
+    //   (1) shared_rssid_map for runtime-deduped old-tablet-local mappings.
+    //   (2) natural offset (rssid + ctx.rssid_offset).
     StatusOr<uint32_t> map_rssid(uint32_t rssid) const {
-        if (_projection_plan != nullptr) {
-            auto plan_it = _projection_plan->explicit_rssid_map.find({_child_index, rssid});
-            if (plan_it != _projection_plan->explicit_rssid_map.end()) {
-                return plan_it->second;
-            }
-        }
         auto it = _shared_rssid_map.find(rssid);
         if (it != _shared_rssid_map.end()) {
             return it->second;
@@ -151,12 +110,11 @@ public:
     }
 
     // Precomputes the sorted set of source-effective rssids whose
-    // map_rssid would return a value DIFFERENT from
-    // rssid + this->_rssid_offset under the plan/shared_rssid priority.
+    // map_rssid would return a value DIFFERENT from rssid + this->_rssid_offset.
     // merge_sstables calls this once per ctx, then uses
     // mapping_disagrees_with_natural_in_range below to range-test each
-    // non-shared sstable in O(log N) instead of re-scanning the plan +
-    // shared_rssid_map per sstable.
+    // non-shared sstable in O(log N) instead of re-scanning shared_rssid_map
+    // per sstable.
     //
     // Conservative: arithmetic overflow on natural-offset projection is
     // treated as a disagreement so the rebuild path runs and rejects
@@ -171,18 +129,8 @@ public:
             return value != static_cast<uint32_t>(natural);
         };
 
-        const size_t plan_size = (_projection_plan != nullptr) ? _projection_plan->explicit_rssid_map.size() : 0;
         std::vector<uint32_t> keys;
-        keys.reserve(plan_size + _shared_rssid_map.size());
-
-        if (_projection_plan != nullptr) {
-            for (const auto& [source_key, final_rssid] : _projection_plan->explicit_rssid_map) {
-                if (source_key.child_index != _child_index) continue;
-                if (disagrees(source_key.source_rssid, final_rssid)) {
-                    keys.push_back(source_key.source_rssid);
-                }
-            }
-        }
+        keys.reserve(_shared_rssid_map.size());
         for (const auto& [source_rssid, final_rssid] : _shared_rssid_map) {
             if (disagrees(source_rssid, final_rssid)) {
                 keys.push_back(source_rssid);
@@ -224,11 +172,8 @@ private:
     TabletMetadataPtr _metadata;
     int64_t _rssid_offset = 0;
     int _current_rowset_index = 0;
-    uint32_t _child_index = 0;
-    // Non-owning. Lifetime guaranteed by merge_tablet's stack frame.
-    const detail::RssidProjectionPlan* _projection_plan = nullptr;
     // Dedup-produced rssid remap table.
-    // key: original rssid in this child metadata
+    // key: original rssid in this old tablet metadata
     // value: canonical rowset's actual rssid in the final output
     // rssid not in this map uses the default offset mapping.
     std::unordered_map<uint32_t, uint32_t> _shared_rssid_map;
@@ -251,12 +196,12 @@ inline uint64_t encode_rss_rowid(uint32_t rssid_high, uint64_t rowid_low) {
     return (static_cast<uint64_t>(rssid_high) << kRssRowidHighShift) | rowid_low;
 }
 
-// Tracks the contributing children's child-local ranges per canonical rowset
+// Tracks the contributing old tablets' old-tablet-local ranges per canonical rowset
 // in new_metadata. Used by the post-merge_rowsets PK coverage check and by
 // gap-delvec synthesis.
 //
 // Key: index of the canonical rowset in new_metadata->rowsets().
-// Value: each entry is the contributing child's effective_child_local_range
+// Value: each entry is the contributing old tablet's effective_old_tablet_local_range
 // (rowset.range, fallback ctx.metadata.range, fallback unbounded), captured
 // BEFORE update_canonical's union_range mutates the canonical's stored range
 // — otherwise the convex hull would swallow gaps and the coverage / gap
@@ -308,25 +253,15 @@ int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const Tablet
     return static_cast<int64_t>(base_metadata.next_rowset_id()) - min_id;
 }
 
+// Duplicate detection for merge: two rowsets are the same logical rowset across
+// split siblings iff they carry the same global uid. The uid is minted once at
+// rowset creation and carried verbatim by CopyFrom across SPLIT and cross-publish,
+// so siblings descended from one logical rowset (split-pruned, or a concurrent
+// write cross-published to every old tablet) compare equal, while an independently
+// produced rowset (e.g. a post-split local compaction output) carries a fresh uid
+// and never aliases. A rowset without a valid uid is never treated as a duplicate.
 bool is_duplicate_rowset(const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
-    // Two predicates at the same version -> duplicate
-    if (a.has_delete_predicate() && b.has_delete_predicate()) {
-        return true;
-    }
-    // Has segments: compare first segment's file_name, bundle_file_offset, shared
-    if (a.segment_metas_size() > 0 && b.segment_metas_size() > 0) {
-        if (a.segment_metas(0).filename() != b.segment_metas(0).filename()) return false;
-        int64_t a_off = a.segment_metas(0).has_bundle_file_offset() ? a.segment_metas(0).bundle_file_offset() : 0;
-        int64_t b_off = b.segment_metas(0).has_bundle_file_offset() ? b.segment_metas(0).bundle_file_offset() : 0;
-        if (a_off != b_off) return false;
-        bool a_shared = a.segment_metas(0).shared();
-        bool b_shared = b.segment_metas(0).shared();
-        return a_shared && b_shared;
-    } else if (a.del_files_size() > 0 && b.del_files_size() > 0) {
-        // Delete-only: compare first del_file's name, shared
-        return a.del_files(0).name() == b.del_files(0).name() && a.del_files(0).shared() && b.del_files(0).shared();
-    }
-    return false;
+    return tablet_reshard_helper::same_rowset_uid(a, b);
 }
 
 Status add_rowset(TabletMergeContext& ctx, const RowsetMetadataPB& rowset, TabletMetadataPB* new_metadata) {
@@ -354,6 +289,88 @@ Status add_rowset(TabletMergeContext& ctx, const RowsetMetadataPB& rowset, Table
     return Status::OK();
 }
 
+// The defaulted bundle-file offset of a segment: an absent offset means 0 (the only or
+// first segment in a bundle), a present one is its byte offset into the shared file.
+int64_t segment_bundle_offset(const SegmentMetadataPB& seg) {
+    return seg.has_bundle_file_offset() ? seg.bundle_file_offset() : 0;
+}
+
+// Physical identity of a segment: (filename, bundle_file_offset). File bundling packs
+// several segments into one physical file distinguished only by offset, so filename alone
+// is insufficient. Used both to dedup same-uid sibling segments at the same segment_idx
+// and to detect whether two siblings' segment lists already match.
+bool same_segment_identity(const SegmentMetadataPB& a, const SegmentMetadataPB& b) {
+    return a.filename() == b.filename() && segment_bundle_offset(a) == segment_bundle_offset(b);
+}
+
+// Union the duplicate's segments into the canonical for two same-uid sibling rowsets,
+// so the merged rowset reconstructs the ancestor rowset's full segment set. Dedup by
+// segment_idx — the rssid key (rowset.id + segment_idx) — so the merged rowset can
+// never hold two segments at the same index. The output is written back to canonical
+// sorted by segment_idx, matching the ancestor rowset's logical segment layout. Note
+// this ordering alone does NOT prove key-range non-overlap, so the caller still
+// conservatively sets overlapped=true after a union that leaves >1 segment. Each
+// SegmentMetadataPB is the self-contained canonical home for a segment's file
+// attributes (filename/size/encryption_meta/shared/bundle_file_offset) plus segment_idx,
+// so the union simply merges the segment_metas[] repeated field — there are no parallel
+// arrays to keep in lockstep — and segment_idx is preserved verbatim, keeping the merge
+// rssid map valid.
+Status union_segments_by_idx(RowsetMetadataPB* canonical, const RowsetMetadataPB& duplicate) {
+    // A contributor with zero segments (all of them pruned to other new tablets) adds
+    // nothing; return early.
+    if (duplicate.segment_metas_size() == 0) {
+        return Status::OK();
+    }
+
+    // Build the union keyed on segment_idx so the merged rowset's segment_metas[] is
+    // sorted by segment_idx (the rssid space rowset.id + segment_idx), matching the
+    // ancestor rowset's logical layout. std::map iterates in key order, so writing back
+    // from it restores the sorted layout — readers that iterate by position can rely on
+    // segment_idx monotonicity, and the canonical's original `overlapped` flag stays
+    // meaningful. Two same-uid siblings either share a segment that spanned multiple
+    // ranges (kept by both with identical segment_idx AND identity) or own disjoint
+    // pruned segments (distinct segment_idx). Deduping on segment_idx guarantees the
+    // merged rowset never holds two segments at the same index, which would collide in
+    // the rssid space.
+    std::map<uint32_t, SegmentMetadataPB> by_segment_idx;
+    auto ingest = [&](const RowsetMetadataPB& source) -> Status {
+        for (int position = 0; position < source.segment_metas_size(); ++position) {
+            const uint32_t segment_idx = get_segment_idx(source, position);
+            const auto& seg = source.segment_metas(position);
+            auto [iter, inserted] = by_segment_idx.try_emplace(segment_idx);
+            if (inserted) {
+                iter->second = seg;
+                continue;
+            }
+            // A spanning segment is kept by both siblings with the same segment_idx. Its
+            // identity is (filename, bundle_file_offset): file bundling packs several
+            // segments into one physical file, so distinct segments can share a file name
+            // and differ only by offset. A same-idx-but-different-identity pair cannot
+            // arise for one uid (a rewrite re-mints the uid, so it never reaches this
+            // dedup) and fails closed rather than silently dropping a slice.
+            if (iter->second.filename() != seg.filename()) {
+                return Status::Corruption(
+                        "rowset segment union: two siblings carry different files at the same segment_idx");
+            }
+            if (segment_bundle_offset(iter->second) != segment_bundle_offset(seg)) {
+                return Status::Corruption(
+                        "rowset segment union: two siblings carry the same segment_idx and file but different "
+                        "bundle_file_offsets");
+            }
+        }
+        return Status::OK();
+    };
+    RETURN_IF_ERROR(ingest(*canonical));
+    RETURN_IF_ERROR(ingest(duplicate));
+
+    // Rewrite canonical's segment_metas in segment_idx order.
+    canonical->clear_segment_metas();
+    for (auto& [segment_idx, seg] : by_segment_idx) {
+        *canonical->add_segment_metas() = std::move(seg);
+    }
+    return Status::OK();
+}
+
 Status update_canonical(RowsetMetadataPB* canonical_rowset, const TabletRangePB& duplicate_effective_range,
                         const RowsetMetadataPB& duplicate_rowset) {
     // Always extend the canonical range with the duplicate's *effective* range
@@ -375,12 +392,49 @@ Status update_canonical(RowsetMetadataPB* canonical_rowset, const TabletRangePB&
     // tablet_splitter.cpp / tablet_reshard_helper.cpp with num_dels <= num_rows.
     // Summation therefore preserves that invariant on the canonical rowset, so no
     // clamp is needed. Tablet merge is greenfield; there is no legacy state with
-    // the parent's full num_dels inherited by every child to guard against.
+    // the old tablet's full num_dels inherited by every new tablet to guard against.
     DCHECK_LE(canonical_rowset->num_dels(), canonical_rowset->num_rows());
     DCHECK_LE(duplicate_rowset.num_dels(), duplicate_rowset.num_rows());
     canonical_rowset->set_num_rows(canonical_rowset->num_rows() + duplicate_rowset.num_rows());
     canonical_rowset->set_data_size(canonical_rowset->data_size() + duplicate_rowset.data_size());
     canonical_rowset->set_num_dels(canonical_rowset->num_dels() + duplicate_rowset.num_dels());
+
+    // Per-segment reconstruction: union the duplicate's segment list into the
+    // canonical so the merged rowset carries every segment its same-uid siblings
+    // contributed. Gate on actual divergence of the segment lists rather than the
+    // shared=false flag: a multi-level split can produce same-uid siblings with
+    // DISJOINT all-shared segment subsets (compute_rowset_segment_ownership keeps
+    // shared=true when the source segment was already shared, regardless of overlap count), so a
+    // shared=false filter alone would skip those unions and silently lose data. When
+    // the lists already match (cross-publish — identical segments across siblings),
+    // the union would be a no-op and is skipped.
+    // A segment's identity is (file, bundle_file_offset): file bundling packs several
+    // segments into one physical file, so distinct segments can share a file name and
+    // differ only by offset. Comparing file names alone would treat two siblings that
+    // carry different bundled segments (same names, different offsets) as identical and
+    // skip the union, silently dropping a sibling's segments. Compare offsets too.
+    // Comparing (file, offset) rather than the union's segment_idx dedup key is sound:
+    // the split preserves a segment's file, offset, and segment_idx together, so for
+    // same-uid siblings identical (file, offset) lists imply identical segment_idx lists
+    // -- i.e. the union really would be a no-op exactly when this skip fires.
+    auto segment_lists_differ = [](const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
+        if (a.segment_metas_size() != b.segment_metas_size()) return true;
+        for (int i = 0; i < a.segment_metas_size(); ++i) {
+            if (!same_segment_identity(a.segment_metas(i), b.segment_metas(i))) return true;
+        }
+        return false;
+    };
+    if (segment_lists_differ(*canonical_rowset, duplicate_rowset)) {
+        RETURN_IF_ERROR(union_segments_by_idx(canonical_rowset, duplicate_rowset));
+        // tablet_splitter.cpp resets overlapped=false on a one-segment post-prune
+        // output; if MERGE later unions sibling segments back in, that flag is
+        // stale (segment_idx-sorted ordering does NOT prove key-range non-overlap).
+        // Conservatively force overlapped=true whenever the union leaves more
+        // than one segment on the canonical rowset.
+        if (canonical_rowset->segment_metas_size() > 1) {
+            canonical_rowset->set_overlapped(true);
+        }
+    }
     return Status::OK();
 }
 
@@ -391,22 +445,38 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
     int64_t current_version = -1;
 
     for (;;) {
-        // Find child with minimum (version, child_index).
-        // Forward iteration with strict < ensures the smallest child_index wins on ties.
-        int min_child_index = -1;
+        // Find old tablet with minimum (version, old_tablet_index).
+        // Forward iteration with strict < ensures the smallest old_tablet_index wins on ties.
+        int min_old_tablet_index = -1;
         int64_t min_version = std::numeric_limits<int64_t>::max();
         for (int i = 0; i < static_cast<int>(merge_contexts.size()); ++i) {
             if (!merge_contexts[i].has_next_rowset()) continue;
             int64_t version = merge_contexts[i].current_rowset().version();
             if (version < min_version) {
                 min_version = version;
-                min_child_index = i;
+                min_old_tablet_index = i;
             }
         }
-        if (min_child_index < 0) break;
+        if (min_old_tablet_index < 0) break;
 
-        const auto& rowset = merge_contexts[min_child_index].current_rowset();
-        const auto& ctx_meta = *merge_contexts[min_child_index].metadata();
+        const auto& rowset = merge_contexts[min_old_tablet_index].current_rowset();
+        const auto& ctx_meta = *merge_contexts[min_old_tablet_index].metadata();
+
+        // Invariant: every rowset reaching a reshard merge carries a valid uid. Lake
+        // writers mint at creation; split / identical-reshard preserve it via the metadata
+        // copy; cross-publish preserves it via CopyFrom; synthesized rowsets (column-mode
+        // new_rows) derive a deterministic uid from op_write.uid. Range-distribution is a
+        // new feature (no legacy uid-less data), so a missing uid here means a producer
+        // site is uncovered — fail loudly rather than silently miss dedup and emit
+        // duplicate rows.
+        DCHECK(tablet_reshard_helper::has_valid_uid(rowset))
+                << "rowset reaching reshard merge must carry a valid uid: rowset_id=" << rowset.id()
+                << " version=" << rowset.version();
+        if (!tablet_reshard_helper::has_valid_uid(rowset)) {
+            return Status::InternalError(
+                    fmt::format("rowset reaching reshard merge has no uid: rowset_id={} version={}", rowset.id(),
+                                rowset.version()));
+        }
 
         // Version change: update version_start_index
         if (rowset.version() != current_version) {
@@ -414,28 +484,38 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
             version_start_index = new_metadata->rowsets_size();
         }
 
-        // Search [version_start_index, end) for a dedup candidate. Decision:
-        //   - Delete-predicate dups: keep original unconditional skip path.
-        //   - Shared-segment / shared-del_file dups (the only other case
-        //     is_duplicate_rowset returns true on): PK always dedups; non-PK
-        //     dedups only when ranges are contiguous so that the convex-hull
-        //     range stored on the canonical does not span a gap left by a
-        //     compacted sibling.
+        // Search [version_start_index, end) for a dedup candidate. The window is a
+        // single version (the k-way merge above feeds rowsets in version order). Decision:
+        //   - Delete-predicate rowsets dedup by VERSION, not uid: a version is one
+        //     transaction carrying one predicate, so two same-version predicates from
+        //     different merged siblings are the same logical delete. A normal post-split
+        //     DELETE runs Tablet::delete_data independently per sibling tablet and mints
+        //     an independent uid each time, so keying on uid would wrongly retain one
+        //     copy per sibling; the pre-uid merge deduped these by version. (The uid is
+        //     still required by the invariant above -- it just isn't the predicate
+        //     dedup key.)
+        //   - Shared-segment / shared-del_file dups (the only case is_duplicate_rowset
+        //     returns true on): PK always dedups; non-PK dedups only when ranges are
+        //     contiguous so that the convex-hull range stored on the canonical does not
+        //     span a gap left by a compacted sibling.
         int canonical_index = -1;
         bool non_pk_skip_dedup_fired = false;
         for (int i = version_start_index; i < new_metadata->rowsets_size(); ++i) {
+            if (rowset.has_delete_predicate()) {
+                if (new_metadata->rowsets(i).has_delete_predicate()) {
+                    canonical_index = i;
+                    break;
+                }
+                continue;
+            }
             if (!is_duplicate_rowset(rowset, new_metadata->rowsets(i))) continue;
 
-            if (rowset.has_delete_predicate()) {
-                canonical_index = i;
-                break;
-            }
             if (is_pk) {
                 canonical_index = i;
                 break;
             }
             const auto& candidate_range = new_metadata->rowsets(i).range();
-            const auto& incoming_range = tablet_reshard_helper::effective_child_local_range(rowset, ctx_meta);
+            const auto& incoming_range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, ctx_meta);
             if (tablet_reshard_helper::ranges_are_contiguous(candidate_range, incoming_range)) {
                 canonical_index = i;
                 break;
@@ -455,20 +535,24 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
         if (canonical_index >= 0) {
             // Duplicate: skip output
             const auto& canonical = new_metadata->rowsets(canonical_index);
-            DCHECK(rowset.segment_metas_size() == canonical.segment_metas_size() &&
-                   rowset.del_files_size() == canonical.del_files_size())
-                    << "Shared rowset dedup hit but payload shape differs: segments(" << rowset.segment_metas_size()
-                    << " vs " << canonical.segment_metas_size() << "), del_files(" << rowset.del_files_size() << " vs "
-                    << canonical.del_files_size() << ")";
+            // Same-uid siblings legitimately carry different segment lists when split
+            // pruned them to disjoint subsets (whether shared=false per-segment pruning
+            // or shared=true multi-level pruning of already-shared segments), so do NOT assert on
+            // segment count parity — update_canonical's segment_lists_differ gate handles the
+            // segment-list union. del_files are never pruned and stay equal across
+            // siblings, so that invariant is the one worth asserting here.
+            DCHECK_EQ(rowset.del_files_size(), canonical.del_files_size())
+                    << "Shared rowset dedup hit but del_files diverge: " << rowset.del_files_size() << " vs "
+                    << canonical.del_files_size();
             if (!rowset.has_delete_predicate()) {
-                merge_contexts[min_child_index].update_shared_rssid_map(rowset, canonical);
-                // Capture the duplicate's child-local effective range BEFORE
+                merge_contexts[min_old_tablet_index].update_shared_rssid_map(rowset, canonical);
+                // Capture the duplicate's old-tablet-local effective range BEFORE
                 // update_canonical mutates canonical.range via union_range. The
                 // same effective range is also passed into update_canonical so
                 // that a rowset without its own .range() but with a ctx tablet
                 // range still extends the canonical range.
                 const auto& duplicate_effective_range =
-                        tablet_reshard_helper::effective_child_local_range(rowset, ctx_meta);
+                        tablet_reshard_helper::effective_old_tablet_local_range(rowset, ctx_meta);
                 if (canonical_contribs != nullptr) {
                     (*canonical_contribs)[canonical_index].push_back(duplicate_effective_range);
                 }
@@ -477,20 +561,20 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
             }
             // predicate: just skip
         } else {
-            // First occurrence: output. Capture child-local range first so that
+            // First occurrence: output. Capture old-tablet-local range first so that
             // we record the pre-clip view (add_rowset clips to ctx tablet range).
-            TabletRangePB initial_child_range;
+            TabletRangePB initial_old_tablet_range;
             if (canonical_contribs != nullptr && !rowset.has_delete_predicate()) {
-                initial_child_range = tablet_reshard_helper::effective_child_local_range(rowset, ctx_meta);
+                initial_old_tablet_range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, ctx_meta);
             }
             const int new_index = new_metadata->rowsets_size();
-            RETURN_IF_ERROR(add_rowset(merge_contexts[min_child_index], rowset, new_metadata));
+            RETURN_IF_ERROR(add_rowset(merge_contexts[min_old_tablet_index], rowset, new_metadata));
             if (canonical_contribs != nullptr && !rowset.has_delete_predicate()) {
-                (*canonical_contribs)[new_index].push_back(std::move(initial_child_range));
+                (*canonical_contribs)[new_index].push_back(std::move(initial_old_tablet_range));
             }
         }
 
-        merge_contexts[min_child_index].advance_rowset();
+        merge_contexts[min_old_tablet_index].advance_rowset();
     }
 
     return Status::OK();
@@ -558,10 +642,10 @@ Status verify_dcg_entry_consistency(const DeltaColumnGroupVerPB& existing, int j
 // merge_dcg_meta: two-pass entry-level merge with per-target .cols rebuild.
 //
 // Pass 1 collects per-target "surviving" entries (after exact-dedup by .cols
-// filename) and per-target source-rowset references (the child rowsets that
+// filename) and per-target source-rowset references (the old tablet rowsets that
 // reference target rssid T through get_rssid/map_rssid). Ranges are captured
-// from each source-child rowset BEFORE merge_rowsets() has widened shared
-// ranges via union_range, so a coverage gap between child ranges cannot be
+// from each source old tablet rowset BEFORE merge_rowsets() has widened shared
+// ranges via union_range, so a coverage gap between old tablet ranges cannot be
 // masked by the merged rowset's convex hull.
 //
 // Pass 2 classifies each target's entries: columns claimed by only one entry
@@ -573,13 +657,13 @@ Status verify_dcg_entry_consistency(const DeltaColumnGroupVerPB& existing, int j
 //
 // Per-target rebuild (rebuild_dcg_for_target_segment) implements Steps A-F of the
 // design: locate base segment via get_rssid scan, resolve merged schema,
-// compute row windows per source-child rowset using the existing range ->
+// compute row windows per source old tablet rowset using the existing range ->
 // SeekRange -> rowid-range pipeline, validate coverage, assemble rebuilt
-// chunk (donor file per column + updater-child window overrides), write a
+// chunk (donor file per column + updater old tablet window overrides), write a
 // new .cols file, install one entry into new_dcgs[T].
 
 struct DcgSurvivingEntry {
-    size_t child_index;
+    size_t old_tablet_index;
     uint32_t original_segment_id;
     int entry_index;
     // Single-entry normalized copy of the source DCG entry (all 5 fields at
@@ -620,7 +704,7 @@ inline std::vector<bool> mark_conflicting_dcg_entries(const std::vector<DcgSurvi
 }
 
 struct DcgSourceRowsetReference {
-    size_t child_index;
+    size_t old_tablet_index;
     const RowsetMetadataPB* rowset = nullptr;
     int segment_position = 0;
     const TabletRangePB* effective_range = nullptr; // rowset.range() else ctx tablet range; null = unbounded
@@ -641,18 +725,18 @@ DeltaColumnGroupVerPB make_single_entry_dcg(const DeltaColumnGroupVerPB& source,
     return out;
 }
 
-// Pass 1 — walk each child's dcg_meta and rowsets, dedup by filename across
-// children, and accumulate source-rowset refs per target T.
+// Pass 1 — walk each old tablet's dcg_meta and rowsets, dedup by filename across
+// old tablets, and accumulate source-rowset refs per target T.
 Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContext>& merge_contexts,
                                              std::map<uint32_t, DcgTargetWorkItem>* work_by_target) {
     // Track which .cols filenames we have already observed per target so that
-    // subsequent children with the same filename are deduped (and verified).
+    // subsequent old tablets with the same filename are deduped (and verified).
     // Store size_t indexes into DcgTargetWorkItem::entries (NOT raw pointers),
     // since push_back can reallocate the vector and invalidate pointers.
     std::map<uint32_t, std::unordered_map<std::string, size_t>> seen_files_by_target;
 
-    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
-        const auto& context = merge_contexts[child_index];
+    for (size_t old_tablet_index = 0; old_tablet_index < merge_contexts.size(); ++old_tablet_index) {
+        const auto& context = merge_contexts[old_tablet_index];
 
         // (a) Accumulate source-rowset references from every rowset that
         // references any target via get_rssid -> context.map_rssid.
@@ -663,7 +747,7 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
                 if (!target_or.ok()) continue;
                 uint32_t target_rssid = *target_or;
                 DcgSourceRowsetReference source_reference;
-                source_reference.child_index = child_index;
+                source_reference.old_tablet_index = old_tablet_index;
                 source_reference.rowset = &rowset;
                 source_reference.segment_position = segment_position;
                 if (rowset.has_range()) {
@@ -694,7 +778,7 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
                 auto& seen_files = seen_files_by_target[target_rssid];
                 auto seen_iter = seen_files.find(file_name);
                 if (seen_iter != seen_files.end()) {
-                    // Exact dedup across children: verify entry-level consistency
+                    // Exact dedup across old tablets: verify entry-level consistency
                     // against the previously stored entry. Index lookup is safe
                     // even if the vector reallocated between insertions.
                     RETURN_IF_ERROR(verify_dcg_entry_consistency(target_work.entries[seen_iter->second].single_entry, 0,
@@ -703,7 +787,7 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
                 }
 
                 DcgSurvivingEntry entry;
-                entry.child_index = child_index;
+                entry.old_tablet_index = old_tablet_index;
                 entry.original_segment_id = segment_id;
                 entry.entry_index = entry_index;
                 entry.single_entry = make_single_entry_dcg(normalized, entry_index);
@@ -753,11 +837,11 @@ const TabletSchemaPB* resolve_rowset_schema_pb(const TabletMetadataPB& new_metad
 }
 
 struct DcgRowWindow {
-    size_t child_index;
+    size_t old_tablet_index;
     Range<rowid_t> range;
 };
 
-// Step C — compute row windows in the target segment for every source-child
+// Step C — compute row windows in the target segment for every source old tablet
 // rowset that references it. Coverage over [0, num_rows_of_target) is validated.
 Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int64_t new_tablet_id,
                                               const RowsetMetadataPB& target_rowset, int target_segment_position,
@@ -809,7 +893,7 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
                 continue;
             }
         }
-        out_windows->push_back({source_reference.child_index, window});
+        out_windows->push_back({source_reference.old_tablet_index, window});
     }
 
     if (out_windows->empty()) {
@@ -817,23 +901,23 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
                 "DCG rebuild: no valid row windows computed for target rssid (num_rows={})", num_rows_in_target));
     }
 
-    // Dedup windows that belong to the SAME child AND have the same range
-    // (e.g., a child's shared rowset surfaced twice through different scans).
-    // Do NOT dedup windows from different children even if the range matches:
+    // Dedup windows that belong to the SAME old tablet AND have the same range
+    // (e.g., an old tablet's shared rowset surfaced twice through different scans).
+    // Do NOT dedup windows from different old tablets even if the range matches:
     // those represent distinct authoritative updaters for the same rows and
     // must surface as an overlap failure, not be silently collapsed.
     std::sort(out_windows->begin(), out_windows->end(), [](const DcgRowWindow& left, const DcgRowWindow& right) {
         if (left.range.begin() != right.range.begin()) return left.range.begin() < right.range.begin();
         if (left.range.end() != right.range.end()) return left.range.end() < right.range.end();
-        return left.child_index < right.child_index;
+        return left.old_tablet_index < right.old_tablet_index;
     });
     std::vector<DcgRowWindow> deduped_windows;
     deduped_windows.reserve(out_windows->size());
     for (auto& window : *out_windows) {
         if (!deduped_windows.empty() && deduped_windows.back().range.begin() == window.range.begin() &&
             deduped_windows.back().range.end() == window.range.end() &&
-            deduped_windows.back().child_index == window.child_index) {
-            continue; // same child + same range: safe to collapse
+            deduped_windows.back().old_tablet_index == window.old_tablet_index) {
+            continue; // same old tablet + same range: safe to collapse
         }
         deduped_windows.push_back(window);
     }
@@ -842,11 +926,11 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
     // Coverage validation: windows must be contiguous and cover [0, num_rows_in_target).
     //
     // Known limitation: the synthesized gap delvec from
-    // compute_synthesized_gap_specs masks rowids that no contributing child
+    // compute_synthesized_gap_specs masks rowids that no contributing old tablet
     // claims, but DCG rebuild does not yet consult that bitmap. A
-    // (compacted-child gap) × (DCG conflict on canonical R0) combination
+    // (compacted-old-tablet gap) × (DCG conflict on canonical R0) combination
     // therefore returns NotSupported here. FE scheduling currently avoids
-    // the combo by requiring all children compacted before merge for any
+    // the combo by requiring all old tablets compacted before merge for any
     // tablet with active partial-update DCGs.
     if ((*out_windows)[0].range.begin() != 0) {
         return Status::NotSupported(
@@ -979,11 +1063,11 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
 
     // For each rebuild column, pick:
     // - default donor: any conflicting entry that claims the UID (first found).
-    // - per-child overrides: the conflicting entry from the child that claims
-    //   the UID, to be used for rows in that child's owner window.
+    // - per-old-tablet overrides: the conflicting entry from the old tablet that claims
+    //   the UID, to be used for rows in that old tablet's owner window.
     struct ColumnSourceInfo {
         const DcgSurvivingEntry* default_donor = nullptr;
-        std::unordered_map<size_t, const DcgSurvivingEntry*> override_by_child_index;
+        std::unordered_map<size_t, const DcgSurvivingEntry*> override_by_old_tablet_index;
     };
     std::unordered_map<uint32_t, ColumnSourceInfo> column_source_info_by_unique_id;
     for (uint32_t unique_id : rebuild_columns) {
@@ -991,7 +1075,7 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
             if (!entry_claims_column_uid(*entry, unique_id)) continue;
             auto& info = column_source_info_by_unique_id[unique_id];
             if (info.default_donor == nullptr) info.default_donor = entry;
-            info.override_by_child_index[entry->child_index] = entry;
+            info.override_by_old_tablet_index[entry->old_tablet_index] = entry;
         }
         if (column_source_info_by_unique_id[unique_id].default_donor == nullptr) {
             return Status::InternalError(fmt::format("DCG rebuild: no donor found for column UID {}", unique_id));
@@ -1010,7 +1094,7 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
             entry_unique_ids.push_back(static_cast<ColumnUID>(column_id));
         }
         TabletSchemaCSPtr entry_schema = TabletSchema::create_with_uid(full_tablet_schema, entry_unique_ids);
-        int64_t owner_tablet_id = merge_contexts[entry->child_index].metadata()->id();
+        int64_t owner_tablet_id = merge_contexts[entry->old_tablet_index].metadata()->id();
         const std::string& file_name = entry->single_entry.column_files(0);
         const std::string& encryption_meta = entry->single_entry.encryption_metas(0);
         ASSIGN_OR_RETURN(auto segment, open_source_dcg_segment(tablet_manager, owner_tablet_id, file_name,
@@ -1054,9 +1138,10 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
 
         for (const auto& window : windows) {
             const DcgSurvivingEntry* selected_source = nullptr;
-            auto override_iter = source_info.override_by_child_index.find(window.child_index);
-            selected_source = (override_iter != source_info.override_by_child_index.end()) ? override_iter->second
-                                                                                           : source_info.default_donor;
+            auto override_iter = source_info.override_by_old_tablet_index.find(window.old_tablet_index);
+            selected_source = (override_iter != source_info.override_by_old_tablet_index.end())
+                                      ? override_iter->second
+                                      : source_info.default_donor;
             ASSIGN_OR_RETURN(auto source_segment, get_source_segment(selected_source));
             RETURN_IF_ERROR(read_column_range_from_segment(source_segment, entry_schemas[selected_source], unique_id,
                                                            window.range.begin(), window.range.end(),
@@ -1209,13 +1294,13 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
 }
 
 // Phase 0 output: per-target rowid bitmaps representing keys in the
-// shared physical segment that no contributing child claims. Read-path
+// shared physical segment that no contributing old tablet claims. Read-path
 // consumers:
 //   - canonical R0's segment iterator already filters by canonical.range, so
 //     gap rowids outside the convex hull are no-ops for scans.
 //   - PersistentIndexSstable::multi_get filters by the projected delvec on
 //     the sstable PB regardless of LSM block-sort order, which keeps the
-//     first-child-compacts case safe.
+//     first-old-tablet-compacts case safe.
 struct CanonicalGapSpec {
     uint32_t target_rssid;
     Roaring gap_bits;
@@ -1227,8 +1312,8 @@ struct CanonicalGapSpec {
 //
 // Bound = merged tablet range, not unbounded `(-∞, +∞)`. The plan's original
 // motivation for unbounded was to surface keys outside canonical.range (left
-// or right edges); but since each child's tablet.range is a sub-range of the
-// pre-split tablet, and merged_tablet.range = union of children's tablet
+// or right edges); but since each old tablet's tablet.range is a sub-range of the
+// pre-split tablet, and merged_tablet.range = union of old tablets' tablet
 // ranges, the shared physical segment never carries keys outside the merged
 // tablet range. The unbounded helper would just generate edge complements
 // that seek to empty rowid windows. Bounded-by-merged-tablet-range is both
@@ -1244,9 +1329,9 @@ StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletMana
                     fmt::format("compute_synthesized_gap_specs: invalid canonical_index {}", canonical_index));
         }
         const auto& canonical = new_metadata.rowsets(canonical_index);
-        // segment_metas_size() alone is insufficient because metadata
-        // transforms can leave an all-false vector behind. Only synthesize
-        // gap bits when at least one segment is actually shared.
+        // segment_metas_size() alone is insufficient because a rowset can own only
+        // non-shared segments. Only synthesize gap bits when at least one segment is
+        // actually shared.
         bool has_shared = false;
         for (const auto& segment_meta : canonical.segment_metas()) {
             if (segment_meta.shared()) {
@@ -1314,11 +1399,11 @@ StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletMana
 
 // Phase 2.5 of merge_delvecs: union each synthesized gap bitmap into the
 // corresponding target state. Mirrors the Phase 2 transitions but the source
-// is a synthesized Roaring rather than a child delvec page — so no
+// is a synthesized Roaring rather than an old tablet delvec page — so no
 // (file_name, offset) entry goes into seen_sources.
 //
 // Uses DelVector::union_with(Roaring) directly (no rowid-vector round-trip):
-// a compacted-away child's gap can span millions of rowids, and the legacy
+// a compacted-away old tablet's gap can span millions of rowids, and the legacy
 // path through std::vector<uint32_t> + DelVector::init(uint32_t*, size) +
 // union_delvec would re-enumerate every rowid into a vector twice.
 Status inject_synthesized_gaps_into_target_states(TabletManager* tablet_manager,
@@ -1363,7 +1448,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
         g_tablet_merge_gap_delvec_total << 1;
     }
 
-    // Phase 1: Collect unique delvec files across all children
+    // Phase 1: Collect unique delvec files across all old tablets
     std::vector<DelvecFileInfo> unique_delvec_files;
     std::unordered_map<std::string, size_t> file_name_to_index;
 
@@ -1392,13 +1477,13 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
 
     // Early-return only when there is no work at all: no source delvec files
     // AND no synthesized gaps. A clean PK table with no prior deletes can
-    // still need a synthesized gap delvec to mask compacted-away child rowids.
+    // still need a synthesized gap delvec to mask compacted-away old tablet rowids.
     if (unique_delvec_files.empty() && synthesized_gap_specs.empty()) {
         return Status::OK();
     }
 
     // Phase 2: Scan pages, build TargetDelvecState for each target rssid.
-    // File name is resolved inline via each child's version_to_file map.
+    // File name is resolved inline via each old tablet's version_to_file map.
     std::map<uint32_t, TargetDelvecState> target_states;
 
     for (const auto& ctx : merge_contexts) {
@@ -1477,7 +1562,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
 
     // Phase 2.5: inject synthesized gap delvecs into target_states. Each spec's
     // bitmap masks rowids in the shared physical segment whose key was
-    // contributed by no surviving child (e.g., a child that compacted away
+    // contributed by no surviving old tablet (e.g., an old tablet that compacted away
     // its copy of the shared rowset). Promotes any single_source state to
     // merged so the bitmap can be unioned in.
     RETURN_IF_ERROR(inject_synthesized_gaps_into_target_states(tablet_manager, synthesized_gap_specs, new_version,
@@ -1572,9 +1657,9 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     return Status::OK();
 }
 
-// Lookup maps from a child-id-space rssid to the merged tablet's final
+// Lookup maps from an old-tablet-id-space rssid to the merged tablet's final
 // rssid. Built once per rebuild from the merge_contexts, scoped per
-// inferred family (or per orphan child for kNoFamily ctxs) so a multi-
+// inferred family (or per orphan old tablet for kNoFamily ctxs) so a multi-
 // family merge with overlapping source rssids never returns another
 // family's mapping. Each PerFamilyMaps half follows first-emitter-wins:
 //
@@ -1596,29 +1681,29 @@ struct LegacyRssidLookupMaps {
 
     // family_id → maps populated from that family's member ctxs only.
     std::unordered_map<uint32_t, PerFamilyMaps> per_family;
-    // child_index → maps populated from THAT specific orphan ctx only.
+    // old_tablet_index → maps populated from THAT specific orphan ctx only.
     // Each orphan ctx (kNoFamily) gets its own scoped entry so two
-    // unrelated orphan children with overlapping source rssids do not
+    // unrelated orphan old tablets with overlapping source rssids do not
     // pollute each other — orphan ctxs each have an independent
-    // child-local id space, so a global orphan map would be susceptible
+    // old-tablet-local id space, so a global orphan map would be susceptible
     // to the same first-emitter-wins pollution that the per-family
     // structure was designed to prevent for family ctxs.
-    std::unordered_map<size_t, PerFamilyMaps> orphan_by_child;
+    std::unordered_map<size_t, PerFamilyMaps> orphan_by_old_tablet;
 };
 
-// Locate the PerFamilyMaps slot for (family_id, child_index): a family ctx
-// shares its family map; an orphan ctx (kNoFamily) has its own child-scoped
-// map so unrelated orphan children with overlapping source rssids stay
+// Locate the PerFamilyMaps slot for (family_id, old_tablet_index): a family ctx
+// shares its family map; an orphan ctx (kNoFamily) has its own old-tablet-scoped
+// map so unrelated orphan old tablets with overlapping source rssids stay
 // isolated. Returns nullptr on miss; callers wrap the result in either an
 // InternalError or a DCHECK depending on whether they're building or reading.
 template <typename Maps>
-auto* find_per_family_maps_slot(Maps& maps, uint32_t family_id, size_t child_index) {
+auto* find_per_family_maps_slot(Maps& maps, uint32_t family_id, size_t old_tablet_index) {
     if (family_id != detail::InferredSplitFamilies::kNoFamily) {
         auto iter = maps.per_family.find(family_id);
         return iter == maps.per_family.end() ? nullptr : &iter->second;
     }
-    auto iter = maps.orphan_by_child.find(child_index);
-    return iter == maps.orphan_by_child.end() ? nullptr : &iter->second;
+    auto iter = maps.orphan_by_old_tablet.find(old_tablet_index);
+    return iter == maps.orphan_by_old_tablet.end() ? nullptr : &iter->second;
 }
 
 // Read-side accessor: missing entry surfaces as InternalError so the merge
@@ -1626,43 +1711,44 @@ auto* find_per_family_maps_slot(Maps& maps, uint32_t family_id, size_t child_ind
 // miss is a programmer bug; falling back to an empty map would silently drop
 // every PK entry and manifest as data loss.
 StatusOr<const LegacyRssidLookupMaps::PerFamilyMaps*> lookup_maps_for_ctx(const LegacyRssidLookupMaps& maps,
-                                                                          uint32_t family_id, size_t child_index) {
-    if (const auto* slot = find_per_family_maps_slot(maps, family_id, child_index); slot != nullptr) {
+                                                                          uint32_t family_id, size_t old_tablet_index) {
+    if (const auto* slot = find_per_family_maps_slot(maps, family_id, old_tablet_index); slot != nullptr) {
         return slot;
     }
-    return Status::InternalError(
-            fmt::format("LegacyRssidLookupMaps: missing slot (family_id={}, child_index={})", family_id, child_index));
+    return Status::InternalError(fmt::format("LegacyRssidLookupMaps: missing slot (family_id={}, old_tablet_index={})",
+                                             family_id, old_tablet_index));
 }
 
 // Build-phase accessor: same lookup, but DCHECK on miss since
 // build_legacy_rssid_lookup_maps just pre-created the entry it's about to
 // populate.
 LegacyRssidLookupMaps::PerFamilyMaps& mutable_per_family_maps_for_ctx(LegacyRssidLookupMaps& maps, uint32_t family_id,
-                                                                      size_t child_index) {
-    auto* slot = find_per_family_maps_slot(maps, family_id, child_index);
+                                                                      size_t old_tablet_index) {
+    auto* slot = find_per_family_maps_slot(maps, family_id, old_tablet_index);
     DCHECK(slot != nullptr) << "PerFamilyMaps not pre-created (family_id=" << family_id
-                            << ", child_index=" << child_index << ")";
+                            << ", old_tablet_index=" << old_tablet_index << ")";
     return *slot;
 }
 
 StatusOr<LegacyRssidLookupMaps> build_legacy_rssid_lookup_maps(const std::vector<TabletMergeContext>& merge_contexts,
                                                                const detail::InferredSplitFamilies& families) {
-    if (families.child_to_family.size() != merge_contexts.size()) {
-        return Status::InvalidArgument(fmt::format(
-                "InferredSplitFamilies.child_to_family size {} != merge_contexts size {}; the families must be built "
-                "from the same contexts",
-                families.child_to_family.size(), merge_contexts.size()));
+    if (families.old_tablet_to_family.size() != merge_contexts.size()) {
+        return Status::InvalidArgument(
+                fmt::format("InferredSplitFamilies.old_tablet_to_family size {} != merge_contexts size {}; the "
+                            "families must be built "
+                            "from the same contexts",
+                            families.old_tablet_to_family.size(), merge_contexts.size()));
     }
-    // Validate every child_to_family entry is either kNoFamily or a real
+    // Validate every old_tablet_to_family entry is either kNoFamily or a real
     // family id so the population loop's find()-based lookups can rely on
     // pre-created entries (and the lookup helper never silently skips a
     // bad family id by treating it as orphan).
-    for (size_t child_index = 0; child_index < families.child_to_family.size(); ++child_index) {
-        const uint32_t family_id = families.child_to_family[child_index];
+    for (size_t old_tablet_index = 0; old_tablet_index < families.old_tablet_to_family.size(); ++old_tablet_index) {
+        const uint32_t family_id = families.old_tablet_to_family[old_tablet_index];
         if (family_id != detail::InferredSplitFamilies::kNoFamily && family_id >= families.families.size()) {
             return Status::InvalidArgument(
-                    fmt::format("InferredSplitFamilies.child_to_family[{}]={} is out of range (families.size={})",
-                                child_index, family_id, families.families.size()));
+                    fmt::format("InferredSplitFamilies.old_tablet_to_family[{}]={} is out of range (families.size={})",
+                                old_tablet_index, family_id, families.families.size()));
         }
     }
 
@@ -1673,18 +1759,18 @@ StatusOr<LegacyRssidLookupMaps> build_legacy_rssid_lookup_maps(const std::vector
     for (uint32_t family_id = 0; family_id < families.families.size(); ++family_id) {
         lookup_maps.per_family.emplace(family_id, LegacyRssidLookupMaps::PerFamilyMaps{});
     }
-    // Pre-create one PerFamilyMaps per orphan child_index so consumers
+    // Pre-create one PerFamilyMaps per orphan old_tablet_index so consumers
     // can assume the entry exists for every kNoFamily ctx.
-    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
-        if (families.child_to_family[child_index] == detail::InferredSplitFamilies::kNoFamily) {
-            lookup_maps.orphan_by_child.emplace(child_index, LegacyRssidLookupMaps::PerFamilyMaps{});
+    for (size_t old_tablet_index = 0; old_tablet_index < merge_contexts.size(); ++old_tablet_index) {
+        if (families.old_tablet_to_family[old_tablet_index] == detail::InferredSplitFamilies::kNoFamily) {
+            lookup_maps.orphan_by_old_tablet.emplace(old_tablet_index, LegacyRssidLookupMaps::PerFamilyMaps{});
         }
     }
 
-    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
-        const auto& ctx = merge_contexts[child_index];
-        const uint32_t family_id = families.child_to_family[child_index];
-        auto& target = mutable_per_family_maps_for_ctx(lookup_maps, family_id, child_index);
+    for (size_t old_tablet_index = 0; old_tablet_index < merge_contexts.size(); ++old_tablet_index) {
+        const auto& ctx = merge_contexts[old_tablet_index];
+        const uint32_t family_id = families.old_tablet_to_family[old_tablet_index];
+        auto& target = mutable_per_family_maps_for_ctx(lookup_maps, family_id, old_tablet_index);
 
         for (const auto& rowset : ctx.metadata()->rowsets()) {
             // Watermark map: rowset id (catches delete-only rowsets).
@@ -1757,7 +1843,7 @@ Status validate_legacy_shared_sstable_form(const PersistentIndexSstablePB& src_p
 // rebuilt file inherit a sensible max even when it ends up tombstone-only or
 // when its source max points at a delete-only rowset.
 // Convention: PersistentIndexSstablePB.max_rss_rowid.high is the EFFECTIVE
-// (post-projection) max rssid in the SOURCE child's id space — i.e. it
+// (post-projection) max rssid in the SOURCE old tablet's id space — i.e. it
 // already includes any accumulated src_pb.rssid_offset. Cross-sstable
 // invariants in lake_persistent_index.cpp (the I1 ordering check at
 // apply_opcompaction line 875-886, the _memtable seed at line 146-160,
@@ -1768,7 +1854,7 @@ Status validate_legacy_shared_sstable_form(const PersistentIndexSstablePB& src_p
 // Therefore the source rssid offset must NOT be added again here; doing
 // so would double-shift for any stacked-offset src (anything that has
 // gone through one round of project_non_shared). The lookup key is just
-// source_max_rssid_high directly — it is the source child's effective
+// source_max_rssid_high directly — it is the source old tablet's effective
 // max rssid, exactly the key shape watermark_rssid_map records.
 std::optional<uint64_t> project_source_max_rss_rowid(
         const PersistentIndexSstablePB& src_pb, int32_t /*source_rssid_offset*/,
@@ -1908,114 +1994,6 @@ StatusOr<bool> remap_legacy_entry_or_drop(IndexValuesWithVerPB* values_pb, int32
     return true;
 }
 
-// Try to project an ancestor-inherited shared PK sstable (shared=true,
-// !has_shared_rssid) without reading the source file. canonical_offset is
-// read from plan.family_legacy_sstable_offset; the dense walk verifies
-// data_rssid_map[lifted_rssid] == lifted_rssid + canonical_offset and that
-// the merged delvec at the final rssid is empty. Emit accumulates:
-//   out_pb.rssid_offset       = src_pb.rssid_offset + canonical_offset
-//   out_pb.max_rss_rowid.high = source_lifted_max + canonical_offset
-//
-// Returns true with out_pb filled when every safety check passes. On any
-// miss returns false and the caller falls back to
-// rebuild_legacy_shared_sstable; each fallback path increments a dedicated
-// counter so production can break down why fast-path missed.
-StatusOr<bool> try_fastpath_project_legacy_shared_sstable(const PersistentIndexSstablePB& src_pb, uint32_t family_id,
-                                                          const detail::RssidProjectionPlan& plan,
-                                                          const TabletMetadataPB& new_metadata,
-                                                          const LegacyRssidLookupMaps::PerFamilyMaps& rssid_lookup_maps,
-                                                          PersistentIndexSstablePB* out_pb) {
-    constexpr uint32_t kFastPathMaxRssidSpan = 8192;
-
-    if (family_id == detail::InferredSplitFamilies::kNoFamily) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_no_family << 1;
-        return false;
-    }
-    if (plan.unsafe_families.count(family_id) > 0) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family << 1;
-        return false;
-    }
-    auto family_offset_it = plan.family_legacy_sstable_offset.find(family_id);
-    if (family_offset_it == plan.family_legacy_sstable_offset.end()) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_no_family << 1;
-        return false;
-    }
-    const int64_t canonical_offset = family_offset_it->second;
-
-    // Form / range / fileset_id gates: identical legality contract to v1.
-    // Rebuild's PersistentIndexSstableFileset::init(vector) DCHECK requires
-    // a fileset_id on any ranged sstable, so the fast-path must too.
-    if (!validate_legacy_shared_sstable_form(src_pb).ok()) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_invalid_form << 1;
-        return false;
-    }
-    if (!new_metadata.has_range()) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_merged_no_range << 1;
-        return false;
-    }
-    if (src_pb.has_range() && !src_pb.has_fileset_id()) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_ranged_no_fileset_id << 1;
-        return false;
-    }
-
-    // Boundary / overflow checks. accumulated_offset must fit in int32 so
-    // it can be written back to the PB; new_lifted_max must fit in uint32
-    // so the high word is well-defined.
-    const int64_t accumulated_offset = static_cast<int64_t>(src_pb.rssid_offset()) + canonical_offset;
-    if (accumulated_offset < std::numeric_limits<int32_t>::min() ||
-        accumulated_offset > std::numeric_limits<int32_t>::max()) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
-        return false;
-    }
-    // max_rss_rowid.high is already in source-effective space (post-PR0).
-    const int64_t source_lifted_max = static_cast<int64_t>(extract_rss_rowid_high(src_pb.max_rss_rowid()));
-    const int64_t source_lifted_lower = static_cast<int64_t>(src_pb.rssid_offset()) + 1; // skip stored rssid 0
-    if (source_lifted_max < source_lifted_lower) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
-        return false;
-    }
-    if (source_lifted_max - source_lifted_lower + 1 > kFastPathMaxRssidSpan) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
-        return false;
-    }
-    const int64_t new_lifted_max = source_lifted_max + canonical_offset;
-    if (new_lifted_max < 0 || new_lifted_max > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
-        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
-        return false;
-    }
-
-    // Dense walk of [source_lifted_lower, source_lifted_max] in source-
-    // effective (canonical_ctx-local) space. For each lifted_rssid, expect:
-    //   data_rssid_map[lifted_rssid] == lifted_rssid + canonical_offset
-    // and the merged delvec at the FINAL rssid is empty (fast-path can't
-    // physically drop entries).
-    const auto& family_data_rssid_map = rssid_lookup_maps.data_rssid_map;
-    const auto& merged_delvecs = new_metadata.delvec_meta().delvecs();
-    for (int64_t lifted_rssid_64 = source_lifted_lower; lifted_rssid_64 <= source_lifted_max; ++lifted_rssid_64) {
-        const auto lifted_rssid = static_cast<uint32_t>(lifted_rssid_64);
-        const auto expected_final = static_cast<uint32_t>(lifted_rssid_64 + canonical_offset);
-        auto data_entry = family_data_rssid_map.find(lifted_rssid);
-        if (data_entry == family_data_rssid_map.end() || data_entry->second != expected_final) {
-            g_tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction << 1;
-            return false;
-        }
-        auto delvec_entry = merged_delvecs.find(expected_final);
-        if (delvec_entry != merged_delvecs.end() && delvec_entry->second.size() > 0) {
-            g_tablet_merge_legacy_sstable_fastpath_fallback_merged_delvec_nonempty << 1;
-            return false;
-        }
-    }
-
-    // Emit projected PB. PB.rssid_offset accumulates; max_rss_rowid.high
-    // (in effective space) shifts by canonical_offset. low word and every
-    // other field copy through unchanged.
-    out_pb->CopyFrom(src_pb);
-    out_pb->set_rssid_offset(static_cast<int32_t>(accumulated_offset));
-    out_pb->set_max_rss_rowid(
-            encode_rss_rowid(static_cast<uint32_t>(new_lifted_max), extract_rss_rowid_low(src_pb.max_rss_rowid())));
-    return true;
-}
-
 // Rebuilds an ancestor-inherited shared PK sstable (shared=true,
 // !has_shared_rssid) by reading every entry, remapping stored rssids to the
 // merged tablet's final rssid space via merge_contexts, applying the merged
@@ -2025,7 +2003,7 @@ StatusOr<bool> try_fastpath_project_legacy_shared_sstable(const PersistentIndexS
 // Why this is needed (run4 ghost-rssid bug): the legacy projection path only
 // accumulates a single rssid_offset per PB, but a single PK sstable file holds
 // entries for many ancestor rowsets. After multi-cycle split/merge with partial
-// child compaction, a surviving rowset can be assigned a NEW id by add_rowset
+// old tablet compaction, a surviving rowset can be assigned a NEW id by add_rowset
 // in some merge while the inherited sstable still stores the OLD id. PK lookup
 // then returns a stored rssid that no longer corresponds to any live rowset
 // in the merged tablet — `unexpected segment id` at publish time.
@@ -2039,11 +2017,11 @@ StatusOr<bool> try_fastpath_project_legacy_shared_sstable(const PersistentIndexS
 //       must apply it inline.
 //   (2) Per-entry rssid remap via the precomputed data_rssid_map (built once
 //       by build_legacy_rssid_lookup_maps) — drops entries whose source rowset
-//       is dead in every child.
+//       is dead in every old tablet.
 //   (3) Per-entry delvec filter via new_metadata.delvec_meta() — drops entries
 //       whose rowid is in the merged delvec, which by Phase 5 of merge_delvecs
 //       includes both real deletes and synthesized gap-bits for shared segments
-//       not covered by any contributing child's range.
+//       not covered by any contributing old tablet's range.
 //   (4) Watermark projection via the watermark_rssid_map (superset of the data
 //       map; also covers delete-only rowsets) — sets max_rss_rowid even when
 //       the file is tombstone-only or its source max points at a delete-only
@@ -2093,10 +2071,8 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
     }
     const sstable::Comparator* bytewise_comparator = sstable::BytewiseComparator();
 
-    // Maps are built once per merge_sstables() call and shared with the fast-path
-    // helper; both paths consult the same data + watermark mappings, so building
-    // them at the merge_sstables top avoids the quadratic walk that would
-    // otherwise scan merge_contexts × rowsets × segments per stored entry.
+    // Maps are built once per merge_sstables() call so the per-entry rebuild path
+    // doesn't re-scan merge_contexts × rowsets × segments for every stored entry.
 
     // Open the output writer and arm a cleanup guard so any failure path —
     // parse error, delvec load, builder Add, builder Finish, close — and the
@@ -2108,7 +2084,7 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
 
     // Stored rssids in the file are in pre-projection space. The read path at
     // persistent_index_sstable.cpp:222-225 shifts them by src_pb.rssid_offset()
-    // to derive the effective rssid in the current child's id space. Apply the
+    // to derive the effective rssid in the current old tablet's id space. Apply the
     // same shift before lookup so a stacked-offset legacy sstable still
     // resolves correctly.
     const int32_t source_rssid_offset = src_pb.rssid_offset();
@@ -2191,47 +2167,23 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
     return Status::OK();
 }
 
-// Emit the projected PB for one ancestor-inherited shared PK sstable into
-// |out_pb|. Tries the metadata-only fast-path first; on any safety miss
-// falls back to rebuild_legacy_shared_sstable. An empty out_pb after this
-// call means rebuild dropped every entry — the caller should NOT emit it
-// to the merged sstable_meta.
-Status emit_legacy_shared_sstable_via_fastpath_or_rebuild(TabletManager* tablet_manager, int64_t merged_tablet_id,
-                                                          const PersistentIndexSstablePB& src_pb,
-                                                          const TabletMetadataPtr& src_metadata,
-                                                          const TabletMetadataPB& new_metadata, uint32_t family_id,
-                                                          const detail::RssidProjectionPlan& plan,
-                                                          const LegacyRssidLookupMaps::PerFamilyMaps& rssid_lookup_maps,
-                                                          PersistentIndexSstablePB* out_pb) {
-    ASSIGN_OR_RETURN(bool fastpath_succeeded,
-                     try_fastpath_project_legacy_shared_sstable(src_pb, family_id, plan, new_metadata,
-                                                                rssid_lookup_maps, out_pb));
-    if (fastpath_succeeded) {
-        g_tablet_merge_legacy_sstable_fastpath_total << 1;
-        return Status::OK();
-    }
-    g_tablet_merge_legacy_sstable_fastpath_fallback_to_rebuild_total << 1;
-    return rebuild_legacy_shared_sstable(tablet_manager, merged_tablet_id, src_pb, src_metadata, new_metadata,
-                                         rssid_lookup_maps, out_pb);
-}
-
 // Rebuild a non-shared legacy sstable (shared=false, !has_shared_rssid)
 // by reading every entry, remapping stored rssid via ctx.map_rssid (which
 // honors the family-canonical projection), and writing a fresh non-shared
 // sstable. Used when the source sstable contains entries referencing both
-// shared-ancestor and child-local rowsets — typically a post-split PK-index
+// shared-ancestor and old-tablet-local rowsets — typically a post-split PK-index
 // compaction output that crossed the shared-ancestor boundary — which a
 // single PB-level rssid_offset shift cannot translate uniformly.
 //
 // Differences from rebuild_legacy_shared_sstable:
-//   - SeekToFirst (non-shared sstable was written within this child's
+//   - SeekToFirst (non-shared sstable was written within this old tablet's
 //     range, which is a subset of the merged range; no tablet-range
 //     filter needed).
 //   - No per-rssid delvec filter (matches v1 project_non_shared_legacy_-
 //     sstable; merged delvec is applied by the read path at lookup
 //     time, not pre-baked into the projected PB).
 //   - Per-entry remap via ctx.map_rssid instead of a family-scoped
-//     data_rssid_map (covers both shared-ancestor and child-local
+//     data_rssid_map (covers both shared-ancestor and old-tablet-local
 //     rowsets in a single funnel).
 //
 // On success out_pb carries a non-shared PB pointing at a new file with
@@ -2333,7 +2285,7 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
 // Always re-attaches the merged delvec from |new_metadata->delvec_meta()|
 // regardless of whether the source carried one — this is what lets a
 // synthesized gap-delvec (created by merge_delvecs Phase 0 for keys covered
-// by no contributing child) reach the rebuilt sstable PB. Without it,
+// by no contributing old tablet) reach the rebuilt sstable PB. Without it,
 // PersistentIndexSstable::multi_get could return stale rssids when the LSM
 // block-sort order is inverted.
 Status project_modern_shared_rssid_sstable(const PersistentIndexSstablePB& sst, TabletMergeContext& ctx,
@@ -2352,9 +2304,9 @@ Status project_modern_shared_rssid_sstable(const PersistentIndexSstablePB& sst, 
     return Status::OK();
 }
 
-// Project a non-shared sstable without shared_rssid: a child-local file
+// Project a non-shared sstable without shared_rssid: an old-tablet-local file
 // produced by flush_pk_memtable for THIS merge round, or a rebuilt legacy
-// file from a prior merge. Stored rssids already live in the child's id
+// file from a prior merge. Stored rssids already live in the old tablet's id
 // space, so a single ctx.rssid_offset() shift suffices. The accumulation
 // preserves correctness when the file already carries a non-zero
 // rssid_offset (stacked merge case).
@@ -2410,8 +2362,8 @@ Status project_non_shared_legacy_sstable(const PersistentIndexSstablePB& sst, co
 // flushed sstable inherit an existing fileset's _fileset_id whenever the
 // new sstable's key range strictly extends the existing range. In a
 // multi-cycle SPLIT/MERGE flow, flush_pk_memtable on each merge context can
-// add a per-child sstable that inherits the same source FID-X from a long-
-// lived shared sstable. After projection these per-child flushes spread
+// add a per-old-tablet sstable that inherits the same source FID-X from a long-
+// lived shared sstable. After projection these per-old-tablet flushes spread
 // across a wide max_rss_rowid range intermixed with other-FID compaction
 // outputs, so a single sort by max_rss_rowid necessarily produces multiple
 // non-contiguous runs of FID-X.
@@ -2502,24 +2454,15 @@ ClampedLiftedRange clamp_lifted_range_to_uint32(int32_t source_rssid_offset, uin
     return range;
 }
 
-// Resolve the family-canonical projection plan for a ctx. Non-PK merges
-// leave the plan pointer null; the fast-path emit still wants a plan
-// reference, so an empty static instance acts as a safe identity.
-const detail::RssidProjectionPlan& projection_plan_or_empty(const TabletMergeContext& ctx) {
-    static const detail::RssidProjectionPlan kEmptyPlan{};
-    const auto* plan = ctx.projection_plan();
-    return (plan != nullptr) ? *plan : kEmptyPlan;
-}
-
 // Returns the highest (rowset.id + step + ctx.rssid_offset) seen across
 // merge_contexts[0..upper_exclusive), or |base_next_rowset_id| if higher.
 // Phase 1 in merge_tablet uses this as the watermark for ctx[i]'s
-// rssid_offset assignment so each child's projected rowset ids land
-// strictly above every earlier child's projected ids.
+// rssid_offset assignment so each old tablet's projected rowset ids land
+// strictly above every earlier old tablet's projected ids.
 //
 // Each uint32_t addend is widened to int64_t before the addition to avoid
 // uint32_t wrap when rowset.id() approaches UINT32_MAX — wrap there would
-// under-estimate the watermark and let later children reuse occupied rssids.
+// under-estimate the watermark and let later old tablets reuse occupied rssids.
 uint32_t compute_cumulative_rowset_id_ceiling(const std::vector<TabletMergeContext>& merge_contexts,
                                               size_t upper_exclusive, uint32_t base_next_rowset_id) {
     uint32_t ceiling = base_next_rowset_id;
@@ -2537,22 +2480,21 @@ uint32_t compute_cumulative_rowset_id_ceiling(const std::vector<TabletMergeConte
 }
 
 // Emit one ancestor-inherited shared PK sstable (shared=true,
-// !has_shared_rssid) into dest via the fast-path or its rebuild fallback.
-// Resolves family_id, the family's PerFamilyMaps, and the projection plan
-// from ctx. Drops sstables whose rebuild emitted no entries (matches the
-// cleanup contract documented on rebuild_legacy_shared_sstable).
+// !has_shared_rssid) into dest by rebuilding it onto the merged tablet's id
+// space. Resolves family_id and the family's PerFamilyMaps from ctx. Drops
+// sstables whose rebuild emitted no entries (matches the cleanup contract
+// documented on rebuild_legacy_shared_sstable).
 Status emit_legacy_shared_sstable_into_dest(TabletManager* tablet_manager, const TabletMergeContext& ctx,
-                                            size_t child_index, const PersistentIndexSstablePB& src_pb,
+                                            size_t old_tablet_index, const PersistentIndexSstablePB& src_pb,
                                             const TabletMetadataPB& new_metadata,
                                             const detail::InferredSplitFamilies& families,
                                             const LegacyRssidLookupMaps& rssid_lookup_maps,
                                             ::google::protobuf::RepeatedPtrField<PersistentIndexSstablePB>* dest) {
-    const uint32_t family_id = families.child_to_family[child_index];
-    ASSIGN_OR_RETURN(const auto* family_maps_ptr, lookup_maps_for_ctx(rssid_lookup_maps, family_id, child_index));
+    const uint32_t family_id = families.old_tablet_to_family[old_tablet_index];
+    ASSIGN_OR_RETURN(const auto* family_maps_ptr, lookup_maps_for_ctx(rssid_lookup_maps, family_id, old_tablet_index));
     PersistentIndexSstablePB projected_pb;
-    RETURN_IF_ERROR(emit_legacy_shared_sstable_via_fastpath_or_rebuild(
-            tablet_manager, new_metadata.id(), src_pb, ctx.metadata(), new_metadata, family_id,
-            projection_plan_or_empty(ctx), *family_maps_ptr, &projected_pb));
+    RETURN_IF_ERROR(rebuild_legacy_shared_sstable(tablet_manager, new_metadata.id(), src_pb, ctx.metadata(),
+                                                  new_metadata, *family_maps_ptr, &projected_pb));
     if (!projected_pb.filename().empty()) {
         dest->Add()->Swap(&projected_pb);
     }
@@ -2560,8 +2502,8 @@ Status emit_legacy_shared_sstable_into_dest(TabletManager* tablet_manager, const
 }
 
 // Emit one non-shared legacy PK sstable (shared=false, !has_shared_rssid)
-// into dest. Routes through the per-entry rebuild path when the projection
-// plan would map some referenced rssid to a value that disagrees with the
+// into dest. Routes through the per-entry rebuild path when ctx.map_rssid
+// would remap some referenced rssid to a value that disagrees with the
 // natural ctx.rssid_offset shift; otherwise the metadata-only
 // project_non_shared_legacy_sstable path applies.
 Status emit_non_shared_legacy_sstable_into_dest(TabletManager* tablet_manager, const TabletMergeContext& ctx,
@@ -2591,7 +2533,7 @@ Status emit_non_shared_legacy_sstable_into_dest(TabletManager* tablet_manager, c
 Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeContext>& merge_contexts,
                       TabletMetadataPB* new_metadata) {
     auto* dest = new_metadata->mutable_sstable_meta()->mutable_sstables();
-    // Tracks shared sstables by filename so subsequent occurrences across child
+    // Tracks shared sstables by filename so subsequent occurrences across old tablet
     // contexts are deduped + consistency-checked against the original source PB.
     // We cache the SOURCE PB (not an index into dest) because the legacy-shared
     // rebuild path can either replace the emitted PB with one that has a
@@ -2603,32 +2545,31 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
 
     // PK-index memtable flush has to run first (below) before the lookup maps
     // can be built — flushed metadata may add new rowsets the legacy path needs
-    // to remap into. Build the maps lazily once after the flush phase, and
-    // reuse them for both the fast-path and the rebuild fallback.
+    // to remap into. Build the maps lazily once after the flush phase.
     bool rssid_lookup_maps_initialized = false;
     LegacyRssidLookupMaps rssid_lookup_maps;
     detail::InferredSplitFamilies inferred_families;
     auto ensure_rssid_lookup_maps = [&]() -> Status {
         if (rssid_lookup_maps_initialized) return Status::OK();
         // Family inference and lookup-map population must consume the same
-        // merge_contexts snapshot so per-ctx child_index → family_id mapping
+        // merge_contexts snapshot so per-ctx old_tablet_index → family_id mapping
         // remains in lockstep with per-ctx contributions to the per-family
         // PerFamilyMaps.
-        std::vector<detail::SplitFamilyInferenceInput> inference_inputs;
+        TabletMetadataPtrs inference_inputs;
         inference_inputs.reserve(merge_contexts.size());
         for (const auto& ctx : merge_contexts) {
-            inference_inputs.push_back({ctx.metadata(), ctx.rssid_offset()});
+            inference_inputs.push_back(ctx.metadata());
         }
         ASSIGN_OR_RETURN(inferred_families, detail::infer_split_families(inference_inputs));
         ASSIGN_OR_RETURN(rssid_lookup_maps, build_legacy_rssid_lookup_maps(merge_contexts, inferred_families));
         rssid_lookup_maps_initialized = true;
         return Status::OK();
     };
-    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
-        auto& ctx = merge_contexts[child_index];
+    for (size_t old_tablet_index = 0; old_tablet_index < merge_contexts.size(); ++old_tablet_index) {
+        auto& ctx = merge_contexts[old_tablet_index];
         // Flush the tablet's PK-index memtable into sstables so that the
         // inherited sstable_meta covers all live data of its rowsets. Covers
-        // the case where a child accumulated post-split DML that never
+        // the case where an old tablet accumulated post-split DML that never
         // reached shared storage before merge; see the symmetric call in
         // split_tablet for the pre-split side of the invariant.
         ASSIGN_OR_RETURN(auto flushed_metadata, update_manager->flush_pk_memtable(ctx.metadata()));
@@ -2660,12 +2601,12 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
 
             // (2) Ancestor-inherited shared PK sstable (shared=true,
             // !has_shared_rssid): legacy form, may need rebuild after
-            // multi-cycle split/merge with partial-child compaction.
+            // multi-cycle split/merge with partial-old-tablet compaction.
             // The current ctx is the dedup-winner by construction:
             // shared_dedup_sources only emplaces on first sighting.
             if (sst.shared() && !sst.has_shared_rssid()) {
                 RETURN_IF_ERROR(ensure_rssid_lookup_maps());
-                RETURN_IF_ERROR(emit_legacy_shared_sstable_into_dest(tablet_manager, ctx, child_index, sst,
+                RETURN_IF_ERROR(emit_legacy_shared_sstable_into_dest(tablet_manager, ctx, old_tablet_index, sst,
                                                                      *new_metadata, inferred_families,
                                                                      rssid_lookup_maps, dest));
                 continue;
@@ -2680,13 +2621,13 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
                 continue;
             }
 
-            // (4) Non-shared, non-modern: child-local PK sstable.
+            // (4) Non-shared, non-modern: old-tablet-local PK sstable.
             RETURN_IF_ERROR(emit_non_shared_legacy_sstable_into_dest(tablet_manager, ctx, sst, *new_metadata,
                                                                      ctx_disagreement_keys, dest));
         }
     }
 
-    // The merge above appended projected sstables in source-child iteration
+    // The merge above appended projected sstables in source old tablet iteration
     // order. Re-sort by signed max_rss_rowid and reassign fileset_ids on
     // non-contiguous reuse so the emitted sstable_meta satisfies both the
     // signed-monotone (I1) and contiguous-fileset (I2) invariants. See the
@@ -2703,10 +2644,10 @@ void update_next_rowset_id(TabletMetadataPB* metadata) {
     // Also consider sstable_meta projected max_rss_rowid. merge_sstables advances
     // each shared sstable's high word by ctx.rssid_offset (tablet_merger.cpp ~615),
     // and the legacy non-shared_rssid branch can produce projected high words
-    // larger than any surviving rowset.id (e.g. when a delete-only sstable from a
-    // child contributes a high rssid that has no corresponding rowset in the merged
+    // larger than any surviving rowset.id (e.g. when a delete-only sstable from an
+    // old tablet contributes a high rssid that has no corresponding rowset in the merged
     // metadata). If next_rowset_id is set from rowset.id alone, future writes on
-    // this tablet — and on SPLIT children that inherit this metadata — will assign
+    // this tablet — and on SPLIT new tablets that inherit this metadata — will assign
     // rssids smaller than the projected sstable highs, producing sstables whose
     // max_rss_rowid is LESS than existing entries and violating the ascending-order
     // invariant that LakePersistentIndex::commit() (lake_persistent_index.cpp:881)
@@ -2729,7 +2670,7 @@ void update_next_rowset_id(TabletMetadataPB* metadata) {
 }
 
 void merge_schemas(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
-    // Step 1: Collect all historical_schemas from all children (union by schema_id)
+    // Step 1: Collect all historical_schemas from all old tablets (union by schema_id)
     auto* merged_schemas = new_metadata->mutable_historical_schemas();
     merged_schemas->clear();
     for (const auto& ctx : merge_contexts) {
@@ -2828,38 +2769,9 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     }
     new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
 
-    // Phase 1.5: build the family-canonical projection plan once Phase 1
-    // has populated rssid_offset, and wire (_child_index, _projection_plan)
-    // onto every TabletMergeContext. The plan drives three consumers:
-    //   - TabletMergeContext::map_rssid (priority 1 lookup);
-    //   - the legacy-sstable fast-path (plan.family_legacy_sstable_offset
-    //     + per-family LegacyRssidLookupMaps);
-    //   - merge_sstables's non-shared dispatch via
-    //     mapping_disagrees_with_natural_in_range, which routes mixed-
-    //     reference sstables to rebuild_non_shared_legacy_sstable.
-    //
-    // PK gate only — non-PK tables skip the build and leave the plan
-    // pointer null; map_rssid then degenerates to the
-    // shared_rssid_map → natural offset path.
-    detail::InferredSplitFamilies inferred_families;
-    detail::RssidProjectionPlan projection_plan;
-    if (is_primary_key(*new_tablet_metadata)) {
-        std::vector<detail::SplitFamilyInferenceInput> inference_inputs;
-        inference_inputs.reserve(merge_contexts.size());
-        for (const auto& ctx : merge_contexts) {
-            inference_inputs.push_back({ctx.metadata(), ctx.rssid_offset()});
-        }
-        ASSIGN_OR_RETURN(inferred_families, detail::infer_split_families(inference_inputs));
-        ASSIGN_OR_RETURN(projection_plan, detail::build_rssid_projection_plan(inference_inputs, inferred_families));
-        for (size_t i = 0; i < merge_contexts.size(); ++i) {
-            merge_contexts[i].set_child_index(static_cast<uint32_t>(i));
-            merge_contexts[i].set_projection_plan(&projection_plan);
-        }
-    }
-
     // Phase 2: Merge rowsets (version-driven k-way merge with dedup).
     // canonical_contribs collects each canonical rowset's contributing
-    // children's child-local ranges; consumed by the PK fail-fast coverage
+    // old tablets' old-tablet-local ranges; consumed by the PK fail-fast coverage
     // check below and by gap-delvec synthesis.
     CanonicalContribMap canonical_contribs;
     RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get(), &canonical_contribs));
@@ -2882,6 +2794,15 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // Phase 4: Finalize
     update_next_rowset_id(new_tablet_metadata.get());
 
+    // No re-share here: the merged tablet OWNS its segments via the same ownership-transfer
+    // model that the identical-tablet and split paths already use. The source old tablets
+    // are marked all-shared (set_all_data_files_shared in tablet_reshard.cpp), so their
+    // drop/vacuum skips these files; the merged tablet then inherits the split-side
+    // per-segment flags unchanged. A split-pruned segment keeps shared=false (owned by the
+    // merged tablet, freed by its own GC); a spanning segment keeps shared=true (still
+    // referenced by any non-merged split sibling). Leaving the flags untouched keeps
+    // genuinely-private compaction/rewrite outputs on the local-output GC path rather than
+    // leaking them onto the shared-file path.
     return new_tablet_metadata;
 }
 

--- a/be/src/storage/lake/tablet_merger_split_family.cpp
+++ b/be/src/storage/lake/tablet_merger_split_family.cpp
@@ -14,44 +14,21 @@
 
 #include "storage/lake/tablet_merger_split_family.h"
 
-#include <fmt/format.h>
-
-#include <algorithm>
-#include <optional>
+#include <map>
 #include <unordered_map>
 #include <utility>
 
-#include "base/hash/hash_util.hpp"
-#include "common/logging.h"
+#include "base/uid_util.h"
 #include "common/status.h"
-#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet_reshard_helper.h"
 
 namespace starrocks::lake::detail {
 
 namespace {
 
-// Compute a rowset's lifted rssid for a given segment position WITHOUT
-// risking uint32_t wraparound that get_rssid()'s native return type would
-// silently allow. Returns std::nullopt when rowset.id() + segment_idx
-// would overflow uint32; the caller must mark the affected family unsafe
-// in that case.
-std::optional<uint32_t> safe_lifted_segment_rssid(const RowsetMetadataPB& rowset_meta, int32_t segment_pos) {
-    const uint64_t lifted =
-            static_cast<uint64_t>(rowset_meta.id()) + static_cast<uint64_t>(get_segment_idx(rowset_meta, segment_pos));
-    if (lifted > std::numeric_limits<uint32_t>::max()) {
-        return std::nullopt;
-    }
-    return static_cast<uint32_t>(lifted);
-}
-
-template <typename T>
-inline void fold_into_hash(size_t& hash, const T& value) {
-    HashUtil::hash_combine(hash, value);
-}
-
 // Standard union-find with the smallest member always rising to the root.
-// This makes find(x) deterministically return the minimum child_index in
-// x's family, which is exactly what canonical_child_index needs.
+// This makes find(x) deterministically return the minimum old_tablet_index in
+// x's family, which is exactly what canonical_old_tablet_index needs.
 class UnionFind {
 public:
     explicit UnionFind(uint32_t n) : _parent(n) {
@@ -71,7 +48,7 @@ public:
         const uint32_t root_y = find(y);
         if (root_x == root_y) return;
         // The smaller root absorbs the larger root, so the canonical
-        // (smallest) child stays at the family's root after every union.
+        // (smallest) old tablet stays at the family's root after every union.
         if (root_x < root_y) {
             _parent[root_y] = root_x;
         } else {
@@ -85,296 +62,84 @@ private:
 
 } // namespace
 
-size_t RowsetPhysicalKeyHash::operator()(const RowsetPhysicalKey& key) const noexcept {
-    size_t hash = std::hash<int64_t>{}(key.version);
-    for (const auto& segment : key.segments) {
-        fold_into_hash(hash, segment);
-    }
-    for (const auto offset : key.bundle_file_offsets) {
-        fold_into_hash(hash, offset);
-    }
-    for (const auto flag : key.shared_segments_flags) {
-        // std::hash<bool> exists but is trivial; cast to int8 first so
-        // false / true don't collide with adjacent integer fields.
-        fold_into_hash(hash, static_cast<int8_t>(flag));
-    }
-    for (const auto idx : key.segment_idx_layout) {
-        fold_into_hash(hash, idx);
-    }
-    return hash;
-}
-
-RowsetPhysicalKey make_rowset_physical_key(const RowsetMetadataPB& rowset_meta) {
-    RowsetPhysicalKey key;
-    key.version = rowset_meta.version();
-
-    // Normalize bundle_file_offsets and segment_idx_layout to ALWAYS have one
-    // entry per segment, falling back to documented defaults when the PB
-    // omits them. Without this, two physically-equivalent rowsets where one
-    // copy has the field populated (e.g., `bundle_file_offset = 0`)
-    // and the other has it absent would hash
-    // and compare unequal — a false-negative family inference that loses the
-    // canonical projection. PB defaults match production read semantics:
-    // bundle_file_offset defaults to 0 per segment, and segment_idx falls
-    // back to positional index per get_segment_idx() in meta_file.cpp.
-    const int segments_count = rowset_meta.segment_metas_size();
-    key.segments.reserve(segments_count);
-    key.shared_segments_flags.reserve(segments_count);
-    key.bundle_file_offsets.reserve(segments_count);
-    key.segment_idx_layout.reserve(segments_count);
-    for (int segment_pos = 0; segment_pos < segments_count; ++segment_pos) {
-        const auto& segment_meta = rowset_meta.segment_metas(segment_pos);
-        key.segments.push_back(segment_meta.filename());
-        key.shared_segments_flags.push_back(segment_meta.shared());
-        const int64_t bundle_offset = segment_meta.has_bundle_file_offset() ? segment_meta.bundle_file_offset() : 0;
-        key.bundle_file_offsets.push_back(bundle_offset);
-        key.segment_idx_layout.push_back(static_cast<int32_t>(get_segment_idx(rowset_meta, segment_pos)));
-    }
-    return key;
-}
-
-bool is_shared_ancestor_rowset(const RowsetMetadataPB& rowset_meta) {
-    if (rowset_meta.segment_metas_size() == 0) return false;
-    return std::all_of(rowset_meta.segment_metas().begin(), rowset_meta.segment_metas().end(),
-                       [](const auto& segment_meta) { return segment_meta.shared(); });
-}
-
-StatusOr<InferredSplitFamilies> infer_split_families(const std::vector<SplitFamilyInferenceInput>& inputs) {
+StatusOr<InferredSplitFamilies> infer_split_families(const TabletMetadataPtrs& old_tablet_metadatas) {
     InferredSplitFamilies result;
-    const auto child_count = static_cast<uint32_t>(inputs.size());
-    result.child_to_family.assign(child_count, InferredSplitFamilies::kNoFamily);
-    if (child_count == 0) {
+    const auto old_tablet_count = static_cast<uint32_t>(old_tablet_metadatas.size());
+    result.old_tablet_to_family.assign(old_tablet_count, InferredSplitFamilies::kNoFamily);
+    if (old_tablet_count == 0) {
         return result;
     }
 
-    UnionFind union_find(child_count);
+    UnionFind union_find(old_tablet_count);
 
     // Edge (1): legacy `shared && !has_shared_rssid` sstable filename.
-    // Two children that reference the same legacy file must come from the
+    // Two old tablets that reference the same legacy file must come from the
     // same SPLIT family (the file is bytes-immutable; SPLIT marks shared
     // copies but doesn't rewrite anything).
-    std::unordered_map<std::string, uint32_t> filename_to_first_child;
-    for (uint32_t child_index = 0; child_index < child_count; ++child_index) {
-        const auto& metadata = inputs[child_index].metadata;
+    std::unordered_map<std::string, uint32_t> filename_to_first_old_tablet;
+    for (uint32_t old_tablet_index = 0; old_tablet_index < old_tablet_count; ++old_tablet_index) {
+        const auto& metadata = old_tablet_metadatas[old_tablet_index];
         if (metadata == nullptr || !metadata->has_sstable_meta()) continue;
         for (const auto& sstable : metadata->sstable_meta().sstables()) {
             if (!sstable.shared() || sstable.has_shared_rssid()) continue;
-            auto [iter, inserted] = filename_to_first_child.emplace(sstable.filename(), child_index);
+            auto [iter, inserted] = filename_to_first_old_tablet.emplace(sstable.filename(), old_tablet_index);
             if (!inserted) {
-                union_find.unite(iter->second, child_index);
+                union_find.unite(iter->second, old_tablet_index);
             }
         }
     }
 
-    // Edge (2): full physical identity of a shared-ancestor rowset. Both
-    // children must satisfy is_shared_ancestor_rowset() — delete-only and
-    // child-local rowsets are filtered out so two physically-matching but
-    // unrelated rowsets cannot create a false union.
-    std::unordered_map<RowsetPhysicalKey, uint32_t, RowsetPhysicalKeyHash> rowset_key_to_first_child;
-    for (uint32_t child_index = 0; child_index < child_count; ++child_index) {
-        const auto& metadata = inputs[child_index].metadata;
+    // Edge (2): uid family edge. Every rowset that should land in the same family
+    // carries the same uid: split lineage preserves it via CopyFrom, cross-publish writes
+    // mint and propagate it through the txn log, and synthesized rowsets like the
+    // column-mode "new rows" derive it deterministically from the source op_write's
+    // uid. Range-distribution is a new feature (no migration from existing tables),
+    // so every rowset reaching this point carries a valid uid — grouping by uid
+    // covers split-pruned siblings (disjoint segments[]) and shared-ancestor
+    // siblings (identical segments[]) alike. A locally produced rowset carries a
+    // unique uid and matches no sibling.
+    std::map<UniqueId, uint32_t> uid_to_first_old_tablet;
+    for (uint32_t old_tablet_index = 0; old_tablet_index < old_tablet_count; ++old_tablet_index) {
+        const auto& metadata = old_tablet_metadatas[old_tablet_index];
         if (metadata == nullptr) continue;
         for (const auto& rowset : metadata->rowsets()) {
-            if (!is_shared_ancestor_rowset(rowset)) continue;
-            auto key = make_rowset_physical_key(rowset);
-            auto [iter, inserted] = rowset_key_to_first_child.emplace(std::move(key), child_index);
-            if (!inserted) {
-                union_find.unite(iter->second, child_index);
+            if (!tablet_reshard_helper::has_valid_uid(rowset)) continue;
+            UniqueId uid_key(rowset.uid());
+            auto [iter, inserted] = uid_to_first_old_tablet.emplace(uid_key, old_tablet_index);
+            if (!inserted && iter->second != old_tablet_index) {
+                union_find.unite(iter->second, old_tablet_index);
             }
         }
     }
 
-    // Materialize families. members_by_root[r] ends up holding every child
+    // Materialize families. members_by_root[r] ends up holding every old tablet
     // whose union-find root is r. Because UnionFind always promotes the
     // smaller index to the root, members_by_root[r] is non-empty only when
     // r is the smallest member of its family — which is exactly the
-    // canonical child.
-    std::vector<std::vector<uint32_t>> members_by_root(child_count);
-    for (uint32_t child_index = 0; child_index < child_count; ++child_index) {
-        members_by_root[union_find.find(child_index)].push_back(child_index);
+    // canonical old tablet.
+    std::vector<std::vector<uint32_t>> members_by_root(old_tablet_count);
+    for (uint32_t old_tablet_index = 0; old_tablet_index < old_tablet_count; ++old_tablet_index) {
+        members_by_root[union_find.find(old_tablet_index)].push_back(old_tablet_index);
     }
-    for (uint32_t root_child_index = 0; root_child_index < child_count; ++root_child_index) {
-        auto& members = members_by_root[root_child_index];
+    for (uint32_t root_old_tablet_index = 0; root_old_tablet_index < old_tablet_count; ++root_old_tablet_index) {
+        auto& members = members_by_root[root_old_tablet_index];
         if (members.size() < 2) {
             // size 0 → not a root (its members were absorbed into a smaller root).
-            // size 1 → standalone child with no edges; leave as kNoFamily.
+            // size 1 → standalone old tablet with no edges; leave as kNoFamily.
             continue;
         }
         InferredSplitFamilies::Family family;
-        family.member_child_indexes = std::move(members);
-        // member_child_indexes is already in ascending order because we
-        // pushed children in iteration order (child_index 0..N-1).
-        family.canonical_child_index = family.member_child_indexes.front();
-        family.canonical_rssid_offset = inputs[family.canonical_child_index].rssid_offset;
+        family.member_old_tablet_indexes = std::move(members);
+        // member_old_tablet_indexes is already in ascending order because we
+        // pushed old tablets in iteration order (old_tablet_index 0..N-1).
+        family.canonical_old_tablet_index = family.member_old_tablet_indexes.front();
         const auto family_id = static_cast<uint32_t>(result.families.size());
-        for (const auto member : family.member_child_indexes) {
-            result.child_to_family[member] = family_id;
+        for (const auto member : family.member_old_tablet_indexes) {
+            result.old_tablet_to_family[member] = family_id;
         }
         result.families.push_back(std::move(family));
     }
     return result;
-}
-
-namespace {
-
-// Lift one occupancy candidate into the plan. On a clash with a prior
-// occupant carrying a different physical key, mark both involved families
-// unsafe so merge_rowsets + the fast-path fall back to natural-offset
-// behavior.
-void record_occupancy(uint32_t final_rssid, const RowsetPhysicalKey& key, uint32_t family_id,
-                      RssidProjectionPlan& plan) {
-    auto [iter, inserted] = plan.occupied_rssids.emplace(final_rssid, RssidProjectionPlan::Occupancy{key, family_id});
-    if (inserted) return;
-    if (iter->second.key == key) return; // dedup across family members; no-op
-    // Two physically-distinct rowsets want the same final rssid. Orphan ctx
-    // entries carry kNoFamily and are filtered — orphans use natural offset
-    // and don't go through the canonical projection.
-    if (family_id != InferredSplitFamilies::kNoFamily) {
-        plan.unsafe_families.insert(family_id);
-    }
-    if (iter->second.family_id != InferredSplitFamilies::kNoFamily) {
-        plan.unsafe_families.insert(iter->second.family_id);
-    }
-}
-
-// Try to project a single source rssid through the plan-building pass.
-// Returns false if the projection arithmetic overflows uint32_t (and
-// records the family as unsafe), so the outer loop can skip the
-// unprojectable entry without poisoning the plan.
-bool try_record_projection(uint32_t source_rssid, int64_t offset, const RowsetPhysicalKey& key, uint32_t family_id,
-                           RssidProjectionPlan& plan) {
-    const int64_t final_rssid = static_cast<int64_t>(source_rssid) + offset;
-    if (final_rssid < 0 || final_rssid > std::numeric_limits<uint32_t>::max()) {
-        if (family_id != InferredSplitFamilies::kNoFamily) {
-            plan.unsafe_families.insert(family_id);
-        }
-        return false;
-    }
-    record_occupancy(static_cast<uint32_t>(final_rssid), key, family_id, plan);
-    return true;
-}
-
-} // namespace
-
-StatusOr<RssidProjectionPlan> build_rssid_projection_plan(const std::vector<SplitFamilyInferenceInput>& inputs,
-                                                          const InferredSplitFamilies& families) {
-    // The plan must be built from the same (inputs, families) pair: a
-    // future caller diverging them would produce out-of-bounds accesses
-    // below, so validate in release as well as debug.
-    if (families.child_to_family.size() != inputs.size()) {
-        return Status::InvalidArgument(
-                "child_to_family size mismatches inputs size — InferredSplitFamilies must be built from these inputs");
-    }
-    for (uint32_t child_index = 0; child_index < families.child_to_family.size(); ++child_index) {
-        const uint32_t family_id = families.child_to_family[child_index];
-        if (family_id == InferredSplitFamilies::kNoFamily) continue;
-        if (family_id >= families.families.size()) {
-            return Status::InvalidArgument(fmt::format("child_to_family[{}] = {} but only {} families exist",
-                                                       child_index, family_id, families.families.size()));
-        }
-    }
-    for (uint32_t family_id = 0; family_id < families.families.size(); ++family_id) {
-        const auto& family = families.families[family_id];
-        for (const uint32_t member : family.member_child_indexes) {
-            if (member >= inputs.size()) {
-                return Status::InvalidArgument(
-                        fmt::format("InferredSplitFamilies references child_index {} but only {} inputs were provided",
-                                    member, inputs.size()));
-            }
-            // child_to_family must round-trip: a Family's member must map
-            // back to that family_id. Otherwise step 1 (which reads
-            // child_to_family) and step 2 (which iterates families) operate
-            // on inconsistent assumptions.
-            if (families.child_to_family[member] != family_id) {
-                return Status::InvalidArgument(
-                        fmt::format("InferredSplitFamilies inconsistency: families[{}] lists child {} as member but "
-                                    "child_to_family[{}] = {}",
-                                    family_id, member, member, families.child_to_family[member]));
-            }
-        }
-    }
-
-    RssidProjectionPlan plan;
-
-    // Step 1: walk every rowset in every ctx, claim its final rssids, and
-    // detect cross-family / orphan-vs-family collisions. A rowset's
-    // projection offset depends on whether it is a shared-ancestor inside
-    // a family (canonical offset) or otherwise (natural offset = the ctx's
-    // own rssid_offset, same as v1's add_rowset path).
-    for (uint32_t child_index = 0; child_index < inputs.size(); ++child_index) {
-        const auto& metadata = inputs[child_index].metadata;
-        if (metadata == nullptr) continue;
-        const uint32_t family_id = families.child_to_family[child_index];
-        DCHECK(family_id == InferredSplitFamilies::kNoFamily || family_id < families.families.size());
-        const int64_t natural_offset = inputs[child_index].rssid_offset;
-        const int64_t canonical_offset = (family_id != InferredSplitFamilies::kNoFamily)
-                                                 ? families.families[family_id].canonical_rssid_offset
-                                                 : natural_offset;
-
-        for (const auto& rowset : metadata->rowsets()) {
-            const bool use_canonical =
-                    family_id != InferredSplitFamilies::kNoFamily && is_shared_ancestor_rowset(rowset);
-            const int64_t offset = use_canonical ? canonical_offset : natural_offset;
-            const auto key = make_rowset_physical_key(rowset);
-
-            // Always claim rowset.id() — covers add_rowset's first
-            // map_rssid call AND rowset-level metadata (delvec keys, DCG
-            // keys) that use rowset.id() rather than a segment-position
-            // rssid.
-            try_record_projection(rowset.id(), offset, key, family_id, plan);
-
-            // Also claim every segment position. safe_lifted_segment_rssid
-            // checks for rowset.id() + segment_idx wraparound BEFORE
-            // narrowing to uint32_t; on overflow it returns nullopt and
-            // we mark the family unsafe (matches the wraparound treatment
-            // of the int64 overflow check inside try_record_projection).
-            for (int segment_pos = 0; segment_pos < rowset.segment_metas_size(); ++segment_pos) {
-                const auto lifted_or = safe_lifted_segment_rssid(rowset, segment_pos);
-                if (!lifted_or.has_value()) {
-                    if (family_id != InferredSplitFamilies::kNoFamily) {
-                        plan.unsafe_families.insert(family_id);
-                    }
-                    continue;
-                }
-                try_record_projection(*lifted_or, offset, key, family_id, plan);
-            }
-        }
-    }
-
-    // Step 2: populate explicit_rssid_map and family_legacy_sstable_offset
-    // for SAFE families only. For unsafe families the plan stays silent so
-    // map_rssid falls through to the natural-offset path automatically.
-    for (uint32_t family_id = 0; family_id < families.families.size(); ++family_id) {
-        if (plan.unsafe_families.count(family_id) > 0) continue;
-        const auto& family = families.families[family_id];
-        plan.family_legacy_sstable_offset.emplace(family_id, family.canonical_rssid_offset);
-
-        for (const uint32_t child_index : family.member_child_indexes) {
-            const auto& metadata = inputs[child_index].metadata;
-            if (metadata == nullptr) continue;
-            for (const auto& rowset : metadata->rowsets()) {
-                if (!is_shared_ancestor_rowset(rowset)) continue;
-
-                const int64_t rs_id_final = static_cast<int64_t>(rowset.id()) + family.canonical_rssid_offset;
-                // Step 1 already would have marked the family unsafe on
-                // overflow, but defensively skip the entry here too.
-                if (rs_id_final >= 0 && rs_id_final <= std::numeric_limits<uint32_t>::max()) {
-                    plan.explicit_rssid_map.emplace(SourceRssidKey{child_index, rowset.id()},
-                                                    static_cast<uint32_t>(rs_id_final));
-                }
-                for (int segment_pos = 0; segment_pos < rowset.segment_metas_size(); ++segment_pos) {
-                    const auto lifted_or = safe_lifted_segment_rssid(rowset, segment_pos);
-                    if (!lifted_or.has_value()) continue;
-                    const int64_t segment_final = static_cast<int64_t>(*lifted_or) + family.canonical_rssid_offset;
-                    if (segment_final < 0 || segment_final > std::numeric_limits<uint32_t>::max()) continue;
-                    plan.explicit_rssid_map.emplace(SourceRssidKey{child_index, *lifted_or},
-                                                    static_cast<uint32_t>(segment_final));
-                }
-            }
-        }
-    }
-
-    return plan;
 }
 
 } // namespace starrocks::lake::detail

--- a/be/src/storage/lake/tablet_merger_split_family.h
+++ b/be/src/storage/lake/tablet_merger_split_family.h
@@ -16,10 +16,6 @@
 
 #include <cstdint>
 #include <limits>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include "common/statusor.h"
@@ -28,162 +24,49 @@
 
 namespace starrocks::lake {
 
-// Internal helpers for the legacy shared PK sstable fast-path. Infers split
-// families across merge_contexts, then uses the canonical child's rssid
-// offset to project shared-ancestor rowsets and their referencing legacy
-// sstables onto matching final rssids in the merged tablet — so partial-
-// compaction across siblings can be remapped via metadata instead of
-// rebuilt entry-by-entry.
+// Split-family inference across the old tablets being merged. Groups old tablets
+// that share an sstable filename (Edge 1) or carry the same uid on any rowset
+// (Edge 2) — the canonical old tablet of each family is the smallest member
+// index. Each family identifies its canonical anchor so downstream code (the
+// legacy-shared-sstable rebuild path) can resolve per-family lookup maps.
 namespace detail {
 
-// Full physical identity for a rowset, used by family inference's rowset-
-// identity edge to decide whether two rowsets in different merge_contexts
-// are the same physical rowset (i.e. inherited from the same SPLIT). Must
-// be an exact match — partial signals (first segment only) can falsely
-// union unrelated rowsets across families.
-struct RowsetPhysicalKey {
-    int64_t version = 0;
-    std::vector<std::string> segments;
-    std::vector<int64_t> bundle_file_offsets;
-    std::vector<bool> shared_segments_flags;
-    std::vector<int32_t> segment_idx_layout;
-
-    bool operator==(const RowsetPhysicalKey& other) const = default;
-};
-
-struct RowsetPhysicalKeyHash {
-    size_t operator()(const RowsetPhysicalKey& key) const noexcept;
-};
-
-// Construct a RowsetPhysicalKey by copying every identifying field from a
-// rowset's metadata.
-RowsetPhysicalKey make_rowset_physical_key(const RowsetMetadataPB& rowset_meta);
-
-// Returns true iff the rowset is a candidate for the rowset-identity edge:
-// it has at least one segment, every segment is marked shared (inherited
-// from SPLIT, not produced by post-split DML or compaction), and the
-// shared_segments vector covers every segment position. Delete-only
-// rowsets (no segments) and child-local rowsets are excluded.
-bool is_shared_ancestor_rowset(const RowsetMetadataPB& rowset_meta);
-
-// Pure-data input for split family inference. Decoupled from
-// TabletMergeContext (which lives in tablet_merger.cpp's anonymous
-// namespace and cannot cross the TU boundary), so tests can construct
-// inputs directly without spinning up a full merge context.
-struct SplitFamilyInferenceInput {
-    TabletMetadataPtr metadata;
-    // Already-computed rssid_offset for this child (Phase 1 of merge_tablet
-    // sets ctx[i].rssid_offset before any merge_rowsets work; the inference
-    // helper just records it on the canonical entry of each family).
-    int64_t rssid_offset = 0;
-};
-
 // Inferred split families across a set of merge contexts. Each input
-// (= one child of the merge) belongs to AT MOST one family (or kNoFamily
-// for orphan / standalone children).
+// (= one old tablet of the merge) belongs to AT MOST one family (or kNoFamily
+// for orphan / standalone old tablets).
 struct InferredSplitFamilies {
     static constexpr uint32_t kNoFamily = std::numeric_limits<uint32_t>::max();
 
     struct Family {
-        // member child_indexes in ascending order. The smallest member is
-        // the canonical child for this family.
-        std::vector<uint32_t> member_child_indexes;
-        // == member_child_indexes.front(). Stored explicitly so callers
+        // member old_tablet_indexes in ascending order. The smallest member is
+        // the canonical old tablet for this family.
+        std::vector<uint32_t> member_old_tablet_indexes;
+        // == member_old_tablet_indexes.front(). Stored explicitly so callers
         // don't have to peek into the vector.
-        uint32_t canonical_child_index = 0;
-        // == inputs[canonical_child_index].rssid_offset at the moment of
-        // inference. Recorded once so subsequent consumers don't re-fetch
-        // it from the merge contexts.
-        int64_t canonical_rssid_offset = 0;
+        uint32_t canonical_old_tablet_index = 0;
     };
 
-    // child_index → family_id (kNoFamily for orphan).
-    std::vector<uint32_t> child_to_family;
-    // Indexed by family_id. Emitted in ascending canonical_child_index
+    // old_tablet_index → family_id (kNoFamily for orphan).
+    std::vector<uint32_t> old_tablet_to_family;
+    // Indexed by family_id. Emitted in ascending canonical_old_tablet_index
     // order (so the iteration is deterministic and matches the dedup
     // order in merge_sstables).
     std::vector<Family> families;
 };
 
 // Infer split families from a vector of merge inputs. Edges:
-//   (1) two children share a legacy `shared && !has_shared_rssid` sstable
+//   (1) two old tablets share a legacy `shared && !has_shared_rssid` sstable
 //       filename (catches the case where rowset duplication is incomplete
-//       across children but the shared sstable file is still common);
-//   (2) two children carry a rowset that satisfies is_shared_ancestor_
-//       rowset() AND has identical RowsetPhysicalKey. The shared-ancestor
-//       filter excludes delete-only and child-local rowsets that could
-//       otherwise produce false unions when their physical keys happen
-//       to match.
+//       across old tablets but the shared sstable file is still common);
+//   (2) two old tablets carry a rowset with the same uid (universal uid
+//       coverage in lake-mode range-distribution tablets means every cross-
+//       sibling logical rowset converges on one uid here — split-pruned
+//       siblings, shared-ancestor siblings, cross-published siblings alike).
 //
-// Children with no edges to any other child get kNoFamily. Family ids are
-// assigned in ascending canonical_child_index order; canonical_child_index
-// is always the smallest child_index in the family.
-StatusOr<InferredSplitFamilies> infer_split_families(const std::vector<SplitFamilyInferenceInput>& inputs);
-
-// Composite key for RssidProjectionPlan::explicit_rssid_map. Named fields
-// prevent positional swaps at call sites.
-struct SourceRssidKey {
-    uint32_t child_index = 0;
-    uint32_t source_rssid = 0;
-
-    bool operator==(const SourceRssidKey& other) const = default;
-};
-
-struct SourceRssidKeyHash {
-    size_t operator()(const SourceRssidKey& key) const noexcept {
-        return std::hash<uint64_t>{}((static_cast<uint64_t>(key.child_index) << 32) | key.source_rssid);
-    }
-};
-
-// Concrete projection plan: for each (child_index, source_rssid) the plan
-// records the final rssid the merge will assign in the merged tablet's id
-// space. Consumed by ctx.map_rssid() and the legacy-sstable fast-path.
-struct RssidProjectionPlan {
-    // (child_index, source_rssid) → final_rssid for shared-ancestor rowsets
-    // in safe families. Populated for both the rowset.id() key (covers
-    // add_rowset's first map_rssid call and rowset-level metadata such as
-    // delvec keys) and every get_rssid(rowset, segment_position) key
-    // (covers data-entry remap with sparse segment_idx layouts).
-    std::unordered_map<SourceRssidKey, uint32_t, SourceRssidKeyHash> explicit_rssid_map;
-
-    // family_id → accumulated rssid_offset to write into emitted legacy
-    // sstable PBs by the fast-path. Recorded only for safe families.
-    std::unordered_map<uint32_t, int64_t> family_legacy_sstable_offset;
-
-    // Occupancy table for collision detection during plan build. Each
-    // entry records which physical rowset claimed a given final rssid AND
-    // which family that rowset belonged to (or kNoFamily if it came from
-    // an orphan ctx). The plan's consumers do NOT read this map at runtime;
-    // it is exposed for tests and diagnostics.
-    struct Occupancy {
-        RowsetPhysicalKey key;
-        uint32_t family_id; // == InferredSplitFamilies::kNoFamily for orphan
-    };
-    std::unordered_map<uint32_t, Occupancy> occupied_rssids;
-
-    // family_ids that hit a collision during plan build. The fast-path
-    // treats every sstable in an unsafe family as a fallback rebuild;
-    // merge_rowsets skips the explicit projection for member rowsets and
-    // lets first-emitter natural assignment take over.
-    std::unordered_set<uint32_t> unsafe_families;
-};
-
-// Build the projection plan from the merge inputs and the inferred families.
-//
-// Step 1: for every (ctx, rowset, key_position) — where key_position is
-// rowset.id() or each get_rssid(rowset, segment_position) — record an
-// occupancy at key_position + offset, where offset is the family's
-// canonical_rssid_offset for shared-ancestor rowsets and ctx.rssid_offset
-// otherwise. A second claim on the same final rssid by a different physical
-// rowset marks both involved families unsafe.
-//
-// Step 2: for every safe family, populate explicit_rssid_map for every
-// shared-ancestor rowset's rowset.id() and every segment position, and
-// record family_legacy_sstable_offset[family_id].
-//
-// Any final-rssid arithmetic that overflows uint32_t marks the family unsafe.
-StatusOr<RssidProjectionPlan> build_rssid_projection_plan(const std::vector<SplitFamilyInferenceInput>& inputs,
-                                                          const InferredSplitFamilies& families);
+// Old tablets with no edges to any other old tablet get kNoFamily. Family ids are
+// assigned in ascending canonical_old_tablet_index order; canonical_old_tablet_index
+// is always the smallest old_tablet_index in the family.
+StatusOr<InferredSplitFamilies> infer_split_families(const TabletMetadataPtrs& old_tablet_metadatas);
 
 } // namespace detail
 

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -43,6 +43,9 @@ bvar::Adder<int64_t> g_tablet_reshard_split_output_tablet_count("tablet_reshard_
 bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total("tablet_reshard_split_fallback_total");
 bvar::Adder<int64_t> g_tablet_reshard_split_external_boundaries_fallback_total(
         "tablet_reshard_split_external_boundaries_fallback_total");
+// Phase-1 per-segment shared optimization counters.
+bvar::Adder<int64_t> g_tablet_reshard_split_exclusive_segments_total("tablet_reshard_split_exclusive_segments_total");
+bvar::Adder<int64_t> g_tablet_reshard_split_anomaly_total("tablet_reshard_split_anomaly_total");
 
 // Layer 2: Merge metrics
 bvar::Adder<int64_t> g_tablet_reshard_merge_total("tablet_reshard_merge_total");
@@ -334,14 +337,15 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
     new_tablet_new_metadata->clear_compaction_inputs();
     new_tablet_new_metadata->clear_orphan_files();
     new_tablet_new_metadata->clear_prev_garbage_version();
+    // uid is inherited verbatim from the source rowsets via the metadata copy above.
     new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(new_tablet_new_metadata));
     return Status::OK();
 }
 
-// Transform |txn_log| (which still carries the source tablet id) for publish
+// Transform |txn_log| (which still carries the old tablet id) for publish
 // on the merged tablet. Drops compaction as a no-op (background compaction
 // will rerun it on the merged tablet) and asynchronously deletes the output
-// files that the compaction had already written under the source tablet's path.
+// files that the compaction had already written under the old tablet's path.
 // Other op shapes (op_write only, or empty log) pass through unchanged.
 Status convert_txn_log_for_merging(TxnLogPB* txn_log) {
     if (!txn_log->has_op_compaction() && !txn_log->has_op_parallel_compaction()) {
@@ -354,25 +358,25 @@ Status convert_txn_log_for_merging(TxnLogPB* txn_log) {
     return Status::OK();
 }
 
-// Transform |txn_log| for publish on one of the split child tablets.
+// Transform |txn_log| for publish on one of the split new tablets.
 //
 // Compaction ops are dropped on cross-publish, mirroring the merging-side
 // handling (see convert_txn_log_for_merging above). The reason is the same in
-// the other direction: a compaction transaction committed on the parent before
+// the other direction: a compaction transaction committed on the old tablet before
 // the split has its rows-mapper file (.lcrm) and output rowset built against
-// the parent tablet's full key range. Each split child only owns a subrange,
+// the old tablet's full key range. Each split new tablet only owns a subrange,
 // so when the conflict resolver runs for its op_compaction publish on the
-// child it iterates fewer segment rows than the mapper's stored row_count and
+// new tablet it iterates fewer segment rows than the mapper's stored row_count and
 // `RowsMapperIterator::status()` rejects the publish with
 //   "Chunk vs rows mapper's row count mismatch. <N> vs <total>"
 // (see storage/rows_mapper.cpp:155, storage/primary_key_compaction_conflict_resolver.cpp:124,175).
-// Because the compaction's input rowsets are still present in every child's
+// Because the compaction's input rowsets are still present in every new tablet's
 // metadata (shared via set_all_data_files_shared), it is safe to drop the
-// compaction here — background compaction on the child will rerun it. The
-// compaction's output files were written under the parent tablet's path and
+// compaction here — background compaction on the new tablet will rerun it. The
+// compaction's output files were written under the old tablet's path and
 // are deleted async so they do not leak. The async cleanup is gated to a
-// single child (split_index == 0) because publish runs convert_txn_log once
-// per split child against the same parent txn_log; without the gate the
+// single new tablet (split_index == 0) because publish runs convert_txn_log once
+// per split new tablet against the same old tablet txn_log; without the gate the
 // identical output paths would be queued for deletion split_count times.
 Status convert_txn_log_for_splitting(TxnLogPB* txn_log, const TabletMetadataPtr& base_tablet_metadata,
                                      const PublishTabletInfo& publish_tablet_info) {
@@ -455,7 +459,7 @@ StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetada
     auto new_txn_log = std::make_shared<TxnLogPB>(*txn_log);
 
     // Each case increments its per-type metric and applies any op-level
-    // transform while the log still carries the source tablet id (critical for
+    // transform while the log still carries the old tablet id (critical for
     // MERGING, benign for others). Final tablet_id rewrite happens uniformly.
     switch (type) {
     case PublishTabletInfo::SPLITTING_TABLET:

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -79,12 +79,12 @@ private:
 
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info);
 
-// Convert |txn_log| so it can be applied to the target tablet identified by
+// Convert |txn_log| so it can be applied to the new tablet identified by
 // |publish_tablet_info|.
 //
 // For MERGING_TABLET, a compaction payload (op_compaction / op_parallel_compaction)
 // is dropped rather than re-projected: the payload's input/output rowset-id
-// references live in the source tablet's rowset-id space, which is not valid
+// references live in the old tablet's rowset-id space, which is not valid
 // against the merged tablet. After dropping, the log becomes a pure no-op at
 // apply time; background compaction on the merged tablet will re-run the
 // optimization in the merged rssid space. The compaction's already-written

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -53,6 +53,20 @@ bool same_rowset_uid(const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
     return has_valid_uid(a) && has_valid_uid(b) && UniqueId(a.uid()) == UniqueId(b.uid());
 }
 
+// Gives |dst| the identity of |src|: copies src's uid if it has a valid one, else mints a
+// fresh uid on |dst|. The validity check keys off |src| (not |dst|, which may already hold a
+// stale or default uid, e.g. after proto MergeFrom), so this is not interchangeable with
+// ensure_rowset_uid (which keys off |dst|). Used where a rowset should adopt a source's
+// identity but the source might predate the uid field (legacy rolling-upgrade txn log, never
+// cross-published) — that case is backfilled rather than failing the in-flight publish.
+void inherit_or_set_uid(RowsetMetadataPB* dst, const RowsetMetadataPB& src) {
+    if (has_valid_uid(src)) {
+        dst->mutable_uid()->CopyFrom(src.uid());
+    } else {
+        set_rowset_uid(dst);
+    }
+}
+
 void allocate_proportionally(int64_t total, const std::vector<int64_t>& weights, std::vector<int64_t>* out) {
     DCHECK(out != nullptr);
     DCHECK_GE(total, 0);
@@ -240,7 +254,7 @@ void set_all_data_files_shared(TxnLogPB* txn_log) {
     if (txn_log->has_op_replication()) {
         // Each replication op_write flows through the same apply_opwrite path on
         // publish (see txn_log_applier.cpp apply_write_log). Share the same rule as
-        // the top-level op_write so shared_dels / ssts are populated consistently.
+        // the top-level op_write so dels_meta[].shared / ssts are populated consistently.
         for (auto& op_write : *txn_log->mutable_op_replication()->mutable_op_writes()) {
             set_all_data_files_shared(&op_write);
         }
@@ -264,11 +278,7 @@ void set_all_data_files_shared(TxnLogPB* txn_log) {
     }
 }
 
-void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs) {
-    for (auto& rowset_metadata : *tablet_metadata->mutable_rowsets()) {
-        set_all_data_files_shared(&rowset_metadata);
-    }
-
+void set_non_segment_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs) {
     if (!skip_delvecs && tablet_metadata->has_delvec_meta()) {
         for (auto& pair : *tablet_metadata->mutable_delvec_meta()->mutable_version_to_file()) {
             pair.second.set_shared(true);
@@ -277,9 +287,7 @@ void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delv
 
     if (tablet_metadata->has_dcg_meta()) {
         for (auto& dcg : *tablet_metadata->mutable_dcg_meta()->mutable_dcgs()) {
-            auto* shared_files = dcg.second.mutable_shared_files();
-            shared_files->Clear();
-            shared_files->Resize(dcg.second.column_files_size(), true);
+            set_dcg_shared(&dcg.second, true);
         }
     }
 
@@ -288,6 +296,19 @@ void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delv
             sstable.set_shared(true);
         }
     }
+}
+
+void set_dcg_shared(DeltaColumnGroupVerPB* dcg, bool shared) {
+    auto* shared_files = dcg->mutable_shared_files();
+    shared_files->Clear();
+    shared_files->Resize(dcg->column_files_size(), shared);
+}
+
+void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs) {
+    for (auto& rowset_metadata : *tablet_metadata->mutable_rowsets()) {
+        set_all_data_files_shared(&rowset_metadata);
+    }
+    set_non_segment_files_shared(tablet_metadata, skip_delvecs);
 }
 
 StatusOr<TabletRangePB> intersect_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb) {
@@ -460,7 +481,8 @@ StatusOr<std::vector<TabletRangePB>> compute_non_contributed_ranges(
     return compute_disjoint_gaps_within(unbounded, sorted_disjoint_children);
 }
 
-const TabletRangePB& effective_child_local_range(const RowsetMetadataPB& rowset, const TabletMetadataPB& ctx_metadata) {
+const TabletRangePB& effective_old_tablet_local_range(const RowsetMetadataPB& rowset,
+                                                      const TabletMetadataPB& ctx_metadata) {
     static const TabletRangePB kUnbounded;
     if (rowset.has_range()) return rowset.range();
     if (ctx_metadata.has_range()) return ctx_metadata.range();

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -50,9 +50,43 @@ bool has_valid_uid(const RowsetMetadataPB& rowset_metadata);
 // rowset across split siblings. The single source of truth for MERGE dedup.
 bool same_rowset_uid(const RowsetMetadataPB& a, const RowsetMetadataPB& b);
 
+// Gives |dst| the identity of |src|: copies src's uid if it has a valid one, else mints a
+// fresh uid on |dst|. The validity check keys off |src|, not |dst| (which may already hold a
+// stale or default uid, e.g. after proto MergeFrom), so this is NOT interchangeable with
+// ensure_rowset_uid. Used by the publish combine paths and column-mode partial update so a
+// rowset adopts its source's uid; a source predating the uid field (legacy rolling-upgrade
+// log, never cross-published) is backfilled rather than failing the in-flight publish.
+void inherit_or_set_uid(RowsetMetadataPB* dst, const RowsetMetadataPB& src);
+
 void set_all_data_files_shared(RowsetMetadataPB* rowset_metadata);
 void set_all_data_files_shared(TxnLogPB* txn_log);
+
+// Whole-tablet variant: marks every rowset's segments shared (delegates per
+// rowset to set_all_data_files_shared(RowsetMetadataPB*)) AND marks every
+// non-segment file (dcg, sstable, and unless skip_delvecs is true, delvec)
+// shared. Composed of the rowset loop plus set_non_segment_files_shared
+// below; the split exists so the SPLIT path can call only the non-segment
+// portion after computing per-segment ownership.
+//
+// skip_delvecs=true is the MERGE source-tablet path: when marking the source
+// old tablets all-shared for ownership transfer to the merged new tablet,
+// delvecs are deliberately left as-is. Delvecs are per-tablet versioned
+// bitmaps that the merged tablet rebuilds independently; the source's delvec
+// files become unreferenced after merge and vacuum reclaims them, so marking
+// them shared would only inflate retention.
 void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs = false);
+
+// Marks only non-segment files (delvec, dcg, sstable) shared, leaving every
+// rowset's segment_metas[].shared untouched so the caller can decide per-segment
+// ownership. The TabletMetadataPB set_all_data_files_shared wrapper delegates
+// the non-segment portion here. skip_delvecs has the same meaning as above.
+void set_non_segment_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs = false);
+
+// Sets a delta-column-group's per-file shared flags uniformly to |shared|, sized
+// to its column_files. Centralizes the "mark a whole dcg shared / private" idiom
+// used by set_non_segment_files_shared (shared) and tablet split's per-segment
+// ownership propagation (private for an exclusive segment).
+void set_dcg_shared(DeltaColumnGroupVerPB* dcg, bool shared);
 
 StatusOr<TabletRangePB> intersect_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
 StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
@@ -88,7 +122,8 @@ StatusOr<std::vector<TabletRangePB>> compute_non_contributed_ranges(
 // Mirrors Rowset::get_seek_range() fallback chain:
 //   rowset.range if has_range, else ctx_metadata.range if has_range,
 //   else an unbounded singleton owned by this function.
-const TabletRangePB& effective_child_local_range(const RowsetMetadataPB& rowset, const TabletMetadataPB& ctx_metadata);
+const TabletRangePB& effective_old_tablet_local_range(const RowsetMetadataPB& rowset,
+                                                      const TabletMetadataPB& ctx_metadata);
 
 void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index);
 void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index);
@@ -97,9 +132,9 @@ void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t s
 // |txn_log|, resolved under |txn_log.tablet_id()| (the tablet where the
 // compaction writer emitted them).
 //
-// Used by MERGING cross-publish: a compaction txn committed on a source tablet
+// Used by MERGING cross-publish: a compaction txn committed on an old tablet
 // may be published after the merge, and its output files were written under
-// the source tablet's directory. Dropping the compaction leaves those files
+// the old tablet's directory. Dropping the compaction leaves those files
 // unreferenced; the caller should pass the returned paths to delete_files_async.
 //
 // Only output-side files are collected. Input rowsets/sstables are deliberately

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common/logging.h"
@@ -35,6 +36,8 @@
 
 extern bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total;
 extern bvar::Adder<int64_t> g_tablet_reshard_split_external_boundaries_fallback_total;
+extern bvar::Adder<int64_t> g_tablet_reshard_split_exclusive_segments_total;
+extern bvar::Adder<int64_t> g_tablet_reshard_split_anomaly_total;
 
 namespace starrocks::lake {
 
@@ -327,7 +330,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     // The overlap predicate mirrors find_overlapping_ranges' last-range
     // semantics: every ordered_range except the last is the half-open interval
     // [min, max); the last range is the closed interval [min, max]. The check
-    // also has to honor TabletRange's lower / upper inclusion flags (a child
+    // also has to honor TabletRange's lower / upper inclusion flags (a new tablet
     // produced by split has lower_bound_included=true and upper_bound_included
     // =false, so e.g. a range whose r.max == tablet_range.lower_bound is
     // entirely below the tablet — TabletRange::greater_than alone misses this
@@ -502,8 +505,8 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
 
 namespace {
 
-// Per-rowset anchor totals taken from the parent's recorded metadata. Used to
-// renormalize per-split-group estimates so Σ children equals parent exactly,
+// Per-rowset anchor totals taken from the old tablet's recorded metadata. Used to
+// renormalize per-split-group estimates so Σ new tablets equals the old tablet exactly,
 // preserving stat conservation across re-splits regardless of how the
 // underlying segment-distribution model approximates straddling sub-segments.
 struct RowsetAnchor {
@@ -512,12 +515,12 @@ struct RowsetAnchor {
     int64_t num_dels = 0;
 };
 
-// Build the per-rowset anchor map from the parent tablet metadata. For PK
+// Build the per-rowset anchor map from the old tablet metadata. For PK
 // tablets without a populated num_dels field on the rowset (legacy
 // metadata), derive num_dels from the delvec — same fallback as the
 // pre-anchor code path. If a rowset reports num_dels > num_rows
 // (pathological metadata), clamp up front with a WARNING; the
-// cap-and-redistribute contract assumes parent.num_dels <= parent.num_rows.
+// cap-and-redistribute contract assumes the old tablet's num_dels <= num_rows.
 std::unordered_map<uint32_t, RowsetAnchor> build_rowset_anchor(const TabletMetadataPB& metadata,
                                                                TabletManager* tablet_manager) {
     std::unordered_map<uint32_t, RowsetAnchor> anchor;
@@ -528,7 +531,7 @@ std::unordered_map<uint32_t, RowsetAnchor> build_rowset_anchor(const TabletMetad
         // Anchor totals: prefer the rowset-level fields. When legacy /
         // incomplete metadata omits them, fall back to summing the
         // segment-level fields. Without this fallback, anchor=0 collapses
-        // every child's stat to 0 even though segment metadata still
+        // every new tablet's stat to 0 even though segment metadata still
         // carries real values — the pre-anchor path implicitly used the
         // segment-derived numbers via range_source_stats, so we preserve
         // that property explicitly here.
@@ -563,10 +566,10 @@ std::unordered_map<uint32_t, RowsetAnchor> build_rowset_anchor(const TabletMetad
     return anchor;
 }
 
-// Anchor each split group's per-rowset stats to the parent's recorded totals
-// using the Hare-Niemeyer helper. Σ children stat == parent stat exactly for
+// Anchor each split group's per-rowset stats to the old tablet's recorded totals
+// using the Hare-Niemeyer helper. Σ new tablets stat == old tablet stat exactly for
 // num_rows, data_size, and num_dels per rowset (modulo cap-and-redistribute
-// for invalid parents — see tablet_reshard_helper.h contracts).
+// for invalid old tablets — see tablet_reshard_helper.h contracts).
 //
 // Replaces the pre-anchor flow which wrote per-source weights raw into
 // rowset_stats and ran a separate num_dels Hare-Niemeyer pass after.
@@ -729,11 +732,11 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
                 fmt::format("Insufficient split boundaries: requested {}, produced {}", split_count, produced));
     }
 
-    // Anchor per-split per-rowset stats to the parent's recorded totals so
-    // that Σ children stat == parent stat exactly for num_rows / data_size /
+    // Anchor per-split per-rowset stats to the old tablet's recorded totals so
+    // that Σ new tablets stat == old tablet stat exactly for num_rows / data_size /
     // num_dels. The segment-level distribution from
     // calculate_range_split_boundaries is used as relative weights only;
-    // absolute values come from the parent metadata. This eliminates the
+    // absolute values come from the old tablet metadata. This eliminates the
     // residual drift seen across multi-level splits when the algorithm
     // re-runs on the same physical segments under a different
     // ordered_boundaries set.
@@ -767,6 +770,8 @@ MutableTabletMetadataPtr make_identical_new_tablet_metadata(const TabletMetadata
     new_tablet_metadata->clear_compaction_inputs();
     new_tablet_metadata->clear_orphan_files();
     new_tablet_metadata->clear_prev_garbage_version();
+    // Every rowset already carries a uid (minted by its producer); the metadata copy
+    // above preserves it, so no per-rowset uid handling is needed here.
     return new_tablet_metadata;
 }
 
@@ -787,8 +792,8 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
     DCHECK(split_ranges->empty());
 
     // 1a. Structural validation (schema-free): closed-open per range, no
-    //     byte-equal zero-width child, first.lower matches parent.lower,
-    //     last.upper matches parent.upper, adjacent ranges meet exactly.
+    //     byte-equal zero-width new tablet, first.lower matches old tablet.lower,
+    //     last.upper matches old tablet.upper, adjacent ranges meet exactly.
     RETURN_IF_ERROR(TabletRangeHelper::validate_new_tablet_ranges(old_tablet_metadata->range(), external_ranges));
 
     // 1b. Schema-aware validation of FE-supplied TuplePB bounds. Without
@@ -906,9 +911,9 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
         bool hi_explicit = false;
     };
     // validate_new_tablet_ranges already enforces that first.has_lower_bound() ==
-    // parent.has_lower_bound() and last.has_upper_bound() == parent.has_upper_bound(),
+    // old tablet.has_lower_bound() and last.has_upper_bound() == old tablet.has_upper_bound(),
     // and that interior bounds are always set. So an absent external bound here means
-    // parent is unbounded on that side too — no parent inheritance is ever needed.
+    // the old tablet is unbounded on that side too — no old tablet inheritance is ever needed.
     std::vector<ParsedBounds> parsed(external_ranges.size());
     for (int i = 0; i < external_ranges.size(); ++i) {
         const auto& external_range = external_ranges[i];
@@ -982,8 +987,9 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
     // both cases return InvalidArgument and the caller falls back.
     if (effective_lo.compare(effective_hi) >= 0) {
         return Status::InvalidArgument(
-                "effective envelope empty or degenerate-point (segments don't overlap parent's range or collapse to a "
-                "single key)");
+                "effective envelope empty or degenerate-point (segments don't overlap old tablet's range or collapse "
+                "to "
+                "a single key)");
     }
 
     // 7. Build distribution vector covering the FULL segment envelope.
@@ -1025,14 +1031,14 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
     }
     // Defense-in-depth: should be unreachable under v20 invariants (envelope
     // check at step 5 ensures effective_lo < effective_hi; FE ranges tile
-    // parent's range; at least one FE range must overlap effective envelope).
+    // the old tablet's range; at least one FE range must overlap effective envelope).
     // Asserted at runtime so a future regression in invariants doesn't OOB
     // find_overlapping_ranges' last_range_index = size()-1.
     if (dist_ranges.empty()) {
         return Status::InvalidArgument("distribution vector empty (degenerate envelope or all active slots skipped)");
     }
 
-    // 8. Distribute segments into the full distribution vector. Out-of-parent
+    // 8. Distribute segments into the full distribution vector. Out-of-old-tablet
     //    data flows into sink buckets; sink stats are discarded at step 10.
     for (const auto& seg : segments) {
         distribute_segment_to_ranges(seg, dist_ranges, /*track_sources=*/true);
@@ -1084,7 +1090,7 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
         fake_result.range_source_stats[dist_to_final[j]] = dist_ranges[j].source_stats;
     }
 
-    // 12. Anchor: Σ children stat == parent stat exactly for num_rows /
+    // 12. Anchor: Σ new tablets stat == old tablet stat exactly for num_rows /
     //     data_size / num_dels. Writes split_ranges[i].rowset_stats.
     apply_rowset_anchor(anchor, fake_result, split_ranges);
 
@@ -1099,12 +1105,68 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
 // and its rowset list is restricted to the new range with per-rowset stats
 // applied from split_ranges[i].rowset_stats.
 //
+// Propagates per-segment split ownership of |rowset| (computed in |ownership| for
+// the new tablet at |new_tablet_index|) onto |new_tablet_metadata|'s non-segment
+// files (delvec pages, dcg entries), so they follow the per-segment shared decision
+// instead of all staying shared:
+//   - a segment pruned away from this new tablet (keep == false): erase its dcg
+//     entry (sstable projection never consults dcg), and erase its delvec page
+//     unless a surviving has_shared_rssid sstable still needs it (protected_rssids);
+//   - an exclusive kept segment (shared == false): mark its dcg files private, so
+//     vacuum can reclaim them alongside the now-private segment. (Delvec FILES stay
+//     shared: one file holds pages for many segments, so it is not reclaimed per-rssid.)
+//
+// Must run BEFORE apply_segment_ownership_to_new_tablet_rowset, which compacts the
+// segment arrays away (this needs each segment's original rssid). Returns true if any
+// pruned segment of |rowset| had a protected rssid, which blocks removal of an
+// otherwise-empty rowset (the surviving sstable still anchors that rssid at MERGE).
+bool propagate_pruned_ownership_to_non_segment_files(const RowsetMetadataPB& rowset, const RowsetOwnership& ownership,
+                                                     int new_tablet_index,
+                                                     const std::unordered_set<uint32_t>& protected_rssids,
+                                                     TabletMetadataPB* new_tablet_metadata) {
+    auto* delvecs = new_tablet_metadata->has_delvec_meta()
+                            ? new_tablet_metadata->mutable_delvec_meta()->mutable_delvecs()
+                            : nullptr;
+    auto* dcgs =
+            new_tablet_metadata->has_dcg_meta() ? new_tablet_metadata->mutable_dcg_meta()->mutable_dcgs() : nullptr;
+    bool has_pruned_protected_rssid = false;
+    for (int segment_index = 0; segment_index < rowset.segment_metas_size(); ++segment_index) {
+        const uint32_t rssid = get_rssid(rowset, segment_index);
+        const auto& segment_ownership = ownership.segments[segment_index];
+        if (!segment_ownership.keep[new_tablet_index]) {
+            if (dcgs != nullptr) dcgs->erase(rssid);
+            if (protected_rssids.contains(rssid)) {
+                // Leave the delvec page as-is (all-shared) rather than erasing it: MERGE's
+                // modern sstable projection re-reads this rssid's delvec, so erasing risks
+                // dropping real deletions. Keeping it preserves the pre-cleanup baseline --
+                // before per-segment delvec erase existed, every pruned segment's delvec was
+                // carried into MERGE unconditionally, so this is not a new orphan; this cleanup
+                // only ever REDUCES carried pages. The protected residual can still map to an
+                // unreferenced rssid at MERGE (e.g. a delvec kept by a non-first shared-sstable
+                // duplicate that merge_sstables skips before projection); bounding/remapping
+                // those orphan delvec keys is left to the merge-side follow-up.
+                has_pruned_protected_rssid = true;
+            } else if (delvecs != nullptr) {
+                delvecs->erase(rssid);
+            }
+        } else if (!segment_ownership.shared[new_tablet_index]) {
+            if (dcgs != nullptr) {
+                auto dcg_it = dcgs->find(rssid);
+                if (dcg_it != dcgs->end()) {
+                    tablet_reshard_helper::set_dcg_shared(&dcg_it->second, /*shared=*/false);
+                }
+            }
+        }
+    }
+    return has_pruned_protected_rssid;
+}
+
 // Precondition: split_ranges.size() == splitting_tablet.new_tablet_ids_size().
 // Per-rowset stats are honored when present in split_ranges[i].rowset_stats;
 // otherwise the rowset is preserved in the new tablet's metadata (still
 // referencing the same shared segment files) but with num_rows / data_size /
-// num_dels set to 0, signaling "rowset is visible in this child's metadata
-// but contributes no rows here under the child's range".
+// num_dels set to 0, signaling "rowset is visible in this new tablet's metadata
+// but contributes no rows here under the new tablet's range".
 StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablets_from_split_ranges(
         const TabletMetadataPtr& old_tablet_metadata, const SplittingTabletInfoPB& splitting_tablet,
         int64_t new_version, const TxnInfoPB& txn_info, const std::vector<TabletRangeInfo>& split_ranges) {
@@ -1120,6 +1182,57 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
     std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
     new_metadatas.reserve(splitting_tablet.new_tablet_ids_size());
 
+    // The full set of new-tablet ranges, used by per-segment ownership to test
+    // overlap/containment of each segment against every sibling's range.
+    std::vector<TabletRangePB> new_tablet_ranges(split_ranges.size());
+    for (size_t new_tablet_index = 0; new_tablet_index < split_ranges.size(); ++new_tablet_index) {
+        new_tablet_ranges[new_tablet_index] = split_ranges[new_tablet_index].range;
+    }
+
+    // Per-segment ownership depends only on (source rowset, new_tablet_ranges),
+    // not on which new tablet we build, so compute it ONCE per source rowset before
+    // the per-new-tablet loop. This keeps the bvar counters per-decision (not
+    // per-new-tablet) and avoids recomputing the geometry split_count times.
+    // rowset_prunable[rowset_index] is false when the rowset is non-pruneable OR
+    // was degraded to all-shared on an unparseable sort key.
+    //
+    // Parse new_tablet_ranges into TabletRange ONCE before the per-rowset loop;
+    // the parsed form is invariant across rowsets, so this saves N redundant
+    // proto parses for a tablet with N pruneable rowsets.
+    ASSIGN_OR_RETURN(auto parsed_new_tablet_ranges, parse_tablet_ranges(new_tablet_ranges));
+    const int rowset_count = old_tablet_metadata->rowsets_size();
+    std::vector<RowsetOwnership> rowset_ownership(rowset_count);
+    std::vector<bool> rowset_prunable(rowset_count, false);
+    for (int rowset_index = 0; rowset_index < rowset_count; ++rowset_index) {
+        const auto& source_rowset = old_tablet_metadata->rowsets(rowset_index);
+        if (!can_prune_rowset_segments(source_rowset)) continue;
+        auto ownership_or = compute_rowset_segment_ownership(source_rowset, parsed_new_tablet_ranges);
+        if (ownership_or.ok()) {
+            rowset_ownership[rowset_index] = std::move(ownership_or.value());
+            rowset_prunable[rowset_index] = true;
+        } else {
+            // Unparseable sort key: degrade the whole rowset to all-shared below.
+            g_tablet_reshard_split_anomaly_total << 1;
+        }
+    }
+
+    // rssids referenced by a surviving modern `has_shared_rssid` PK-index sstable.
+    // When such a segment is pruned from a new tablet we must NOT erase its delvec
+    // page: MERGE's modern shared_rssid sstable projection reads the delvec for that
+    // rssid directly (it does NOT go through the legacy remap_legacy_entry_or_drop
+    // drop path), so erasing it would break MERGE. This exception is load-bearing.
+    // DCG is never consulted by sstable projection, so DCG erase is never gated.
+    // sstable_meta is identical across new tablets (each is a copy of the old
+    // tablet), so compute the protected set once.
+    std::unordered_set<uint32_t> protected_rssids;
+    if (old_tablet_metadata->has_sstable_meta()) {
+        for (const auto& sstable : old_tablet_metadata->sstable_meta().sstables()) {
+            if (sstable.has_shared_rssid()) {
+                protected_rssids.insert(sstable.shared_rssid());
+            }
+        }
+    }
+
     for (int32_t i = 0; i < splitting_tablet.new_tablet_ids_size(); ++i) {
         auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
         new_tablet_new_metadata->set_id(splitting_tablet.new_tablet_ids(i));
@@ -1130,14 +1243,52 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
         new_tablet_new_metadata->clear_orphan_files();
         new_tablet_new_metadata->clear_prev_garbage_version();
         new_tablet_new_metadata->mutable_range()->CopyFrom(split_ranges[i].range);
-        tablet_reshard_helper::set_all_data_files_shared(new_tablet_new_metadata.get());
+        // Non-segment files (delvec/dcg/sstable) stay all-shared; each rowset's
+        // per-segment shared flags are (re)written below by exactly one branch per rowset.
+        tablet_reshard_helper::set_non_segment_files_shared(new_tablet_new_metadata.get());
 
+        // The copy preserves rowset order, so rowset_index aligns with old_tablet_metadata.
+        // keep_rowset[idx] is cleared for a rowset whose every segment was pruned from
+        // this new tablet (and which carries no other semantics); such rowsets are
+        // compacted out of rowsets[] after the loop.
+        const int rowset_count = new_tablet_new_metadata->rowsets_size();
+        std::vector<bool> keep_rowset(rowset_count, true);
+        std::vector<uint32_t> removed_rowset_ids;
+        int rowset_index = 0;
         for (auto& rowset_metadata : *new_tablet_new_metadata->mutable_rowsets()) {
             RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(&rowset_metadata, split_ranges[i].range));
+
+            // Phase-1 per-segment shared. The uid (family identity for the later MERGE) is
+            // preserved verbatim by the metadata copy, identical across new tablets. Segments
+            // are then pruned to those overlapping this new tablet (shared=false where provably
+            // exclusive+contained), or for non-pruneable / degraded rowsets stay all-shared.
+            if (rowset_prunable[rowset_index]) {
+                const bool has_pruned_protected_rssid = propagate_pruned_ownership_to_non_segment_files(
+                        rowset_metadata, rowset_ownership[rowset_index], i, protected_rssids,
+                        new_tablet_new_metadata.get());
+
+                RETURN_IF_ERROR(apply_segment_ownership_to_new_tablet_rowset(&rowset_metadata,
+                                                                             rowset_ownership[rowset_index], i));
+                // del_files stay shared (per-segment pruning operates on segments, not del_files).
+                for (auto& del_file : *rowset_metadata.mutable_del_files()) del_file.set_shared(true);
+
+                // A rowset whose every segment was pruned from this new tablet carries no
+                // data here. Remove it (and its rowset_to_schema mapping) unless it still
+                // holds a delete predicate, del_files, or a pruned protected rssid that a
+                // surviving sstable still anchors at MERGE.
+                if (rowset_metadata.segment_metas_size() == 0 && !rowset_metadata.has_delete_predicate() &&
+                    rowset_metadata.del_files_size() == 0 && !has_pruned_protected_rssid) {
+                    keep_rowset[rowset_index] = false;
+                    removed_rowset_ids.push_back(rowset_metadata.id());
+                }
+            } else {
+                tablet_reshard_helper::set_all_data_files_shared(&rowset_metadata);
+            }
+
             const auto it = split_ranges[i].rowset_stats.find(rowset_metadata.id());
             if (it != split_ranges[i].rowset_stats.end()) {
                 // apply_rowset_anchor + cap_and_redistribute_dels guarantee
-                // num_dels <= num_rows for every (rowset, child). The std::min
+                // num_dels <= num_rows for every (rowset, new tablet). The std::min
                 // below is defense-in-depth against an upstream regression.
                 DCHECK_LE(it->second.num_dels, it->second.num_rows);
                 int64_t scaled_num_dels = std::min<int64_t>(it->second.num_dels, it->second.num_rows);
@@ -1149,6 +1300,32 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
                 rowset_metadata.set_data_size(0);
                 rowset_metadata.set_num_dels(0);
             }
+            ++rowset_index;
+        }
+
+        // Compact out removed (fully-pruned) rowsets, preserving order, and drop their
+        // rowset_to_schema mappings. Move survivors into a fresh field then swap — the
+        // order-stable RepeatedPtrField idiom (positional swap-compaction would desync
+        // from the original-position keep_rowset[] vector).
+        if (!removed_rowset_ids.empty()) {
+            // cumulative_point indexes into rowsets[] (base rowsets are [0, cp), cumulative
+            // [cp, size)) for non-PK base+cumulative compaction. Removing rowsets shifts
+            // positions, so recompute the point as the number of SURVIVING rowsets that
+            // were originally in the base region [0, old_cp); otherwise the inherited point
+            // could misclassify rowsets or exceed rowsets_size().
+            const int old_cumulative_point = static_cast<int>(new_tablet_new_metadata->cumulative_point());
+            google::protobuf::RepeatedPtrField<RowsetMetadataPB> survivors;
+            auto* rowsets = new_tablet_new_metadata->mutable_rowsets();
+            uint32_t new_cumulative_point = 0;
+            for (int idx = 0; idx < rowsets->size(); ++idx) {
+                if (!keep_rowset[idx]) continue;
+                if (idx < old_cumulative_point) ++new_cumulative_point;
+                survivors.Add()->Swap(rowsets->Mutable(idx));
+            }
+            rowsets->Swap(&survivors);
+            new_tablet_new_metadata->set_cumulative_point(new_cumulative_point);
+            auto* rowset_to_schema = new_tablet_new_metadata->mutable_rowset_to_schema();
+            for (uint32_t id : removed_rowset_ids) rowset_to_schema->erase(id);
         }
 
         new_metadatas.emplace(new_tablet_new_metadata->id(), std::move(new_tablet_new_metadata));
@@ -1180,6 +1357,155 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
                                         colocate_column_count);
 }
 
+// -----------------------------------------------------------------------------
+// Phase-1 per-segment shared optimization helpers (declared in tablet_splitter.h).
+// -----------------------------------------------------------------------------
+
+bool can_prune_rowset_segments(const RowsetMetadataPB& rowset) {
+    if (rowset.next_compaction_offset() != 0) return false; // (a) no partial-compaction cursor
+    // (b) every segment must carry sort-key bounds so it maps to a key range. Each
+    // SegmentMetadataPB is self-contained (filename/size/shared/bundle_file_offset all
+    // travel with it), so a bundled rowset prunes uniformly with any other — no separate
+    // parallel-array shape check is needed.
+    for (const auto& segment_meta : rowset.segment_metas()) {
+        if (!segment_meta.has_sort_key_min() || !segment_meta.has_sort_key_max()) return false;
+    }
+    return true;
+}
+
+StatusOr<std::vector<TabletRange>> parse_tablet_ranges(const std::vector<TabletRangePB>& new_tablet_ranges) {
+    std::vector<TabletRange> parsed(new_tablet_ranges.size());
+    for (size_t i = 0; i < new_tablet_ranges.size(); ++i) {
+        RETURN_IF_ERROR(parsed[i].from_proto(new_tablet_ranges[i]));
+    }
+    return parsed;
+}
+
+StatusOr<RowsetOwnership> compute_rowset_segment_ownership(const RowsetMetadataPB& rowset,
+                                                           const std::vector<TabletRangePB>& new_tablet_ranges) {
+    ASSIGN_OR_RETURN(auto parsed_ranges, parse_tablet_ranges(new_tablet_ranges));
+    return compute_rowset_segment_ownership(rowset, parsed_ranges);
+}
+
+StatusOr<RowsetOwnership> compute_rowset_segment_ownership(const RowsetMetadataPB& rowset,
+                                                           const std::vector<TabletRange>& parsed_ranges) {
+    const int new_tablet_count = static_cast<int>(parsed_ranges.size());
+
+    RowsetOwnership ownership;
+    ownership.segments.resize(rowset.segment_metas_size());
+
+    for (int segment_index = 0; segment_index < rowset.segment_metas_size(); ++segment_index) {
+        const auto& segment_meta = rowset.segment_metas(segment_index);
+        VariantTuple segment_min_key;
+        VariantTuple segment_max_key;
+        // An unparseable key means we cannot reason about this rowset's geometry;
+        // return non-OK so the caller degrades the whole rowset to all-shared.
+        RETURN_IF_ERROR(segment_min_key.from_proto(segment_meta.sort_key_min()));
+        RETURN_IF_ERROR(segment_max_key.from_proto(segment_meta.sort_key_max()));
+        // The segment spans the inclusive key interval [min, max].
+        TabletRange segment_range(segment_min_key, segment_max_key, /*lower_bound_included=*/true,
+                                  /*upper_bound_included=*/true);
+
+        auto& segment_ownership = ownership.segments[segment_index];
+        segment_ownership.keep.assign(new_tablet_count, false);
+        segment_ownership.shared.assign(new_tablet_count, false);
+
+        // Which new tablets the segment overlaps, and which fully contain it.
+        int overlap_count = 0;
+        std::vector<bool> contained_in_tablet(new_tablet_count, false);
+        for (int tablet_index = 0; tablet_index < new_tablet_count; ++tablet_index) {
+            ASSIGN_OR_RETURN(auto intersection, segment_range.intersect(parsed_ranges[tablet_index]));
+            if (!intersection.is_empty()) {
+                segment_ownership.keep[tablet_index] = true;
+                ++overlap_count;
+                contained_in_tablet[tablet_index] = parsed_ranges[tablet_index].contains(segment_min_key) &&
+                                                    parsed_ranges[tablet_index].contains(segment_max_key);
+            }
+        }
+
+        const bool source_segment_shared = segment_meta.shared();
+
+        if (overlap_count == 0) {
+            // Defensive: the partition property guarantees every segment overlaps
+            // at least one new tablet, so this is a should-not-happen anomaly.
+            // Data-safe fallback: keep the segment on every new tablet with
+            // shared=true so the file survives until every new tablet is dropped.
+            // Trade-off: if source_segment_shared was false (exclusively owned),
+            // the fallback relaxes ownership to all-shared, which causes vacuum
+            // to retain the file beyond the original owner's drop. We accept
+            // this garbage-retention cost in exchange for data safety in a path
+            // that should never fire — routing to one new tablet without proven
+            // containment would risk dangling references on the others.
+            LOG_EVERY_N(WARNING, 1024) << "tablet_split: segment with no overlapping new-tablet range, rowset="
+                                       << rowset.id() << " segment=" << segment_index
+                                       << " source_segment_shared=" << source_segment_shared
+                                       << " new_tablet_count=" << new_tablet_count;
+            g_tablet_reshard_split_anomaly_total << 1;
+            segment_ownership.keep.assign(new_tablet_count, true);
+            segment_ownership.shared.assign(new_tablet_count, true);
+            continue;
+        }
+
+        for (int tablet_index = 0; tablet_index < new_tablet_count; ++tablet_index) {
+            if (!segment_ownership.keep[tablet_index]) continue;
+            const bool must_stay_shared = source_segment_shared || overlap_count >= 2;
+            if (must_stay_shared) {
+                segment_ownership.shared[tablet_index] = true;
+            } else if (contained_in_tablet[tablet_index]) {
+                // Exclusive to this tablet AND provably contained -> private.
+                segment_ownership.shared[tablet_index] = false;
+                g_tablet_reshard_split_exclusive_segments_total << 1;
+            } else {
+                // Fail-closed: cannot prove containment, so keep it shared.
+                segment_ownership.shared[tablet_index] = true;
+                g_tablet_reshard_split_anomaly_total << 1;
+            }
+        }
+    }
+    return ownership;
+}
+
+Status apply_segment_ownership_to_new_tablet_rowset(RowsetMetadataPB* rowset, const RowsetOwnership& ownership,
+                                                    int new_tablet_index) {
+    const int segment_count = rowset->segment_metas_size();
+
+    // STEP 0: validate shapes; on any mismatch return WITHOUT mutating the rowset.
+    if (static_cast<int>(ownership.segments.size()) != segment_count) {
+        return Status::InternalError(
+                fmt::format("ownership size {} != segment_metas_size {}", ownership.segments.size(), segment_count));
+    }
+    for (const auto& segment_ownership : ownership.segments) {
+        if (static_cast<int>(segment_ownership.keep.size()) <= new_tablet_index ||
+            static_cast<int>(segment_ownership.shared.size()) <= new_tablet_index) {
+            return Status::InternalError("ownership inner vector shorter than new_tablet_index");
+        }
+    }
+
+    // STEP 1: keep only the segments this new tablet owns. Each SegmentMetadataPB is
+    // self-contained, so filtering segment_metas[] carries filename/size/encryption_meta/
+    // bundle_file_offset along automatically — no parallel arrays to keep in lockstep.
+    // The kept segment's shared flag is overwritten with the freshly computed ownership
+    // (source_segment_shared || overlap), and a positional segment_idx is synthesized when absent so
+    // the global rssid (rowset.id + segment_idx) stays stable. bundle_file_offset is an
+    // absolute byte offset into the untouched shared physical file, so it is preserved
+    // verbatim with its segment.
+    std::vector<SegmentMetadataPB> kept_segment_metas;
+    kept_segment_metas.reserve(segment_count);
+    for (int segment_index = 0; segment_index < segment_count; ++segment_index) {
+        if (!ownership.segments[segment_index].keep[new_tablet_index]) continue;
+        SegmentMetadataPB segment_meta = rowset->segment_metas(segment_index);
+        if (!segment_meta.has_segment_idx()) segment_meta.set_segment_idx(segment_index);
+        segment_meta.set_shared(ownership.segments[segment_index].shared[new_tablet_index]);
+        kept_segment_metas.push_back(std::move(segment_meta));
+    }
+
+    rowset->clear_segment_metas();
+    for (auto& segment_meta : kept_segment_metas) *rowset->add_segment_metas() = std::move(segment_meta);
+
+    if (rowset->segment_metas_size() <= 1) rowset->set_overlapped(false);
+    return Status::OK();
+}
+
 StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
         const SplittingTabletInfoPB& splitting_tablet, int64_t new_version, const TxnInfoPB& txn_info) {
@@ -1190,8 +1516,8 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         return Status::InvalidArgument("splitting tablet has no new tablet");
     }
 
-    // Flush the parent's PK-index memtable into sstables before propagating
-    // metadata to the children, so every child inherits an sstable_meta that
+    // Flush the old tablet's PK-index memtable into sstables before propagating
+    // metadata to the new tablets, so every new tablet inherits an sstable_meta that
     // already covers its rowsets' live data. This is the pre-split half of
     // the "reshard inputs must have full sstable coverage" invariant; merge
     // does the post-split half in merge_sstables.
@@ -1205,7 +1531,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     //
     // Symmetric identical-fallback: either path's non-OK Status routes through
     // make_identical_new_tablet_metadata to produce a single identical new
-    // tablet that inherits parent's data. Distinct bvar counters distinguish
+    // tablet that inherits the old tablet's data. Distinct bvar counters distinguish
     // the failure root cause for ops alerting.
     std::vector<TabletRangeInfo> split_ranges;
     // colocate_column_count is carried at the txn level (single split job = single txn) since

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -146,4 +146,56 @@ Status compute_split_ranges_from_external_boundaries(
         const google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges,
         std::vector<TabletRangeInfo>* split_ranges);
 
+// -----------------------------------------------------------------------------
+// Phase-1 per-segment shared optimization. The helpers below are exposed for
+// unit testing; the production call site is build_new_tablets_from_split_ranges.
+// -----------------------------------------------------------------------------
+
+// Per-segment keep/shared decision across all new tablets (parallel to the
+// new_tablet_ranges vector index).
+struct SegmentOwnership {
+    std::vector<bool> keep; // keep[new_tablet_index]: segment overlaps that new tablet's range
+    std::vector<bool>
+            shared; // shared[new_tablet_index]: shared flag for that new tablet (meaningful where keep is set)
+};
+struct RowsetOwnership {
+    std::vector<SegmentOwnership> segments; // size == rowset.segment_metas_size()
+};
+
+// True iff a rowset's metadata shape permits per-segment ownership pruning:
+// (a) no partial-compaction cursor, (b) every segment has sort-key bounds. Each
+// SegmentMetadataPB is self-contained (filename/size/shared/bundle_file_offset travel
+// with it), so bundled rowsets prune uniformly with any other.
+bool can_prune_rowset_segments(const RowsetMetadataPB& rowset);
+
+// Computes per-segment ownership of a pruneable rowset against the new tablets'
+// ranges. Fail-closed: returns non-OK (caller degrades the whole rowset to
+// shared) on an unparseable sort key; per-segment, only marks shared=false when
+// the segment is provably contained in exactly one new tablet's range.
+//
+// Two overloads:
+//   - PB form: convenient for tests and one-shot callers; parses
+//     new_tablet_ranges into TabletRange on every call.
+//   - Pre-parsed form: hot-path callers that loop over many source rowsets
+//     against the same new_tablet_ranges should parse once via
+//     parse_tablet_ranges() and call this overload to avoid
+//     N redundant proto parses per rowset.
+StatusOr<RowsetOwnership> compute_rowset_segment_ownership(const RowsetMetadataPB& rowset,
+                                                           const std::vector<TabletRangePB>& new_tablet_ranges);
+StatusOr<RowsetOwnership> compute_rowset_segment_ownership(const RowsetMetadataPB& rowset,
+                                                           const std::vector<TabletRange>& parsed_ranges);
+
+// Parse a vector of TabletRangePB into TabletRange, returning the first
+// from_proto error encountered. Used by callers of compute_rowset_segment_
+// ownership that need to parse ranges once outside a hot loop.
+StatusOr<std::vector<TabletRange>> parse_tablet_ranges(const std::vector<TabletRangePB>& new_tablet_ranges);
+
+// Filters a copied-into-new-tablet rowset's segment_metas[] down to the segments kept
+// for new_tablet_index, setting each kept segment's `shared` flag from ownership.
+// Validate-then-mutate: returns Status::InternalError with the rowset
+// UNMODIFIED on any impossible post-compute shape mismatch (logic bug; aborts
+// the split).
+Status apply_segment_ownership_to_new_tablet_rowset(RowsetMetadataPB* rowset, const RowsetOwnership& ownership,
+                                                    int new_tablet_index);
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -28,6 +28,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reshard.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/txn_log_applier.h"
 #include "storage/lake/update_manager.h"
@@ -604,7 +605,7 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::sp
             // single load_id field carried over from the first source no longer applies.
             merged->clear_load_id();
             if (txn_logs.size() > 1) {
-                // MergeFrom appends repeated fields (segments, dels, segment_size, ...)
+                // MergeFrom appends repeated fields (segment_metas, dels_meta, ...)
                 // and recursively merges optional message fields, which is what we want
                 // for the per-segment lists. But it overwrites scalar accumulators with
                 // the last source's value, so sum num_rows / data_size / num_dels back
@@ -630,6 +631,10 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::sp
                     rowset->set_data_size(data_size);
                     rowset->set_num_dels(num_dels);
                     rowset->set_overlapped(rowset->segment_metas_size() > 1);
+                    // MergeFrom above overwrote the combined rowset's uid with the last source's;
+                    // restore the first log's identity by re-reading txn_logs.front() (MergeFrom
+                    // never mutates the sources) so it stays stable across cross-published children.
+                    tablet_reshard_helper::inherit_or_set_uid(rowset, txn_logs.front()->op_write().rowset());
                 }
             }
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -35,6 +35,7 @@
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/update_manager.h"
 #include "util/dynamic_cache.h"
@@ -883,7 +884,12 @@ public:
             if (log->has_op_write()) {
                 const auto& op_write = log->op_write();
                 RETURN_IF_ERROR(update_metadata_schema(op_write, log->txn_id(), _metadata, _tablet.tablet_mgr()));
-                if (op_write.has_rowset() && op_write.rowset().num_rows() > 0) {
+                // Decide segment contribution by SEGMENTS, not num_rows: a cross-published op_write
+                // has its num_rows scaled per child (update_rowset_data_stats), so a statement with
+                // num_rows < split_count scales to 0 on some children even though its segments carry
+                // data. Gating on num_rows would drop those segments; segment count is structural
+                // and identical across children.
+                if (op_write.has_rowset() && op_write.rowset().segment_metas_size() > 0) {
                     const auto& rowset = op_write.rowset();
 
                     // Check for delete predicate - not supported in batch mode
@@ -935,8 +941,10 @@ public:
             }
         }
 
-        // If no valid rowset data, return directly
-        if (total_num_rows == 0) {
+        // If no segments to apply, return directly. Keyed on segments (not total_num_rows)
+        // for the same reason as the per-op gate above: a fully cross-published txn can scale
+        // every contributing op_write's num_rows to 0 while its segments still carry data.
+        if (all_segment_metas.empty()) {
             VLOG(2) << "No valid rowset data to apply for tablet " << _tablet.id();
             return Status::OK();
         }
@@ -948,6 +956,10 @@ public:
         merged_rowset->set_num_rows(total_num_rows);
         merged_rowset->set_data_size(total_data_size);
         merged_rowset->set_overlapped(all_segment_metas.size() > 1);
+        // MERGE dedup identity: adopt the first log's uid. All logs of one txn share a producer
+        // version and uids are CopyFrom-preserved across cross-publish, so this is stable across
+        // cross-published split children.
+        tablet_reshard_helper::inherit_or_set_uid(merged_rowset, txn_logs.front()->op_write().rowset());
 
         // Set segment metas (each entry already carries filename/size/encryption/shared/bundle_offset).
         for (const auto& segment_meta : all_segment_metas) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -851,19 +851,11 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
         // (apply_column_mode_partial_update orphans them into orphan_files for GC), and
         // only this new_rows_op is added via apply_opwrite below. So the uid here can't
         // collide with any concurrent top-level rowset in this metadata.
-        if (tablet_reshard_helper::has_valid_uid(op_write.rowset())) {
-            // Reuse op_write.uid (minted by delta_writer at write time, preserved
-            // verbatim across cross-publish by proto CopyFrom) so every split sibling
-            // that re-runs this publish converges on the same identity.
-            new_rows_op.mutable_rowset()->mutable_uid()->CopyFrom(op_write.rowset().uid());
-        } else {
-            // A legacy in-flight COLUMN_UPSERT_MODE op_write written before the uid
-            // field existed (rolling upgrade / BE restart with pending txn logs) carries
-            // no uid. Such a write is never range-distributed (range distribution is a
-            // new, post-uid feature) and therefore never cross-published, so mint a
-            // fresh uid rather than hard-failing the in-flight transaction.
-            tablet_reshard_helper::set_rowset_uid(new_rows_op.mutable_rowset());
-        }
+        // Reuse op_write.uid (minted by delta_writer at write time, preserved verbatim across
+        // cross-publish by proto CopyFrom) so every split sibling that re-runs this publish
+        // converges on the same identity. A legacy pre-uid op_write (rolling upgrade / pending
+        // txn log) is never range-distributed, hence never cross-published, so it is backfilled.
+        tablet_reshard_helper::inherit_or_set_uid(new_rows_op.mutable_rowset(), op_write.rowset());
         builder->apply_opwrite(new_rows_op, {}, {});
         if (!segment_id_to_add_dels_new_acc.empty()) {
             (void)builder->update_num_del_stat(segment_id_to_add_dels_new_acc);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -55,6 +55,7 @@
 #include "storage/lake/schema_change.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/test_util.h"
 #include "storage/lake/txn_log.h"
 #include "storage/rowset/segment_writer.h"
@@ -144,6 +145,9 @@ protected:
         rowset->set_overlapped(false);
         rowset->set_num_rows(10);
         rowset->set_data_size(100);
+        // Production rowset producers mint a uid; emulate that here so the
+        // strict-uid invariant in tablet_merger holds when MERGE later runs.
+        lake::tablet_reshard_helper::ensure_rowset_uid(rowset);
         auto* segment_meta = rowset->add_segment_metas();
         segment_meta->set_filename("seg_" + std::to_string(tablet_id) + "_0");
         segment_meta->set_size(100);
@@ -171,6 +175,9 @@ protected:
         rowset->set_overlapped(false);
         rowset->set_num_rows(10);
         rowset->set_data_size(100);
+        // Production rowset producers mint a uid; emulate that here so the
+        // strict-uid invariant in tablet_merger holds when MERGE later runs.
+        lake::tablet_reshard_helper::ensure_rowset_uid(rowset);
         auto* segment_meta = rowset->add_segment_metas();
         segment_meta->set_filename("seg_" + std::to_string(tablet_id) + "_0");
         segment_meta->set_size(100);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -37,6 +37,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/test_util.h"
 #include "storage/rowset/segment.h"
@@ -2402,6 +2403,159 @@ TEST_F(LakeColumnUpsertModeTest, upsert_with_new_rows_adds_new_segments) {
     EXPECT_GT(md_after->rowsets_size(), prev_rowsets);
     auto total = check(version, [](int c0, int c1, int c2) { return (c2 == c0 * 4) || (c2 == 10); });
     EXPECT_EQ(total, kChunkSize * 2);
+}
+
+// Locks down the CopyFrom contract in _handle_column_upsert_mode: the synthesized
+// new_rows_op rowset must inherit the source op_write's uid verbatim. The DCG path
+// (apply_column_mode_partial_update) orphans the original op_write segments, so
+// new_rows_op is the only top-level rowset this publish adds; reusing op_write.uid
+// gives split siblings replaying the same op_write an identical uid → MERGE dedup.
+//
+// If a future change accidentally re-introduces XOR-salt derivation or a fresh
+// mint here, this test fails (uid would differ from the captured op_write.uid).
+TEST_F(LakeColumnUpsertModeTest, new_rows_op_inherits_op_write_uid) {
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // Phase 1: baseline INSERT to populate the table so subsequent COLUMN_UPSERT_MODE
+    // writes against new PK offsets hit the "new rows" synthesis path.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSIGN_OR_ABORT(auto md_before, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto prev_rowsets = md_before->rowsets_size();
+
+    // Phase 2: COLUMN_UPSERT_MODE write at PK offset 100 (disjoint from baseline 0..kChunkSize),
+    // so every row is "new" and goes through the new_rows_op synthesis path.
+    auto chunk_insert = generate_data(kChunkSize, 100, true, 7);
+    PUniqueId captured_op_write_uid;
+    auto txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_insert, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+
+        // Capture op_write.rowset.uid before publish consumes the txn_log.
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        ASSERT_TRUE(txn_log->has_op_write());
+        ASSERT_TRUE(tablet_reshard_helper::has_valid_uid(txn_log->op_write().rowset()))
+                << "delta_writer must mint a uid on the op_write rowset at write time";
+        captured_op_write_uid = txn_log->op_write().rowset().uid();
+
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Phase 3: verify the new top-level rowset (new_rows_op) inherits the op_write's uid.
+    // apply_opwrite appends via _tablet_meta->add_rowsets(), so new_rows_op is the last entry.
+    ASSIGN_OR_ABORT(auto md_after, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    ASSERT_GT(md_after->rowsets_size(), prev_rowsets);
+    const auto& new_rows_rs = md_after->rowsets(md_after->rowsets_size() - 1);
+    EXPECT_TRUE(tablet_reshard_helper::has_valid_uid(new_rows_rs))
+            << "synthesized new_rows_op rowset must carry a valid uid";
+    EXPECT_EQ(captured_op_write_uid.hi(), new_rows_rs.uid().hi())
+            << "new_rows_op.uid.hi must CopyFrom op_write.rowset.uid.hi (no derivation)";
+    EXPECT_EQ(captured_op_write_uid.lo(), new_rows_rs.uid().lo())
+            << "new_rows_op.uid.lo must CopyFrom op_write.rowset.uid.lo (no derivation)";
+}
+
+// Column-mode legacy compatibility: a COLUMN_UPSERT_MODE op_write written before the
+// uid field existed (rolling upgrade / BE restart with pending txn logs) carries no
+// uid. _handle_column_upsert_mode must MINT a fresh uid for the synthesized new_rows_op
+// rather than hard-fail the in-flight transaction. Such a legacy write is never
+// range-distributed (a new, post-uid feature), hence never cross-published, so a fresh
+// per-publish uid is safe. delta_writer always mints in production; we rewrite the
+// persisted txn log (clear its uid) between write and publish to drive the legacy path.
+TEST_F(LakeColumnUpsertModeTest, new_rows_op_without_op_write_uid_mints_fresh) {
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // Phase 1: baseline INSERT.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Phase 2: COLUMN_UPSERT_MODE write at a disjoint PK offset (all rows new), then
+    // rewrite the persisted txn log to drop the op_write uid before publish.
+    auto chunk_insert = generate_data(kChunkSize, 100, true, 7);
+    auto txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_slot_descriptors(&_slot_pointers)
+                                               .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(chunk_insert, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_TRUE(txn_log->has_op_write());
+    auto rewritten = std::make_shared<TxnLog>(*txn_log);
+    rewritten->mutable_op_write()->mutable_rowset()->clear_uid(); // producer-side regression
+    ASSERT_OK(_tablet_mgr->put_txn_log(rewritten));
+
+    // Publish must SUCCEED (mint-if-absent), not hard-fail on the missing uid.
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+    version++;
+
+    // The synthesized new_rows_op (appended last by apply_opwrite) must carry a
+    // freshly-minted valid uid even though the source op_write had none.
+    ASSIGN_OR_ABORT(auto md_after, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    ASSERT_GT(md_after->rowsets_size(), 0);
+    const auto& new_rows_rs = md_after->rowsets(md_after->rowsets_size() - 1);
+    EXPECT_TRUE(tablet_reshard_helper::has_valid_uid(new_rows_rs))
+            << "legacy uid-less column-mode op_write must yield a freshly-minted new_rows_op uid";
 }
 
 TEST_F(LakeColumnUpsertModeTest, test_default_values_handling) {

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -32,45 +32,6 @@ using namespace tablet_reshard_helper;
 
 class TabletReshardHelperTest : public ::testing::Test {};
 
-// Exercises the per-rowset uid helpers introduced for the reshard MERGE identity.
-TEST_F(TabletReshardHelperTest, RowsetUidHelpers) {
-    // make_rowset_uid: fresh, non-zero, and distinct across calls.
-    auto a = make_rowset_uid();
-    auto b = make_rowset_uid();
-    EXPECT_TRUE(a.hi() != 0 || a.lo() != 0);
-    EXPECT_FALSE(a.hi() == b.hi() && a.lo() == b.lo());
-
-    RowsetMetadataPB rs;
-    EXPECT_FALSE(has_valid_uid(rs)); // absent => invalid
-
-    ensure_rowset_uid(&rs); // mints when absent
-    EXPECT_TRUE(has_valid_uid(rs));
-    auto minted = rs.uid();
-
-    ensure_rowset_uid(&rs); // idempotent: preserves the existing uid
-    EXPECT_EQ(minted.hi(), rs.uid().hi());
-    EXPECT_EQ(minted.lo(), rs.uid().lo());
-
-    set_rowset_uid(&rs); // always re-mints (replaces)
-    EXPECT_TRUE(has_valid_uid(rs));
-    EXPECT_FALSE(rs.uid().hi() == minted.hi() && rs.uid().lo() == minted.lo());
-
-    // same_rowset_uid: equal valid uids match; differing uids do not.
-    RowsetMetadataPB x;
-    RowsetMetadataPB y;
-    x.mutable_uid()->CopyFrom(a);
-    y.mutable_uid()->CopyFrom(a);
-    EXPECT_TRUE(same_rowset_uid(x, y));
-    y.mutable_uid()->CopyFrom(b);
-    EXPECT_FALSE(same_rowset_uid(x, y));
-
-    // A present-but-zero uid is not valid and never matches.
-    RowsetMetadataPB z;
-    z.mutable_uid();
-    EXPECT_FALSE(has_valid_uid(z));
-    EXPECT_FALSE(same_rowset_uid(x, z));
-}
-
 namespace {
 
 int64_t sum_of(const std::vector<int64_t>& v) {
@@ -338,17 +299,16 @@ TEST_F(TabletReshardHelperTest, test_set_all_data_files_shared_covers_ssts) {
     }
 }
 
-// Verify that set_all_data_files_shared populates op_write.shared_dels (parallel to
-// op_write.dels) so that new del files produced by an in-flight write that is
-// cross-published during tablet split are persisted with shared=true in the child
-// tablets' rowset.del_files.
-TEST_F(TabletReshardHelperTest, test_set_all_data_files_shared_populates_shared_dels) {
+// Verify that set_all_data_files_shared marks every op_write.dels_meta[].shared so that
+// new del files produced by an in-flight write that is cross-published during tablet
+// split are persisted with shared=true in the child tablets' rowset.del_files.
+TEST_F(TabletReshardHelperTest, test_set_all_data_files_shared_marks_dels_meta_shared) {
     TxnLogPB txn_log;
     auto* op_write = txn_log.mutable_op_write();
     op_write->add_dels_meta()->set_name("del1.del");
     op_write->add_dels_meta()->set_name("del2.del");
     op_write->add_dels_meta()->set_name("del3.del");
-    // Start with shared_dels empty (pre-split state).
+    // Start with each del's shared flag unset (pre-split state).
     ASSERT_FALSE(op_write->dels_meta(0).shared());
 
     set_all_data_files_shared(&txn_log);
@@ -772,34 +732,120 @@ TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_empty_childr
     EXPECT_FALSE(result.value()[0].has_upper_bound());
 }
 
-// effective_child_local_range --------------------------------------------------
+// effective_old_tablet_local_range --------------------------------------------------
 
-TEST_F(TabletReshardHelperTest, test_effective_child_local_range_rowset_present) {
+TEST_F(TabletReshardHelperTest, test_effective_old_tablet_local_range_rowset_present) {
     RowsetMetadataPB rowset;
     *rowset.mutable_range() = co_range(0, 10);
     TabletMetadataPB ctx;
     *ctx.mutable_range() = co_range(0, 30);
 
-    const auto& result = effective_child_local_range(rowset, ctx);
+    const auto& result = effective_old_tablet_local_range(rowset, ctx);
     EXPECT_TRUE(ranges_pb_equal(co_range(0, 10), result));
 }
 
-TEST_F(TabletReshardHelperTest, test_effective_child_local_range_rowset_absent_ctx_present) {
+TEST_F(TabletReshardHelperTest, test_effective_old_tablet_local_range_rowset_absent_ctx_present) {
     RowsetMetadataPB rowset; // no range
     TabletMetadataPB ctx;
     *ctx.mutable_range() = co_range(0, 30);
 
-    const auto& result = effective_child_local_range(rowset, ctx);
+    const auto& result = effective_old_tablet_local_range(rowset, ctx);
     EXPECT_TRUE(ranges_pb_equal(co_range(0, 30), result));
 }
 
-TEST_F(TabletReshardHelperTest, test_effective_child_local_range_both_absent) {
+TEST_F(TabletReshardHelperTest, test_effective_old_tablet_local_range_both_absent) {
     RowsetMetadataPB rowset;
     TabletMetadataPB ctx;
 
-    const auto& result = effective_child_local_range(rowset, ctx);
+    const auto& result = effective_old_tablet_local_range(rowset, ctx);
     EXPECT_FALSE(result.has_lower_bound());
     EXPECT_FALSE(result.has_upper_bound());
+}
+
+// -----------------------------------------------------------------------------
+// Per-segment shared refactor: set_non_segment_files_shared / rowset uid helpers /
+// the segment+non-segment wrapper.
+// -----------------------------------------------------------------------------
+
+TEST_F(TabletReshardHelperTest, SetNonSegmentFilesShared_leaves_segments_untouched) {
+    TabletMetadataPB md;
+    auto* rs = md.add_rowsets();
+    {
+        auto* sm = rs->add_segment_metas();
+        sm->set_filename("seg0");
+        sm->set_shared(false);
+    }
+    {
+        auto* sm = rs->add_segment_metas();
+        sm->set_filename("seg1");
+        sm->set_shared(false);
+    }
+    auto& dv = (*md.mutable_delvec_meta()->mutable_version_to_file())[1];
+    dv.set_name("dv1");
+    dv.set_shared(false);
+
+    set_non_segment_files_shared(&md);
+
+    // shared_segments left untouched (caller handles per-segment).
+    EXPECT_FALSE(rs->segment_metas(0).shared());
+    EXPECT_FALSE(rs->segment_metas(1).shared());
+    // non-segment file (delvec) flipped to shared.
+    EXPECT_TRUE(md.delvec_meta().version_to_file().at(1).shared());
+}
+
+TEST_F(TabletReshardHelperTest, SetAllDataFilesShared_TabletMetadata_shares_segments_and_non_segment) {
+    TabletMetadataPB md;
+    auto* rs = md.add_rowsets();
+    {
+        auto* sm = rs->add_segment_metas();
+        sm->set_filename("seg0");
+        sm->set_shared(false);
+    }
+    auto* del = rs->add_del_files();
+    del->set_name("del0");
+    del->set_shared(false);
+    auto& dv = (*md.mutable_delvec_meta()->mutable_version_to_file())[1];
+    dv.set_shared(false);
+
+    set_all_data_files_shared(&md);
+
+    EXPECT_TRUE(rs->segment_metas(0).shared());
+    EXPECT_TRUE(rs->del_files(0).shared());
+    EXPECT_TRUE(md.delvec_meta().version_to_file().at(1).shared());
+}
+
+TEST_F(TabletReshardHelperTest, MakeRowsetUid_is_fresh_and_nonzero) {
+    auto a = make_rowset_uid();
+    auto b = make_rowset_uid();
+    EXPECT_TRUE(a.hi() != 0 || a.lo() != 0);
+    EXPECT_TRUE(b.hi() != 0 || b.lo() != 0);
+    // Two independent mints must differ.
+    EXPECT_FALSE(a.hi() == b.hi() && a.lo() == b.lo());
+}
+
+TEST_F(TabletReshardHelperTest, SetRowsetUid_set_if_absent) {
+    RowsetMetadataPB rs;
+    EXPECT_FALSE(has_valid_uid(rs));
+
+    ensure_rowset_uid(&rs);
+    ASSERT_TRUE(has_valid_uid(rs));
+    auto minted = rs.uid();
+
+    // Idempotent: a second call preserves the existing uid (inherited via CopyFrom
+    // across split / cross-publish must not be overwritten).
+    ensure_rowset_uid(&rs);
+    EXPECT_EQ(minted.hi(), rs.uid().hi());
+    EXPECT_EQ(minted.lo(), rs.uid().lo());
+}
+
+TEST_F(TabletReshardHelperTest, HasValidUid_rejects_absent_and_zero) {
+    RowsetMetadataPB rs;
+    EXPECT_FALSE(has_valid_uid(rs)); // absent
+    rs.mutable_uid()->set_hi(0);
+    rs.mutable_uid()->set_lo(0);
+    EXPECT_FALSE(has_valid_uid(rs)); // present but zero
+    rs.mutable_uid()->set_lo(1);
+    EXPECT_TRUE(has_valid_uid(rs));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -60,6 +60,20 @@
 
 namespace starrocks {
 
+// Mirror reality for tests that build child metadata directly: cross-published / split
+// siblings carry a uid that is IDENTICAL across siblings (set at write time in the
+// shared txn log, or backfilled once at split). Derive a deterministic uid from a
+// physical-identity seed (a shared segment filename, or a shared del-file name) so two
+// siblings modeling "the same logical rowset" (same shared file) dedup at merge,
+// exactly as the pre-uid physical-identity rule did. A private (per-child) file name is
+// unique, so it yields a distinct uid and never falsely dedups. No-op if the rowset
+// already carries an explicit uid (pruned-sibling tests set their own matching uid).
+inline void stamp_physical_identity_uid(RowsetMetadataPB* rowset, const std::string& seed) {
+    if (rowset->has_uid()) return;
+    rowset->mutable_uid()->set_hi(1); // non-zero => valid even if the hash is 0
+    rowset->mutable_uid()->set_lo(static_cast<int64_t>(std::hash<std::string>{}(seed)));
+}
+
 class LakeTabletReshardTest : public testing::Test {
 public:
     static TuplePB generate_sort_key(int value) {
@@ -120,6 +134,32 @@ protected:
         schema.set_keys_type(PRIMARY_KEYS);
     }
 
+    // Test-only wrapper for TabletManager::put_tablet_metadata. Stamps a fresh uid on
+    // every rowset that doesn't already carry one before persisting. Production rowset
+    // producers (delta_writer, compaction, schema_change, splitter backfill, column-mode
+    // synthesis, ...) all mint a uid at creation, so the merge-side strict invariant
+    // (DCHECK + Status::InternalError on missing uid in tablet_merger.cpp) never fires
+    // in production. Synthetic test fixtures that omit uid would otherwise trip that
+    // invariant; auto-stamp them with a fresh random uid here so they behave like
+    // production local-data writes (distinct uid across tablets → no false dedup).
+    // Dedup tests that need siblings to share a uid stamp it explicitly via
+    // stamp_physical_identity_uid BEFORE calling this helper, and the ensure_rowset_uid
+    // below is a no-op (set-if-absent semantics).
+    Status put_tablet_metadata(TabletMetadataPB metadata) {
+        for (auto& rowset : *metadata.mutable_rowsets()) {
+            lake::tablet_reshard_helper::ensure_rowset_uid(&rowset);
+        }
+        return _tablet_manager->put_tablet_metadata(metadata);
+    }
+
+    Status put_tablet_metadata(const TabletMetadataPtr& metadata) {
+        auto mutable_meta = std::make_shared<TabletMetadataPB>(*metadata);
+        for (auto& rowset : *mutable_meta->mutable_rowsets()) {
+            lake::tablet_reshard_helper::ensure_rowset_uid(&rowset);
+        }
+        return _tablet_manager->put_tablet_metadata(mutable_meta);
+    }
+
     RowsetMetadataPB* add_rowset(TabletMetadataPB* metadata, uint32_t rowset_id, uint32_t max_compact_input_rowset_id,
                                  uint32_t del_origin_rowset_id) {
         auto* rowset = metadata->add_rowsets();
@@ -133,6 +173,9 @@ protected:
         auto* del_file = rowset->add_del_files();
         del_file->set_name("del.dat");
         del_file->set_origin_rowset_id(del_origin_rowset_id);
+        // Match production: every lake writer mints a unique uid so distinct local
+        // rowsets never alias across tablets at merge.
+        lake::tablet_reshard_helper::set_rowset_uid(rowset);
         return rowset;
     }
 
@@ -150,6 +193,9 @@ protected:
             }
             rowset->set_num_rows(1);
             rowset->set_data_size(128);
+            // Match production: every lake writer mints a unique uid, so distinct
+            // per-tablet data rowsets never alias across tablets at merge.
+            lake::tablet_reshard_helper::set_rowset_uid(rowset);
             return rowset;
         }
 
@@ -161,6 +207,10 @@ protected:
         binary_predicate->set_column_name("c0");
         binary_predicate->set_op(">");
         binary_predicate->set_value("0");
+        // Production-faithful: Tablet::delete_data mints an independent (random) uid
+        // per tablet, so sibling predicates at the same version do NOT share a uid.
+        // MERGE must dedup them by version, not uid -- this exercises that path.
+        lake::tablet_reshard_helper::set_rowset_uid(rowset);
         return rowset;
     }
 
@@ -466,7 +516,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
 
     metadata.mutable_sstable_meta()->add_sstables()->set_filename("test.sst");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding_tablet_for_splitting;
     auto& splitting_tablet = *resharding_tablet_for_splitting.mutable_splitting_tablet_info();
@@ -553,6 +603,528 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
     EXPECT_EQ(0, tablet_ranges.size());
 }
 
+// Phase-1 per-segment shared (end-to-end). After splitting a rowset whose two
+// segments occupy disjoint key ranges, each child keeps only its overlapping
+// segment, marks it private (shared=false), drops the sibling's segment,
+// backfills a uid (the source rowset has none) identically on both children, and
+// conserves Σ stats. NOTE: built but NOT run locally (LLVM-16/18 thirdparty
+// mismatch); verify in CI.
+TEST_F(LakeTabletReshardTest, test_tablet_split_per_segment_shared_invariants) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+
+    auto* rs = metadata.add_rowsets();
+    rs->set_id(2);
+    {
+        auto* m0 = rs->add_segment_metas();
+        m0->set_filename("seg_lo.dat");
+        m0->set_size(512);
+        m0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        m0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        m0->set_num_rows(50);
+    }
+    {
+        auto* m1 = rs->add_segment_metas();
+        m1->set_filename("seg_hi.dat");
+        m1->set_size(512);
+        m1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        m1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        m1->set_num_rows(50);
+    }
+    rs->set_overlapped(true);
+    rs->set_data_size(1024);
+    rs->set_num_rows(100);
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    auto c0 = tablet_metadatas.at(child0);
+    auto c1 = tablet_metadatas.at(child1);
+    ASSERT_EQ(1, c0->rowsets_size());
+    ASSERT_EQ(1, c1->rowsets_size());
+    const auto& r0 = c0->rowsets(0);
+    const auto& r1 = c1->rowsets(0);
+
+    // The source rowset's uid (stamped by the test put_tablet_metadata wrapper) is
+    // preserved verbatim onto every new tablet at split time, so cross-sibling
+    // dedup at a later merge sees identical uids.
+    ASSERT_TRUE(r0.has_uid());
+    ASSERT_TRUE(r1.has_uid());
+    EXPECT_TRUE(r0.uid().hi() != 0 || r0.uid().lo() != 0);
+    EXPECT_EQ(r0.uid().hi(), r1.uid().hi());
+    EXPECT_EQ(r0.uid().lo(), r1.uid().lo());
+
+    auto all_segs = [](const RowsetMetadataPB& r) {
+        std::set<std::string> a;
+        for (const auto& s : r.segment_metas()) a.insert(s.filename());
+        return a;
+    };
+    auto private_segs = [](const RowsetMetadataPB& r) {
+        std::set<std::string> p;
+        for (int i = 0; i < r.segment_metas_size(); ++i) {
+            if (!r.segment_metas(i).shared()) p.insert(r.segment_metas(i).filename());
+        }
+        return p;
+    };
+
+    // No data loss: union of children's segments == parent's two segments.
+    std::set<std::string> seen = all_segs(r0);
+    for (const auto& s : all_segs(r1)) seen.insert(s);
+    EXPECT_EQ((std::set<std::string>{"seg_lo.dat", "seg_hi.dat"}), seen);
+
+    // A private (shared=false) segment must be exclusive to its child.
+    for (const auto& s : private_segs(r0)) EXPECT_EQ(0u, all_segs(r1).count(s));
+    for (const auto& s : private_segs(r1)) EXPECT_EQ(0u, all_segs(r0).count(s));
+
+    // The optimization engaged: disjoint segments split cleanly into private ones.
+    EXPECT_GE(private_segs(r0).size() + private_segs(r1).size(), 1u);
+
+    // Σ stats conserved (anchor path).
+    EXPECT_EQ(100, r0.num_rows() + r1.num_rows());
+    EXPECT_EQ(1024, r0.data_size() + r1.data_size());
+}
+
+// SPLIT propagates per-segment ownership to non-segment metadata:
+//   - a pruned-away segment's delvec page + dcg entry are erased on the tablet
+//     that doesn't keep it;
+//   - an exclusive (shared=false) kept segment's dcg is marked private;
+//   - the kept segment's delvec page is retained (delvec files stay shared).
+// Setup: one rowset (id=2) with two disjoint segments seg_lo[0,49] (rssid 2) and
+// seg_hi[50,99] (rssid 3); split into two children so each keeps exactly one
+// segment exclusively.
+TEST_F(LakeTabletReshardTest, test_tablet_split_propagates_ownership_to_delvec_dcg) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+
+    auto* rs = metadata.add_rowsets();
+    rs->set_id(2);
+    {
+        auto* m0 = rs->add_segment_metas();
+        m0->set_filename("seg_lo.dat");
+        m0->set_size(512);
+        m0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        m0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        m0->set_num_rows(50);
+    }
+    {
+        auto* m1 = rs->add_segment_metas();
+        m1->set_filename("seg_hi.dat");
+        m1->set_size(512);
+        m1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        m1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        m1->set_num_rows(50);
+    }
+    rs->set_overlapped(true);
+    rs->set_data_size(1024);
+    rs->set_num_rows(100);
+
+    // delvec + dcg for both segments' rssids (rowset id 2 + segment_idx {0,1}).
+    add_delvec(&metadata, tablet_id, /*version=*/1, /*segment_id=*/2, "dv_lo.dat", "aa");
+    add_delvec(&metadata, tablet_id, /*version=*/1, /*segment_id=*/3, "dv_hi.dat", "bb");
+    add_dcg_with_columns(&metadata, /*segment_id=*/2, "dcg_lo.col", {101}, 1);
+    add_dcg_with_columns(&metadata, /*segment_id=*/3, "dcg_hi.col", {102}, 1);
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    // For each child, the kept segment's rssid is private dcg + present delvec; the
+    // pruned-away segment's rssid is absent from both dcg and delvec.
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        ASSERT_EQ(1, c->rowsets_size());
+        const auto& r = c->rowsets(0);
+        ASSERT_EQ(1, r.segment_metas_size()) << "each child keeps exactly one exclusive segment";
+        const uint32_t kept_rssid = r.id() + r.segment_metas(0).segment_idx();
+        const uint32_t pruned_rssid = (kept_rssid == 2) ? 3 : 2;
+
+        // Exclusive kept segment -> segment_metas[0].shared()==false -> its dcg is private.
+        EXPECT_FALSE(r.segment_metas(0).shared()) << "kept segment is exclusive (provably contained)";
+        ASSERT_TRUE(c->dcg_meta().dcgs().contains(kept_rssid));
+        const auto& kept_dcg = c->dcg_meta().dcgs().at(kept_rssid);
+        ASSERT_EQ(kept_dcg.column_files_size(), kept_dcg.shared_files_size());
+        for (bool sf : kept_dcg.shared_files()) EXPECT_FALSE(sf) << "exclusive segment dcg must be private";
+
+        // Kept segment's delvec page retained (delvec files stay shared).
+        EXPECT_TRUE(c->delvec_meta().delvecs().contains(kept_rssid));
+
+        // Pruned-away segment's delvec page + dcg entry erased.
+        EXPECT_FALSE(c->delvec_meta().delvecs().contains(pruned_rssid))
+                << "pruned segment delvec must be erased on the tablet that dropped it";
+        EXPECT_FALSE(c->dcg_meta().dcgs().contains(pruned_rssid))
+                << "pruned segment dcg must be erased on the tablet that dropped it";
+    }
+}
+
+// SPLIT removes a rowset whose every segment was pruned from a new tablet, along
+// with its rowset_to_schema mapping and its (now-orphan) delvec/dcg. Setup: two
+// rowsets in disjoint key ranges so each is exclusive to exactly one child.
+TEST_F(LakeTabletReshardTest, test_tablet_split_removes_fully_pruned_rowset) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    metadata.set_next_rowset_id(20);
+    // Base+cumulative split index: rowset at position 0 (rs_a) is "base", position 1
+    // (rs_b) is "cumulative". Removing one shifts positions, so the children's
+    // cumulative_point must be recomputed (not inherited stale).
+    metadata.set_cumulative_point(1);
+
+    auto* rs_a = metadata.add_rowsets(); // lives entirely in [0,49]
+    rs_a->set_id(2);
+    {
+        auto* ma = rs_a->add_segment_metas();
+        ma->set_filename("a_seg.dat");
+        ma->set_size(512);
+        ma->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        ma->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        ma->set_num_rows(50);
+    }
+    rs_a->set_data_size(512);
+    rs_a->set_num_rows(50);
+    (*metadata.mutable_rowset_to_schema())[2] = 1001;
+
+    auto* rs_b = metadata.add_rowsets(); // lives entirely in [50,99]
+    rs_b->set_id(10);
+    {
+        auto* mb = rs_b->add_segment_metas();
+        mb->set_filename("b_seg.dat");
+        mb->set_size(512);
+        mb->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        mb->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        mb->set_num_rows(50);
+    }
+    rs_b->set_data_size(512);
+    rs_b->set_num_rows(50);
+    (*metadata.mutable_rowset_to_schema())[10] = 1002;
+
+    // delvec/dcg for both rowsets' single segments (rssid = id + 0).
+    add_delvec(&metadata, tablet_id, 1, /*segment_id=*/2, "dv_a.dat", "aa");
+    add_delvec(&metadata, tablet_id, 1, /*segment_id=*/10, "dv_b.dat", "bb");
+    add_dcg_with_columns(&metadata, /*segment_id=*/2, "dcg_a.col", {101}, 1);
+    add_dcg_with_columns(&metadata, /*segment_id=*/10, "dcg_b.col", {102}, 1);
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    // Each child keeps exactly the one rowset whose segment overlaps its range; the
+    // other rowset is fully pruned and removed (entry, rowset_to_schema, delvec, dcg).
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        ASSERT_EQ(1, c->rowsets_size()) << "fully-pruned rowset removed from rowsets[]";
+        const uint32_t kept_id = c->rowsets(0).id();
+        const uint32_t removed_id = (kept_id == 2) ? 10 : 2;
+        EXPECT_TRUE(c->rowset_to_schema().contains(kept_id));
+        EXPECT_FALSE(c->rowset_to_schema().contains(removed_id)) << "removed rowset's schema mapping erased";
+        EXPECT_FALSE(c->delvec_meta().delvecs().contains(removed_id)) << "removed rowset's delvec erased";
+        EXPECT_FALSE(c->dcg_meta().dcgs().contains(removed_id)) << "removed rowset's dcg erased";
+        // The surviving rowset's metadata is intact.
+        EXPECT_TRUE(c->delvec_meta().delvecs().contains(kept_id));
+        EXPECT_TRUE(c->dcg_meta().dcgs().contains(kept_id));
+
+        // cumulative_point recomputed against surviving positions, never exceeding
+        // rowsets_size(). The child keeping rs_a (base, original pos 0) keeps it in the
+        // base region -> cp==1; the child keeping rs_b (cumulative, pos 1) had rs_a
+        // removed from the base region -> cp==0.
+        EXPECT_LE(c->cumulative_point(), static_cast<uint32_t>(c->rowsets_size()));
+        EXPECT_EQ(kept_id == 2 ? 1u : 0u, c->cumulative_point());
+    }
+}
+
+// A fully-pruned rowset carrying del_files must NOT be removed (the del_files keep
+// guard), even with 0 segments -- mirrors the delete-predicate guard. rs_a's only
+// segment lives in [0,49] so it is pruned from the [50,99] child, but its del_files
+// keep it there; rs_b (no del_files) is removed from the child it does not overlap.
+TEST_F(LakeTabletReshardTest, test_tablet_split_keeps_del_files_rowset) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    metadata.set_next_rowset_id(20);
+
+    auto* rs_a = metadata.add_rowsets(); // segment lives entirely in [0,49]
+    rs_a->set_id(2);
+    {
+        auto* ma = rs_a->add_segment_metas();
+        ma->set_filename("a_seg.dat");
+        ma->set_size(512);
+        ma->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        ma->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        ma->set_num_rows(50);
+    }
+    rs_a->set_data_size(512);
+    rs_a->set_num_rows(50);
+    rs_a->add_del_files()->set_name("del_a.dat"); // keeps rs_a where its segment is pruned
+    (*metadata.mutable_rowset_to_schema())[2] = 1001;
+
+    auto* rs_b = metadata.add_rowsets(); // segment lives entirely in [50,99], no del_files
+    rs_b->set_id(10);
+    {
+        auto* mb = rs_b->add_segment_metas();
+        mb->set_filename("b_seg.dat");
+        mb->set_size(512);
+        mb->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        mb->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        mb->set_num_rows(50);
+    }
+    rs_b->set_data_size(512);
+    rs_b->set_num_rows(50);
+    (*metadata.mutable_rowset_to_schema())[10] = 1002;
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    int rs_a_fully_pruned_but_kept = 0;
+    int rs_b_present = 0;
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        const RowsetMetadataPB* rs_a_out = nullptr;
+        for (const auto& r : c->rowsets()) {
+            if (r.id() == 2) rs_a_out = &r;
+            if (r.id() == 10) ++rs_b_present;
+        }
+        ASSERT_NE(rs_a_out, nullptr) << "rs_a must survive on every child (overlap or del_files guard)";
+        EXPECT_GT(rs_a_out->del_files_size(), 0) << "rs_a keeps its del_files";
+        if (rs_a_out->segment_metas_size() == 0) ++rs_a_fully_pruned_but_kept; // kept purely by the del_files guard
+    }
+    EXPECT_EQ(1, rs_a_fully_pruned_but_kept)
+            << "exactly one child fully prunes rs_a's segment yet keeps it for del_files";
+    EXPECT_EQ(1, rs_b_present) << "rs_b (no del_files) is removed from the non-overlapping child";
+}
+
+// A fully-pruned rowset carrying a delete predicate must NOT be removed: the
+// predicate applies to the whole key range and must propagate to every child.
+TEST_F(LakeTabletReshardTest, test_tablet_split_keeps_delete_predicate_rowset) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    metadata.set_next_rowset_id(20);
+
+    // Data rowset spanning [0,99] so the split produces two ranges.
+    auto* data_lo = metadata.add_rowsets();
+    data_lo->set_id(2);
+    {
+        auto* dm0 = data_lo->add_segment_metas();
+        dm0->set_filename("lo.dat");
+        dm0->set_size(512);
+        dm0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        dm0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        dm0->set_num_rows(50);
+    }
+    {
+        auto* dm1 = data_lo->add_segment_metas();
+        dm1->set_filename("hi.dat");
+        dm1->set_size(512);
+        dm1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        dm1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        dm1->set_num_rows(50);
+    }
+    data_lo->set_overlapped(true);
+    data_lo->set_data_size(1024);
+    data_lo->set_num_rows(100);
+
+    // Delete-predicate rowset: 0 segments by design.
+    add_rowset_with_predicate(&metadata, /*rowset_id=*/10, /*version=*/2, /*has_predicate=*/true);
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    // The delete-predicate rowset (id 10) survives on BOTH children despite 0 segments.
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        bool found_predicate = false;
+        for (const auto& r : c->rowsets()) {
+            if (r.id() == 10) {
+                found_predicate = true;
+                EXPECT_TRUE(r.has_delete_predicate());
+            }
+        }
+        EXPECT_TRUE(found_predicate) << "delete-predicate rowset must propagate to every child";
+    }
+}
+
+// The load-bearing protected-rssid exception: when a fully-pruned rowset's rssid is
+// referenced by a surviving has_shared_rssid sstable, the delvec page is KEPT (MERGE's
+// modern sstable projection needs it) and the rowset is NOT removed — but the dcg entry
+// (never consulted by sstable projection) is still erased.
+TEST_F(LakeTabletReshardTest, test_tablet_split_protected_rssid_keeps_delvec_blocks_removal) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    metadata.set_next_rowset_id(20);
+
+    auto* rs_a = metadata.add_rowsets(); // [0,49], rssid 2
+    rs_a->set_id(2);
+    {
+        auto* ma = rs_a->add_segment_metas();
+        ma->set_filename("a_seg.dat");
+        ma->set_size(512);
+        ma->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        ma->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        ma->set_num_rows(50);
+    }
+    rs_a->set_data_size(512);
+    rs_a->set_num_rows(50);
+
+    auto* rs_b = metadata.add_rowsets(); // [50,99], rssid 10
+    rs_b->set_id(10);
+    {
+        auto* mb = rs_b->add_segment_metas();
+        mb->set_filename("b_seg.dat");
+        mb->set_size(512);
+        mb->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        mb->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        mb->set_num_rows(50);
+    }
+    rs_b->set_data_size(512);
+    rs_b->set_num_rows(50);
+
+    add_delvec(&metadata, tablet_id, 1, /*segment_id=*/2, "dv_a.dat", "aa");
+    add_dcg_with_columns(&metadata, /*segment_id=*/2, "dcg_a.col", {101}, 1);
+    // A surviving modern sstable that projects rssid 2 (rs_a's segment).
+    auto* sstable = metadata.mutable_sstable_meta()->add_sstables();
+    sstable->set_filename("idx.sst");
+    sstable->set_shared_rssid(2);
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    // Find the child that fully prunes rs_a (the one whose range is [50,..)).
+    const TabletMetadataPB* pruning_child = nullptr;
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        bool has_a_segment = false;
+        for (const auto& r : c->rowsets()) {
+            for (const auto& s : r.segment_metas()) {
+                if (s.filename() == "a_seg.dat") has_a_segment = true;
+            }
+        }
+        if (!has_a_segment) pruning_child = c.get();
+    }
+    ASSERT_NE(nullptr, pruning_child) << "one child must fully prune rs_a";
+
+    // rs_a (id 2) is NOT removed (protected), retained as a 0-segment rowset.
+    bool found_rs_a = false;
+    for (const auto& r : pruning_child->rowsets()) {
+        if (r.id() == 2) {
+            found_rs_a = true;
+            EXPECT_EQ(0, r.segment_metas_size());
+        }
+    }
+    EXPECT_TRUE(found_rs_a) << "protected rowset must not be removed";
+    // delvec page for the protected rssid is KEPT; dcg is still erased.
+    EXPECT_TRUE(pruning_child->delvec_meta().delvecs().contains(2))
+            << "protected rssid delvec must be kept for MERGE sstable projection";
+    EXPECT_FALSE(pruning_child->dcg_meta().dcgs().contains(2)) << "dcg is never sstable-referenced -> erased";
+}
+
 // Regression for the crash discovered during SSB SF100 testing: FE requests
 // N new tablet ids, but the sampled algorithm can only produce M < N ranges.
 // Before the fix, get_tablet_split_ranges silently returned M ranges and
@@ -583,7 +1155,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_fewer_ranges_than_requested_
     rowset_meta_pb->set_num_rows(300);
     rowset_meta_pb->set_data_size(1024);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding;
     auto& splitting_tablet = *resharding.mutable_splitting_tablet_info();
@@ -644,7 +1216,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_with_gap_boundary) {
     rowset_meta_pb->set_data_size(1024);
     rowset_meta_pb->set_num_rows(200);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding_tablet_for_splitting;
     auto& splitting_tablet = *resharding_tablet_for_splitting.mutable_splitting_tablet_info();
@@ -749,7 +1321,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_keeps_raw_rowset_stats) {
     delvec.init(base_version, deleted_rows, 3);
     add_delvec(&metadata, tablet_id, base_version, rowset->id(), "test.delvec", delvec.save());
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
@@ -823,7 +1395,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_scales_num_dels) {
         sm->set_num_rows(5);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
@@ -907,7 +1479,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_fallback_reads_delvec_for
     delvec.init(base_version, deleted_rows, 4);
     add_delvec(&metadata, tablet_id, base_version, rowset->id(), "test.delvec", delvec.save());
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
@@ -1006,7 +1578,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_per_rowset_conserv
         sm->set_num_rows(30);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding;
     auto& splitting = *resharding.mutable_splitting_tablet_info();
@@ -1104,7 +1676,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_clamps_invalid_par
         sm->set_num_rows(5);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding;
     auto& splitting = *resharding.mutable_splitting_tablet_info();
@@ -1187,7 +1759,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_falls_back_to_segm
         sm->set_num_rows(4);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding;
     auto& splitting = *resharding.mutable_splitting_tablet_info();
@@ -1302,7 +1874,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_three_level_chain_
     add_sampled_rowset(&metadata, /*rs_id=*/3, /*min=*/500, /*max=*/1499, /*num_rows=*/1000,
                        /*data_size=*/6000, /*num_dels=*/12, /*interval=*/100);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(put_tablet_metadata(metadata));
 
     TxnInfoPB txn_info;
     txn_info.set_commit_time(1);
@@ -1408,7 +1980,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);
     add_rowset_with_predicate(&meta_a, 2, 10, true);
     add_rowset_with_predicate(&meta_a, 3, 11, false);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     TabletMetadataPB meta_b;
     meta_b.set_id(tablet_b);
@@ -1417,7 +1989,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     add_rowset_with_predicate(&meta_b, 1, 1, false);
     add_rowset_with_predicate(&meta_b, 2, 10, true);
     add_rowset_with_predicate(&meta_b, 3, 11, false);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1484,7 +2056,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);  // data
     add_rowset_with_predicate(&meta_a, 2, 10, true);  // predicate v10
     add_rowset_with_predicate(&meta_a, 3, 11, false); // data
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     // Tablet B: data(v1) -> predicate(v10) -> data(v11) -> predicate(v20) -> data(v21)
     TabletMetadataPB meta_b;
@@ -1496,7 +2068,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
     add_rowset_with_predicate(&meta_b, 3, 11, false); // data
     add_rowset_with_predicate(&meta_b, 4, 20, true);  // predicate v20 (only in tablet_b)
     add_rowset_with_predicate(&meta_b, 5, 21, false); // data
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1566,7 +2138,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);
     add_rowset_with_predicate(&meta_a, 2, 2, false);
     add_rowset_with_predicate(&meta_a, 3, 3, false);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     TabletMetadataPB meta_b;
     meta_b.set_id(tablet_b);
@@ -1575,7 +2147,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
     add_rowset_with_predicate(&meta_b, 1, 1, false);
     add_rowset_with_predicate(&meta_b, 2, 2, false);
     add_rowset_with_predicate(&meta_b, 3, 3, false);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1610,7 +2182,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
     }
 
     EXPECT_EQ(0, predicate_count);
-    // Version-driven k-way merge interleaves by (version, child_index):
+    // Version-driven k-way merge interleaves by (version, old_tablet_index):
     // v1: A(id=1), B(id=4); v2: A(id=2), B(id=5); v3: A(id=3), B(id=6)
     EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 5, 3, 6}), rowset_ids);
 }
@@ -1639,7 +2211,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_single_tablet_predicate) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);  // data
     add_rowset_with_predicate(&meta_a, 2, 10, true);  // predicate v10
     add_rowset_with_predicate(&meta_a, 3, 11, false); // data
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     // Tablet B: data(v1) -> data(v2) -> data(v3) (no predicates)
     TabletMetadataPB meta_b;
@@ -1649,7 +2221,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_single_tablet_predicate) {
     add_rowset_with_predicate(&meta_b, 1, 1, false);
     add_rowset_with_predicate(&meta_b, 2, 2, false);
     add_rowset_with_predicate(&meta_b, 3, 3, false);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1712,7 +2284,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_all_predicates) {
     meta_a.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_a, 1, 10, true); // predicate v10
     add_rowset_with_predicate(&meta_a, 2, 20, true); // predicate v20
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     // Tablet B: predicate(v10) -> predicate(v20) (same versions)
     TabletMetadataPB meta_b;
@@ -1721,7 +2293,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_all_predicates) {
     meta_b.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_b, 1, 10, true); // predicate v10
     add_rowset_with_predicate(&meta_b, 2, 20, true); // predicate v20
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1796,8 +2368,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     add_sstable(meta2.get(), "sst-2", (static_cast<uint64_t>(2) << 32) | 5, true);
     add_dcg_with_columns(meta2.get(), 1, "dcg-2", {201, 202}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1882,6 +2454,69 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     EXPECT_TRUE(merged->historical_schemas().find(1001) != merged->historical_schemas().end());
 }
 
+// Strict-uid gate (MERGE side): a rowset reaching reshard merge without a valid
+// uid must fail loudly, not silently mis-dedup. Every production producer mints a
+// uid, and the test put_tablet_metadata wrapper auto-stamps one on every synthetic
+// rowset specifically so fixtures behave like production — which means this gate is
+// otherwise never exercised. Here we bypass the wrapper (persist via _tablet_manager
+// directly) AND clear the uid that add_rowset stamps, driving a genuinely uid-less
+// rowset into merge_rowsets. The gate is DCHECK-first (fail-fast abort in debug) with
+// a Status::InternalError fallback for release, so the assertion is build-conditional.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rowset_without_uid_fails) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(100);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_rowset(meta1.get(), 10, 7, 10); // keeps its stamped uid (valid input)
+    (*meta1->mutable_rowset_to_schema())[10] = 1001;
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(3);
+    set_primary_key_schema(meta2.get(), 2002);
+    add_rowset(meta2.get(), 1, 3, 1)->clear_uid(); // producer-side regression: no uid
+    (*meta2->mutable_rowset_to_schema())[1] = 2002;
+
+    // Persist directly, bypassing the uid-auto-stamping fixture wrapper.
+    ASSERT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    ASSERT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+
+    auto do_merge = [&]() {
+        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+        return lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                               txn_info, false, tablet_metadatas, tablet_ranges);
+    };
+#if DCHECK_IS_ON()
+    ASSERT_DEATH({ (void)do_merge(); }, "rowset reaching reshard merge must carry a valid uid");
+#else
+    auto st = do_merge();
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("rowset reaching reshard merge has no uid")) << st.to_string();
+#endif
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_without_delvec) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -1907,8 +2542,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_without_delvec) {
     set_primary_key_schema(meta2.get(), 1002);
     add_rowset(meta2.get(), 2, 2, 2);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -1953,8 +2588,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_missing_delvec_meta) {
     set_primary_key_schema(meta2.get(), 1002);
     add_rowset(meta2.get(), 2, 2, 2);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2005,8 +2640,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_version_missing) {
     page.set_size(1);
     (*delvec_meta->mutable_delvecs())[2] = page;
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2053,8 +2688,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) 
     add_rowset(meta2.get(), 2, 2, 2);
     add_delvec(meta2.get(), old_tablet_id_2, base_version, 2, "delvec-2", "bbb");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2110,8 +2745,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_file_offset) {
     add_rowset(meta2.get(), 2, 2, 2);
     add_delvec(meta2.get(), old_tablet_id_2, base_version, 2, "delvec-2", "bbb");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2163,8 +2798,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cache_miss_fallback) {
     meta2->set_next_rowset_id(5);
     add_rowset(meta2.get(), 2, 2, 2);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     auto cached_meta1 = std::make_shared<TabletMetadataPB>(*meta1);
     cached_meta1->set_version(new_version);
@@ -2225,9 +2860,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_base_version_not_found) {
     meta_new->set_next_rowset_id(5);
     meta_new->set_gtid(100);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_new));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta_new));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2300,8 +2935,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_segment_overflow) {
     add_rowset(meta2.get(), 90, 90, 90);
     add_dcg_with_columns(meta2.get(), std::numeric_limits<uint32_t>::max() - 5, "dcg-overflow", {301}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2355,8 +2990,8 @@ TEST_F(LakeTabletReshardTest, test_split_cross_publish_sets_rowset_range_in_txn_
     new_meta->set_id(new_tablet_id);
     new_meta->set_version(base_version);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(old_meta));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(new_meta));
+    EXPECT_OK(put_tablet_metadata(old_meta));
+    EXPECT_OK(put_tablet_metadata(new_meta));
 
     TxnLogPB log;
     log.set_tablet_id(old_tablet_id);
@@ -2505,6 +3140,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         // Add shared sstable with shared_rssid
         auto* sst = meta->mutable_sstable_meta()->add_sstables();
         sst->set_filename("shared_sst.sst");
@@ -2519,8 +3155,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2561,6 +3197,329 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
     EXPECT_EQ((static_cast<uint64_t>(out_sst.shared_rssid()) << 32) | 99, out_sst.max_rss_rowid());
 }
 
+// Phase-1 merge (end-to-end): two siblings with matching uid and a shared segment
+// + distinct private segments. uid dedup unions their segments into one merged
+// rowset. No re-share: the merged tablet owns its segments via the ownership-transfer
+// model (the source old tablets are marked all-shared so their drop/vacuum skips the
+// files), so the union preserves per-segment flags -- a spanning segment stays
+// shared=true, split-pruned segments stay shared=false. NOTE: built but NOT run
+// locally (LLVM thirdparty mismatch); verify in CI.
+TEST_F(LakeTabletReshardTest, test_tablet_merge_segment_union_preserves_ownership) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, const std::string& private_seg, uint32_t private_idx) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        meta->mutable_schema()->set_keys_type(DUP_KEYS);
+        meta->mutable_schema()->set_id(1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        // Shared segment (identical in both siblings) + private (per-sibling).
+        {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename("shared.dat");
+            sm->set_size(100);
+            sm->set_shared(true);
+            sm->set_segment_idx(0);
+            sm->set_encryption_meta("enc_shared");
+        }
+        {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename(private_seg);
+            sm->set_size(50);
+            sm->set_shared(false);
+            sm->set_segment_idx(private_idx);
+            sm->set_encryption_meta("enc_" + private_seg);
+        }
+        // Same uid => same logical rowset => dedup at merge.
+        rowset->mutable_uid()->set_hi(0);
+        rowset->mutable_uid()->set_lo(777);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, "a_private.dat", 1)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, "b_private.dat", 2)));
+
+    ReshardingTabletInfoPB resharding;
+    auto& merging = *resharding.mutable_merging_tablet_info();
+    merging.add_old_tablet_ids(child_a);
+    merging.add_old_tablet_ids(child_b);
+    merging.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size()); // family dedup => single merged rowset
+    const auto& mr = merged->rowsets(0);
+
+    std::set<std::string> segs;
+    for (const auto& s : mr.segment_metas()) segs.insert(s.filename());
+    EXPECT_EQ((std::set<std::string>{"shared.dat", "a_private.dat", "b_private.dat"}), segs); // union, shared deduped
+
+    // Each segment carries its own encryption_meta inside its SegmentMetadataPB, so the
+    // union keeps every segment's encryption meta aligned with the segment.
+    std::map<std::string, std::string> seg_to_enc;
+    for (int i = 0; i < mr.segment_metas_size(); ++i)
+        seg_to_enc[mr.segment_metas(i).filename()] = mr.segment_metas(i).encryption_meta();
+    EXPECT_EQ("enc_shared", seg_to_enc["shared.dat"]);
+    EXPECT_EQ("enc_a_private.dat", seg_to_enc["a_private.dat"]);
+    EXPECT_EQ("enc_b_private.dat", seg_to_enc["b_private.dat"]);
+
+    // No re-share: the merged tablet owns its segments. The union preserves per-segment
+    // flags -- the spanning segment stays shared=true (still referenced by any non-merged
+    // sibling), while split-pruned segments stay shared=false (owned by the merged tablet,
+    // freed by its own GC instead of leaking onto the shared-file path).
+    std::map<std::string, bool> seg_shared;
+    for (int i = 0; i < mr.segment_metas_size(); ++i) {
+        seg_shared[mr.segment_metas(i).filename()] = mr.segment_metas(i).shared();
+    }
+    EXPECT_TRUE(seg_shared.at("shared.dat"));
+    EXPECT_FALSE(seg_shared.at("a_private.dat"));
+    EXPECT_FALSE(seg_shared.at("b_private.dat"));
+    EXPECT_EQ(20, mr.num_rows());
+    EXPECT_EQ(200, mr.data_size());
+    EXPECT_TRUE(mr.has_uid()); // preserved across merge
+    EXPECT_EQ(777, mr.uid().lo());
+}
+
+// Multi-level split regression: an already-shared ancestor segment that is later
+// pruned to one new tablet retains shared=true (compute_rowset_segment_ownership
+// keeps was_shared regardless of overlap count). Two siblings of such a multi-level
+// split therefore carry the SAME uid and DISJOINT all-shared segment subsets. The
+// segment-union gate must fire on segment-list divergence — not just on the
+// shared=false flag — or the merged rowset silently loses the duplicate sibling's
+// segments.
+TEST_F(LakeTabletReshardTest, test_tablet_merge_multi_level_disjoint_all_shared_segment_metas) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, const std::string& segment_name, uint32_t segment_idx) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        meta->mutable_schema()->set_keys_type(DUP_KEYS);
+        meta->mutable_schema()->set_id(1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        // Each sibling carries a DIFFERENT segment, but BOTH are marked shared=true
+        // (the multi-level was_shared propagation result). The segments_differ gate in
+        // update_canonical fires on the per-position filename mismatch, so the union runs
+        // even though neither sibling has a segment_metas[i].shared()==false flag.
+        {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename(segment_name);
+            sm->set_size(100);
+            sm->set_shared(true);
+            sm->set_segment_idx(segment_idx);
+        }
+        // Same uid => same logical rowset => dedup at merge.
+        rowset->mutable_uid()->set_hi(0);
+        rowset->mutable_uid()->set_lo(2024);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, "ancestor_seg_0.dat", 0)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, "ancestor_seg_1.dat", 1)));
+
+    ReshardingTabletInfoPB resharding;
+    auto& merging = *resharding.mutable_merging_tablet_info();
+    merging.add_old_tablet_ids(child_a);
+    merging.add_old_tablet_ids(child_b);
+    merging.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size()); // dedup => single merged rowset
+    const auto& mr = merged->rowsets(0);
+    std::set<std::string> segs;
+    for (const auto& s : mr.segment_metas()) segs.insert(s.filename());
+    EXPECT_EQ((std::set<std::string>{"ancestor_seg_0.dat", "ancestor_seg_1.dat"}), segs)
+            << "the merged rowset must union the disjoint all-shared segment sets, not silently drop one sibling's";
+}
+
+// File bundling packs multiple segments into one physical file, so a bundled rowset's
+// segments share a file NAME and differ only by bundle_file_offset. After a split prunes
+// such a rowset, two same-uid siblings carry DISJOINT bundled segment subsets with
+// IDENTICAL file-name lists. update_canonical must (1) detect divergence by comparing
+// offsets (not just names) so the union fires, and (2) union bundle_file_offsets in
+// lockstep with segments -- otherwise a sibling's bundled segments are silently dropped.
+TEST_F(LakeTabletReshardTest, test_tablet_merge_bundled_segments_union_offsets) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto add_seg = [](RowsetMetadataPB* rowset, uint32_t idx, int64_t off) {
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("bundle.dat"); // same physical file for every slice
+        sm->set_size(100);
+        sm->set_bundle_file_offset(off);
+        sm->set_shared(true);
+        sm->set_segment_idx(idx);
+    };
+    // Two bundled segments per child; the children hold DISJOINT idx subsets {0,1} and
+    // {2,3} but identical file-name lists ["bundle.dat","bundle.dat"].
+    auto make_child = [&](int64_t tablet_id, uint32_t idx0, int64_t off0, uint32_t idx1, int64_t off1) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        meta->mutable_schema()->set_keys_type(DUP_KEYS);
+        meta->mutable_schema()->set_id(1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_overlapped(true);
+        rowset->set_num_rows(20);
+        rowset->set_data_size(200);
+        add_seg(rowset, idx0, off0);
+        add_seg(rowset, idx1, off1);
+        rowset->mutable_uid()->set_hi(0); // same uid => same logical rowset => dedup at merge
+        rowset->mutable_uid()->set_lo(2024);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, 0, 0, 1, 1024)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, 2, 2048, 3, 3072)));
+
+    ReshardingTabletInfoPB resharding;
+    auto& merging = *resharding.mutable_merging_tablet_info();
+    merging.add_old_tablet_ids(child_a);
+    merging.add_old_tablet_ids(child_b);
+    merging.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size()); // same uid => single merged rowset
+    const auto& mr = merged->rowsets(0);
+    // All four bundled slices survive the union (not just canonical child_a's two).
+    ASSERT_EQ(4, mr.segment_metas_size()) << "bundled siblings' disjoint segments must union, not drop";
+    int bundle_offset_count = 0;
+    for (const auto& sm : mr.segment_metas()) {
+        if (sm.has_bundle_file_offset()) ++bundle_offset_count;
+    }
+    ASSERT_EQ(4, bundle_offset_count) << "bundle_file_offset must union in lockstep with segments";
+    // segment_idx-sorted order => offsets line up as [0,1024,2048,3072].
+    std::vector<int64_t> offsets;
+    for (const auto& sm : mr.segment_metas()) offsets.push_back(sm.bundle_file_offset());
+    EXPECT_EQ((std::vector<int64_t>{0, 1024, 2048, 3072}), offsets);
+}
+
+// Companion regression to the test above, exercising same-uid all-shared siblings
+// with UNEQUAL segment counts (one carried two ancestor segments after split, the
+// other carried just one). The original DCHECK asserted segments_size parity for
+// non-pruned siblings, which would falsely fire here; the fix relaxes the assertion
+// to del_files parity only.
+TEST_F(LakeTabletReshardTest, test_tablet_merge_multi_level_unequal_count_all_shared_segment_metas) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, const std::vector<std::string>& segment_names,
+                          const std::vector<uint32_t>& segment_indexes) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        meta->mutable_schema()->set_keys_type(DUP_KEYS);
+        meta->mutable_schema()->set_id(1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(static_cast<int64_t>(segment_names.size() * 5));
+        rowset->set_data_size(static_cast<int64_t>(segment_names.size() * 50));
+        for (size_t i = 0; i < segment_names.size(); ++i) {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename(segment_names[i]);
+            sm->set_size(50);
+            sm->set_shared(true);
+            sm->set_segment_idx(segment_indexes[i]);
+        }
+        rowset->mutable_uid()->set_hi(0);
+        rowset->mutable_uid()->set_lo(2025);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, {"seg_0.dat", "seg_1.dat"}, {0, 1})));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, {"seg_2.dat"}, {2})));
+
+    ReshardingTabletInfoPB resharding;
+    auto& merging = *resharding.mutable_merging_tablet_info();
+    merging.add_old_tablet_ids(child_a);
+    merging.add_old_tablet_ids(child_b);
+    merging.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    const auto& mr = merged->rowsets(0);
+    std::set<std::string> segs;
+    for (const auto& s : mr.segment_metas()) segs.insert(s.filename());
+    EXPECT_EQ((std::set<std::string>{"seg_0.dat", "seg_1.dat", "seg_2.dat"}), segs);
+}
+
 // Verify merge-back accumulates num_dels alongside num_rows / data_size. Without this,
 // update_canonical would keep only the first child's per-range num_dels slice so the
 // merged rowset loses (N-1)/N of the parent's deletes and get_tablet_stats over-reports
@@ -2594,6 +3553,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_num_dels) {
             sm->set_size(data_size);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         return meta;
     };
 
@@ -2601,8 +3561,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_num_dels) {
     auto meta_a = make_child(child_a, /*num_rows=*/4, /*data_size=*/40, /*num_dels=*/3);
     auto meta_b = make_child(child_b, /*num_rows=*/6, /*data_size=*/60, /*num_dels=*/3);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -2657,6 +3617,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(shared_a, "shared_seg.dat"); // same uid across siblings => dedup
     // Local upsert (new data after split)
     auto* local_a = meta_a->add_rowsets();
     local_a->set_id(2);
@@ -2686,6 +3647,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(shared_b, "shared_seg.dat"); // same uid across siblings => dedup
     // Local upsert (different new data)
     auto* local_b = meta_b->add_rowsets();
     local_b->set_id(2);
@@ -2698,8 +3660,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         sm->set_size(30);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -2782,8 +3744,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_compaction) {
         sm->set_shared(true);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -2850,8 +3812,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_rowset_on_non_first_chi
         sm->set_shared(true);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -2901,14 +3863,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_only_shared_rowset) {
         del_file->set_name("shared_del.dat");
         del_file->set_shared(true);
         del_file->set_origin_rowset_id(1);
+        stamp_physical_identity_uid(rowset, "shared_del.dat"); // same uid across siblings => dedup
         return meta;
     };
 
     auto meta_a = make_del_only_child(child_a);
     auto meta_b = make_del_only_child(child_b);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -2978,8 +3941,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_different_split_families) {
         sm->set_shared(true);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_d));
+    EXPECT_OK(put_tablet_metadata(meta_c));
+    EXPECT_OK(put_tablet_metadata(meta_d));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3031,6 +3994,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_publish_different_id) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    // Cross-publish: the same write txn log is applied to both children, so both
+    // inherit the SAME write-time uid. Model that with a matching uid here.
+    stamp_physical_identity_uid(rowset_a, "cross_pub.dat");
 
     auto meta_b = std::make_shared<TabletMetadataPB>();
     meta_b->set_id(child_b);
@@ -3047,9 +4013,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_publish_different_id) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_b, "cross_pub.dat"); // same uid as A (cross-publish)
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3101,6 +4068,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_fail_fast) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_a, "shared_seg.dat"); // same uid across siblings => dedup
     // DCG from child A's independent partial update
     add_dcg_with_columns(meta_a.get(), 1, "dcg_a.cols", {1}, 1);
 
@@ -3119,11 +4087,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_fail_fast) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_b, "shared_seg.dat"); // same uid across siblings => dedup
     // DCG from child B's different independent partial update
     add_dcg_with_columns(meta_b.get(), 1, "dcg_b.cols", {1}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3163,7 +4132,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_predicate_dedup) {
     meta_a.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_a, 1, 5, true);  // predicate v5
     add_rowset_with_predicate(&meta_a, 2, 6, false); // data v6
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     TabletMetadataPB meta_b;
     meta_b.set_id(child_b);
@@ -3171,7 +4140,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_predicate_dedup) {
     meta_b.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_b, 1, 5, true);  // same predicate v5
     add_rowset_with_predicate(&meta_b, 2, 6, false); // data v6
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3230,6 +4199,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_dcg_dedup) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         // Same shared DCG on both children (inherited from split)
         add_dcg_with_columns(meta.get(), 1, "shared_dcg.cols", {1, 2}, 1);
         return meta;
@@ -3238,8 +4208,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_dcg_dedup) {
     auto meta_a = make_child_with_dcg(child_a);
     auto meta_b = make_child_with_dcg(child_b);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3309,6 +4279,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_independent_delete) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_a, "shared_seg.dat"); // same uid across siblings => dedup
     // Delvec from child_a's independent delete
     add_delvec(meta_a.get(), child_a, 1, 1, "delvec_a.dv", dv_a_data);
 
@@ -3328,11 +4299,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_independent_delete) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_b, "shared_seg.dat"); // same uid across siblings => dedup
     // Delvec from child_b's different independent delete
     add_delvec(meta_b.get(), child_b, 2, 1, "delvec_b.dv", dv_b_data);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3433,6 +4405,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_a, "shared_seg1.dat"); // same uid across siblings => dedup
     // Delvec for segment 1 (rssid 1) and segment 2 (rssid 2) from child_a
     // Write a combined delvec file for child_a with both pages
     std::string combined_a = dv_a1_data + dv_a2_data;
@@ -3479,6 +4452,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_b, "shared_seg1.dat"); // same uid across siblings => dedup
     // Delvec for segment 1 and 2 from child_b
     std::string combined_b = dv_b1_data + dv_b2_data;
     {
@@ -3502,8 +4476,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
         write_file(_tablet_manager->delvec_location(child_b, "delvec_b.dv"), combined_b);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3606,6 +4580,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_three_way_union) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         add_delvec(meta.get(), tablet_id, delvec_version, 1, delvec_file_name, delvec_data);
         return meta;
     };
@@ -3614,9 +4589,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_three_way_union) {
     auto meta_b = make_child_meta(child_b, 2, "delvec_b.dv", dv_b_data);
     auto meta_c = make_child_meta(child_c, 3, "delvec_c.dv", dv_c_data);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3692,6 +4667,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) 
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_a, "shared_seg.dat"); // same uid across siblings => dedup
     // Both children reference the same delvec file (shared after split)
     add_delvec(meta_a.get(), child_a, 1, 1, "shared_delvec.dv", dv_data);
 
@@ -3711,11 +4687,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) 
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset_b, "shared_seg.dat"); // same uid across siblings => dedup
     // Same file name, same offset/size -> page-ref dedup
     add_delvec(meta_b.get(), child_b, 1, 1, "shared_delvec.dv", dv_data);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3788,6 +4765,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         return meta;
     };
 
@@ -3797,8 +4775,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns) {
     auto meta_b = make_child(child_b);
     add_dcg_with_columns(meta_b.get(), 1, "b.cols", {3, 4}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3865,6 +4843,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        // Matching uid across siblings so the rowsets dedup at merge — without this
+        // the test put_tablet_metadata wrapper would auto-mint distinct random uids
+        // and the DCG-dedup invariant below would not actually be exercised.
+        stamp_physical_identity_uid(rowset, "shared_seg.dat");
         add_dcg_with_columns(meta.get(), 1, "shared.cols", {1, 2}, 1);
         return meta;
     };
@@ -3872,8 +4854,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup) {
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3892,6 +4874,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup) {
                                               txn_info, false, tablet_metadatas, tablet_ranges));
 
     auto merged = tablet_metadatas.at(merged_tablet);
+    // Both children's rowsets share one uid → rowset dedup leaves a single merged
+    // rowset, and DCG-exact-dedup folds the two identical .cols entries into one.
+    ASSERT_EQ(1, merged->rowsets_size()) << "matching-uid rowsets must dedup at merge";
     auto dcg_it = merged->dcg_meta().dcgs().find(merged->rowsets(0).id());
     ASSERT_TRUE(dcg_it != merged->dcg_meta().dcgs().end());
     ASSERT_EQ(1, dcg_it->second.column_files_size());
@@ -3927,6 +4912,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_same_column_conflict) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         return meta;
     };
 
@@ -3936,8 +4922,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_same_column_conflict) {
     auto meta_b = make_child(child_b);
     add_dcg_with_columns(meta_b.get(), 1, "b.cols", {1}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -3986,6 +4972,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_partial_overlap) {
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         return meta;
     };
 
@@ -3995,8 +4982,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_partial_overlap) {
     auto meta_b = make_child(child_b);
     add_dcg_with_columns(meta_b.get(), 1, "b.cols", {2, 3}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -4044,7 +5031,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_missing_shape) {
     // Use legacy add_dcg (no unique_column_ids/versions)
     add_dcg(meta_a.get(), 1, "malformed.cols");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -4092,7 +5079,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_duplicate_column_uid) {
     add_dcg_with_columns(meta_a.get(), 1, "first.cols", {1, 2}, 1);
     add_dcg_with_columns(meta_a.get(), 1, "second.cols", {2, 3}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_a));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -4112,94 +5099,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_duplicate_column_uid) {
 }
 
 // --- sstable merge tests ---
-
-TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_without_shared_rssid) {
-    // Legacy shared sstable (shared=true && !has_shared_rssid). With the
-    // metadata-only fast-path on top of PR #72219's rebuild, a clean family
-    // (no partial compaction, no delvec) is projected without reading or
-    // writing a new file: output PB is byte-identical to the source PB.
-    // PR #72219's rebuild remains as a fallback for non-clean cases (covered
-    // by the test_tablet_merging_legacy_sstable_rebuild_* tests).
-    const int64_t base_version = 1;
-    const int64_t new_version = 2;
-    const int64_t child_a = next_id();
-    const int64_t child_b = next_id();
-    const int64_t merged_tablet = next_id();
-
-    prepare_tablet_dirs(child_a);
-    prepare_tablet_dirs(child_b);
-    prepare_tablet_dirs(merged_tablet);
-
-    // Write a real PK sstable shared by both children. Stored rssid 1 must
-    // match a live child rowset for the rebuild to keep the entries; rowset
-    // id 1 below satisfies that.
-    const std::string legacy_filename = "legacy_sst.sst";
-    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
-    const uint64_t legacy_filesize =
-            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/1, /*rowid=*/1}});
-
-    auto make_child = [&](int64_t tablet_id) {
-        auto meta = std::make_shared<TabletMetadataPB>();
-        meta->set_id(tablet_id);
-        meta->set_version(base_version);
-        meta->set_next_rowset_id(3);
-        set_primary_key_schema(meta.get(), 1001);
-        auto* rowset = meta->add_rowsets();
-        rowset->set_id(1);
-        rowset->set_version(1);
-        rowset->set_num_rows(10);
-        rowset->set_data_size(100);
-        {
-            auto* sm = rowset->add_segment_metas();
-            sm->set_filename("shared_seg.dat");
-            sm->set_size(100);
-            sm->set_shared(true);
-        }
-        // Legacy shared sstable: no shared_rssid, no delvec
-        auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename(legacy_filename);
-        sst->set_filesize(legacy_filesize);
-        sst->set_shared(true);
-        sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 50);
-        return meta;
-    };
-
-    auto meta_a = make_child(child_a);
-    auto meta_b = make_child(child_b);
-
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-
-    ReshardingTabletInfoPB resharding_tablet;
-    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
-    merging_info.add_old_tablet_ids(child_a);
-    merging_info.add_old_tablet_ids(child_b);
-    merging_info.set_new_tablet_id(merged_tablet);
-
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(1);
-    txn_info.set_commit_time(1);
-    txn_info.set_gtid(1);
-
-    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                              txn_info, false, tablet_metadatas, tablet_ranges));
-
-    auto merged = tablet_metadatas.at(merged_tablet);
-    // Deduped to a single sstable. Both children kept rowset id=1 alive and
-    // there is no merged delvec → fast-path safety conditions hold; output is
-    // a byte-for-byte copy of the source PB (same filename, shared=true).
-    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
-    const auto& out_sst = merged->sstable_meta().sstables(0);
-    EXPECT_EQ(legacy_filename, out_sst.filename());
-    EXPECT_TRUE(out_sst.shared());
-    EXPECT_FALSE(out_sst.has_shared_rssid());
-    EXPECT_EQ(0, out_sst.rssid_offset());
-    EXPECT_FALSE(out_sst.has_delvec());
-    EXPECT_EQ(static_cast<uint32_t>(1), static_cast<uint32_t>(out_sst.max_rss_rowid() >> 32));
-    EXPECT_EQ(legacy_filesize, out_sst.filesize());
-}
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_mixed_shared_and_local) {
     // Child A has shared + local sstable, child B has same shared sstable.
@@ -4281,8 +5180,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_mixed_shared_and_local
     sst_shared_b->set_shared_version(1);
     sst_shared_b->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -4368,8 +5267,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_no_dedup_different_fil
     sst_b->set_shared_version(1);
     sst_b->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 50);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -4446,8 +5345,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_rssid_projectio
     sst_b->set_shared_version(2);
     sst_b->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -4817,6 +5716,7 @@ RowsetMetadataPB* add_shared_rowset(TabletMetadataPB* metadata, uint32_t rowset_
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset, segment_filename);
     return rowset;
 }
 
@@ -5009,7 +5909,7 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel
                                                 _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
 }
 
-// Regression: partial compaction's output_rowset.segments() concatenates
+// Regression: partial compaction's output_rowset.segment_metas() concatenates
 // reused input segments with newly written ones; only the new window
 // (new_segment_offset / new_segment_count) should be queued for deletion.
 // Deleting reused segments would corrupt the merged tablet because those
@@ -5144,8 +6044,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_sorted_by_max_rss_row
     sst_b_local->set_filesize(128);
     sst_b_local->set_max_rss_rowid((static_cast<uint64_t>(3) << 32) | 50);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -5247,8 +6147,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_sort_uses_signed_comp
     sst_b_low->set_filesize(128);
     sst_b_low->set_max_rss_rowid((static_cast<uint64_t>(7) << 32) | 50);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -5379,8 +6279,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_keep_same_fileset_id_
     // Child B's lone F_A sstable falls inside F_X's max_rss_rowid range.
     add_sst(meta_b.get(), "fa_high200.sst", 200, 0, fid_a);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -5547,8 +6447,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_split_inherited_files
         sm->set_size(100);
     }
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -5624,106 +6524,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_split_inherited_files
     EXPECT_EQ(pos5_fid, fid_pair(merged->sstable_meta().sstables(7).fileset_id()));
 }
 
-// Two PK parents (not cloud-native, so flush_parent_for_merge is a pass-through)
-// each carry a shared legacy standalone sstable with the same filename but
-// different `fileset_id` values (as would happen when PersistentIndexSstableFileset
-// init synthesizes a random id per load). The shared-sstable consistency check
-// must exclude fileset_id (identity is pinned by filename + filesize +
-// encryption_meta + range), so the dedup keeps a single source PB and the
-// rebuild path emits exactly one rebuilt sstable for the merged tablet.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_dedup_legacy_standalone_sstable) {
-    const int64_t base_version = 1;
-    const int64_t new_version = 2;
-    const int64_t child_a = next_id();
-    const int64_t child_b = next_id();
-    const int64_t merged_tablet = next_id();
-
-    prepare_tablet_dirs(child_a);
-    prepare_tablet_dirs(child_b);
-    prepare_tablet_dirs(merged_tablet);
-
-    // Both children share the SAME physical legacy sstable file. We write it
-    // once into the test FS — the FixedLocationProvider routes any tablet_id's
-    // sst_location to the same shared segments dir.
-    const std::string legacy_filename = "legacy_shared.sst";
-    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
-    const uint64_t legacy_filesize =
-            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/1, /*rowid=*/1}});
-
-    // Both children reference the same legacy standalone sstable but carry
-    // different synthesized fileset_id values.
-    auto make_child = [&](int64_t tablet_id, uint64_t fileset_hi, uint64_t fileset_lo) {
-        auto meta = std::make_shared<TabletMetadataPB>();
-        meta->set_id(tablet_id);
-        meta->set_version(base_version);
-        meta->set_next_rowset_id(3);
-        set_primary_key_schema(meta.get(), 1001);
-        auto* rowset = meta->add_rowsets();
-        rowset->set_id(1);
-        rowset->set_version(1);
-        rowset->set_num_rows(10);
-        rowset->set_data_size(100);
-        {
-            auto* sm = rowset->add_segment_metas();
-            sm->set_filename("shared_seg.dat");
-            sm->set_size(100);
-            sm->set_shared(true);
-        }
-        auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename(legacy_filename);
-        sst->set_filesize(legacy_filesize);
-        sst->set_shared(true);
-        // Legacy standalone: no shared_rssid. Simulated per-parent synthesized
-        // fileset_id (differs across parents).
-        sst->mutable_fileset_id()->set_hi(fileset_hi);
-        sst->mutable_fileset_id()->set_lo(fileset_lo);
-        sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
-        return meta;
-    };
-
-    auto meta_a = make_child(child_a, 0x1111, 0x2222);
-    auto meta_b = make_child(child_b, 0x3333, 0x4444); // different fileset_id
-
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-
-    ReshardingTabletInfoPB resharding_tablet;
-    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
-    merging_tablet.add_old_tablet_ids(child_a);
-    merging_tablet.add_old_tablet_ids(child_b);
-    merging_tablet.set_new_tablet_id(merged_tablet);
-
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(1);
-    txn_info.set_commit_time(1);
-    txn_info.set_gtid(1);
-
-    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                              txn_info, false, tablet_metadatas, tablet_ranges));
-
-    auto it = tablet_metadatas.find(merged_tablet);
-    ASSERT_TRUE(it != tablet_metadatas.end());
-    const auto& merged = it->second;
-
-    // Differing fileset_ids do not block dedup; the merge produces exactly one
-    // sstable. With the fast-path on a clean family the output PB is a
-    // byte-for-byte copy of the source PB (the dedup-winner ctx[0]'s PB),
-    // including its fileset_id; the C2' check is vacuous here because the
-    // source PB has no range field.
-    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
-    const auto& out_sst = merged->sstable_meta().sstables(0);
-    EXPECT_EQ(legacy_filename, out_sst.filename());
-    EXPECT_TRUE(out_sst.shared());
-    EXPECT_FALSE(out_sst.has_shared_rssid());
-    EXPECT_EQ(0, out_sst.rssid_offset());
-    // Fast-path keeps the ctx[0] (dedup-winner) source PB's fileset_id.
-    ASSERT_TRUE(out_sst.has_fileset_id());
-    EXPECT_EQ(static_cast<uint64_t>(0x1111), out_sst.fileset_id().hi());
-    EXPECT_EQ(static_cast<uint64_t>(0x2222), out_sst.fileset_id().lo());
-}
-
 // Reproduces run4 cycle-3 ghost-rssid shape at the metadata level: the legacy
 // shared sstable inherited from an ancestor still stores entries for rowsets
 // that have been compacted out of every surviving child. The bug-fix rebuild
@@ -5733,8 +6533,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dedup_legacy_standalone_sstabl
 // Setup:
 //   - Children A and B both inherit one shared PK sstable with three entries:
 //       k1 -> rssid 1, k2 -> rssid 2, k3 -> rssid 3
-//   - A keeps rowset id=1 alive (shared_segments=true).
-//   - B keeps rowset id=2 alive (shared_segments=true).
+//   - A keeps rowset id=1 alive (segment_metas[].shared()=true).
+//   - B keeps rowset id=2 alive (segment_metas[].shared()=true).
 //   - Neither child has rowset id=3 — that ancestor rowset has been compacted
 //     out everywhere, but the legacy sstable cannot be rewritten by the old
 //     metadata-only projection so its entry for k3 is the run4 ghost.
@@ -5788,8 +6588,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_drops_d
     auto meta_a = make_child(child_a, /*live_rowset_id=*/1, "seg_a.dat");
     auto meta_b = make_child(child_b, /*live_rowset_id=*/2, "seg_b.dat");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -5911,8 +6711,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_filters
 
     auto meta_a = make_child(child_a, "delvec_a.dv");
     auto meta_b = make_child(child_b, "delvec_b.dv");
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6010,8 +6810,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_sparse_
 
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6107,8 +6907,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_with_so
 
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6205,8 +7005,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_tombsto
 
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6305,8 +7105,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_stacked
 
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6391,8 +7191,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_tombsto
 
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6438,22 +7238,20 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_tombsto
 }
 
 // =============================================================================
-// Fast-path metadata-only projection tests (PR following PR #72219)
+// Legacy shared-sstable rebuild edge-case tests
 // =============================================================================
 //
-// These tests verify try_fastpath_project_legacy_shared_sstable's behavior
-// through the merge end-to-end. Distinguishing the two paths via output PB
-// shape:
-//   * Fast-path hit  → output filename == source, shared==true,
-//                      rssid_offset == 0 (= source), no new file written.
-//   * Fallback       → output filename != source (rebuild wrote a new UUID),
-//                      shared==false, has fileset_id (rebuild assigned).
+// MERGE rebuilds every legacy `shared && !has_shared_rssid` sstable, writing a
+// fresh file with remapped rssids. These tests drive specific input shapes
+// through the merge end-to-end and assert the rebuild output signature:
+//   output filename != source (rebuild wrote a new UUID), shared==false,
+//   has fileset_id (rebuild assigned).
 
-// Clean family: both children share the legacy sstable and both contribute the
-// full set of ancestor rowsets. data_rssid_map == identity over [1, M], no
-// merged delvec → all of C0, C0', C2, C3, C5, C6, C7 hold → fast-path emits
-// the source PB byte-for-byte.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_clean_family) {
+// child_a (= ctx[0]) does NOT carry the legacy sstable, only child_b (= ctx[1])
+// does. ctx[1].rssid_offset is non-zero whenever ctx[0]'s rowset id-space pushes
+// ctx[1]'s ids upward; the rebuild must apply that offset exactly once. Guards
+// against a regression that double-shifts an already-offset canonical.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_with_nonzero_canonical_offset) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
     const int64_t child_a = next_id();
@@ -6464,95 +7262,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_clean_
     prepare_tablet_dirs(child_b);
     prepare_tablet_dirs(merged_tablet);
 
-    const std::string legacy_filename = "fastpath_clean.sst";
-    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
-    const uint64_t legacy_filesize = write_legacy_pk_sstable(
-            legacy_path,
-            {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}, {"k3", /*rssid=*/3, /*rowid=*/0}});
-
-    auto make_child = [&](int64_t tablet_id) {
-        auto meta = std::make_shared<TabletMetadataPB>();
-        meta->set_id(tablet_id);
-        meta->set_version(base_version);
-        meta->set_next_rowset_id(4);
-        set_primary_key_schema(meta.get(), 1001);
-        // Rowsets 1, 2, 3 are all shared between children → dedup at
-        // merge_rowsets, canonical = ctx[0]'s mapping (offset 0).
-        for (uint32_t rs_id : {1u, 2u, 3u}) {
-            auto* rowset = meta->add_rowsets();
-            rowset->set_id(rs_id);
-            rowset->set_version(1);
-            rowset->set_num_rows(10);
-            rowset->set_data_size(100);
-            {
-                auto* sm = rowset->add_segment_metas();
-                sm->set_filename(fmt::format("shared_seg_{}.dat", rs_id));
-                sm->set_size(100);
-                sm->set_shared(true);
-            }
-        }
-        auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename(legacy_filename);
-        sst->set_filesize(legacy_filesize);
-        sst->set_shared(true);
-        // No has_shared_rssid: this is the legacy ancestor-inherited form.
-        // No rssid_offset (C0). max_rss_rowid.high == 3 == |rowsets|.
-        sst->set_max_rss_rowid((static_cast<uint64_t>(3) << 32) | 0);
-        return meta;
-    };
-
-    auto meta_a = make_child(child_a);
-    auto meta_b = make_child(child_b);
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-
-    ReshardingTabletInfoPB resharding_tablet;
-    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
-    merging_info.add_old_tablet_ids(child_a);
-    merging_info.add_old_tablet_ids(child_b);
-    merging_info.set_new_tablet_id(merged_tablet);
-
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(1);
-    txn_info.set_commit_time(1);
-    txn_info.set_gtid(1);
-
-    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                              txn_info, false, tablet_metadatas, tablet_ranges));
-
-    auto merged = tablet_metadatas.at(merged_tablet);
-    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
-    const auto& out_sst = merged->sstable_meta().sstables(0);
-
-    // Fast-path signature: output PB is byte-identical to source PB.
-    EXPECT_EQ(legacy_filename, out_sst.filename()) << "fast-path keeps source filename, no new UUID written";
-    EXPECT_TRUE(out_sst.shared()) << "fast-path keeps shared=true";
-    EXPECT_FALSE(out_sst.has_shared_rssid()) << "fast-path keeps !has_shared_rssid";
-    EXPECT_EQ(0, out_sst.rssid_offset()) << "C0+C0' force zero offset";
-    EXPECT_EQ(legacy_filesize, out_sst.filesize());
-    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid());
-}
-
-// Inverse of clean-family: child_a (= ctx[0]) does NOT carry the legacy
-// sstable, only child_b (= ctx[1]) does. Phase 1 makes ctx[1].rssid_offset
-// non-zero whenever ctx[0]'s rowset id-space pushes ctx[1]'s ids upward, so
-// canonical_offset != 0 → C0' fails → fallback to rebuild. Required by the
-// plan as defense-in-depth against a fast-path output with non-zero
-// rssid_offset that would later get double-shifted by another rebuild.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_nonzero_canonical_offset_falls_back) {
-    const int64_t base_version = 1;
-    const int64_t new_version = 2;
-    const int64_t child_a = next_id();
-    const int64_t child_b = next_id();
-    const int64_t merged_tablet = next_id();
-
-    prepare_tablet_dirs(child_a);
-    prepare_tablet_dirs(child_b);
-    prepare_tablet_dirs(merged_tablet);
-
-    const std::string legacy_filename = "fastpath_nonzero_canonical.sst";
+    const std::string legacy_filename = "legacy_nonzero_canonical.sst";
     const auto legacy_path = _tablet_manager->sst_location(child_b, legacy_filename);
     const uint64_t legacy_filesize =
             write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
@@ -6599,8 +7309,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_nonzer
     sst->set_shared(true);
     sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6619,21 +7329,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_nonzer
     ASSERT_EQ(1, merged->sstable_meta().sstables_size());
     const auto& out_sst = merged->sstable_meta().sstables(0);
     // Rebuild signature: new filename, !shared, fresh fileset_id, has_range.
-    EXPECT_NE(legacy_filename, out_sst.filename()) << "fallback rebuild wrote a new file";
+    EXPECT_NE(legacy_filename, out_sst.filename()) << "rebuild wrote a new file";
     EXPECT_FALSE(out_sst.shared());
     EXPECT_TRUE(out_sst.has_fileset_id());
 }
 
-// C0: source PB carries a non-zero rssid_offset (a stacked-merge legacy
-// sstable). Even if everything else is clean, fast-path falls back unconditionally
-// to avoid an emitted PB whose accumulated offset would later get double-shifted
-// by a subsequent rebuild.
-// v2 update: source PB carrying a non-zero rssid_offset (= a stacked-merge
-// legacy sstable) used to fall back to rebuild under v1's C0 zero-offset
-// gate. v2 drops C0, so the fast-path now accumulates the source offset
-// into the emitted PB (out.rssid_offset = src.rssid_offset +
-// canonical_offset) and shifts max_rss_rowid.high accordingly.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_v2_src_offset_hit) {
+// Source PB has range but no fileset_id. PersistentIndexSstableFileset::
+// init(vector) DCHECKs has_fileset_id() for ranged sstables, so the rebuild
+// must assign a fresh fileset_id explicitly rather than carrying the source PB
+// forward. Asserts the rebuilt sstable has a fileset_id.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_for_range_without_fileset_id) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
     const int64_t child_a = next_id();
@@ -6644,93 +7349,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_v2_src
     prepare_tablet_dirs(child_b);
     prepare_tablet_dirs(merged_tablet);
 
-    const std::string legacy_filename = "fastpath_nonzero_src.sst";
-    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
-    // Stored rssids must be >= 1 (rs.id >= 1 invariant). The dense walk
-    // skips effective rssid below src.rssid_offset+1 because there is no
-    // valid stored rssid 0 in production sstables.
-    const uint64_t legacy_filesize =
-            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
-
-    auto make_child = [&](int64_t tablet_id) {
-        auto meta = std::make_shared<TabletMetadataPB>();
-        meta->set_id(tablet_id);
-        meta->set_version(base_version);
-        meta->set_next_rowset_id(4);
-        set_primary_key_schema(meta.get(), 1001);
-        for (uint32_t rs_id : {1u, 2u, 3u}) {
-            auto* rs = meta->add_rowsets();
-            rs->set_id(rs_id);
-            rs->set_version(1);
-            rs->set_num_rows(10);
-            rs->set_data_size(100);
-            {
-                auto* sm = rs->add_segment_metas();
-                sm->set_filename(fmt::format("nzs_seg_{}.dat", rs_id));
-                sm->set_size(100);
-                sm->set_shared(true);
-            }
-        }
-        auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename(legacy_filename);
-        sst->set_filesize(legacy_filesize);
-        sst->set_shared(true);
-        // Non-zero src rssid_offset: prior merge already shifted stored ids
-        // by 1, so stored 1/2 lift to effective 2/3 in this child's space.
-        sst->set_rssid_offset(1);
-        sst->set_max_rss_rowid((static_cast<uint64_t>(3) << 32) | 0);
-        return meta;
-    };
-
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_a)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_b)));
-
-    ReshardingTabletInfoPB resharding_tablet;
-    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
-    merging_info.add_old_tablet_ids(child_a);
-    merging_info.add_old_tablet_ids(child_b);
-    merging_info.set_new_tablet_id(merged_tablet);
-
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(3);
-    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                              txn_info, false, tablet_metadatas, tablet_ranges));
-
-    auto merged = tablet_metadatas.at(merged_tablet);
-    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
-    const auto& out_sst = merged->sstable_meta().sstables(0);
-    // Fast-path signature: original filename preserved, shared=true, no
-    // new fileset_id minted. canonical_offset is 0 (canonical = ctx[0],
-    // rssid_offset = 0) so accumulated == 1, and max_rss_rowid.high
-    // shifts from 3 to 3 + 0 = 3.
-    EXPECT_EQ(legacy_filename, out_sst.filename())
-            << "v2 fast-path keeps source filename even with non-zero src offset";
-    EXPECT_TRUE(out_sst.shared());
-    EXPECT_FALSE(out_sst.has_shared_rssid());
-    EXPECT_EQ(1, out_sst.rssid_offset()) << "accumulated = src.rssid_offset(1) + canonical_offset(0)";
-    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid())
-            << "max_rss_rowid.high shifts by canonical_offset (0 here)";
-}
-
-// C2': source PB has range but no fileset_id. PersistentIndexSstableFileset::
-// init(vector) DCHECKs has_fileset_id() for ranged sstables; the fast-path
-// preserves the source PB so we cannot mint a new fileset_id without losing
-// the no-write-no-read guarantee. Fallback to rebuild, which assigns a fresh
-// fileset_id explicitly.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_range_without_fileset_id_falls_back) {
-    const int64_t base_version = 1;
-    const int64_t new_version = 2;
-    const int64_t child_a = next_id();
-    const int64_t child_b = next_id();
-    const int64_t merged_tablet = next_id();
-
-    prepare_tablet_dirs(child_a);
-    prepare_tablet_dirs(child_b);
-    prepare_tablet_dirs(merged_tablet);
-
-    const std::string legacy_filename = "fastpath_range_no_fid.sst";
+    const std::string legacy_filename = "legacy_range_no_fid.sst";
     const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
     const uint64_t legacy_filesize =
             write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
@@ -6766,8 +7385,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_range_
         return meta;
     };
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_a)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_b)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_a)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6793,7 +7412,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_range_
 // Regression for fast-path v2 commit 3 (per-child orphan scoping): two
 // children that family inference classifies as kNoFamily — their legacy
 // shared sstables have distinct filenames (no filename edge) and their
-// rowsets are child-local (shared_segments=false → not shared-ancestor,
+// rowsets are child-local (segment_metas[].shared()=false → not shared-ancestor,
 // no rowset edge). Both children's source rssid space overlaps at
 // rssid=1.
 //
@@ -6837,7 +7456,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_orphan_per_chil
         meta->set_version(base_version);
         meta->set_next_rowset_id(2);
         set_primary_key_schema(meta.get(), 1001);
-        // Child-local rowset (shared_segments=false): not a shared-ancestor,
+        // Child-local rowset (segment_metas[].shared()=false): not a shared-ancestor,
         // so the rowset edge in family inference does not fire across
         // children.
         auto* rowset = meta->add_rowsets();
@@ -6862,10 +7481,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_orphan_per_chil
         return meta;
     };
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(
-            make_child(child_a, "a_local_seg.dat", legacy_a_filename, legacy_a_filesize)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(
-            make_child(child_b, "b_local_seg.dat", legacy_b_filename, legacy_b_filesize)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, "a_local_seg.dat", legacy_a_filename, legacy_a_filesize)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, "b_local_seg.dat", legacy_b_filename, legacy_b_filesize)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -6888,7 +7505,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_orphan_per_chil
 
     // Both ctxs are kNoFamily (no edges), so v2 fast-path falls through to
     // rebuild for both legacy sstables. Each rebuild consults its own
-    // per-child orphan PerFamilyMaps (orphan_by_child[child_index]). Both
+    // per-child orphan PerFamilyMaps (orphan_by_child[old_tablet_index]). Both
     // emitted PBs therefore wear the rebuild signature: !shared, fresh
     // fileset_id, new (UUID) filename. They differ in max_rss_rowid.high:
     //   ctx_a (rssid_offset=0): orphan_by_child[0][1] = 1, high = 1.
@@ -6910,122 +7527,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_orphan_per_chil
     std::set<uint64_t> rebuilt_highs{sstables.Get(0).max_rss_rowid() >> 32, sstables.Get(1).max_rss_rowid() >> 32};
     EXPECT_EQ((std::set<uint64_t>{1, 2}), rebuilt_highs)
             << "ctx_b's rebuild must consult orphan_by_child[1], not a polluted shared orphan map";
-}
-
-// v2 fast-path headline win: canonical_ctx for the family carries a
-// non-zero rssid_offset (it is NOT ctx[0]) yet the family-canonical
-// projection still produces a byte-mappable shift. Under v1 this hit the
-// C0' canonical-offset-nonzero gate and fell back to rebuild. Under v2
-// the family's safe canonical_offset accumulates into the emitted PB.
-//
-// Setup:
-//   ctx_a (= ctx[0]): unrelated child-local rowset, no edge to b/c.
-//   ctx_b (= ctx[1]): shared-ancestor rowsets {1, 2} + legacy sstable.
-//   ctx_c (= ctx[2]): same shared-ancestor rowsets + same legacy sstable.
-// Family inference unions ctx_b + ctx_c via either edge; ctx_a stays
-// kNoFamily. canonical_child_index = 1 (smallest member of {1, 2}), so
-// canonical_rssid_offset = ctx_b.rssid_offset = 1 (Phase 1 lifts ctx_b's
-// id space by ctx_a's contribution of 1 rowset).
-TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_v2_canonical_offset_hit) {
-    const int64_t base_version = 1;
-    const int64_t new_version = 2;
-    const int64_t child_a = next_id();
-    const int64_t child_b = next_id();
-    const int64_t child_c = next_id();
-    const int64_t merged_tablet = next_id();
-
-    prepare_tablet_dirs(child_a);
-    prepare_tablet_dirs(child_b);
-    prepare_tablet_dirs(child_c);
-    prepare_tablet_dirs(merged_tablet);
-
-    const std::string legacy_filename = "fastpath_v2_canonical.sst";
-    // The legacy sstable file lives only on ctx_b's storage; ctx_c's PB
-    // points at the same logical filename (shared sstable file). For the
-    // fast-path that is byte-mapped, the source file isn't actually read,
-    // so single-side write is fine.
-    const auto legacy_path = _tablet_manager->sst_location(child_b, legacy_filename);
-    const uint64_t legacy_filesize =
-            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
-
-    auto meta_a = std::make_shared<TabletMetadataPB>();
-    meta_a->set_id(child_a);
-    meta_a->set_version(base_version);
-    meta_a->set_next_rowset_id(2);
-    set_primary_key_schema(meta_a.get(), 1001);
-    auto* rs_a = meta_a->add_rowsets();
-    rs_a->set_id(1);
-    rs_a->set_version(1);
-    rs_a->set_num_rows(10);
-    rs_a->set_data_size(100);
-    {
-        auto* sm = rs_a->add_segment_metas();
-        sm->set_filename("seg_a_local.dat");
-        sm->set_size(100);
-        sm->set_shared(false);
-    }
-
-    auto make_family_member = [&](int64_t tablet_id) {
-        auto meta = std::make_shared<TabletMetadataPB>();
-        meta->set_id(tablet_id);
-        meta->set_version(base_version);
-        meta->set_next_rowset_id(3);
-        set_primary_key_schema(meta.get(), 1001);
-        for (uint32_t rs_id : {1u, 2u}) {
-            auto* rs = meta->add_rowsets();
-            rs->set_id(rs_id);
-            rs->set_version(1);
-            rs->set_num_rows(10);
-            rs->set_data_size(100);
-            // Family-shared segment: same filename across ctx_b and ctx_c
-            // gives them identical RowsetPhysicalKey for the rowset edge.
-            {
-                auto* sm = rs->add_segment_metas();
-                sm->set_filename(fmt::format("family_seg_{}.dat", rs_id));
-                sm->set_size(100);
-                sm->set_shared(true);
-            }
-        }
-        auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename(legacy_filename);
-        sst->set_filesize(legacy_filesize);
-        sst->set_shared(true);
-        sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
-        return meta;
-    };
-
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_family_member(child_b)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_family_member(child_c)));
-
-    ReshardingTabletInfoPB resharding_tablet;
-    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
-    merging_info.add_old_tablet_ids(child_a);
-    merging_info.add_old_tablet_ids(child_b);
-    merging_info.add_old_tablet_ids(child_c);
-    merging_info.set_new_tablet_id(merged_tablet);
-
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(2);
-    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                              txn_info, false, tablet_metadatas, tablet_ranges));
-
-    auto merged = tablet_metadatas.at(merged_tablet);
-    // dedup'd to one legacy sstable PB.
-    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
-    const auto& out_sst = merged->sstable_meta().sstables(0);
-    // v2 fast-path signature: original filename preserved (byte-mapped),
-    // shared=true, no fileset_id minted. canonical_offset = ctx_b's
-    // rssid_offset = 1, accumulating into the emitted PB.
-    EXPECT_EQ(legacy_filename, out_sst.filename())
-            << "v2 fast-path keeps source filename even with non-zero canonical offset";
-    EXPECT_TRUE(out_sst.shared());
-    EXPECT_FALSE(out_sst.has_shared_rssid());
-    EXPECT_EQ(1, out_sst.rssid_offset()) << "accumulated = src.rssid_offset(0) + canonical_offset(1)";
-    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid())
-            << "max_rss_rowid.high shifts by canonical_offset (=1)";
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -7107,8 +7608,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_pure_child_
         return meta;
     };
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_a, /*include_local_and_sstable=*/false)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_b, /*include_local_and_sstable=*/true)));
+    EXPECT_OK(put_tablet_metadata(make_meta(child_a, /*include_local_and_sstable=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_meta(child_b, /*include_local_and_sstable=*/true)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -7175,6 +7676,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rs_a1, "shared.dat"); // shared ancestor: same uid across siblings => dedup
 
     auto meta_b = std::make_shared<TabletMetadataPB>();
     meta_b->set_id(child_b);
@@ -7192,6 +7694,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rs_b1, "shared.dat"); // shared ancestor: same uid as rs_a1 => dedup
     auto* rs_b2 = meta_b->add_rowsets();
     rs_b2->set_id(2);
     rs_b2->set_version(1);
@@ -7209,8 +7712,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_
     sst_b->set_shared(false);
     sst_b->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -7242,7 +7745,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_
     EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid());
 }
 
-// T3: when ctx is the family canonical (smallest child_index member of
+// T3: when ctx is the family canonical (smallest old_tablet_index member of
 // a multi-ctx family), plan id == natural offset by construction
 // (canonical_rssid_offset == ctx.rssid_offset == 0 for ctx[0]). The
 // predicate must NOT fire even when the sstable references shared-
@@ -7271,7 +7774,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_canonical_c
         meta->set_next_rowset_id(2);
         set_primary_key_schema(meta.get(), 1001);
         // Same shared-ancestor rowset on both ctxs → family inference
-        // unions them via the rowset edge; canonical_child_index = 0.
+        // unions them via the rowset edge; canonical_old_tablet_index = 0.
         auto* rs = meta->add_rowsets();
         rs->set_id(1);
         rs->set_version(1);
@@ -7293,8 +7796,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_canonical_c
         return meta;
     };
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_a, /*include_sstable=*/true)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_b, /*include_sstable=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_meta(child_a, /*include_sstable=*/true)));
+    EXPECT_OK(put_tablet_metadata(make_meta(child_b, /*include_sstable=*/false)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -7379,8 +7882,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_with_delvec
         return meta;
     };
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_a, /*include_sstable=*/false)));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_b, /*include_sstable=*/true)));
+    EXPECT_OK(put_tablet_metadata(make_meta(child_a, /*include_sstable=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_meta(child_b, /*include_sstable=*/true)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -7464,8 +7967,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_stacked_rssid_offs
     auto meta_b = make_child(child_b, /*rowset_id=*/5, "seg_b.dat", "sst_b.sst",
                              /*sst_rssid_offset=*/3, /*sst_shared=*/false);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7561,8 +8064,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cloud_native_pk_flush_path) {
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7620,7 +8123,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_cloud_native_pk_flush_path) 
     meta->set_enable_persistent_index(true);
     meta->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta));
+    EXPECT_OK(put_tablet_metadata(meta));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
@@ -7814,8 +8317,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_next_rowset_id_covers_projecte
     sst_b->set_filesize(256);
     sst_b->set_max_rss_rowid((static_cast<uint64_t>(200) << 32) | 99);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -7882,8 +8385,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_preserves_pass
     (*meta2->mutable_rowset_to_schema())[1] = 1001;
     add_dcg_with_columns(meta2.get(), /*segment_id=*/1, "shared.cols", {101, 102}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7938,8 +8441,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns_append) {
     (*meta2->mutable_rowset_to_schema())[1] = 2001;
     add_dcg_with_columns(meta2.get(), 1, "b.cols", {301, 302}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8001,8 +8504,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_triggers_rebuild_
     // Column 401 overlaps with child1.cols => rebuild triggered.
     add_dcg_with_columns(meta2.get(), 1, "child2.cols", {401, 403}, 1);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(put_tablet_metadata(meta1));
+    EXPECT_OK(put_tablet_metadata(meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8165,6 +8668,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_two_children_same_
             sm->set_size(base_segment_size);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset,
+                                    shared_segment_name); // same uid across siblings => one family via Edge (uid)
         *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
         *rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(upper_key);
         rowset->mutable_range()->set_lower_bound_included(true);
@@ -8183,8 +8688,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_two_children_same_
     auto meta_a = build_child(child_a, 0, kBoundary, cols_a_name);
     auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b_name);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     // 4. Run merge.
     ReshardingTabletInfoPB resharding_tablet;
@@ -8262,6 +8767,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_consistency_fa
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => one family via Edge (uid)
         (*metadata->mutable_rowset_to_schema())[1] = 5001;
         add_dcg_with_columns(metadata.get(), 1, "inconsistent.cols", dcg_columns, 1);
         return metadata;
@@ -8271,8 +8777,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_consistency_fa
     auto meta_a = make_child(tablet_a, {601, 602});
     auto meta_b = make_child(tablet_b, {603}); // differs from A
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8325,6 +8831,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_missing_uid_falls_
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => one family via Edge (uid)
         (*metadata->mutable_rowset_to_schema())[1] = 6001;
         auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[1];
         dcg.add_column_files(cols_filename);
@@ -8336,8 +8843,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_missing_uid_falls_
     auto meta_a = make_child(child_a, "a_missing.cols");
     auto meta_b = make_child(child_b, "b_missing.cols");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8458,8 +8965,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure
     auto meta_a = build_child(child_a, 0, kBoundary, cols_a, "bad_a.cols");
     auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b, "bad_b.cols");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     // Snapshot merged tablet's segment dir so we can detect leftover files.
     const std::string merged_segment_dir = _location_provider->segment_root_location(merged_tablet);
@@ -8543,6 +9050,7 @@ inline std::shared_ptr<TabletMetadataPB> make_shared_child(int64_t tablet_id, in
         sm->set_size(100);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across shared siblings => dedup
     set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
     return meta;
 }
@@ -8624,6 +9132,7 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_shared_child_with_real_segment(
         sm->set_size(segment_size);
         sm->set_shared(true);
     }
+    stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across shared siblings => dedup
     set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
     return meta;
 }
@@ -8691,7 +9200,7 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_compacted_child(int64_t tablet_
                 metas[i] = make_pk_shared_child_with_real_segment(child_ids[i], base_version, /*shared_id=*/10, lower, \
                                                                   upper, segment_size);                                \
             }                                                                                                          \
-            EXPECT_OK(_tablet_manager->put_tablet_metadata(metas[i]));                                                 \
+            EXPECT_OK(put_tablet_metadata(metas[i]));                                                                  \
         }                                                                                                              \
         ReshardingTabletInfoPB resharding_tablet;                                                                      \
         auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();                                         \
@@ -8779,8 +9288,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_sstable_pb_delvec_projectio
     auto meta_b = make_pk_compacted_child(child_b, base_version, /*compacted_id=*/11, /*lower=*/10, /*upper=*/20,
                                           "compacted_b.dat");
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -8800,7 +9309,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_sstable_pb_delvec_projectio
     auto merged = tablet_metadatas.at(merged_tablet);
     ASSERT_NE(merged, nullptr);
 
-    // Locate canonical R0 (the rowset with at least one shared_segments(i)==true).
+    // Locate canonical R0 (the rowset with at least one segment_metas(i).shared()==true).
     uint32_t canonical_rssid = 0;
     for (const auto& r : merged->rowsets()) {
         bool has_shared = false;
@@ -8909,9 +9418,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_no_gap_passthrough) {
     auto meta_b = make_shared_child(child_b, base_version, 10, PRIMARY_KEYS, 10, 20);
     auto meta_c = make_shared_child(child_c, base_version, 10, PRIMARY_KEYS, 20, 30);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -8955,9 +9464,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dup_keys_skip_dedup_on_gap) {
     auto meta_b = make_compacted_child(child_b, base_version, 11, DUP_KEYS, 10, 20, "cb.dat");
     auto meta_c = make_shared_child(child_c, base_version, 10, DUP_KEYS, 20, 30);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9014,9 +9523,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_agg_keys_skip_dedup_on_gap) {
     auto meta_b = make_compacted_child(child_b, base_version, 11, AGG_KEYS, 10, 20, "cb.dat");
     auto meta_c = make_shared_child(child_c, base_version, 10, AGG_KEYS, 20, 30);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9053,9 +9562,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_unique_keys_skip_dedup_on_gap)
     auto meta_b = make_compacted_child(child_b, base_version, 11, UNIQUE_KEYS, 10, 20, "cb.dat");
     auto meta_c = make_shared_child(child_c, base_version, 10, UNIQUE_KEYS, 20, 30);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9091,8 +9600,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_pk_contiguous_still_dedups
     auto meta_a = make_shared_child(child_a, base_version, 10, DUP_KEYS, 0, 10);
     auto meta_b = make_shared_child(child_b, base_version, 10, DUP_KEYS, 10, 20);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9148,6 +9657,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_canonical_range_extends_for_du
             sm->set_size(100);
             sm->set_shared(true);
         }
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         // intentionally NO rowset->mutable_range(): rely on ctx tablet range
         return meta;
     };
@@ -9155,8 +9665,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_canonical_range_extends_for_du
     auto meta_a = make_no_rowset_range_child(child_a, 0, 10);
     auto meta_b = make_no_rowset_range_child(child_b, 10, 20);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9218,14 +9728,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_predicate_dedup_unchang
         auto* pred = rowset->mutable_delete_predicate();
         pred->set_version(base_version); // required field
         pred->mutable_in_predicates();   // make has_delete_predicate true
+        // Same delete predicate cross-published to both children => same uid => dedup.
+        stamp_physical_identity_uid(rowset, "shared_pk_predicate");
         return meta;
     };
 
     auto meta_a = make_pred_child(child_a, 0, 10);
     auto meta_b = make_pred_child(child_b, 10, 20);
 
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
-    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9255,35 +9767,35 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_predicate_dedup_unchang
 
 namespace {
 
-// Lightweight fixture that builds mutable metadata + offsets, then snapshots
-// them as immutable SplitFamilyInferenceInput records when infer_split_
-// families is invoked. Splitting the mutable build phase from the const
-// input phase matches how production constructs TabletMetadataPtr (=
-// shared_ptr<const TabletMetadataPB>).
+// Lightweight fixture that builds mutable per-old-tablet metadata, then
+// snapshots it as an immutable TabletMetadataPtrs (= vector<shared_ptr<const
+// TabletMetadataPB>>) when infer_split_families is invoked. Splitting the
+// mutable build phase from the const input phase matches how production
+// constructs TabletMetadataPtr.
 struct SplitFamilyTestBuilder {
-    std::vector<std::pair<std::shared_ptr<TabletMetadataPB>, int64_t>> mutable_children;
+    std::vector<std::shared_ptr<TabletMetadataPB>> mutable_old_tablet_metadatas;
 
-    uint32_t add_empty_child(int64_t rssid_offset) {
-        mutable_children.emplace_back(std::make_shared<TabletMetadataPB>(), rssid_offset);
-        return static_cast<uint32_t>(mutable_children.size() - 1);
+    uint32_t add_empty_old_tablet() {
+        mutable_old_tablet_metadatas.emplace_back(std::make_shared<TabletMetadataPB>());
+        return static_cast<uint32_t>(mutable_old_tablet_metadatas.size() - 1);
     }
 
     // Add a legacy `shared && !has_shared_rssid` PK sstable (used by the
     // filename edge).
-    void add_legacy_shared_sstable(uint32_t child_index, const std::string& filename) {
-        auto* sstable = mutable_children[child_index].first->mutable_sstable_meta()->add_sstables();
+    void add_legacy_shared_sstable(uint32_t old_tablet_index, const std::string& filename) {
+        auto* sstable = mutable_old_tablet_metadatas[old_tablet_index]->mutable_sstable_meta()->add_sstables();
         sstable->set_filename(filename);
         sstable->set_filesize(1);
         sstable->set_shared(true);
         // !has_shared_rssid is the default — leave shared_rssid unset.
     }
 
-    // Add a shared-ancestor rowset (segments_size > 0, all shared_segments
+    // Add a shared-ancestor rowset (segment_metas_size > 0, all segment_metas[].shared()
     // true) with the given physical fingerprint. Used by the rowset-
     // identity edge.
-    void add_shared_ancestor_rowset(uint32_t child_index, uint32_t rowset_id, int64_t version,
+    void add_shared_ancestor_rowset(uint32_t old_tablet_index, uint32_t rowset_id, int64_t version,
                                     const std::vector<std::string>& segments) {
-        auto* rowset = mutable_children[child_index].first->add_rowsets();
+        auto* rowset = mutable_old_tablet_metadatas[old_tablet_index]->add_rowsets();
         rowset->set_id(rowset_id);
         rowset->set_version(version);
         rowset->set_num_rows(10);
@@ -9295,14 +9807,25 @@ struct SplitFamilyTestBuilder {
             sm->set_shared(true);
             sm->set_segment_idx(static_cast<uint32_t>(rowset->segment_metas_size() - 1));
         }
+        // Match production: shared-ancestor rowsets carry the same uid across every
+        // sibling that inherited them (CopyFrom at split time preserves uid; the
+        // splitter backfills one for legacy uid-less rowsets). Seed on the first
+        // segment so siblings calling this helper with identical segments converge.
+        if (!segments.empty()) {
+            stamp_physical_identity_uid(rowset, segments.front());
+        }
     }
 
-    // Add a child-local (NOT shared) rowset. The rowset-identity edge must
+    // Add a tablet-local (NOT shared) rowset. The rowset-identity edge must
     // ignore these even when the physical fingerprint matches a shared-
-    // ancestor on another child.
-    void add_child_local_rowset(uint32_t child_index, uint32_t rowset_id, int64_t version,
-                                const std::vector<std::string>& segments) {
-        auto* rowset = mutable_children[child_index].first->add_rowsets();
+    // ancestor on another old tablet.
+    // mark_segments_pruned=true models a SPLIT-pruned rowset: each segment is marked
+    // segment_metas[i].shared()=false (the post-split owned-but-shared-file state that MERGE
+    // force-rebuilds). mark_segments_pruned=false models a fresh tablet-local write,
+    // which in production leaves segment_metas[].shared() unset (so it is not force-rebuilt).
+    void add_tablet_local_rowset(uint32_t old_tablet_index, uint32_t rowset_id, int64_t version,
+                                 const std::vector<std::string>& segments, bool mark_segments_pruned = true) {
+        auto* rowset = mutable_old_tablet_metadatas[old_tablet_index]->add_rowsets();
         rowset->set_id(rowset_id);
         rowset->set_version(version);
         rowset->set_num_rows(10);
@@ -9311,31 +9834,39 @@ struct SplitFamilyTestBuilder {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(segment);
             sm->set_size(100);
-            sm->set_shared(false);
+            // mark_segments_pruned=true explicitly stamps shared=false (the post-split
+            // owned-but-shared-file state MERGE force-rebuilds). A fresh local write
+            // (mark_segments_pruned=false) leaves the shared flag unset, matching the
+            // old "segment_metas[].shared() unset" signal that suppresses force-rebuild.
+            if (mark_segments_pruned) {
+                sm->set_shared(false);
+            }
             sm->set_segment_idx(static_cast<uint32_t>(rowset->segment_metas_size() - 1));
         }
     }
 
     // Add a delete-only rowset (segments_size == 0). The rowset-identity
     // edge must ignore these too.
-    void add_delete_only_rowset(uint32_t child_index, uint32_t rowset_id, int64_t version) {
-        auto* rowset = mutable_children[child_index].first->add_rowsets();
+    void add_delete_only_rowset(uint32_t old_tablet_index, uint32_t rowset_id, int64_t version) {
+        auto* rowset = mutable_old_tablet_metadatas[old_tablet_index]->add_rowsets();
         rowset->set_id(rowset_id);
         rowset->set_version(version);
         rowset->mutable_delete_predicate(); // mark as a delete predicate; no segments
     }
 
-    std::vector<lake::detail::SplitFamilyInferenceInput> snapshot() const {
-        std::vector<lake::detail::SplitFamilyInferenceInput> inputs;
-        inputs.reserve(mutable_children.size());
-        for (const auto& [metadata, rssid_offset] : mutable_children) {
-            inputs.push_back({metadata, rssid_offset});
+    TabletMetadataPtrs snapshot() const {
+        TabletMetadataPtrs inputs;
+        inputs.reserve(mutable_old_tablet_metadatas.size());
+        for (const auto& metadata : mutable_old_tablet_metadatas) {
+            inputs.push_back(metadata);
         }
         return inputs;
     }
 
-    // Helper for tests that need to write directly into a child's metadata.
-    TabletMetadataPB* metadata_of(uint32_t child_index) { return mutable_children[child_index].first.get(); }
+    // Helper for tests that need to write directly into an old tablet's metadata.
+    TabletMetadataPB* metadata_of(uint32_t old_tablet_index) {
+        return mutable_old_tablet_metadatas[old_tablet_index].get();
+    }
 };
 
 } // namespace
@@ -9344,17 +9875,56 @@ struct SplitFamilyTestBuilder {
 TEST(SplitFamilyInferenceTest, empty_input) {
     SplitFamilyTestBuilder builder;
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    EXPECT_TRUE(result.child_to_family.empty());
+    EXPECT_TRUE(result.old_tablet_to_family.empty());
     EXPECT_TRUE(result.families.empty());
+}
+
+// Set uid on a child's rowset (test helper for the uid family edge in split inference).
+static void set_uid(SplitFamilyTestBuilder& builder, uint32_t old_tablet_index, int rowset_pos, int64_t hi,
+                    int64_t lo) {
+    auto* uid = builder.metadata_of(old_tablet_index)->mutable_rowsets(rowset_pos)->mutable_uid();
+    uid->set_hi(hi);
+    uid->set_lo(lo);
+}
+
+// Edge (2): same-uid siblings are grouped even when pruned to disjoint
+// PRIVATE segments (no shared sstable, disjoint segments[]). Matching uid
+// groups them regardless of segments[] layout.
+TEST(SplitFamilyInferenceTest, edge3_uid_groups_pruned_siblings) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
+    builder.add_tablet_local_rowset(0, /*rowset_id=*/3, /*version=*/2, {"a0"});
+    builder.add_tablet_local_rowset(1, /*rowset_id=*/3, /*version=*/2, {"b0"});
+    set_uid(builder, 0, /*rowset_pos=*/0, /*hi=*/0, /*lo=*/55);
+    set_uid(builder, 1, /*rowset_pos=*/0, /*hi=*/0, /*lo=*/55); // same uid => same family
+
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_THAT(result.families.front().member_old_tablet_indexes, ::testing::ElementsAre(0u, 1u));
+}
+
+// Distinct uids must NOT be grouped together.
+TEST(SplitFamilyInferenceTest, edge3_distinct_uid_not_grouped) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
+    builder.add_tablet_local_rowset(0, 3, 2, {"a0"});
+    builder.add_tablet_local_rowset(1, 3, 2, {"b0"});
+    set_uid(builder, 0, 0, /*hi=*/0, /*lo=*/55);
+    set_uid(builder, 1, 0, /*hi=*/0, /*lo=*/66); // different uid
+
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    EXPECT_TRUE(result.families.empty()); // no edge unites them
 }
 
 // Single child with no edges → kNoFamily, no families produced.
 TEST(SplitFamilyInferenceTest, single_child_no_edges) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_old_tablet();
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    ASSERT_EQ(1u, result.child_to_family.size());
-    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[0]);
+    ASSERT_EQ(1u, result.old_tablet_to_family.size());
+    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.old_tablet_to_family[0]);
     EXPECT_TRUE(result.families.empty());
 }
 
@@ -9362,164 +9932,86 @@ TEST(SplitFamilyInferenceTest, single_child_no_edges) {
 // family, canonical = child 0.
 TEST(SplitFamilyInferenceTest, filename_edge_unions_two_children) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_legacy_shared_sstable(0, "shared.sst");
     builder.add_legacy_shared_sstable(1, "shared.sst");
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
     const auto& family = result.families.front();
-    EXPECT_EQ(0u, family.canonical_child_index);
-    EXPECT_EQ(0, family.canonical_rssid_offset);
-    EXPECT_THAT(family.member_child_indexes, ::testing::ElementsAre(0u, 1u));
-    EXPECT_EQ(0u, result.child_to_family[0]);
-    EXPECT_EQ(0u, result.child_to_family[1]);
+    EXPECT_EQ(0u, family.canonical_old_tablet_index);
+    EXPECT_THAT(family.member_old_tablet_indexes, ::testing::ElementsAre(0u, 1u));
+    EXPECT_EQ(0u, result.old_tablet_to_family[0]);
+    EXPECT_EQ(0u, result.old_tablet_to_family[1]);
 }
 
 // Two children share an exact-match shared-ancestor rowset → one family,
 // canonical = child 0.
 TEST(SplitFamilyInferenceTest, rowset_edge_unions_two_children) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
     builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
-    EXPECT_EQ(0u, result.families.front().canonical_child_index);
-    EXPECT_EQ(0, result.families.front().canonical_rssid_offset);
-}
-
-// Two children with rowsets that LOOK identical except for segment_idx
-// layout (one inherited contiguous {0,1}, the other has a sparse {0,2}
-// after middle compaction) — they are NOT physically identical and must
-// not be unioned.
-TEST(SplitFamilyInferenceTest, rowset_edge_segment_idx_layout_must_match) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    auto* rowset_a = builder.metadata_of(0)->add_rowsets();
-    rowset_a->set_id(3);
-    rowset_a->set_version(2);
-    {
-        auto* sm = rowset_a->add_segment_metas();
-        sm->set_filename("seg_a");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(0);
-    }
-    {
-        auto* sm = rowset_a->add_segment_metas();
-        sm->set_filename("seg_b");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(1);
-    }
-    auto* rowset_b = builder.metadata_of(1)->add_rowsets();
-    rowset_b->set_id(3);
-    rowset_b->set_version(2);
-    {
-        auto* sm = rowset_b->add_segment_metas();
-        sm->set_filename("seg_a");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(0);
-    }
-    {
-        auto* sm = rowset_b->add_segment_metas();
-        sm->set_filename("seg_b");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(2); // sparse!
-    }
-    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    EXPECT_TRUE(result.families.empty()) << "different segment_idx layouts must not union";
-    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[0]);
-    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[1]);
-}
-
-// Delete-only rowsets (segments_size == 0) must NOT participate in the
-// rowset-identity edge — two delete-only rowsets with empty vectors would
-// otherwise falsely match each other.
-TEST(SplitFamilyInferenceTest, delete_only_rowsets_excluded_from_edge) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    builder.add_delete_only_rowset(0, /*rowset_id=*/3, /*version=*/2);
-    builder.add_delete_only_rowset(1, /*rowset_id=*/3, /*version=*/2);
-    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    EXPECT_TRUE(result.families.empty()) << "delete-only rowsets must not produce family edges";
-}
-
-// Child-local rowsets (shared_segments NOT all true) must not produce edges
-// even when the physical fingerprint matches.
-TEST(SplitFamilyInferenceTest, child_local_rowsets_excluded_from_edge) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    builder.add_child_local_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
-    builder.add_child_local_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
-    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    EXPECT_TRUE(result.families.empty()) << "child-local rowsets must not produce family edges";
+    EXPECT_EQ(0u, result.families.front().canonical_old_tablet_index);
 }
 
 // Three children unioned via filename edge into one family. canonical is
 // the smallest member regardless of which two children matched first.
 TEST(SplitFamilyInferenceTest, three_children_one_family_via_filename) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    builder.add_empty_child(/*rssid_offset=*/10);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_legacy_shared_sstable(0, "f.sst");
     builder.add_legacy_shared_sstable(1, "f.sst");
     builder.add_legacy_shared_sstable(2, "f.sst");
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
-    EXPECT_EQ(0u, result.families.front().canonical_child_index);
-    EXPECT_EQ(0, result.families.front().canonical_rssid_offset);
-    EXPECT_THAT(result.families.front().member_child_indexes, ::testing::ElementsAre(0u, 1u, 2u));
+    EXPECT_EQ(0u, result.families.front().canonical_old_tablet_index);
+    EXPECT_THAT(result.families.front().member_old_tablet_indexes, ::testing::ElementsAre(0u, 1u, 2u));
 }
 
 // Two disjoint families on the same merge: child{0,1} share file_a;
 // child{2,3} share file_b. Each family gets its own canonical.
 TEST(SplitFamilyInferenceTest, two_disjoint_families) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    builder.add_empty_child(/*rssid_offset=*/10);
-    builder.add_empty_child(/*rssid_offset=*/15);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_legacy_shared_sstable(0, "file_a.sst");
     builder.add_legacy_shared_sstable(1, "file_a.sst");
     builder.add_legacy_shared_sstable(2, "file_b.sst");
     builder.add_legacy_shared_sstable(3, "file_b.sst");
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(2u, result.families.size());
-    // Families are emitted in ascending canonical_child_index order.
-    EXPECT_EQ(0u, result.families[0].canonical_child_index);
-    EXPECT_EQ(0, result.families[0].canonical_rssid_offset);
-    EXPECT_THAT(result.families[0].member_child_indexes, ::testing::ElementsAre(0u, 1u));
-    EXPECT_EQ(2u, result.families[1].canonical_child_index);
-    EXPECT_EQ(10, result.families[1].canonical_rssid_offset);
-    EXPECT_THAT(result.families[1].member_child_indexes, ::testing::ElementsAre(2u, 3u));
-    EXPECT_EQ(0u, result.child_to_family[0]);
-    EXPECT_EQ(0u, result.child_to_family[1]);
-    EXPECT_EQ(1u, result.child_to_family[2]);
-    EXPECT_EQ(1u, result.child_to_family[3]);
+    // Families are emitted in ascending canonical_old_tablet_index order.
+    EXPECT_EQ(0u, result.families[0].canonical_old_tablet_index);
+    EXPECT_THAT(result.families[0].member_old_tablet_indexes, ::testing::ElementsAre(0u, 1u));
+    EXPECT_EQ(2u, result.families[1].canonical_old_tablet_index);
+    EXPECT_THAT(result.families[1].member_old_tablet_indexes, ::testing::ElementsAre(2u, 3u));
+    EXPECT_EQ(0u, result.old_tablet_to_family[0]);
+    EXPECT_EQ(0u, result.old_tablet_to_family[1]);
+    EXPECT_EQ(1u, result.old_tablet_to_family[2]);
+    EXPECT_EQ(1u, result.old_tablet_to_family[3]);
 }
 
 // Filename edge AND rowset-identity edge can BOTH apply to the same pair —
 // the union-find handles re-unions trivially.
 TEST(SplitFamilyInferenceTest, both_edges_apply_to_same_pair) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_legacy_shared_sstable(0, "f.sst");
     builder.add_legacy_shared_sstable(1, "f.sst");
     builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
     builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
-    EXPECT_THAT(result.families.front().member_child_indexes, ::testing::ElementsAre(0u, 1u));
+    EXPECT_THAT(result.families.front().member_old_tablet_indexes, ::testing::ElementsAre(0u, 1u));
 }
 
 // Edge-only-via-rowset case: filename does not match (sstables compacted
@@ -9527,23 +10019,23 @@ TEST(SplitFamilyInferenceTest, both_edges_apply_to_same_pair) {
 // family relationship.
 TEST(SplitFamilyInferenceTest, family_inferred_via_rowset_only) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_legacy_shared_sstable(0, "side_a.sst"); // no overlap
     builder.add_legacy_shared_sstable(1, "side_b.sst");
     builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
     builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
-    EXPECT_EQ(0u, result.families.front().canonical_child_index);
+    EXPECT_EQ(0u, result.families.front().canonical_old_tablet_index);
 }
 
 // Edge-only-via-filename case: the rowsets diverged (one side compacted
 // the rowset away) but the legacy sstable is still common.
 TEST(SplitFamilyInferenceTest, family_inferred_via_filename_only) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_old_tablet();
+    builder.add_empty_old_tablet();
     builder.add_legacy_shared_sstable(0, "f.sst");
     builder.add_legacy_shared_sstable(1, "f.sst");
     // Different rowsets on each side; should NOT contribute an edge but
@@ -9552,398 +10044,25 @@ TEST(SplitFamilyInferenceTest, family_inferred_via_filename_only) {
     builder.add_shared_ancestor_rowset(1, /*rowset_id=*/4, /*version=*/2, {"seg_b"});
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
-    EXPECT_THAT(result.families.front().member_child_indexes, ::testing::ElementsAre(0u, 1u));
-}
-
-// Two children carry the same physical rowset, but one has segment_metas
-// fully populated (segment_idx = positional index) while the other has
-// segment_metas absent. The PB read path falls back to positional index
-// when segment_metas is missing, so both metadata variants describe the
-// same physical layout — they MUST union into one family. (Codex round-1
-// catch: without normalization, the keys differ and family inference
-// silently misses the legacy fast-path.)
-TEST(SplitFamilyInferenceTest, rowset_edge_normalizes_absent_segment_metas) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    auto* rowset_a = builder.metadata_of(0)->add_rowsets();
-    rowset_a->set_id(3);
-    rowset_a->set_version(2);
-    {
-        auto* sm = rowset_a->add_segment_metas();
-        sm->set_filename("seg_a");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(0);
-    }
-    {
-        auto* sm = rowset_a->add_segment_metas();
-        sm->set_filename("seg_b");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(1);
-    }
-    auto* rowset_b = builder.metadata_of(1)->add_rowsets();
-    rowset_b->set_id(3);
-    rowset_b->set_version(2);
-    {
-        auto* sm = rowset_b->add_segment_metas();
-        sm->set_filename("seg_a");
-        sm->set_size(100);
-        sm->set_shared(true);
-    }
-    {
-        auto* sm = rowset_b->add_segment_metas();
-        sm->set_filename("seg_b");
-        sm->set_size(100);
-        sm->set_shared(true);
-    }
-    // segment_idx intentionally absent — read path falls back to
-    // positional index, which equals A's explicit (0, 1).
-    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    ASSERT_EQ(1u, result.families.size()) << "default positional segment_idx must equal explicit (0, 1) layout";
-}
-
-// Same family-defining physical rowset, but one child has bundle_file_
-// offsets explicitly set to (0, 0) while the other has the field absent.
-// PB defaults to 0 per segment when absent, so the two variants describe
-// the same physical placement and must union into one family.
-TEST(SplitFamilyInferenceTest, rowset_edge_normalizes_absent_bundle_file_offsets) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    auto* rowset_a = builder.metadata_of(0)->add_rowsets();
-    rowset_a->set_id(3);
-    rowset_a->set_version(2);
-    {
-        auto* sm = rowset_a->add_segment_metas();
-        sm->set_filename("seg_a");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_bundle_file_offset(0);
-        sm->set_segment_idx(0);
-    }
-    {
-        auto* sm = rowset_a->add_segment_metas();
-        sm->set_filename("seg_b");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_bundle_file_offset(0);
-        sm->set_segment_idx(1);
-    }
-    auto* rowset_b = builder.metadata_of(1)->add_rowsets();
-    rowset_b->set_id(3);
-    rowset_b->set_version(2);
-    // bundle_file_offset absent — PB default 0 per segment, equal to A's
-    // explicit (0, 0).
-    {
-        auto* sm = rowset_b->add_segment_metas();
-        sm->set_filename("seg_a");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(0);
-    }
-    {
-        auto* sm = rowset_b->add_segment_metas();
-        sm->set_filename("seg_b");
-        sm->set_size(100);
-        sm->set_shared(true);
-        sm->set_segment_idx(1);
-    }
-    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
-    ASSERT_EQ(1u, result.families.size()) << "absent bundle_file_offsets must equal explicit (0, 0) layout";
+    EXPECT_THAT(result.families.front().member_old_tablet_indexes, ::testing::ElementsAre(0u, 1u));
 }
 
 // Mix of orphan + family children. The orphan stays kNoFamily; the family
-// records the right canonical_child_index.
+// records the right canonical_old_tablet_index.
 TEST(SplitFamilyInferenceTest, mix_orphan_and_family) {
     SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);  // orphan
-    builder.add_empty_child(/*rssid_offset=*/5);  // family member
-    builder.add_empty_child(/*rssid_offset=*/10); // family member
+    builder.add_empty_old_tablet(); // orphan
+    builder.add_empty_old_tablet(); // family member
+    builder.add_empty_old_tablet(); // family member
     builder.add_legacy_shared_sstable(1, "f.sst");
     builder.add_legacy_shared_sstable(2, "f.sst");
     ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
     ASSERT_EQ(1u, result.families.size());
-    EXPECT_EQ(1u, result.families.front().canonical_child_index);
-    EXPECT_EQ(5, result.families.front().canonical_rssid_offset);
-    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[0]);
-    EXPECT_EQ(0u, result.child_to_family[1]);
-    EXPECT_EQ(0u, result.child_to_family[2]);
+    EXPECT_EQ(1u, result.families.front().canonical_old_tablet_index);
+    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.old_tablet_to_family[0]);
+    EXPECT_EQ(0u, result.old_tablet_to_family[1]);
+    EXPECT_EQ(0u, result.old_tablet_to_family[2]);
 }
 
 // =============================================================================
-// Fast-path v2 — RssidProjectionPlan build (commit 2)
-//
-// These tests exercise lake::detail::build_rssid_projection_plan directly.
-// The plan is "passive" in this commit (no caller wires it through
-// merge_rowsets / map_rssid yet); commit 4 will.
-// =============================================================================
-
-namespace {
-
-// Convenience helper: run inference + plan build in one call, returning the
-// plan. Used by all RssidProjectionPlanTest tests that don't care about the
-// inferred families themselves.
-lake::detail::RssidProjectionPlan build_plan_for(SplitFamilyTestBuilder& builder) {
-    auto inputs = builder.snapshot();
-    auto families_or = lake::detail::infer_split_families(inputs);
-    CHECK_OK(families_or.status());
-    auto plan_or = lake::detail::build_rssid_projection_plan(inputs, *families_or);
-    CHECK_OK(plan_or.status());
-    return std::move(*plan_or);
-}
-
-} // namespace
-
-// Empty input → empty plan, no families, no occupied entries.
-TEST(RssidProjectionPlanTest, empty_input) {
-    SplitFamilyTestBuilder builder;
-    auto plan = build_plan_for(builder);
-    EXPECT_TRUE(plan.explicit_rssid_map.empty());
-    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
-    EXPECT_TRUE(plan.occupied_rssids.empty());
-    EXPECT_TRUE(plan.unsafe_families.empty());
-}
-
-// Two-child family with a shared-ancestor rowset, no collisions.
-// explicit_rssid_map records both rowset.id and segment positions.
-TEST(RssidProjectionPlanTest, family_canonical_projection_emitted) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/8);
-    // Shared rowset id=3 with two segments → segment_idx layout [0, 1].
-    // canonical_offset = 0 (canonical = ctx[0]).
-    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
-    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
-    auto plan = build_plan_for(builder);
-
-    EXPECT_TRUE(plan.unsafe_families.empty());
-    ASSERT_EQ(1u, plan.family_legacy_sstable_offset.size());
-    EXPECT_EQ(0, plan.family_legacy_sstable_offset.at(0u));
-
-    // Both children's (3, 4) entries point to canonical-offset finals.
-    // (rs.id=3 → final 3; lifted segment 0 = 3+0=3, lifted segment 1 = 3+1=4 → finals 3, 4.)
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u}));
-    EXPECT_EQ(4u, plan.explicit_rssid_map.at({0u, 4u}));
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({1u, 3u}));
-    EXPECT_EQ(4u, plan.explicit_rssid_map.at({1u, 4u}));
-
-    // Occupancy: finals 3, 4 are claimed by the family.
-    ASSERT_EQ(2u, plan.occupied_rssids.size());
-    EXPECT_EQ(0u, plan.occupied_rssids.at(3u).family_id);
-    EXPECT_EQ(0u, plan.occupied_rssids.at(4u).family_id);
-}
-
-// Family canonical_offset != 0: the explicit map's finals shift by it,
-// and family_legacy_sstable_offset records it for the fast-path.
-TEST(RssidProjectionPlanTest, family_with_nonzero_canonical_offset) {
-    SplitFamilyTestBuilder builder;
-    // child 0 has rowsets so phase-1-style next_rowset_id pushes the
-    // canonical offset upward when child 1 is the canonical (per the
-    // SplitFamilyInferenceInput.rssid_offset). Here we pass canonical_offset=10
-    // directly via builder.add_empty_child. Tests don't run phase 1; they
-    // just feed the offset.
-    builder.add_empty_child(/*rssid_offset=*/10);
-    builder.add_empty_child(/*rssid_offset=*/15);
-    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
-    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
-    auto plan = build_plan_for(builder);
-
-    EXPECT_TRUE(plan.unsafe_families.empty());
-    EXPECT_EQ(10, plan.family_legacy_sstable_offset.at(0u));
-    // rs.id=3 → final 3+10=13; segment 0 lifted=3 → final 13.
-    EXPECT_EQ(13u, plan.explicit_rssid_map.at({0u, 3u}));
-    EXPECT_EQ(13u, plan.explicit_rssid_map.at({1u, 3u}));
-}
-
-// Child-local (non-shared) rowset → does NOT enter explicit_rssid_map even
-// if its ctx is a family member. Goes through natural offset; occupancy
-// records it under the family_id of the ctx, but explicit_rssid_map stays
-// silent so commit 4's map_rssid will fall through to the natural-offset
-// path for it.
-TEST(RssidProjectionPlanTest, child_local_rowsets_not_in_explicit_map) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/8);
-    // Family edge via a shared sstable filename; rowsets diverge.
-    builder.add_legacy_shared_sstable(0, "shared.sst");
-    builder.add_legacy_shared_sstable(1, "shared.sst");
-    // Child-local rowset on ctx 1.
-    builder.add_child_local_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
-    auto plan = build_plan_for(builder);
-    EXPECT_TRUE(plan.unsafe_families.empty());
-    EXPECT_EQ(0u, plan.explicit_rssid_map.count({1u, 3u}));
-}
-
-// Two physically-distinct rowsets want the same final rssid → both
-// involved families are marked unsafe.
-TEST(RssidProjectionPlanTest, cross_family_collision_marks_both_unsafe) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0); // family A canonical
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/0); // family B canonical
-    builder.add_empty_child(/*rssid_offset=*/0);
-    // Family A: ctx 0 + ctx 1 share a rowset that lands at final=5.
-    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
-    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
-    // Family B: ctx 2 + ctx 3 share a DIFFERENT physical rowset that ALSO
-    // wants final=5 (same id, but seg_b vs seg_a → different physical key).
-    builder.add_shared_ancestor_rowset(2, /*rowset_id=*/5, /*version=*/3, {"seg_b"});
-    builder.add_shared_ancestor_rowset(3, /*rowset_id=*/5, /*version=*/3, {"seg_b"});
-    auto plan = build_plan_for(builder);
-    // Both families A and B claim final=5 with different physical keys →
-    // both marked unsafe; explicit_rssid_map drops them; family_legacy_
-    // sstable_offset stays empty.
-    EXPECT_EQ(2u, plan.unsafe_families.size());
-    EXPECT_TRUE(plan.unsafe_families.contains(0u));
-    EXPECT_TRUE(plan.unsafe_families.contains(1u));
-    EXPECT_TRUE(plan.explicit_rssid_map.empty());
-    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
-}
-
-// Same physical rowset across family members deduplicates in occupied_rssids.
-// The family stays safe and the explicit_rssid_map records all member ctx
-// entries.
-TEST(RssidProjectionPlanTest, same_physical_dedup_is_safe) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/8);
-    builder.add_empty_child(/*rssid_offset=*/16);
-    for (uint32_t child_index : {0u, 1u, 2u}) {
-        builder.add_shared_ancestor_rowset(child_index, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
-    }
-    auto plan = build_plan_for(builder);
-    EXPECT_TRUE(plan.unsafe_families.empty());
-    EXPECT_EQ(0, plan.family_legacy_sstable_offset.at(0u));
-    // All 3 children's (3, 3) entries point to canonical-offset final 3.
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u}));
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({1u, 3u}));
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({2u, 3u}));
-}
-
-// Sparse segment_idx layout ({0, 2}) is preserved by the projection. The
-// occupancy claims rssid 3 and 5 (= 3+0, 3+2), NOT rssid 4 (which would
-// belong to a hypothetical compacted-out segment_idx=1).
-TEST(RssidProjectionPlanTest, sparse_segment_idx_projection) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/8);
-    auto add_sparse_rowset = [&](uint32_t child_index) {
-        auto* rowset = builder.metadata_of(child_index)->add_rowsets();
-        rowset->set_id(3);
-        rowset->set_version(2);
-        {
-            auto* sm = rowset->add_segment_metas();
-            sm->set_filename("seg_0");
-            sm->set_size(100);
-            sm->set_shared(true);
-            sm->set_segment_idx(0);
-        }
-        {
-            auto* sm = rowset->add_segment_metas();
-            sm->set_filename("seg_2");
-            sm->set_size(100);
-            sm->set_shared(true);
-            sm->set_segment_idx(2);
-        }
-    };
-    add_sparse_rowset(0);
-    add_sparse_rowset(1);
-    auto plan = build_plan_for(builder);
-    EXPECT_TRUE(plan.unsafe_families.empty());
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u})); // rs.id
-    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u})); // segment_idx=0 → lifted 3
-    EXPECT_EQ(5u, plan.explicit_rssid_map.at({0u, 5u})); // segment_idx=2 → lifted 5
-    // Final 4 was never claimed.
-    EXPECT_EQ(0u, plan.occupied_rssids.count(4u));
-    // Finals 3 and 5 are claimed.
-    EXPECT_EQ(1u, plan.occupied_rssids.count(3u));
-    EXPECT_EQ(1u, plan.occupied_rssids.count(5u));
-}
-
-// Orphan-vs-family collision: an orphan ctx's child-local rowset projects
-// (via natural offset) to the same final as a family's canonical
-// projection. The family is marked unsafe; the orphan stays untouched.
-TEST(RssidProjectionPlanTest, orphan_vs_family_collision_marks_family_unsafe) {
-    SplitFamilyTestBuilder builder;
-    // ctx 0 + ctx 1 form family A (via filename edge).
-    // ctx 2 is an orphan with a child-local rowset that lifts to 5
-    // through natural offset = 5 (rs.id 0 + offset 5).
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/5);
-    builder.add_legacy_shared_sstable(0, "shared.sst");
-    builder.add_legacy_shared_sstable(1, "shared.sst");
-    // Family A's shared-ancestor rowset id=5, canonical_offset=0, claims final 5.
-    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
-    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
-    // Orphan ctx 2: a child-local rowset id=0 + offset 5 → final 5, with a
-    // DIFFERENT physical key (different segment filename).
-    builder.add_child_local_rowset(2, /*rowset_id=*/0, /*version=*/3, {"seg_b"});
-    auto plan = build_plan_for(builder);
-    // Family A marked unsafe; orphan family is kNoFamily so nothing else
-    // gets added to unsafe_families.
-    EXPECT_EQ(1u, plan.unsafe_families.size());
-    EXPECT_TRUE(plan.unsafe_families.contains(0u));
-    EXPECT_TRUE(plan.explicit_rssid_map.empty());
-    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
-}
-
-// Boundary case: a shared-ancestor rowset with rowset.id() == UINT32_MAX
-// and any non-zero segment_idx would overflow uint32 if we naively added
-// id + segment_idx without checking. The plan must mark the family unsafe
-// so commit 4's map_rssid falls through to natural-offset / v1 path.
-TEST(RssidProjectionPlanTest, segment_rssid_overflow_marks_family_unsafe) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/0);
-    auto add_overflow_rowset = [&](uint32_t child_index) {
-        auto* rowset = builder.metadata_of(child_index)->add_rowsets();
-        rowset->set_id(std::numeric_limits<uint32_t>::max());
-        rowset->set_version(2);
-        {
-            auto* sm = rowset->add_segment_metas();
-            sm->set_filename("seg_0");
-            sm->set_size(100);
-            sm->set_shared(true);
-            sm->set_segment_idx(0); // lifted = UINT32_MAX, OK
-        }
-        {
-            auto* sm = rowset->add_segment_metas();
-            sm->set_filename("seg_1");
-            sm->set_size(100);
-            sm->set_shared(true);
-            sm->set_segment_idx(1); // lifted = UINT32_MAX + 1 → overflow
-        }
-    };
-    add_overflow_rowset(0);
-    add_overflow_rowset(1);
-    auto plan = build_plan_for(builder);
-    ASSERT_EQ(1u, plan.unsafe_families.size());
-    EXPECT_TRUE(plan.unsafe_families.contains(0u)) << "rowset.id()+segment_idx overflow must mark the family unsafe, "
-                                                      "not record a wrapped low rssid";
-    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
-}
-
-// Delete-only and no-segments rowsets still claim rowset.id() in
-// occupied_rssids (they own the rsid as a watermark even with no segments).
-// Two delete-only rowsets at the same version with the same id are the
-// "same physical" → safe dedup; at different versions → collision.
-TEST(RssidProjectionPlanTest, delete_only_rowset_id_occupancy_dedup) {
-    SplitFamilyTestBuilder builder;
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_empty_child(/*rssid_offset=*/0);
-    builder.add_legacy_shared_sstable(0, "shared.sst");
-    builder.add_legacy_shared_sstable(1, "shared.sst");
-    builder.add_delete_only_rowset(0, /*rowset_id=*/3, /*version=*/2);
-    builder.add_delete_only_rowset(1, /*rowset_id=*/3, /*version=*/2);
-    auto plan = build_plan_for(builder);
-    // Family A is safe (no collision; delete-only rowsets dedup at id 3).
-    EXPECT_TRUE(plan.unsafe_families.empty());
-    // Final 3 is claimed under family A. The delete-only path uses natural
-    // offset (canonical_offset == 0 here, so result is the same).
-    EXPECT_EQ(1u, plan.occupied_rssids.count(3u));
-}
-
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -1177,4 +1177,219 @@ TEST(TabletSplitterParityTest, external_boundaries_matches_data_driven_when_fed_
     }
 }
 
+// -----------------------------------------------------------------------------
+// Phase-1 per-segment shared ownership helpers.
+// -----------------------------------------------------------------------------
+
+namespace {
+// Append a segment with bigint [mn, mx] sort-key bounds.
+static void add_bigint_seg(RowsetMetadataPB* rs, int64_t mn, int64_t mx, const std::string& name) {
+    auto* m = rs->add_segment_metas();
+    m->set_filename(name);
+    *m->mutable_sort_key_min() = make_bigint_tuple_pb(mn);
+    *m->mutable_sort_key_max() = make_bigint_tuple_pb(mx);
+}
+} // namespace
+
+TEST(TabletSplitterTest, CanPruneRowsetSegments_predicates) {
+    auto make_pruneable = []() {
+        RowsetMetadataPB rs;
+        add_bigint_seg(&rs, 0, 1, "s0");
+        return rs;
+    };
+    EXPECT_TRUE(can_prune_rowset_segments(make_pruneable()));
+
+    {
+        auto rs = make_pruneable();
+        rs.mutable_segment_metas(0)->set_bundle_file_offset(0); // bundled segment is pruneable
+        EXPECT_TRUE(can_prune_rowset_segments(rs));
+    } // (a) ok
+    {
+        auto rs = make_pruneable();
+        rs.set_next_compaction_offset(1);
+        EXPECT_FALSE(can_prune_rowset_segments(rs));
+    } // (b)
+    {
+        auto rs = make_pruneable();
+        rs.add_segment_metas(); // extra segment lacking sort-key bounds
+        EXPECT_FALSE(can_prune_rowset_segments(rs));
+    } // (c) missing bound on extra segment
+    {
+        auto rs = make_pruneable();
+        rs.mutable_segment_metas(0)->clear_sort_key_max();
+        EXPECT_FALSE(can_prune_rowset_segments(rs));
+    } // (c) missing bound
+    {
+        auto rs = make_pruneable();
+        rs.mutable_segment_metas(0)->set_shared(true);
+        EXPECT_TRUE(can_prune_rowset_segments(rs));
+    } // (d) ok
+}
+
+TEST(TabletSplitterTest, ComputeOwnership_exclusive_segment_becomes_private) {
+    // Tiled ranges [0,11) and [11,21); segment [1,5] strictly inside range 0.
+    std::vector<TabletRangePB> ranges{make_bigint_range_pb(0, 11), make_bigint_range_pb(11, 21)};
+    RowsetMetadataPB rs;
+    add_bigint_seg(&rs, 1, 5, "s0");
+    auto own = compute_rowset_segment_ownership(rs, ranges);
+    ASSERT_TRUE(own.ok());
+    EXPECT_TRUE(own->segments[0].keep[0]);
+    EXPECT_FALSE(own->segments[0].keep[1]);
+    EXPECT_FALSE(own->segments[0].shared[0]); // exclusive + contained -> private
+}
+
+TEST(TabletSplitterTest, ComputeOwnership_spanning_segment_stays_shared) {
+    std::vector<TabletRangePB> ranges{make_bigint_range_pb(0, 11), make_bigint_range_pb(11, 21)};
+    RowsetMetadataPB rs;
+    add_bigint_seg(&rs, 5, 15, "s0"); // spans both
+    auto own = compute_rowset_segment_ownership(rs, ranges);
+    ASSERT_TRUE(own.ok());
+    EXPECT_TRUE(own->segments[0].keep[0]);
+    EXPECT_TRUE(own->segments[0].keep[1]);
+    EXPECT_TRUE(own->segments[0].shared[0]); // overlap_count>=2 -> shared
+    EXPECT_TRUE(own->segments[0].shared[1]);
+}
+
+TEST(TabletSplitterTest, ComputeOwnership_old_shared_stays_shared) {
+    std::vector<TabletRangePB> ranges{make_bigint_range_pb(0, 11), make_bigint_range_pb(11, 21)};
+    RowsetMetadataPB rs;
+    add_bigint_seg(&rs, 1, 5, "s0");
+    rs.mutable_segment_metas(0)->set_shared(true); // inherited shared (multi-level)
+    auto own = compute_rowset_segment_ownership(rs, ranges);
+    ASSERT_TRUE(own.ok());
+    EXPECT_TRUE(own->segments[0].shared[0]); // old_shared -> stays shared even though exclusive
+}
+
+TEST(TabletSplitterTest, ComputeOwnership_failclosed_when_not_contained) {
+    // Single range [0,11) does not cover the segment's max (15). overlap_count==1,
+    // old_shared=false, but seg_max=15 not contained -> must stay shared (fail-closed).
+    std::vector<TabletRangePB> ranges{make_bigint_range_pb(0, 11)};
+    RowsetMetadataPB rs;
+    add_bigint_seg(&rs, 5, 15, "s0");
+    auto own = compute_rowset_segment_ownership(rs, ranges);
+    ASSERT_TRUE(own.ok());
+    EXPECT_TRUE(own->segments[0].keep[0]);
+    EXPECT_TRUE(own->segments[0].shared[0]); // fail-closed (not provably contained)
+}
+
+TEST(TabletSplitterTest, ApplyOwnership_prunes_and_rebuilds_shared) {
+    RowsetMetadataPB source_rowset;
+    add_bigint_seg(&source_rowset, 0, 1, "s0");
+    add_bigint_seg(&source_rowset, 5, 15, "s1");
+    add_bigint_seg(&source_rowset, 18, 19, "s2");
+    source_rowset.mutable_segment_metas(0)->set_size(10);
+    source_rowset.mutable_segment_metas(1)->set_size(20);
+    source_rowset.mutable_segment_metas(2)->set_size(30);
+
+    RowsetOwnership ownership;
+    ownership.segments.resize(3);
+    ownership.segments[0] = {{true, false}, {false, false}};
+    ownership.segments[1] = {{true, true}, {true, true}};
+    ownership.segments[2] = {{false, true}, {false, false}};
+
+    RowsetMetadataPB rowset_for_tablet0 = source_rowset;
+    ASSERT_OK(apply_segment_ownership_to_new_tablet_rowset(&rowset_for_tablet0, ownership, 0));
+    ASSERT_EQ(2, rowset_for_tablet0.segment_metas_size());
+    EXPECT_EQ("s0", rowset_for_tablet0.segment_metas(0).filename());
+    EXPECT_EQ("s1", rowset_for_tablet0.segment_metas(1).filename());
+    EXPECT_FALSE(rowset_for_tablet0.segment_metas(0).shared());
+    EXPECT_TRUE(rowset_for_tablet0.segment_metas(1).shared());
+    EXPECT_EQ(0u, rowset_for_tablet0.segment_metas(0).segment_idx()); // synthesized to original positional index
+    EXPECT_EQ(1u, rowset_for_tablet0.segment_metas(1).segment_idx());
+
+    RowsetMetadataPB rowset_for_tablet1 = source_rowset;
+    ASSERT_OK(apply_segment_ownership_to_new_tablet_rowset(&rowset_for_tablet1, ownership, 1));
+    ASSERT_EQ(2, rowset_for_tablet1.segment_metas_size());
+    EXPECT_EQ("s1", rowset_for_tablet1.segment_metas(0).filename());
+    EXPECT_EQ("s2", rowset_for_tablet1.segment_metas(1).filename());
+    EXPECT_TRUE(rowset_for_tablet1.segment_metas(0).shared());
+    EXPECT_FALSE(rowset_for_tablet1.segment_metas(1).shared());
+    EXPECT_EQ(1u, rowset_for_tablet1.segment_metas(0).segment_idx());
+    EXPECT_EQ(2u, rowset_for_tablet1.segment_metas(1).segment_idx());
+}
+
+// encryption_meta travels inside each SegmentMetadataPB, so it must prune in lockstep
+// with the segment it describes; a misaligned/dropped entry is load-time corruption.
+TEST(TabletSplitterTest, ApplyOwnership_prunes_segment_encryption_metas) {
+    RowsetMetadataPB source_rowset;
+    add_bigint_seg(&source_rowset, 0, 1, "s0");
+    add_bigint_seg(&source_rowset, 5, 15, "s1");
+    add_bigint_seg(&source_rowset, 18, 19, "s2");
+    source_rowset.mutable_segment_metas(0)->set_size(10);
+    source_rowset.mutable_segment_metas(1)->set_size(20);
+    source_rowset.mutable_segment_metas(2)->set_size(30);
+    source_rowset.mutable_segment_metas(0)->set_encryption_meta("enc0");
+    source_rowset.mutable_segment_metas(1)->set_encryption_meta("enc1");
+    source_rowset.mutable_segment_metas(2)->set_encryption_meta("enc2");
+
+    RowsetOwnership ownership;
+    ownership.segments.resize(3);
+    ownership.segments[0] = {{true, false}, {false, false}};
+    ownership.segments[1] = {{true, true}, {true, true}};
+    ownership.segments[2] = {{false, true}, {false, false}};
+
+    // tablet0 keeps segments 0,1 -> encryption metas align to enc0,enc1.
+    RowsetMetadataPB rowset_for_tablet0 = source_rowset;
+    ASSERT_OK(apply_segment_ownership_to_new_tablet_rowset(&rowset_for_tablet0, ownership, 0));
+    ASSERT_EQ(2, rowset_for_tablet0.segment_metas_size());
+    EXPECT_EQ("enc0", rowset_for_tablet0.segment_metas(0).encryption_meta());
+    EXPECT_EQ("enc1", rowset_for_tablet0.segment_metas(1).encryption_meta());
+
+    // tablet1 keeps segments 1,2 -> enc1,enc2.
+    RowsetMetadataPB rowset_for_tablet1 = source_rowset;
+    ASSERT_OK(apply_segment_ownership_to_new_tablet_rowset(&rowset_for_tablet1, ownership, 1));
+    ASSERT_EQ(2, rowset_for_tablet1.segment_metas_size());
+    EXPECT_EQ("enc1", rowset_for_tablet1.segment_metas(0).encryption_meta());
+    EXPECT_EQ("enc2", rowset_for_tablet1.segment_metas(1).encryption_meta());
+}
+
+// bundle_file_offset is an absolute byte offset into one shared physical file carried
+// inside each SegmentMetadataPB; it must prune in lockstep with the segment. The offsets
+// are positional (not derived from neighbors), so pruning a middle segment must not shift
+// survivors.
+TEST(TabletSplitterTest, ApplyOwnership_prunes_bundle_file_offsets) {
+    RowsetMetadataPB source_rowset;
+    add_bigint_seg(&source_rowset, 0, 1, "bundle.dat");
+    add_bigint_seg(&source_rowset, 5, 15, "bundle.dat");
+    add_bigint_seg(&source_rowset, 18, 19, "bundle.dat");
+    source_rowset.mutable_segment_metas(0)->set_size(10);
+    source_rowset.mutable_segment_metas(1)->set_size(20);
+    source_rowset.mutable_segment_metas(2)->set_size(30);
+    source_rowset.mutable_segment_metas(0)->set_bundle_file_offset(0);
+    source_rowset.mutable_segment_metas(1)->set_bundle_file_offset(10);
+    source_rowset.mutable_segment_metas(2)->set_bundle_file_offset(30);
+
+    RowsetOwnership ownership;
+    ownership.segments.resize(3);
+    ownership.segments[0] = {{true, false}, {false, false}};
+    ownership.segments[1] = {{true, true}, {true, true}};
+    ownership.segments[2] = {{false, true}, {false, false}};
+
+    // tablet0 keeps segments 0,1 -> offsets 0,10.
+    RowsetMetadataPB rowset_for_tablet0 = source_rowset;
+    ASSERT_OK(apply_segment_ownership_to_new_tablet_rowset(&rowset_for_tablet0, ownership, 0));
+    ASSERT_EQ(2, rowset_for_tablet0.segment_metas_size());
+    EXPECT_EQ(0, rowset_for_tablet0.segment_metas(0).bundle_file_offset());
+    EXPECT_EQ(10, rowset_for_tablet0.segment_metas(1).bundle_file_offset());
+
+    // tablet1 keeps segments 1,2 -> offsets 10,30 (pruned middle does not shift them).
+    RowsetMetadataPB rowset_for_tablet1 = source_rowset;
+    ASSERT_OK(apply_segment_ownership_to_new_tablet_rowset(&rowset_for_tablet1, ownership, 1));
+    ASSERT_EQ(2, rowset_for_tablet1.segment_metas_size());
+    EXPECT_EQ(10, rowset_for_tablet1.segment_metas(0).bundle_file_offset());
+    EXPECT_EQ(30, rowset_for_tablet1.segment_metas(1).bundle_file_offset());
+}
+
+TEST(TabletSplitterTest, ApplyOwnership_step0_shape_mismatch_aborts_unmodified) {
+    RowsetMetadataPB source_rowset;
+    add_bigint_seg(&source_rowset, 0, 1, "s0");
+    add_bigint_seg(&source_rowset, 2, 3, "s1");
+    RowsetOwnership ownership;
+    ownership.segments.resize(1); // size != segment_metas_size() (2)
+    ownership.segments[0] = {{true}, {false}};
+    auto status = apply_segment_ownership_to_new_tablet_rowset(&source_rowset, ownership, 0);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(2, source_rowset.segment_metas_size()); // unmodified
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -18,6 +18,7 @@
 #include "runtime/exec_env.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_reshard_helper.h"
 
 namespace starrocks {
 namespace lake {
@@ -74,6 +75,9 @@ std::shared_ptr<TxnLogPB> make_op_write_log(int64_t tablet_id, int64_t txn_id, i
     auto* rowset = opw->mutable_rowset();
     rowset->set_num_rows(num_rows);
     rowset->set_data_size(data_size);
+    // Production op_writes mint a uid at delta_writer time; emulate that here so
+    // batch-apply's strict-uid invariant in apply_op_write_batch holds.
+    tablet_reshard_helper::ensure_rowset_uid(rowset);
     for (auto& s : segments) {
         auto* sm = rowset->add_segment_metas();
         sm->set_filename(s);
@@ -134,6 +138,52 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeBasic) {
     EXPECT_EQ(4u, meta->next_rowset_id()); // 批量合并仍消耗3个额外rowset id
 }
 
+// Regression: a cross-published op_write whose num_rows scaled to 0 on this child (but still
+// carries a segment) must NOT be dropped, and the merged uid must be taken from it (the first
+// op_write carrying segments) so split children converge on one identity. Gating on num_rows
+// instead would skip seg_zero, set num_rows-driven uid to log1's, and diverge across children.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchZeroNumRowsKeepsSegmentAndUid) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10020);
+    auto meta = build_non_pk_metadata(10020);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log0 = make_op_write_log(10020, 20, /*num_rows=*/0, /*data_size=*/0, {"seg_zero"});
+    auto log1 = make_op_write_log(10020, 21, /*num_rows=*/10, /*data_size=*/200, {"seg_data"});
+    const PUniqueId first_uid = log0->op_write().rowset().uid();
+
+    TxnLogVector logs{log0, log1};
+    Status st = applier->apply(logs);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(1, meta->rowsets_size());
+    const auto& rs = meta->rowsets(0);
+    EXPECT_EQ(2, rs.segment_metas_size()) << "the num_rows==0 op_write's segment must be retained";
+    EXPECT_EQ(10, rs.num_rows()) << "num_rows still summed faithfully (0 + 10)";
+    ASSERT_TRUE(rs.has_uid());
+    EXPECT_EQ(first_uid.hi(), rs.uid().hi());
+    EXPECT_EQ(first_uid.lo(), rs.uid().lo());
+}
+
+// Regression for the early-exit: if EVERY contributing op_write scaled to num_rows==0 but
+// segments are present, the merged rowset must still be created (the early-exit keys on
+// segments, not total_num_rows) — otherwise the whole cross-published txn's data is dropped.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchAllZeroNumRowsKeepsSegments) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10021);
+    auto meta = build_non_pk_metadata(10021);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    logs.push_back(make_op_write_log(10021, 22, 0, 0, {"seg_x"}));
+    logs.push_back(make_op_write_log(10021, 23, 0, 0, {"seg_y"}));
+
+    Status st = applier->apply(logs);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(1, meta->rowsets_size()) << "rowset must be created even when total num_rows is 0";
+    EXPECT_EQ(2, meta->rowsets(0).segment_metas_size());
+    EXPECT_EQ(0, meta->rowsets(0).num_rows());
+}
+
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeSparseSegmentIdStep) {
     Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10004);
     auto meta = build_non_pk_metadata(10004);
@@ -145,6 +195,7 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeSparseSegmentIdStep) {
     auto* rowset = log->mutable_op_write()->mutable_rowset();
     rowset->set_num_rows(5);
     rowset->set_data_size(100);
+    tablet_reshard_helper::ensure_rowset_uid(rowset);
     {
         auto* sm0 = rowset->add_segment_metas();
         sm0->set_filename("seg_sparse_a");
@@ -176,6 +227,7 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeRemapSegmentId) {
     auto* rowset1 = log1->mutable_op_write()->mutable_rowset();
     rowset1->set_num_rows(3);
     rowset1->set_data_size(30);
+    tablet_reshard_helper::ensure_rowset_uid(rowset1);
     {
         auto* sm = rowset1->add_segment_metas();
         sm->set_filename("seg_a");
@@ -189,6 +241,7 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeRemapSegmentId) {
     auto* rowset2 = log2->mutable_op_write()->mutable_rowset();
     rowset2->set_num_rows(4);
     rowset2->set_data_size(40);
+    tablet_reshard_helper::ensure_rowset_uid(rowset2);
     {
         auto* sm = rowset2->add_segment_metas();
         sm->set_filename("seg_b");
@@ -504,6 +557,28 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeBundleOffsetSizeMismatchRetu
     Status st = applier->apply(logs);
     EXPECT_TRUE(st.is_internal_error()) << st.to_string();
     EXPECT_NE(std::string::npos, st.to_string().find("mismatch"));
+}
+
+// Legacy/upgrade path: a txn log written before the uid field existed carries no producer
+// uid. Batch-apply must NOT hard-fail on it (that would strand a pending multi-statement
+// txn across a rolling upgrade) — instead the merged rowset backfills a fresh uid so the
+// publish succeeds. Such a txn predates range distribution and is never cross-published, so
+// the backfilled (non-deterministic) uid is safe. We clear the uid that make_op_write_log
+// auto-stamps to simulate the legacy log.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeNoUidBackfills) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10015);
+    auto meta = build_non_pk_metadata(10015);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    auto log = make_op_write_log(10015, 10, 5, 100, {"seg_a"});
+    log->mutable_op_write()->mutable_rowset()->clear_uid(); // simulate a legacy pre-uid txn log
+    logs.push_back(std::move(log));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(1, meta->rowsets_size());
+    EXPECT_TRUE(meta->rowsets(0).has_uid()) << "merged rowset must backfill a uid for a legacy log";
 }
 
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyReplicationWithoutTabletMetaSparseSegmentIdStep) {


### PR DESCRIPTION
## Why I'm doing:

In shared-data range-distribution tablet **SPLIT**, every data file inherited by a new tablet is currently marked `shared=true`, even when the file's key range falls entirely inside that one new tablet. The over-broad shared flag keeps the file alive (vacuum skips shared files) for every cross-published sibling, so garbage-version reclamation lags long after the file is logically owned by exactly one tablet. The companion **MERGE** then needs a robust way to dedup cross-sibling rowsets from the same logical source, but the prior `split_origin` design fragmented identity across multiple producer paths and was awkward to extend.

This PR (a) prunes per-segment ownership at split time so vacuum can reclaim eagerly, and (b) replaces split_origin with a single per-rowset `uid` (PUniqueId) as the unified MERGE dedup key.

## What I'm doing:

Built on the canonical `segment_metas[]` model (#74107): every per-segment attribute — filename, size, encryption_meta, `shared`, `bundle_file_offset`, `segment_idx` — lives in one `SegmentMetadataPB`, so the split/merge logic below operates directly on `segment_metas[]` with no parallel arrays to keep in lockstep.

**Split — per-segment shared optimization:**
- A segment whose key range falls entirely inside one new tablet's range is assigned `shared=false` and pruned from the non-overlapping siblings; `shared=false` is a data-loss gate (runtime fail-closed containment — kept shared unless containment is proven).
- `compute_rowset_segment_ownership` reads the source segment's current `shared` (so a multi-level split keeps an already-shared ancestor segment shared regardless of overlap count); `apply_segment_ownership_to_new_tablet_rowset` is validate-then-mutate (filters `segment_metas[]` to the kept segments and stamps each kept segment's `shared`). Ownership is computed once per source rowset and applied per new tablet. A post-prune single-segment rowset has `overlapped` reset to false; MERGE re-asserts it if a union later restores multiple segments.
- File-bundled rowsets prune uniformly: a segment's identity is `(filename, bundle_file_offset)`, so segments packed into one physical file (same name, different offset) are pruned/kept individually.
- A fully-pruned rowset (no surviving segment, no delete predicate, no del_files, no protected rssid) is removed; per-segment delvec/dcg ownership is propagated to the non-segment metadata.

**Merge — uid-based identity + segment union:**
- Single identity field: `optional PUniqueId uid = 19` on `RowsetMetadataPB`. Cross-sibling rowsets converge on one uid: split lineage preserves it via proto `CopyFrom`; a write cross-published during split mints it at the producer and propagates it through the txn log. Range-distribution is a brand-new feature (new tables only), so universal uid coverage is a strict invariant — a rowset reaching MERGE without a valid uid hard-fails (no random-uid fallback that would diverge across siblings).
- Dedup is `same_rowset_uid` (uid equality). `update_canonical` unions sibling segments via a `segment_idx`-keyed map (output sorted by segment_idx, dedup on segment_idx, fail-closed on a same-idx identity mismatch). The union gate `segment_lists_differ` compares segment identity `(filename, bundle_file_offset)`, so multi-level splits with disjoint all-shared subsets — and bundled rowsets — correctly trigger the union. After a union leaves >1 segment, `overlapped` is conservatively forced true (segment_idx ordering is not a key-range-non-overlap proof).
- PK family inference: a legacy `shared && !has_shared_rssid` sstable-filename edge plus a uid edge (rowsets with identical uid). Old tablets connected by either edge form a SPLIT family; the canonical is the smallest old-tablet index.

**uid helper API (`tablet_reshard_helper`):**
- `make_rowset_uid()` — factory returning a fresh 128-bit random PUniqueId.
- `set_rowset_uid(rowset)` — unconditional assignment. Used at every fresh-rowset producer (delta_writer, compaction, parallel-compaction merged output, schema change, replication, spark_load, the column-mode synthesized `new_rows`, and the `meta_file` segment-rewrite boundary): a freshly built rowset has no uid to inherit and must not alias a cross-published sibling.
- `ensure_rowset_uid(rowset)` — set-if-absent (idempotent). Sole call site: `LinkedSchemaChange`, which `CopyFrom`s the source rowset metadata and must keep the same-data identity rather than mint a new one.
- `has_valid_uid` / `same_rowset_uid` — the MERGE-side validity check and dedup predicate.
- `inherit_or_set_uid(dst, src)` — adopt-a-source's-identity primitive: copies `src`'s uid if valid, else mints a fresh one on `dst`. It keys off the *source* (not `dst`, which may already hold a stale uid after proto `MergeFrom`), so it is distinct from `ensure_rowset_uid`. Shared by the two PUBLISH combine paths and column-mode partial-update synthesis.

**Producer-side uid invariants** (all via `inherit_or_set_uid` — adopt the source's uid, backfill only a legacy pre-uid source):
- Column-mode partial update: the synthesized `new_rows_op.rowset` adopts `op_write.rowset().uid` so split siblings converge on one identity; a legacy uid-less in-flight write (never range-distributed, never cross-published) is backfilled.
- Publish combine paths (batch txn-log apply, and multi-`load_id` vlog materialization): the merged rowset adopts the first contributing log's uid. All logs of one txn share a producer version and uids are `CopyFrom`-preserved across cross-publish, so the merged identity stays stable across cross-published split children; a source predating the uid field (legacy pre-uid txn log from a rolling upgrade, never cross-published) is backfilled rather than failing the in-flight publish.

**Ownership transfer at merge:** the source old tablets are marked all-shared (their files survive drop/vacuum until every sibling is gone); the merged new tablet inherits the per-segment flags unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5


