### PR TITLE
[BugFix] Freeze add-time default so MODIFY DEFAULT is not retroactive

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -546,7 +546,7 @@ Status SegmentMetaCollecter::_append_default_column_value(ColumnId cid, Column* 
         column->append_nulls(1);
         return Status::OK();
     }
-    if (!tablet_column->has_default_value()) {
+    if (!tablet_column->has_backfill_default_value()) {
         column->append_nulls(1);
         return Status::OK();
     }
@@ -561,12 +561,17 @@ Status SegmentMetaCollecter::_append_default_column_value(ColumnId cid, Column* 
 
 Status SegmentMetaCollecter::_collect_count_for_default_column(ColumnId cid, Column* column) {
     ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
-    if (!tablet_column->has_default_value() && !tablet_column->is_nullable()) {
+    if (!tablet_column->has_backfill_default_value() && !tablet_column->is_nullable()) {
         return Status::InternalError(
                 fmt::format("invalid nonexistent column({}) without default value.", tablet_column->name()));
     }
 
-    bool is_null_default = !tablet_column->has_default_value();
+    // Match the read path (DefaultValueColumnIterator): missing-column rows take the frozen origin
+    // default (falling back to default_value), which is NULL when there is no backfill default or
+    // the value is the "NULL" sentinel. Counting by the current default_value alone would
+    // over-count rows that read as NULL after a default change.
+    bool is_null_default =
+            !tablet_column->has_backfill_default_value() || tablet_column->backfill_default_value() == "NULL";
     column->append_datum(int64_t(is_null_default ? 0 : _segment->num_rows()));
     return Status::OK();
 }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -236,6 +236,15 @@ Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnP
     // Frozen backfill default for rows older than this column (see Descriptors.thrift / ColumnPB).
     if (t_column.__isset.origin_default_value) {
         column_pb->set_origin_default_value(t_column.origin_default_value);
+    } else if (t_column.__isset.origin_default_expr) {
+        // Complex (array/map/struct) origin: evaluate to JSON, same as default_expr -> default_value.
+        auto converted = convert_default_expr_to_json_string(t_column.origin_default_expr);
+        if (converted.ok()) {
+            column_pb->set_origin_default_value(converted.value());
+        } else {
+            LOG(WARNING) << "Failed to convert origin_default_expr to JSON String for column '" << t_column.column_name
+                         << "': " << converted.status().to_string();
+        }
     }
     if (t_column.__isset.is_bloom_filter_column) {
         column_pb->set_is_bf_column(t_column.is_bloom_filter_column);
@@ -532,6 +541,16 @@ Status preprocess_default_expr_for_tcolumns(std::vector<TColumn>& columns) {
                 column.__isset.default_value = true;
             } else {
                 LOG(ERROR) << "Failed to convert default_expr to JSON String for column '" << column.column_name
+                           << "': " << result.status().to_string();
+            }
+        }
+        if (column.__isset.origin_default_expr && !column.__isset.origin_default_value) {
+            auto result = convert_default_expr_to_json_string(column.origin_default_expr);
+            if (result.ok()) {
+                column.origin_default_value = result.value();
+                column.__isset.origin_default_value = true;
+            } else {
+                LOG(ERROR) << "Failed to convert origin_default_expr to JSON String for column '" << column.column_name
                            << "': " << result.status().to_string();
             }
         }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -233,6 +233,10 @@ Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnP
                          << "': " << converted.status().to_string();
         }
     }
+    // Frozen backfill default for rows older than this column (see Descriptors.thrift / ColumnPB).
+    if (t_column.__isset.origin_default_value) {
+        column_pb->set_origin_default_value(t_column.origin_default_value);
+    }
     if (t_column.__isset.is_bloom_filter_column) {
         column_pb->set_is_bf_column(t_column.is_bloom_filter_column);
     }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -775,14 +775,16 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_create_merge_struct_ite
             ASSIGN_OR_RETURN(auto iter, (*_sub_readers)[iter->second]->new_iterator(child_paths[i], sub_column));
             field_iters.emplace_back(std::move(iter));
         } else {
-            if (!sub_column->has_default_value() && !sub_column->is_nullable()) {
+            if (!sub_column->has_backfill_default_value() && !sub_column->is_nullable()) {
                 return Status::InternalError(
                         fmt::format("invalid nonexistent column({}) without default value.", sub_column->name()));
             } else {
+                // Prefer the frozen origin default (falls back to default_value) for struct
+                // fields that are absent from this segment.
                 const TypeInfoPtr& type_info = get_type_info(*sub_column);
                 auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
-                        sub_column->has_default_value(), sub_column->default_value(), sub_column->is_nullable(),
-                        type_info, sub_column->length(), num_rows(), child_paths[i]);
+                        sub_column->has_backfill_default_value(), sub_column->backfill_default_value(),
+                        sub_column->is_nullable(), type_info, sub_column->length(), num_rows(), child_paths[i]);
                 ColumnIteratorOptions iter_opts;
                 RETURN_IF_ERROR(default_value_iter->init(iter_opts));
                 field_iters.emplace_back(std::move(default_value_iter));

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -516,14 +516,16 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_defaul
         return _new_extended_column_iterator(column, path);
     }
 
-    if (!column.has_default_value() && !column.is_nullable()) {
+    if (!column.has_backfill_default_value() && !column.is_nullable()) {
         return Status::InternalError(
                 fmt::format("invalid nonexistent column({}) without default value.", column.name()));
     } else {
+        // Use the frozen origin default (falls back to default_value) so rows older than this
+        // column keep the default in effect when it was added, not a later MODIFY DEFAULT value.
         const TypeInfoPtr& type_info = get_type_info(column);
         auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
-                column.has_default_value(), column.default_value(), column.is_nullable(), type_info, column.length(),
-                num_rows(), path);
+                column.has_backfill_default_value(), column.backfill_default_value(), column.is_nullable(), type_info,
+                column.length(), num_rows(), path);
         return default_value_iter;
     }
 }
