### PR TITLE
[BugFix] Fix memory-leak introduced by udaf cache (backport #74025)

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -237,8 +237,6 @@ Status Aggregator::open(RuntimeState* state) {
         auto& opts = state->query_options();
         bool enable_cache = opts.__isset.enable_cache_udaf && opts.enable_cache_udaf;
         auto promise_st = call_function_in_pthread(state, [this, enable_cache]() {
-            std::vector<int> attached_udaf_idx;
-            attached_udaf_idx.reserve(_agg_fn_ctxs.size());
             for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
                 if (_fns[i].binary_type == TFunctionBinaryType::SRJAR) {
                     const auto& fn = _fns[i];
@@ -258,13 +256,7 @@ Status Aggregator::open(RuntimeState* state) {
                             COUNTER_UPDATE(_agg_stat->udaf_cache_populate_count, 1);
                         }
                     }
-                    if (!st.ok()) {
-                        for (int idx : attached_udaf_idx) {
-                            destroy_java_udaf_context(_agg_fn_ctxs[idx]);
-                        }
-                        return st;
-                    }
-                    attached_udaf_idx.emplace_back(i);
+                    RETURN_IF_ERROR(st);
                 }
             }
             return Status::OK();

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -94,9 +94,11 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_contex
 }
 
 // Build a per-aggregator JavaUDAFUniqueContext on top of a (possibly cached) JavaUDAFSharedContext.
-static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> udaf_ctx, FunctionContext* context) {
-    auto agg_ctx = std::make_unique<JavaUDAFUniqueContext>();
-    agg_ctx->ctx = std::move(udaf_ctx);
+// The context is already pre-allocated in FunctionContext::_jvm_udaf_ctxs; we populate it here.
+static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> udaf_shared_ctx,
+                                        FunctionContext* context) {
+    auto* agg_ctx = context->udaf_ctxs();
+    agg_ctx->ctx = std::move(udaf_shared_ctx);
 
     // Create a per-aggregator UDAF object instance
     ASSIGN_OR_RETURN(agg_ctx->handle, agg_ctx->ctx->udaf_class.newInstance());
@@ -121,8 +123,7 @@ static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> u
             JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_add_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_remove_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_clear_method.handle())));
-    agg_ctx->_func = std::make_unique<UDAFFunction>(agg_ctx->handle.handle(), context, agg_ctx.get());
-    attach_java_udaf_context(context, std::move(agg_ctx));
+    agg_ctx->_func = std::make_unique<UDAFFunction>(agg_ctx->handle.handle(), context, agg_ctx);
     return Status::OK();
 }
 

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -71,8 +71,9 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_window_shared_cont
 }
 
 // Build a per-aggregator JavaUDAFUniqueContext for a window function on top of a shared context.
+// The context is already pre-allocated in FunctionContext::_jvm_udaf_ctxs; we populate it here.
 static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext> shared, FunctionContext* context) {
-    auto udaf_ctx = std::make_unique<JavaUDAFUniqueContext>();
+    auto* udaf_ctx = context->udaf_ctxs();
     udaf_ctx->ctx = std::move(shared);
 
     ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->ctx->udaf_class.newInstance());
@@ -87,8 +88,7 @@ static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext>
             JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_add_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_remove_method.handle())),
             JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_clear_method.handle())));
-    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx.get());
-    attach_java_udaf_context(context, std::move(udaf_ctx));
+    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx);
     return Status::OK();
 }
 

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -38,6 +38,9 @@ FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* p
     ctx->_mem_pool = pool;
     ctx->_return_type = return_type;
     ctx->_arg_types = arg_types;
+#if !defined(BUILD_FORMAT_LIB)
+    ctx->_jvm_udaf_ctxs = std::make_unique<JavaUDAFUniqueContext>();
+#endif
     return ctx;
 }
 
@@ -51,6 +54,9 @@ FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* p
     ctx->_mem_pool = pool;
     ctx->_return_type = return_type;
     ctx->_arg_types = arg_types;
+#if !defined(BUILD_FORMAT_LIB)
+    ctx->_jvm_udaf_ctxs = std::make_unique<JavaUDAFUniqueContext>();
+#endif
     ctx->_is_distinct = is_distinct;
     ctx->_is_asc_order = is_asc_order;
     ctx->_nulls_first = nulls_first;
