### PR TITLE
[BugFix] Encode __ROW_ID__ for GROUP BY-only incremental MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -313,16 +313,19 @@ public class IVMAnalyzer {
 
     private boolean checkAggregate(SelectRelation selectRelation) throws AnalysisException {
         List<FunctionCallExpr> aggregateExprs = selectRelation.getAggregate();
-        if (CollectionUtils.isEmpty(aggregateExprs)) {
+        List<Expr> groupByExprs = selectRelation.getGroupBy();
+
+        // Gate on GROUP BY, not aggregates: the refresh path (IvmDeltaAggregateRule) keys on
+        // GROUP BY, so a GROUP BY-only query must also get QUERY_COMPUTED row ids here — else the
+        // AUTO_INCREMENT MV it would otherwise build crashes refresh on a row-id type mismatch.
+        if (CollectionUtils.isEmpty(groupByExprs)) {
+            if (CollectionUtils.isNotEmpty(aggregateExprs)) {
+                throw new SemanticException("IVMAnalyzer requires group by expressions for incremental view maintenance.");
+            }
             return false;
         }
 
-        List<Expr> groupByExprs = selectRelation.getGroupBy();
-        if (CollectionUtils.isEmpty(groupByExprs)) {
-            // If there are no group by expressions, we cannot apply IVM optimizations.
-            throw new SemanticException("IVMAnalyzer requires group by expressions for incremental view maintenance.");
-        }
-        // new aggregate functions
+        // getAggregate() is non-null post-analysis, so for no aggregates this loop just no-ops.
         List<IVMAggFunctionInfo> newAggFuncInfos = Lists.newArrayList();
         ExprSubstitutionMap substitutionMap = new ExprSubstitutionMap();
         for (FunctionCallExpr aggFuncExpr : aggregateExprs) {
@@ -338,7 +341,6 @@ public class IVMAnalyzer {
             // are allowed. Unsupported combinations would either fail at refresh time or silently
             // produce wrong data; reject them here so the user sees a clear CREATE-time error.
             checkAggregateFunctionInWhitelist(aggFuncExpr, aggFuncName);
-            // build intermediate aggregate function
             FunctionCallExpr intermediateAggFuncExpr = buildIntermediateAggregateFunc(aggFuncExpr);
             String newAggFuncName = IvmOpUtils.getIvmAggStateColumnName(aggFuncExpr);
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -75,6 +75,25 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
     }
 
     @Test
+    public void testIVMWithGroupByNoAggregate() throws Exception {
+        // Guards the row-id fix: GROUP BY-only refresh used to fail TypeChecker on the
+        // __ROW_ID__ merge join (BIGINT vs VARCHAR).
+        doTestWith3RunsNoCheckRewrite("SELECT id FROM `iceberg0`.`unpartitioned_db`.`t0` as a GROUP BY id;",
+                plan -> {
+                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
+                            "TABLE: unpartitioned_db.t0\n" +
+                                    "     TABLE VERSION: Delta@[0,1]");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "__ROW_ID__ = ");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
     public void testIVMWithScanProjectFilter() throws Exception {
         doTestWith3Runs("SELECT id * 2 + 1, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` where id > 10;",
                 plan -> {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -95,6 +95,30 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * GROUP BY without aggregates (a DISTINCT-on-keys MV) must yield QUERY_COMPUTED, not
+     * AUTO_INCREMENT — otherwise the MV row-id type disagrees with the refresh plan.
+     */
+    @Test
+    public void testGroupByWithoutAggregateYieldsQueryComputedStrategy() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_distinct "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL);
+
+        assertTrue(result.isPresent(), "GROUP BY-only MV query must produce an IVM rewrite result");
+        assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy(),
+                "GROUP BY without aggregate must yield QUERY_COMPUTED, not AUTO_INCREMENT");
+    }
+
+    /**
      * Distinct aggregates must be rejected at IVM analysis time; otherwise incremental
      * refresh would silently produce wrong data (the rewrite drops the DISTINCT flag).
      * MIN/MAX(DISTINCT) is not covered: the analyzer normalizes their DISTINCT away


### PR DESCRIPTION
## Why I'm doing:

An incremental materialized view whose query has GROUP BY but no aggregate — e.g. `SELECT k FROM t GROUP BY k` (a DISTINCT-on-keys MV) — is accepted at CREATE but crashes on the second (incremental) refresh:

```
Type check failed. hash join equal predicate type mismatch:
left VARCHAR, right BIGINT, predicate: __ROW_ID__ = from_binary
```

Root cause: `IVMAnalyzer.checkAggregate` decided the `__ROW_ID__` strategy from *"are there aggregates"*, while `IvmDeltaAggregateRule` (the refresh-side rewrite) keys on *"is there GROUP BY"*. The two disagree exactly for GROUP BY without aggregates:

- CREATE: `checkAggregate` sees an empty aggregate list, returns early, and the MV is built with an `AUTO_INCREMENT` `BIGINT __ROW_ID__`.
- REFRESH: `IvmDeltaAggregateRule` fires on the GROUP BY and encodes the group keys as `FROM_BINARY(ENCODE_ROW_ID(...))` → `VARCHAR`, then joins delta against the MV on `__ROW_ID__`.

`BIGINT = VARCHAR` fails the planner's type check (`TypeChecker` during `InsertPlanner.buildExecPlan`), so refresh never completes.

## What I'm doing:

Fixes #issue: N/A — no public tracking issue.

Align the analyzer's row-id decision to GROUP BY, matching the refresh path:

- Any query with GROUP BY encodes its group keys into `__ROW_ID__` (`QUERY_COMPUTED`), regardless of whether it has aggregates.
- Only a query with no GROUP BY stays `AUTO_INCREMENT` (append-only projection).
- The aggregate-rewrite loop is skipped when there are no aggregates (`getAggregate()` is non-null post-analysis, so it just no-ops), producing a DISTINCT-on-keys MV whose refresh plan (`IvmDeltaAggregateRule` with an empty aggregation map) already degrades to a dedup-by-row-id join.

Aggregate-with-GROUP-BY and no-GROUP-BY projection paths are unchanged.

### Tests

- **`IVMBasedMvRefreshProcessorIcebergTest.testIVMWithGroupByNoAggregate`** — end-to-end: generates the incremental refresh plan for `SELECT id FROM t0 GROUP BY id` across 3 runs. On the unpatched analyzer this reproduces the exact crash (`TypeChecker` rejects `__ROW_ID__ = from_binary`, BIGINT vs VARCHAR, in `InsertPlanner.buildExecPlan`); with the fix the plan joins on the encoded VARCHAR `__ROW_ID__` and refresh succeeds.
- **`IVMAnalyzerTest.testGroupByWithoutAggregateYieldsQueryComputedStrategy`** — analyzer-level: `SELECT id FROM t0 GROUP BY id` yields `QUERY_COMPUTED` (was `AUTO_INCREMENT` before the fix).

Both verified RED on the unpatched code (the refresh test throws the TypeChecker exception; the analyzer test asserts `AUTO_INCREMENT`) and GREEN after. Full `IVMAnalyzerTest` (26) and `IVMBasedMvRefreshProcessorIcebergTest` (51) green; `mvn checkstyle:check` clean.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: a GROUP BY-only incremental MV that previously crashed at refresh now works; such MVs are created with a VARCHAR `__ROW_ID__` instead of BIGINT.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5