### PR TITLE
[Enhancement] Support Arrow IPC compression (LZ4/ZSTD) for Arrow Flight SQL DoGet

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -603,6 +603,11 @@ CONF_mInt32(periodic_counter_update_period_ms, "500");
 
 CONF_Int32(arrow_flight_port, "-1");
 
+// Cluster-wide default Arrow IPC compression codec for Arrow Flight SQL DoGet
+// responses: "none" (default, off), "lz4" (Arrow LZ4_FRAME), or "zstd". A non-empty
+// session variable `arrow_flight_compression` overrides this per connection.
+CONF_mString(arrow_flight_ipc_compression, "none");
+
 // Used for mini Load. mini load data file will be removed after this time.
 CONF_Int64(load_data_reserve_hours, "4");
 // log error log will be removed after this time

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -559,6 +559,7 @@
         "heartbeat_service_port",
         "heartbeat_service_thread_count",
         "arrow_flight_port",
+        "arrow_flight_ipc_compression",
         "be_service_threads",
         "brpc_num_threads",
         "enable_https",

--- a/be/src/common/config_network_fwd.h
+++ b/be/src/common/config_network_fwd.h
@@ -82,6 +82,11 @@ CONF_Alias(be_http_port, webserver_port);
 
 CONF_Int32(arrow_flight_port, "-1");
 
+// Cluster-wide default Arrow IPC compression codec for Arrow Flight SQL DoGet
+// responses: "none" (default, off), "lz4" (Arrow LZ4_FRAME), or "zstd". A non-empty
+// session variable `arrow_flight_compression` overrides this per connection.
+CONF_mString(arrow_flight_ipc_compression, "none");
+
 // Maximum size of a single message body in all protocols.
 CONF_Int64(brpc_max_body_size, "2147483648");
 

--- a/be/src/compute_env/result/result_buffer_mgr.cpp
+++ b/be/src/compute_env/result/result_buffer_mgr.cpp
@@ -135,6 +135,19 @@ std::shared_ptr<arrow::Schema> ResultBufferMgr::get_arrow_schema(const TUniqueId
     return nullptr;
 }
 
+void ResultBufferMgr::set_arrow_compression(const TUniqueId& query_id, arrow::Compression::type codec) {
+    std::lock_guard<std::mutex> l(_lock);
+    _arrow_compression_map[query_id] = codec;
+}
+
+arrow::Compression::type ResultBufferMgr::get_arrow_compression(const TUniqueId& query_id) {
+    std::lock_guard<std::mutex> l(_lock);
+    if (auto iter = _arrow_compression_map.find(query_id); _arrow_compression_map.end() != iter) {
+        return iter->second;
+    }
+    return arrow::Compression::UNCOMPRESSED;
+}
+
 Status ResultBufferMgr::cancel(const TUniqueId& query_id) {
     std::lock_guard<std::mutex> l(_lock);
 
@@ -144,6 +157,7 @@ Status ResultBufferMgr::cancel(const TUniqueId& query_id) {
     }
 
     _arrow_schema_map.erase(query_id);
+    _arrow_compression_map.erase(query_id);
 
     return Status::OK();
 }

--- a/be/src/compute_env/result/result_buffer_mgr.h
+++ b/be/src/compute_env/result/result_buffer_mgr.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <arrow/record_batch.h>
+#include <arrow/util/compression.h>
 
 #include <atomic>
 #include <map>
@@ -64,10 +65,15 @@ public:
 
     std::shared_ptr<arrow::Schema> get_arrow_schema(const TUniqueId& query_id);
 
+    void set_arrow_compression(const TUniqueId& query_id, arrow::Compression::type codec);
+
+    arrow::Compression::type get_arrow_compression(const TUniqueId& query_id);
+
 private:
     typedef std::unordered_map<TUniqueId, std::shared_ptr<BufferControlBlock>> BufferMap;
     typedef std::map<time_t, std::vector<TUniqueId>> TimeoutMap;
     typedef std::unordered_map<TUniqueId, std::shared_ptr<arrow::Schema>> ArrowSchemaMap;
