### PR TITLE
[BugFix] Pass tablet metadata when applying PK index compaction output sstables

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -675,7 +675,9 @@ StatusOr<AsyncCompactCBPtr> LakePersistentIndex::early_sst_compact(
     ASSIGN_OR_RETURN(auto cb,
                      compact_mgr->async_compact(
                              result.candidate_filesets, metadata, is_merge_base_level,
-                             [&, result](const std::vector<PersistentIndexSstablePB>& sstables) {
+                             // Capture `result` and `metadata` by value: this callback runs
+                             // asynchronously on the compaction thread pool.
+                             [&, result, metadata](const std::vector<PersistentIndexSstablePB>& sstables) {
                                  // 4. Merge output sstables into current index.
                                  //    reuse `apply_opcompaction` to do this.
                                  TxnLogPB txn_log;
@@ -701,7 +703,7 @@ StatusOr<AsyncCompactCBPtr> LakePersistentIndex::early_sst_compact(
                                      output_sstable->CopyFrom(sstable_pb);
                                      output_sstable->set_max_rss_rowid(result.max_max_rss_rowid);
                                  }
-                                 return apply_opcompaction(txn_log.op_compaction());
+                                 return apply_opcompaction(metadata, txn_log.op_compaction());
                              }));
     return cb;
 }
@@ -780,7 +782,8 @@ Status LakePersistentIndex::major_compact(TabletManager* tablet_mgr, const Table
     return Status::OK();
 }
 
-Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction) {
+Status LakePersistentIndex::apply_opcompaction(const TabletMetadataPtr& metadata,
+                                               const TxnLogPB_OpCompaction& op_compaction) {
     if (op_compaction.input_sstables().empty()) {
         return Status::OK();
     }
@@ -788,6 +791,15 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
     if (block_cache == nullptr) {
         return Status::InternalError("Block cache is null.");
     }
+
+    // A compaction output sstable may carry an embedded delete vector (the parallel-compaction
+    // "move" path keeps the input sstable's); loading it needs the tablet metadata, like init() --
+    // otherwise new_sstable() fails with "metadata is null when loading delvec from file".
+    auto open_output_sstable = [&](const PersistentIndexSstablePB& sstable_pb) {
+        return PersistentIndexSstable::new_sstable(
+                sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()), block_cache->cache(),
+                /*need_filter=*/true, /*delvec=*/nullptr, metadata, _tablet_mgr);
+    };
 
     // Handle multiple output sstables (from parallel compaction).
     std::unique_ptr<PersistentIndexSstableFileset> new_sstable_fileset;
@@ -797,18 +809,13 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
         sstable_pb.CopyFrom(op_compaction.output_sstable());
         sstable_pb.set_max_rss_rowid(
                 op_compaction.input_sstables(op_compaction.input_sstables().size() - 1).max_rss_rowid());
-        ASSIGN_OR_RETURN(auto sstable, PersistentIndexSstable::new_sstable(
-                                               sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()),
-                                               block_cache->cache()));
+        ASSIGN_OR_RETURN(auto sstable, open_output_sstable(sstable_pb));
         new_sstable_fileset = std::make_unique<PersistentIndexSstableFileset>();
         RETURN_IF_ERROR(new_sstable_fileset->init(sstable));
     } else if (!op_compaction.output_sstables().empty()) {
         std::vector<std::unique_ptr<PersistentIndexSstable>> new_sstables;
         for (const auto& sstable_pb : op_compaction.output_sstables()) {
-            ASSIGN_OR_RETURN(auto sstable,
-                             PersistentIndexSstable::new_sstable(
-                                     sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()),
-                                     block_cache->cache()));
+            ASSIGN_OR_RETURN(auto sstable, open_output_sstable(sstable_pb));
             new_sstables.push_back(std::move(sstable));
         }
         new_sstable_fileset = std::make_unique<PersistentIndexSstableFileset>();

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -119,7 +119,7 @@ public:
     static Status parallel_major_compact(LakePersistentIndexParallelCompactMgr* compact_mgr, TabletManager* tablet_mgr,
                                          const TabletMetadataPtr& metadata, TxnLogPB* txn_log);
 
-    Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
+    Status apply_opcompaction(const TabletMetadataPtr& metadata, const TxnLogPB_OpCompaction& op_compaction);
 
     Status commit(MetaFileBuilder* builder);
 

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -188,27 +188,27 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
     return Status::OK();
 }
 
