### PR TITLE
[BugFix] Fix memory-leak introduced by udaf cache (backport #74025)

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -285,8 +285,6 @@ Status Aggregator::open(RuntimeState* state) {
         auto& opts = state->query_options();
         bool enable_cache = opts.__isset.enable_cache_udaf && opts.enable_cache_udaf;
         auto promise_st = call_function_in_pthread(state, [this, enable_cache]() {
-            std::vector<int> attached_udaf_idx;
-            attached_udaf_idx.reserve(_agg_fn_ctxs.size());
             for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
                 if (_fns[i].binary_type == TFunctionBinaryType::SRJAR) {
                     const auto& fn = _fns[i];
@@ -307,13 +305,7 @@ Status Aggregator::open(RuntimeState* state) {
                             COUNTER_UPDATE(_agg_stat->udaf_cache_populate_count, 1);
                         }
                     }
-                    if (!st.ok()) {
-                        for (int idx : attached_udaf_idx) {
-                            destroy_java_udaf_context(_agg_fn_ctxs[idx]);
-                        }
-                        return st;
-                    }
-                    attached_udaf_idx.emplace_back(i);
+                    RETURN_IF_ERROR(st);
                 }
             }
             return Status::OK();

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -122,9 +122,11 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_contex
 }
 
 // Build a per-aggregator JavaUDAFUniqueContext on top of a (possibly cached) JavaUDAFSharedContext.
-static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> udaf_ctx, FunctionContext* context) {
-    auto agg_ctx = std::make_unique<JavaUDAFUniqueContext>();
-    agg_ctx->ctx = std::move(udaf_ctx);
+// The context is already pre-allocated in FunctionContext::_jvm_udaf_ctxs; we populate it here.
+static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> udaf_shared_ctx,
+                                        FunctionContext* context) {
+    auto* agg_ctx = context->udaf_ctxs();
+    agg_ctx->ctx = std::move(udaf_shared_ctx);
 
     // Create a per-aggregator UDAF object instance
     ASSIGN_OR_RETURN(agg_ctx->handle, agg_ctx->ctx->udaf_class.newInstance());
@@ -149,8 +151,7 @@ static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> u
             JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_add_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_remove_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_clear_method.handle())));
-    agg_ctx->_func = std::make_unique<UDAFFunction>(agg_ctx->handle.handle(), context, agg_ctx.get());
-    attach_java_udaf_context(context, std::move(agg_ctx));
+    agg_ctx->_func = std::make_unique<UDAFFunction>(agg_ctx->handle.handle(), context, agg_ctx);
     return Status::OK();
 }
 

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -57,7 +57,7 @@ public:
             input_column = down_cast<const BinaryColumn*>(column);
         }
         Slice slice = input_column->get_slice(row_num);
-        auto* udaf_ctx = get_java_udaf_context(ctx);
+        auto* udaf_ctx = ctx->udaf_ctxs();
 
         if (udaf_ctx->buffer->capacity() < slice.get_size()) {
             udaf_ctx->buffer_data.resize(slice.get_size());
@@ -83,7 +83,7 @@ public:
         }
 
         size_t old_size = column->get_bytes().size();