+    typedef std::unordered_map<TUniqueId, arrow::Compression::type> ArrowCompressionMap;
 
     std::shared_ptr<BufferControlBlock> find_control_block(const TUniqueId& query_id);
 
@@ -91,5 +97,7 @@ private:
     std::unique_ptr<std::thread> _cancel_thread;
 
     ArrowSchemaMap _arrow_schema_map;
+
+    ArrowCompressionMap _arrow_compression_map;
 };
 } // namespace starrocks

--- a/be/src/exec/data_sinks/arrow_result_writer.cpp
+++ b/be/src/exec/data_sinks/arrow_result_writer.cpp
@@ -18,8 +18,10 @@
 #include <arrow/record_batch.h>
 #include <bvar/recorder.h>
 #include <column/column_helper.h>
+#include <exec_primitive/arrow/arrow_flight_compression.h>
 
 #include "column/const_column.h"
+#include "common/config_network_fwd.h"
 #include "compute_env/result/buffer_control_block.h"
 #include "compute_env/result/result_buffer_mgr.h"
 #include "exec/exec_env.h"
@@ -69,7 +71,15 @@ Status ArrowResultWriter::init(RuntimeState* state) {
                                             &_output_column_names, state->arrow_flight_sql_version()));
 
     auto* query_execution_services = state->query_execution_services();
-    query_execution_services->runtime->result_mgr->set_arrow_schema(state->fragment_instance_id(), _arrow_schema);
+    auto* result_mgr = query_execution_services->runtime->result_mgr;
+    result_mgr->set_arrow_schema(state->fragment_instance_id(), _arrow_schema);
+
+    // Resolve the effective Arrow IPC compression codec (per-connection session variable,
+    // else the cluster-wide BE config) and stash it so DoGetStatement can apply it when
+    // serializing the result stream. An unset session value ("") inherits the BE config.
+    const std::string config_codec = config::arrow_flight_ipc_compression.value();
+    const auto codec = resolve_arrow_flight_compression(state->query_options().arrow_flight_compression, config_codec);
+    result_mgr->set_arrow_compression(state->fragment_instance_id(), codec);
 
     return Status::OK();
 }

--- a/be/src/exec_primitive/arrow/arrow_flight_compression.h
+++ b/be/src/exec_primitive/arrow/arrow_flight_compression.h
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/util/compression.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
+
+namespace starrocks {
+
+// Maps a user-facing codec name to an Arrow IPC compression type.
+// "lz4" -> LZ4_FRAME (frame format, enum 6; NOT raw LZ4 block format, enum 5).
+// "zstd" -> ZSTD. "none"/""/unrecognized -> UNCOMPRESSED. Case-insensitive.
+inline arrow::Compression::type arrow_flight_compression_from_string(std::string_view name) {
+    std::string lower(name);
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (lower == "lz4") {
+        return arrow::Compression::LZ4_FRAME;
+    }
+    if (lower == "zstd") {
+        return arrow::Compression::ZSTD;
+    }
+    return arrow::Compression::UNCOMPRESSED;
+}
+
+// Resolves the effective codec: a non-empty per-connection session value wins
+// (including an explicit "none"); an empty session value inherits the cluster default.
+inline arrow::Compression::type resolve_arrow_flight_compression(std::string_view session_value,
+                                                                 std::string_view config_default) {
+    const std::string_view effective = session_value.empty() ? config_default : session_value;
+    return arrow_flight_compression_from_string(effective);
+}
+
+} // namespace starrocks

--- a/be/src/service/service_be/arrow_flight_sql_service.cpp
+++ b/be/src/service/service_be/arrow_flight_sql_service.cpp
@@ -17,6 +17,8 @@
 #include <arrow/array/builder_binary.h>
 #include <arrow/flight/server.h>
 #include <arrow/flight/types.h>