-Status LakePrimaryIndex::apply_opcompaction(const TabletMetadata& metadata,
+Status LakePrimaryIndex::apply_opcompaction(const TabletMetadataPtr& metadata,
                                             const TxnLogPB_OpCompaction& op_compaction) {
     if (!_enable_persistent_index) {
         return Status::OK();
     }
 
-    switch (metadata.persistent_index_type()) {
+    switch (metadata->persistent_index_type()) {
     case PersistentIndexTypePB::LOCAL: {
         return Status::OK();
     }
     case PersistentIndexTypePB::CLOUD_NATIVE: {
         auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
         if (lake_persistent_index != nullptr) {
-            return lake_persistent_index->apply_opcompaction(op_compaction);
+            return lake_persistent_index->apply_opcompaction(metadata, op_compaction);
         } else {
             return Status::InternalError("Persistent index is not a LakePersistentIndex.");
         }
     }
     default:
         return Status::InternalError("Unsupported lake_persistent_index_type " +
-                                     PersistentIndexTypePB_Name(metadata.persistent_index_type()));
+                                     PersistentIndexTypePB_Name(metadata->persistent_index_type()));
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -69,7 +69,7 @@ public:
         _enable_persistent_index = enable_persistent_index;
     }
 
-    Status apply_opcompaction(const TabletMetadata& metadata, const TxnLogPB_OpCompaction& op_compaction);
+    Status apply_opcompaction(const TabletMetadataPtr& metadata, const TxnLogPB_OpCompaction& op_compaction);
 
     Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder);
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -535,14 +535,14 @@ private:
                 return Status::OK();
             }
             RETURN_IF_ERROR(prepare_primary_index());
-            RETURN_IF_ERROR(_index_entry->value().apply_opcompaction(*_metadata, op_compaction));
+            RETURN_IF_ERROR(_index_entry->value().apply_opcompaction(_metadata, op_compaction));
             return Status::OK();
         }
         RETURN_IF_ERROR(prepare_primary_index());
 
         // Single output compaction
-        return _tablet.update_mgr()->publish_primary_compaction(op_compaction, txn_id, *_metadata, _tablet,
-                                                                _index_entry, &_builder, _base_version);
+        return _tablet.update_mgr()->publish_primary_compaction(op_compaction, txn_id, _metadata, _tablet, _index_entry,
+                                                                &_builder, _base_version);
     }
 
     // Apply parallel compaction log: process multiple subtask compactions
@@ -575,7 +575,7 @@ private:
             // Reuse publish_primary_compaction for each subtask
             // - Internal conflict check is performed per subtask
             // - Primary index and metadata are updated
-            RETURN_IF_ERROR(_tablet.update_mgr()->publish_primary_compaction(subtask_op, txn_id, *_metadata, _tablet,
+            RETURN_IF_ERROR(_tablet.update_mgr()->publish_primary_compaction(subtask_op, txn_id, _metadata, _tablet,
                                                                              _index_entry, &_builder, _base_version));
         }
 
@@ -594,7 +594,7 @@ private:
             for (const auto& output_sst : op_parallel.output_sstables()) {
                 sst_op.add_output_sstables()->CopyFrom(output_sst);
             }
-            RETURN_IF_ERROR(_index_entry->value().apply_opcompaction(*_metadata, sst_op));
+            RETURN_IF_ERROR(_index_entry->value().apply_opcompaction(_metadata, sst_op));
             _builder.remove_compacted_sst(sst_op);
         }
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1912,14 +1912,14 @@ bool UpdateManager::_use_light_publish_primary_compaction(TabletManager* mgr,
 }
 
 Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
-                                                       const TabletMetadata& metadata, const Tablet& tablet,
+                                                       const TabletMetadataPtr& metadata, const Tablet& tablet,
                                                        IndexEntry* index_entry, MetaFileBuilder* builder,
                                                        int64_t base_version) {
     // 1. init some state
     auto& index = index_entry->value();
     std::vector<uint32_t> input_rowsets_id(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end());
     ASSIGN_OR_RETURN(auto tablet_schema, ExecEnv::GetInstance()->lake_tablet_manager()->get_output_rowset_schema(
-                                                 input_rowsets_id, &metadata));
+                                                 input_rowsets_id, metadata.get()));
 
     Rowset output_rowset(tablet.tablet_mgr(), tablet.id(), &op_compaction.output_rowset(), -1 /*unused*/,
                          tablet_schema);