-        auto* udaf_ctx = get_java_udaf_context(ctx);
+        auto* udaf_ctx = ctx->udaf_ctxs();
         int serialize_size = udaf_ctx->_func->serialize_size(this->data(state).handle);
         if (udaf_ctx->buffer->capacity() < serialize_size) {
             udaf_ctx->buffer_data.resize(serialize_size);
@@ -101,7 +101,7 @@ public:
 
     void finalize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
                             Column* to) const final {
-        auto* udaf_ctx = get_java_udaf_context(ctx);
+        auto* udaf_ctx = ctx->udaf_ctxs();
         DCHECK(udaf_ctx != nullptr);
         jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
         // STRUCT-bearing return types route through append_jvalue's STRUCT path with the
@@ -117,7 +117,7 @@ public:
                                      ColumnPtr* dst) const final {
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = helper.getEnv();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
         // 1 convert input as state
         // 1.1 create state list
         auto rets =
@@ -192,12 +192,12 @@ public:
     // jclass
     // newInstance -> handle
     void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {
-        new (ptr) State(get_java_udaf_context(ctx)->_func->create());
+        new (ptr) State(ctx->udaf_ctxs()->_func->create());
     }
 
     // Call Destroy method
     void destroy(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {
-        get_java_udaf_context(ctx)->_func->destroy(data(ptr).handle);
+        ctx->udaf_ctxs()->_func->destroy(data(ptr).handle);
         data(ptr).~State();
     }
 
@@ -222,7 +222,7 @@ public:
     void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
         helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
@@ -244,7 +244,7 @@ public:
     void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
                                   AggDataPtr* states, const Filter& filter) const override {
         auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
         helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
@@ -269,7 +269,7 @@ public:
         auto* env = helper.getEnv();
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
         env->PushLocalFrame(num_cols * 3 + 1);
         auto defer = DeferOp([env = env]() { env->PopLocalFrame(nullptr); });
         {
@@ -279,7 +279,7 @@ public:
             SET_FUNCTION_CONTEXT_ERR(st, ctx);
             RETURN_IF_UNLIKELY(!st.ok(), (void)0);
 
-            auto* stub = get_java_udaf_context(ctx)->update_batch_call_stub.get();
+            auto* stub = ctx->udaf_ctxs()->update_batch_call_stub.get();
             auto state_handle = this->data(state).handle;
             helper.batch_update_single(stub, state_handle, args.data(), num_cols, batch_size);
         }
@@ -320,7 +320,7 @@ public:
         // batch merge
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = helper.getEnv();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
 
         auto provider = [&]() {
             auto state_id_list = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
@@ -341,7 +341,7 @@ public:
                                  AggDataPtr* states, const Filter& filter) const override {
         // batch merge
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
 
         auto provider = [&]() {
             auto state_id_list = JavaDataTypeConverter::convert_to_states_with_filter(ctx, states, state_offset,
@@ -360,7 +360,7 @@ public:
                                   size_t size) const override {
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = helper.getEnv();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
         auto provider = [&]() {
             auto state_handle = reinterpret_cast<JavaUDAFState*>(state)->handle;
             auto res = helper.convert_handle_to_jobject(ctx, state_handle);
@@ -379,7 +379,7 @@ public:
                          size_t state_offset, Column* to) const override {
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = helper.getEnv();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
 
         const size_t origin_chunk_size = to->size();
         auto defer = DeferOp([&]() {
@@ -435,7 +435,7 @@ public:
                         size_t state_offset, Column* to) const override {
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = helper.getEnv();
-        auto* udf_ctxs = get_java_udaf_context(ctx);
+        auto* udf_ctxs = ctx->udaf_ctxs();
 
         const size_t origin_chunk_size = to->size();
         auto defer = DeferOp([&]() {

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -71,8 +71,9 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_window_shared_cont
 }
 
 // Build a per-aggregator JavaUDAFUniqueContext for a window function on top of a shared context.
+// The context is already pre-allocated in FunctionContext::_jvm_udaf_ctxs; we populate it here.
 static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext> shared, FunctionContext* context) {
-    auto udaf_ctx = std::make_unique<JavaUDAFUniqueContext>();
+    auto* udaf_ctx = context->udaf_ctxs();
     udaf_ctx->ctx = std::move(shared);
 
     ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->ctx->udaf_class.newInstance());
@@ -87,8 +88,7 @@ static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext>
             JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_add_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_remove_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_clear_method.handle())));
-    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx.get());
-    attach_java_udaf_context(context, std::move(udaf_ctx));
+    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx);
     return Status::OK();
 }
 

--- a/be/src/exprs/agg/java_window_function.h
+++ b/be/src/exprs/agg/java_window_function.h
@@ -34,7 +34,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
 class JavaWindowFunction final : public JavaUDAFAggregateFunction {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        get_java_udaf_context(ctx)->_func->reset(data(state).handle);
+        ctx->udaf_ctxs()->_func->reset(data(state).handle);
     }
 
     std::string get_name() const override { return "java_window"; }
@@ -64,8 +64,8 @@ public:
         SET_FUNCTION_CONTEXT_ERR(st, ctx);
         RETURN_IF_UNLIKELY(!st.ok(), (void)0);
 
-        get_java_udaf_context(ctx)->_func->window_update_batch(data(state).handle, peer_group_start, peer_group_end,
-                                                               frame_start, frame_end, num_args, args.data());
+        ctx->udaf_ctxs()->_func->window_update_batch(data(state).handle, peer_group_start, peer_group_end, frame_start,
+                                                     frame_end, num_args, args.data());
         // release input cols
         for (int i = 0; i < num_args; ++i) {
             env->DeleteLocalRef(args[i]);
@@ -75,7 +75,7 @@ public:
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        jvalue val = get_java_udaf_context(ctx)->_func->finalize(this->data(state).handle);
+        jvalue val = ctx->udaf_ctxs()->_func->finalize(this->data(state).handle);
         // insert values to column
         JNIEnv* env = helper.getEnv();
         const auto& return_type = ctx->get_return_type();

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -38,6 +38,9 @@ FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* p
     ctx->_mem_pool = pool;
     ctx->_return_type = return_type;
     ctx->_arg_types = arg_types;
+#if !defined(BUILD_FORMAT_LIB)
+    ctx->_jvm_udaf_ctxs = std::make_unique<JavaUDAFUniqueContext>();
+#endif
     return ctx;
 }
 
@@ -51,6 +54,9 @@ FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* p
     ctx->_mem_pool = pool;
     ctx->_return_type = return_type;
     ctx->_arg_types = arg_types;
+#if !defined(BUILD_FORMAT_LIB)
+    ctx->_jvm_udaf_ctxs = std::make_unique<JavaUDAFUniqueContext>();
+#endif
     ctx->_is_distinct = is_distinct;
     ctx->_is_asc_order = is_asc_order;
     ctx->_nulls_first = nulls_first;
@@ -131,11 +137,12 @@ void* FunctionContext::get_function_state(FunctionStateScope scope) const {
 }
 
 void FunctionContext::release_mems() {
-    auto* udaf_ctx = get_java_udaf_context(this);
-    if (udaf_ctx != nullptr && udaf_ctx->states) {
+#if !defined(BUILD_FORMAT_LIB)
+    if (_jvm_udaf_ctxs != nullptr && _jvm_udaf_ctxs->states) {
         auto env = JVMFunctionHelper::getInstance().getEnv();
-        udaf_ctx->states->clear(this, env);
+        _jvm_udaf_ctxs->states->clear(this, env);
     }
+#endif
 }
 
 void FunctionContext::set_error(const char* error_msg, const bool is_udf) {

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -35,6 +35,7 @@ class RuntimeState;
 class Column;
 class Slice;
 struct NgramBloomFilterState;
+struct JavaUDAFUniqueContext;
 
 class FunctionContext {
 public:
@@ -163,6 +164,8 @@ public:
     bool has_error() const;
     const char* error_msg() const;
 
+    JavaUDAFUniqueContext* udaf_ctxs() { return _jvm_udaf_ctxs.get(); }
+
     void release_mems();
 
     ssize_t get_group_concat_max_len() { return group_concat_max_len; }
@@ -213,6 +216,9 @@ private:
     // If it is not explicitly set externally (e.g. AggFuncBasedValueAggregator),
     // it will point to the internal _mem_usage
     int64_t* _mem_usage_counter = &_mem_usage;
+
+    // UDAF Context
+    std::unique_ptr<JavaUDAFUniqueContext> _jvm_udaf_ctxs;
 
     std::vector<bool> _is_asc_order;
     std::vector<bool> _nulls_first;

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -120,49 +120,6 @@ static JNINativeMethod java_native_methods[] = {
 };
 #pragma GCC diagnostic pop
 
-JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx) {
-    if (ctx == nullptr) {
-        return nullptr;
-    }
-    return reinterpret_cast<JavaUDAFUniqueContext*>(ctx->get_function_state(FunctionContext::THREAD_LOCAL));
-}
-
-void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx) {
-    DCHECK(ctx != nullptr);
-    DCHECK(udaf_ctx != nullptr);
-    auto* old_ctx = get_java_udaf_context(ctx);
-    DCHECK(old_ctx == nullptr) << "duplicate Java UDAF context attach";
-    if (old_ctx != nullptr) {
-        delete old_ctx;
-    }
-    ctx->set_function_state(FunctionContext::THREAD_LOCAL, udaf_ctx.release());
-}
-
-void clear_java_udaf_states(FunctionContext* ctx) {
-    auto* udaf_ctx = get_java_udaf_context(ctx);
-    if (udaf_ctx == nullptr || udaf_ctx->states == nullptr) {
-        return;
-    }
-
-    auto env = JVMFunctionHelper::getInstance().getEnv();
-    udaf_ctx->states->clear(ctx, env);
-}
-
-void destroy_java_udaf_context(FunctionContext* ctx) {
-    if (ctx == nullptr) {
-        return;
-    }
-
-    auto* udaf_ctx = get_java_udaf_context(ctx);
-    if (udaf_ctx == nullptr) {
-        return;
-    }
-
-    clear_java_udaf_states(ctx);
-    ctx->set_function_state(FunctionContext::THREAD_LOCAL, nullptr);
-    delete udaf_ctx;
-}
-
 StatusOr<jobject> MapMeta::newLocalInstance(jobject keys, jobject values) const {
     JNIEnv* env = getJNIEnv();
     auto res = env->NewObject(immutable_map_class->clazz(), immutable_map_constructor, keys, values);
@@ -540,8 +497,8 @@ void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject
                                      int cols) {
     jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
     LOCAL_REF_GUARD(input_arr);
-    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update,
-                               get_java_udaf_context(ctx)->states->handle(), states, input_arr);
+    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update, ctx->udaf_ctxs()->states->handle(),
+                               states, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
 }
 
@@ -558,7 +515,7 @@ void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject u
     jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_if_not_null, udaf, update,
-                               get_java_udaf_context(ctx)->states->handle(), states, input_arr);
+                               ctx->udaf_ctxs()->states->handle(), states, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
 }
 