@@ -72,14 +78,6 @@ FunctionContext* FunctionContext::create_test_context(std::vector<TypeDesc>&& ar
 
 FunctionContext::FunctionContext() = default;
 FunctionContext::~FunctionContext() = default;
-
-JavaUDAFUniqueContext* FunctionContext::udaf_ctxs() {
-#if !defined(BUILD_FORMAT_LIB)
-    return get_java_udaf_context(this);
-#else
-    return nullptr;
-#endif
-}
 
 FunctionContext* FunctionContext::clone(MemPool* pool) {
     FunctionContext* new_context = create_context(_state, pool, _return_type, _arg_types);
@@ -140,7 +138,10 @@ void* FunctionContext::get_function_state(FunctionStateScope scope) const {
 
 void FunctionContext::release_mems() {
 #if !defined(BUILD_FORMAT_LIB)
-    clear_java_udaf_states(this);
+    if (_jvm_udaf_ctxs != nullptr && _jvm_udaf_ctxs->states) {
+        auto env = JVMFunctionHelper::getInstance().getEnv();
+        _jvm_udaf_ctxs->states->clear(this, env);
+    }
 #endif
 }
 

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -164,7 +164,7 @@ public:
     bool has_error() const;
     const char* error_msg() const;
 
-    JavaUDAFUniqueContext* udaf_ctxs();
+    JavaUDAFUniqueContext* udaf_ctxs() { return _jvm_udaf_ctxs.get(); }
 
     void release_mems();
 
@@ -216,6 +216,9 @@ private:
     // If it is not explicitly set externally (e.g. AggFuncBasedValueAggregator),
     // it will point to the internal _mem_usage
     int64_t* _mem_usage_counter = &_mem_usage;
+
+    // UDAF Context
+    std::unique_ptr<JavaUDAFUniqueContext> _jvm_udaf_ctxs;
 
     std::vector<bool> _is_asc_order;
     std::vector<bool> _nulls_first;

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -108,49 +108,6 @@ static JNINativeMethod java_native_methods[] = {
 };
 #pragma GCC diagnostic pop
 
-JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx) {
-    if (ctx == nullptr) {
-        return nullptr;
-    }
-    return reinterpret_cast<JavaUDAFUniqueContext*>(ctx->get_function_state(FunctionContext::THREAD_LOCAL));
-}
-
-void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx) {
-    DCHECK(ctx != nullptr);
-    DCHECK(udaf_ctx != nullptr);
-    auto* old_ctx = get_java_udaf_context(ctx);
-    DCHECK(old_ctx == nullptr) << "duplicate Java UDAF context attach";
-    if (old_ctx != nullptr) {
-        delete old_ctx;
-    }
-    ctx->set_function_state(FunctionContext::THREAD_LOCAL, udaf_ctx.release());
-}
-
-void clear_java_udaf_states(FunctionContext* ctx) {
-    auto* udaf_ctx = get_java_udaf_context(ctx);
-    if (udaf_ctx == nullptr || udaf_ctx->states == nullptr) {
-        return;
-    }
-
-    auto env = JVMFunctionHelper::getInstance().getEnv();
-    udaf_ctx->states->clear(ctx, env);
-}
-
-void destroy_java_udaf_context(FunctionContext* ctx) {
-    if (ctx == nullptr) {
-        return;
-    }
-
-    auto* udaf_ctx = get_java_udaf_context(ctx);
-    if (udaf_ctx == nullptr) {
-        return;
-    }
-
-    clear_java_udaf_states(ctx);
-    ctx->set_function_state(FunctionContext::THREAD_LOCAL, nullptr);
-    delete udaf_ctx;
-}
-
 StatusOr<jobject> MapMeta::newLocalInstance(jobject keys, jobject values) const {
     JNIEnv* env = getJNIEnv();
     auto res = env->NewObject(immutable_map_class->clazz(), immutable_map_constructor, keys, values);

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -562,7 +562,7 @@ struct JavaUDAFSharedContext {
     JavaGlobalRef states_clear_method = nullptr;
 };
 
-// Per-aggregator UDAF context stored as FunctionContext::THREAD_LOCAL.
+// Per-aggregator UDAF context owned by FunctionContext::_jvm_udaf_ctxs.
 // Holds a reference to the shared class-level JavaUDAFSharedContext plus
 // mutable per-aggregation state.
 struct JavaUDAFUniqueContext;
@@ -615,12 +615,6 @@ struct JavaUDAFUniqueContext {
     std::unique_ptr<DirectByteBuffer> buffer;
     std::vector<uint8_t> buffer_data;
 };
-
-// Java UDAF lifecycle management based on FunctionContext::THREAD_LOCAL state.
-JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx);
-void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx);
-void clear_java_udaf_states(FunctionContext* ctx);
-void destroy_java_udaf_context(FunctionContext* ctx);
 
 // Check whether java runtime can work
 Status detect_java_runtime();


### PR DESCRIPTION
## Why I'm doing:

when cp  #72038 from main to lower version, udaf context create/destroy code in #69382 has also ported, it is not compatible in lower version and cause memory leak via unique_ptr::release.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