@@ -1931,9 +1931,9 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
 
     // 2. update primary index, and generate delete info.
     auto resolver = std::make_unique<LakePrimaryKeyCompactionConflictResolver>(
-            &metadata, &output_rowset, _tablet_mgr, builder, &index, txn_id, base_version, op_compaction.lcrm_file(),
-            &segment_id_to_add_dels, &delvecs);
-    if (op_compaction.ssts_size() > 0 && use_cloud_native_pk_index(metadata)) {
+            metadata.get(), &output_rowset, _tablet_mgr, builder, &index, txn_id, base_version,
+            op_compaction.lcrm_file(), &segment_id_to_add_dels, &delvecs);
+    if (op_compaction.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
         RETURN_IF_ERROR(resolver->execute_without_update_index());
     } else {
         RETURN_IF_ERROR(resolver->execute());
@@ -1945,11 +1945,11 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
     // 4. ingest ssts to index
     DCHECK(op_compaction.ssts_size() == 0 || delvecs.size() == op_compaction.ssts_size())
             << "delvecs.size(): " << delvecs.size() << ", op_compaction.ssts_size(): " << op_compaction.ssts_size();
-    for (int i = 0; i < op_compaction.ssts_size() && use_cloud_native_pk_index(metadata); i++) {
-        uint32_t rssid = metadata.next_rowset_id() + get_segment_idx(op_compaction.output_rowset(), i);
+    for (int i = 0; i < op_compaction.ssts_size() && use_cloud_native_pk_index(*metadata); i++) {
+        uint32_t rssid = metadata->next_rowset_id() + get_segment_idx(op_compaction.output_rowset(), i);
         DelvecPagePB delvec_page_pb = builder->delvec_page(rssid);
-        delvec_page_pb.set_version(metadata.version());
-        RETURN_IF_ERROR(index.ingest_sst(op_compaction.ssts(i), op_compaction.sst_ranges(i), rssid, metadata.version(),
+        delvec_page_pb.set_version(metadata->version());
+        RETURN_IF_ERROR(index.ingest_sst(op_compaction.ssts(i), op_compaction.sst_ranges(i), rssid, metadata->version(),
                                          delvec_page_pb, delvecs[i].second));
     }
     _index_cache.update_object_size(index_entry, index.memory_usage());
@@ -1969,20 +1969,20 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
 
 DEFINE_FAIL_POINT(hook_publish_primary_key_tablet_compaction);
 Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
-                                                 const TabletMetadata& metadata, const Tablet& tablet,
+                                                 const TabletMetadataPtr& metadata, const Tablet& tablet,
                                                  IndexEntry* index_entry, MetaFileBuilder* builder,
                                                  int64_t base_version) {
     FAIL_POINT_TRIGGER_EXECUTE(hook_publish_primary_key_tablet_compaction, {
         std::vector<uint32_t> input_rowsets_id(op_compaction.input_rowsets().begin(),
                                                op_compaction.input_rowsets().end());
         ASSIGN_OR_RETURN(auto tablet_schema, ExecEnv::GetInstance()->lake_tablet_manager()->get_output_rowset_schema(
-                                                     input_rowsets_id, &metadata));
+                                                     input_rowsets_id, metadata.get()));
         return builder->apply_opcompaction(
                 op_compaction,
                 *std::max_element(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end()),
                 tablet_schema->id());
     });
-    if (CompactionUpdateConflictChecker::conflict_check(op_compaction, txn_id, metadata, builder)) {
+    if (CompactionUpdateConflictChecker::conflict_check(op_compaction, txn_id, *metadata, builder)) {
         // conflict happens
         return Status::OK();
     }
@@ -1994,7 +1994,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     // 1. iterate output rowset, update primary index and generate delvec
     std::vector<uint32_t> input_rowsets_id(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end());
     ASSIGN_OR_RETURN(auto tablet_schema, ExecEnv::GetInstance()->lake_tablet_manager()->get_output_rowset_schema(
-                                                 input_rowsets_id, &metadata));
+                                                 input_rowsets_id, metadata.get()));
     Rowset output_rowset(tablet.tablet_mgr(), tablet.id(), &op_compaction.output_rowset(), -1 /*unused*/,
                          tablet_schema);
     auto compaction_entry = _compaction_cache.get_or_create(cache_key(tablet.id(), txn_id));
@@ -2006,16 +2006,16 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     size_t total_rows = 0;
     vector<std::pair<uint32_t, DelVectorPtr>> delvecs;
     vector<uint32_t> tmp_deletes;
-    const uint32_t rowset_id = metadata.next_rowset_id();
+    const uint32_t rowset_id = metadata->next_rowset_id();
     // get max rowset id in input rowsets
     uint32_t max_rowset_id =
             *std::max_element(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end());
     // then get the max src rssid, to solve conflict between write and compaction
-    auto input_rowset = std::find_if(metadata.rowsets().begin(), metadata.rowsets().end(),
+    auto input_rowset = std::find_if(metadata->rowsets().begin(), metadata->rowsets().end(),
                                      [&](const RowsetMetadata& r) { return r.id() == max_rowset_id; });
-    if (input_rowset == metadata.rowsets().end()) {
+    if (input_rowset == metadata->rowsets().end()) {
         LOG(ERROR) << "cannot find input rowset in tablet metadata, rowset_id: " << max_rowset_id
-                   << ", meta : " << metadata.ShortDebugString();
+                   << ", meta : " << metadata->ShortDebugString();
         return Status::InternalError("cannot find input rowset in tablet metadata");
     }
     uint32_t max_src_rssid = max_rowset_id;
@@ -2041,9 +2041,9 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
         }
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {
-            dv->init(metadata.version(), nullptr, 0);
+            dv->init(metadata->version(), nullptr, 0);
         } else {
-            dv->init(metadata.version(), tmp_deletes.data(), tmp_deletes.size());
+            dv->init(metadata->version(), tmp_deletes.data(), tmp_deletes.size());
             total_deletes += tmp_deletes.size();
         }
         segment_id_to_add_dels[rssid] += tmp_deletes.size();

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -147,11 +147,11 @@ public:
     size_t get_rowset_num_deletes(const TabletMetadata& metadata, const RowsetMetadataPB& rowset_meta);
 
     Status publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
-                                      const TabletMetadata& metadata, const Tablet& tablet, IndexEntry* index_entry,
+                                      const TabletMetadataPtr& metadata, const Tablet& tablet, IndexEntry* index_entry,
                                       MetaFileBuilder* builder, int64_t base_version);
 
     Status light_publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
-                                            const TabletMetadata& metadata, const Tablet& tablet,
+                                            const TabletMetadataPtr& metadata, const Tablet& tablet,
                                             IndexEntry* index_entry, MetaFileBuilder* builder, int64_t base_version);
 
     bool try_remove_primary_index_cache(uint32_t tablet_id);

