### PR TITLE
[BugFix] PlannerMetaLocker: skip unlock when lock() never succeeded (POST-1561)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -74,14 +74,33 @@ public class PlannerMetaLocker implements AutoCloseable {
     private Map<Long, Set<Long>> tables = Maps.newTreeMap(Long::compareTo);
 
     /**
-     * Entries successfully locked by the most recent {@link #lock()} or {@link #tryLock} call.
-     * Null when no acquisition is currently held (initial state, after a failed {@code lock()}
-     * that rolled itself back, or after {@link #unlock()}). {@code unlock()} only releases entries
-     * recorded here, so it never tries to release rids that were never locked by this instance
-     * — which would otherwise surface as {@code IllegalMonitorStateException: "Attempt to unlock
-     * lock, not locked by current locker"}. See POST-1561 / PR following #69284.
+     * Entries successfully locked by the outermost {@link #lock()} / {@link #tryLock} that
+     * is currently active on this instance. {@code unlock()} uses this snapshot to release
+     * the right rids, regardless of how deeply nested the lock/unlock calls are.
+     *
+     * <p>Null when {@link #lockDepth} is 0 (no acquisition currently in scope, or already
+     * fully released). See {@code lockDepth} for the depth semantics.
      */
     private List<Map.Entry<Long, Set<Long>>> heldEntries;
+
+    /**
+     * Number of currently-pending {@code lock()}/{@code tryLock()} acquisitions on this
+     * instance — i.e., how many matching {@code unlock()} calls are still owed.
+     *
+     * <p>Nested acquisitions happen for real on the optimistic-retry path:
+     * {@link com.starrocks.sql.InsertPlanner#buildExecPlanWithRetry} unlocks during planning
+     * then re-locks before validation, and {@link com.starrocks.sql.StatementPlanner#reAnalyzeStmt}
+     * additionally calls {@code lock()}/{@code unlock()} on the SAME instance inside the retry
+     * iteration. The inner pair must not release the outer acquisition's LockManager refCount,
+     * and the inner {@code unlock()} must not clear {@link #heldEntries} (otherwise the outer
+     * {@code unlock()} would become a no-op and leak the locks).
+     *
+     * <p>{@code lock()} increments after a successful acquire; {@code unlock()} decrements
+     * unconditionally when in-scope and clears {@code heldEntries} once it hits zero. A failed
+     * {@code lock()} (partial-acquire that rolled itself back) does NOT increment, so the
+     * outer state — if any — is preserved untouched.
+     */
+    private int lockDepth = 0;
 
     public PlannerMetaLocker(ConnectContext session, StatementBase statementBase) {
         new TableCollector(session, dbs, tables).visit(statementBase);
@@ -109,7 +128,13 @@ public class PlannerMetaLocker implements AutoCloseable {
                 lockedEntries.add(entry);
             }
             isLockSuccess = true;
-            heldEntries = lockedEntries;
+            lockDepth++;
+            // Only the outermost successful acquisition records the snapshot. Nested calls
+            // re-enter the same rids in LockManager (refCount++) but the entry list is
+            // unchanged because `tables` is fixed at construction time.
+            if (lockDepth == 1) {
+                heldEntries = lockedEntries;
+            }
         } finally {
             if (!isLockSuccess) {
                 for (Database database : lockedDbs) {
@@ -135,13 +160,23 @@ public class PlannerMetaLocker implements AutoCloseable {
                 locker.lockTablesWithIntensiveDbLock(database.getId(), tableIds, LockType.READ);
                 lockedEntries.add(entry);
             }
-            heldEntries = lockedEntries;
+            lockDepth++;
+            // Only the outermost successful acquisition records the snapshot. Nested lock()
+            // calls re-enter the same rids in LockManager (refCount goes up by 1 per call) but
+            // the snapshot is unchanged because `tables` is fixed at construction. Overwriting
+            // here would let an inner unlock() clear the outer's record and turn the outer
+            // unlock() into a no-op, leaking the locks. See POST-1561 review feedback.
+            if (lockDepth == 1) {
+                heldEntries = lockedEntries;
+            }
         } catch (Throwable t) {
             // Partial-acquire rollback at the multi-db level. Inner
-            // Locker.lockTablesWithIntensiveDbLock is atomic per-db (it rolls itself back on failure),
-            // so a throw here means earlier (db, tableIds) entries are fully held while the current
-            // and later ones are not. Release the earlier ones in reverse order before re-throwing
-            // so the caller's matching unLock(...) only ever sees a fully-balanced state.
+            // Locker.lockTablesWithIntensiveDbLock is atomic per-db (it rolls itself back on
+            // failure), so a throw here means earlier (db, tableIds) entries are fully held
+            // while the current and later ones are not. Release the earlier ones in reverse
+            // order before re-throwing. {@code lockDepth} / {@code heldEntries} are NOT
+            // modified — we never reached the increment, so outer state (if this was a nested
+            // call) stays exactly as it was.
             for (int i = lockedEntries.size() - 1; i >= 0; i--) {
                 Map.Entry<Long, Set<Long>> entry = lockedEntries.get(i);
                 try {
@@ -152,21 +187,28 @@ public class PlannerMetaLocker implements AutoCloseable {
                             entry.getKey(), releaseEx);
                 }
             }
-            heldEntries = null;
             throw t;
         }
     }
 
     public void unlock() {
-        if (heldEntries == null) {
-            // lock()/tryLock() was never called successfully (or already unlocked). Nothing to do.
-            // This protects callers that always pair lock() with unlock() in a finally block
-            // from spurious "Attempt to unlock lock" when lock() failed partway and rolled back.
+        if (lockDepth == 0) {
+            // No acquisition currently in scope. Either lock()/tryLock() was never called
+            // successfully on this instance, or all prior acquisitions have already been
+            // released. This is the safety net that lets callers pair lock() with unlock() in
+            // a finally block without spurious "Attempt to unlock lock" when lock() failed
+            // partway and rolled back.
             return;
         }
         Locker locker = new Locker();
+        // Each unlock() decrements LockManager refCount by 1 per rid. The snapshot
+        // (heldEntries) is the same across nested unlocks because `tables` is fixed; we use
+        // it for every release and only clear it on the outermost unlock.
         List<Map.Entry<Long, Set<Long>>> entriesToRelease = heldEntries;
-        heldEntries = null;
+        lockDepth--;
+        if (lockDepth == 0) {
+            heldEntries = null;
+        }
         for (Map.Entry<Long, Set<Long>> entry : entriesToRelease) {
             Database database = dbs.get(entry.getKey());
             List<Long> tableIds = new ArrayList<>(entry.getValue());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -40,7 +40,9 @@ import com.starrocks.sql.ast.ViewRelation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -74,33 +76,23 @@ public class PlannerMetaLocker implements AutoCloseable {
     private Map<Long, Set<Long>> tables = Maps.newTreeMap(Long::compareTo);
 
     /**
-     * Entries successfully locked by the outermost {@link #lock()} / {@link #tryLock} that
-     * is currently active on this instance. {@code unlock()} uses this snapshot to release
-     * the right rids, regardless of how deeply nested the lock/unlock calls are.
+     * Stack of acquisitions still owed a matching {@code unlock()}. Each successful
+     * {@link #lock()} / {@link #tryLock} pushes the list of {@code (dbId, tableIds)} entries it
+     * acquired; each {@link #unlock()} pops the most recent frame and releases its entries in
+     * reverse order. {@link #close()} drains the whole stack.
      *
-     * <p>Null when {@link #lockDepth} is 0 (no acquisition currently in scope, or already
-     * fully released). See {@code lockDepth} for the depth semantics.
+     * <p>This makes nested lock/unlock symmetric without a separate depth counter. Nesting
+     * happens for real on the optimistic-retry path:
+     * {@link com.starrocks.sql.InsertPlanner#buildExecPlanWithRetry} unlocks during planning then
+     * re-locks before validation, and {@link com.starrocks.sql.StatementPlanner#reAnalyzeStmt}
+     * additionally does {@code try { lock(); ... } finally { unlock(); }} on the SAME instance
+     * inside the retry iteration. The underlying {@link Locker} is reentrant (LockManager
+     * refcounts per rid), so each lock()/unlock() pair only adjusts its own refCount slot and a
+     * full unwind leaves the LockManager balanced. An empty stack makes {@code unlock()} a no-op,
+     * so callers that always pair lock() with unlock() in a {@code finally} block never hit a
+     * spurious "Attempt to unlock lock" when lock() failed partway and rolled itself back.
      */
-    private List<Map.Entry<Long, Set<Long>>> heldEntries;
-
-    /**
-     * Number of currently-pending {@code lock()}/{@code tryLock()} acquisitions on this
-     * instance — i.e., how many matching {@code unlock()} calls are still owed.
-     *
-     * <p>Nested acquisitions happen for real on the optimistic-retry path:
-     * {@link com.starrocks.sql.InsertPlanner#buildExecPlanWithRetry} unlocks during planning
-     * then re-locks before validation, and {@link com.starrocks.sql.StatementPlanner#reAnalyzeStmt}
-     * additionally calls {@code lock()}/{@code unlock()} on the SAME instance inside the retry
-     * iteration. The inner pair must not release the outer acquisition's LockManager refCount,
-     * and the inner {@code unlock()} must not clear {@link #heldEntries} (otherwise the outer
-     * {@code unlock()} would become a no-op and leak the locks).
-     *
-     * <p>{@code lock()} increments after a successful acquire; {@code unlock()} decrements
-     * unconditionally when in-scope and clears {@code heldEntries} once it hits zero. A failed
-     * {@code lock()} (partial-acquire that rolled itself back) does NOT increment, so the
-     * outer state — if any — is preserved untouched.
-     */
-    private int lockDepth = 0;
+    private final Deque<List<Map.Entry<Long, Set<Long>>>> heldStack = new ArrayDeque<>();
 
     public PlannerMetaLocker(ConnectContext session, StatementBase statementBase) {
         new TableCollector(session, dbs, tables).visit(statementBase);
@@ -128,13 +120,8 @@ public class PlannerMetaLocker implements AutoCloseable {
                 lockedEntries.add(entry);
             }
             isLockSuccess = true;
-            lockDepth++;
-            // Only the outermost successful acquisition records the snapshot. Nested calls
-            // re-enter the same rids in LockManager (refCount++) but the entry list is
-            // unchanged because `tables` is fixed at construction time.
-            if (lockDepth == 1) {
-                heldEntries = lockedEntries;
-            }
+            // Record this acquisition so the matching unlock() releases exactly what it locked.
+            heldStack.push(lockedEntries);
         } finally {
             if (!isLockSuccess) {
                 for (Database database : lockedDbs) {
@@ -160,23 +147,17 @@ public class PlannerMetaLocker implements AutoCloseable {
                 locker.lockTablesWithIntensiveDbLock(database.getId(), tableIds, LockType.READ);
                 lockedEntries.add(entry);
             }
-            lockDepth++;
-            // Only the outermost successful acquisition records the snapshot. Nested lock()
-            // calls re-enter the same rids in LockManager (refCount goes up by 1 per call) but
-            // the snapshot is unchanged because `tables` is fixed at construction. Overwriting
-            // here would let an inner unlock() clear the outer's record and turn the outer
-            // unlock() into a no-op, leaking the locks. See POST-1561 review feedback.
-            if (lockDepth == 1) {
-                heldEntries = lockedEntries;
-            }
+            // Record this acquisition so the matching unlock() releases exactly what it locked.
+            // Each lock() pushes its own frame, so nested calls stack independently and a later
+            // unlock() pops them one at a time in reverse acquisition order.
+            heldStack.push(lockedEntries);
         } catch (Throwable t) {
             // Partial-acquire rollback at the multi-db level. Inner
             // Locker.lockTablesWithIntensiveDbLock is atomic per-db (it rolls itself back on
             // failure), so a throw here means earlier (db, tableIds) entries are fully held
             // while the current and later ones are not. Release the earlier ones in reverse
-            // order before re-throwing. {@code lockDepth} / {@code heldEntries} are NOT
-            // modified — we never reached the increment, so outer state (if this was a nested
-            // call) stays exactly as it was.
+            // order before re-throwing. The stack is NOT pushed — we never reached the push, so
+            // any outer frame (if this was a nested call) stays exactly as it was.
             for (int i = lockedEntries.size() - 1; i >= 0; i--) {
                 Map.Entry<Long, Set<Long>> entry = lockedEntries.get(i);
                 try {
@@ -192,7 +173,7 @@ public class PlannerMetaLocker implements AutoCloseable {
     }
 
     public void unlock() {
-        if (lockDepth == 0) {
+        if (heldStack.isEmpty()) {
             // No acquisition currently in scope. Either lock()/tryLock() was never called
             // successfully on this instance, or all prior acquisitions have already been
             // released. This is the safety net that lets callers pair lock() with unlock() in
@@ -201,15 +182,13 @@ public class PlannerMetaLocker implements AutoCloseable {
             return;
         }
         Locker locker = new Locker();
-        // Each unlock() decrements LockManager refCount by 1 per rid. The snapshot
-        // (heldEntries) is the same across nested unlocks because `tables` is fixed; we use
-        // it for every release and only clear it on the outermost unlock.
-        List<Map.Entry<Long, Set<Long>>> entriesToRelease = heldEntries;
-        lockDepth--;
-        if (lockDepth == 0) {
-            heldEntries = null;
-        }
-        for (Map.Entry<Long, Set<Long>> entry : entriesToRelease) {
+        // Pop the most recent acquisition and release its entries in reverse order — the
+        // mirror image of how lock() acquired them. Each unlock() drops exactly one frame, so
+        // nested lock()/unlock() pairs stay symmetric and the underlying reentrant LockManager
+        // refCount is decremented once per rid per pop.
+        List<Map.Entry<Long, Set<Long>>> entriesToRelease = heldStack.pop();
+        for (int i = entriesToRelease.size() - 1; i >= 0; i--) {
+            Map.Entry<Long, Set<Long>> entry = entriesToRelease.get(i);
             Database database = dbs.get(entry.getKey());
             List<Long> tableIds = new ArrayList<>(entry.getValue());
             try {
@@ -226,9 +205,9 @@ public class PlannerMetaLocker implements AutoCloseable {
     public void close() {
         // AutoCloseable contract: release everything this instance still holds, regardless of
         // how many lock()/tryLock() calls have not yet been matched by an explicit unlock().
-        // Drain the nested depth so try-with-resources cleanup is total even if the body did
+        // Drain the whole stack so try-with-resources cleanup is total even if the body did
         // multiple lock()s. (No current caller does that, but the contract should hold.)
-        while (lockDepth > 0) {
+        while (!heldStack.isEmpty()) {
             unlock();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.starrocks.sql.analyzer;
 
-import com.google.api.client.util.Lists;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
@@ -107,7 +106,6 @@ public class PlannerMetaLocker implements AutoCloseable {
         Locker locker = new Locker(queryId);
 
         boolean isLockSuccess = false;
-        List<Database> lockedDbs = Lists.newArrayList();
         List<Map.Entry<Long, Set<Long>>> lockedEntries = new ArrayList<>(tables.size());
         try {
             for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
@@ -116,7 +114,6 @@ public class PlannerMetaLocker implements AutoCloseable {
                         LockType.READ, timeout, unit)) {
                     return false;
                 }
-                lockedDbs.add(database);
                 lockedEntries.add(entry);
             }
             isLockSuccess = true;
@@ -124,9 +121,18 @@ public class PlannerMetaLocker implements AutoCloseable {
             heldStack.push(lockedEntries);
         } finally {
             if (!isLockSuccess) {
-                for (Database database : lockedDbs) {
-                    locker.unLockTablesWithIntensiveDbLock(database.getId(), new ArrayList<>(tables.get(database.getId())),
-                            LockType.READ);
+                // Roll back the entries we did acquire (lockedEntries already records everything
+                // needed). Release in reverse order, exception-safe per entry so one failed
+                // release doesn't leave the remaining entries leaked.
+                for (int i = lockedEntries.size() - 1; i >= 0; i--) {
+                    Map.Entry<Long, Set<Long>> entry = lockedEntries.get(i);
+                    try {
+                        locker.unLockTablesWithIntensiveDbLock(
+                                entry.getKey(), new ArrayList<>(entry.getValue()), LockType.READ);
+                    } catch (Throwable releaseEx) {
+                        LOG.warn("PlannerMetaLocker.tryLock partial rollback: db {} release failed, continuing",
+                                entry.getKey(), releaseEx);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -37,6 +37,8 @@ import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.ViewRelation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -57,6 +59,8 @@ import java.util.stream.Collectors;
  * and obtain the db-read-lock of all dbs involved in the query.
  */
 public class PlannerMetaLocker implements AutoCloseable {
+    private static final Logger LOG = LogManager.getLogger(PlannerMetaLocker.class);
+
     // Map database id -> database
     private Map<Long, Database> dbs = Maps.newTreeMap(Long::compareTo);
 
@@ -68,6 +72,16 @@ public class PlannerMetaLocker implements AutoCloseable {
      * so the table ids do not need to be ordered here.
      */
     private Map<Long, Set<Long>> tables = Maps.newTreeMap(Long::compareTo);
+
+    /**
+     * Entries successfully locked by the most recent {@link #lock()} or {@link #tryLock} call.
+     * Null when no acquisition is currently held (initial state, after a failed {@code lock()}
+     * that rolled itself back, or after {@link #unlock()}). {@code unlock()} only releases entries
+     * recorded here, so it never tries to release rids that were never locked by this instance
+     * — which would otherwise surface as {@code IllegalMonitorStateException: "Attempt to unlock
+     * lock, not locked by current locker"}. See POST-1561 / PR following #69284.
+     */
+    private List<Map.Entry<Long, Set<Long>>> heldEntries;
 
     public PlannerMetaLocker(ConnectContext session, StatementBase statementBase) {
         new TableCollector(session, dbs, tables).visit(statementBase);
@@ -83,6 +97,7 @@ public class PlannerMetaLocker implements AutoCloseable {
 
         boolean isLockSuccess = false;
         List<Database> lockedDbs = Lists.newArrayList();
+        List<Map.Entry<Long, Set<Long>>> lockedEntries = new ArrayList<>(tables.size());
         try {
             for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
                 Database database = dbs.get(entry.getKey());
@@ -91,8 +106,10 @@ public class PlannerMetaLocker implements AutoCloseable {
                     return false;
                 }
                 lockedDbs.add(database);
+                lockedEntries.add(entry);
             }
             isLockSuccess = true;
+            heldEntries = lockedEntries;
         } finally {
             if (!isLockSuccess) {
                 for (Database database : lockedDbs) {
@@ -110,19 +127,56 @@ public class PlannerMetaLocker implements AutoCloseable {
 
     public void lock() {
         Locker locker = new Locker(queryId);
-        for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
-            Database database = dbs.get(entry.getKey());
-            List<Long> tableIds = new ArrayList<>(entry.getValue());
-            locker.lockTablesWithIntensiveDbLock(database.getId(), tableIds, LockType.READ);
+        List<Map.Entry<Long, Set<Long>>> lockedEntries = new ArrayList<>(tables.size());
+        try {
+            for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
+                Database database = dbs.get(entry.getKey());
+                List<Long> tableIds = new ArrayList<>(entry.getValue());
+                locker.lockTablesWithIntensiveDbLock(database.getId(), tableIds, LockType.READ);
+                lockedEntries.add(entry);
+            }
+            heldEntries = lockedEntries;
+        } catch (Throwable t) {
+            // Partial-acquire rollback at the multi-db level. Inner
+            // Locker.lockTablesWithIntensiveDbLock is atomic per-db (it rolls itself back on failure),
+            // so a throw here means earlier (db, tableIds) entries are fully held while the current
+            // and later ones are not. Release the earlier ones in reverse order before re-throwing
+            // so the caller's matching unLock(...) only ever sees a fully-balanced state.
+            for (int i = lockedEntries.size() - 1; i >= 0; i--) {
+                Map.Entry<Long, Set<Long>> entry = lockedEntries.get(i);
+                try {
+                    locker.unLockTablesWithIntensiveDbLock(
+                            entry.getKey(), new ArrayList<>(entry.getValue()), LockType.READ);
+                } catch (Throwable releaseEx) {
+                    LOG.warn("PlannerMetaLocker.lock partial rollback: db {} release failed, continuing",
+                            entry.getKey(), releaseEx);
+                }
+            }
+            heldEntries = null;
+            throw t;
         }
     }
 
     public void unlock() {
+        if (heldEntries == null) {
+            // lock()/tryLock() was never called successfully (or already unlocked). Nothing to do.
+            // This protects callers that always pair lock() with unlock() in a finally block
+            // from spurious "Attempt to unlock lock" when lock() failed partway and rolled back.
+            return;
+        }
         Locker locker = new Locker();
-        for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
+        List<Map.Entry<Long, Set<Long>>> entriesToRelease = heldEntries;
+        heldEntries = null;
+        for (Map.Entry<Long, Set<Long>> entry : entriesToRelease) {
             Database database = dbs.get(entry.getKey());
             List<Long> tableIds = new ArrayList<>(entry.getValue());
-            locker.unLockTablesWithIntensiveDbLock(database.getId(), tableIds, LockType.READ);
+            try {
+                locker.unLockTablesWithIntensiveDbLock(database.getId(), tableIds, LockType.READ);
+            } catch (Throwable t) {
+                // A fully-balanced lock state should never trigger this; if it does, log and
+                // continue so the remaining entries still get released.
+                LOG.warn("PlannerMetaLocker.unlock: db {} release failed, continuing", database.getId(), t);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -224,7 +224,13 @@ public class PlannerMetaLocker implements AutoCloseable {
 
     @Override
     public void close() {
-        unlock();
+        // AutoCloseable contract: release everything this instance still holds, regardless of
+        // how many lock()/tryLock() calls have not yet been matched by an explicit unlock().
+        // Drain the nested depth so try-with-resources cleanup is total even if the body did
+        // multiple lock()s. (No current caller does that, but the contract should hold.)
+        while (lockDepth > 0) {
+            unlock();
+        }
     }
     /**
      * Collect tables that need to be protected by the PlannerMetaLock

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
@@ -14,7 +14,6 @@
 package com.starrocks.common.lock;
 
 import com.google.common.collect.ImmutableList;
-import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.util.concurrent.lock.LockException;
 import com.starrocks.common.util.concurrent.lock.LockManager;
@@ -47,7 +46,6 @@ public class LockerIntensiveLockRollbackTest {
     @BeforeEach
     public void setUp() {
         GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
-        Config.lock_manager_enabled = true;
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
@@ -159,7 +159,7 @@ public class LockerIntensiveLockRollbackTest {
      * Success path remains unchanged: acquire, then matching unlock, no exceptions, no leaks.
      */
     @Test
-    public void successfulLockUnlockPathUnchanged() {
+    public void successfulLockUnlockPathUnchanged() throws LockException {
         long dbId = 1_005_001L;
         long ridA = 1_005_002L;
         long ridB = 1_005_003L;

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
@@ -27,6 +27,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 /**
  * Regression tests for POST-1561: when {@code Locker.lock(Table|Tables)WithIntensiveDbLock}
  * fails partway, it must roll back any partially-acquired locks before re-throwing. Without
@@ -175,13 +182,59 @@ public class LockerIntensiveLockRollbackTest {
     }
 
     /**
-     * Acquire an exclusive lock on {@code rid} from a fresh Locker with a short timeout.
-     * Succeeds only if no other locker still holds a conflicting lock on {@code rid}.
+     * Acquire an exclusive WRITE lock on {@code rid} <b>from a different thread</b> with a
+     * short timeout.
+     *
+     * <p>This MUST run on a different thread than the test thread. {@code Locker.equals} /
+     * {@code hashCode} use {@code threadId} (Locker.java:508-522), so a fresh {@code Locker}
+     * created on the test thread is treated by {@link LockManager} as the same owner as any
+     * Locker leaked by the code under test. {@link com.starrocks.common.util.concurrent.lock.MultiUserLock#tryLock}
+     * (lines 98-130) then either re-enters / upgrades the lock (vacuous pass) or throws
+     * {@code NotSupportLockException} (failure for the wrong reason). Running on a different
+     * thread gives a different {@code threadId} so the LockManager applies the normal
+     * conflict matrix: a leaked IS/IX/READ/WRITE will conflict with a fresh-thread WRITE,
+     * cause the acquire to wait, and time out — which is exactly the signal we want.
      */
-    private void assertCanAcquireExclusively(long rid) throws LockException {
+    private void assertCanAcquireExclusively(long rid) {
         LockManager mgr = GlobalStateMgr.getCurrentState().getLockManager();
-        Locker fresh = new Locker();
-        mgr.lock(rid, fresh, LockType.WRITE, 1_000);
-        mgr.release(rid, fresh, LockType.WRITE);
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "assertCanAcquireExclusively-rid" + rid);
+            t.setDaemon(true);
+            return t;
+        });
+        try {
+            Future<?> future = executor.submit(() -> {
+                Locker fresh = new Locker();
+                try {
+                    mgr.lock(rid, fresh, LockType.WRITE, 1_000);
+                } catch (LockException e) {
+                    throw new RuntimeException(e);
+                }
+                try {
+                    mgr.release(rid, fresh, LockType.WRITE);
+                } catch (Exception releaseEx) {
+                    // Best-effort: the assertion below uses the acquire result; release
+                    // failure here would only mask a (different) bug.
+                }
+            });
+            try {
+                future.get(5, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                Assertions.fail("Expected to acquire exclusive WRITE on rid " + rid
+                        + " from a different thread, but acquisition failed — a leaked lock"
+                        + " on this rid likely remains. cause=" + e.getCause(), e.getCause());
+            } catch (TimeoutException e) {
+                future.cancel(true);
+                Assertions.fail("Acquiring exclusive WRITE on rid " + rid
+                        + " from a different thread did not return within 5s — the inner lock"
+                        + " timeout (1s) should have surfaced as a LockException long before"
+                        + " this; the test setup is wrong or the LockManager is stuck.");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Assertions.fail("Interrupted while waiting for exclusive WRITE on rid " + rid);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/LockerIntensiveLockRollbackTest.java
@@ -1,0 +1,187 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.lock;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.Config;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.util.concurrent.lock.LockException;
+import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Regression tests for POST-1561: when {@code Locker.lock(Table|Tables)WithIntensiveDbLock}
+ * fails partway, it must roll back any partially-acquired locks before re-throwing. Without
+ * this rollback, the caller's matching {@code unLock*} call would attempt to release rids that
+ * were never held and crash with
+ * {@code IllegalMonitorStateException: "Attempt to unlock lock, not locked by current locker"}
+ * (surfaced to clients as {@code ERROR 5600}).
+ */
+public class LockerIntensiveLockRollbackTest {
+
+    @BeforeEach
+    public void setUp() {
+        GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
+        Config.lock_manager_enabled = true;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Reset to default so other tests are unaffected.
+        GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
+    }
+
+    /**
+     * lockTablesWithIntensiveDbLock: failure on an inner table-rid lock must roll back
+     * the previously-acquired db intent lock and any earlier table-rid locks.
+     */
+    @Test
+    public void lockTablesRollsBackOnRidFailure() throws LockException {
+        long dbId = 1_000_001L;
+        long ridA = 1_000_002L;
+        long ridB = 1_000_003L; // We make the inner lock(ridB, ...) throw.
+        long ridC = 1_000_004L;
+
+        Locker spy = Mockito.spy(new Locker());
+        Mockito.doThrow(new LockException("simulated mid-iteration LockException on " + ridB))
+                .when(spy).lock(Mockito.eq(ridB), Mockito.eq(LockType.READ), Mockito.anyLong());
+
+        Assertions.assertThrows(ErrorReportException.class, () ->
+                spy.lockTablesWithIntensiveDbLock(dbId, ImmutableList.of(ridA, ridB, ridC), LockType.READ));
+
+        // After rollback the LockManager must be clean: a fresh Locker on a different thread
+        // must be able to acquire WRITE on dbId immediately. WRITE conflicts with INTENTION_SHARED,
+        // so if the IS leaked, this would block / time out.
+        assertCanAcquireExclusively(dbId);
+        // ridA should also be fully released. READ does not conflict with READ, so use WRITE
+        // to detect leaks.
+        assertCanAcquireExclusively(ridA);
+    }
+
+    /**
+     * lockTablesWithIntensiveDbLock: failure on the very first table-rid lock must still
+     * release the db intent that was acquired moments earlier.
+     */
+    @Test
+    public void lockTablesRollsBackWhenFirstRidFails() throws LockException {
+        long dbId = 1_001_001L;
+        long ridA = 1_001_002L;
+
+        Locker spy = Mockito.spy(new Locker());
+        Mockito.doThrow(new LockException("simulated on first rid"))
+                .when(spy).lock(Mockito.eq(ridA), Mockito.eq(LockType.READ), Mockito.anyLong());
+
+        Assertions.assertThrows(ErrorReportException.class, () ->
+                spy.lockTablesWithIntensiveDbLock(dbId, ImmutableList.of(ridA), LockType.READ));
+
+        assertCanAcquireExclusively(dbId);
+    }
+
+    /**
+     * lockTablesWithIntensiveDbLock: failure on the very first acquire (db intent itself)
+     * must not leak anything.
+     */
+    @Test
+    public void lockTablesRollsBackWhenDbIntentFails() throws LockException {
+        long dbId = 1_002_001L;
+        long ridA = 1_002_002L;
+
+        Locker spy = Mockito.spy(new Locker());
+        Mockito.doThrow(new LockException("simulated on db intent"))
+                .when(spy).lock(Mockito.eq(dbId), Mockito.eq(LockType.INTENTION_SHARED), Mockito.anyLong());
+
+        Assertions.assertThrows(ErrorReportException.class, () ->
+                spy.lockTablesWithIntensiveDbLock(dbId, ImmutableList.of(ridA), LockType.READ));
+
+        // Nothing should have been acquired, so a fresh acquire is immediate.
+        assertCanAcquireExclusively(dbId);
+        assertCanAcquireExclusively(ridA);
+    }
+
+    /**
+     * lockTableWithIntensiveDbLock (single-table variant): same rollback contract.
+     */
+    @Test
+    public void lockTableRollsBackOnTableFailure() throws LockException {
+        long dbId = 1_003_001L;
+        long tableId = 1_003_002L;
+
+        Locker spy = Mockito.spy(new Locker());
+        Mockito.doThrow(new LockException("simulated table-lock failure"))
+                .when(spy).lock(Mockito.eq(tableId), Mockito.eq(LockType.READ), Mockito.anyLong());
+
+        Assertions.assertThrows(ErrorReportException.class, () ->
+                spy.lockTableWithIntensiveDbLock(dbId, tableId, LockType.READ));
+
+        assertCanAcquireExclusively(dbId);
+        assertCanAcquireExclusively(tableId);
+    }
+
+    /**
+     * WRITE-mode rollback: the same logic with INTENTION_EXCLUSIVE on the db side.
+     */
+    @Test
+    public void lockTablesWriteModeRollback() throws LockException {
+        long dbId = 1_004_001L;
+        long ridA = 1_004_002L;
+        long ridB = 1_004_003L;
+
+        Locker spy = Mockito.spy(new Locker());
+        Mockito.doThrow(new LockException("simulated"))
+                .when(spy).lock(Mockito.eq(ridB), Mockito.eq(LockType.WRITE), Mockito.anyLong());
+
+        Assertions.assertThrows(ErrorReportException.class, () ->
+                spy.lockTablesWithIntensiveDbLock(dbId, ImmutableList.of(ridA, ridB), LockType.WRITE));
+
+        assertCanAcquireExclusively(dbId);
+        assertCanAcquireExclusively(ridA);
+    }
+
+    /**
+     * Success path remains unchanged: acquire, then matching unlock, no exceptions, no leaks.
+     */
+    @Test
+    public void successfulLockUnlockPathUnchanged() {
+        long dbId = 1_005_001L;
+        long ridA = 1_005_002L;
+        long ridB = 1_005_003L;
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(dbId, ImmutableList.of(ridA, ridB), LockType.READ);
+        locker.unLockTablesWithIntensiveDbLock(dbId, ImmutableList.of(ridA, ridB), LockType.READ);
+
+        // Both rids and dbId must be free now.
+        assertCanAcquireExclusively(dbId);
+        assertCanAcquireExclusively(ridA);
+        assertCanAcquireExclusively(ridB);
+    }
+
+    /**
+     * Acquire an exclusive lock on {@code rid} from a fresh Locker with a short timeout.
+     * Succeeds only if no other locker still holds a conflicting lock on {@code rid}.
+     */
+    private void assertCanAcquireExclusively(long rid) throws LockException {
+        LockManager mgr = GlobalStateMgr.getCurrentState().getLockManager();
+        Locker fresh = new Locker();
+        mgr.lock(rid, fresh, LockType.WRITE, 1_000);
+        mgr.release(rid, fresh, LockType.WRITE);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
@@ -1,0 +1,186 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+/**
+ * Regression tests for POST-1561: when {@link PlannerMetaLocker#lock()} fails partway
+ * (typically because the inner {@code Locker.lockTablesWithIntensiveDbLock} throws under
+ * concurrent pressure / deadlock detection), the {@link PlannerMetaLocker} must roll itself
+ * back so that the caller's matching {@link PlannerMetaLocker#unlock()} in finally does NOT
+ * attempt to release rids that were never acquired — which would otherwise surface as
+ * {@code IllegalMonitorStateException: "Attempt to unlock lock, not locked by current locker"}
+ * (error code 5600, masquerading as ERR_NO_FILES_FOUND in customer reports).
+ */
+public class PlannerMetaLockerRollbackTest extends PlanTestBase {
+
+    @BeforeEach
+    public void resetLockManager() {
+        GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
+        Config.lock_manager_enabled = true;
+    }
+
+    @AfterEach
+    public void cleanupLockManager() {
+        GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
+    }
+
+    /**
+     * Calling unlock() before any successful lock() must be a safe no-op. This is the direct
+     * regression check for the SmartNews 4.0.9 incident: when planning fails before lock() is
+     * called (or after it has rolled itself back), the outer try/finally still invokes unlock();
+     * pre-fix, that hit the LockManager mismatch path.
+     */
+    @Test
+    public void unlockWithoutLockIsNoOp() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+        Assertions.assertDoesNotThrow(locker::unlock);
+        // Idempotent: a second unlock is still a no-op.
+        Assertions.assertDoesNotThrow(locker::unlock);
+    }
+
+    /**
+     * AutoCloseable contract: {@code close()} on a PlannerMetaLocker that was never locked
+     * must not throw — this allows try-with-resources patterns to fail-fast in the body without
+     * polluting the failure with a release-side exception.
+     */
+    @Test
+    public void closeWithoutLockIsNoOp() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
+        Assertions.assertDoesNotThrow(() -> {
+            try (PlannerMetaLocker ignored = new PlannerMetaLocker(connectContext, stmt)) {
+                // intentionally do not call lock()
+            }
+        });
+    }
+
+    /**
+     * Successful lock() then unlock() round-trip must work end-to-end without throwing,
+     * and a subsequent unlock() must be a no-op (heldEntries was cleared by the first unlock).
+     */
+    @Test
+    public void lockThenUnlockRoundTrip() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+        Assertions.assertDoesNotThrow(locker::lock);
+        Assertions.assertDoesNotThrow(locker::unlock);
+        // Second unlock is a no-op (heldEntries already cleared).
+        Assertions.assertDoesNotThrow(locker::unlock);
+    }
+
+    /**
+     * If {@link PlannerMetaLocker#lock()} fails because the inner {@code Locker} throws
+     * mid-acquisition, the outer caller's standard {@code finally { unlock(); }} pattern must
+     * not crash with {@code IllegalMonitorStateException}. This mirrors the SmartNews failure
+     * mode exactly: ERR_NO_FILES_FOUND or any other planning-time exception triggers cleanup;
+     * if the lock state is asymmetric, cleanup crashes and overwrites the original error.
+     */
+    @Test
+    public void lockRollsBackOnInnerFailureLeavingUnlockNoOp() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
+
+        try (MockedConstruction<Locker> mocked = Mockito.mockConstruction(Locker.class,
+                (mock, ctx) -> Mockito.doThrow(ErrorReportException.report(
+                                com.starrocks.common.ErrorCode.ERR_LOCK_ERROR, "simulated inner failure"))
+                        .when(mock)
+                        .lockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class)))) {
+
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+            Assertions.assertThrows(ErrorReportException.class, locker::lock);
+
+            // After a failed lock() that rolled itself back, unlock() must be a no-op even though
+            // PlannerMetaLocker has `tables` populated. Before the POST-1561 fix this threw
+            // IllegalMonitorStateException because unlock() would iterate `tables` and try to
+            // release rids that were never held.
+            Assertions.assertDoesNotThrow(locker::unlock);
+
+            // Verify the rollback was invoked exactly as many times as needed: i.e., we did NOT
+            // attempt extra release calls on rids we never held. With single-db single-table SQL
+            // ("select * from t0"), the rollback inside PlannerMetaLocker.lock()'s catch has no
+            // prior entries to release (inner Locker already rolled itself back), so the outer
+            // unLockTablesWithIntensiveDbLock should never be called.
+            List<Locker> constructed = mocked.constructed();
+            Assertions.assertFalse(constructed.isEmpty(), "Locker should have been constructed");
+            Mockito.verify(constructed.get(0), Mockito.never())
+                    .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
+        }
+    }
+
+    /**
+     * Multi-db variant: when the inner Locker throws on the SECOND db, PlannerMetaLocker's
+     * own rollback loop must release the FIRST db before re-throwing — otherwise the caller's
+     * unlock() in finally would either skip release (post-fix, via heldEntries=null) and leak
+     * the first db's lock, or (pre-fix) try to release the second db's never-acquired locks
+     * and crash.
+     */
+    @Test
+    public void lockRollsBackEarlierDbsOnLaterDbFailure() throws Exception {
+        // A SQL that locks two databases worth of tables (default-db.t0 + db1.tbl1).
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(
+                "select t0.v1 from t0 join db1.tbl1 on true", connectContext);
+
+        try (MockedConstruction<Locker> mocked = Mockito.mockConstruction(Locker.class,
+                (mock, ctx) -> {
+                    // First Locker (created in lock()): 1st call succeeds, 2nd throws.
+                    if (ctx.getCount() == 1) {
+                        Mockito.doNothing()
+                                .doThrow(ErrorReportException.report(
+                                        com.starrocks.common.ErrorCode.ERR_LOCK_ERROR,
+                                        "simulated failure on second db"))
+                                .when(mock)
+                                .lockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
+                    }
+                })) {
+
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+            Assertions.assertThrows(ErrorReportException.class, locker::lock);
+
+            // Verify the rollback released the first db (i.e., unLockTablesWithIntensiveDbLock
+            // was invoked exactly once on the first Locker — for the only db that succeeded).
+            List<Locker> constructed = mocked.constructed();
+            Assertions.assertFalse(constructed.isEmpty());
+            Mockito.verify(constructed.get(0), Mockito.times(1))
+                    .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
+
+            // After rollback, unlock() must still be a no-op (heldEntries cleared).
+            Assertions.assertDoesNotThrow(locker::unlock);
+            // And the unlock() call above must not have invoked unLockTablesWithIntensiveDbLock again.
+            Mockito.verify(constructed.get(0), Mockito.times(1))
+                    .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.analyzer;
 
-import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.util.concurrent.lock.LockManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -51,7 +50,6 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
     @BeforeEach
     public void resetLockManager() {
         GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
-        Config.lock_manager_enabled = true;
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
@@ -245,6 +245,41 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
         Assertions.assertNull(readHeldEntries(locker));
     }
 
+    /**
+     * AutoCloseable contract: close() must release every pending acquisition, not just one
+     * level. If a caller does multiple lock()s inside try-with-resources without matching
+     * unlock()s, the implicit close() at the end of the block must drain them all — otherwise
+     * the leftover acquisitions leak (LockManager keeps a non-zero refCount on every rid that
+     * was acquired). No current caller does this today, but the AutoCloseable contract should
+     * hold regardless.
+     */
+    @Test
+    public void closeDrainsAllNestedLocks() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+
+        locker.lock();
+        locker.lock();
+        locker.lock();
+        Assertions.assertEquals(3, readLockDepth(locker));
+        Assertions.assertNotNull(readHeldEntries(locker));
+
+        locker.close();
+
+        Assertions.assertEquals(0, readLockDepth(locker),
+                "close() must drain all nested lock acquisitions, not just one level");
+        Assertions.assertNull(readHeldEntries(locker),
+                "close() must clear the snapshot once depth hits zero");
+
+        // After close() drains, the LockManager state must allow a fresh lock/unlock cycle.
+        // If close() left stale LockHolders behind, the next lock() would reenter at a higher
+        // refCount than expected; if it left depth/heldEntries inconsistent, the next
+        // unlock() would either no-op or crash.
+        Assertions.assertDoesNotThrow(locker::lock);
+        Assertions.assertDoesNotThrow(locker::unlock);
+        Assertions.assertEquals(0, readLockDepth(locker));
+    }
+
     private static int readLockDepth(PlannerMetaLocker locker) throws Exception {
         Field f = PlannerMetaLocker.class.getDeclaredField("lockDepth");
         f.setAccessible(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
@@ -91,7 +91,7 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
 
     /**
      * Successful lock() then unlock() round-trip must work end-to-end without throwing,
-     * and a subsequent unlock() must be a no-op (heldEntries was cleared by the first unlock).
+     * and a subsequent unlock() must be a no-op (the stack was emptied by the first unlock).
      */
     @Test
     public void lockThenUnlockRoundTrip() throws Exception {
@@ -99,7 +99,7 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
         PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
         Assertions.assertDoesNotThrow(locker::lock);
         Assertions.assertDoesNotThrow(locker::unlock);
-        // Second unlock is a no-op (heldEntries already cleared).
+        // Second unlock is a no-op (the stack is already empty).
         Assertions.assertDoesNotThrow(locker::unlock);
     }
 
@@ -144,9 +144,9 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
     /**
      * Multi-db variant: when the inner Locker throws on the SECOND db, PlannerMetaLocker's
      * own rollback loop must release the FIRST db before re-throwing — otherwise the caller's
-     * unlock() in finally would either skip release (post-fix, via heldEntries=null) and leak
-     * the first db's lock, or (pre-fix) try to release the second db's never-acquired locks
-     * and crash.
+     * unlock() in finally would either skip release (post-fix, because a failed lock() pushes
+     * no frame) and leak the first db's lock, or (pre-fix) try to release the second db's
+     * never-acquired locks and crash.
      */
     @Test
     public void lockRollsBackEarlierDbsOnLaterDbFailure() throws Exception {
@@ -177,7 +177,7 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
             Mockito.verify(constructed.get(0), Mockito.times(1))
                     .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
 
-            // After rollback, unlock() must still be a no-op (heldEntries cleared).
+            // After rollback, unlock() must still be a no-op (no frame was pushed).
             Assertions.assertDoesNotThrow(locker::unlock);
             // And the unlock() call above must not have invoked unLockTablesWithIntensiveDbLock again.
             Mockito.verify(constructed.get(0), Mockito.times(1))
@@ -191,48 +191,39 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
      * and the retry iteration calls {@code StatementPlanner.reAnalyzeStmt}, which itself
      * does {@code try { lock(); ... } finally { unlock(); }} on the same instance).
      *
-     * <p>Pre-fix, lock() unconditionally overwrote {@code heldEntries} every call, and
-     * unlock() unconditionally cleared it. So:
+     * <p>Pre-fix, lock() kept a single {@code heldEntries} snapshot that every call overwrote and
+     * every unlock() cleared. So:
      *   <ul>
      *     <li>inner lock() overwrote outer's snapshot (with the same content — no observable harm yet);</li>
-     *     <li>inner unlock() decremented LockManager refCount by 1 per rid (2 → 1) AND cleared {@code heldEntries};</li>
-     *     <li>outer unlock() saw {@code heldEntries == null} and was a no-op — but LockManager refCount
+     *     <li>inner unlock() decremented LockManager refCount by 1 per rid (2 → 1) AND cleared the snapshot;</li>
+     *     <li>outer unlock() saw the snapshot gone and was a no-op — but LockManager refCount
      *         was still 1 per rid, so the locks were LEAKED, and the retry body continued to plan WHILE
      *         STILL HOLDING the meta locks (the opposite of the design intent of the unlock-plan-relock cycle).</li>
      *   </ul>
      *
-     * <p>Fix uses an explicit {@code lockDepth} counter so nested lock()/unlock() pairs only
-     * touch their own LockManager refCount slot, and {@code heldEntries} is only cleared
-     * when the outermost unlock() drains the depth.
+     * <p>Fix keeps a stack of acquisition frames: each lock() pushes its own frame and each
+     * unlock() pops exactly one (releasing it in reverse order), so nested pairs only touch
+     * their own LockManager refCount slot and a full unwind leaves the manager balanced.
      */
     @Test
     public void nestedLockUnlockReleasesAllReferences() throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
         PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
 
-        Assertions.assertEquals(0, readLockDepth(locker), "fresh instance must have depth 0");
-        Assertions.assertNull(readHeldEntries(locker), "fresh instance must have no snapshot");
+        Assertions.assertEquals(0, readLockDepth(locker), "fresh instance must hold no frames");
 
         locker.lock();                                              // outer
-        Assertions.assertEquals(1, readLockDepth(locker), "outer lock must increment depth to 1");
-        Assertions.assertNotNull(readHeldEntries(locker), "outer lock must record the snapshot");
-        Object outerSnapshot = readHeldEntries(locker);
+        Assertions.assertEquals(1, readLockDepth(locker), "outer lock must push one frame");
 
         locker.lock();                                              // inner (nested)
-        Assertions.assertEquals(2, readLockDepth(locker), "nested lock must bump depth to 2");
-        Assertions.assertSame(outerSnapshot, readHeldEntries(locker),
-                "nested lock must NOT overwrite the outer snapshot — the outer unlock relies on it");
+        Assertions.assertEquals(2, readLockDepth(locker), "nested lock must push a second frame");
 
         locker.unlock();                                            // inner
         Assertions.assertEquals(1, readLockDepth(locker),
-                "inner unlock must decrement depth to 1, not drain to 0");
-        Assertions.assertSame(outerSnapshot, readHeldEntries(locker),
-                "inner unlock must NOT clear the snapshot — outer still needs it");
+                "inner unlock must pop exactly one frame, not drain the stack");
 
         locker.unlock();                                            // outer
-        Assertions.assertEquals(0, readLockDepth(locker), "outer unlock must drain depth to 0");
-        Assertions.assertNull(readHeldEntries(locker),
-                "outer unlock must clear the snapshot now that no acquisition is in scope");
+        Assertions.assertEquals(0, readLockDepth(locker), "outer unlock must pop the last frame");
 
         // After full unwind a new lock/unlock cycle must work cleanly — proves the LockManager
         // state is balanced (no leaked LockHolders carrying refCount from the previous cycle).
@@ -242,7 +233,6 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
         Assertions.assertDoesNotThrow(locker::unlock,
                 "follow-up unlock() must release cleanly.");
         Assertions.assertEquals(0, readLockDepth(locker));
-        Assertions.assertNull(readHeldEntries(locker));
     }
 
     /**
@@ -262,33 +252,29 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
         locker.lock();
         locker.lock();
         Assertions.assertEquals(3, readLockDepth(locker));
-        Assertions.assertNotNull(readHeldEntries(locker));
 
         locker.close();
 
         Assertions.assertEquals(0, readLockDepth(locker),
                 "close() must drain all nested lock acquisitions, not just one level");
-        Assertions.assertNull(readHeldEntries(locker),
-                "close() must clear the snapshot once depth hits zero");
 
         // After close() drains, the LockManager state must allow a fresh lock/unlock cycle.
         // If close() left stale LockHolders behind, the next lock() would reenter at a higher
-        // refCount than expected; if it left depth/heldEntries inconsistent, the next
-        // unlock() would either no-op or crash.
+        // refCount than expected; if it left the stack inconsistent, the next unlock() would
+        // either no-op or crash.
         Assertions.assertDoesNotThrow(locker::lock);
         Assertions.assertDoesNotThrow(locker::unlock);
         Assertions.assertEquals(0, readLockDepth(locker));
     }
 
+    /**
+     * Number of acquisition frames the locker still owes an unlock() for — i.e. the size of the
+     * internal {@code heldStack}. Read reflectively so the test can assert the nested
+     * lock/unlock bookkeeping without widening the production API.
+     */
     private static int readLockDepth(PlannerMetaLocker locker) throws Exception {
-        Field f = PlannerMetaLocker.class.getDeclaredField("lockDepth");
+        Field f = PlannerMetaLocker.class.getDeclaredField("heldStack");
         f.setAccessible(true);
-        return f.getInt(locker);
-    }
-
-    private static Object readHeldEntries(PlannerMetaLocker locker) throws Exception {
-        Field f = PlannerMetaLocker.class.getDeclaredField("heldEntries");
-        f.setAccessible(true);
-        return f.get(locker);
+        return ((java.util.Collection<?>) f.get(locker)).size();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -182,5 +183,77 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
             Mockito.verify(constructed.get(0), Mockito.times(1))
                     .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
         }
+    }
+
+    /**
+     * Nested lock()/unlock() pattern (the optimistic-retry path:
+     * {@code InsertPlanner.buildExecPlanWithRetry} unlocks during planning then re-locks,
+     * and the retry iteration calls {@code StatementPlanner.reAnalyzeStmt}, which itself
+     * does {@code try { lock(); ... } finally { unlock(); }} on the same instance).
+     *
+     * <p>Pre-fix, lock() unconditionally overwrote {@code heldEntries} every call, and
+     * unlock() unconditionally cleared it. So:
+     *   <ul>
+     *     <li>inner lock() overwrote outer's snapshot (with the same content — no observable harm yet);</li>
+     *     <li>inner unlock() decremented LockManager refCount by 1 per rid (2 → 1) AND cleared {@code heldEntries};</li>
+     *     <li>outer unlock() saw {@code heldEntries == null} and was a no-op — but LockManager refCount
+     *         was still 1 per rid, so the locks were LEAKED, and the retry body continued to plan WHILE
+     *         STILL HOLDING the meta locks (the opposite of the design intent of the unlock-plan-relock cycle).</li>
+     *   </ul>
+     *
+     * <p>Fix uses an explicit {@code lockDepth} counter so nested lock()/unlock() pairs only
+     * touch their own LockManager refCount slot, and {@code heldEntries} is only cleared
+     * when the outermost unlock() drains the depth.
+     */
+    @Test
+    public void nestedLockUnlockReleasesAllReferences() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser("select * from t0", connectContext);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+
+        Assertions.assertEquals(0, readLockDepth(locker), "fresh instance must have depth 0");
+        Assertions.assertNull(readHeldEntries(locker), "fresh instance must have no snapshot");
+
+        locker.lock();                                              // outer
+        Assertions.assertEquals(1, readLockDepth(locker), "outer lock must increment depth to 1");
+        Assertions.assertNotNull(readHeldEntries(locker), "outer lock must record the snapshot");
+        Object outerSnapshot = readHeldEntries(locker);
+
+        locker.lock();                                              // inner (nested)
+        Assertions.assertEquals(2, readLockDepth(locker), "nested lock must bump depth to 2");
+        Assertions.assertSame(outerSnapshot, readHeldEntries(locker),
+                "nested lock must NOT overwrite the outer snapshot — the outer unlock relies on it");
+
+        locker.unlock();                                            // inner
+        Assertions.assertEquals(1, readLockDepth(locker),
+                "inner unlock must decrement depth to 1, not drain to 0");
+        Assertions.assertSame(outerSnapshot, readHeldEntries(locker),
+                "inner unlock must NOT clear the snapshot — outer still needs it");
+
+        locker.unlock();                                            // outer
+        Assertions.assertEquals(0, readLockDepth(locker), "outer unlock must drain depth to 0");
+        Assertions.assertNull(readHeldEntries(locker),
+                "outer unlock must clear the snapshot now that no acquisition is in scope");
+
+        // After full unwind a new lock/unlock cycle must work cleanly — proves the LockManager
+        // state is balanced (no leaked LockHolders carrying refCount from the previous cycle).
+        Assertions.assertDoesNotThrow(locker::lock,
+                "follow-up lock() after nested cycle must work — would fail if a stale LockHolder "
+                        + "was left in LockManager and a hierarchical/upgrade guard fired.");
+        Assertions.assertDoesNotThrow(locker::unlock,
+                "follow-up unlock() must release cleanly.");
+        Assertions.assertEquals(0, readLockDepth(locker));
+        Assertions.assertNull(readHeldEntries(locker));
+    }
+
+    private static int readLockDepth(PlannerMetaLocker locker) throws Exception {
+        Field f = PlannerMetaLocker.class.getDeclaredField("lockDepth");
+        f.setAccessible(true);
+        return f.getInt(locker);
+    }
+
+    private static Object readHeldEntries(PlannerMetaLocker locker) throws Exception {
+        Field f = PlannerMetaLocker.class.getDeclaredField("heldEntries");
+        f.setAccessible(true);
+        return f.get(locker);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerRollbackTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -178,6 +179,46 @@ public class PlannerMetaLockerRollbackTest extends PlanTestBase {
             // After rollback, unlock() must still be a no-op (no frame was pushed).
             Assertions.assertDoesNotThrow(locker::unlock);
             // And the unlock() call above must not have invoked unLockTablesWithIntensiveDbLock again.
+            Mockito.verify(constructed.get(0), Mockito.times(1))
+                    .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
+        }
+    }
+
+    /**
+     * tryLock multi-db variant: when a later db cannot be acquired (tryLock returns false),
+     * tryLock's finally block must roll back the earlier db(s) it did acquire and return false,
+     * leaving no leaked locks. Mirrors {@link #lockRollsBackEarlierDbsOnLaterDbFailure} for the
+     * non-throwing tryLock path.
+     */
+    @Test
+    public void tryLockRollsBackEarlierDbsOnLaterDbFailure() throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(
+                "select t0.v1 from t0 join db1.tbl1 on true", connectContext);
+
+        try (MockedConstruction<Locker> mocked = Mockito.mockConstruction(Locker.class,
+                (mock, ctx) -> {
+                    // First Locker (created in tryLock()): 1st db acquires, 2nd db times out (false).
+                    if (ctx.getCount() == 1) {
+                        Mockito.doReturn(true).doReturn(false)
+                                .when(mock)
+                                .tryLockTablesWithIntensiveDbLock(
+                                        anyLong(), anyList(), any(LockType.class), anyLong(), any(TimeUnit.class));
+                    }
+                })) {
+
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+            boolean acquired = locker.tryLock(0, TimeUnit.MILLISECONDS);
+            Assertions.assertFalse(acquired, "tryLock must return false when a later db cannot be acquired");
+
+            // The finally rollback must release the one db that was acquired, exactly once.
+            List<Locker> constructed = mocked.constructed();
+            Assertions.assertFalse(constructed.isEmpty());
+            Mockito.verify(constructed.get(0), Mockito.times(1))
+                    .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
+
+            // A failed tryLock() pushes no frame, so a following unlock() must be a no-op and
+            // must not release anything again.
+            Assertions.assertDoesNotThrow(locker::unlock);
             Mockito.verify(constructed.get(0), Mockito.times(1))
                     .unLockTablesWithIntensiveDbLock(anyLong(), anyList(), any(LockType.class));
         }


### PR DESCRIPTION
Companion to the Locker-level rollback that already landed upstream (#72423, #72789). Those PRs ensure that
`Locker.lock(Table|Tables)WithIntensiveDbLock` releases anything it partially acquired before re-throwing. This commit closes the remaining symptom at the PlannerMetaLocker layer.

Pre-fix behavior (the SmartNews 4.0.9 incident):

  caller: try { plannerMetaLocker.lock(); ... } finally { unlock(); }

  1. lock() iterates (db, tables) entries calling inner Locker.lockTablesWithIntensiveDbLock on each.
  2. The inner call throws on some entry (e.g. ERR_NO_FILES_FOUND in the FILES() planning path forcing the planner to bail, or a real LockException). Inner Locker rolls itself back — good.
  3. PlannerMetaLocker.lock() does NOT roll back any earlier (db, tables) entries that already succeeded; it just lets the exception propagate.
  4. The caller's finally calls unlock(), which blindly iterates the full `tables` map and releases entries that were never acquired.
  5. LockManager.release sees a Locker with no matching LockHolder and throws IllegalMonitorStateException: "Attempt to unlock lock, not locked by current locker" — surfaced to the client as ERROR 5600, masquerading as the original ERR_NO_FILES_FOUND.

Fix:

* `PlannerMetaLocker` now records `heldEntries` on successful lock()/tryLock(). unlock() only releases entries in `heldEntries`, and is a no-op when null.
* lock() wraps its multi-db loop in try/catch: on failure it releases the earlier (db, tables) entries it had successfully acquired (in reverse order, best-effort with logging), clears `heldEntries`, and re-throws. Inner-layer rollback (already in upstream Locker) handles the failing entry itself; this outer rollback only addresses entries that fully succeeded before the failing one.
* AutoCloseable.close() → unlock() is now safe to call when lock() was never invoked or threw.

Tests:

* `PlannerMetaLockerRollbackTest` (new): unlock-without-lock, close-without-lock, normal lock/unlock round-trip, single-db rollback (inner fails), multi-db rollback (first db succeeds, second throws — asserts the first db's release happened).
* `LockerIntensiveLockRollbackTest` (new): regression test pinning the contract that the Locker-layer fix from #72423/#72789 provides — six cases (mid-loop failure, first-rid failure, db-intent failure, single-table variant, WRITE mode, success path), each verified by trying to acquire an exclusive WRITE on the rid afterward from a fresh Locker (any leaked IS/READ would time out the attempt).

Related: POST-1561.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
