### PR TITLE
[Enhancement] Move slow-publishPartition threshold into Config for live tuning

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -497,6 +497,15 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum number of threads for Version Publish tasks in a shared-data cluster.
 - Introduced in: v3.2.0
 
+### `slow_publish_partition_log_threshold_ms`
+
+- Default: 3000
+- Type: Long
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: The threshold above which `PublishVersionDaemon` logs a per-phase breakdown (`executor_queue` + `db_lock_wait` + `fe_prep` + `rpc`) of a slow partition publish at the WARN level. Lower this value to capture sub-second jitter when investigating publish latency on a live cluster; raise it to silence routine slow-but-acceptable publishes. There is no behavior change at the default value.
+- Introduced in: v4.2
+
 ### `meta_sync_force_delete_shard_meta`
 
 - Default: false

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -496,6 +496,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：共有データクラスターでのバージョン公開タスクの最大スレッド数。
 - 導入時期：v3.2.0
 
+### `slow_publish_partition_log_threshold_ms`
+
+- デフォルト：3000
+- タイプ：Long
+- 単位：ミリ秒
+- 変更可能：Yes
+- 説明：`PublishVersionDaemon` がパーティション公開の所要時間がこの値を超えた場合に、各フェーズの内訳（`executor_queue` + `db_lock_wait` + `fe_prep` + `rpc`）を WARN レベルで出力するしきい値です。稼働中のクラスターで公開レイテンシを調査する際は、この値を下げてサブ秒単位のジッターを捕捉できます。通常の許容範囲内の遅い公開を抑制するには、この値を上げます。デフォルト値では動作に変更はありません。
+- 導入時期：v4.2
+
 ### `meta_sync_force_delete_shard_meta`
 
 - デフォルト：false

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -496,6 +496,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 存算分离集群中版本发布任务的最大线程数。
 - 引入版本: v3.2.0
 
+### `slow_publish_partition_log_threshold_ms`
+
+- 默认值: 3000
+- 类型: Long
+- 单位: 毫秒
+- 是否可变: Yes
+- 描述: 该阈值用于控制 `PublishVersionDaemon` 在分区发布耗时超过此值时，以 WARN 级别打印各阶段耗时明细（`executor_queue` + `db_lock_wait` + `fe_prep` + `rpc`）。在线上集群排查发布延迟时，可调小该值以捕获亚秒级抖动；可调大该值以屏蔽常规的、可接受的慢发布。在默认值下行为无变化。
+- 引入版本: v4.2
+
 ### `meta_sync_force_delete_shard_meta`
 
 - 默认值: false

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3453,6 +3453,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "the max number of threads for lake table delete txnLog when enable batch publish")
     public static int lake_publish_delete_txnlog_max_threads = 16;
 
+    @ConfField(mutable = true, comment = "Threshold (ms) above which publishPartition logs a per-phase breakdown " +
+            "(executor_queue + db_lock_wait + fe_prep + rpc) at WARN level. Lower to capture sub-second jitter " +
+            "during latency investigations; raise to silence routine slow-but-acceptable publishes.")
+    public static long slow_publish_partition_log_threshold_ms = 3000;
+
     @ConfField(mutable = true, comment =
             "Whether to enable ADMIN SKIP COMMITTED TRANSACTION. When false, the admin SQL is " +
                     "rejected with an error. Default is false to prevent accidental data loss. " +

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -104,7 +104,10 @@ public class PublishVersionDaemon extends LeaderDaemon {
     // each thread under the default configurations
     private static final int PUBLISH_MAX_QUEUE_SIZE = 4096;
 
-    private static final long SLOW_PUBLISH_PARTITION_LOG_THRESHOLD_MS = 3000;
+    // Threshold for slow-publishPartition phase-breakdown WARN. Lives in
+    // Config.slow_publish_partition_log_threshold_ms so it can be tuned at runtime
+    // (ADMIN SET FRONTEND CONFIG) without a restart — handy for narrowing latency
+    // investigations against a live cluster.
 
     // for shared-data, task executor thread will be responsible for sending publish tasks to BE
     // and modify transaction state on FE
@@ -1149,7 +1152,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
                                              long submitTimeMs, long lambdaEntryMs, long lockAcquiredMs,
                                              long rpcStartMs, long rpcEndMs) {
         long totalMs = rpcEndMs - submitTimeMs;
-        if (totalMs < SLOW_PUBLISH_PARTITION_LOG_THRESHOLD_MS) {
+        if (totalMs < Config.slow_publish_partition_log_threshold_ms) {
             return;
         }
         LOG.warn("Slow publishPartition: txn={} partition={} table={}, total={}ms " +


### PR DESCRIPTION
## Why I'm doing:

The phase-breakdown WARN at `maybeLogSlowPublishPartition` is the right tool for investigating lake-publish latency outliers, but its threshold was a hardcoded `3000` ms constant — it could not be tuned without a code change and FE restart. When chasing sub-second publish-latency jitter on a live cluster, that coarse, immutable threshold leaves the gap between "start publish lake" and the `publish_version` BRPC unexplained.

## What I'm doing:

Surface the threshold as `Config.slow_publish_partition_log_threshold_ms` (mutable, default **3000 ms**) so operators can dial it in via `ADMIN SET FRONTEND CONFIG` against a live cluster without a restart, then restore the default once an investigation completes.

- Replace the `SLOW_PUBLISH_PARTITION_LOG_THRESHOLD_MS = 3000` constant in `PublishVersionDaemon` with a read of `Config.slow_publish_partition_log_threshold_ms`.
- Add the config field in `Config.java` (mutable, default 3000 ms).

No behavior change at the default 3000 ms; lowering it makes the daemon WARN with the `executor_queue / db_lock_wait / fe_prep / rpc` decomposition.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5