### PR TITLE
[BugFix] count_combine(nullable_col) silently counted NULL rows like count(*)

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -213,14 +213,9 @@ void AggregatorParams::init() {
 
         if (AggStateUtils::is_count_function(fn.name.function_name) &&
             fn.name.function_name != FUNCTION_COUNT + AggStateUtils::AGG_STATE_COMBINE_SUFFIX) {
-            // count / count_if / count_union / count_merge route Count* through
-            // serialize_to_column that writes into a plain Int64Column. Only
-            // AggStateCombine unwraps NullableColumn before that write, so for
-            // every other carrier the output column must stay non-nullable —
-            // the mocked (has_nullable_child=false, is_nullable=false) here
-            // delivers that. count_combine MUST fall through so the nested
-            // count lookup sees the real input nullability and picks
-            // CountNullableAggregateFunction for nullable input columns.
+            // count family output is always non-nullable BIGINT. count_combine is the
+            // exception: it needs the real input nullability so the nested lookup picks
+            // the NULL-skipping CountNullableAggregateFunction (else it counts NULLs too).
             agg_fn_types[i] = {TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_BIGINT), {}, false, false};
         } else {
             // whether agg function has nullable child

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -211,8 +211,16 @@ void AggregatorParams::init() {
         const TExpr& desc = aggregate_functions[i];
         const TFunction& fn = desc.nodes[0].fn;
 
-        if (AggStateUtils::is_count_function(fn.name.function_name)) {
-            // count function is always not nullable
+        if (AggStateUtils::is_count_function(fn.name.function_name) &&
+            fn.name.function_name != FUNCTION_COUNT + AggStateUtils::AGG_STATE_COMBINE_SUFFIX) {
+            // count / count_if / count_union / count_merge route Count* through
+            // serialize_to_column that writes into a plain Int64Column. Only
+            // AggStateCombine unwraps NullableColumn before that write, so for
+            // every other carrier the output column must stay non-nullable —
+            // the mocked (has_nullable_child=false, is_nullable=false) here
+            // delivers that. count_combine MUST fall through so the nested
+            // count lookup sees the real input nullability and picks
+            // CountNullableAggregateFunction for nullable input columns.
             agg_fn_types[i] = {TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_BIGINT), {}, false, false};
         } else {
             // whether agg function has nullable child

--- a/test/sql/test_agg_state/R/test_count_combine_nullable
+++ b/test/sql/test_agg_state/R/test_count_combine_nullable
@@ -1,11 +1,11 @@
 -- name: test_count_combine_nullable
-DROP DATABASE IF EXISTS test_count_combine_nullable;
+DROP DATABASE IF EXISTS test_count_combine_nullable_${uuid0};
 -- result:
 -- !result
-CREATE DATABASE test_count_combine_nullable;
+CREATE DATABASE test_count_combine_nullable_${uuid0};
 -- result:
 -- !result
-USE test_count_combine_nullable;
+USE test_count_combine_nullable_${uuid0};
 -- result:
 -- !result
 CREATE TABLE t (
@@ -43,6 +43,6 @@ FROM t;
 -- result:
 5	5
 -- !result
-DROP DATABASE test_count_combine_nullable;
+DROP DATABASE test_count_combine_nullable_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_agg_state/R/test_count_combine_nullable
+++ b/test/sql/test_agg_state/R/test_count_combine_nullable
@@ -1,0 +1,48 @@
+-- name: test_count_combine_nullable
+DROP DATABASE IF EXISTS test_count_combine_nullable;
+-- result:
+-- !result
+CREATE DATABASE test_count_combine_nullable;
+-- result:
+-- !result
+USE test_count_combine_nullable;
+-- result:
+-- !result
+CREATE TABLE t (
+    region VARCHAR(8),
+    nullable_score INT
+) DUPLICATE KEY(region) DISTRIBUTED BY HASH(region) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES
+    ('CN', 5),
+    ('US', NULL),
+    ('CN', NULL),
+    ('US', 8),
+    ('CN', 12);
+-- result:
+-- !result
+SELECT region, COUNT(*) AS c_all, COUNT(nullable_score) AS c_non_null
+FROM t GROUP BY region ORDER BY region;
+-- result:
+CN	3	2
+US	2	1
+-- !result
+SELECT region,
+       count_state_merge(count_combine())               AS via_star,
+       count_state_merge(count_combine(nullable_score)) AS via_col
+FROM t GROUP BY region ORDER BY region;
+-- result:
+CN	3	2
+US	2	1
+-- !result
+SELECT count_state_merge(count_combine(region)) AS via_combine_nonnull,
+       COUNT(region) AS direct_nonnull
+FROM t;
+-- result:
+5	5
+-- !result
+DROP DATABASE test_count_combine_nullable;
+-- result:
+-- !result

--- a/test/sql/test_agg_state/T/test_count_combine_nullable
+++ b/test/sql/test_agg_state/T/test_count_combine_nullable
@@ -1,0 +1,35 @@
+-- name: test_count_combine_nullable
+-- Regression: count_combine(nullable_col) must skip NULL rows just like
+-- count(col). The bug was that BE's count dispatch picked the
+-- unconditional-increment variant instead of the NULL-skipping one when
+-- the input column was nullable.
+DROP DATABASE IF EXISTS test_count_combine_nullable;
+CREATE DATABASE test_count_combine_nullable;
+USE test_count_combine_nullable;
+
+CREATE TABLE t (
+    region VARCHAR(8),
+    nullable_score INT
+) DUPLICATE KEY(region) DISTRIBUTED BY HASH(region) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t VALUES
+    ('CN', 5),
+    ('US', NULL),
+    ('CN', NULL),
+    ('US', 8),
+    ('CN', 12);
+
+SELECT region, COUNT(*) AS c_all, COUNT(nullable_score) AS c_non_null
+FROM t GROUP BY region ORDER BY region;
+
+SELECT region,
+       count_state_merge(count_combine())               AS via_star,
+       count_state_merge(count_combine(nullable_score)) AS via_col
+FROM t GROUP BY region ORDER BY region;
+
+SELECT count_state_merge(count_combine(region)) AS via_combine_nonnull,
+       COUNT(region) AS direct_nonnull
+FROM t;
+
+DROP DATABASE test_count_combine_nullable;

--- a/test/sql/test_agg_state/T/test_count_combine_nullable
+++ b/test/sql/test_agg_state/T/test_count_combine_nullable
@@ -1,8 +1,6 @@
 -- name: test_count_combine_nullable
--- Regression: count_combine(nullable_col) must skip NULL rows just like
--- count(col). The bug was that BE's count dispatch picked the
--- unconditional-increment variant instead of the NULL-skipping one when
--- the input column was nullable.
+-- Regression for the BE count dispatch bug: count_combine(nullable_col) must
+-- skip NULLs like count(col), not count every row like count(*).
 DROP DATABASE IF EXISTS test_count_combine_nullable_${uuid0};
 CREATE DATABASE test_count_combine_nullable_${uuid0};
 USE test_count_combine_nullable_${uuid0};

--- a/test/sql/test_agg_state/T/test_count_combine_nullable
+++ b/test/sql/test_agg_state/T/test_count_combine_nullable
@@ -3,9 +3,9 @@
 -- count(col). The bug was that BE's count dispatch picked the
 -- unconditional-increment variant instead of the NULL-skipping one when
 -- the input column was nullable.
-DROP DATABASE IF EXISTS test_count_combine_nullable;
-CREATE DATABASE test_count_combine_nullable;
-USE test_count_combine_nullable;
+DROP DATABASE IF EXISTS test_count_combine_nullable_${uuid0};
+CREATE DATABASE test_count_combine_nullable_${uuid0};
+USE test_count_combine_nullable_${uuid0};
 
 CREATE TABLE t (
     region VARCHAR(8),
@@ -32,4 +32,4 @@ SELECT count_state_merge(count_combine(region)) AS via_combine_nonnull,
        COUNT(region) AS direct_nonnull
 FROM t;
 
-DROP DATABASE test_count_combine_nullable;
+DROP DATABASE test_count_combine_nullable_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`count_combine(nullable_col)` silently counts NULL rows, producing the same result as `count(*)` instead of `count(col)`. Because the `_combine` agg-state combinator is how incremental materialized views persist a `COUNT(col)` aggregate into their `__AGG_STATE__` column, any incremental MV whose defining query contains `COUNT(<nullable column>)` materializes inflated counts. The combinator is also directly callable in SQL, so the bug reproduces without any MV.

## What I'm doing:

`AggregatorParams::init()` routes the whole count family (`count`, `count_if`, `count_union`, `count_merge`, `count_combine`) through a fast-path that mocks `AggFunctionTypes` with `has_nullable_child = false`. That is correct for the carriers whose `serialize_to_column` writes a bare `Int64Column`, because their NULL-skipping decision is re-derived downstream by the dedicated `== "count"` branch in `_is_agg_result_nullable` that reads `desc.nodes[0].has_nullable_child` directly.

`count_combine` has **no** such dedicated branch, so it consumes the mocked `has_nullable_child = false`. That propagates into the nested `get_aggregate_function("count", ..., /*is_null=*/false)` lookup, which then selects `CountAggregateFunction` (unconditional `++count`) instead of `CountNullableAggregateFunction` (which skips NULL).

Fix: exclude `count_combine` from the fast-path so it takes the normal branch and receives the real `has_nullable_child` from the FE plan. `count_combine` is the only count carrier that both (a) needs the real input nullability for its nested lookup and (b) already unwraps `NullableColumn` in `AggStateCombine::_serialize_to_column_nullable`, so it is safe to produce a nullable-capable output column. The other carriers stay in the fast-path: moving them out would create a nullable output column that their non-unwrapping `serialize_to_column` would crash on.

Reproduction (no MV required):

```sql
CREATE TABLE t (region VARCHAR(8), nullable_score INT)
DUPLICATE KEY(region) DISTRIBUTED BY HASH(region) BUCKETS 1
PROPERTIES ('replication_num'='1');
INSERT INTO t VALUES ('CN',5),('US',NULL),('CN',NULL),('US',8),('CN',12);

SELECT region,
       count_state_merge(count_combine(nullable_score)) AS via_combine,
       count(nullable_score)                            AS expected
FROM t GROUP BY region ORDER BY region;
-- before: via_combine = 3 / 2  (counts NULLs, equals count(*))
-- after:  via_combine = 2 / 1  (matches count(nullable_score))
```

`count_combine()` (the zero-arg, `count(*)` form) is unaffected: with no argument `has_nullable_child` is already false, so it keeps selecting `CountAggregateFunction` and counts every row.

Note for existing incremental MVs: an MV built before this fix already has wrong counts persisted in its `__AGG_STATE__` column. The state binary format is unchanged (still an int64 counter), so there is no serialization-compatibility issue, but such MVs need a full refresh to recompute correct values.

Fixes #issue: N/A — found via internal incremental-MV testing; no public StarRocks issue filed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