--- a/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
@@ -752,7 +752,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_reload_after_major_compaction)
         // Apply compaction result
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
+        ASSERT_OK(index->apply_opcompaction(tablet_metadata_ptr, txn_log->op_compaction()));
 
         // Update metadata
         Tablet tablet(_tablet_mgr.get(), tablet_id);

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/raw_data_visitor.h"
@@ -24,6 +25,7 @@
 #include "common/config_primary_key_fwd.h"
 #include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
+#include "storage/del_vector.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_range_helper.h"
@@ -293,12 +295,86 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     ASSERT_OK(LakePersistentIndex::major_compact(_tablet_mgr.get(), tablet_metadata_ptr, txn_log.get()));
     ASSERT_TRUE(txn_log->op_compaction().input_sstables_size() > 0);
     ASSERT_TRUE(txn_log->op_compaction().has_output_sstable());
-    ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
+    ASSERT_OK(index->apply_opcompaction(tablet_metadata_ptr, txn_log->op_compaction()));
     ASSERT_OK(index->get(M * N, total_key_slices.data(), get_values.data()));
     for (int i = 0; i < M * N; i++) {
         ASSERT_EQ(total_values[i], get_values[i]);
     }
     config::l0_max_mem_usage = l0_max_mem_usage;
+}
+
+// Regression test for: publish failing with
+//   "metadata is null when loading delvec from file"
+// when apply_opcompaction opens a compaction output sstable that carries an
+// embedded delvec (as preserved by the parallel-compaction passthrough/move
+// path). apply_opcompaction must pass the tablet metadata so the delvec can be
+// loaded -- exactly like LakePersistentIndex::init() does.
+TEST_F(LakePersistentIndexTest, test_apply_opcompaction_output_sstable_with_delvec) {
+    auto saved_l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10; // force a flush so the upsert produces an on-disk sstable
+    DeferOp restore_config([&]() { config::l0_max_mem_usage = saved_l0_max_mem_usage; });
+
+    using Key = uint64_t;
+    const int kNumKeys = 100;
+    const int64_t kVersion = 2;
+    const uint32_t kSegmentId = 0;
+    auto tablet_id = _tablet_metadata->id();
+
+    // 1. Build an index with a single flushed sstable.
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+    std::vector<Key> keys(kNumKeys);
+    std::vector<Slice> key_slices(kNumKeys);
+    std::vector<IndexValue> values(kNumKeys);
+    for (int i = 0; i < kNumKeys; i++) {
+        keys[i] = i;
+        key_slices[i] = Slice((uint8_t*)(&keys[i]), sizeof(Key));
+        values[i] = i * 2;
+    }
+    index->prepare(EditVersion(1, 0), 0);
+    std::vector<IndexValue> old_values(kNumKeys);
+    ASSERT_OK(index->upsert(kNumKeys, key_slices.data(), values.data(), old_values.data()));
+    ASSERT_OK(index->flush_memtable(true));
+    ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000));
+
+    // 2. Commit the sstable metadata, then append a delete vector into the same metadata and finalize.
+    Tablet tablet(_tablet_mgr.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->CopyFrom(*_tablet_metadata);
+    metadata->set_version(kVersion);
+    MetaFileBuilder builder(tablet, metadata);
+    ASSERT_OK(index->commit(&builder));
+    DelVector delete_vector;
+    delete_vector.set_empty();
+    std::shared_ptr<DelVector> new_delete_vector;
+    std::vector<uint32_t> deleted_row_ids = {1, 3, 5};
+    delete_vector.add_dels_as_new_version(deleted_row_ids, kVersion, &new_delete_vector);
+    builder.append_delvec(new_delete_vector, kSegmentId);
+    ASSERT_OK(builder.finalize(next_id()));
+
+    // 3. Read back the finalized metadata: it now has the sstable plus a delete-vector page.
+    ASSIGN_OR_ABORT(auto committed_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, kVersion));
+    ASSERT_GT(committed_metadata->sstable_meta().sstables_size(), 0);
+    auto delete_vector_entry = committed_metadata->delvec_meta().delvecs().find(kSegmentId);
+    ASSERT_TRUE(delete_vector_entry != committed_metadata->delvec_meta().delvecs().end());
+
+    // 4. Build an op_compaction that simulates the parallel-compaction passthrough: the output
+    //    sstable is the input sstable carried over together with its embedded delete vector.
+    const auto& base_sstable = committed_metadata->sstable_meta().sstables(0);
+    TxnLogPB txn_log;
+    auto* op_compaction = txn_log.mutable_op_compaction();
+    op_compaction->add_input_sstables()->CopyFrom(base_sstable);
+    auto* output_sstable = op_compaction->add_output_sstables();
+    output_sstable->CopyFrom(base_sstable);
+    output_sstable->mutable_delvec()->CopyFrom(delete_vector_entry->second);
+
+    // 5. A fresh index loaded from the committed metadata owns the input fileset.
+    auto reloaded_index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(reloaded_index->init(committed_metadata));
+
+    // Before the fix this returned InvalidArgument:
+    //   "metadata is null when loading delvec from file".
+    ASSERT_OK(reloaded_index->apply_opcompaction(committed_metadata, txn_log.op_compaction()));
 }
 
 TEST_F(LakePersistentIndexTest, test_major_compaction_with_tablet_range) {
@@ -493,7 +569,7 @@ TEST_F(LakePersistentIndexTest, test_range_single_int_pk_end_to_end) {
     ASSERT_EQ(encode_key(100), out_sst.range().start_key());
     ASSERT_EQ(encode_key(100 + 3 * N - 1), out_sst.range().end_key());
 
-    ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
+    ASSERT_OK(index->apply_opcompaction(tablet_metadata_ptr, txn_log->op_compaction()));
 
     std::vector<std::string> probe_keys = {encode_key(99), encode_key(100), encode_key(150), encode_key(189),
                                            encode_key(199)};


### PR DESCRIPTION
## Why I'm doing:

In shared-data (cloud-native) mode, publishing a primary-key table can fail permanently with `Invalid argument: metadata is null when loading delvec from file`. `LakePersistentIndex::apply_opcompaction` reopened a PK-index compaction **output** sstable via `PersistentIndexSstable::new_sstable(sstable_pb, location, cache)` without passing the tablet metadata. When the parallel-compaction "move/passthrough" path carries an input sstable's embedded delete vector (delvec) onto the output sstable, `init()` cannot load that delvec without the metadata and returns the error above, which wedges publish (observed retrying indefinitely).

## What I'm doing:

Thread the tablet metadata (`TabletMetadataPtr`) through `apply_opcompaction` and the `publish_primary_compaction` / `light_publish_primary_compaction` / `early_sst_compact` paths, and pass it down to `new_sstable` so the embedded delvec loads — mirroring what `LakePersistentIndex::init()` and the earlier fix in `sample_keys_from_sstable` (#69846) already do.

The metadata is passed by `const TabletMetadataPtr&` (by reference) throughout, so no `shared_ptr` is copied along the chain; the only by-value capture is the necessary one in the async `early_sst_compact` callback (capturing by reference there would dangle).

Added a regression test (`LakePersistentIndexTest.test_apply_opcompaction_output_sstable_with_delvec`) that reproduces the failure (an op_compaction output sstable carrying a delvec) and verifies the fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)