+#include <arrow/ipc/options.h>
+#include <arrow/util/compression.h>
 #include <base/utility/arrow_utils.h>
 #include <exec/pipeline/query_context.h>
 
@@ -24,6 +26,7 @@
 #include "base/uid_util.h"
 #include "common/status.h"
 #include "common/system/backend_options.h"
+#include "compute_env/result/result_buffer_mgr.h"
 #include "exec/arrow_flight_batch_reader.h"
 #include "exec/exec_env.h"
 
@@ -88,9 +91,21 @@ arrow::Result<std::unique_ptr<arrow::flight::FlightDataStream>> ArrowFlightSqlSe
         return arrow::Status::Invalid("Invalid fragment ID format:", result_fragment_id);
     }
 
-    auto reader = std::make_shared<ArrowFlightBatchReader>(ExecEnv::GetInstance()->result_mgr(), resultfragmentid);
+    auto* result_mgr = ExecEnv::GetInstance()->result_mgr();
+    auto reader = std::make_shared<ArrowFlightBatchReader>(result_mgr, resultfragmentid);
     ARROW_RETURN_NOT_OK(reader->init());
-    return std::make_unique<arrow::flight::RecordBatchStream>(reader);
+
+    arrow::ipc::IpcWriteOptions options = arrow::ipc::IpcWriteOptions::Defaults();
+    const auto codec = result_mgr->get_arrow_compression(resultfragmentid);
+    if (codec != arrow::Compression::UNCOMPRESSED) {
+        ARROW_ASSIGN_OR_RAISE(options.codec, arrow::util::Codec::Create(codec));
+        // Skip compression for batches that shrink by less than 5% (e.g. dense numeric
+        // columns) to avoid negative-compression overhead.
+        options.min_space_savings = 0.05;
+    }
+    // options.write_legacy_ipc_format stays false (the default); the legacy IPC format
+    // does not support compression.
+    return std::make_unique<arrow::flight::RecordBatchStream>(reader, options);
 }
 
 arrow::Result<std::pair<std::string, std::string>> ArrowFlightSqlServer::decode_ticket(const std::string& ticket) {

--- a/be/test/exec/data_sinks/arrow_result_writer_test.cpp
+++ b/be/test/exec/data_sinks/arrow_result_writer_test.cpp
@@ -24,10 +24,48 @@
 #include "compute_env/result/buffer_control_block.h"
 #include "compute_env/result/result_buffer_mgr.h"
 #include "exec/exec_env.h"
+#include "exec_primitive/arrow/arrow_flight_compression.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
+
+TEST(ArrowFlightCompressionTest, from_string_maps_codecs) {
+    EXPECT_EQ(arrow::Compression::LZ4_FRAME, arrow_flight_compression_from_string("lz4"));
+    EXPECT_EQ(arrow::Compression::LZ4_FRAME, arrow_flight_compression_from_string("LZ4"));
+    EXPECT_EQ(arrow::Compression::ZSTD, arrow_flight_compression_from_string("zstd"));
+    EXPECT_EQ(arrow::Compression::ZSTD, arrow_flight_compression_from_string("ZSTD"));
+    EXPECT_EQ(arrow::Compression::UNCOMPRESSED, arrow_flight_compression_from_string("none"));
+    EXPECT_EQ(arrow::Compression::UNCOMPRESSED, arrow_flight_compression_from_string(""));
+    // Unknown values are defensively treated as uncompressed (FE rejects them at SET time).
+    EXPECT_EQ(arrow::Compression::UNCOMPRESSED, arrow_flight_compression_from_string("gzip"));
+}
+
+TEST(ArrowFlightCompressionTest, resolve_session_overrides_config) {
+    // Empty session value falls back to the BE config default.
+    EXPECT_EQ(arrow::Compression::ZSTD, resolve_arrow_flight_compression("", "zstd"));
+    // A non-empty session value wins, including explicit "none" to opt out.
+    EXPECT_EQ(arrow::Compression::LZ4_FRAME, resolve_arrow_flight_compression("lz4", "zstd"));
+    EXPECT_EQ(arrow::Compression::UNCOMPRESSED, resolve_arrow_flight_compression("none", "zstd"));
+    // Both empty => uncompressed.
+    EXPECT_EQ(arrow::Compression::UNCOMPRESSED, resolve_arrow_flight_compression("", ""));
+}
+
+TEST(ResultBufferMgrArrowCompressionTest, set_get_roundtrip) {
+    ResultBufferMgr mgr;
+    TUniqueId fragment_id;
+    fragment_id.hi = 1;
+    fragment_id.lo = 2;
+
+    // Absent entry defaults to uncompressed.
+    EXPECT_EQ(arrow::Compression::UNCOMPRESSED, mgr.get_arrow_compression(fragment_id));
+
+    mgr.set_arrow_compression(fragment_id, arrow::Compression::ZSTD);
+    EXPECT_EQ(arrow::Compression::ZSTD, mgr.get_arrow_compression(fragment_id));
+
+    mgr.set_arrow_compression(fragment_id, arrow::Compression::LZ4_FRAME);
+    EXPECT_EQ(arrow::Compression::LZ4_FRAME, mgr.get_arrow_compression(fragment_id));
+}
 
 TEST(ArrowResultWriterTest, close) {
     BufferControlBlock* sinker = new BufferControlBlock(TUniqueId(), 1024);

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -169,6 +169,15 @@ This topic introduces the following types of BE configurations:
 - Description: TCP port for the BE Arrow Flight SQL server. `-1` indicaes to disable the Arrow Flight service. On non-macOS builds, BE invokes Arrow Flight SQL Server with this port during startup; if the port is unavailable, the server startup fails and the BE process exits. The configured port is reported to the FE in the heartbeat payload.
 - Introduced in: v3.4.0, v3.5.0
 
+### arrow_flight_ipc_compression
+
+- Default: none
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: Cluster-wide default Arrow IPC compression codec for the result data that the BE streams over Arrow Flight SQL (`DoGet`). Valid values: `none` (no compression), `lz4` (Arrow `LZ4_FRAME`), or `zstd`. The session variable `arrow_flight_compression` overrides this per connection when it is set to a non-empty value.
+- Introduced in: -
+
 ### be_exit_after_disk_write_hang_second
 
 - Default: 60

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -198,6 +198,14 @@ If you want to activate the roles assigned to you in a session, use the [SET ROL
 * **Data Type**: boolean
 * **Introduced in**: v3.3.0, v3.4.0, v3.5.0
 
+### arrow_flight_compression
+
+* **Scope**: Session
+* **Description**: Compression codec for the Arrow IPC record batches that the BE returns over Arrow Flight SQL (`DoGet`). Valid values: `lz4` (Arrow `LZ4_FRAME`), `zstd`, `none`, or empty. When empty, the cluster-wide BE configuration `arrow_flight_ipc_compression` is used; a non-empty value (including `none`) overrides it for the current connection. This only affects large query results streamed from the BE; small results streamed directly from the FE are not affected, and when Arrow Flight proxy mode is enabled, client-visible compression applies only on direct BE connections.
+* **Default**: empty
+* **Data Type**: String
+* **Introduced in**: -
+
 ### authentication_policy
 
 * **Scope**: Session

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -157,6 +157,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：TCP 端口，用于 BE 的 Arrow Flight SQL 服务器。将其设置为 `-1` 以禁用 Arrow Flight 服务。在非 macOS 构建中，BE 在启动期间会调用通过该端口启动 Arrow Flight SQL Server；如果端口不可用，服务器启动会失败并且 BE 进程退出。配置的端口会在心跳负载中上报给 FE。
 - 引入版本：v3.4.0, v3.5.0
 
+### arrow_flight_ipc_compression
+
+- 默认值：none
+- 类型：String
+- 单位：-
+- 是否动态：是
+- 描述：BE 通过 Arrow Flight SQL（`DoGet`）流式返回结果数据时使用的集群级默认 Arrow IPC 压缩编码。有效值：`none`（不压缩）、`lz4`（对应 Arrow `LZ4_FRAME`）或 `zstd`。当会话变量 `arrow_flight_compression` 设置为非空值时，会针对该连接覆盖此默认值。
+- 引入版本：-
+
 ### be_exit_after_disk_write_hang_second
 
 - 默认值：60

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -194,6 +194,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **数据类型**: boolean
 * **引入版本**: v3.3.0, v3.4.0, v3.5.0
 
+### arrow_flight_compression
+
+* **作用域**: Session
+* **描述**: BE 通过 Arrow Flight SQL（`DoGet`）返回的 Arrow IPC record batch 所使用的压缩编码。有效值：`lz4`（对应 Arrow `LZ4_FRAME`）、`zstd`、`none` 或空值。为空时使用集群级 BE 配置项 `arrow_flight_ipc_compression`；非空值（包括 `none`）会针对当前连接覆盖该配置。该变量仅影响由 BE 流式返回的大结果集；由 FE 直接返回的小结果集不受影响。当启用 Arrow Flight 代理模式时，仅在直连 BE 的情况下客户端才能获得压缩效果。
+* **默认值**: 空
+* **数据类型**: String
+* **引入版本**: -
+
 ### auto_increment_increment
 
 * 描述：用于兼容 MySQL 客户端。无实际作用。

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -243,6 +243,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PROFILE = "enable_profile";
     public static final String ENABLE_EXPLAIN_IN_PROFILE = "enable_explain_in_profile";
     public static final String BINARY_ENCODING_FORMAT = "binary_encoding_format";
+    public static final String ARROW_FLIGHT_COMPRESSION = "arrow_flight_compression";
     public static final String BINARY_ENCODING_LEVEL = "binary_encoding_level";
 
     public static final String ENABLE_LOAD_PROFILE = "enable_load_profile";
@@ -1381,6 +1382,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = BINARY_ENCODING_FORMAT)
     private String binaryEncodingFormat = BinaryEncodingFormat.HEX.sessionValue();
+
+    @VariableMgr.VarAttr(name = ARROW_FLIGHT_COMPRESSION)
+    private String arrowFlightCompression = "";
 
     @VariableMgr.VarAttr(name = BINARY_ENCODING_LEVEL)
     private String binaryEncodingLevel = BinaryEncodingLevel.NESTED.sessionValue();
@@ -4870,6 +4874,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.binaryEncodingLevel = level.sessionValue();
     }
 
+    public String getArrowFlightCompression() {
+        return arrowFlightCompression;
+    }
+
+    public void setArrowFlightCompression(String mode) {
+        if (mode == null || mode.isEmpty()
+                || mode.equalsIgnoreCase("lz4")
+                || mode.equalsIgnoreCase("zstd")
+                || mode.equalsIgnoreCase("none")) {
+            arrowFlightCompression = (mode == null) ? "" : mode.toLowerCase();
+        } else {
+            throw new IllegalArgumentException(
+                    "Legal values of arrow_flight_compression are lz4|zstd|none");
+        }
+    }
+
     public void setEnableAsyncProfile(boolean enableAsyncProfile) {
         this.enableAsyncProfile = enableAsyncProfile;
     }
@@ -6474,6 +6494,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
         tResult.setEnable_profile(enableProfile);
         tResult.setBinary_encoding_format(BinaryEncodingFormat.fromString(binaryEncodingFormat).thriftValue());
+        tResult.setArrow_flight_compression(arrowFlightCompression);
         tResult.setBinary_encoding_level(BinaryEncodingLevel.fromString(binaryEncodingLevel).thriftValue());
         tResult.setBig_query_profile_threshold(TimeValue.parseTimeValue(bigQueryProfileThreshold).getMillis());
         tResult.setBig_query_profile_threshold_unit(TTimeUnit.MILLISECOND);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -201,4 +201,33 @@ public class SessionVariableTest {
                 SessionVariable.SCAN_HIVE_PARTITION_NUM_LIMIT + "\": 512}");
         Assertions.assertEquals(4096, sessionVariable.getScanLakePartitionNumLimit());
     }
