### PR TITLE
[Build] bump bundled C++ protobuf from 3.14.0 to 3.16.1

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -103,10 +103,10 @@ THRIFT_SOURCE=thrift-0.23.0
 THRIFT_MD5SUM="7b62f4258ded41e233a638fe8b9fcf64"
 
 # protobuf
-PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.14.0.tar.gz"
-PROTOBUF_NAME=protobuf-3.14.0.tar.gz
-PROTOBUF_SOURCE=protobuf-3.14.0
-PROTOBUF_MD5SUM="0c9d2a96f3656ba7ef3b23b533fb6170"
+PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.16.1.tar.gz"
+PROTOBUF_NAME=protobuf-3.16.1.tar.gz
+PROTOBUF_SOURCE=protobuf-3.16.1
+PROTOBUF_MD5SUM="6294f01dedea72a76b9e113369f55097"
 
 # gflags
 GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"


### PR DESCRIPTION
## Summary

Bumps the BE C++ protobuf from `3.14.0` → `3.16.1`, matching the planned bump in `StarRocks/staros` (PR [staros#1256](https://github.com/StarRocks/staros/pull/1256)).

Changed: `thirdparty/vars.sh` — `PROTOBUF_DOWNLOAD` / `NAME` / `SOURCE` / `MD5SUM`.

```
$ md5 protobuf-3.16.1.tar.gz
MD5 (protobuf-3.16.1.tar.gz) = 6294f01dedea72a76b9e113369f55097
```

## Why this needs to happen before staros#1256 lands

`be/cmake_modules/PreBuildModule.cmake` makes the BE build resolve `Protobuf` to the libprotobuf.a built here in `thirdparty/`, *not* the one built in staros's `starlet/third_party/`:

```cmake
# Tell cmake that PROTOBUF library is already found
set(PROTOBUF_FOUND TRUE)
# starrocks project has its imported libprotobuf.a and libre2.a
```

Result: starlet's generated `*.pb.cc` files (compiled against starlet's own protobuf headers) and starrocks's generated `*.pb.cc` files end up sharing **one** libprotobuf.a at link time. Protobuf's `GOOGLE_PROTOBUF_VERIFY_VERSION` macro (run at every translation unit's static init) requires headers version **exactly equal** to library version — not just same major. So if staros moves to 3.16.1 while this repo stays on 3.14.0, the resulting BE binary aborts during static init with a version mismatch fatal.

## Risk

Very low — minor bump inside the protobuf 3.x major series:

- C++ ABI backward-compatible.
- Wire format unchanged → all journal / RPC payloads interoperate.
- gRPC v1.43.0 still in the supported range (no gRPC bump needed).
- `build-thirdparty.sh` rebuilds every protobuf-consuming downstream (brpc, grpc, arrow, etc.) unconditionally per invocation — no `_SN` cache marker concept here, so no risk of a stale brpc.a / grpc.a sitting on top of fresh libprotobuf.a.
- No version-conditional code fires: `download-thirdparty.sh`'s `protobuf-3.5.1.patch` hook only matches that exact source, and `brpc-1.9.0.patch`'s `PROTOBUF_VERSION >= 4022000` branch is for protobuf 4.x.

## Test plan

- [ ] One clean `./thirdparty/build-thirdparty.sh` (verifies the new tarball downloads, unpacks, builds; brpc/grpc/arrow rebuild against new headers).
- [ ] One full BE build + UT pass.
- [ ] Verify a representative `*.pb.cc` link doesn't trip `GOOGLE_PROTOBUF_VERIFY_VERSION` at process startup.

## Follow-up

After this lands, `staros#1256` (which bumps `starlet/third_party/vars.sh` and `starlet/src/starcachelib/third_party/vars.sh` to the same 3.16.1) can land safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)