@@ -620,12 +577,12 @@ void JVMFunctionHelper::get_result_from_boxed_array(FunctionContext* ctx, int ty
 
 // convert UDAF ctx to jobject
 jobject JVMFunctionHelper::convert_handle_to_jobject(FunctionContext* ctx, int state) {
-    auto* states = get_java_udaf_context(ctx)->states.get();
+    auto* states = ctx->udaf_ctxs()->states.get();
     return states->get_state(ctx, _env, state);
 }
 
 jobject JVMFunctionHelper::convert_handles_to_jobjects(FunctionContext* ctx, jobject state_ids) {
-    auto* states = get_java_udaf_context(ctx)->states.get();
+    auto* states = ctx->udaf_ctxs()->states.get();
     return states->get_state(ctx, _env, state_ids);
 }
 

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -693,7 +693,7 @@ struct JavaUDAFSharedContext {
     JavaGlobalRef finalize_return_type_desc = nullptr;
 };
 
-// Per-aggregator UDAF context stored as FunctionContext::THREAD_LOCAL.
+// Per-aggregator UDAF context owned by FunctionContext::_jvm_udaf_ctxs.
 // Holds a reference to the shared class-level JavaUDAFSharedContext plus
 // mutable per-aggregation state.
 struct JavaUDAFUniqueContext;
@@ -746,12 +746,6 @@ struct JavaUDAFUniqueContext {
     std::unique_ptr<DirectByteBuffer> buffer;
     std::vector<uint8_t> buffer_data;
 };
-
-// Java UDAF lifecycle management based on FunctionContext::THREAD_LOCAL state.
-JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx);
-void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx);
-void clear_java_udaf_states(FunctionContext* ctx);
-void destroy_java_udaf_context(FunctionContext* ctx);
 
 // Check whether java runtime can work
 Status detect_java_runtime();


### PR DESCRIPTION
## Why I'm doing:

when cp  #72038 from main to lower version, udaf context create/destroy code in #69382 has also ported, it is not compatible in lower version and cause memory leak via unique_ptr::release.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