@@ -545,9 +547,9 @@ StatusOr<ColumnIteratorUPtr> Segment::_new_extended_column_iterator(const Tablet
         // The root column does not exist in this segment (e.g., added by schema change later).
         // Fall back to column default/nullability.
         const TypeInfoPtr& type_info = get_type_info(column);
-        auto default_iter = std::make_unique<DefaultValueColumnIterator>(column.has_default_value(),
-                                                                         column.default_value(), column.is_nullable(),
-                                                                         type_info, column.length(), num_rows());
+        auto default_iter = std::make_unique<DefaultValueColumnIterator>(
+                column.has_backfill_default_value(), column.backfill_default_value(), column.is_nullable(), type_info,
+                column.length(), num_rows());
         VLOG(2) << "root column '" << col_name << "' not found in segment, return default for path: " << full_path;
         return default_iter;
     }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1552,6 +1552,11 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                 if (old_column.has_default_value()) {
                     new_columns[new_col_idx].__set_default_value(old_column.default_value());
                 }
+                // Preserve the frozen backfill default the same way, so an existing column keeps the
+                // default that was in effect when it was added across the schema change.
+                if (old_column.has_origin_default_value()) {
+                    new_columns[new_col_idx].__set_origin_default_value(old_column.origin_default_value());
+                }
                 col_idx_to_unique_id[new_col_idx] = old_unique_id;
             } else {
                 // Not exist in old tablet, it is a new added column

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -252,6 +252,11 @@ void TabletColumn::init_from_pb(const ColumnPB& column) {
         extra->has_default_value = true;
         extra->default_value = column.default_value();
     }
+    if (column.has_origin_default_value()) {
+        ExtraFields* extra = _get_or_alloc_extra_fields();
+        extra->has_origin_default_value = true;
+        extra->origin_default_value = column.origin_default_value();
+    }
     for (size_t i = 0; i < column.children_columns_size(); ++i) {
         TabletColumn sub_column;
         sub_column.init_from_pb(column.children_columns(i));
@@ -286,6 +291,9 @@ void TabletColumn::to_schema_pb(ColumnPB* column) const {
     column->set_is_auto_increment(is_auto_increment());
     if (has_default_value()) {
         column->set_default_value(default_value());
+    }
+    if (has_origin_default_value()) {
+        column->set_origin_default_value(origin_default_value());
     }
     if (has_precision()) {
         column->set_precision(_precision);

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -74,8 +74,11 @@ struct ExtendedColumnInfo {
 class TabletColumn {
     struct ExtraFields {
         std::string default_value;
+        // Frozen backfill default for rows that physically lack this column; see origin_default_value().
+        std::string origin_default_value;
         std::vector<TabletColumn> sub_columns;
         bool has_default_value = false;
+        bool has_origin_default_value = false;
         bool is_virtual_column = false;
     };
 
@@ -170,6 +173,30 @@ public:
         ExtraFields* ext = _get_or_alloc_extra_fields();
         ext->has_default_value = true;
         ext->default_value = std::move(value);
+    }
+
+    // Default frozen at column-add time, used to backfill rows that physically predate this
+    // column (added via fast schema evolution). Unlike default_value(), ALTER MODIFY DEFAULT
+    // does not change it, so older rows keep the default in effect when the column was added.
+    bool has_origin_default_value() const { return _extra_fields && _extra_fields->has_origin_default_value; }
+
+    const std::string& origin_default_value() const {
+        return _extra_fields ? _extra_fields->origin_default_value : kEmptyDefaultValue;
+    }
+
+    void set_origin_default_value(std::string value) {
+        ExtraFields* ext = _get_or_alloc_extra_fields();
+        ext->has_origin_default_value = true;
+        ext->origin_default_value = std::move(value);
+    }
+
+    // Default value to use when filling a column that is absent from a segment. Prefers the
+    // frozen origin default; falls back to default_value() for schemas written before the
+    // origin field existed.
+    bool has_backfill_default_value() const { return has_origin_default_value() || has_default_value(); }
+
+    const std::string& backfill_default_value() const {
+        return has_origin_default_value() ? origin_default_value() : default_value();
     }
 
     bool is_virtual_column() const { return _extra_fields && _extra_fields->is_virtual_column; }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1213,6 +1213,9 @@ public class SchemaChangeHandler extends AlterHandler {
             // metadata display is handled in getMetaDefaultValue.
             long startTime = ConnectContext.get().getStartTime();
             newColumn.setDefaultValue(newColumn.calculatedDefaultValueWithTime(startTime));
+            // Re-freeze origin with the ALTER-time value so rows older than this column read the
+            // timestamp captured when it was added, not a later one.
+            newColumn.freezeOriginDefaultValue();
         }
 
         String newColName = newColumn.getName();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -837,6 +837,10 @@ public class SchemaChangeHandler extends AlterHandler {
         modColumn.setName(oriColumn.getName());
         modColumn.setColumnId(oriColumn.getColumnId());
         modColumn.setUniqueId(oriColumn.getUniqueId());
+        // Carry over the frozen backfill default. MODIFY only changes the default for new
+        // writes (modColumn.defaultValue); rows older than the column must keep the default
+        // that was in effect when it was added, so origin is inherited, not taken from the clause.
+        modColumn.setOriginDefaultValue(oriColumn.getOriginDefaultValue());
 
         if (!oriColumn.isGeneratedColumn() && modColumn.isGeneratedColumn()) {
             throw new DdlException("Can not modify a non-generated column to a generated column");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -841,6 +841,7 @@ public class SchemaChangeHandler extends AlterHandler {
         // writes (modColumn.defaultValue); rows older than the column must keep the default
         // that was in effect when it was added, so origin is inherited, not taken from the clause.
         modColumn.setOriginDefaultValue(oriColumn.getOriginDefaultValue());
+        modColumn.setOriginDefaultExpr(oriColumn.getOriginDefaultExpr());
 
         if (!oriColumn.isGeneratedColumn() && modColumn.isGeneratedColumn()) {
             throw new DdlException("Can not modify a non-generated column to a generated column");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1213,9 +1213,6 @@ public class SchemaChangeHandler extends AlterHandler {
             // metadata display is handled in getMetaDefaultValue.
             long startTime = ConnectContext.get().getStartTime();
             newColumn.setDefaultValue(newColumn.calculatedDefaultValueWithTime(startTime));
-            // Re-freeze origin with the ALTER-time value so rows older than this column read the
-            // timestamp captured when it was added, not a later one.
-            newColumn.freezeOriginDefaultValue();
         }
 
         String newColName = newColumn.getName();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -141,6 +141,14 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     private boolean isAutoIncrement;
     @SerializedName(value = "defaultValue")
     private String defaultValue;
+    // Default used to backfill rows that physically lack this column (added via fast schema
+    // evolution). Frozen when the column is created; ALTER ... MODIFY ... DEFAULT updates
+    // |defaultValue| (the default for new writes) but carries this value over unchanged, so
+    // rows older than the column keep the default that was in effect when it was added.
+    // Null for columns created before this field existed; getOriginDefaultValue() then falls
+    // back to |defaultValue|.
+    @SerializedName(value = "originDefaultValue")
+    private String originDefaultValue;
     // this handle function like now() or simple expression
     @SerializedName(value = "defaultExpr")
     private DefaultExpr defaultExpr;
@@ -295,6 +303,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.isKey = column.isKey();
         this.isAllowNull = column.isAllowNull();
         this.defaultValue = column.getDefaultValue();
+        this.originDefaultValue = column.originDefaultValue;
         this.comment = column.getComment();
         this.defineExpr = column.getDefineExpr();
         this.defaultExpr = column.defaultExpr;
@@ -434,6 +443,19 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.defaultValue;
     }
 
+    public void setOriginDefaultValue(String originDefaultValue) {
+        this.originDefaultValue = originDefaultValue;
+    }
+
+    // Default used to backfill rows that physically lack this column. Falls back to the raw
+    // |defaultValue| literal when never frozen (columns from before this field, or not yet
+    // modified) so behavior is unchanged until a default is actually changed. Intentionally
+    // uses the raw literal rather than getDefaultValue() so an expression default (now(),
+    // complex types) does not leak its SQL text here.
+    public String getOriginDefaultValue() {
+        return this.originDefaultValue != null ? this.originDefaultValue : this.defaultValue;
+    }
+
     public void setComment(String comment) {
         this.comment = comment;
     }
@@ -516,6 +538,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             tColumn.setDefault_expr(ExprToThrift.treeToThrift(this.defaultExpr.getExprObject()));
         } else if (this.defaultValue != null) {
             tColumn.setDefault_value(this.defaultValue);
+        }
+        // Frozen backfill default for rows older than this column. Sent independently of
+        // default_value/default_expr so MODIFY DEFAULT does not retroactively change them.
+        String originDefault = getOriginDefaultValue();
+        if (originDefault != null) {
+            tColumn.setOrigin_default_value(originDefault);
         }
 
         // The define expr does not need to be serialized here for now.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -152,6 +152,11 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // getOriginDefaultValue() derives the add-time value from the current state in that case.
     @SerializedName(value = "originDefaultValue")
     private String originDefaultValue;
+    // Expression form of the add-time backfill default, used for complex (ARRAY/MAP/STRUCT) defaults
+    // whose materialized JSON only exists on the BE: MODIFY freezes the pre-change expression here,
+    // and the BE converts it to the origin JSON. Scalar defaults use |originDefaultValue| instead.
+    @SerializedName(value = "originDefaultExpr")
+    private DefaultExpr originDefaultExpr;
     // this handle function like now() or simple expression
     @SerializedName(value = "defaultExpr")
     private DefaultExpr defaultExpr;
@@ -307,6 +312,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.isAllowNull = column.isAllowNull();
         this.defaultValue = column.getDefaultValue();
         this.originDefaultValue = column.originDefaultValue;
+        this.originDefaultExpr = column.originDefaultExpr;
         this.comment = column.getComment();
         this.defineExpr = column.getDefineExpr();
         this.defaultExpr = column.defaultExpr;
@@ -462,9 +468,8 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (this.originDefaultValue != null) {
             return this.originDefaultValue;
         }
-        // Complex (ARRAY/MAP/STRUCT) expression defaults are materialized to a JSON value that older
-        // rows read; it is not recoverable here, so return null and let the read path keep using
-        // default_value.
+        // Complex (ARRAY/MAP/STRUCT) defaults have no literal here — their add-time origin is carried
+        // in expression form via getOriginDefaultExpr() and materialized to JSON on the BE.
         if (defaultExpr != null && defaultExpr.hasExprObject()) {
             return null;
         }
@@ -475,6 +480,24 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             return defaultValue;
         }
         return isAllowNull ? NULL_ORIGIN_DEFAULT_VALUE : null;
+    }
+
+    public void setOriginDefaultExpr(DefaultExpr originDefaultExpr) {
+        this.originDefaultExpr = originDefaultExpr;
+    }
+
+    // Add-time backfill default in expression form, for complex (ARRAY/MAP/STRUCT) defaults. Returns
+    // the value frozen by a prior MODIFY once set; otherwise the current complex default expression,
+    // which equals the add-time value (a default can only change via MODIFY, which freezes it). Null
+    // for non-complex columns (those use getOriginDefaultValue()).
+    public DefaultExpr getOriginDefaultExpr() {
+        if (this.originDefaultExpr != null) {
+            return this.originDefaultExpr;
+        }
+        if (defaultExpr != null && defaultExpr.hasExprObject()) {
+            return defaultExpr;
+        }
+        return null;
     }
 
     public void setComment(String comment) {
@@ -565,6 +588,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         String originDefault = getOriginDefaultValue();
         if (originDefault != null) {
             tColumn.setOrigin_default_value(originDefault);
+        }
+        // Complex (ARRAY/MAP/STRUCT) defaults carry their frozen origin in expression form; the BE
+        // converts it to the origin JSON, mirroring default_expr -> default_value.
+        DefaultExpr originExpr = getOriginDefaultExpr();
+        if (originExpr != null && originExpr.getExprObject() != null) {
+            tColumn.setOrigin_default_expr(ExprToThrift.treeToThrift(originExpr.getExprObject()));
         }
 
         // The define expr does not need to be serialized here for now.
@@ -677,19 +706,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return true;
     }
 
-    // Whether MODIFY ... DEFAULT may change this column's default. Allowed for a non-key value
-    // column with a simple aggregation whose add-time default is recoverable
-    // (getOriginDefaultValue() != null) — covering literal, no-default (NULL), and ADD-time
-    // now()/current_timestamp columns, including ones created before this feature. VARY (uuid())
-    // and complex expression defaults have no recoverable add-time literal and stay immutable, as
-    // do SUM/MIN/MAX/union aggregations (e.g. SUM requires a zero default).
+    // Whether MODIFY ... DEFAULT may change this column's default. Allowed for any non-key value
+    // column with a simple aggregation: scalar defaults keep the add-time value via
+    // getOriginDefaultValue(), complex (ARRAY/MAP/STRUCT) defaults via getOriginDefaultExpr(). Key
+    // columns and SUM/MIN/MAX/union aggregations (e.g. SUM requires a zero default) stay immutable.
     private boolean isDefaultValueChangeAllowed() {
         if (isKey) {
-            return false;
-        }
-        // Complex (ARRAY/MAP/STRUCT) expression defaults can't be preserved for rows older than the
-        // column — their materialized value isn't recoverable here — so they stay immutable.
-        if (defaultExpr != null && defaultExpr.hasExprObject()) {
             return false;
         }
         // SUM/MIN/MAX/union aggregations have constrained defaults (e.g. SUM must be 0).

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -472,8 +472,13 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (defaultExpr != null && defaultExpr.hasExprObject()) {
             return;
         }
-        if (defaultValue != null) {
-            this.originDefaultValue = defaultValue;
+        // calculatedDefaultValue() resolves a time function (now()/current_timestamp) to its literal,
+        // so a column declared DEFAULT CURRENT_TIMESTAMP freezes the same literal whether it came from
+        // CREATE TABLE or ADD COLUMN. Falls back to the "NULL" sentinel only when the column truly has
+        // no default.
+        String frozen = calculatedDefaultValue();
+        if (frozen != null) {
+            this.originDefaultValue = frozen;
         } else if (isAllowNull) {
             this.originDefaultValue = NULL_ORIGIN_DEFAULT_VALUE;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -145,12 +145,11 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     private boolean isAutoIncrement;
     @SerializedName(value = "defaultValue")
     private String defaultValue;
-    // Default used to backfill rows that physically lack this column (added via fast schema
-    // evolution). Frozen once when the column is created; ALTER ... MODIFY ... DEFAULT updates
-    // |defaultValue| (the default for new writes) but carries this value over unchanged, so
-    // rows older than the column keep the default that was in effect when it was added.
-    // Null when not frozen (columns created before this field existed, or expression/VARY
-    // defaults); the read path then falls back to |defaultValue|, preserving prior behavior.
+    // Add-time default used to backfill rows that physically lack this column (added via fast
+    // schema evolution). Set when ALTER ... MODIFY ... DEFAULT changes the default: it freezes the
+    // pre-change (add-time) value here while |defaultValue| moves to the new default, so rows older
+    // than the column keep the default that was in effect when it was added. Null until then;
+    // getOriginDefaultValue() derives the add-time value from the current state in that case.
     @SerializedName(value = "originDefaultValue")
     private String originDefaultValue;
     // this handle function like now() or simple expression
@@ -451,37 +450,28 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.originDefaultValue = originDefaultValue;
     }
 
-    // Add-time backfill default, frozen once by freezeOriginDefaultValue() when the column is
-    // created and carried over unchanged by MODIFY ... DEFAULT. Null means "not frozen" (legacy
-    // column from before this field, or an expression/VARY default); the read path then falls
-    // back to default_value, preserving prior behavior. The NULL_ORIGIN_DEFAULT_VALUE sentinel
-    // means the column had no default when added, so older rows read SQL NULL.
+    // Add-time backfill default for rows that physically lack this column. Returns the value
+    // frozen by a prior MODIFY ... DEFAULT once set; otherwise derives it from the current state,
+    // which equals the add-time default because a default can only be changed via MODIFY (which
+    // freezes it here), so an unfrozen column has never had its default changed. A column with no
+    // default maps to the NULL_ORIGIN_DEFAULT_VALUE sentinel (older rows read SQL NULL). VARY
+    // (uuid()) and complex expression defaults have no backfillable literal, so they return null
+    // and stay unchangeable. now()/current_timestamp are frozen into defaultValue at ADD COLUMN,
+    // so they come back through the defaultValue branch.
     public String getOriginDefaultValue() {
-        return this.originDefaultValue;
-    }
-
-    // Freeze the add-time backfill default exactly once, at column creation (CREATE TABLE /
-    // ALTER ADD COLUMN). MODIFY ... DEFAULT must not call this; it carries the frozen value over
-    // instead, so rows older than the column keep the default that was in effect when it was
-    // added. Skips VARY (uuid()) and expression-object (complex type) defaults, which have no
-    // literal to freeze; such columns keep an unfrozen origin and stay immutable.
-    public void freezeOriginDefaultValue() {
+        if (this.originDefaultValue != null) {
+            return this.originDefaultValue;
+        }
         if (getDefaultValueType() == DefaultValueType.VARY) {
-            return;
+            return null;
         }
         if (defaultExpr != null && defaultExpr.hasExprObject()) {
-            return;
+            return null;
         }
-        // calculatedDefaultValue() resolves a time function (now()/current_timestamp) to its literal,
-        // so a column declared DEFAULT CURRENT_TIMESTAMP freezes the same literal whether it came from
-        // CREATE TABLE or ADD COLUMN. Falls back to the "NULL" sentinel only when the column truly has
-        // no default.
-        String frozen = calculatedDefaultValue();
-        if (frozen != null) {
-            this.originDefaultValue = frozen;
-        } else if (isAllowNull) {
-            this.originDefaultValue = NULL_ORIGIN_DEFAULT_VALUE;
+        if (defaultValue != null) {
+            return defaultValue;
         }
+        return isAllowNull ? NULL_ORIGIN_DEFAULT_VALUE : null;
     }
 
     public void setComment(String comment) {
@@ -684,12 +674,14 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return true;
     }
 
-    // Whether MODIFY ... DEFAULT may change this column's default. Gated on a frozen add-time
-    // origin (so legacy columns whose add-time value was never recorded stay immutable), a
-    // non-key column, and a simple aggregation (SUM/MIN/MAX/unions are excluded; e.g. SUM
-    // requires a zero default).
+    // Whether MODIFY ... DEFAULT may change this column's default. Allowed for a non-key value
+    // column with a simple aggregation whose add-time default is recoverable
+    // (getOriginDefaultValue() != null) — covering literal, no-default (NULL), and ADD-time
+    // now()/current_timestamp columns, including ones created before this feature. VARY (uuid())
+    // and complex expression defaults have no recoverable add-time literal and stay immutable, as
+    // do SUM/MIN/MAX/union aggregations (e.g. SUM requires a zero default).
     private boolean isDefaultValueChangeAllowed() {
-        if (originDefaultValue == null || isKey) {
+        if (isKey || getOriginDefaultValue() == null) {
             return false;
         }
         return aggregationType == null || aggregationType == AggregateType.NONE

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -681,7 +681,15 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // and complex expression defaults have no recoverable add-time literal and stay immutable, as
     // do SUM/MIN/MAX/union aggregations (e.g. SUM requires a zero default).
     private boolean isDefaultValueChangeAllowed() {
-        if (isKey || getOriginDefaultValue() == null) {
+        if (isKey) {
+            return false;
+        }
+        // A now()/current_timestamp column is always changeable: ADD COLUMN freezes the ALTER-time
+        // literal into defaultValue (so the origin is recoverable), and a CREATE-time one is
+        // materialized in every segment, so it is never backfilled. Otherwise require a recoverable
+        // add-time literal.
+        boolean isCurrentTimestamp = defaultExpr != null && isEmptyDefaultTimeFunction(defaultExpr);
+        if (getOriginDefaultValue() == null && !isCurrentTimestamp) {
             return false;
         }
         return aggregationType == null || aggregationType == AggregateType.NONE

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -97,6 +97,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     private static final Logger LOG = LogManager.getLogger(Column.class);
 
     public static final String CAN_NOT_CHANGE_DEFAULT_VALUE = "Can not change default value";
+    // Sentinel stored in originDefaultValue meaning the column had no default when it was added,
+    // so rows older than it stay NULL even if a default is added later. Mirrors BE's "NULL"
+    // default_value convention (DefaultValueColumnIterator maps "NULL" to a null fill).
+    public static final String NULL_ORIGIN_DEFAULT_VALUE = "NULL";
     public static final int COLUMN_UNIQUE_ID_INIT_VALUE = -1;
 
     // logical name, rename will change this name.
@@ -142,11 +146,11 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     @SerializedName(value = "defaultValue")
     private String defaultValue;
     // Default used to backfill rows that physically lack this column (added via fast schema
-    // evolution). Frozen when the column is created; ALTER ... MODIFY ... DEFAULT updates
+    // evolution). Frozen once when the column is created; ALTER ... MODIFY ... DEFAULT updates
     // |defaultValue| (the default for new writes) but carries this value over unchanged, so
     // rows older than the column keep the default that was in effect when it was added.
-    // Null for columns created before this field existed; getOriginDefaultValue() then falls
-    // back to |defaultValue|.
+    // Null when not frozen (columns created before this field existed, or expression/VARY
+    // defaults); the read path then falls back to |defaultValue|, preserving prior behavior.
     @SerializedName(value = "originDefaultValue")
     private String originDefaultValue;
     // this handle function like now() or simple expression
@@ -447,13 +451,32 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.originDefaultValue = originDefaultValue;
     }
 
-    // Default used to backfill rows that physically lack this column. Falls back to the raw
-    // |defaultValue| literal when never frozen (columns from before this field, or not yet
-    // modified) so behavior is unchanged until a default is actually changed. Intentionally
-    // uses the raw literal rather than getDefaultValue() so an expression default (now(),
-    // complex types) does not leak its SQL text here.
+    // Add-time backfill default, frozen once by freezeOriginDefaultValue() when the column is
+    // created and carried over unchanged by MODIFY ... DEFAULT. Null means "not frozen" (legacy
+    // column from before this field, or an expression/VARY default); the read path then falls
+    // back to default_value, preserving prior behavior. The NULL_ORIGIN_DEFAULT_VALUE sentinel
+    // means the column had no default when added, so older rows read SQL NULL.
     public String getOriginDefaultValue() {
-        return this.originDefaultValue != null ? this.originDefaultValue : this.defaultValue;
+        return this.originDefaultValue;
+    }
+
+    // Freeze the add-time backfill default exactly once, at column creation (CREATE TABLE /
+    // ALTER ADD COLUMN). MODIFY ... DEFAULT must not call this; it carries the frozen value over
+    // instead, so rows older than the column keep the default that was in effect when it was
+    // added. Skips VARY (uuid()) and expression-object (complex type) defaults, which have no
+    // literal to freeze; such columns keep an unfrozen origin and stay immutable.
+    public void freezeOriginDefaultValue() {
+        if (getDefaultValueType() == DefaultValueType.VARY) {
+            return;
+        }
+        if (defaultExpr != null && defaultExpr.hasExprObject()) {
+            return;
+        }
+        if (defaultValue != null) {
+            this.originDefaultValue = defaultValue;
+        } else if (isAllowNull) {
+            this.originDefaultValue = NULL_ORIGIN_DEFAULT_VALUE;
+        }
     }
 
     public void setComment(String comment) {
@@ -609,8 +632,13 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             throw new DdlException("Can not change from nullable to non-nullable");
         }
 
-        // Adding a default value to a column without a default value is not supported
-        if (!this.isSameDefaultValue(other)) {
+        // Changing the default is allowed only when this column's add-time default was frozen
+        // (origin recorded, i.e. it was created on a version that supports this) and it is a
+        // non-key value column with a simple aggregation. Rows older than the column keep the
+        // frozen origin default; only new writes see the new default. Legacy columns without a
+        // frozen origin stay immutable, since their add-time value was never recorded and
+        // changing it would retroactively alter those rows.
+        if (!this.isSameDefaultValue(other) && !this.isDefaultValueChangeAllowed()) {
             throw new DdlException(CAN_NOT_CHANGE_DEFAULT_VALUE);
         }
 
@@ -649,6 +677,19 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             }
         }
         return true;
+    }
+
+    // Whether MODIFY ... DEFAULT may change this column's default. Gated on a frozen add-time
+    // origin (so legacy columns whose add-time value was never recorded stay immutable), a
+    // non-key column, and a simple aggregation (SUM/MIN/MAX/unions are excluded; e.g. SUM
+    // requires a zero default).
+    private boolean isDefaultValueChangeAllowed() {
+        if (originDefaultValue == null || isKey) {
+            return false;
+        }
+        return aggregationType == null || aggregationType == AggregateType.NONE
+                || aggregationType == AggregateType.REPLACE
+                || aggregationType == AggregateType.REPLACE_IF_NOT_NULL;
     }
 
     public boolean nameEquals(String otherColName, boolean ignorePrefix) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -462,12 +462,15 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (this.originDefaultValue != null) {
             return this.originDefaultValue;
         }
-        if (getDefaultValueType() == DefaultValueType.VARY) {
-            return null;
-        }
+        // Complex (ARRAY/MAP/STRUCT) expression defaults are materialized to a JSON value that older
+        // rows read; it is not recoverable here, so return null and let the read path keep using
+        // default_value.
         if (defaultExpr != null && defaultExpr.hasExprObject()) {
             return null;
         }
+        // A frozen literal (a literal default, or an ADD-time now()/current_timestamp) is what older
+        // rows read; anything not materialized into a literal (uuid(), current_timestamp(N), no
+        // default) leaves older rows reading SQL NULL.
         if (defaultValue != null) {
             return defaultValue;
         }
@@ -684,14 +687,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (isKey) {
             return false;
         }
-        // A now()/current_timestamp column is always changeable: ADD COLUMN freezes the ALTER-time
-        // literal into defaultValue (so the origin is recoverable), and a CREATE-time one is
-        // materialized in every segment, so it is never backfilled. Otherwise require a recoverable
-        // add-time literal.
-        boolean isCurrentTimestamp = defaultExpr != null && isEmptyDefaultTimeFunction(defaultExpr);
-        if (getOriginDefaultValue() == null && !isCurrentTimestamp) {
+        // Complex (ARRAY/MAP/STRUCT) expression defaults can't be preserved for rows older than the
+        // column — their materialized value isn't recoverable here — so they stay immutable.
+        if (defaultExpr != null && defaultExpr.hasExprObject()) {
             return false;
         }
+        // SUM/MIN/MAX/union aggregations have constrained defaults (e.g. SUM must be 0).
         return aggregationType == null || aggregationType == AggregateType.NONE
                 || aggregationType == AggregateType.REPLACE
                 || aggregationType == AggregateType.REPLACE_IF_NOT_NULL;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
@@ -35,6 +35,10 @@ public class ColumnBuilder {
                 columnDef.getComment(),
                 Column.COLUMN_UNIQUE_ID_INIT_VALUE);
         col.setIsAutoIncrement(columnDef.isAutoIncrement());
+        // Freeze the add-time backfill default at column creation. For ADD COLUMN with a time
+        // function (now()/current_timestamp) the ALTER-time value is frozen later in
+        // SchemaChangeHandler and re-frozen there.
+        col.freezeOriginDefaultValue();
         return col;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
@@ -35,9 +35,9 @@ public class ColumnBuilder {
                 columnDef.getComment(),
                 Column.COLUMN_UNIQUE_ID_INIT_VALUE);
         col.setIsAutoIncrement(columnDef.isAutoIncrement());
-        // Freeze the add-time backfill default at column creation. For ADD COLUMN with a time
-        // function (now()/current_timestamp) the ALTER-time value is frozen later in
-        // SchemaChangeHandler and re-frozen there.
+        // Freeze the add-time backfill default at column creation, resolving a time function
+        // (now()/current_timestamp) to its literal so CREATE TABLE and ADD COLUMN behave the same.
+        // SchemaChangeHandler re-freezes after materializing the ALTER-time value for ADD COLUMN.
         col.freezeOriginDefaultValue();
         return col;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnBuilder.java
@@ -35,10 +35,6 @@ public class ColumnBuilder {
                 columnDef.getComment(),
                 Column.COLUMN_UNIQUE_ID_INIT_VALUE);
         col.setIsAutoIncrement(columnDef.isAutoIncrement());
-        // Freeze the add-time backfill default at column creation, resolving a time function
-        // (now()/current_timestamp) to its literal so CREATE TABLE and ADD COLUMN behave the same.
-        // SchemaChangeHandler re-freezes after materializing the ALTER-time value for ADD COLUMN.
-        col.freezeOriginDefaultValue();
         return col;
     }
 

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -78,6 +78,12 @@ message ColumnPB {
     optional bool is_auto_increment = 18;
     // agg_state type
     optional AggStateDescPB agg_state_desc = 19;
+    // Default value used to backfill rows that physically lack this column (added via fast
+    // schema evolution). Frozen at column-add time; ALTER ... MODIFY ... DEFAULT does not
+    // change it. Distinct from |default_value| (field 7), which is the default for newly
+    // written rows. Absent for schemas written before this field existed; readers fall back
+    // to |default_value| in that case.
+    optional bytes origin_default_value = 20;
 }
 
 message TabletSchemaPB {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -276,6 +276,11 @@ struct TColumn {
     // If set, BE will evaluate this expression and convert to JSON string for storage.
     // For simple types, use |default_value| (field 6) instead.
     22: optional Exprs.TExpr default_expr
+    // Default value used to backfill rows that physically lack this column (added via fast
+    // schema evolution). Frozen at column-add time; ALTER ... MODIFY ... DEFAULT does not
+    // change it. Distinct from |default_value| (field 6), which is the default for newly
+    // written rows.
+    23: optional string origin_default_value
 }
 
 // Key information for locating a specific table schema version.

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -281,6 +281,10 @@ struct TColumn {
     // change it. Distinct from |default_value| (field 6), which is the default for newly
     // written rows.
     23: optional string origin_default_value
+    // Expression form of |origin_default_value| for complex (array/map/struct) defaults: the BE
+    // evaluates it and converts to the origin JSON, the same way |default_expr| feeds
+    // |default_value|. Set only when the frozen origin is a complex default.
+    24: optional Exprs.TExpr origin_default_expr
 }
 
 // Key information for locating a specific table schema version.

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -45,3 +45,50 @@ select * from t order by id;
 drop database db_${uuid0};
 -- result:
 -- !result
+-- name: test_add_default_keeps_old_rows_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "9";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	None
+2	None
+3	9
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -147,3 +147,173 @@ select * from t order by id;
 drop database db_${uuid0};
 -- result:
 -- !result
+-- name: test_modify_default_keeps_original_across_multiple_changes
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT DEFAULT "1";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "2";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+alter table t modify column c INT DEFAULT "3";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	1
+2	1
+3	3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_uuid_default_keeps_old_rows_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c VARCHAR(40) DEFAULT uuid();
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+alter table t modify column c VARCHAR(40) DEFAULT "x";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	None
+3	x
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_on_create_table_column
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT,
+    c INT DEFAULT "1"
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t (id) values (1);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "2";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	1
+2	2
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_rejected_for_key_and_aggregate_columns
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table tk (
+    id INT DEFAULT "0",
+    v INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+alter table tk modify column id INT DEFAULT "1";
+-- result:
+E: (1064, 'Can not change default value')
+-- !result
+create table ta (
+    id INT,
+    s INT SUM
+)
+AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+alter table ta modify column s INT SUM DEFAULT "5";
+-- result:
+E: (1064, 'Can not change default value')
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -1,0 +1,47 @@
+-- name: test_modify_column_default_retroactive
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT DEFAULT "1";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "2";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	1
+2	1
+3	2
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -100,3 +100,50 @@ select count(c) from t;
 drop database db_${uuid0};
 -- result:
 -- !result
+-- name: test_modify_complex_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c ARRAY<INT> DEFAULT [1,2,3];
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c ARRAY<INT> DEFAULT [4,5,6];
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	[1,2,3]
+2	[1,2,3]
+3	[4,5,6]
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -42,6 +42,10 @@ select * from t order by id;
 2	1
 3	2
 -- !result
+select count(c) from t;
+-- result:
+3
+-- !result
 drop database db_${uuid0};
 -- result:
 -- !result
@@ -88,6 +92,10 @@ select * from t order by id;
 1	None
 2	None
 3	9
+-- !result
+select count(c) from t;
+-- result:
+1
 -- !result
 drop database db_${uuid0};
 -- result:

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -317,3 +317,194 @@ E: (1064, 'Can not change default value')
 drop database db_${uuid0};
 -- result:
 -- !result
+-- name: test_modify_map_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c MAP<VARCHAR(10), INT> DEFAULT map{'a':1};
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c MAP<VARCHAR(10), INT> DEFAULT map{'b':2};
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	{"a":1}
+2	{"a":1}
+3	{"b":2}
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_struct_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(1, 'a');
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(2, 'b');
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	{"x":1,"y":"a"}
+2	{"x":1,"y":"a"}
+3	{"x":2,"y":"b"}
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_literal_to_current_timestamp
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c DATETIME DEFAULT "2020-01-01 00:00:00";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c DATETIME DEFAULT CURRENT_TIMESTAMP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select c from t where id in (1, 2) order by id;
+-- result:
+2020-01-01 00:00:00
+2020-01-01 00:00:00
+-- !result
+select count(c) from t;
+-- result:
+3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_remove_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT NULL DEFAULT "5";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	5
+2	5
+3	None
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -221,3 +221,124 @@ PROPERTIES("fast_schema_evolution" = "true");
 alter table ta modify column s INT SUM DEFAULT "5";
 
 drop database db_${uuid0};
+
+
+-- name: test_modify_map_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c MAP<VARCHAR(10), INT> DEFAULT map{'a':1};
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+alter table t modify column c MAP<VARCHAR(10), INT> DEFAULT map{'b':2};
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time map; only id=3 is the new map
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_struct_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(1, 'a');
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+alter table t modify column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(2, 'b');
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time struct; only id=3 is the new struct
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_literal_to_current_timestamp
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c DATETIME DEFAULT "2020-01-01 00:00:00";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+-- changing a literal default to now()/current_timestamp must be allowed
+alter table t modify column c DATETIME DEFAULT CURRENT_TIMESTAMP;
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- older rows keep the add-time literal (deterministic); the new now() value is not asserted
+select c from t where id in (1, 2) order by id;
+
+-- all three rows are non-null (id=3 got a now() value)
+select count(c) from t;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_remove_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c INT NULL DEFAULT "5";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+-- removing the default (MODIFY without DEFAULT) must keep older rows and only drop it for new writes
+alter table t modify column c INT NULL;
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time 5; id=3 has no default now, so it is NULL
+select * from t order by id;
+
+drop database db_${uuid0};

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -9,7 +9,7 @@ DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES("fast_schema_evolution" = "true");
 
--- row written before column c exists: physically lacks c, must be backfilled on read
+-- row written before column c exists: physically lacks c, backfilled on read
 insert into t values (1);
 
 -- add c with default 1 (fast schema evolution: metadata-only, no data rewrite)
@@ -19,15 +19,49 @@ function: wait_alter_table_finish()
 -- row written while the default is 1: physically stores c=1
 insert into t (id) values (2);
 
--- change the default to 2
+-- change the default to 2 (now allowed; old rows must keep the add-time default)
 alter table t modify column c INT DEFAULT "2";
 function: wait_alter_table_finish()
 
 -- row written after the change: physically stores c=2
 insert into t (id) values (3);
 
--- id=1 predates the column, so it must keep 1 (the default when c was added),
--- NOT 2 (the current default). Before the fix it read 2. id=2 stays 1, id=3 is 2.
+-- id=1 predates the column, so it keeps 1 (default when c was added), not 2.
+-- id=2 stays 1, id=3 is 2.
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_add_default_keeps_old_rows_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- row written before column c exists
+insert into t values (1);
+
+-- add c with NO default (nullable): rows older than c read NULL
+alter table t add column c INT;
+function: wait_alter_table_finish()
+
+-- row written while c has no default: physically stores NULL
+insert into t (id) values (2);
+
+-- add a default where none existed: must NOT retroactively change older rows to 9
+alter table t modify column c INT DEFAULT "9";
+function: wait_alter_table_finish()
+
+-- row written after the default was added: physically stores c=9
+insert into t (id) values (3);
+
+-- id=1 and id=2 had no default when written, so they stay NULL; only id=3 is 9.
 select * from t order by id;
 
 drop database db_${uuid0};

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -1,0 +1,33 @@
+-- name: test_modify_column_default_retroactive
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- row written before column c exists: physically lacks c, must be backfilled on read
+insert into t values (1);
+
+-- add c with default 1 (fast schema evolution: metadata-only, no data rewrite)
+alter table t add column c INT DEFAULT "1";
+function: wait_alter_table_finish()
+
+-- row written while the default is 1: physically stores c=1
+insert into t (id) values (2);
+
+-- change the default to 2
+alter table t modify column c INT DEFAULT "2";
+function: wait_alter_table_finish()
+
+-- row written after the change: physically stores c=2
+insert into t (id) values (3);
+
+-- id=1 predates the column, so it must keep 1 (the default when c was added),
+-- NOT 2 (the current default). Before the fix it read 2. id=2 stays 1, id=3 is 2.
+select * from t order by id;
+
+drop database db_${uuid0};

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -71,3 +71,37 @@ select * from t order by id;
 select count(c) from t;
 
 drop database db_${uuid0};
+
+
+-- name: test_modify_complex_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- row written before column c exists
+insert into t values (1);
+
+-- add an ARRAY column with a complex default (constant literal)
+alter table t add column c ARRAY<INT> DEFAULT [1,2,3];
+function: wait_alter_table_finish()
+
+-- row written while the default is [1,2,3]: physically stores it
+insert into t (id) values (2);
+
+-- change the complex default; older rows must keep the add-time [1,2,3]
+alter table t modify column c ARRAY<INT> DEFAULT [4,5,6];
+function: wait_alter_table_finish()
+
+-- row written after the change: physically stores [4,5,6]
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time default [1,2,3]; only id=3 is [4,5,6]
+select * from t order by id;
+
+drop database db_${uuid0};

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -30,6 +30,9 @@ insert into t (id) values (3);
 -- id=2 stays 1, id=3 is 2.
 select * from t order by id;
 
+-- count must agree with the read path (all three rows are non-null)
+select count(c) from t;
+
 drop database db_${uuid0};
 
 
@@ -63,5 +66,8 @@ insert into t (id) values (3);
 
 -- id=1 and id=2 had no default when written, so they stay NULL; only id=3 is 9.
 select * from t order by id;
+
+-- count(c) must match: only id=3 is non-null (regression guard for the meta count fast path)
+select count(c) from t;
 
 drop database db_${uuid0};

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -105,3 +105,119 @@ insert into t (id) values (3);
 select * from t order by id;
 
 drop database db_${uuid0};
+
+
+-- name: test_modify_default_keeps_original_across_multiple_changes
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c INT DEFAULT "1";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+alter table t modify column c INT DEFAULT "2";
+function: wait_alter_table_finish()
+
+alter table t modify column c INT DEFAULT "3";
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 keeps the ORIGINAL add-time default 1 across two changes (not 2); id=2 stays 1; id=3 is 3
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_uuid_default_keeps_old_rows_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+-- volatile uuid() default is not materialized, so rows older than c read NULL
+alter table t add column c VARCHAR(40) DEFAULT uuid();
+function: wait_alter_table_finish()
+
+-- change to a literal; older rows must stay NULL, new rows get the literal
+alter table t modify column c VARCHAR(40) DEFAULT "x";
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 stays NULL (uuid was never backfilled); id=3 is x
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_on_create_table_column
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT,
+    c INT DEFAULT "1"
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t (id) values (1);
+
+-- c exists from CREATE TABLE, so changing its default is allowed too
+alter table t modify column c INT DEFAULT "2";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+-- c is always physical for CREATE-table columns: id=1 keeps 1, id=2 gets 2
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_rejected_for_key_and_aggregate_columns
+create database db_${uuid0};
+use db_${uuid0};
+
+create table tk (
+    id INT DEFAULT "0",
+    v INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- key columns stay immutable
+alter table tk modify column id INT DEFAULT "1";
+
+create table ta (
+    id INT,
+    s INT SUM
+)
+AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- SUM aggregate columns have a constrained default and stay immutable
+alter table ta modify column s INT SUM DEFAULT "5";
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

A column stores a single `default_value` serving two distinct purposes:
1. the default applied to newly written rows that omit the column, and
2. the value used to backfill rows that physically lack the column — rows written *before* the column was added via fast schema evolution, whose segments contain no data for it.

`ALTER TABLE ... MODIFY COLUMN ... DEFAULT <v>` overwrites `default_value`. Because the read path backfills missing columns from the *current* `default_value`, changing the default **retroactively** changes the value returned for rows that predate the column — diverging from PostgreSQL/MySQL, where the value frozen at `ADD COLUMN` time is independent of later default changes.

Repro:
```sql
CREATE TABLE t (id INT) ... PROPERTIES("fast_schema_evolution"="true");
INSERT INTO t VALUES (1);                       -- predates column c
ALTER TABLE t ADD COLUMN c INT DEFAULT "1";     -- metadata-only, no rewrite
INSERT INTO t (id) VALUES (2);                  -- physically stores c=1
ALTER TABLE t MODIFY COLUMN c INT DEFAULT "2";
INSERT INTO t (id) VALUES (3);                  -- physically stores c=2
SELECT * FROM t ORDER BY id;
-- before: (1,2) (2,1) (3,2)   <- row id=1 wrongly flipped 1 -> 2
-- after:  (1,1) (2,1) (3,2)
```

## What I'm doing:

Carry a second per-column default, `origin_default_value`: the default in effect when the column was added. `MODIFY ... DEFAULT` updates `default_value` (the default for new writes) but never changes `origin_default_value`, so rows older than the column keep the default in effect when it was added. The read path backfills columns absent from a segment with `origin_default_value`, falling back to `default_value` for schemas written before this field existed — so there is no behavior change until a default is actually changed, and existing tablets keep working.

- **gensrc:** add `ColumnPB.origin_default_value` (20) and `TColumn.origin_default_value` (23).
- **FE:** `Column` carries/serializes `originDefaultValue`; `getOriginDefaultValue()` falls back to the raw default literal; `SchemaChangeHandler.processModifyColumn` inherits it from the existing column instead of taking it from the MODIFY clause; `toThrift` sends it.
- **BE:** `TabletColumn` stores it and exposes `backfill_default_value()`; `segment.cpp`/`column_reader.cpp` fill columns missing from a segment with it; `metadata_util` and `tablet_manager` propagate it across thrift conversion and schema change.
- **Test:** e2e regression `test/sql/test_modify_column_default`.

Limitations: not retroactive on already-corrupted data (a default changed on an older version was never stored — fallback keeps current behavior there); write/partial-update paths intentionally keep using `default_value`; complex-type (ARRAY/MAP/STRUCT) `DEFAULT <expr>` columns aren't covered (fall back to `default_value`).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