+
+    @Test
+    public void testArrowFlightCompressionDefaultsAndToThrift() {
+        SessionVariable sv = new SessionVariable();
+        Assertions.assertEquals("", sv.getArrowFlightCompression());
+        TQueryOptions opts = sv.toThrift();
+        Assertions.assertEquals("", opts.getArrow_flight_compression());
+    }
+
+    @Test
+    public void testArrowFlightCompressionSettersNormalizeAndValidate() {
+        SessionVariable sv = new SessionVariable();
+
+        sv.setArrowFlightCompression("LZ4");
+        Assertions.assertEquals("lz4", sv.getArrowFlightCompression());
+        Assertions.assertEquals("lz4", sv.toThrift().getArrow_flight_compression());
+
+        sv.setArrowFlightCompression("ZSTD");
+        Assertions.assertEquals("zstd", sv.getArrowFlightCompression());
+
+        sv.setArrowFlightCompression("none");
+        Assertions.assertEquals("none", sv.getArrowFlightCompression());
+
+        sv.setArrowFlightCompression("");
+        Assertions.assertEquals("", sv.getArrowFlightCompression());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> sv.setArrowFlightCompression("gzip"));
+    }
 }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -418,6 +418,10 @@ struct TQueryOptions {
   222: optional i64 topn_back_pressure_num_rows = 1024;
   223: optional i64 topn_back_pressure_throttle_time_ms = 8;
   224: optional i64 topn_back_pressure_throttle_time_upper_bound_ms = 100;
+
+  // Arrow IPC compression codec for Arrow Flight SQL DoGet responses:
+  // "" (inherit BE config arrow_flight_ipc_compression), "none", "lz4", or "zstd".
+  225: optional string arrow_flight_compression;
 }
 
 // A scan range plus the parameters needed to execute that scan.


### PR DESCRIPTION
## Why I'm doing:

StarRocks returns Arrow IPC data over Arrow Flight SQL completely uncompressed. `DoGetStatement` in `be/src/service/service_be/arrow_flight_sql_service.cpp` builds `RecordBatchStream(reader)` with no `IpcWriteOptions`, so the codec defaults to `UNCOMPRESSED`, and there is no BE/FE knob to enable compression. Client-side gRPC compression (`grpc-encoding: gzip`) only affects client→server messages, not the server→client `DoGet` response, and is inferior to Arrow IPC body compression.

## What I'm doing:

Add per-connection Arrow IPC compression for BE-streamed Arrow Flight SQL results:

- New session variable `arrow_flight_compression` = `lz4` (Arrow `LZ4_FRAME`) / `zstd` / `none` (default empty = inherit BE config).
- New cluster-wide BE config `arrow_flight_ipc_compression` (default `none`).
- The codec travels FE→BE via a new optional `TQueryOptions.arrow_flight_compression` field, is resolved at result-write time (session value, else BE config) and stored in `ResultBufferMgr` keyed by fragment id (next to the existing arrow schema), then applied as `arrow::ipc::IpcWriteOptions` (with `min_space_savings = 0.05`) in `DoGetStatement`.

Scope/limitations (documented): only the BE-streamed `DoGet` path is compressed; FE-held small results and the FE proxy re-stream are unaffected, so client-visible compression applies on direct BE connections.

Tests: FE `SessionVariableTest` (normalize/validate/`toThrift`) verified locally in the dev-env container (11/11 pass); BE unit tests added for the codec resolver and the `ResultBufferMgr` roundtrip (run in CI).

Fixes #73876

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5