### PR TITLE
[Enhancement] Avro schema evolution for Kafka routine load

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -17,6 +17,7 @@
 #include "connector/file_scan_metrics.h"
 #include "exec/file_scanner/avro_cpp_scanner.h"
 #include "exec/file_scanner/avro_scanner.h"
+#include "exec/file_scanner/avro_stream_scanner.h"
 #include "exec/file_scanner/csv_scanner.h"
 #include "exec/file_scanner/json_scanner.h"
 #include "exec/file_scanner/orc_scanner.h"
@@ -104,8 +105,18 @@ Status FileDataSource::_create_scanner() {
              _scan_range.params.file_scan_type == TFileScanType::FILES_QUERY)) {
             _scanner = std::make_unique<AvroCppScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
         } else {
-            // avro routine load
-            _scanner = std::make_unique<AvroScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+            // avro routine load. FE resolves the per-job `avro.use_native_reader` property against its
+            // own default and sets use_native_avro_reader on every scan range, so the choice is uniform
+            // across BE nodes. Unset (older FE) falls back to the legacy scanner.
+            bool use_native =
+                    _scan_range.params.__isset.use_native_avro_reader && _scan_range.params.use_native_avro_reader;
+            if (use_native) {
+                // avrocpp stack (STRUCT/MAP support)
+                _scanner =
+                        std::make_unique<AvroStreamScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+            } else {
+                _scanner = std::make_unique<AvroScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+            }
         }
     } else {
         _scanner = std::make_unique<CSVScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -418,7 +418,10 @@ set(EXEC_NON_PIPELINE_FILES
     hdfs_scanner/hdfs_scanner.cpp
     hdfs_scanner/jni_scanner.cpp
     file_scanner/avro_cpp_scanner.cpp
+    file_scanner/avro_datum_path.cpp
     file_scanner/avro_scanner.cpp
+    file_scanner/avro_stream_scanner.cpp
+    file_scanner/confluent_avro_decoder.cpp
     file_scanner/csv_scanner.cpp
     file_scanner/file_scanner.cpp
     file_scanner/json_scanner.cpp

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -427,6 +427,7 @@ set(EXEC_NON_PIPELINE_FILES
     file_scanner/json_scanner.cpp
     file_scanner/orc_scanner.cpp
     file_scanner/parquet_scanner.cpp
+    file_scanner/stream_source_meta.cpp
     schema_scanner/schema_analyze_status.cpp
     schema_scanner/schema_tables_scanner.cpp
     schema_scanner/schema_schemata_scanner.cpp

--- a/be/src/exec/file_scanner/avro_datum_path.cpp
+++ b/be/src/exec/file_scanner/avro_datum_path.cpp
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/avro_datum_path.h"
+
+#include <avrocpp/GenericDatum.hh>
+#include <avrocpp/Types.hh>
+
+#include "common/status.h"
+#include "gutil/strings/substitute.h"
+
+namespace starrocks {
+
+static void replace_all(std::string& str, const std::string& from, const std::string& to) {
+    size_t pos = 0;
+    while ((pos = str.find(from, pos)) != std::string::npos) {
+        str.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+}
+
+std::string avro_preprocess_jsonpaths(std::string jsonpaths) {
+    replace_all(jsonpaths, ".*.", ".");
+    replace_all(jsonpaths, ".*", "");
+    return jsonpaths;
+}
+
+// A nullable Avro field is encoded as a union; the decoded GenericDatum holds the selected branch.
+// Peel unions until a non-union (possibly null) branch is reached. Avro forbids unions of unions, so
+// the loop normally runs at most once; it stays a loop only for defensiveness.
+static const avro::GenericDatum* unwrap_union(const avro::GenericDatum* datum) {
+    while (datum->type() == avro::AVRO_UNION) {
+        datum = &datum->value<avro::GenericUnion>().datum();
+    }
+    return datum;
+}
+
+static StatusOr<const avro::GenericDatum*> array_element(const avro::GenericDatum* datum, int idx) {
+    const auto& elements = datum->value<avro::GenericArray>().value();
+    // idx < 0 covers the wildcard [*] (idx == -2), which is intentionally unsupported.
+    if (idx < 0 || static_cast<size_t>(idx) >= elements.size()) {
+        return Status::InternalError(
+                strings::Substitute("array index $0 out of range (size $1)", idx, elements.size()));
+    }
+    return &elements[idx];
+}
+
+// Looks up `key` in a record (by field name) or a map (linear scan of key/value pairs). avrocpp's
+// GenericMap has no by-key accessor, hence the linear scan; map lookups via jsonpath are rare.
+static StatusOr<const avro::GenericDatum*> lookup(const avro::GenericDatum* datum, const std::string& key) {
+    if (datum->type() == avro::AVRO_RECORD) {
+        const auto& record = datum->value<avro::GenericRecord>();
+        if (!record.hasField(key)) {
+            return Status::NotFound(strings::Substitute("field not found: $0", key));
+        }
+        return &record.field(key);
+    }
+    // AVRO_MAP
+    for (const auto& entry : datum->value<avro::GenericMap>().value()) {
+        if (entry.first == key) {
+            return &entry.second;
+        }
+    }
+    return Status::NotFound(strings::Substitute("map key not found: $0", key));
+}
+
+StatusOr<const avro::GenericDatum*> avro_extract_field(const avro::GenericDatum& root,
+                                                       const std::vector<SimpleJsonPath>& path) {
+    const avro::GenericDatum* cur = &root;
+
+    // Whole-datum selector "$": return it (after peeling a top-level union).
+    if (path.size() == 1 && path[0].key == "$" && path[0].idx == -1) {
+        return unwrap_union(cur);
+    }
+
+    // Peel a top-level union before the root checks, so a nullable top-level array still takes the
+    // root-index branch below; a null root value makes every path NULL.
+    cur = unwrap_union(cur);
+    if (cur->type() == avro::AVRO_NULL) {
+        return cur;
+    }
+
+    if (cur->type() == avro::AVRO_ARRAY) {
+        // Root is an array: only $[i] selects into it.
+        if (path[0].key != "$" || path[0].idx < 0) {
+            return Status::InternalError("the avro root type is an array, select a specific array element");
+        }
+        ASSIGN_OR_RETURN(cur, array_element(cur, path[0].idx));
+    } else if (path[0].idx != -1) {
+        // Deliberate divergence from the legacy reader, which silently ignores a root array index on
+        // a non-array root and returns the whole datum (e.g. $[0] on a record yields the record).
+        return Status::InternalError("jsonpath has a root array index but the avro root value is not an array");
+    }
+
+    // path[0] is "$"; descend through the remaining segments.
+    for (size_t i = 1; i < path.size(); ++i) {
+        cur = unwrap_union(cur);
+        if (cur->type() == avro::AVRO_NULL) {
+            return cur;
+        }
+        const auto type = cur->type();
+        if (type != avro::AVRO_RECORD && type != avro::AVRO_MAP) {
+            // Deliberate divergence from the legacy AvroScanner::_extract_field, which on the LAST
+            // segment returns the scalar itself (e.g. $.id.x on a long `id` silently yields `id`).
+            // The native reader is opt-in, so a path that overshoots a leaf fails loudly instead of
+            // loading the parent value into the wrong column.
+            return Status::InternalError(strings::Substitute(
+                    "jsonpath segment '$0' descends into a non-record/map avro value", path[i].key));
+        }
+        ASSIGN_OR_RETURN(cur, lookup(cur, path[i].key));
+
+        if (path[i].idx != -1) {
+            cur = unwrap_union(cur);
+            if (cur->type() == avro::AVRO_NULL) {
+                return cur;
+            }
+            if (cur->type() != avro::AVRO_ARRAY) {
+                return Status::InternalError("a non-array type was found where an array index was expected");
+            }
+            ASSIGN_OR_RETURN(cur, array_element(cur, path[i].idx));
+        }
+    }
+
+    return unwrap_union(cur);
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/avro_datum_path.h
+++ b/be/src/exec/file_scanner/avro_datum_path.h
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <avrocpp/Generic.hh>
+#include <vector>
+
+#include "common/statusor.h"
+#include "exprs/json_functions.h" // SimpleJsonPath
+
+namespace starrocks {
+
+// Rewrites a jsonpaths string for the avrocpp navigator: ".*." -> "." and a trailing ".*" -> "",
+// so paths written for the old union-tag style (e.g. "$.*.id") resolve as "$.id". Must run before
+// JsonFunctions::parse_json_paths.
+std::string avro_preprocess_jsonpaths(std::string jsonpaths);
+
+// Navigates a decoded Avro datum along a parsed jsonpath (the same SimpleJsonPath vector produced by
+// JsonFunctions::parse_json_paths) and returns a pointer to the selected sub-datum. The pointer is
+// valid only as long as `root` is alive and unmodified.
+//
+// Returns NotFound when a record/map key along the path is absent, so the caller can append a null.
+// Returns InternalError on a structural mismatch (e.g. indexing a non-array). Wildcard `[*]`
+// (idx == -2) is intentionally unsupported and reported as an error.
+StatusOr<const avro::GenericDatum*> avro_extract_field(const avro::GenericDatum& root,
+                                                       const std::vector<SimpleJsonPath>& path);
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/avro_stream_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_stream_scanner.cpp
@@ -1,0 +1,257 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/avro_stream_scanner.h"
+
+#include <fmt/format.h>
+
+#include <avrocpp/Exception.hh>
+#include <avrocpp/GenericDatum.hh>
+#include <avrocpp/Types.hh>
+
+#include "base/time/timezone_utils.h"
+#include "column/adaptive_nullable_column.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "common/runtime_profile.h"
+#include "exec/file_scanner/json_scanner.h" // JsonScanner::parse_json_paths
+#include "fs/fs.h"
+#include "gutil/casts.h"
+#include "runtime/runtime_state.h"
+#include "runtime/runtime_state_helper.h"
+#include "runtime/stream_load/stream_load_pipe.h"
+#include "util/byte_buffer.h"
+
+namespace starrocks {
+
+AvroStreamScanner::AvroStreamScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                                     ScannerCounter* counter)
+        : FileScanner(state, profile, scan_range.params, counter),
+          _scan_range(scan_range),
+          _max_chunk_size(state->chunk_size()) {
+    _file_format_str = "avro";
+}
+
+AvroStreamScanner::~AvroStreamScanner() = default;
+
+Status AvroStreamScanner::open() {
+    RETURN_IF_ERROR(FileScanner::open());
+    if (_scan_range.ranges.empty()) {
+        return Status::OK();
+    }
+
+    if (!TimezoneUtils::find_cctz_time_zone(_state->timezone(), _timezone)) {
+        return Status::InvalidArgument(fmt::format("can not find cctz time zone {}", _state->timezone()));
+    }
+
+    const TBrokerRangeDesc& range_desc = _scan_range.ranges[0];
+
+    if (!_scan_range.params.__isset.confluent_schema_registry_url) {
+        return Status::InternalError("'confluent_schema_registry_url' not set");
+    }
+    _decoder = std::make_unique<ConfluentAvroDecoder>(_scan_range.params.confluent_schema_registry_url);
+    RETURN_IF_ERROR(_decoder->init());
+
+    if (range_desc.__isset.jsonpaths) {
+        std::string jsonpaths = avro_preprocess_jsonpaths(range_desc.jsonpaths);
+        RETURN_IF_ERROR(JsonScanner::parse_json_paths(jsonpaths, &_json_paths));
+    }
+
+    RETURN_IF_ERROR(create_column_readers());
+    RETURN_IF_ERROR(create_sequential_file(range_desc, _scan_range.broker_addresses[0], _scan_range.params, &_file));
+    ++_counter->num_files_read;
+    return Status::OK();
+}
+
+Status AvroStreamScanner::create_column_readers() {
+    _column_readers.resize(_src_slot_descriptors.size());
+    _field_names.resize(_src_slot_descriptors.size());
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        auto* slot_desc = _src_slot_descriptors[i];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        _column_readers[i] = avrocpp::ColumnReader::get_nullable_column_reader(slot_desc->col_name(), slot_desc->type(),
+                                                                               _timezone, !_strict_mode);
+        // Materialize the avro field name once; fill_row() reuses it per message instead of rebuilding a
+        // std::string from the pmr-backed col_name() string_view for every cell.
+        _field_names[i] = slot_desc->col_name();
+    }
+    return Status::OK();
+}
+
+Status AvroStreamScanner::create_src_chunk(ChunkPtr* chunk) {
+    SCOPED_RAW_TIMER(&_counter->init_chunk_ns);
+    *chunk = std::make_shared<Chunk>();
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        auto* slot_desc = _src_slot_descriptors[i];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        auto column = ColumnHelper::create_column(slot_desc->type(), true, false, 0, true);
+        (*chunk)->append_column(std::move(column), slot_desc->id());
+    }
+    return Status::OK();
+}
+
+Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk) {
+    const bool use_jsonpath = !_json_paths.empty();
+
+    const avro::GenericRecord* record = nullptr;
+    if (!use_jsonpath) {
+        const avro::GenericDatum* d = &datum;
+        while (d->type() == avro::AVRO_UNION) {
+            d = &d->value<avro::GenericUnion>().datum();
+        }
+        if (d->type() != avro::AVRO_RECORD) {
+            return Status::InternalError("avro message top-level value is not a record");
+        }
+        record = &d->value<avro::GenericRecord>();
+    }
+
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        auto* slot_desc = _src_slot_descriptors[i];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        auto* column = down_cast<AdaptiveNullableColumn*>(chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()));
+
+        if (use_jsonpath) {
+            if (i >= _json_paths.size()) {
+                column->append_nulls(1);
+                continue;
+            }
+            auto extracted = avro_extract_field(datum, _json_paths[i]);
+            if (extracted.status().is_not_found()) {
+                column->append_nulls(1);
+                continue;
+            }
+            RETURN_IF_ERROR(extracted.status());
+            RETURN_IF_ERROR(_column_readers[i]->read_datum_for_adaptive_column(*extracted.value(), column));
+        } else {
+            // GenericRecord::hasField/field take const std::string&; reuse the name materialized once in
+            // create_column_readers() (col_name() is a pmr-backed std::string_view).
+            const std::string& field_name = _field_names[i];
+            if (record->hasField(field_name)) {
+                RETURN_IF_ERROR(_column_readers[i]->read_datum_for_adaptive_column(record->field(field_name), column));
+            } else {
+                column->append_nulls(1);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status AvroStreamScanner::parse_one_message(const uint8_t* data, size_t size, Chunk* chunk) {
+    const size_t rows_before = chunk->num_rows();
+
+    Status st = _decoder->decode(data, size, &_datum);
+    if (!st.ok()) {
+        _counter->num_rows_filtered++;
+        RuntimeStateHelper::append_error_msg_to_file(_state, "", st.to_string());
+        return st;
+    }
+
+    // decode() converts avrocpp exceptions to Status itself; the readers below it do not, and a datum
+    // shape the guards don't anticipate must cost one filtered row, never the BE.
+    try {
+        st = fill_row(_datum, chunk);
+    } catch (const avro::Exception& e) {
+        st = Status::DataQualityError(fmt::format("avro read failed: {}", e.what()));
+    }
+    if (!st.ok()) {
+        if (_counter->num_rows_filtered++ < MAX_ERROR_LINES_IN_FILE) {
+            RuntimeStateHelper::append_error_msg_to_file(_state, "", st.to_string());
+        }
+        chunk->set_num_rows(rows_before);
+        return st;
+    }
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> AvroStreamScanner::get_next() {
+    SCOPED_RAW_TIMER(&_counter->total_ns);
+    // open() succeeds without initializing _file when the scan range carries no ranges.
+    if (_file == nullptr) {
+        return Status::EndOfFile("no avro ranges to read");
+    }
+    ChunkPtr src_chunk;
+    RETURN_IF_ERROR(create_src_chunk(&src_chunk));
+
+    auto* stream = down_cast<StreamLoadPipeInputStream*>(_file->stream().get());
+
+    Status st = Status::OK();
+    while (src_chunk->num_rows() < static_cast<size_t>(_max_chunk_size)) {
+        ByteBufferPtr buf;
+        {
+            ++_counter->file_read_count;
+            SCOPED_RAW_TIMER(&_counter->file_read_ns);
+            auto res = stream->pipe()->read();
+            if (!res.ok()) {
+                st = res.status();
+                break;
+            }
+            buf = std::move(res.value());
+        }
+        if (buf == nullptr || buf->remaining() == 0) {
+            continue;
+        }
+        // Confluent framing requires one message per buffer; StreamLoadPipe::read() returns the whole
+        // buffer that KafkaConsumerPipe::append_json enqueued, so each buffer is exactly one message.
+        RETURN_IF_ERROR(
+                parse_one_message(reinterpret_cast<const uint8_t*>(buf->ptr), buf->remaining(), src_chunk.get()));
+    }
+
+    // A non-timeout/non-EOF read error (cancel/abort/internal) is fatal regardless of how many rows
+    // were already filled, matching the legacy AvroScanner. Otherwise it would be deferred to the next
+    // get_next(), or lost entirely if the caller stops after consuming this chunk.
+    if (!st.ok() && !st.is_time_out() && !st.is_end_of_file()) {
+        return st;
+    }
+
+    if (src_chunk->num_rows() == 0) {
+        if (st.is_end_of_file()) {
+            return Status::EndOfFile("EOF of reading avro stream, nothing read");
+        }
+        // Timeout with nothing read yet: surface it so the task retries; with rows already filled we
+        // fall through and materialize what we have (legacy behavior).
+        if (st.is_time_out()) {
+            return st;
+        }
+    }
+
+    materialize_src_chunk_adaptive_nullable_column(src_chunk);
+    return materialize(src_chunk, src_chunk);
+}
+
+void AvroStreamScanner::materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk) {
+    chunk->materialized_nullable();
+    for (int i = 0; i < chunk->num_columns(); i++) {
+        auto* adaptive_column = down_cast<AdaptiveNullableColumn*>(chunk->get_column_raw_ptr_by_index(i));
+        chunk->update_column_by_index(NullableColumn::create(adaptive_column->materialized_raw_data_column(),
+                                                             adaptive_column->materialized_raw_null_column()),
+                                      i);
+    }
+}
+
+void AvroStreamScanner::close() {
+    if (!_closed) {
+        _file.reset();
+        _closed = true;
+    }
+    FileScanner::close();
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/avro_stream_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_stream_scanner.cpp
@@ -27,6 +27,7 @@
 #include "column/nullable_column.h"
 #include "common/runtime_profile.h"
 #include "exec/file_scanner/json_scanner.h" // JsonScanner::parse_json_paths
+#include "exec/file_scanner/stream_source_meta.h"
 #include "fs/fs.h"
 #include "gutil/casts.h"
 #include "runtime/runtime_state.h"
@@ -69,6 +70,8 @@ Status AvroStreamScanner::open() {
         RETURN_IF_ERROR(JsonScanner::parse_json_paths(jsonpaths, &_json_paths));
     }
 
+    _meta_cols = build_stream_source_meta_columns(_scan_range.params.stream_source_meta_columns);
+
     RETURN_IF_ERROR(create_column_readers());
     RETURN_IF_ERROR(create_sequential_file(range_desc, _scan_range.broker_addresses[0], _scan_range.params, &_file));
     ++_counter->num_files_read;
@@ -106,7 +109,7 @@ Status AvroStreamScanner::create_src_chunk(ChunkPtr* chunk) {
     return Status::OK();
 }
 
-Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk) {
+Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk, const StreamMessageMeta* meta) {
     const bool use_jsonpath = !_json_paths.empty();
 
     const avro::GenericRecord* record = nullptr;
@@ -121,6 +124,10 @@ Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk
         record = &d->value<avro::GenericRecord>();
     }
 
+    // Hidden metadata columns carry no jsonpath, so they are transparent to the positional
+    // slot->jsonpath mapping: a jsonpath maps to the i-th non-metadata slot. This keeps payload columns
+    // aligned even when a metadata column sits before jsonpath-backed columns.
+    size_t meta_count = 0;
     for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
         auto* slot_desc = _src_slot_descriptors[i];
         if (slot_desc == nullptr) {
@@ -128,12 +135,21 @@ Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk
         }
         auto* column = down_cast<AdaptiveNullableColumn*>(chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()));
 
+        // Hidden source-metadata slots are filled from the message meta (by slot id), not the payload,
+        // before the jsonpath/by-name extraction below.
+        if (auto it = _meta_cols.find(slot_desc->id()); it != _meta_cols.end()) {
+            RETURN_IF_ERROR(fill_stream_source_meta_column(it->second.kind, it->second.key, meta, column));
+            meta_count++;
+            continue;
+        }
+
         if (use_jsonpath) {
-            if (i >= _json_paths.size()) {
+            size_t jp = i - meta_count;
+            if (jp >= _json_paths.size()) {
                 column->append_nulls(1);
                 continue;
             }
-            auto extracted = avro_extract_field(datum, _json_paths[i]);
+            auto extracted = avro_extract_field(datum, _json_paths[jp]);
             if (extracted.status().is_not_found()) {
                 column->append_nulls(1);
                 continue;
@@ -154,26 +170,30 @@ Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk
     return Status::OK();
 }
 
-Status AvroStreamScanner::parse_one_message(const uint8_t* data, size_t size, Chunk* chunk) {
+Status AvroStreamScanner::parse_one_message(const uint8_t* data, size_t size, Chunk* chunk,
+                                            const StreamMessageMeta* meta) {
     const size_t rows_before = chunk->num_rows();
+    auto meta_ctx = [meta]() -> std::string {
+        return meta != nullptr ? fmt::format("[meta: {}]", meta->to_string()) : "";
+    };
 
     Status st = _decoder->decode(data, size, &_datum);
     if (!st.ok()) {
         _counter->num_rows_filtered++;
-        RuntimeStateHelper::append_error_msg_to_file(_state, "", st.to_string());
+        RuntimeStateHelper::append_error_msg_to_file(_state, meta_ctx(), st.to_string());
         return st;
     }
 
     // decode() converts avrocpp exceptions to Status itself; the readers below it do not, and a datum
     // shape the guards don't anticipate must cost one filtered row, never the BE.
     try {
-        st = fill_row(_datum, chunk);
+        st = fill_row(_datum, chunk, meta);
     } catch (const avro::Exception& e) {
         st = Status::DataQualityError(fmt::format("avro read failed: {}", e.what()));
     }
     if (!st.ok()) {
         if (_counter->num_rows_filtered++ < MAX_ERROR_LINES_IN_FILE) {
-            RuntimeStateHelper::append_error_msg_to_file(_state, "", st.to_string());
+            RuntimeStateHelper::append_error_msg_to_file(_state, meta_ctx(), st.to_string());
         }
         chunk->set_num_rows(rows_before);
         return st;
@@ -210,8 +230,8 @@ StatusOr<ChunkPtr> AvroStreamScanner::get_next() {
         }
         // Confluent framing requires one message per buffer; StreamLoadPipe::read() returns the whole
         // buffer that KafkaConsumerPipe::append_json enqueued, so each buffer is exactly one message.
-        RETURN_IF_ERROR(
-                parse_one_message(reinterpret_cast<const uint8_t*>(buf->ptr), buf->remaining(), src_chunk.get()));
+        RETURN_IF_ERROR(parse_one_message(reinterpret_cast<const uint8_t*>(buf->ptr), buf->remaining(), src_chunk.get(),
+                                          stream_source_meta_of(buf)));
     }
 
     // A non-timeout/non-EOF read error (cancel/abort/internal) is fatal regardless of how many rows

--- a/be/src/exec/file_scanner/avro_stream_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_stream_scanner.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <avrocpp/Exception.hh>
 #include <avrocpp/GenericDatum.hh>
 #include <avrocpp/Types.hh>
@@ -28,11 +29,13 @@
 #include "common/runtime_profile.h"
 #include "exec/file_scanner/json_scanner.h" // JsonScanner::parse_json_paths
 #include "exec/file_scanner/stream_source_meta.h"
+#include "formats/avro/cpp/avro_schema_builder.h"
 #include "fs/fs.h"
 #include "gutil/casts.h"
 #include "runtime/runtime_state.h"
 #include "runtime/runtime_state_helper.h"
 #include "runtime/stream_load/stream_load_pipe.h"
+#include "types/type_descriptor.h"
 #include "util/byte_buffer.h"
 
 namespace starrocks {
@@ -65,6 +68,8 @@ Status AvroStreamScanner::open() {
     _decoder = std::make_unique<ConfluentAvroDecoder>(_scan_range.params.confluent_schema_registry_url);
     RETURN_IF_ERROR(_decoder->init());
 
+    _enable_schema_evolution = _state->query_options().enable_avro_schema_evolution;
+
     if (range_desc.__isset.jsonpaths) {
         std::string jsonpaths = avro_preprocess_jsonpaths(range_desc.jsonpaths);
         RETURN_IF_ERROR(JsonScanner::parse_json_paths(jsonpaths, &_json_paths));
@@ -91,6 +96,13 @@ Status AvroStreamScanner::create_column_readers() {
         // Materialize the avro field name once; fill_row() reuses it per message instead of rebuilding a
         // std::string from the pmr-backed col_name() string_view for every cell.
         _field_names[i] = slot_desc->col_name();
+        // Classify the slot for schema-evolution detection: metadata slots are a reserved namespace
+        // (filled by id, not from payload), payload slots are the ones that can evolve.
+        if (_meta_cols.count(slot_desc->id()) > 0) {
+            _meta_slot_names.insert(_field_names[i]);
+        } else {
+            _payload_types.emplace(_field_names[i], slot_desc->type());
+        }
     }
     return Status::OK();
 }
@@ -161,13 +173,239 @@ Status AvroStreamScanner::fill_row(const avro::GenericDatum& datum, Chunk* chunk
             // create_column_readers() (col_name() is a pmr-backed std::string_view).
             const std::string& field_name = _field_names[i];
             if (record->hasField(field_name)) {
-                RETURN_IF_ERROR(_column_readers[i]->read_datum_for_adaptive_column(record->field(field_name), column));
+                const avro::GenericDatum& field_datum = record->field(field_name);
+                // varchar/varbinary length evolution: an over-length value fails the task so the FE can
+                // widen the column (the avro schema carries no length, so this is value-driven).
+                if (_enable_schema_evolution) {
+                    RETURN_IF_ERROR(check_varchar_widen(field_name, slot_desc->type(), field_datum));
+                }
+                RETURN_IF_ERROR(_column_readers[i]->read_datum_for_adaptive_column(field_datum, column));
             } else {
                 column->append_nulls(1);
             }
         }
     }
     return Status::OK();
+}
+
+// Unwrap an avro union down to its single non-null branch (the shape of a nullable field, ["null", T]).
+// A genuine multi-branch union has no single mapped type, so it is returned as-is and treated as opaque.
+static avro::NodePtr avro_non_null_branch(const avro::NodePtr& node) {
+    if (node->type() != avro::AVRO_UNION) {
+        return node;
+    }
+    avro::NodePtr branch;
+    for (size_t i = 0; i < node->leaves(); ++i) {
+        if (node->leafAt(i)->type() != avro::AVRO_NULL) {
+            if (branch != nullptr) {
+                return node; // more than one non-null branch: opaque
+            }
+            branch = node->leafAt(i);
+        }
+    }
+    return branch != nullptr ? branch : node;
+}
+
+// Byte-width rank within the integer and float families, so "is the column wide enough" is a comparison.
+static int numeric_rank(LogicalType t) {
+    switch (t) {
+    case TYPE_TINYINT:
+        return 1;
+    case TYPE_SMALLINT:
+        return 2;
+    case TYPE_INT:
+    case TYPE_FLOAT:
+        return 4;
+    case TYPE_BIGINT:
+    case TYPE_DOUBLE:
+        return 8;
+    case TYPE_LARGEINT:
+        return 16;
+    default:
+        return 0;
+    }
+}
+
+// True if column `col` can hold the writer field's mapped scalar type `desired` without loss. A
+// varchar/varbinary column accommodates any value (the reader stringifies / JSON-encodes it), so it always
+// fits. Otherwise the column must be the same type or a wider one in the same family; cross-family or
+// narrowing changes (long->INT, double->FLOAT, int->DATE, scalar->other scalar) do not fit and are
+// escalated to the FE. Varchar *length* is not judged here (avro strings are unbounded) — an over-length
+// value is caught per row in fill_row().
+static bool avro_scalar_fits(const TypeDescriptor& desired, const TypeDescriptor& col) {
+    if (is_string_type(col.type) || is_binary_type(col.type)) {
+        return true;
+    }
+    if (is_decimalv3_field_type(col.type)) {
+        if (is_decimalv3_field_type(desired.type)) {
+            return col.precision >= desired.precision && col.scale >= desired.scale;
+        }
+        // integer/float into decimal: the reader casts with a per-value overflow check.
+        return is_integer_type(desired.type) || is_float_type(desired.type);
+    }
+    if (is_integer_type(col.type)) {
+        return is_integer_type(desired.type) && numeric_rank(col.type) >= numeric_rank(desired.type);
+    }
+    if (is_float_type(col.type)) {
+        if (is_integer_type(desired.type)) {
+            return true; // an integer always fits a float column
+        }
+        return is_float_type(desired.type) && numeric_rank(col.type) >= numeric_rank(desired.type);
+    }
+    // DATE/DATETIME/BOOLEAN/JSON/...: only an exact type match fits.
+    return desired.type == col.type;
+}
+
+// True if everything the avro node carries is accommodated by `table_type`: every struct field has a
+// matching column/subfield (by name) AND every scalar's writer type fits the column type, recursing
+// through struct/array/map. A false return is the signal to escalate the schema to the FE.
+static bool avro_field_covered(const avro::NodePtr& node_in, const TypeDescriptor& table_type) {
+    const avro::NodePtr node = avro_non_null_branch(node_in);
+    switch (node->type()) {
+    case avro::AVRO_RECORD: {
+        // A non-struct column still holds a record if it is varchar/varbinary (the reader JSON-encodes it);
+        // any other column type cannot, so the kind change must be escalated.
+        if (table_type.type != TYPE_STRUCT) {
+            return is_string_type(table_type.type) || is_binary_type(table_type.type);
+        }
+        for (size_t i = 0; i < node->leaves(); ++i) {
+            const std::string& field_name = node->nameAt(i);
+            auto it = std::find(table_type.field_names.begin(), table_type.field_names.end(), field_name);
+            if (it == table_type.field_names.end()) {
+                return false; // a struct subfield with no matching field on the table side
+            }
+            size_t idx = std::distance(table_type.field_names.begin(), it);
+            if (!avro_field_covered(node->leafAt(i), table_type.children[idx])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    case avro::AVRO_ARRAY:
+        if (table_type.type != TYPE_ARRAY || table_type.children.empty()) {
+            return is_string_type(table_type.type) || is_binary_type(table_type.type);
+        }
+        return avro_field_covered(node->leafAt(0), table_type.children[0]);
+    case avro::AVRO_MAP:
+        if (table_type.type != TYPE_MAP || table_type.children.size() < 2) {
+            return is_string_type(table_type.type) || is_binary_type(table_type.type);
+        }
+        // Avro map keys are always strings; a non-string key column cannot take them (the map reader
+        // rejects it per row), so escalate instead of letting every row fail.
+        if (!is_string_type(table_type.children[0].type) && !is_binary_type(table_type.children[0].type)) {
+            return false;
+        }
+        return avro_field_covered(node->leafAt(1), table_type.children[1]); // children: [0]=key, [1]=value
+    default: {
+        TypeDescriptor desired;
+        if (!get_avro_type(node, &desired).ok()) {
+            return true; // unmappable writer type: don't escalate (defensive, avoids spurious failures)
+        }
+        return avro_scalar_fits(desired, table_type);
+    }
+    }
+}
+
+bool avro_schema_needs_evolution(const avro::NodePtr& record_node,
+                                 const std::unordered_map<std::string, TypeDescriptor>& payload_types,
+                                 const std::unordered_set<std::string>& meta_names) {
+    for (size_t i = 0; i < record_node->leaves(); ++i) {
+        const std::string& field_name = record_node->nameAt(i);
+        // A field colliding with a hidden metadata column: the slot is filled by id, not from the payload,
+        // so a same-named field would be silently dropped. Escalate so the FE can fail the job and the user
+        // resolves the clash (the FE recognizes the collision from the full schema).
+        if (meta_names.count(field_name) > 0) {
+            return true;
+        }
+        auto it = payload_types.find(field_name);
+        if (it == payload_types.end()) {
+            return true; // a top-level field with no table column
+        }
+        if (!avro_field_covered(record_node->leafAt(i), it->second)) {
+            return true; // a new struct subfield somewhere under an existing column
+        }
+    }
+    return false;
+}
+
+StatusOr<std::vector<TColumn>> avro_record_to_columns(const avro::NodePtr& record_node) {
+    std::vector<TColumn> columns;
+    columns.reserve(record_node->leaves());
+    for (size_t i = 0; i < record_node->leaves(); ++i) {
+        TypeDescriptor type_desc;
+        RETURN_IF_ERROR(get_avro_type(record_node->leafAt(i), &type_desc));
+        TColumn col;
+        col.__set_column_name(record_node->nameAt(i));
+        col.__set_type_desc(type_desc.to_thrift());
+        col.__set_is_allow_null(true);
+        columns.emplace_back(std::move(col));
+    }
+    return columns;
+}
+
+bool avro_value_overflows_varchar(const TypeDescriptor& col_type, const avro::GenericDatum& datum) {
+    const bool varchar = col_type.type == TYPE_VARCHAR;
+    const bool varbinary = col_type.type == TYPE_VARBINARY;
+    if ((!varchar && !varbinary) || col_type.len >= TypeDescriptor::MAX_VARCHAR_LENGTH) {
+        return false; // not a narrow varchar/varbinary: nothing to widen
+    }
+    const avro::GenericDatum* d = &datum;
+    while (d->type() == avro::AVRO_UNION) {
+        d = &d->value<avro::GenericUnion>().datum();
+    }
+    size_t value_len = 0;
+    if (varchar && d->type() == avro::AVRO_STRING) {
+        value_len = d->value<std::string>().size();
+    } else if (varbinary && d->type() == avro::AVRO_BYTES) {
+        value_len = d->value<std::vector<uint8_t>>().size();
+    } else {
+        return false; // other value kinds become a per-row data error in the reader, not a widen
+    }
+    return static_cast<int>(value_len) > col_type.len;
+}
+
+Status AvroStreamScanner::check_varchar_widen(const std::string& field_name, const TypeDescriptor& col_type,
+                                              const avro::GenericDatum& field_datum) {
+    if (!avro_value_overflows_varchar(col_type, field_datum)) {
+        return Status::OK();
+    }
+    _state->add_avro_widen_column(_last_checked_schema_id, field_name);
+    return Status::InternalError(
+            fmt::format("avro schema evolution: value exceeds {}({}) column '{}'; column needs widening",
+                        col_type.type == TYPE_VARCHAR ? "varchar" : "varbinary", col_type.len, field_name));
+}
+
+Status AvroStreamScanner::check_for_new_columns(const avro::GenericDatum& datum, int32_t schema_id) {
+    // Unwrap unions down to the record, mirroring fill_row().
+    const avro::GenericDatum* d = &datum;
+    while (d->type() == avro::AVRO_UNION) {
+        d = &d->value<avro::GenericUnion>().datum();
+    }
+    if (d->type() != avro::AVRO_RECORD) {
+        // Non-record top level has no columns to evolve; remember the id so we don't re-check it.
+        _last_checked_schema_id = schema_id;
+        return Status::OK();
+    }
+
+    const avro::GenericRecord& record = d->value<avro::GenericRecord>();
+    _last_checked_schema_id = schema_id;
+    if (!avro_schema_needs_evolution(record.schema(), _payload_types, _meta_slot_names)) {
+        // Schema id changed but the table already covers every field (also how the loop ends after an
+        // ALTER: the next task's dest tuple covers the schema, so it no longer escalates); nothing to do.
+        return Status::OK();
+    }
+
+    // The table is missing at least one field this schema carries. Ship the full writer schema to the FE
+    // (every top-level field with its complete nested type) and fail the task. The FE diffs it against the
+    // live table and owns every decision: ADD COLUMN for an absent column, ADD FIELD for a new struct
+    // subfield, or fail the job on a metadata-column collision. The BE neither computes the diff nor picks
+    // the DDL — with the whole schema in hand that all belongs on the FE.
+    ASSIGN_OR_RETURN(auto columns, avro_record_to_columns(record.schema()));
+    const size_t num_cols = columns.size();
+    _state->set_avro_schema_change(schema_id, std::move(columns));
+    return Status::InternalError(fmt::format(
+            "avro schema evolution required: schema id {} not covered by table; sent {} schema column(s) to FE",
+            schema_id, num_cols));
 }
 
 Status AvroStreamScanner::parse_one_message(const uint8_t* data, size_t size, Chunk* chunk,
@@ -177,11 +415,21 @@ Status AvroStreamScanner::parse_one_message(const uint8_t* data, size_t size, Ch
         return meta != nullptr ? fmt::format("[meta: {}]", meta->to_string()) : "";
     };
 
-    Status st = _decoder->decode(data, size, &_datum);
+    int32_t schema_id = -1;
+    Status st = _decoder->decode(data, size, &_datum, &schema_id);
     if (!st.ok()) {
         _counter->num_rows_filtered++;
         RuntimeStateHelper::append_error_msg_to_file(_state, meta_ctx(), st.to_string());
         return st;
+    }
+
+    // Detect new columns before filling the row. On the first message of a new schema id this either
+    // returns an error (table needs an ALTER) or marks the id as checked; fill_row then runs as usual.
+    // Schema evolution runs only on the by-name path (_json_paths empty). jsonpaths are excluded because
+    // routine-load avro never had a working jsonpath->column mapping, so that path carries no by-name
+    // field->column binding for evolution to build on.
+    if (_enable_schema_evolution && _json_paths.empty() && schema_id != _last_checked_schema_id) {
+        RETURN_IF_ERROR(check_for_new_columns(_datum, schema_id));
     }
 
     // decode() converts avrocpp exceptions to Status itself; the readers below it do not, and a datum

--- a/be/src/exec/file_scanner/avro_stream_scanner.h
+++ b/be/src/exec/file_scanner/avro_stream_scanner.h
@@ -19,11 +19,13 @@
 #include "exec/file_scanner/avro_datum_path.h"
 #include "exec/file_scanner/confluent_avro_decoder.h"
 #include "exec/file_scanner/file_scanner.h"
+#include "exec/file_scanner/stream_source_meta.h"
 #include "formats/avro/cpp/column_reader.h"
 
 namespace starrocks {
 
 class SequentialFile;
+class StreamMessageMeta;
 
 // Routine-load (Kafka) Avro scanner on the avrocpp stack. Reads one Confluent-framed message per pipe
 // buffer, decodes it to an avro::GenericDatum, and fills columns through the avrocpp column readers
@@ -44,9 +46,10 @@ private:
     Status create_column_readers();
     Status create_src_chunk(ChunkPtr* chunk);
     // Decodes one message and appends one row; per-field "not found" becomes null, while decode and
-    // structural failures return an error and fail the task.
-    Status parse_one_message(const uint8_t* data, size_t size, Chunk* chunk);
-    Status fill_row(const avro::GenericDatum& datum, Chunk* chunk);
+    // structural failures return an error and fail the task. `meta` carries the message's source
+    // metadata for the hidden metadata columns described by _meta_cols (may be null).
+    Status parse_one_message(const uint8_t* data, size_t size, Chunk* chunk, const StreamMessageMeta* meta);
+    Status fill_row(const avro::GenericDatum& datum, Chunk* chunk, const StreamMessageMeta* meta);
     void materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk);
 
     const TBrokerScanRange& _scan_range;
@@ -58,6 +61,8 @@ private:
     // create_column_readers() so the non-jsonpath fill_row() does not rebuild a std::string per cell.
     std::vector<std::string> _field_names;
     std::vector<std::vector<SimpleJsonPath>> _json_paths;
+    // Hidden source-metadata slots (source slot id -> descriptor), built from the scan-range params.
+    StreamSourceMetaColumns _meta_cols;
     std::shared_ptr<SequentialFile> _file;
     // Reused across messages; the GenericDatum from the previous message is overwritten on each decode.
     avro::GenericDatum _datum;

--- a/be/src/exec/file_scanner/avro_stream_scanner.h
+++ b/be/src/exec/file_scanner/avro_stream_scanner.h
@@ -15,17 +15,44 @@
 #pragma once
 
 #include <avrocpp/Generic.hh>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "exec/file_scanner/avro_datum_path.h"
 #include "exec/file_scanner/confluent_avro_decoder.h"
 #include "exec/file_scanner/file_scanner.h"
 #include "exec/file_scanner/stream_source_meta.h"
 #include "formats/avro/cpp/column_reader.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks {
 
 class SequentialFile;
 class StreamMessageMeta;
+
+// Serialize every top-level field of an avro record's writer schema (`record_node`) into a TColumn with
+// its full avro-derived type (nested struct/array/map preserved via type_desc) and is_allow_null=true.
+// This is the whole writer schema, not a diff: the FE compares it against the live table and decides what
+// to do. Exposed for unit tests.
+StatusOr<std::vector<TColumn>> avro_record_to_columns(const avro::NodePtr& record_node);
+
+// True if the writer schema (`record_node`) carries anything the table does not yet accommodate: a
+// top-level field with no payload column, a struct subfield (recursively) with no matching field, a scalar
+// whose writer type does not fit the column type (e.g. long into INT, decimal precision growth, scalar
+// turned struct), or a field colliding with a hidden metadata column. `payload_types` maps each payload
+// column's name to its table type; `meta_names` are the reserved metadata-column names. Varchar *length*
+// is not judged here (avro strings are unbounded); over-length values are handled per row by the scanner.
+// Used to decide whether to escalate the schema to the FE. Exposed for unit tests.
+bool avro_schema_needs_evolution(const avro::NodePtr& record_node,
+                                 const std::unordered_map<std::string, TypeDescriptor>& payload_types,
+                                 const std::unordered_set<std::string>& meta_names);
+
+// True if `col_type` is a length-limited varchar/varbinary (below the hard max) and the avro `datum` would
+// not fit by length — the signal to widen that column. Avro strings/bytes carry no length, so an over-narrow
+// string column is only detectable per value, here. Other column types and value kinds return false (an
+// over-length non-string value is an ordinary per-row data error in the reader). Exposed for unit tests.
+bool avro_value_overflows_varchar(const TypeDescriptor& col_type, const avro::GenericDatum& datum);
 
 // Routine-load (Kafka) Avro scanner on the avrocpp stack. Reads one Confluent-framed message per pipe
 // buffer, decodes it to an avro::GenericDatum, and fills columns through the avrocpp column readers
@@ -50,6 +77,20 @@ private:
     // metadata for the hidden metadata columns described by _meta_cols (may be null).
     Status parse_one_message(const uint8_t* data, size_t size, Chunk* chunk, const StreamMessageMeta* meta);
     Status fill_row(const avro::GenericDatum& datum, Chunk* chunk, const StreamMessageMeta* meta);
+    // Schema evolution: when a message's writer schema carries a field the table does not yet cover (a
+    // missing column, a missing struct subfield, or a metadata-column collision), record the full writer
+    // schema on the RuntimeState and return an error so the task fails and the FE can diff + ALTER +
+    // retry. The BE only decides whether to escalate; the FE picks ADD COLUMN vs ADD FIELD vs fail.
+    // Checked once per distinct schema id (cached via _last_checked_schema_id).
+    // Not supported in jsonpath mode: routine-load avro never had a working jsonpath->column mapping, so
+    // that path carries no by-name field->column binding for evolution to build on — the caller skips the
+    // check then.
+    Status check_for_new_columns(const avro::GenericDatum& datum, int32_t schema_id);
+    // Schema evolution for varchar/varbinary length: avro strings/bytes are unbounded, so an over-narrow
+    // column only shows up when a value overruns it. On overrun, record the column on the RuntimeState and
+    // return an error so the task fails and the FE widens the column (to the varchar max).
+    Status check_varchar_widen(const std::string& field_name, const TypeDescriptor& col_type,
+                               const avro::GenericDatum& field_datum);
     void materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk);
 
     const TBrokerScanRange& _scan_range;
@@ -60,10 +101,21 @@ private:
     // Avro field name per source slot (parallel to _column_readers), materialized once in
     // create_column_readers() so the non-jsonpath fill_row() does not rebuild a std::string per cell.
     std::vector<std::string> _field_names;
+    // Payload (non-metadata) columns by avro field name -> table type, built once in
+    // create_column_readers(). check_for_new_columns() walks it to test, recursively, whether the message
+    // schema is already covered (top-level columns and nested struct subfields alike).
+    std::unordered_map<std::string, TypeDescriptor> _payload_types;
+    // Names of hidden metadata slots; an avro field colliding with one of these fails the task instead
+    // of being treated as covered or new (the metadata slot is filled by id, not from the payload).
+    std::unordered_set<std::string> _meta_slot_names;
     std::vector<std::vector<SimpleJsonPath>> _json_paths;
     // Hidden source-metadata slots (source slot id -> descriptor), built from the scan-range params.
     StreamSourceMetaColumns _meta_cols;
     std::shared_ptr<SequentialFile> _file;
+    // Schema-evolution gate (from query_options) and the last schema id already checked, so the
+    // per-field comparison runs only when the message's schema id changes. -2 = nothing checked yet.
+    bool _enable_schema_evolution = false;
+    int32_t _last_checked_schema_id = -2;
     // Reused across messages; the GenericDatum from the previous message is overwritten on each decode.
     avro::GenericDatum _datum;
     bool _closed = false;

--- a/be/src/exec/file_scanner/avro_stream_scanner.h
+++ b/be/src/exec/file_scanner/avro_stream_scanner.h
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <avrocpp/Generic.hh>
+
+#include "exec/file_scanner/avro_datum_path.h"
+#include "exec/file_scanner/confluent_avro_decoder.h"
+#include "exec/file_scanner/file_scanner.h"
+#include "formats/avro/cpp/column_reader.h"
+
+namespace starrocks {
+
+class SequentialFile;
+
+// Routine-load (Kafka) Avro scanner on the avrocpp stack. Reads one Confluent-framed message per pipe
+// buffer, decodes it to an avro::GenericDatum, and fills columns through the avrocpp column readers
+// (which support STRUCT/MAP/ARRAY). Selected per job via the thrift use_native_avro_reader flag, which
+// the FE resolves at job creation (defaulting to the FE config enable_routine_load_native_avro_reader).
+// Pulsar avro never reaches here: PulsarTaskInfo sends every non-json format to the BE as CSV_PLAIN.
+class AvroStreamScanner final : public FileScanner {
+public:
+    AvroStreamScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                      ScannerCounter* counter);
+    ~AvroStreamScanner() override;
+
+    Status open() override;
+    StatusOr<ChunkPtr> get_next() override;
+    void close() override;
+
+private:
+    Status create_column_readers();
+    Status create_src_chunk(ChunkPtr* chunk);
+    // Decodes one message and appends one row; per-field "not found" becomes null, while decode and
+    // structural failures return an error and fail the task.
+    Status parse_one_message(const uint8_t* data, size_t size, Chunk* chunk);
+    Status fill_row(const avro::GenericDatum& datum, Chunk* chunk);
+    void materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk);
+
+    const TBrokerScanRange& _scan_range;
+    const int _max_chunk_size;
+    cctz::time_zone _timezone;
+    std::unique_ptr<ConfluentAvroDecoder> _decoder;
+    std::vector<avrocpp::ColumnReaderUniquePtr> _column_readers;
+    // Avro field name per source slot (parallel to _column_readers), materialized once in
+    // create_column_readers() so the non-jsonpath fill_row() does not rebuild a std::string per cell.
+    std::vector<std::string> _field_names;
+    std::vector<std::vector<SimpleJsonPath>> _json_paths;
+    std::shared_ptr<SequentialFile> _file;
+    // Reused across messages; the GenericDatum from the previous message is overwritten on each decode.
+    avro::GenericDatum _datum;
+    bool _closed = false;
+};
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/confluent_avro_decoder.cpp
+++ b/be/src/exec/file_scanner/confluent_avro_decoder.cpp
@@ -63,7 +63,7 @@ StatusOr<const avro::ValidSchema*> ConfluentAvroDecoder::_resolve(int32_t schema
     return &it->second;
 }
 
-Status ConfluentAvroDecoder::decode(const uint8_t* data, size_t size, avro::GenericDatum* datum) {
+Status ConfluentAvroDecoder::decode(const uint8_t* data, size_t size, avro::GenericDatum* datum, int32_t* schema_id) {
     try {
         const avro::ValidSchema* schema = nullptr;
         const uint8_t* payload = data;
@@ -72,6 +72,9 @@ Status ConfluentAvroDecoder::decode(const uint8_t* data, size_t size, avro::Gene
         if (_test_mode) {
             // Input is a raw Avro datum without Confluent framing.
             schema = &_test_schema;
+            if (schema_id != nullptr) {
+                *schema_id = -1;
+            }
         } else {
             // serdes_framing_read strips the Confluent framing per the serdes config, advances the
             // payload pointer/length past it, and resolves the writer schema (registry-cached).
@@ -84,7 +87,11 @@ Status ConfluentAvroDecoder::decode(const uint8_t* data, size_t size, avro::Gene
             }
             payload = static_cast<const uint8_t*>(p);
             payload_size = sz;
-            ASSIGN_OR_RETURN(schema, _resolve(serdes_schema_id(serdes_schema), serdes_schema));
+            int32_t resolved_id = serdes_schema_id(serdes_schema);
+            if (schema_id != nullptr) {
+                *schema_id = resolved_id;
+            }
+            ASSIGN_OR_RETURN(schema, _resolve(resolved_id, serdes_schema));
         }
 
         auto input = avro::memoryInputStream(payload, payload_size);

--- a/be/src/exec/file_scanner/confluent_avro_decoder.cpp
+++ b/be/src/exec/file_scanner/confluent_avro_decoder.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/confluent_avro_decoder.h"
+
+#include <fmt/format.h>
+
+#include <avrocpp/Compiler.hh>
+#include <avrocpp/Decoder.hh>
+#include <avrocpp/Exception.hh>
+#include <avrocpp/Stream.hh>
+
+namespace starrocks {
+
+ConfluentAvroDecoder::ConfluentAvroDecoder(std::string schema_registry_url)
+        : _test_mode(false), _registry_url(std::move(schema_registry_url)) {}
+
+ConfluentAvroDecoder::ConfluentAvroDecoder(avro::ValidSchema test_schema)
+        : _test_mode(true), _test_schema(std::move(test_schema)) {}
+
+ConfluentAvroDecoder::~ConfluentAvroDecoder() {
+    if (_serdes != nullptr) {
+        serdes_destroy(_serdes);
+        _serdes = nullptr;
+    }
+}
+
+Status ConfluentAvroDecoder::init() {
+    if (_test_mode) {
+        return Status::OK();
+    }
+    // serdes_new takes ownership of the conf object.
+    serdes_conf_t* conf = serdes_conf_new(nullptr, 0, "schema.registry.url", _registry_url.c_str(), NULL);
+    _serdes = serdes_new(conf, _err_buf, sizeof(_err_buf));
+    if (_serdes == nullptr) {
+        return Status::InternalError(fmt::format("failed to create serdes handle: {}", _err_buf));
+    }
+    return Status::OK();
+}
+
+StatusOr<const avro::ValidSchema*> ConfluentAvroDecoder::_resolve(int32_t schema_id, serdes_schema_t* serdes_schema) {
+    if (auto it = _schema_cache.find(schema_id); it != _schema_cache.end()) {
+        return &it->second;
+    }
+    const char* definition = serdes_schema_definition(serdes_schema);
+    if (definition == nullptr) {
+        return Status::InternalError(fmt::format("empty schema definition for schema id {}", schema_id));
+    }
+    // compileJsonSchemaFromString may throw avro::Exception on malformed JSON; decode() catches it.
+    avro::ValidSchema valid_schema = avro::compileJsonSchemaFromString(definition);
+    auto [it, _] = _schema_cache.emplace(schema_id, std::move(valid_schema));
+    return &it->second;
+}
+
+Status ConfluentAvroDecoder::decode(const uint8_t* data, size_t size, avro::GenericDatum* datum) {
+    try {
+        const avro::ValidSchema* schema = nullptr;
+        const uint8_t* payload = data;
+        size_t payload_size = size;
+
+        if (_test_mode) {
+            // Input is a raw Avro datum without Confluent framing.
+            schema = &_test_schema;
+        } else {
+            // serdes_framing_read strips the Confluent framing per the serdes config, advances the
+            // payload pointer/length past it, and resolves the writer schema (registry-cached).
+            const void* p = data;
+            size_t sz = size;
+            serdes_schema_t* serdes_schema = nullptr;
+            ssize_t framing = serdes_framing_read(_serdes, &p, &sz, &serdes_schema, _err_buf, sizeof(_err_buf));
+            if (framing == -1 || serdes_schema == nullptr) {
+                return Status::InternalError(fmt::format("confluent framing/schema resolve failed: {}", _err_buf));
+            }
+            payload = static_cast<const uint8_t*>(p);
+            payload_size = sz;
+            ASSIGN_OR_RETURN(schema, _resolve(serdes_schema_id(serdes_schema), serdes_schema));
+        }
+
+        auto input = avro::memoryInputStream(payload, payload_size);
+        avro::DecoderPtr decoder = avro::binaryDecoder();
+        decoder->init(*input);
+        avro::GenericReader::read(*decoder, *datum, *schema);
+        return Status::OK();
+    } catch (const avro::Exception& e) {
+        return Status::InternalError(fmt::format("avro decode failed: {}", e.what()));
+    }
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/confluent_avro_decoder.h
+++ b/be/src/exec/file_scanner/confluent_avro_decoder.h
@@ -59,8 +59,9 @@ public:
     Status init();
 
     // Decodes one message into `datum`. `datum` may be reused across calls by the caller.
-    // Any framing/registry/decode failure returns InternalError.
-    Status decode(const uint8_t* data, size_t size, avro::GenericDatum* datum);
+    // If `schema_id` is non-null it receives the Confluent schema id of the message (or -1 in
+    // test mode, which has no framing). Any framing/registry/decode failure returns InternalError.
+    Status decode(const uint8_t* data, size_t size, avro::GenericDatum* datum, int32_t* schema_id = nullptr);
 
 private:
     // Returns the compiled ValidSchema for `schema_id`, compiling+caching it from `serdes_schema`

--- a/be/src/exec/file_scanner/confluent_avro_decoder.h
+++ b/be/src/exec/file_scanner/confluent_avro_decoder.h
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <avrocpp/Generic.hh>
+#include <avrocpp/ValidSchema.hh>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "common/status.h"
+#include "common/statusor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "libserdes/serdes.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+// Decodes one Confluent-wire-format Avro message (magic byte 0x00 + 4-byte big-endian schema id +
+// raw Avro datum) into an avro::GenericDatum, resolving the writer schema by id from the Confluent
+// Schema Registry via libserdes.
+//
+// The compiled ValidSchema is cached per schema id. Schema ids are immutable, so the cache never
+// needs invalidation. libserdes already caches the raw registry schema; the only thing cached here
+// is the JSON->ValidSchema compilation.
+class ConfluentAvroDecoder {
+public:
+    // Production: resolve schemas from the Confluent Schema Registry at `schema_registry_url`.
+    // init() must be called before decode().
+    explicit ConfluentAvroDecoder(std::string schema_registry_url);
+
+    // Test: a single fixed writer schema, no registry/serdes. decode() then treats the input as a
+    // raw Avro datum without Confluent framing.
+    explicit ConfluentAvroDecoder(avro::ValidSchema test_schema);
+
+    ~ConfluentAvroDecoder();
+
+    ConfluentAvroDecoder(const ConfluentAvroDecoder&) = delete;
+    ConfluentAvroDecoder& operator=(const ConfluentAvroDecoder&) = delete;
+
+    // Creates the serdes handle (production mode); no-op in test mode.
+    Status init();
+
+    // Decodes one message into `datum`. `datum` may be reused across calls by the caller.
+    // Any framing/registry/decode failure returns InternalError.
+    Status decode(const uint8_t* data, size_t size, avro::GenericDatum* datum);
+
+private:
+    // Returns the compiled ValidSchema for `schema_id`, compiling+caching it from `serdes_schema`
+    // on first use. May throw avro::Exception on malformed schema JSON (caught by decode()).
+    StatusOr<const avro::ValidSchema*> _resolve(int32_t schema_id, serdes_schema_t* serdes_schema);
+
+    const bool _test_mode;
+    std::string _registry_url;
+    serdes_t* _serdes = nullptr;
+    std::unordered_map<int32_t, avro::ValidSchema> _schema_cache;
+    avro::ValidSchema _test_schema;
+    char _err_buf[512];
+};
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -27,6 +27,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/runtime_profile.h"
 #include "common/simdjson_util.h"
+#include "exec/file_scanner/stream_source_meta.h"
 #include "exec/json_parser.h"
 #include "exprs/cast_expr.h"
 #include "exprs/column_ref.h"
@@ -292,6 +293,7 @@ JsonReader::JsonReader(RuntimeState* state, ScannerCounter* counter, JsonScanner
           _type_descs(std::move(type_descs)),
           _range_desc(range_desc),
           _envelope_type(range_desc.__isset.envelope ? range_desc.envelope : TEnvelopeType::NONE) {
+    _meta_col_by_slot_id = build_stream_source_meta_columns(_scanner->_scan_range.params.stream_source_meta_columns);
     int index = 0;
     for (size_t i = 0; i < _slot_descs.size(); ++i) {
         const auto& desc = _slot_descs[i];
@@ -300,6 +302,8 @@ JsonReader::JsonReader(RuntimeState* state, ScannerCounter* counter, JsonScanner
         }
         if (UNLIKELY(desc->col_name() == "__op")) {
             _op_col_index = index;
+        } else if (auto m = _meta_col_by_slot_id.find(desc->id()); m != _meta_col_by_slot_id.end()) {
+            _meta_col_by_index.emplace(index, m->second);
         }
         index++;
         _slot_desc_dict.emplace(desc->col_name(), desc);
@@ -493,6 +497,11 @@ Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_
 Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* row, Chunk* chunk) {
     _parsed_columns.assign(chunk->num_columns(), false);
 
+    // Hidden source-metadata columns are filled from the buffer's Kafka/Pulsar metadata (routine load),
+    // never from the payload. Their slots have generated names that cannot appear in the payload, so no
+    // payload field is ever shadowed.
+    const StreamMessageMeta* meta = stream_source_meta_of(_file_stream_buffer);
+
     faststring buffer;
     try {
         uint32_t key_index = 0;
@@ -544,8 +553,22 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
                 auto slot_desc = itr->second;
                 auto type_desc = _type_desc_dict[key];
 
-                // update the prev parsed position
                 column_index = chunk->get_index_by_slot_id(slot_desc->id());
+                // A hidden metadata slot is filled from the message meta in the null-fill pass, never
+                // from the payload; if a payload field happens to use its internal name, skip it (cache
+                // as a skip via column_index = -1) so the metadata value still wins.
+                if (_meta_col_by_index.count(column_index) > 0) {
+                    if (_prev_parsed_position.size() <= key_index) {
+                        _prev_parsed_position.emplace_back(key);
+                    } else {
+                        _prev_parsed_position[key_index].key = key;
+                        _prev_parsed_position[key_index].column_index = -1;
+                    }
+                    key_index++;
+                    continue;
+                }
+
+                // update the prev parsed position
                 if (_prev_parsed_position.size() <= key_index) {
                     _prev_parsed_position.emplace_back(key, column_index, type_desc);
                 } else {
@@ -580,7 +603,7 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
         return Status::DataQualityError(err_msg);
     }
 
-    // append null to the column without data.
+    // append null (or synthetic metadata) to the columns without data.
     for (int i = 0; i < chunk->num_columns(); i++) {
         if (!_parsed_columns[i]) {
             auto* column = chunk->get_column_raw_ptr_by_index(i);
@@ -594,6 +617,9 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
                 } else {
                     column->append_datum(Datum(op_val));
                 }
+            } else if (auto it = _meta_col_by_index.find(i); it != _meta_col_by_index.end()) {
+                // Fill from meta (NULL when the buffer carries none).
+                RETURN_IF_ERROR(fill_stream_source_meta_column(it->second.kind, it->second.key, meta, column));
             } else {
                 column->append_nulls(1);
             }
@@ -605,6 +631,11 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
 Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row, Chunk* chunk) {
     size_t slot_size = _slot_descs.size();
     size_t jsonpath_size = _scanner->_json_paths.size();
+    const StreamMessageMeta* meta = stream_source_meta_of(_file_stream_buffer);
+    // Hidden metadata columns carry no jsonpath, so they are transparent to the positional
+    // slot->jsonpath mapping: a jsonpath maps to the i-th non-metadata slot. This keeps payload columns
+    // aligned even when a metadata column sits before jsonpath-backed columns.
+    size_t meta_count = 0;
     for (size_t i = 0; i < slot_size; i++) {
         if (_slot_descs[i] == nullptr) {
             continue;
@@ -613,7 +644,18 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
 
         // The columns in JsonReader's chunk are all in NullableColumn type;
         auto* column = down_cast<NullableColumn*>(chunk->get_column_raw_ptr_by_slot_id(_slot_descs[i]->id()));
-        if (i >= jsonpath_size) {
+
+        // Hidden source-metadata slots are filled from the message meta, not the payload, before the
+        // jsonpath extraction. Fill unconditionally (NULL when the buffer carries no meta) and always
+        // advance meta_count, so a metadata slot stays transparent to the positional jsonpath mapping
+        // regardless of whether meta is present.
+        if (auto it = _meta_col_by_slot_id.find(_slot_descs[i]->id()); UNLIKELY(it != _meta_col_by_slot_id.end())) {
+            RETURN_IF_ERROR(fill_stream_source_meta_column(it->second.kind, it->second.key, meta, column));
+            meta_count++;
+            continue;
+        }
+        size_t jp = i - meta_count;
+        if (jp >= jsonpath_size) {
             if (column_name.compare("__op") == 0) {
                 // special treatment for __op column, fill default value rather than null.
                 // For Debezium CDC format, use the op from the CDC envelope.
@@ -635,7 +677,7 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
         // simdjson's api is limited, which coult not convert ondemand::object to ondemand::value.
         // As a workaround, extract procedure is duplicated, for both ondemand::object and ondemand::value
         // TODO(mofei) make it more elegant
-        if (_scanner->_json_paths[i].size() == 1 && _scanner->_json_paths[i][0].key == "$") {
+        if (_scanner->_json_paths[jp].size() == 1 && _scanner->_json_paths[jp][0].key == "$") {
             // add_nullable_column may invoke a for-range iterating to the row.
             // If the for-range iterating is invoked after field access, or a second for-range iterating is invoked,
             // it would get an error "Objects and arrays can only be iterated when they are first encountered",
@@ -645,7 +687,7 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
                     column, _slot_descs[i]->type(), _slot_descs[i]->col_name(), row, !_strict_mode));
         } else {
             simdjson::ondemand::value val;
-            auto st = JsonFunctions::extract_from_object(*row, _scanner->_json_paths[i], &val);
+            auto st = JsonFunctions::extract_from_object(*row, _scanner->_json_paths[jp], &val);
             if (st.ok()) {
                 RETURN_IF_ERROR(_construct_column(val, column, _slot_descs[i]->type(), _slot_descs[i]->col_name()));
             } else if (st.is_not_found()) {

--- a/be/src/exec/file_scanner/json_scanner.h
+++ b/be/src/exec/file_scanner/json_scanner.h
@@ -19,6 +19,7 @@
 
 #include "column/nullable_column.h"
 #include "exec/file_scanner/file_scanner.h"
+#include "exec/file_scanner/stream_source_meta.h"
 #include "exprs/json_functions.h"
 #include "fs/fs.h"
 #include "runtime/stream_load/load_stream_mgr.h"
@@ -156,6 +157,12 @@ private:
     std::vector<uint8_t> _parsed_columns;
     // record the "__op" column's index
     int _op_col_index{-1};
+    // Hidden source-metadata columns, filled from the message's ByteBuffer meta (by slot id) rather than
+    // the JSON payload. _meta_col_by_slot_id keys by source slot id (used in the jsonpath path, which
+    // iterates _slot_descs); _meta_col_by_index keys by chunk column index -- the running slot order used
+    // for _op_col_index -- for the object-order null-fill path. Both empty for non-routine-load.
+    StreamSourceMetaColumns _meta_col_by_slot_id;
+    std::unordered_map<int, TRoutineLoadMetaColumn> _meta_col_by_index;
 
     ByteBufferPtr _file_stream_buffer;
 

--- a/be/src/exec/file_scanner/stream_source_meta.cpp
+++ b/be/src/exec/file_scanner/stream_source_meta.cpp
@@ -1,0 +1,142 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/stream_source_meta.h"
+
+#include <fmt/format.h>
+
+#include "base/string/slice.h"
+#include "column/column.h"
+#include "types/datum.h"
+#include "util/byte_buffer.h"
+
+namespace starrocks {
+
+StreamSourceMetaColumns build_stream_source_meta_columns(const std::vector<TRoutineLoadMetaColumn>& descs) {
+    StreamSourceMetaColumns columns;
+    for (const auto& desc : descs) {
+        if (desc.__isset.slot_id && desc.__isset.kind) {
+            columns.emplace(desc.slot_id, desc);
+        }
+    }
+    return columns;
+}
+
+const StreamMessageMeta* stream_source_meta_of(const ByteBufferPtr& buf) {
+    if (buf == nullptr) {
+        return nullptr;
+    }
+    auto type = buf->meta()->type();
+    if (type == ByteBufferMetaType::KAFKA || type == ByteBufferMetaType::PULSAR) {
+        return static_cast<const StreamMessageMeta*>(buf->meta());
+    }
+    return nullptr;
+}
+
+// The last value for `key` among the message headers (Kafka headers are an ordered multimap; Pulsar
+// properties are unique). Returns nullptr if the key is absent.
+static const std::string* last_header_value(const StreamMessageMeta* meta, const std::string& key) {
+    const std::string* found = nullptr;
+    for (const auto& kv : meta->headers()) {
+        if (kv.first == key) {
+            found = &kv.second;
+        }
+    }
+    return found;
+}
+
+Status fill_stream_source_meta_column(TStreamSourceMetaKind::type kind, const std::string& key,
+                                      const StreamMessageMeta* meta, Column* column) {
+    if (meta == nullptr) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+
+    switch (kind) {
+    case TStreamSourceMetaKind::TOPIC:
+        if (meta->topic().empty()) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(Slice(meta->topic())));
+        }
+        break;
+    case TStreamSourceMetaKind::PARTITION:
+        if (meta->partition() < 0) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(static_cast<int32_t>(meta->partition())));
+        }
+        break;
+    case TStreamSourceMetaKind::OFFSET:
+        if (meta->offset() < 0) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(static_cast<int64_t>(meta->offset())));
+        }
+        break;
+    case TStreamSourceMetaKind::MESSAGE_ID:
+        if (meta->message_id().empty()) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(Slice(meta->message_id())));
+        }
+        break;
+    case TStreamSourceMetaKind::TIMESTAMP:
+        if (meta->timestamp() < 0) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(static_cast<int64_t>(meta->timestamp())));
+        }
+        break;
+    case TStreamSourceMetaKind::EVENT_TIME:
+        if (meta->event_timestamp() < 0) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(static_cast<int64_t>(meta->event_timestamp())));
+        }
+        break;
+    case TStreamSourceMetaKind::KEY:
+        if (!meta->has_key()) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(Slice(meta->key())));
+        }
+        break;
+    case TStreamSourceMetaKind::HEADER: {
+        const std::string* value = last_header_value(meta, key);
+        if (value == nullptr) {
+            column->append_nulls(1);
+        } else {
+            column->append_datum(Datum(Slice(*value)));
+        }
+        break;
+    }
+    case TStreamSourceMetaKind::HEADERS: {
+        // MAP<VARCHAR,VARCHAR>; duplicate keys collapse last-wins (DatumMap assignment overwrites).
+        // Header values are raw bytes placed into VARCHAR as-is (no UTF-8 validation). Always present
+        // (possibly empty), so this column is never NULL.
+        DatumMap datum_map;
+        for (const auto& kv : meta->headers()) {
+            datum_map[Slice(kv.first)] = Datum(Slice(kv.second));
+        }
+        column->append_datum(Datum(std::move(datum_map)));
+        break;
+    }
+    default:
+        return Status::InternalError(fmt::format("unknown stream source meta kind: {}", static_cast<int>(kind)));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/exec/file_scanner/stream_source_meta.h
+++ b/be/src/exec/file_scanner/stream_source_meta.h
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common/status.h"
+#include "gen_cpp/PlanNodes_types.h"
+
+namespace starrocks {
+
+class Column;
+class StreamMessageMeta;
+struct ByteBuffer;
+using ByteBufferPtr = std::shared_ptr<ByteBuffer>;
+
+// Routine-load source-metadata bindings for a scan range, keyed by source slot id. The FE lowers
+// metadata functions (kafka_topic(), kafka_header('k'), ...) in the COLUMNS clause into hidden source
+// slots and sends a TRoutineLoadMetaColumn per slot; the scanner fills those slots from the message
+// metadata by id instead of from the payload, so a payload field of the same name is never shadowed.
+using StreamSourceMetaColumns = std::unordered_map<int32_t, TRoutineLoadMetaColumn>;
+
+// Builds the slot-id -> descriptor map from the scan-range descriptor list. Empty for non-routine-load
+// and for jobs that use no metadata function.
+StreamSourceMetaColumns build_stream_source_meta_columns(const std::vector<TRoutineLoadMetaColumn>& descs);
+
+// Returns the StreamMessageMeta carried by `buf`, or nullptr if the buffer has no Kafka/Pulsar meta
+// (e.g. CSV, or a job that references no metadata function).
+const StreamMessageMeta* stream_source_meta_of(const ByteBufferPtr& buf);
+
+// Appends one row to `column` from `meta` for a metadata column of the given `kind` (and `key` for a
+// HEADER lookup, last-wins). `column` must be a nullable scalar for the scalar kinds, or a nullable
+// MAP<VARCHAR,VARCHAR> for HEADERS. Fields absent on the message (null key, unavailable timestamp,
+// non-partitioned Pulsar topic, missing header key) are appended as SQL NULL; a null `meta` appends
+// NULL for every kind.
+Status fill_stream_source_meta_column(TStreamSourceMetaKind::type kind, const std::string& key,
+                                      const StreamMessageMeta* meta, Column* column);
+
+} // namespace starrocks

--- a/be/src/formats/avro/cpp/complex_column_reader.cpp
+++ b/be/src/formats/avro/cpp/complex_column_reader.cpp
@@ -29,7 +29,12 @@ StructColumnReader::StructColumnReader(std::string_view col_name, const TypeDesc
 }
 
 Status StructColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    DCHECK_EQ(datum.type(), avro::AVRO_RECORD);
+    // The reader is built from the table column type while the datum carries whatever the writer sent,
+    // so a kind mismatch is reachable data, not a programming error: value<T>() on it would crash.
+    if (UNLIKELY(datum.type() != avro::AVRO_RECORD)) {
+        return Status::DataQualityError(
+                fmt::format("Unsupported avro type {} to struct. column: {}", avro::toString(datum.type()), _col_name));
+    }
 
     auto struct_column = down_cast<StructColumn*>(column);
     const auto& record = datum.value<avro::GenericRecord>();
@@ -52,7 +57,10 @@ Status StructColumnReader::read_datum(const avro::GenericDatum& datum, Column* c
 }
 
 Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    DCHECK_EQ(datum.type(), avro::AVRO_ARRAY);
+    if (UNLIKELY(datum.type() != avro::AVRO_ARRAY)) {
+        return Status::DataQualityError(
+                fmt::format("Unsupported avro type {} to array. column: {}", avro::toString(datum.type()), _col_name));
+    }
 
     auto array_column = down_cast<ArrayColumn*>(column);
     auto* elements_column = array_column->elements_column_raw_ptr();
@@ -78,12 +86,23 @@ Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* co
 }
 
 Status MapColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    DCHECK_EQ(datum.type(), avro::AVRO_MAP);
+    if (UNLIKELY(datum.type() != avro::AVRO_MAP)) {
+        return Status::DataQualityError(
+                fmt::format("Unsupported avro type {} to map. column: {}", avro::toString(datum.type()), _col_name));
+    }
 
     auto map_column = down_cast<MapColumn*>(column);
     auto keys_column = down_cast<NullableColumn*>(map_column->keys_column_raw_ptr());
     auto* values_column = map_column->values_column_raw_ptr();
     auto* offsets_column = map_column->offsets_column_raw_ptr();
+
+    // Avro map keys are always strings, and the key path below appends raw bytes into a binary key
+    // column. FILES() always types the key column VARCHAR (inferred schema), but routine load types it
+    // straight from the table, so e.g. MAP<INT,...> reaches here: reject it instead of corrupting it.
+    if (_key_reader != nullptr && UNLIKELY(!keys_column->data_column_raw_ptr()->is_binary())) {
+        return Status::DataQualityError(
+                fmt::format("avro map keys are strings; the key type of map column '{}' cannot hold them", _col_name));
+    }
 
     const auto& map = datum.value<avro::GenericMap>();
     const auto& map_values = map.value();

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -33,6 +33,9 @@
 // under the License.
 #include "runtime/routine_load/data_consumer_group.h"
 
+#include <limits>
+#include <sstream>
+
 #include "base/utility/defer_op.h"
 #include "librdkafka/rdkafka.h"
 #include "librdkafka/rdkafkacpp.h"
@@ -41,6 +44,57 @@
 #include "runtime/stream_load/stream_load_context.h"
 
 namespace starrocks {
+
+int32_t parse_pulsar_partition_index(const std::string& logical_topic, const std::string& message_topic) {
+    static const std::string kSuffix = "-partition-";
+    auto pos = message_topic.rfind(kSuffix);
+    if (pos == std::string::npos) {
+        return -1;
+    }
+    const size_t digits_start = pos + kSuffix.size();
+    if (digits_start >= message_topic.size()) {
+        return -1;
+    }
+    // Accumulate in int64 and bail past INT32_MAX so a pathological suffix can't overflow (signed
+    // overflow is UB). Real Pulsar partition indices are small, so this only guards malformed names.
+    int64_t value = 0;
+    for (size_t i = digits_start; i < message_topic.size(); ++i) {
+        char c = message_topic[i];
+        if (c < '0' || c > '9') {
+            return -1;
+        }
+        value = value * 10 + (c - '0');
+        if (value > std::numeric_limits<int32_t>::max()) {
+            return -1;
+        }
+    }
+    // The suffix is a real partition only if what precedes it is the configured logical topic; this is
+    // what keeps a standalone topic literally named "<x>-partition-<n>" from being mistaken for a
+    // partition. Accept either an exact match (configured topic already fully qualified) or a match at
+    // the leading "/" boundary (configured topic given in short form against the canonical name).
+    const std::string prefix = message_topic.substr(0, pos);
+    if (prefix == logical_topic) {
+        return static_cast<int32_t>(value);
+    }
+    if (prefix.size() > logical_topic.size() &&
+        prefix.compare(prefix.size() - logical_topic.size(), logical_topic.size(), logical_topic) == 0 &&
+        prefix[prefix.size() - logical_topic.size() - 1] == '/') {
+        return static_cast<int32_t>(value);
+    }
+    return -1;
+}
+
+namespace {
+
+// Render a Pulsar MessageId as a stable string for the __message_id__ column. operator<< is what the
+// BE already uses to log MessageId, so the format is consistent across the codebase.
+std::string pulsar_message_id_to_string(const pulsar::MessageId& id) {
+    std::ostringstream oss;
+    oss << id;
+    return oss.str();
+}
+
+} // namespace
 
 Status KafkaDataConsumerGroup::assign_topic_partitions(StreamLoadContext* ctx) {
     DCHECK(ctx->kafka_info);
@@ -119,14 +173,11 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
     std::map<int32_t, int64_t> cmt_offset = ctx->kafka_info->cmt_offset;
     std::map<int32_t, int64_t> cmt_offset_timestamp;
 
-    //improve performance
-    Status (KafkaConsumerPipe::*append_data)(const char* data, size_t size, char row_delimiter, int32_t partition,
-                                             int64_t offset);
+    // JSON/Avro: one message per buffer (with source metadata). CSV: rows separated by row_delimiter.
+    const bool append_as_message =
+            ctx->format == TFileFormatType::FORMAT_JSON || ctx->format == TFileFormatType::FORMAT_AVRO;
     char row_delimiter = '\n';
-    if (ctx->format == TFileFormatType::FORMAT_JSON || ctx->format == TFileFormatType::FORMAT_AVRO) {
-        append_data = &KafkaConsumerPipe::append_json;
-    } else {
-        append_data = &KafkaConsumerPipe::append_with_row_delimiter;
+    if (!append_as_message) {
         auto& per_node_scan_ranges = ctx->put_result.params.params.per_node_scan_ranges;
 
         if (!per_node_scan_ranges.empty()) {
@@ -137,6 +188,12 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
             row_delimiter = static_cast<char>(params.row_delimiter);
         }
     }
+    // Attach the extended metadata (topic/timestamp/key/headers) only when the job's COLUMNS clause
+    // references a metadata column.
+    const bool need_meta = ctx->kafka_info->need_source_metadata;
+    // Only copy the (potentially large) key/headers when the job references __key__ / __headers__.
+    const bool need_key = ctx->kafka_info->need_message_key;
+    const bool need_headers = ctx->kafka_info->need_message_headers;
 
     MonotonicStopWatch watch;
     watch.start();
@@ -219,18 +276,52 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                     }
                 }
             } else {
-                Status st = Status::OK();
-                st = (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()),
-                                                      static_cast<size_t>(msg->len()), row_delimiter, msg->partition(),
-                                                      msg->offset());
+                auto timestamp = msg->timestamp();
+                Status st;
+                if (append_as_message) {
+                    StreamMessageMeta meta(ByteBufferMetaType::KAFKA);
+                    // Always set: the scanner stamps partition/offset into error logs so rejected rows
+                    // stay locatable even when the job selects no metadata column.
+                    meta.set_partition(msg->partition());
+                    meta.set_offset(msg->offset());
+                    if (need_meta) {
+                        meta.set_topic(ctx->kafka_info->topic);
+                        // Leave the timestamp at its -1 sentinel when the broker reports none, so the
+                        // column renders as NULL instead of a bogus epoch value.
+                        if (timestamp.type != RdKafka::MessageTimestamp::MSG_TIMESTAMP_NOT_AVAILABLE) {
+                            meta.set_timestamp(timestamp.timestamp);
+                        }
+                        if (need_key && msg->key_pointer() != nullptr) {
+                            meta.set_key(std::string(static_cast<const char*>(msg->key_pointer()), msg->key_len()));
+                        }
+                        if (need_headers) {
+                            // The Headers wrapper is owned by the message (its lifetime is the same as the
+                            // Message, per RdKafka::Message::headers() docs) and is freed when `msg` is
+                            // deleted below via msgDeleter. Do NOT delete it here, or it is a double free.
+                            RdKafka::Headers* headers = msg->headers();
+                            if (headers != nullptr) {
+                                for (const auto& h : headers->get_all()) {
+                                    meta.add_header(h.key(), h.value() != nullptr
+                                                                     ? std::string(static_cast<const char*>(h.value()),
+                                                                                   h.value_size())
+                                                                     : std::string());
+                                }
+                            }
+                        }
+                    }
+                    st = kafka_pipe->append_json(static_cast<const char*>(msg->payload()),
+                                                 static_cast<size_t>(msg->len()), row_delimiter, &meta);
+                } else {
+                    st = kafka_pipe->append_with_row_delimiter(static_cast<const char*>(msg->payload()),
+                                                               static_cast<size_t>(msg->len()), row_delimiter);
+                }
                 if (st.ok()) {
                     received_rows++;
                     left_bytes -= msg->len();
                     cmt_offset[msg->partition()] = msg->offset();
 
-                    auto timestamp = msg->timestamp();
                     if (timestamp.type != RdKafka::MessageTimestamp::MSG_TIMESTAMP_NOT_AVAILABLE) {
-                        cmt_offset_timestamp[msg->partition()] = msg->timestamp().timestamp;
+                        cmt_offset_timestamp[msg->partition()] = timestamp.timestamp;
                     }
                     VLOG(3) << "consume partition[" << msg->partition() << " - " << msg->offset() << "]";
                 } else {
@@ -338,13 +429,12 @@ Status PulsarDataConsumerGroup::start_all(StreamLoadContext* ctx) {
     // copy one
     std::map<std::string, pulsar::MessageId> ack_offset = ctx->pulsar_info->ack_offset;
 
-    //improve performance
-    Status (PulsarConsumerPipe::*append_data)(const char* data, size_t size, char row_delimiter);
+    // JSON: one message per buffer, carrying source metadata. CSV: rows separated by row_delimiter.
+    // The Pulsar path only ever sees JSON or CSV: PulsarTaskInfo maps every non-json format (including
+    // avro) to CSV_PLAIN, so the avro scanner never runs for Pulsar.
+    const bool append_as_message = ctx->format == TFileFormatType::FORMAT_JSON;
     char row_delimiter = '\n';
-    if (ctx->format == TFileFormatType::FORMAT_JSON) {
-        append_data = &PulsarConsumerPipe::append_json;
-    } else {
-        append_data = &PulsarConsumerPipe::append_with_row_delimiter;
+    if (!append_as_message) {
         auto& per_node_scan_ranges = ctx->put_result.params.params.per_node_scan_ranges;
 
         if (!per_node_scan_ranges.empty()) {
@@ -355,6 +445,12 @@ Status PulsarDataConsumerGroup::start_all(StreamLoadContext* ctx) {
             row_delimiter = static_cast<char>(params.row_delimiter);
         }
     }
+    // Attach per-message source metadata only when the job references a metadata column; otherwise the
+    // buffer stays metadata-free and the scanner reads every field from the payload.
+    const bool need_meta = ctx->pulsar_info->need_source_metadata;
+    // Only copy the (potentially large) partition key/properties when the job references __key__ / __headers__.
+    const bool need_key = ctx->pulsar_info->need_message_key;
+    const bool need_headers = ctx->pulsar_info->need_message_headers;
 
     MonotonicStopWatch watch;
     watch.start();
@@ -409,8 +505,40 @@ Status PulsarDataConsumerGroup::start_all(StreamLoadContext* ctx) {
             VLOG(3) << "get pulsar message"
                     << ", partition: " << partition << ", message id: " << msg_id << ", len: " << len;
 
-            Status st = (pulsar_pipe.get()->*append_data)(static_cast<const char*>(msg->getData()),
-                                                          static_cast<size_t>(len), row_delimiter);
+            Status st;
+            if (append_as_message) {
+                StreamMessageMeta meta(ByteBufferMetaType::PULSAR);
+                const StreamMessageMeta* meta_ptr = nullptr;
+                if (need_meta) {
+                    // pulsar_topic() exposes the configured logical topic; pulsar_partition() surfaces
+                    // the index parsed out of the per-message "<topic>-partition-N" name. The full
+                    // per-partition name (`partition`) stays the ack key.
+                    meta.set_topic(ctx->pulsar_info->topic);
+                    int32_t partition_index = parse_pulsar_partition_index(ctx->pulsar_info->topic, partition);
+                    if (partition_index >= 0) {
+                        meta.set_partition(partition_index);
+                    }
+                    meta.set_message_id(pulsar_message_id_to_string(msg_id));
+                    meta.set_timestamp(static_cast<int64_t>(msg->getPublishTimestamp()));
+                    // Pulsar uses 0 for an unset event time; map it to -1 so the column renders as NULL.
+                    int64_t event_ts = static_cast<int64_t>(msg->getEventTimestamp());
+                    meta.set_event_timestamp(event_ts > 0 ? event_ts : -1);
+                    if (need_key && msg->hasPartitionKey()) {
+                        meta.set_key(msg->getPartitionKey());
+                    }
+                    if (need_headers) {
+                        for (const auto& kv : msg->getProperties()) {
+                            meta.add_header(kv.first, kv.second);
+                        }
+                    }
+                    meta_ptr = &meta;
+                }
+                st = pulsar_pipe->append_json(static_cast<const char*>(msg->getData()), static_cast<size_t>(len),
+                                              row_delimiter, meta_ptr);
+            } else {
+                st = pulsar_pipe->append_with_row_delimiter(static_cast<const char*>(msg->getData()),
+                                                            static_cast<size_t>(len), row_delimiter);
+            }
 
             if (st.ok()) {
                 received_rows++;

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -96,6 +96,17 @@ std::string pulsar_message_id_to_string(const pulsar::MessageId& id) {
 
 } // namespace
 
+// Declared in the header (exposed for unit tests); see header comment for the wire-format contract.
+bool parse_confluent_schema_id(const char* data, size_t size, int32_t* schema_id) {
+    if (data == nullptr || size < 5 || static_cast<uint8_t>(data[0]) != 0x00) {
+        return false;
+    }
+    const auto* p = reinterpret_cast<const uint8_t*>(data);
+    *schema_id = (static_cast<int32_t>(p[1]) << 24) | (static_cast<int32_t>(p[2]) << 16) |
+                 (static_cast<int32_t>(p[3]) << 8) | static_cast<int32_t>(p[4]);
+    return true;
+}
+
 Status KafkaDataConsumerGroup::assign_topic_partitions(StreamLoadContext* ctx) {
     DCHECK(ctx->kafka_info);
     DCHECK(_consumers.size() >= 1);
@@ -176,6 +187,11 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
     // JSON/Avro: one message per buffer (with source metadata). CSV: rows separated by row_delimiter.
     const bool append_as_message =
             ctx->format == TFileFormatType::FORMAT_JSON || ctx->format == TFileFormatType::FORMAT_AVRO;
+
+    // Schema-evolution boundary detection: when enabled (Avro only), track the last Confluent
+    // schema id seen per partition so we can stop a batch right before a schema change.
+    const bool detect_schema_boundary = ctx->enable_schema_evolution && ctx->format == TFileFormatType::FORMAT_AVRO;
+    std::map<int32_t, int32_t> last_schema_id;
     char row_delimiter = '\n';
     if (!append_as_message) {
         auto& per_node_scan_ranges = ctx->put_result.params.params.per_node_scan_ranges;
@@ -277,6 +293,26 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                 }
             } else {
                 auto timestamp = msg->timestamp();
+                // Stop the batch at a Confluent schema-id boundary: if this message carries a
+                // different schema id than the last one seen on its partition, end the batch
+                // *before* appending it. The offset is not advanced, so the next task re-fetches
+                // this message; everything already appended commits cleanly via the normal path.
+                // A partition's first message only seeds last_schema_id (nothing to compare), so a
+                // boundary never fires on it — there is always at least one appended message first.
+                if (detect_schema_boundary) {
+                    int32_t schema_id = 0;
+                    if (parse_confluent_schema_id(static_cast<const char*>(msg->payload()),
+                                                  static_cast<size_t>(msg->len()), &schema_id)) {
+                        auto [it, inserted] = last_schema_id.try_emplace(msg->partition(), schema_id);
+                        if (!inserted && it->second != schema_id) {
+                            LOG(INFO) << "schema-evolution boundary on partition " << msg->partition() << ": schema id "
+                                      << it->second << " -> " << schema_id << ", stopping batch before offset "
+                                      << msg->offset() << ". grp: " << _grp_id;
+                            eos = true;
+                            continue;
+                        }
+                    }
+                }
                 Status st;
                 if (append_as_message) {
                     StreamMessageMeta meta(ByteBufferMetaType::KAFKA);

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -34,11 +34,37 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
+
 #include "base/concurrency/blocking_queue.hpp"
 #include "common/thread/priority_thread_pool.hpp"
 #include "runtime/routine_load/data_consumer.h"
 
 namespace starrocks {
+
+// Recover a Pulsar message's partition index from its topic name. The Pulsar C++ Message API exposes
+// no partition number at all -- only getTopicName() -- so the partition has to be parsed out of the
+// per-partition name Pulsar gives the Nth partition of a partitioned topic: "<topic>-partition-N".
+// (pulsar_topic() does not go through here; it is taken straight from the job's configured logical
+// topic, so only the index is parsed below.)
+//
+// The "-partition-N" suffix on its own is ambiguous: Pulsar lets you create a standalone
+// non-partitioned topic literally named "<x>-partition-<n>" (it only refuses the name when a
+// partitioned topic <x> with more than n partitions already exists), and that topic's getTopicName()
+// is byte-for-byte identical to partition n of a partitioned topic <x>. The job's configured logical
+// topic is the only thing that tells the two apart, so we anchor on it: a trailing "-partition-N" is a
+// real partition only when stripping it leaves exactly the configured topic.
+//
+// getTopicName() is the fully-qualified canonical name ("persistent://tenant/ns/<local-name>"), while
+// the configured topic may be the short local form ("<local-name>"). Pulsar only prepends the
+// scheme/tenant/namespace defaults and never rewrites the local name, so the configured topic is
+// always a suffix of the canonical name aligned on a "/" -- hence the match accepts either an exact
+// equality or a match at a leading "/" boundary.
+//
+// Returns the partition index, or -1 when message_topic is not a partition of logical_topic (the
+// scanner renders -1 as SQL NULL).
+int32_t parse_pulsar_partition_index(const std::string& logical_topic, const std::string& message_topic);
 
 // data consumer group saves a group of data consumers.
 // These data consumers share the same stream load pipe.

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -66,6 +66,12 @@ namespace starrocks {
 // scanner renders -1 as SQL NULL).
 int32_t parse_pulsar_partition_index(const std::string& logical_topic, const std::string& message_topic);
 
+// Parse the Confluent wire-format schema id from a message: a 0x00 magic byte followed by a 4-byte
+// big-endian schema id. Writes the id to *schema_id and returns true on success; returns false for
+// anything not framed this way (raw Avro, fewer than 5 bytes, wrong magic), so the caller falls back
+// to the normal append path. Used to detect schema-id boundaries within a routine-load batch.
+bool parse_confluent_schema_id(const char* data, size_t size, int32_t* schema_id);
+
 // data consumer group saves a group of data consumers.
 // These data consumers share the same stream load pipe.
 // This class is not thread safe.

--- a/be/src/runtime/routine_load/kafka_consumer_pipe.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe.h
@@ -54,39 +54,30 @@ public:
 
     ~KafkaConsumerPipe() override = default;
 
+    // CSV path: one buffer may hold many rows separated by row_delimiter. No source metadata is
+    // carried here (a CSV message can expand to N rows, so message-level meta is ambiguous).
     Status append_with_row_delimiter(const char* data, size_t size, char row_delimiter) {
-        return append_with_row_delimiter(data, size, row_delimiter, -1, -1);
-    }
-
-    Status append_with_row_delimiter(const char* data, size_t size, char row_delimiter, int32_t partition,
-                                     int64_t offset) {
-        // TODO support to add partition and offset to buffer meta
         Status st = append(data, size);
         if (!st.ok()) {
             return st;
         }
-
         // append the row delimiter
         st = append(&row_delimiter, 1);
         return st;
     }
 
-    Status append_json(const char* data, size_t size, char row_delimiter) {
-        return append_json(data, size, row_delimiter, -1, -1);
-    }
-
-    Status append_json(const char* data, size_t size, char row_delimiter, int32_t partition, int64_t offset) {
-        bool need_meta = partition >= 0 && offset >= 0;
+    // JSON/Avro path: exactly one message per buffer (no row delimiter) so the scanner can decode each
+    // message individually. When `meta` is non-null it is copied onto the buffer; the scanner reads it
+    // to fill metadata columns and to stamp source context into error logs. Its source type
+    // (KAFKA/PULSAR) selects the buffer meta type. row_delimiter is unused on this path.
+    Status append_json(const char* data, size_t size, char /*row_delimiter*/, const StreamMessageMeta* meta = nullptr) {
+        ByteBufferMetaType meta_type = (meta != nullptr) ? meta->type() : ByteBufferMetaType::NONE;
         // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
-        ASSIGN_OR_RETURN(auto buf, ByteBuffer::allocate_with_tracker(
-                                           size, simdjson::SIMDJSON_PADDING,
-                                           need_meta ? ByteBufferMetaType::KAFKA : ByteBufferMetaType::NONE));
+        ASSIGN_OR_RETURN(auto buf, ByteBuffer::allocate_with_tracker(size, simdjson::SIMDJSON_PADDING, meta_type));
         buf->put_bytes(data, size);
         buf->flip_to_read();
-        if (need_meta) {
-            KafkaByteBufferMeta* meta = static_cast<KafkaByteBufferMeta*>(buf->meta());
-            meta->set_partition(partition);
-            meta->set_offset(offset);
+        if (meta != nullptr) {
+            RETURN_IF_ERROR(buf->meta()->copy_from(const_cast<StreamMessageMeta*>(meta)));
         }
         return append(std::move(buf));
     }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -354,6 +354,9 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     } else {
         ctx->max_filter_ratio = 1.0;
     }
+    if (task.__isset.enable_schema_evolution) {
+        ctx->enable_schema_evolution = task.enable_schema_evolution;
+    }
 
     // set source related params
     switch (task.type) {
@@ -364,6 +367,8 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
         // real source instead of the SequentialFile placeholder name.
         ctx->put_result.params.query_options.__set_routine_load_source_info(
                 build_kafka_source_info(task.kafka_load_info));
+        // Thread the schema-evolution gate to the fragment so the Avro scanner can detect new columns.
+        ctx->put_result.params.query_options.__set_enable_avro_schema_evolution(ctx->enable_schema_evolution);
         break;
 #ifndef __APPLE__
     case TLoadSourceType::PULSAR:

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -51,6 +51,7 @@
 #include "cctz/time_zone.h"
 #include "common/global_types.h"
 #include "common/logging.h"
+#include "gen_cpp/Descriptors_types.h"     // for TColumn
 #include "gen_cpp/InternalService_types.h" // for TQueryOptions
 #include "gen_cpp/Types_types.h"           // for TUniqueId
 #include "runtime/arena_allocator.h"
@@ -538,6 +539,31 @@ public:
         _sink_commit_infos.emplace_back(sink_commit_info);
     }
 
+    // Avro routine-load schema evolution: set once by the Avro scanner when it reads a message whose
+    // schema is not yet covered by the table. Carries the full writer schema (every top-level field with
+    // its type), not a diff — the FE diffs it and decides the DDL. Read by the load task after the
+    // fragment finishes, to drive ALTER + retry. Single writer (one scan instance), read after the
+    // fragment completes, so no lock is needed.
+    void set_avro_schema_change(int32_t schema_id, std::vector<TColumn> schema_columns) {
+        _avro_schema_change_id = schema_id;
+        _avro_schema_columns = std::move(schema_columns);
+    }
+
+    // A varchar/varbinary column whose width an avro value overran; the FE widens it (to the varchar max).
+    // Length is not part of the avro schema, so this is detected per value, not at the schema-id gate.
+    void add_avro_widen_column(int32_t schema_id, std::string column_name) {
+        _avro_schema_change_id = schema_id;
+        _avro_widen_columns.emplace_back(std::move(column_name));
+    }
+
+    bool has_avro_schema_change() const { return !_avro_schema_columns.empty() || !_avro_widen_columns.empty(); }
+
+    int32_t avro_schema_change_id() const { return _avro_schema_change_id; }
+
+    const std::vector<TColumn>& avro_schema_columns() const { return _avro_schema_columns; }
+
+    const std::vector<std::string>& avro_widen_columns() const { return _avro_widen_columns; }
+
     // get mem limit for load channel
     // if load mem limit is not set, or is zero, using query mem limit instead.
     int64_t get_load_mem_limit() const;
@@ -765,6 +791,11 @@ private:
 
     std::mutex _sink_commit_infos_lock;
     std::vector<TSinkCommitInfo> _sink_commit_infos;
+
+    // Avro routine-load schema evolution; see set_avro_schema_change() / add_avro_widen_column().
+    int32_t _avro_schema_change_id = -1;
+    std::vector<TColumn> _avro_schema_columns;
+    std::vector<std::string> _avro_widen_columns;
 
     RuntimeFilterPort* _runtime_filter_port = nullptr;
     RuntimeFilterRegistry* _runtime_filter_registry = nullptr;

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -49,6 +49,7 @@
 #include "common/status.h"
 #include "common/system/backend_options.h"
 #include "gen_cpp/BackendService_types.h"
+#include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "pulsar/Client.h"
 #include "runtime/exec_env_fwd.h"
@@ -254,6 +255,10 @@ public:
     bool use_streaming = false;
     TFileFormatType::type format = TFileFormatType::FORMAT_CSV_PLAIN;
 
+    // Avro routine load: stop a batch at a Confluent schema-id boundary so old-schema
+    // messages commit before the new schema triggers an ALTER (see KafkaDataConsumerGroup).
+    bool enable_schema_evolution = false;
+
     TStreamLoadPutResult put_result;
 
     int64_t number_total_rows = 0;
@@ -282,6 +287,15 @@ public:
 
     std::vector<TTabletCommitInfo> commit_infos;
     std::vector<TTabletFailInfo> fail_infos;
+
+    // Avro schema evolution: copied from RuntimeState after the fragment finishes when the Avro scanner
+    // hit a schema the table does not cover. detected_schema_columns is the full writer schema, not a
+    // diff. Packed into the rollback attachment so the FE can diff + ALTER + retry.
+    bool schema_change_needed = false;
+    int32_t detected_schema_id = -1;
+    std::vector<TColumn> detected_schema_columns;
+    // varchar/varbinary columns an over-length value overran; the FE widens them (to the varchar max).
+    std::vector<std::string> detected_widen_columns;
 
     std::mutex lock;
 

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -67,7 +67,10 @@ public:
               topic(t_info.topic),
               confluent_schema_registry_url(t_info.confluent_schema_registry_url),
               begin_offset(t_info.partition_begin_offset),
-              properties(t_info.properties) {
+              properties(t_info.properties),
+              need_source_metadata(t_info.__isset.need_source_metadata && t_info.need_source_metadata),
+              need_message_key(t_info.__isset.need_message_key && t_info.need_message_key),
+              need_message_headers(t_info.__isset.need_message_headers && t_info.need_message_headers) {
         // The offset(begin_offset) sent from FE is the starting offset,
         // and the offset(cmt_offset) reported by BE to FE is the consumed offset,
         // so we need to minus 1 here.
@@ -96,6 +99,12 @@ public:
     std::map<int32_t, int64_t> cmt_offset_timestamp;
     //custom kafka property key -> value
     std::map<std::string, std::string> properties;
+    // Attach the extended per-message metadata (topic/timestamp/key/headers) to the buffer only when
+    // the job references a metadata column.
+    bool need_source_metadata{false};
+    // Only extract the message key / headers into buffer meta when the job references __key__ / __headers__.
+    bool need_message_key{false};
+    bool need_message_headers{false};
 };
 
 // pulsar related info
@@ -106,7 +115,10 @@ public:
               topic(t_info.topic),
               subscription(t_info.subscription),
               partitions(t_info.partitions),
-              properties(t_info.properties) {
+              properties(t_info.properties),
+              need_source_metadata(t_info.__isset.need_source_metadata && t_info.need_source_metadata),
+              need_message_key(t_info.__isset.need_message_key && t_info.need_message_key),
+              need_message_headers(t_info.__isset.need_message_headers && t_info.need_message_headers) {
         if (t_info.__isset.initial_positions) {
             initial_positions = t_info.initial_positions;
         }
@@ -131,6 +143,12 @@ public:
 
     // custom kafka property key -> value
     std::map<std::string, std::string> properties;
+    // Attach per-message source metadata to the buffer only when the job references a metadata column.
+    bool need_source_metadata{false};
+    // Only extract the message key (partition key) / headers (properties) when the job references
+    // __key__ / __headers__.
+    bool need_message_key{false};
+    bool need_message_headers{false};
 };
 
 class MessageBodySink;

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -97,6 +97,15 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
                 ctx->commit_infos = std::move(executor->runtime_state()->tablet_commit_infos());
                 ctx->fail_infos = std::move(executor->runtime_state()->tablet_fail_infos());
                 Status status = executor->status();
+                // Avro schema evolution drives a failed task (the scanner returns an error), so copy
+                // the detected schema out before the status branch below — the rollback attachment
+                // carries it to FE.
+                if (executor->runtime_state()->has_avro_schema_change()) {
+                    ctx->schema_change_needed = true;
+                    ctx->detected_schema_id = executor->runtime_state()->avro_schema_change_id();
+                    ctx->detected_schema_columns = executor->runtime_state()->avro_schema_columns();
+                    ctx->detected_widen_columns = executor->runtime_state()->avro_widen_columns();
+                }
                 if (status.ok()) {
                     ctx->number_total_rows = executor->runtime_state()->num_rows_load_sink() +
                                              executor->runtime_state()->num_rows_load_filtered() +
@@ -477,6 +486,16 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         rl_attach.__set_loadCostMs(ctx->load_cost_nanos / 1000 / 1000);
         if (!ctx->status.ok() && is_non_retryable_load_error(ctx->status.message())) {
             rl_attach.__set_nonRetryable(true);
+        }
+        if (ctx->schema_change_needed) {
+            rl_attach.__set_schemaChangeNeeded(true);
+            rl_attach.__set_detectedSchemaId(ctx->detected_schema_id);
+            if (!ctx->detected_schema_columns.empty()) {
+                rl_attach.__set_detectedSchemaColumns(ctx->detected_schema_columns);
+            }
+            if (!ctx->detected_widen_columns.empty()) {
+                rl_attach.__set_detectedWidenColumns(ctx->detected_widen_columns);
+            }
         }
 
         attach->rlTaskTxnCommitAttachment = rl_attach;

--- a/be/src/util/byte_buffer.cpp
+++ b/be/src/util/byte_buffer.cpp
@@ -21,6 +21,8 @@ std::string byte_buffer_meta_type_name(ByteBufferMetaType type) {
         return "NONE";
     } else if (type == ByteBufferMetaType::KAFKA) {
         return "KAFKA";
+    } else if (type == ByteBufferMetaType::PULSAR) {
+        return "PULSAR";
     } else {
         return "UNKNOWN";
     }
@@ -31,7 +33,8 @@ StatusOr<ByteBufferMeta*> ByteBufferMeta::create(ByteBufferMetaType meta_type) {
     case ByteBufferMetaType::NONE:
         return NoneByteBufferMeta::instance();
     case ByteBufferMetaType::KAFKA:
-        return new KafkaByteBufferMeta();
+    case ByteBufferMetaType::PULSAR:
+        return new StreamMessageMeta(meta_type);
     }
     return Status::NotSupported(fmt::format("unknown byte buffer meta type {}", byte_buffer_meta_type_name(meta_type)));
 }
@@ -45,16 +48,36 @@ Status NoneByteBufferMeta::copy_from(ByteBufferMeta* source) {
     return Status::OK();
 }
 
-Status KafkaByteBufferMeta::copy_from(ByteBufferMeta* source) {
-    if (source->type() != ByteBufferMetaType::KAFKA) {
+Status StreamMessageMeta::copy_from(ByteBufferMeta* source) {
+    if (source->type() != _source) {
         return Status::NotSupported(fmt::format("can't copy byte buffer {} meta to {} meta",
                                                 byte_buffer_meta_type_name(source->type()),
                                                 byte_buffer_meta_type_name(type())));
     }
-    auto kafka_meta = static_cast<KafkaByteBufferMeta*>(source);
-    _partition = kafka_meta->_partition;
-    _offset = kafka_meta->_offset;
+    auto* meta = static_cast<StreamMessageMeta*>(source);
+    // Overwrite every field; never append. A negative/empty/!has_key value means "absent" and must
+    // replace any stale data from the message this buffer previously held.
+    _topic = meta->_topic;
+    _partition = meta->_partition;
+    _offset = meta->_offset;
+    _message_id = meta->_message_id;
+    _timestamp = meta->_timestamp;
+    _event_timestamp = meta->_event_timestamp;
+    _has_key = meta->_has_key;
+    _key = meta->_has_key ? meta->_key : std::string();
+    _headers = meta->_headers;
     return Status::OK();
+}
+
+std::string StreamMessageMeta::to_string() const {
+    if (_source == ByteBufferMetaType::PULSAR) {
+        return fmt::format("pulsar topic: {}, partition: {}, message_id: {}", _topic, _partition, _message_id);
+    }
+    if (_topic.empty()) {
+        // A Kafka buffer from a job with no metadata column carries only partition/offset.
+        return fmt::format("kafka partition: {}, offset: {}", _partition, _offset);
+    }
+    return fmt::format("kafka topic: {}, partition: {}, offset: {}", _topic, _partition, _offset);
 }
 
 } // namespace starrocks

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -37,6 +37,9 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "base/testutil/sync_point.h"
 #include "common/logging.h"
@@ -63,16 +66,16 @@ struct MemTrackerDeleter {
     }
 };
 
-enum class ByteBufferMetaType { NONE, KAFKA };
+enum class ByteBufferMetaType { NONE, KAFKA, PULSAR };
 
 std::string byte_buffer_meta_type_name(ByteBufferMetaType type);
 
 class ByteBufferMeta {
 public:
     virtual ~ByteBufferMeta() = default;
-    virtual ByteBufferMetaType type() = 0;
+    virtual ByteBufferMetaType type() const = 0;
     virtual Status copy_from(ByteBufferMeta* source) = 0;
-    virtual std::string to_string() = 0;
+    virtual std::string to_string() const = 0;
 
     static StatusOr<ByteBufferMeta*> create(ByteBufferMetaType meta_type);
 };
@@ -84,10 +87,10 @@ public:
     NoneByteBufferMeta(NoneByteBufferMeta&&) = delete;
     NoneByteBufferMeta& operator=(NoneByteBufferMeta&&) = delete;
 
-    ByteBufferMetaType type() override { return ByteBufferMetaType::NONE; }
+    ByteBufferMetaType type() const override { return ByteBufferMetaType::NONE; }
 
     Status copy_from(ByteBufferMeta* source) override;
-    std::string to_string() override { return "none"; }
+    std::string to_string() const override { return "none"; }
 
     static NoneByteBufferMeta* instance() {
         static NoneByteBufferMeta instance;
@@ -98,24 +101,62 @@ private:
     NoneByteBufferMeta() = default;
 };
 
-class KafkaByteBufferMeta : public ByteBufferMeta {
+// Per-message metadata for routine-load stream sources (Kafka/Pulsar). Carries the message-level
+// fields a job may surface via the source-metadata functions (kafka_topic(), kafka_header('k'), ...):
+// topic, partition, offset/message_id, timestamp/event_timestamp, key, headers. One class for both
+// sources, tagged by type(); a field left at its sentinel (negative number / empty / !has_key) is
+// rendered as SQL NULL by the scanner. copy_from() fully overwrites every field so a buffer reused
+// across messages never leaks the previous message's key/headers.
+class StreamMessageMeta : public ByteBufferMeta {
 public:
-    KafkaByteBufferMeta() = default;
+    explicit StreamMessageMeta(ByteBufferMetaType source) : _source(source) {}
 
-    ByteBufferMetaType type() override { return ByteBufferMetaType::KAFKA; }
+    ByteBufferMetaType type() const override { return _source; }
+
+    void set_topic(std::string topic) { _topic = std::move(topic); }
+    const std::string& topic() const { return _topic; }
 
     void set_partition(int32_t partition) { _partition = partition; }
     int32_t partition() const { return _partition; }
+
     void set_offset(int64_t offset) { _offset = offset; }
     int64_t offset() const { return _offset; }
 
+    void set_message_id(std::string message_id) { _message_id = std::move(message_id); }
+    const std::string& message_id() const { return _message_id; }
+
+    void set_timestamp(int64_t timestamp) { _timestamp = timestamp; }
+    int64_t timestamp() const { return _timestamp; }
+
+    void set_event_timestamp(int64_t event_timestamp) { _event_timestamp = event_timestamp; }
+    int64_t event_timestamp() const { return _event_timestamp; }
+
+    // A null key and an empty key are distinct: only set_key() marks the key present.
+    void set_key(std::string key) {
+        _key = std::move(key);
+        _has_key = true;
+    }
+    bool has_key() const { return _has_key; }
+    const std::string& key() const { return _key; }
+
+    void add_header(std::string key, std::string value) { _headers.emplace_back(std::move(key), std::move(value)); }
+    const std::vector<std::pair<std::string, std::string>>& headers() const { return _headers; }
+
     Status copy_from(ByteBufferMeta* source) override;
 
-    std::string to_string() override { return fmt::format("kafka partition: {}, offset: {}", _partition, _offset); }
+    std::string to_string() const override;
 
 private:
+    ByteBufferMetaType _source;
+    std::string _topic;
     int32_t _partition{-1};
-    int64_t _offset{-1};
+    int64_t _offset{-1};          // Kafka position
+    std::string _message_id;      // Pulsar position
+    int64_t _timestamp{-1};       // ms since epoch, -1 = not available (Kafka record ts / Pulsar publish time)
+    int64_t _event_timestamp{-1}; // ms since epoch, -1 = not available (Pulsar event time)
+    bool _has_key{false};
+    std::string _key;
+    std::vector<std::pair<std::string, std::string>> _headers;
 };
 
 struct ByteBuffer {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -134,6 +134,7 @@ set(EXEC_FILES
         ./exec/file_scanner/json_scanner_test.cpp
         ./exec/file_scanner/orc_scanner_test.cpp
         ./exec/file_scanner/parquet_scanner_test.cpp
+        ./exec/file_scanner/stream_source_meta_test.cpp
         ./exec/hdfs_scanner/cache_select_scanner_test.cpp
         ./exec/hdfs_scanner/hdfs_scanner_json_test.cpp
         ./exec/hdfs_scanner/hdfs_scanner_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -127,6 +127,7 @@ set(EXEC_FILES
         ./exec/file_scanner/avro_cpp_scanner_test.cpp
         ./exec/file_scanner/avro_datum_path_test.cpp
         ./exec/file_scanner/avro_scanner_test.cpp
+        ./exec/file_scanner/avro_schema_evolution_test.cpp
         ./exec/file_scanner/avro_struct_map_test.cpp
         ./exec/file_scanner/confluent_avro_decoder_test.cpp
         ./exec/file_scanner/csv_scanner_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -125,7 +125,10 @@ set(EXEC_FILES
         ./exec/table_function_node_test.cpp
         ./exec/olap_scan_prepare_test.cpp
         ./exec/file_scanner/avro_cpp_scanner_test.cpp
+        ./exec/file_scanner/avro_datum_path_test.cpp
         ./exec/file_scanner/avro_scanner_test.cpp
+        ./exec/file_scanner/avro_struct_map_test.cpp
+        ./exec/file_scanner/confluent_avro_decoder_test.cpp
         ./exec/file_scanner/csv_scanner_test.cpp
         ./exec/file_scanner/file_scanner_test.cpp
         ./exec/file_scanner/json_scanner_test.cpp

--- a/be/test/exec/file_scanner/avro_datum_path_test.cpp
+++ b/be/test/exec/file_scanner/avro_datum_path_test.cpp
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/avro_datum_path.h"
+
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <vector>
+
+#include "exec/file_scanner/confluent_avro_decoder.h"
+#include "exprs/json_functions.h"
+
+namespace starrocks {
+
+// Builds one decoded GenericDatum from a fixed schema and hand-encoded Avro binary, then exercises
+// the jsonpath navigator against it (record descent, array index, nullable-union, missing field).
+class AvroDatumPathTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        static const char* kJson = R"({
+            "type": "record",
+            "name": "r",
+            "fields": [
+                {"name": "id", "type": "long"},
+                {"name": "nested", "type": {"type": "record", "name": "n",
+                                            "fields": [{"name": "x", "type": "long"}]}},
+                {"name": "arr", "type": {"type": "array", "items": "long"}},
+                {"name": "opt", "type": ["null", "long"]}
+            ]
+        })";
+        _decoder = std::make_unique<ConfluentAvroDecoder>(avro::compileJsonSchemaFromString(kJson));
+        ASSERT_TRUE(_decoder->init().ok());
+
+        // {id: 5, nested: {x: 7}, arr: [1, 2], opt: null}
+        //   id        long 5  -> zigzag 10 -> 0x0A
+        //   nested.x  long 7  -> zigzag 14 -> 0x0E
+        //   arr       block count 2 (0x04), items 1 (0x02) 2 (0x04), end block 0 (0x00)
+        //   opt       union branch 0 (null) -> 0x00
+        const std::vector<uint8_t> bytes = {0x0A, 0x0E, 0x04, 0x02, 0x04, 0x00, 0x00};
+        ASSERT_TRUE(_decoder->decode(bytes.data(), bytes.size(), &_datum).ok());
+    }
+
+    std::vector<SimpleJsonPath> path(const std::string& p) {
+        std::vector<SimpleJsonPath> parsed;
+        CHECK(JsonFunctions::parse_json_paths(p, &parsed).ok());
+        return parsed;
+    }
+
+    std::unique_ptr<ConfluentAvroDecoder> _decoder;
+    avro::GenericDatum _datum;
+};
+
+TEST_F(AvroDatumPathTest, top_level_field) {
+    auto r = avro_extract_field(_datum, path("$.id"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{5}, r.value()->value<int64_t>());
+}
+
+TEST_F(AvroDatumPathTest, nested_record) {
+    auto r = avro_extract_field(_datum, path("$.nested.x"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{7}, r.value()->value<int64_t>());
+}
+
+TEST_F(AvroDatumPathTest, array_index) {
+    auto r = avro_extract_field(_datum, path("$.arr[1]"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{2}, r.value()->value<int64_t>());
+}
+
+TEST_F(AvroDatumPathTest, array_index_out_of_range_errors) {
+    auto r = avro_extract_field(_datum, path("$.arr[9]"));
+    EXPECT_FALSE(r.ok());
+    EXPECT_FALSE(r.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, nullable_union_null_branch) {
+    auto r = avro_extract_field(_datum, path("$.opt"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(avro::AVRO_NULL, r.value()->type());
+}
+
+TEST_F(AvroDatumPathTest, path_through_scalar_leaf_errors) {
+    // $.id.x on a long `id`: the legacy reader silently returns `id`; the native reader rejects it.
+    auto r = avro_extract_field(_datum, path("$.id.x"));
+    EXPECT_FALSE(r.ok());
+    EXPECT_FALSE(r.status().is_not_found());
+
+    auto deep = avro_extract_field(_datum, path("$.nested.x.y"));
+    EXPECT_FALSE(deep.ok());
+    EXPECT_FALSE(deep.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, missing_field_is_not_found) {
+    auto r = avro_extract_field(_datum, path("$.missing"));
+    EXPECT_TRUE(r.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, whole_datum) {
+    auto r = avro_extract_field(_datum, path("$"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(avro::AVRO_RECORD, r.value()->type());
+}
+
+TEST_F(AvroDatumPathTest, root_index_on_non_array_errors) {
+    // $[0] on a record root: the legacy reader silently ignores the index and returns the whole
+    // record; the native reader rejects it.
+    auto r = avro_extract_field(_datum, path("$[0]"));
+    EXPECT_FALSE(r.ok());
+    EXPECT_FALSE(r.status().is_not_found());
+
+    auto deep = avro_extract_field(_datum, path("$[0].id"));
+    EXPECT_FALSE(deep.ok());
+    EXPECT_FALSE(deep.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, array_root) {
+    ConfluentAvroDecoder decoder(avro::compileJsonSchemaFromString(R"({"type":"array","items":"long"})"));
+    ASSERT_TRUE(decoder.init().ok());
+    // [7, 9]: block count 2 (0x04), items 7 (0x0E) 9 (0x12), end block 0 (0x00)
+    const std::vector<uint8_t> bytes = {0x04, 0x0E, 0x12, 0x00};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(bytes.data(), bytes.size(), &datum).ok());
+
+    auto r = avro_extract_field(datum, path("$[1]"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{9}, r.value()->value<int64_t>());
+
+    // A field selector on an array root is invalid.
+    auto bad = avro_extract_field(datum, path("$.x"));
+    EXPECT_FALSE(bad.ok());
+    EXPECT_FALSE(bad.status().is_not_found());
+}
+
+TEST_F(AvroDatumPathTest, nullable_array_root) {
+    // ["null", array<long>] top-level union: the root union is peeled before the root-array branch,
+    // so $[i] still indexes a nullable array, and a null root yields NULL for any path.
+    ConfluentAvroDecoder decoder(avro::compileJsonSchemaFromString(R"(["null", {"type":"array","items":"long"}])"));
+    ASSERT_TRUE(decoder.init().ok());
+
+    // union branch 1 (0x02), array [5]: count 1 (0x02), item 5 (0x0A), end block 0 (0x00)
+    const std::vector<uint8_t> bytes = {0x02, 0x02, 0x0A, 0x00};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(bytes.data(), bytes.size(), &datum).ok());
+    auto r = avro_extract_field(datum, path("$[0]"));
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(int64_t{5}, r.value()->value<int64_t>());
+
+    // union branch 0 (null)
+    const std::vector<uint8_t> null_bytes = {0x00};
+    avro::GenericDatum null_datum;
+    ASSERT_TRUE(decoder.decode(null_bytes.data(), null_bytes.size(), &null_datum).ok());
+    auto n = avro_extract_field(null_datum, path("$[0]"));
+    ASSERT_TRUE(n.ok());
+    EXPECT_EQ(avro::AVRO_NULL, n.value()->type());
+}
+
+TEST_F(AvroDatumPathTest, preprocess_jsonpaths_rewrites_union_star) {
+    EXPECT_EQ("$.id", avro_preprocess_jsonpaths("$.*.id"));
+    EXPECT_EQ("$.a.b", avro_preprocess_jsonpaths("$.a.*.b"));
+    EXPECT_EQ("$.a", avro_preprocess_jsonpaths("$.a.*"));
+}
+
+} // namespace starrocks

--- a/be/test/exec/file_scanner/avro_schema_evolution_test.cpp
+++ b/be/test/exec/file_scanner/avro_schema_evolution_test.cpp
@@ -1,0 +1,345 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <avrocpp/GenericDatum.hh>
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "exec/file_scanner/avro_stream_scanner.h"    // avro_record_to_columns, avro_schema_needs_evolution
+#include "runtime/routine_load/data_consumer_group.h" // parse_confluent_schema_id
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+// --- parse_confluent_schema_id: Confluent wire-format header parsing ---
+
+static bool parse_id(const std::vector<uint8_t>& wire, int32_t* id) {
+    return parse_confluent_schema_id(reinterpret_cast<const char*>(wire.data()), wire.size(), id);
+}
+
+TEST(ParseConfluentSchemaIdTest, valid_small_id) {
+    int32_t id = -99;
+    ASSERT_TRUE(parse_id({0x00, 0x00, 0x00, 0x00, 0x07}, &id));
+    EXPECT_EQ(7, id);
+}
+
+TEST(ParseConfluentSchemaIdTest, big_endian_order) {
+    int32_t id = 0;
+    // 0x00 magic + 0x00000100 == 256: proves the 4 bytes are read most-significant first.
+    ASSERT_TRUE(parse_id({0x00, 0x00, 0x00, 0x01, 0x00}, &id));
+    EXPECT_EQ(256, id);
+}
+
+TEST(ParseConfluentSchemaIdTest, full_four_bytes) {
+    int32_t id = 0;
+    ASSERT_TRUE(parse_id({0x00, 0x12, 0x34, 0x56, 0x78}, &id));
+    EXPECT_EQ(0x12345678, id);
+}
+
+TEST(ParseConfluentSchemaIdTest, max_int_does_not_overflow) {
+    int32_t id = 0;
+    ASSERT_TRUE(parse_id({0x00, 0x7F, 0xFF, 0xFF, 0xFF}, &id));
+    EXPECT_EQ(INT32_MAX, id);
+}
+
+TEST(ParseConfluentSchemaIdTest, ignores_trailing_payload) {
+    int32_t id = 0;
+    // 5-byte header (id == 7) followed by the avro payload; only the header is parsed.
+    ASSERT_TRUE(parse_id({0x00, 0x00, 0x00, 0x00, 0x07, 0x36, 0x04, 0x68, 0x69}, &id));
+    EXPECT_EQ(7, id);
+}
+
+TEST(ParseConfluentSchemaIdTest, wrong_magic_byte) {
+    int32_t id = 0;
+    EXPECT_FALSE(parse_id({0x01, 0x00, 0x00, 0x00, 0x07}, &id));
+}
+
+TEST(ParseConfluentSchemaIdTest, too_short) {
+    int32_t id = 0;
+    EXPECT_FALSE(parse_id({0x00, 0x00, 0x00, 0x07}, &id)); // 4 bytes, need at least 5
+}
+
+TEST(ParseConfluentSchemaIdTest, null_data) {
+    int32_t id = 0;
+    EXPECT_FALSE(parse_confluent_schema_id(nullptr, 0, &id));
+}
+
+static avro::NodePtr record_root(const char* json) {
+    return avro::compileJsonSchemaFromString(json).root();
+}
+
+// --- avro_record_to_columns: serialize the whole writer schema (a full schema, never a diff) ---
+
+TEST(AvroRecordToColumnsTest, serializes_all_top_level_fields_nullable) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"id","type":"long"},{"name":"name","type":"string"}]})");
+    auto res = avro_record_to_columns(node);
+    ASSERT_TRUE(res.ok());
+    ASSERT_EQ(2u, res.value().size());
+    EXPECT_EQ("id", res.value()[0].column_name);
+    EXPECT_EQ("name", res.value()[1].column_name);
+    // Added columns must be nullable: existing rows have no value for them.
+    EXPECT_TRUE(res.value()[0].is_allow_null);
+    EXPECT_TRUE(res.value()[1].is_allow_null);
+}
+
+TEST(AvroRecordToColumnsTest, preserves_nested_struct_type) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"addr","type":{"type":"record","name":"a","fields":[
+            {"name":"city","type":"string"}]}}]})");
+    auto res = avro_record_to_columns(node);
+    ASSERT_TRUE(res.ok());
+    ASSERT_EQ(1u, res.value().size());
+    const TColumn& col = res.value()[0];
+    EXPECT_EQ("addr", col.column_name);
+    // The nested struct shape survives into type_desc so the FE can diff subfields and emit ADD FIELD.
+    ASSERT_FALSE(col.type_desc.types.empty());
+    EXPECT_EQ(TTypeNodeType::STRUCT, col.type_desc.types[0].type);
+    ASSERT_EQ(1u, col.type_desc.types[0].struct_fields.size());
+    EXPECT_EQ("city", col.type_desc.types[0].struct_fields[0].name);
+}
+
+// --- avro_schema_needs_evolution: recursive coverage gate (decides whether to escalate to the FE) ---
+
+TEST(AvroSchemaNeedsEvolutionTest, all_top_level_covered_is_false) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"id","type":"long"},{"name":"name","type":"string"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"id", TypeDescriptor(TYPE_BIGINT)},
+                                                               {"name", TypeDescriptor(TYPE_VARCHAR)}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, new_top_level_field_is_true) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"id","type":"long"},{"name":"age","type":"int"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"id", TypeDescriptor(TYPE_BIGINT)}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, new_nested_struct_subfield_is_true) {
+    // Table has addr STRUCT<city>; the message's addr now also carries zip -> evolution needed. The old
+    // top-level-only check missed this (addr is a known column); the recursive gate catches it.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"addr","type":{"type":"record","name":"a","fields":[
+            {"name":"city","type":"string"},{"name":"zip","type":"string"}]}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"addr", TypeDescriptor::create_struct_type({"city"}, {TypeDescriptor(TYPE_VARCHAR)})}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, fully_covered_nested_struct_is_false) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"addr","type":{"type":"record","name":"a","fields":[
+            {"name":"city","type":"string"},{"name":"zip","type":"string"}]}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"addr", TypeDescriptor::create_struct_type({"city", "zip"},
+                                                        {TypeDescriptor(TYPE_VARCHAR), TypeDescriptor(TYPE_VARCHAR)})}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, nested_subfield_under_nullable_union_is_true) {
+    // addr is an optional ["null", record] in the writer schema; the union is unwrapped before the
+    // subfield comparison, otherwise the new zip would be missed.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"addr","type":["null",{"type":"record","name":"a","fields":[
+            {"name":"city","type":"string"},{"name":"zip","type":"string"}]}]}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"addr", TypeDescriptor::create_struct_type({"city"}, {TypeDescriptor(TYPE_VARCHAR)})}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, metadata_collision_is_true) {
+    // src_part is a hidden metadata column (e.g. kafka_partition()); a payload field of the same name
+    // must escalate so the FE fails the job rather than silently shadowing it.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"id","type":"long"},{"name":"src_part","type":"int"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"id", TypeDescriptor(TYPE_BIGINT)}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {"src_part"}));
+}
+
+// --- avro_schema_needs_evolution: type fit (same name, changed/incompatible writer type) ---
+
+TEST(AvroSchemaNeedsEvolutionTest, integer_widening_into_narrow_column_is_true) {
+    // Field was int (column INT); writer promoted it to long -> column too narrow -> escalate.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[{"name":"x","type":"long"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"x", TypeDescriptor(TYPE_INT)}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, integer_into_wider_column_is_false) {
+    // Writer int, column BIGINT: fits, no evolution (the common "declared BIGINT, send int" case).
+    auto node = record_root(R"({"type":"record","name":"r","fields":[{"name":"x","type":"int"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"x", TypeDescriptor(TYPE_BIGINT)}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, long_into_bigint_is_false) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[{"name":"x","type":"long"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"x", TypeDescriptor(TYPE_BIGINT)}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, double_into_float_column_is_true) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[{"name":"x","type":"double"}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"x", TypeDescriptor(TYPE_FLOAT)}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, decimal_precision_growth_is_true) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"amt","type":{"type":"bytes","logicalType":"decimal","precision":12,"scale":4}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"amt", TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2)}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, decimal_that_fits_is_false) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"amt","type":{"type":"bytes","logicalType":"decimal","precision":8,"scale":1}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"amt", TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2)}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, scalar_turned_struct_is_true) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"x","type":{"type":"record","name":"x_rec","fields":[{"name":"a","type":"long"}]}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"x", TypeDescriptor(TYPE_INT)}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, record_into_varchar_column_is_false) {
+    // A varchar column accommodates any value (the reader JSON-encodes the record), so no escalation.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"x","type":{"type":"record","name":"x_rec","fields":[{"name":"a","type":"long"}]}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"x", TypeDescriptor(TYPE_VARCHAR)}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, nested_struct_subfield_widened_is_true) {
+    // addr.a was int (STRUCT<a INT>); writer promoted the subfield to long -> escalate via recursion.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"addr","type":{"type":"record","name":"a_rec","fields":[{"name":"a","type":"long"}]}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"addr", TypeDescriptor::create_struct_type({"a"}, {TypeDescriptor(TYPE_INT)})}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+// --- avro_value_overflows_varchar: per-value varchar/varbinary length overrun (widen signal) ---
+
+TEST(AvroValueOverflowsVarcharTest, overlong_string_in_narrow_varchar_is_true) {
+    avro::GenericDatum d(std::string("abcdef")); // length 6
+    EXPECT_TRUE(avro_value_overflows_varchar(TypeDescriptor::create_varchar_type(5), d));
+}
+
+TEST(AvroValueOverflowsVarcharTest, fitting_string_is_false) {
+    avro::GenericDatum d(std::string("abc")); // length 3
+    EXPECT_FALSE(avro_value_overflows_varchar(TypeDescriptor::create_varchar_type(5), d));
+}
+
+TEST(AvroValueOverflowsVarcharTest, max_width_column_never_overflows) {
+    avro::GenericDatum d(std::string("abcdef"));
+    EXPECT_FALSE(
+            avro_value_overflows_varchar(TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH), d));
+}
+
+TEST(AvroValueOverflowsVarcharTest, non_varchar_column_is_false) {
+    avro::GenericDatum d(std::string("abcdef"));
+    EXPECT_FALSE(avro_value_overflows_varchar(TypeDescriptor(TYPE_INT), d));
+}
+
+// --- avro_schema_needs_evolution: ARRAY recurses the element type ---
+
+TEST(AvroSchemaNeedsEvolutionTest, array_element_widened_is_true) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"arr","type":{"type":"array","items":"long"}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"arr", TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT))}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, array_element_that_fits_is_false) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"arr","type":{"type":"array","items":"int"}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"arr", TypeDescriptor::create_array_type(TypeDescriptor(TYPE_BIGINT))}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, array_into_varchar_column_is_false) {
+    // A varchar column accommodates an array (the reader JSON-encodes it), so no escalation.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"arr","type":{"type":"array","items":"int"}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {{"arr", TypeDescriptor(TYPE_VARCHAR)}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+// --- avro_schema_needs_evolution: MAP recurses the value type (the key is a scalar by Avro) ---
+
+TEST(AvroSchemaNeedsEvolutionTest, map_value_widened_is_true) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"m","type":{"type":"map","values":"long"}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"m", TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(16), TypeDescriptor(TYPE_INT))}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, map_value_that_fits_is_false) {
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"m","type":{"type":"map","values":"int"}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"m",
+             TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(16), TypeDescriptor(TYPE_BIGINT))}};
+    EXPECT_FALSE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, map_with_non_string_key_column_is_true) {
+    // Avro map keys are always strings; a MAP<INT,...> column cannot take them even though the value
+    // side fits, so the schema must escalate (the FE pauses the job).
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"m","type":{"type":"map","values":"int"}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"m", TypeDescriptor::create_map_type(TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_BIGINT))}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+TEST(AvroSchemaNeedsEvolutionTest, case_only_struct_subfield_is_true) {
+    // Subfield names are matched exactly here, while the FE's StructType lookup is case-insensitive;
+    // the FE must treat a case-only subfield match as uncovered too, or this escalation would loop.
+    auto node = record_root(R"({"type":"record","name":"r","fields":[
+        {"name":"addr","type":{"type":"record","name":"a","fields":[
+            {"name":"foo","type":"string"}]}}]})");
+    std::unordered_map<std::string, TypeDescriptor> payload = {
+            {"addr", TypeDescriptor::create_struct_type({"Foo"}, {TypeDescriptor(TYPE_VARCHAR)})}};
+    EXPECT_TRUE(avro_schema_needs_evolution(node, payload, {}));
+}
+
+// --- avro_value_overflows_varchar: varbinary (bytes) length overrun ---
+
+TEST(AvroValueOverflowsVarcharTest, overlong_bytes_in_narrow_varbinary_is_true) {
+    avro::GenericDatum d(std::vector<uint8_t>{1, 2, 3, 4, 5, 6}); // length 6
+    EXPECT_TRUE(avro_value_overflows_varchar(TypeDescriptor::create_varbinary_type(5), d));
+}
+
+TEST(AvroValueOverflowsVarcharTest, fitting_bytes_is_false) {
+    avro::GenericDatum d(std::vector<uint8_t>{1, 2, 3}); // length 3
+    EXPECT_FALSE(avro_value_overflows_varchar(TypeDescriptor::create_varbinary_type(5), d));
+}
+
+} // namespace starrocks

--- a/be/test/exec/file_scanner/avro_struct_map_test.cpp
+++ b/be/test/exec/file_scanner/avro_struct_map_test.cpp
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cctz/time_zone.h>
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <vector>
+
+#include "column/column_helper.h"
+#include "exec/file_scanner/confluent_avro_decoder.h"
+#include "formats/avro/cpp/column_reader.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+// Proves STRUCT and MAP end-to-end on the routine-load decode path: decode a message into a
+// GenericDatum (ConfluentAvroDecoder), then fill columns with the same avrocpp column readers the
+// scanner uses, and check the rendered values. No pipe/scanner needed.
+class AvroStructMapTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        static const char* kJson = R"({
+            "type": "record",
+            "name": "r",
+            "fields": [
+                {"name": "s", "type": {"type": "record", "name": "inner",
+                                       "fields": [{"name": "a", "type": "long"},
+                                                  {"name": "b", "type": "string"}]}},
+                {"name": "m", "type": {"type": "map", "values": "long"}}
+            ]
+        })";
+        _decoder = std::make_unique<ConfluentAvroDecoder>(avro::compileJsonSchemaFromString(kJson));
+        ASSERT_TRUE(_decoder->init().ok());
+
+        // {s: {a: 1, b: "x"}, m: {"k1": 10, "k2": 20}}
+        //   s.a   long 1     -> 0x02
+        //   s.b   string "x" -> len 1 (0x02) + 'x' (0x78)
+        //   m     map block count 2 (0x04),
+        //           "k1" (len 2 -> 0x04) 'k'(0x6B)'1'(0x31), value 10 (0x14),
+        //           "k2" (len 2 -> 0x04) 'k'(0x6B)'2'(0x32), value 20 (0x28),
+        //         end block 0 (0x00)
+        const std::vector<uint8_t> bytes = {0x02, 0x02, 0x78, 0x04, 0x04, 0x6B, 0x31,
+                                            0x14, 0x04, 0x6B, 0x32, 0x28, 0x00};
+        ASSERT_TRUE(_decoder->decode(bytes.data(), bytes.size(), &_datum).ok());
+        _tz = cctz::utc_time_zone();
+    }
+
+    std::unique_ptr<ConfluentAvroDecoder> _decoder;
+    avro::GenericDatum _datum;
+    cctz::time_zone _tz;
+};
+
+TEST_F(AvroStructMapTest, struct_field) {
+    auto type = TypeDescriptor::create_struct_type(
+            {"a", "b"}, {TypeDescriptor(TYPE_BIGINT), TypeDescriptor::create_varchar_type(16)});
+    auto reader = avrocpp::ColumnReader::get_nullable_column_reader("s", type, _tz, /*invalid_as_null=*/true);
+    auto column = ColumnHelper::create_column(type, true);
+
+    const auto& field = _datum.value<avro::GenericRecord>().field("s");
+    ASSERT_TRUE(reader->read_datum(field, column.get()).ok());
+    EXPECT_EQ("{a:1,b:'x'}", column->debug_item(0));
+}
+
+TEST_F(AvroStructMapTest, map_field) {
+    auto type = TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(16), TypeDescriptor(TYPE_BIGINT));
+    auto reader = avrocpp::ColumnReader::get_nullable_column_reader("m", type, _tz, /*invalid_as_null=*/true);
+    auto column = ColumnHelper::create_column(type, true);
+
+    const auto& field = _datum.value<avro::GenericRecord>().field("m");
+    ASSERT_TRUE(reader->read_datum(field, column.get()).ok());
+    EXPECT_EQ("{'k1':10,'k2':20}", column->debug_item(0));
+}
+
+TEST_F(AvroStructMapTest, map_with_non_string_key_column_is_rejected) {
+    // Avro map keys are always strings; a MAP<INT,...> column must yield a data error (NULL in
+    // non-strict mode), not raw string bytes appended into the integer key column.
+    auto type = TypeDescriptor::create_map_type(TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_BIGINT));
+    const auto& field = _datum.value<avro::GenericRecord>().field("m");
+
+    auto strict_reader = avrocpp::ColumnReader::get_nullable_column_reader("m", type, _tz, /*invalid_as_null=*/false);
+    auto column = ColumnHelper::create_column(type, true);
+    auto st = strict_reader->read_datum(field, column.get());
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_data_quality_error());
+
+    auto lax_reader = avrocpp::ColumnReader::get_nullable_column_reader("m", type, _tz, /*invalid_as_null=*/true);
+    auto lax_column = ColumnHelper::create_column(type, true);
+    ASSERT_TRUE(lax_reader->read_datum(field, lax_column.get()).ok());
+    EXPECT_EQ("NULL", lax_column->debug_item(0));
+}
+
+TEST_F(AvroStructMapTest, kind_mismatched_datum_is_rejected) {
+    // The reader is built from the table column type while the datum carries whatever the writer
+    // sent: a scalar datum routed into a STRUCT/MAP/ARRAY column must yield a data error (NULL in
+    // non-strict mode), not a crashing value<T>() cast.
+    const auto& scalar = _datum.value<avro::GenericRecord>().field("s").value<avro::GenericRecord>().field("a");
+    const std::vector<TypeDescriptor> types = {
+            TypeDescriptor::create_struct_type({"a"}, {TypeDescriptor(TYPE_BIGINT)}),
+            TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(16), TypeDescriptor(TYPE_BIGINT)),
+            TypeDescriptor::create_array_type(TypeDescriptor(TYPE_BIGINT)),
+    };
+    for (const auto& type : types) {
+        auto strict_reader =
+                avrocpp::ColumnReader::get_nullable_column_reader("c", type, _tz, /*invalid_as_null=*/false);
+        auto column = ColumnHelper::create_column(type, true);
+        auto st = strict_reader->read_datum(scalar, column.get());
+        ASSERT_FALSE(st.ok()) << type.debug_string();
+        EXPECT_TRUE(st.is_data_quality_error()) << type.debug_string();
+
+        auto lax_reader = avrocpp::ColumnReader::get_nullable_column_reader("c", type, _tz, /*invalid_as_null=*/true);
+        auto lax_column = ColumnHelper::create_column(type, true);
+        ASSERT_TRUE(lax_reader->read_datum(scalar, lax_column.get()).ok()) << type.debug_string();
+        EXPECT_EQ("NULL", lax_column->debug_item(0)) << type.debug_string();
+    }
+}
+
+// The decoder must preserve the Avro logicalType so DateColumnReader interprets a logical `date`
+// (int days since epoch) as a DATE, rather than the raw day count the legacy reader would yield.
+TEST_F(AvroStructMapTest, logical_date) {
+    auto schema = avro::compileJsonSchemaFromString(R"({
+        "type": "record",
+        "name": "r",
+        "fields": [{"name": "d", "type": {"type": "int", "logicalType": "date"}}]
+    })");
+    ConfluentAvroDecoder decoder(schema);
+    ASSERT_TRUE(decoder.init().ok());
+
+    // date = 5 days since epoch -> 1970-01-06; int 5 -> zigzag 10 -> 0x0A
+    const std::vector<uint8_t> bytes = {0x0A};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(bytes.data(), bytes.size(), &datum).ok());
+
+    auto type = TypeDescriptor(TYPE_DATE);
+    auto reader = avrocpp::ColumnReader::get_nullable_column_reader("d", type, _tz, /*invalid_as_null=*/true);
+    auto column = ColumnHelper::create_column(type, true);
+    ASSERT_TRUE(reader->read_datum(datum.value<avro::GenericRecord>().field("d"), column.get()).ok());
+    EXPECT_EQ("1970-01-06", column->debug_item(0));
+}
+
+} // namespace starrocks

--- a/be/test/exec/file_scanner/confluent_avro_decoder_test.cpp
+++ b/be/test/exec/file_scanner/confluent_avro_decoder_test.cpp
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/confluent_avro_decoder.h"
+
+#include <gtest/gtest.h>
+
+#include <avrocpp/Compiler.hh>
+#include <vector>
+
+namespace starrocks {
+
+// Schema-injection mode treats input as a raw Avro datum without Confluent framing, so these tests
+// run compile-schema -> GenericReader::read -> GenericDatum without a schema registry.
+class ConfluentAvroDecoderTest : public ::testing::Test {
+protected:
+    static avro::ValidSchema record_schema() {
+        // record { long id; string name }
+        static const char* kJson = R"({
+            "type": "record",
+            "name": "r",
+            "fields": [
+                {"name": "id", "type": "long"},
+                {"name": "name", "type": "string"}
+            ]
+        })";
+        return avro::compileJsonSchemaFromString(kJson);
+    }
+};
+
+TEST_F(ConfluentAvroDecoderTest, decode_raw_datum) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    // Hand-encoded Avro binary for {id: 27, name: "hi"}:
+    //   id   = long 27   -> zigzag(27)=54 -> varint 0x36
+    //   name = string    -> length 2 -> zigzag(2)=4 -> 0x04, then UTF-8 'h'(0x68) 'i'(0x69)
+    const std::vector<uint8_t> payload = {0x36, 0x04, 0x68, 0x69};
+
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(payload.data(), payload.size(), &datum).ok());
+
+    ASSERT_EQ(avro::AVRO_RECORD, datum.type());
+    const auto& record = datum.value<avro::GenericRecord>();
+    EXPECT_EQ(int64_t{27}, record.field("id").value<int64_t>());
+    EXPECT_EQ("hi", record.field("name").value<std::string>());
+}
+
+TEST_F(ConfluentAvroDecoderTest, decode_reuses_datum_across_calls) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    avro::GenericDatum datum;
+    const std::vector<uint8_t> first = {0x02, 0x02, 0x61};  // id=1, name="a"
+    const std::vector<uint8_t> second = {0x04, 0x02, 0x62}; // id=2, name="b"
+
+    ASSERT_TRUE(decoder.decode(first.data(), first.size(), &datum).ok());
+    EXPECT_EQ(int64_t{1}, datum.value<avro::GenericRecord>().field("id").value<int64_t>());
+
+    ASSERT_TRUE(decoder.decode(second.data(), second.size(), &datum).ok());
+    EXPECT_EQ(int64_t{2}, datum.value<avro::GenericRecord>().field("id").value<int64_t>());
+    EXPECT_EQ("b", datum.value<avro::GenericRecord>().field("name").value<std::string>());
+}
+
+TEST_F(ConfluentAvroDecoderTest, truncated_payload_returns_error) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    // Only the long field is present; reading the string runs past the buffer -> avro::Exception
+    // -> InternalError (decode never lets the exception escape).
+    const std::vector<uint8_t> truncated = {0x36};
+
+    avro::GenericDatum datum;
+    EXPECT_FALSE(decoder.decode(truncated.data(), truncated.size(), &datum).ok());
+}
+
+} // namespace starrocks

--- a/be/test/exec/file_scanner/confluent_avro_decoder_test.cpp
+++ b/be/test/exec/file_scanner/confluent_avro_decoder_test.cpp
@@ -73,6 +73,29 @@ TEST_F(ConfluentAvroDecoderTest, decode_reuses_datum_across_calls) {
     EXPECT_EQ("b", datum.value<avro::GenericRecord>().field("name").value<std::string>());
 }
 
+TEST_F(ConfluentAvroDecoderTest, schema_id_out_param_is_sentinel_in_test_mode) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    // Test mode has no Confluent framing, so there is no real schema id: decode reports -1.
+    const std::vector<uint8_t> payload = {0x36, 0x04, 0x68, 0x69}; // {id: 27, name: "hi"}
+    avro::GenericDatum datum;
+    int32_t schema_id = 12345; // pre-seed to prove decode overwrites it
+    ASSERT_TRUE(decoder.decode(payload.data(), payload.size(), &datum, &schema_id).ok());
+    EXPECT_EQ(-1, schema_id);
+}
+
+TEST_F(ConfluentAvroDecoderTest, schema_id_out_param_may_be_null) {
+    ConfluentAvroDecoder decoder(record_schema());
+    ASSERT_TRUE(decoder.init().ok());
+
+    // The schema_id argument is optional; passing nullptr must not crash.
+    const std::vector<uint8_t> payload = {0x36, 0x04, 0x68, 0x69};
+    avro::GenericDatum datum;
+    ASSERT_TRUE(decoder.decode(payload.data(), payload.size(), &datum, nullptr).ok());
+    EXPECT_EQ(int64_t{27}, datum.value<avro::GenericRecord>().field("id").value<int64_t>());
+}
+
 TEST_F(ConfluentAvroDecoderTest, truncated_payload_returns_error) {
     ConfluentAvroDecoder decoder(record_schema());
     ASSERT_TRUE(decoder.init().ok());

--- a/be/test/exec/file_scanner/stream_source_meta_test.cpp
+++ b/be/test/exec/file_scanner/stream_source_meta_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/file_scanner/stream_source_meta.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/column_helper.h"
+#include "types/type_descriptor.h"
+#include "util/byte_buffer.h"
+
+namespace starrocks {
+
+class StreamSourceMetaTest : public testing::Test {
+protected:
+    static MutableColumnPtr varchar_col() {
+        return ColumnHelper::create_column(TypeDescriptor::create_varchar_type(65535), true);
+    }
+    static MutableColumnPtr int_col() {
+        return ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_INT), true);
+    }
+    static MutableColumnPtr bigint_col() {
+        return ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_BIGINT), true);
+    }
+    static MutableColumnPtr map_col() {
+        return ColumnHelper::create_column(TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(65535),
+                                                                           TypeDescriptor::create_varchar_type(65535)),
+                                           true);
+    }
+
+    static TRoutineLoadMetaColumn desc(int32_t slot_id, TStreamSourceMetaKind::type kind, const std::string& key = "") {
+        TRoutineLoadMetaColumn d;
+        d.__set_slot_id(slot_id);
+        d.__set_kind(kind);
+        if (!key.empty()) {
+            d.__set_key(key);
+        }
+        return d;
+    }
+};
+
+TEST_F(StreamSourceMetaTest, build_descriptor_map) {
+    std::vector<TRoutineLoadMetaColumn> descs = {desc(7, TStreamSourceMetaKind::TOPIC),
+                                                 desc(9, TStreamSourceMetaKind::HEADER, "trace-id")};
+    auto cols = build_stream_source_meta_columns(descs);
+    ASSERT_EQ(2, cols.size());
+    ASSERT_EQ(TStreamSourceMetaKind::TOPIC, cols.at(7).kind);
+    ASSERT_EQ(TStreamSourceMetaKind::HEADER, cols.at(9).kind);
+    ASSERT_EQ("trace-id", cols.at(9).key);
+}
+
+TEST_F(StreamSourceMetaTest, fill_scalars) {
+    StreamMessageMeta meta(ByteBufferMetaType::KAFKA);
+    meta.set_topic("orders");
+    meta.set_partition(3);
+    meta.set_offset(100);
+    meta.set_timestamp(1700000000000L);
+    meta.set_key("k1");
+
+    auto topic = varchar_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::TOPIC, "", &meta, topic.get()));
+    ASSERT_FALSE(topic->is_null(0));
+    ASSERT_EQ("orders", topic->get(0).get_slice().to_string());
+
+    auto part = int_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::PARTITION, "", &meta, part.get()));
+    ASSERT_EQ(3, part->get(0).get_int32());
+
+    auto off = bigint_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::OFFSET, "", &meta, off.get()));
+    ASSERT_EQ(100, off->get(0).get_int64());
+
+    auto ts = bigint_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::TIMESTAMP, "", &meta, ts.get()));
+    ASSERT_EQ(1700000000000L, ts->get(0).get_int64());
+
+    auto key = varchar_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::KEY, "", &meta, key.get()));
+    ASSERT_EQ("k1", key->get(0).get_slice().to_string());
+}
+
+TEST_F(StreamSourceMetaTest, fill_null_sentinels) {
+    StreamMessageMeta meta(ByteBufferMetaType::KAFKA); // partition/offset/timestamp default -1, no key
+
+    auto part = int_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::PARTITION, "", &meta, part.get()));
+    ASSERT_TRUE(part->is_null(0));
+
+    auto key = varchar_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::KEY, "", &meta, key.get()));
+    ASSERT_TRUE(key->is_null(0));
+
+    // A null meta appends NULL for any kind.
+    auto topic = varchar_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::TOPIC, "", nullptr, topic.get()));
+    ASSERT_TRUE(topic->is_null(0));
+}
+
+TEST_F(StreamSourceMetaTest, header_last_wins) {
+    StreamMessageMeta meta(ByteBufferMetaType::KAFKA);
+    meta.add_header("h", "v1");
+    meta.add_header("h", "v2"); // duplicate key, last wins
+    meta.add_header("x", "y");
+
+    auto h = varchar_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::HEADER, "h", &meta, h.get()));
+    ASSERT_EQ("v2", h->get(0).get_slice().to_string());
+
+    auto missing = varchar_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::HEADER, "nope", &meta, missing.get()));
+    ASSERT_TRUE(missing->is_null(0));
+
+    // HEADERS map collapses the duplicate key (last-wins) -> 2 entries.
+    auto m = map_col();
+    ASSERT_OK(fill_stream_source_meta_column(TStreamSourceMetaKind::HEADERS, "", &meta, m.get()));
+    ASSERT_FALSE(m->is_null(0));
+    ASSERT_EQ(2, m->get(0).get_map().size());
+}
+
+} // namespace starrocks

--- a/be/test/runtime/kafka_consumer_pipe_test.cpp
+++ b/be/test/runtime/kafka_consumer_pipe_test.cpp
@@ -62,7 +62,7 @@ TEST_F(KafkaConsumerPipeTest, append_read) {
     char row_delimiter = '\n';
     st = k_pipe.append_with_row_delimiter(msg1.c_str(), msg1.length(), row_delimiter);
     ASSERT_TRUE(st.ok());
-    st = k_pipe.append_with_row_delimiter(msg2.c_str(), msg2.length(), row_delimiter, 1, 2);
+    st = k_pipe.append_with_row_delimiter(msg2.c_str(), msg2.length(), row_delimiter);
     ASSERT_TRUE(st.ok());
     st = k_pipe.finish();
     ASSERT_TRUE(st.ok());
@@ -92,7 +92,14 @@ TEST_F(KafkaConsumerPipeTest, append_read_json) {
     char row_delimiter = '\n';
     st = k_pipe.append_json(msg1.c_str(), msg1.length(), row_delimiter);
     ASSERT_TRUE(st.ok());
-    st = k_pipe.append_json(msg2.c_str(), msg2.length(), row_delimiter, 1, 2);
+    StreamMessageMeta src_meta(ByteBufferMetaType::KAFKA);
+    src_meta.set_topic("t");
+    src_meta.set_partition(1);
+    src_meta.set_offset(2);
+    src_meta.set_timestamp(99);
+    src_meta.set_key("kk");
+    src_meta.add_header("h1", "v1");
+    st = k_pipe.append_json(msg2.c_str(), msg2.length(), row_delimiter, &src_meta);
     ASSERT_TRUE(st.ok());
     st = k_pipe.finish();
     ASSERT_TRUE(st.ok());
@@ -107,9 +114,16 @@ TEST_F(KafkaConsumerPipeTest, append_read_json) {
     auto buf2 = buf_st2.value();
     ByteBufferMeta* meta = buf2->meta();
     ASSERT_EQ(ByteBufferMetaType::KAFKA, meta->type());
-    KafkaByteBufferMeta* kafka_meta = static_cast<KafkaByteBufferMeta*>(meta);
+    StreamMessageMeta* kafka_meta = static_cast<StreamMessageMeta*>(meta);
+    ASSERT_EQ("t", kafka_meta->topic());
     ASSERT_EQ(1, kafka_meta->partition());
     ASSERT_EQ(2, kafka_meta->offset());
+    ASSERT_EQ(99, kafka_meta->timestamp());
+    ASSERT_TRUE(kafka_meta->has_key());
+    ASSERT_EQ("kk", kafka_meta->key());
+    ASSERT_EQ(1, kafka_meta->headers().size());
+    ASSERT_EQ("h1", kafka_meta->headers()[0].first);
+    ASSERT_EQ("v1", kafka_meta->headers()[0].second);
 }
 
 } // namespace starrocks

--- a/be/test/runtime/routine_load/data_consumer_test.cpp
+++ b/be/test/runtime/routine_load/data_consumer_test.cpp
@@ -18,10 +18,57 @@
 
 #include "base/testutil/assert.h"
 #include "runtime/exec_env.h"
+#include "runtime/routine_load/data_consumer_group.h"
 
 namespace starrocks {
 
 class KafkaDataConsumerTest : public testing::Test {};
+
+TEST(PulsarTopicTest, parse_partition_index_anchored_on_configured_topic) {
+    // Partitioned topic: the "-partition-N" suffix sits right after the configured logical topic.
+    EXPECT_EQ(3, parse_pulsar_partition_index("persistent://public/default/my-topic",
+                                              "persistent://public/default/my-topic-partition-3"));
+
+    // Partition 0 is a real partition, not "absent".
+    EXPECT_EQ(0, parse_pulsar_partition_index("my-topic", "my-topic-partition-0"));
+
+    // Configured topic in short form still anchors against the canonical per-partition name: the match
+    // lands at the leading "/" boundary.
+    EXPECT_EQ(7, parse_pulsar_partition_index("my-topic", "persistent://public/default/my-topic-partition-7"));
+
+    // Non-partitioned topic: message name equals the configured topic, no suffix -> -1 (SQL NULL).
+    EXPECT_EQ(-1, parse_pulsar_partition_index("persistent://public/default/my-topic",
+                                               "persistent://public/default/my-topic"));
+}
+
+TEST(PulsarTopicTest, standalone_partition_suffix_topic_is_not_a_partition) {
+    // A standalone non-partitioned topic literally named "<x>-partition-<n>" is configured as the
+    // logical topic verbatim, so the trailing suffix must NOT be read as a partition index.
+    EXPECT_EQ(-1, parse_pulsar_partition_index("my-topic-partition-5", "my-topic-partition-5"));
+    EXPECT_EQ(-1, parse_pulsar_partition_index("persistent://public/default/my-topic-partition-5",
+                                               "persistent://public/default/my-topic-partition-5"));
+
+    // A real partition of such a (pathologically named) partitioned topic still resolves correctly:
+    // its partitions are "<x>-partition-5-partition-N".
+    EXPECT_EQ(2, parse_pulsar_partition_index("my-topic-partition-5", "my-topic-partition-5-partition-2"));
+}
+
+TEST(PulsarTopicTest, malformed_or_foreign_suffix_is_not_treated_as_partition) {
+    // Empty index, non-numeric index, and a trailing-dash suffix all yield -1.
+    EXPECT_EQ(-1, parse_pulsar_partition_index("my-topic", "my-topic-partition-"));
+    EXPECT_EQ(-1, parse_pulsar_partition_index("my-topic", "my-topic-partition-x"));
+    EXPECT_EQ(-1, parse_pulsar_partition_index("my-topic", "my-topic-partition-1a"));
+
+    // A value past INT32_MAX is rejected (overflow guard) rather than wrapping.
+    EXPECT_EQ(-1, parse_pulsar_partition_index("my-topic", "my-topic-partition-99999999999"));
+
+    // The prefix before "-partition-N" must be exactly the configured topic, not merely end with it:
+    // "other-my-topic" is a different topic and yields -1 rather than a fabricated partition.
+    EXPECT_EQ(-1, parse_pulsar_partition_index("my-topic", "other-my-topic-partition-2"));
+
+    // Only the last "-partition-N" is considered; an earlier occurrence belongs to the topic name.
+    EXPECT_EQ(2, parse_pulsar_partition_index("a-partition-1-b", "a-partition-1-b-partition-2"));
+}
 
 TEST_F(KafkaDataConsumerTest, test_get_partition_offset_broker_down) {
     TKafkaLoadInfo tKafkaLoadInfo;

--- a/be/test/runtime/stream_load_pipe_test.cpp
+++ b/be/test/runtime/stream_load_pipe_test.cpp
@@ -274,7 +274,7 @@ PARALLEL_TEST(StreamLoadPipeTest, compressed_reader) {
         auto byte_buffer = ByteBuffer::allocate_with_tracker(buf.size(), 0, ByteBufferMetaType::KAFKA).value();
         byte_buffer->put_bytes(buf.data(), buf.size());
         byte_buffer->flip_to_read();
-        KafkaByteBufferMeta* meta = dynamic_cast<KafkaByteBufferMeta*>(byte_buffer->meta());
+        StreamMessageMeta* meta = dynamic_cast<StreamMessageMeta*>(byte_buffer->meta());
         EXPECT_TRUE(meta != nullptr);
         meta->set_partition(1);
         meta->set_offset(5);
@@ -289,7 +289,7 @@ PARALLEL_TEST(StreamLoadPipeTest, compressed_reader) {
     auto buf = res.value();
     EXPECT_EQ(buf->remaining(), 42000021);
     EXPECT_EQ(std::string_view(R"({"foo": 1, "bar": 2})"), std::string_view(buf->ptr, 20));
-    KafkaByteBufferMeta* meta = dynamic_cast<KafkaByteBufferMeta*>(buf->meta());
+    StreamMessageMeta* meta = dynamic_cast<StreamMessageMeta*>(buf->meta());
     EXPECT_TRUE(meta != nullptr);
     EXPECT_EQ(1, meta->partition());
     EXPECT_EQ(5, meta->offset());

--- a/be/test/util/byte_buffer_test.cpp
+++ b/be/test/util/byte_buffer_test.cpp
@@ -67,27 +67,50 @@ TEST_F(ByteBufferTest, test_meta) {
 
     auto kafka_meta_st = ByteBufferMeta::create(ByteBufferMetaType::KAFKA);
     ASSERT_OK(kafka_meta_st.status());
-    KafkaByteBufferMeta* kafka_meta = dynamic_cast<KafkaByteBufferMeta*>(kafka_meta_st.value());
+    StreamMessageMeta* kafka_meta = dynamic_cast<StreamMessageMeta*>(kafka_meta_st.value());
     DeferOp defer([&] { delete kafka_meta; });
     ASSERT_TRUE(kafka_meta != nullptr);
     ASSERT_EQ(ByteBufferMetaType::KAFKA, kafka_meta->type());
     ASSERT_EQ(-1, kafka_meta->partition());
     ASSERT_EQ(-1, kafka_meta->offset());
+    kafka_meta->set_topic("t");
     kafka_meta->set_partition(1);
     kafka_meta->set_offset(2);
+    kafka_meta->set_timestamp(123);
+    kafka_meta->set_key("k");
+    kafka_meta->add_header("h1", "v1");
     ASSERT_EQ(1, kafka_meta->partition());
     ASSERT_EQ(2, kafka_meta->offset());
-    ASSERT_EQ("kafka partition: 1, offset: 2", kafka_meta->to_string());
+    ASSERT_EQ(123, kafka_meta->timestamp());
+    ASSERT_TRUE(kafka_meta->has_key());
+    ASSERT_EQ("k", kafka_meta->key());
+    ASSERT_EQ(1, kafka_meta->headers().size());
+    ASSERT_EQ("kafka topic: t, partition: 1, offset: 2", kafka_meta->to_string());
+
+    // Without a topic (the job references no metadata column) only partition/offset are rendered.
+    StreamMessageMeta bare_kafka_meta(ByteBufferMetaType::KAFKA);
+    bare_kafka_meta.set_partition(4);
+    bare_kafka_meta.set_offset(5);
+    ASSERT_EQ("kafka partition: 4, offset: 5", bare_kafka_meta.to_string());
 
     ASSERT_TRUE(none_meta->copy_from(kafka_meta).is_not_supported());
     ASSERT_TRUE(kafka_meta->copy_from(none_meta).is_not_supported());
 
-    KafkaByteBufferMeta kafka_meta1;
+    // A Pulsar-typed meta is incompatible with a Kafka-typed one.
+    StreamMessageMeta pulsar_meta(ByteBufferMetaType::PULSAR);
+    ASSERT_TRUE(kafka_meta->copy_from(&pulsar_meta).is_not_supported());
+
+    // copy_from fully overwrites and clears absent fields (no stale key/headers leak).
+    StreamMessageMeta kafka_meta1(ByteBufferMetaType::KAFKA);
+    kafka_meta1.set_topic("t2");
     kafka_meta1.set_partition(2);
     kafka_meta1.set_offset(3);
     ASSERT_OK(kafka_meta->copy_from(&kafka_meta1));
     ASSERT_EQ(2, kafka_meta->partition());
     ASSERT_EQ(3, kafka_meta->offset());
+    ASSERT_FALSE(kafka_meta->has_key());
+    ASSERT_TRUE(kafka_meta->key().empty());
+    ASSERT_TRUE(kafka_meta->headers().empty());
 }
 
 TEST_F(ByteBufferTest, test_allocate_with_meta) {
@@ -95,21 +118,24 @@ TEST_F(ByteBufferTest, test_allocate_with_meta) {
     ASSERT_EQ(NoneByteBufferMeta::instance(), buf1->meta());
 
     auto buf2 = ByteBuffer::allocate_with_tracker(4, 0, ByteBufferMetaType::KAFKA).value();
-    KafkaByteBufferMeta* meta2 = dynamic_cast<KafkaByteBufferMeta*>(buf2->meta());
+    StreamMessageMeta* meta2 = dynamic_cast<StreamMessageMeta*>(buf2->meta());
     ASSERT_TRUE(meta2 != nullptr);
     ASSERT_EQ(-1, meta2->partition());
     ASSERT_EQ(-1, meta2->offset());
     meta2->set_partition(2);
     meta2->set_offset(4);
+    meta2->add_header("h", "v");
     ASSERT_EQ(2, meta2->partition());
     ASSERT_EQ(4, meta2->offset());
 
+    // reallocate copies the meta forward, including headers.
     auto buf3 = ByteBuffer::reallocate_with_tracker(buf2, 8).value();
-    KafkaByteBufferMeta* meta3 = dynamic_cast<KafkaByteBufferMeta*>(buf3->meta());
+    StreamMessageMeta* meta3 = dynamic_cast<StreamMessageMeta*>(buf3->meta());
     ASSERT_TRUE(meta3 != nullptr);
     ASSERT_TRUE(meta2 != meta3);
     ASSERT_EQ(2, meta3->partition());
     ASSERT_EQ(4, meta3->offset());
+    ASSERT_EQ(1, meta3->headers().size());
 }
 
 TEST_F(ByteBufferTest, test_flip_to_write_partial_read) {

--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -889,6 +889,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to collect Routine Load Kafka partition offset lag metrics. Please note that set this item to `true` will call the Kafka API to get the partition's latest offset.
 - Introduced in: -
 
+### `enable_routine_load_native_avro_reader`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: The default Avro reader for Routine Load jobs that do not set the `avro.use_native_reader` property. When `true`, such jobs use the native (avrocpp) reader, which loads Avro `record`/`map` fields as `STRUCT`/`MAP` columns and interprets Avro logical types (`date` → DATE, `timestamp` → DATETIME, `decimal` → DECIMAL); when `false`, the legacy reader is used. The reader choice is resolved when a job is created, so changing this item only affects newly created jobs, not existing ones.
+- Introduced in: -
+
 ### `enable_sync_publish`
 
 - Default: true

--- a/docs/en/loading/RoutineLoad.md
+++ b/docs/en/loading/RoutineLoad.md
@@ -568,6 +568,64 @@ FROM KAFKA
 
 A metadata function may be nested inside an expression (as with `from_unixtime(kafka_timestamp_ms() / 1000)` above); only payload columns are listed in `jsonpaths`.
 
+### Evolve the Avro schema automatically
+
+When a Kafka producer changes its Avro writer schema — adds a field, adds a subfield to a `record`, or widens a field's type — Routine Load can evolve the destination table to match and keep loading, instead of failing the job. This is opt-in and works only with the native Avro reader.
+
+Enable it per job with `"avro.enable_schema_evolution" = "true"` (default `false`). It additionally requires `"avro.use_native_reader" = "true"` and no `jsonpaths`, because evolution relies on the reader's by-name field-to-column mapping. A plain column list in `COLUMNS` is rejected too: an explicit list pins the loaded column set, so with it you own the column set yourself. Expression mappings in `COLUMNS` (for example metadata functions) are fine.
+
+When a message carries a schema the table does not yet cover, the table is automatically altered to match. Messages already read under the old schema commit normally; the job briefly holds its tasks while the table is altered, then resumes.
+
+#### Changes applied automatically
+
+- A writer field with no matching column → `ADD COLUMN` (nullable, no default).
+- A new subfield in an existing `STRUCT` column, at any nesting depth → `ADD FIELD`.
+- A column whose type no longer holds the writer value, when the change is a safe widening → `MODIFY COLUMN`. For example `INT` → `BIGINT`, `FLOAT` → `DOUBLE`, a `DECIMAL` precision/scale grow, or a scalar type → `VARCHAR`.
+- A value too long for a length-limited `VARCHAR`/`VARBINARY` column → the column is widened to its maximum length.
+
+A field whose type already fits the column (the same or a wider type, or a `VARCHAR`/`STRUCT`/`MAP`/`ARRAY` that already accommodates it) needs no change.
+
+#### Changes that pause the job
+
+Some changes cannot be made safely and automatically. The job is paused, with the field named in `ReasonOfStateChanged`; resolve it by hand and then [RESUME ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/RESUME_ROUTINE_LOAD.md):
+
+- A writer field whose name collides with a metadata column (see [Access source message metadata](#access-source-message-metadata)).
+- A writer field that differs only in letter case from an existing column (StarRocks forbids two columns differing only in case).
+- A key column whose type would have to change to hold the new value. Key columns are not auto-evolved because a key type change affects sorting and distribution. (A key column that the new value still fits needs no change and does not pause the job.)
+- A type change the engine cannot perform — for example, a field that became a `record` over a non-`VARCHAR` column.
+
+#### Heavy schema changes
+
+Most changes on a table that uses fast schema evolution (`ADD COLUMN`, `ADD FIELD`, integer/float widening, `VARCHAR` length increase) are metadata-only and take effect immediately. A few require a full table rewrite (a background schema-change job): a `DECIMAL` precision/scale grow, a type change to `VARCHAR`, or any change on a table created with `fast_schema_evolution = false`.
+
+`"avro.schema_evolution_allow_heavy_alter"` (default `true`) controls these:
+
+- `true`: heavy changes are applied automatically.
+- `false`: only metadata-only changes are applied automatically. A change that needs a rewrite pauses the job and names the exact `ALTER TABLE` to run by hand — run it and then RESUME, or set the property to `true`.
+
+#### Example
+
+Enable evolution on the native-reader job from [Load Avro-format data](#load-avro-format-data):
+
+```SQL
+CREATE ROUTINE LOAD example_db.events_load_job ON events
+PROPERTIES
+(
+    "format" = "avro",
+    "avro.use_native_reader" = "true",
+    "avro.enable_schema_evolution" = "true"
+)
+FROM KAFKA
+(
+    "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+    "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+    "kafka_topic" = "topic_events",
+    "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+);
+```
+
+If the producer later adds a field `region` (string) and a subfield `event.severity` (int), the table automatically gains a `region` column and an `event.severity` struct field, and loading continues.
+
 ## Check a load job and task
 
 ### Check a load job

--- a/docs/en/loading/RoutineLoad.md
+++ b/docs/en/loading/RoutineLoad.md
@@ -383,6 +383,69 @@ FROM KAFKA
   >
   > You do not need to specify the `COLUMNS` parameter if the names and number of the fields in the Avro record completely match those of columns in the StarRocks table.
 
+- Native Avro reader (`STRUCT`/`MAP` and logical types)
+
+  By default, Routine Load uses the legacy Avro reader, which loads `record`/`map` fields as JSON strings and reads Avro logical types (`date`, `timestamp`, `decimal`) as raw integers/bytes.
+
+  Set `"avro.use_native_reader" = "true"` in `PROPERTIES` to use the native reader instead:
+
+  - `record` is loaded into a `STRUCT` column and `map` into a `MAP` column (instead of JSON).
+  - Avro logical types are interpreted: `date` → `DATE`, `timestamp-millis`/`timestamp-micros` → `DATETIME` (converted with the job time zone), and `decimal(precision, scale)` → `DECIMAL(precision, scale)`.
+
+  The property is set per job. When it is not specified, the FE configuration item `enable_routine_load_native_avro_reader` (default `false`) decides which reader to use. The reader choice is fixed when the job is created, so changing the configuration item later affects only newly created jobs — existing jobs keep their reader.
+
+  For example, given the following Avro schema with a nested `record` field `event`, a `map` field `tags`, a logical `date` field `d`, and a logical `decimal` field `amount`:
+
+  ```JSON
+  {
+      "type": "record",
+      "name": "Event",
+      "fields": [
+          {"name": "id", "type": "long"},
+          {"name": "event", "type": {
+              "type": "record",
+              "name": "EventInfo",
+              "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "code", "type": "int"}
+              ]
+          }},
+          {"name": "tags", "type": {"type": "map", "values": "long"}},
+          {"name": "d", "type": {"type": "int", "logicalType": "date"}},
+          {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}}
+      ]
+  }
+  ```
+
+  Create a matching table and load it with the native reader:
+
+  ```SQL
+  CREATE TABLE example_db.events (
+      id           BIGINT,
+      event        STRUCT<name VARCHAR(64), code INT>,
+      tags         MAP<VARCHAR(64), BIGINT>,
+      d            DATE,
+      amount       DECIMAL(18, 4)
+  )
+  ENGINE = OLAP
+  DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id);
+
+  CREATE ROUTINE LOAD example_db.events_load_job ON events
+  PROPERTIES
+  (
+      "format" = "avro",
+      "avro.use_native_reader" = "true"
+  )
+  FROM KAFKA
+  (
+      "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+      "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+      "kafka_topic" = "topic_events",
+      "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+  );
+  ```
+
 After submitting the load job, you can execute the [SHOW ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md) statement to check the status of the load job.
 
 #### Data types mapping
@@ -406,12 +469,22 @@ The data type mapping between the Avro data fields you want to load and the Star
 
 | Avro           | StarRocks                                                    |
 | -------------- | ------------------------------------------------------------ |
-| record         | Load the entire RECORD or its subfields into StarRocks as JSON. |
+| record         | Legacy reader: the entire RECORD or its subfields as JSON. Native reader (`avro.use_native_reader = true`): `STRUCT`. |
 | enums          | STRING                                                       |
 | arrays         | ARRAY                                                        |
-| maps           | JSON                                                         |
+| maps           | Legacy reader: JSON. Native reader: `MAP`.                  |
 | union(T, null) | NULLABLE(T)                                                  |
 | fixed          | STRING                                                       |
+
+##### Logical types
+
+The native reader (`avro.use_native_reader = true`) also interprets Avro logical types. The legacy reader loads them as their underlying primitive (raw int/long/bytes).
+
+| Avro logical type            | StarRocks (native reader) |
+| ---------------------------- | ------------------------- |
+| date                         | DATE                      |
+| timestamp-millis / -micros   | DATETIME                  |
+| decimal(precision, scale)    | DECIMAL(precision, scale) |
 
 #### Limits
 

--- a/docs/en/loading/RoutineLoad.md
+++ b/docs/en/loading/RoutineLoad.md
@@ -491,6 +491,83 @@ The native reader (`avro.use_native_reader = true`) also interprets Avro logical
 - Currently, StarRocks does not support schema evolution.
 - Each Kafka message must only contain a single Avro data record.
 
+### Access source message metadata
+
+When loading JSON- or Avro-format data, you can populate destination columns from a message's Kafka/Pulsar metadata — topic, partition, offset, timestamp, key, and headers — instead of from the message payload. You reference the metadata with source-specific functions in the `COLUMNS` clause; each call is mapped to a destination column.
+
+This is useful for auditing (which topic/partition/offset a row came from), event-time processing (using the message timestamp), and routing on a header value.
+
+#### Functions
+
+Kafka jobs use the `kafka_*` functions; Pulsar jobs use the `pulsar_*` functions.
+
+| Function | Return type | Description |
+| --- | --- | --- |
+| `kafka_topic()` | VARCHAR | Topic name. |
+| `kafka_partition()` | INT | Partition number. |
+| `kafka_offset()` | BIGINT | Message offset within the partition. |
+| `kafka_timestamp_ms()` | BIGINT | Record timestamp in milliseconds since epoch. `NULL` when the broker reports no timestamp. |
+| `kafka_key()` | VARCHAR | Message key as raw bytes. `NULL` when the message has no key. |
+| `kafka_header('name')` | VARCHAR | Value of the header `name`. When the header appears more than once, the last value wins. `NULL` when the header is absent. |
+| `kafka_headers()` | MAP\<VARCHAR, VARCHAR> | All headers as a map. On duplicate keys, the last value wins. |
+| `pulsar_topic()` | VARCHAR | The logical topic the job consumes (a partitioned topic's `-partition-N` suffix is not included). |
+| `pulsar_partition()` | INT | Partition index, parsed from the per-message topic name. `NULL` for a non-partitioned topic. |
+| `pulsar_message_id()` | VARCHAR | Message ID. |
+| `pulsar_publish_time_ms()` | BIGINT | Publish time in milliseconds since epoch. |
+| `pulsar_event_time_ms()` | BIGINT | Event time in milliseconds since epoch. `NULL` when the producer did not set it. |
+| `pulsar_key()` | VARCHAR | Partition key. `NULL` when the message has no key. |
+| `pulsar_property('name')` | VARCHAR | Value of the property `name`. `NULL` when the property is absent. |
+| `pulsar_properties()` | MAP\<VARCHAR, VARCHAR> | All properties as a map. |
+
+#### Usage notes
+
+- These functions are available for `format = json` (Kafka and Pulsar) and `format = avro` (Kafka only; Pulsar Routine Load does not support Avro). They are not supported for CSV, where one message can expand into many rows and per-message metadata would be ambiguous.
+- For Avro, the native reader is required: set `"avro.use_native_reader" = "true"` (see [Load Avro-format data](#load-avro-format-data)).
+- The functions can only be used in the `COLUMNS` clause. A payload field with the same name as a metadata field is never shadowed — the metadata value is taken from the message, and the payload field is read independently.
+- `kafka_header('name')` and `pulsar_property('name')` take a single string-literal key.
+
+#### Example
+
+Load the order payload field `order_id` together with the source topic, partition, offset, the message timestamp converted to a `DATETIME`, and a `trace-id` header:
+
+```SQL
+CREATE TABLE example_db.orders_with_meta (
+    order_id      BIGINT,
+    src_topic     VARCHAR(256),
+    src_partition INT,
+    src_offset    BIGINT,
+    msg_time      DATETIME,
+    trace_id      VARCHAR(128)
+)
+ENGINE = OLAP
+DUPLICATE KEY(order_id)
+DISTRIBUTED BY HASH(order_id);
+
+CREATE ROUTINE LOAD example_db.orders_with_meta_job ON orders_with_meta
+COLUMNS
+(
+    order_id,
+    src_topic     = kafka_topic(),
+    src_partition = kafka_partition(),
+    src_offset    = kafka_offset(),
+    msg_time      = from_unixtime(kafka_timestamp_ms() / 1000),
+    trace_id      = kafka_header('trace-id')
+)
+PROPERTIES
+(
+    "format" = "json",
+    "jsonpaths" = "[\"$.order_id\"]"
+)
+FROM KAFKA
+(
+    "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+    "kafka_topic" = "topic_orders",
+    "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+);
+```
+
+A metadata function may be nested inside an expression (as with `from_unixtime(kafka_timestamp_ms() / 1000)` above); only payload columns are listed in `jsonpaths`.
+
 ## Check a load job and task
 
 ### Check a load job

--- a/docs/ja/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/management/FE_parameters/user_query_loading.md
@@ -889,6 +889,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：ルーチンロード Kafka パーティションオフセットラグメトリックを収集するかどうか。この項目を `true` に設定すると、Kafka API が呼び出されてパーティションの最新オフセットが取得されることに注意してください。
 - 導入時期：-
 
+### `enable_routine_load_native_avro_reader`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：`avro.use_native_reader` プロパティが設定されていない Routine Load ジョブが既定で使用する Avro リーダー。`true` の場合、該当するジョブはネイティブ（avrocpp）リーダーを使用し、Avro の `record`/`map` フィールドを `STRUCT`/`MAP` カラムとしてロードし、Avro の論理型（`date` → DATE、`timestamp` → DATETIME、`decimal` → DECIMAL）を解釈します。`false` の場合は従来のリーダーを使用します。リーダーの選択はジョブ作成時に確定するため、この項目を変更しても新規作成されるジョブにのみ影響し、既存のジョブには影響しません。
+- 導入時期：-
+
 ### `enable_sync_publish`
 
 - デフォルト：true

--- a/docs/ja/loading/RoutineLoad.md
+++ b/docs/ja/loading/RoutineLoad.md
@@ -383,6 +383,69 @@ FROM KAFKA
   >
   > Avro レコードのフィールドの名前と数が StarRocks テーブルのカラムと完全に一致する場合、`COLUMNS` パラメータを指定する必要はありません。
 
+- ネイティブ Avro リーダー（`STRUCT`/`MAP` と論理型）
+
+  デフォルトでは、Routine Load は従来の Avro リーダーを使用し、`record`/`map` フィールドを JSON 文字列としてロードし、Avro の論理型（`date`、`timestamp`、`decimal`）を生の整数/バイトとして読み取ります。
+
+  `PROPERTIES` に `"avro.use_native_reader" = "true"` を設定すると、代わりにネイティブリーダーを使用します:
+
+  - `record` は `STRUCT` カラムに、`map` は `MAP` カラムにロードされます（JSON ではなく）。
+  - Avro の論理型が解釈されます: `date` → `DATE`、`timestamp-millis`/`timestamp-micros` → `DATETIME`（ジョブのタイムゾーンで変換）、`decimal(precision, scale)` → `DECIMAL(precision, scale)`。
+
+  このプロパティはジョブごとに設定します。指定しない場合、FE 設定項目 `enable_routine_load_native_avro_reader`（デフォルト `false`）がどちらのリーダーを使用するかを決定します。リーダーの選択はジョブ作成時に確定するため、後で設定項目を変更しても新規作成されるジョブにのみ影響し、既存のジョブは元のリーダーを使用し続けます。
+
+  例えば、ネストされた `record` フィールド `event`、`map` フィールド `tags`、論理型 `date` フィールド `d`、論理型 `decimal` フィールド `amount` を持つ次の Avro スキーマの場合:
+
+  ```JSON
+  {
+      "type": "record",
+      "name": "Event",
+      "fields": [
+          {"name": "id", "type": "long"},
+          {"name": "event", "type": {
+              "type": "record",
+              "name": "EventInfo",
+              "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "code", "type": "int"}
+              ]
+          }},
+          {"name": "tags", "type": {"type": "map", "values": "long"}},
+          {"name": "d", "type": {"type": "int", "logicalType": "date"}},
+          {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}}
+      ]
+  }
+  ```
+
+  対応するテーブルを作成し、ネイティブリーダーでロードします:
+
+  ```SQL
+  CREATE TABLE example_db.events (
+      id           BIGINT,
+      event        STRUCT<name VARCHAR(64), code INT>,
+      tags         MAP<VARCHAR(64), BIGINT>,
+      d            DATE,
+      amount       DECIMAL(18, 4)
+  )
+  ENGINE = OLAP
+  DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id);
+
+  CREATE ROUTINE LOAD example_db.events_load_job ON events
+  PROPERTIES
+  (
+      "format" = "avro",
+      "avro.use_native_reader" = "true"
+  )
+  FROM KAFKA
+  (
+      "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+      "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+      "kafka_topic" = "topic_events",
+      "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+  );
+  ```
+
 ロードジョブを送信した後、[SHOW ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md) ステートメントを実行して、ロードジョブのステータスを確認できます。
 
 #### データ型のマッピング
@@ -406,12 +469,22 @@ FROM KAFKA
 
 | Avro           | StarRocks                                                    |
 | -------------- | ------------------------------------------------------------ |
-| record         | RECORD 全体またはそのサブフィールドを JSON として StarRocks にロードします。 |
+| record         | 従来のリーダー: RECORD 全体またはそのサブフィールドを JSON として StarRocks にロードします。ネイティブリーダー（`avro.use_native_reader = true`）: `STRUCT`。 |
 | enums          | STRING                                                       |
 | arrays         | ARRAY                                                        |
-| maps           | JSON                                                         |
+| maps           | 従来のリーダー: JSON。ネイティブリーダー: `MAP`。            |
 | union(T, null) | NULLABLE(T)                                                  |
 | fixed          | STRING                                                       |
+
+##### 論理型
+
+ネイティブリーダー（`avro.use_native_reader = true`）は Avro の論理型も解釈します。従来のリーダーはそれらを基になるプリミティブ型（生の int/long/bytes）としてロードします。
+
+| Avro 論理型                  | StarRocks（ネイティブリーダー） |
+| ---------------------------- | ------------------------- |
+| date                         | DATE                      |
+| timestamp-millis / -micros   | DATETIME                  |
+| decimal(precision, scale)    | DECIMAL(precision, scale) |
 
 #### 制限事項
 

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -889,6 +889,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否收集 Routine Load Kafka 分区偏移量滞后指标。请注意，将此项设置为 `true` 将调用 Kafka API 以获取分区的最新偏移量。
 - 引入版本: -
 
+### `enable_routine_load_native_avro_reader`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 未设置 `avro.use_native_reader` 属性的 Routine Load 作业默认使用的 Avro Reader。设置为 `true` 时，此类作业使用原生（avrocpp）Reader，将 Avro `record`/`map` 字段导入为 `STRUCT`/`MAP` 列，并解析 Avro 逻辑类型（`date` → DATE，`timestamp` → DATETIME，`decimal` → DECIMAL）；设置为 `false` 时使用旧版 Reader。Reader 的选择在作业创建时确定，因此修改该配置项仅影响新创建的作业，不影响已有作业。
+- 引入版本: -
+
 ### `enable_sync_publish`
 
 - 默认值: true

--- a/docs/zh/loading/RoutineLoad.md
+++ b/docs/zh/loading/RoutineLoad.md
@@ -369,6 +369,69 @@ FROM KAFKA
   >
   > 如果一条 Avro record 中字段的名称和数量（顺序不需要对应）都能对应目标表中列，则无需配置 `COLUMNS` 。
 
+- 原生 Avro Reader（`STRUCT`/`MAP` 和逻辑类型）
+
+  默认情况下，Routine Load 使用旧版 Avro Reader，将 `record`/`map` 字段作为 JSON 字符串导入，并将 Avro 逻辑类型（`date`、`timestamp`、`decimal`）作为原始整数/字节读取。
+
+  在 `PROPERTIES` 中设置 `"avro.use_native_reader" = "true"` 可改用原生 Reader：
+
+  - `record` 导入为 `STRUCT` 列，`map` 导入为 `MAP` 列（不再是 JSON）。
+  - 解析 Avro 逻辑类型：`date` → `DATE`，`timestamp-millis`/`timestamp-micros` → `DATETIME`（按作业时区转换），`decimal(precision, scale)` → `DECIMAL(precision, scale)`。
+
+  该属性按作业设置。未指定时，由 FE 配置项 `enable_routine_load_native_avro_reader`（默认 `false`）决定使用哪个 Reader。Reader 的选择在作业创建时确定，之后修改该配置项仅影响新创建的作业，已有作业保持原有 Reader。
+
+  例如，以下 Avro schema 包含嵌套 `record` 字段 `event`、`map` 字段 `tags`、逻辑类型 `date` 字段 `d` 和逻辑类型 `decimal` 字段 `amount`：
+
+  ```JSON
+  {
+      "type": "record",
+      "name": "Event",
+      "fields": [
+          {"name": "id", "type": "long"},
+          {"name": "event", "type": {
+              "type": "record",
+              "name": "EventInfo",
+              "fields": [
+                  {"name": "name", "type": "string"},
+                  {"name": "code", "type": "int"}
+              ]
+          }},
+          {"name": "tags", "type": {"type": "map", "values": "long"}},
+          {"name": "d", "type": {"type": "int", "logicalType": "date"}},
+          {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 4}}
+      ]
+  }
+  ```
+
+  创建对应的表，并使用原生 Reader 导入：
+
+  ```SQL
+  CREATE TABLE example_db.events (
+      id           BIGINT,
+      event        STRUCT<name VARCHAR(64), code INT>,
+      tags         MAP<VARCHAR(64), BIGINT>,
+      d            DATE,
+      amount       DECIMAL(18, 4)
+  )
+  ENGINE = OLAP
+  DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id);
+
+  CREATE ROUTINE LOAD example_db.events_load_job ON events
+  PROPERTIES
+  (
+      "format" = "avro",
+      "avro.use_native_reader" = "true"
+  )
+  FROM KAFKA
+  (
+      "kafka_broker_list" = "<kafka_broker1_ip>:<kafka_broker1_port>,...",
+      "confluent.schema.registry.url" = "http://172.xx.xxx.xxx:8081",
+      "kafka_topic" = "topic_events",
+      "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+  );
+  ```
+
 提交导入作业后，您可以执行 [SHOW ROUTINE LOAD](../sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md)，查看导入作业执行情况。
 
 #### 数据类型映射
@@ -392,12 +455,22 @@ StarRocks 支持导入所有类型的 Avro 数据。导入 Avro 数据至 StarRo
 
 | Avro           |StarRocks                                        |
 | -------------- | ------------------------------------------------ |
-| record         | 将 RECORD 类型的字段或者其子字段中作为 JSON 导入 |
+| record         | 旧版 Reader：将 RECORD 类型的字段或者其子字段中作为 JSON 导入。原生 Reader（`avro.use_native_reader = true`）：`STRUCT`。 |
 | enums          | STRING                                           |
 | arrays         | ARRAY                                            |
-| maps           | JSON                                             |
+| maps           | 旧版 Reader：JSON。原生 Reader：`MAP`。          |
 | union(T, null) | NULLABE(T)                                       |
 | fixed          | STRING                                           |
+
+**逻辑类型**
+
+原生 Reader（`avro.use_native_reader = true`）还会解析 Avro 逻辑类型。旧版 Reader 将其作为底层原始类型（raw int/long/bytes）导入。
+
+| Avro 逻辑类型                | StarRocks（原生 Reader）  |
+| ---------------------------- | ------------------------- |
+| date                         | DATE                      |
+| timestamp-millis / -micros   | DATETIME                  |
+| decimal(precision, scale)    | DECIMAL(precision, scale) |
 
 #### 使用限制
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -69,6 +69,7 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.AutoHeavySchemaChangeForbiddenException;
 import com.starrocks.common.CaseSensibility;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -2256,6 +2257,14 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         if (!fastSchemaEvolution) {
+            // This change needs a full table rewrite. An automatic driver (Avro routine-load schema
+            // evolution) can ask to be refused here rather than silently launching the heavy AlterJobV2;
+            // it then reports the skipped change. A user-issued ALTER never sets this flag.
+            ConnectContext ctx = ConnectContext.get();
+            if (ctx != null && ctx.isForbidAutoHeavySchemaChange()) {
+                throw new AutoHeavySchemaChangeForbiddenException("schema change on table '" + olapTable.getName()
+                        + "' requires a full table rewrite");
+            }
             return createJob(schemaChangeData);
         } else if (RunMode.isSharedNothingMode() ||
                 (olapTable instanceof LakeTable && ((LakeTable) olapTable).isFastSchemaEvolutionV2()) ||

--- a/fe/fe-core/src/main/java/com/starrocks/common/AutoHeavySchemaChangeForbiddenException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/AutoHeavySchemaChangeForbiddenException.java
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+// Thrown by SchemaChangeHandler when a schema change would need a full table rewrite (it is not fast schema
+// evolution) and the caller set ConnectContext.forbidAutoHeavySchemaChange. Lets an automatic driver (Avro
+// routine-load schema evolution) skip the heavy change and report it, instead of silently launching the
+// rewrite. A regular user-issued ALTER never sets that flag, so this is never thrown on the normal path.
+public class AutoHeavySchemaChangeForbiddenException extends DdlException {
+    public AutoHeavySchemaChangeForbiddenException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2110,6 +2110,14 @@ public class Config extends ConfigBase {
     public static long routine_load_pulsar_timeout_second = 12;
 
     /**
+     * Default for avro routine load jobs that do not set the `avro.use_native_reader` property:
+     * when true, use the avrocpp-based scanner (STRUCT/MAP support); when false, the legacy reader.
+     * Resolved on the FE so all BE nodes of a job use the same scanner.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_routine_load_native_avro_reader = false;
+
+    /**
      * it can't auto-resume routine load job as long as one of the backends is down
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -91,7 +92,10 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.thrift.TBrokerScanRangeParams;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TOpType;
+import com.starrocks.thrift.TRoutineLoadMetaColumn;
+import com.starrocks.thrift.TStreamSourceMetaKind;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import org.apache.logging.log4j.LogManager;
@@ -116,6 +120,290 @@ public class Load {
     public static final String VERSION = "v1";
 
     public static final String LOAD_OP_COLUMN = "__op";
+
+    // ---- Routine-load source-metadata functions ----
+    // Per-message Kafka/Pulsar metadata is exposed through source-specific functions usable in the
+    // COLUMNS clause (kafka_topic(), kafka_header('k'), pulsar_message_id(), ...). Each call is lowered
+    // at planning into a hidden source column the BE scanner fills from the message metadata, so a
+    // payload field named like a metadata field is never shadowed. The kinds mirror
+    // TStreamSourceMetaKind in PlanNodes.thrift.
+    public enum StreamMetaKind {
+        TOPIC, PARTITION, OFFSET, MESSAGE_ID, TIMESTAMP, EVENT_TIME, KEY, HEADER, HEADERS
+    }
+
+    // Spec of a metadata function: which source it belongs to, the metadata kind, the fixed return
+    // type, and whether it takes a single string-literal key (header/property lookup).
+    public static final class StreamMetaFunc {
+        public final String source; // "KAFKA" or "PULSAR"
+        public final StreamMetaKind kind;
+        public final Type type;
+        public final boolean takesKey;
+
+        public StreamMetaFunc(String source, StreamMetaKind kind, Type type, boolean takesKey) {
+            this.source = source;
+            this.kind = kind;
+            this.type = type;
+            this.takesKey = takesKey;
+        }
+    }
+
+    private static final Map<String, StreamMetaFunc> STREAM_META_FUNCS = buildStreamMetaFuncs();
+
+    private static Map<String, StreamMetaFunc> buildStreamMetaFuncs() {
+        Type vc = VarcharType.VARCHAR;
+        Type map = new MapType(VarcharType.VARCHAR, VarcharType.VARCHAR);
+        Map<String, StreamMetaFunc> m = Maps.newHashMap();
+        m.put("kafka_topic", new StreamMetaFunc("KAFKA", StreamMetaKind.TOPIC, vc, false));
+        m.put("kafka_partition", new StreamMetaFunc("KAFKA", StreamMetaKind.PARTITION, IntegerType.INT, false));
+        m.put("kafka_offset", new StreamMetaFunc("KAFKA", StreamMetaKind.OFFSET, IntegerType.BIGINT, false));
+        m.put("kafka_timestamp_ms", new StreamMetaFunc("KAFKA", StreamMetaKind.TIMESTAMP, IntegerType.BIGINT, false));
+        m.put("kafka_key", new StreamMetaFunc("KAFKA", StreamMetaKind.KEY, vc, false));
+        m.put("kafka_header", new StreamMetaFunc("KAFKA", StreamMetaKind.HEADER, vc, true));
+        m.put("kafka_headers", new StreamMetaFunc("KAFKA", StreamMetaKind.HEADERS, map, false));
+        m.put("pulsar_topic", new StreamMetaFunc("PULSAR", StreamMetaKind.TOPIC, vc, false));
+        m.put("pulsar_partition", new StreamMetaFunc("PULSAR", StreamMetaKind.PARTITION, IntegerType.INT, false));
+        m.put("pulsar_message_id", new StreamMetaFunc("PULSAR", StreamMetaKind.MESSAGE_ID, vc, false));
+        m.put("pulsar_publish_time_ms", new StreamMetaFunc("PULSAR", StreamMetaKind.TIMESTAMP, IntegerType.BIGINT, false));
+        m.put("pulsar_event_time_ms", new StreamMetaFunc("PULSAR", StreamMetaKind.EVENT_TIME, IntegerType.BIGINT, false));
+        m.put("pulsar_key", new StreamMetaFunc("PULSAR", StreamMetaKind.KEY, vc, false));
+        m.put("pulsar_property", new StreamMetaFunc("PULSAR", StreamMetaKind.HEADER, vc, true));
+        m.put("pulsar_properties", new StreamMetaFunc("PULSAR", StreamMetaKind.HEADERS, map, false));
+        return m;
+    }
+
+    // The spec for an UNQUALIFIED metadata function call like kafka_topic(); null if `fn` is not a
+    // metadata function. A qualified call (db.kafka_topic()) is never treated as metadata, so it can
+    // never shadow a user UDF of the same name.
+    public static StreamMetaFunc streamMetaFuncOf(FunctionCallExpr fn) {
+        List<String> parts = fn.getFnName().getParts();
+        if (parts.size() != 1) {
+            return null;
+        }
+        return STREAM_META_FUNCS.get(parts.get(0).toLowerCase());
+    }
+
+    // Validates every metadata function in the column mappings against the job's data source. Throws on
+    // a wrong-source call (e.g. kafka_offset() in a Pulsar job), use with a non-JSON/Avro format (CSV
+    // maps one message to many rows, so per-message metadata is ambiguous), Avro on a Pulsar job
+    // (PulsarTaskInfo sends non-JSON data to the BE as CSV), Avro without the native
+    // reader (only AvroStreamScanner fills metadata; the non-native AvroScanner would not), a missing/extra
+    // argument, or a header/property lookup whose key is not a string literal. Called at CREATE and ALTER.
+    // `avroNativeReader` is the job's resolved avro.use_native_reader (null when not Avro).
+    public static void validateStreamMetaFunctions(List<ImportColumnDesc> columnDescs, String dataSourceType,
+                                                   String format, Boolean avroNativeReader) throws DdlException {
+        if (columnDescs == null) {
+            return;
+        }
+        boolean isJson = "json".equalsIgnoreCase(format);
+        boolean isAvro = "avro".equalsIgnoreCase(format);
+        for (ImportColumnDesc desc : columnDescs) {
+            Expr expr = desc.getExpr();
+            if (expr == null) {
+                continue;
+            }
+            // collectAll (not collect): collect() stops at the first matching node and does not descend,
+            // so it would miss a metadata call nested inside another function, e.g.
+            // from_unixtime(kafka_timestamp_ms()/1000).
+            List<FunctionCallExpr> funcs = Lists.newArrayList();
+            expr.collectAll((Predicate<Expr>) e -> e instanceof FunctionCallExpr, funcs);
+            for (FunctionCallExpr fn : funcs) {
+                StreamMetaFunc spec = streamMetaFuncOf(fn);
+                if (spec == null) {
+                    continue;
+                }
+                String name = fn.getFnName().getParts().get(0).toLowerCase();
+                if (!isJson && !isAvro) {
+                    throw new DdlException(name + "() requires the data format to be JSON or Avro");
+                }
+                if (isAvro && "PULSAR".equalsIgnoreCase(dataSourceType)) {
+                    // PulsarTaskInfo sends any non-JSON format to the BE as CSV, so an Avro Pulsar job
+                    // would never fill metadata slots.
+                    throw new DdlException(name
+                            + "() requires 'format' = 'json' for Pulsar routine load; Pulsar does not support Avro");
+                }
+                if (isAvro && !Boolean.TRUE.equals(avroNativeReader)) {
+                    throw new DdlException(name
+                            + "() with Avro requires the native Avro reader; set 'avro.use_native_reader' = 'true'");
+                }
+                if (!spec.source.equalsIgnoreCase(dataSourceType)) {
+                    throw new DdlException(name + "() is only available for " + spec.source + " routine load");
+                }
+                int argc = fn.getChildren().size();
+                if (spec.takesKey) {
+                    if (argc != 1 || !(fn.getChild(0) instanceof StringLiteral)) {
+                        throw new DdlException(name + "() requires a single string-literal key argument");
+                    }
+                } else if (argc != 0) {
+                    throw new DdlException(name + "() takes no arguments");
+                }
+            }
+        }
+    }
+
+    // The set of metadata kinds the column mappings reference; drives the BE consumer gates.
+    public static Set<StreamMetaKind> collectStreamMetaKinds(List<ImportColumnDesc> columnDescs) {
+        Set<StreamMetaKind> kinds = Sets.newHashSet();
+        if (columnDescs == null) {
+            return kinds;
+        }
+        for (ImportColumnDesc desc : columnDescs) {
+            Expr expr = desc.getExpr();
+            if (expr == null) {
+                continue;
+            }
+            // collectAll (not collect): collect() stops at the first matching node and does not descend,
+            // so it would miss a metadata call nested inside another function, e.g.
+            // from_unixtime(kafka_timestamp_ms()/1000).
+            List<FunctionCallExpr> funcs = Lists.newArrayList();
+            expr.collectAll((Predicate<Expr>) e -> e instanceof FunctionCallExpr, funcs);
+            for (FunctionCallExpr fn : funcs) {
+                StreamMetaFunc spec = streamMetaFuncOf(fn);
+                if (spec != null) {
+                    kinds.add(spec.kind);
+                }
+            }
+        }
+        return kinds;
+    }
+
+    public static boolean referencesAnyStreamMeta(List<ImportColumnDesc> columnDescs) {
+        return !collectStreamMetaKinds(columnDescs).isEmpty();
+    }
+
+    // A hidden source column synthesized for one distinct metadata function call, plus its BE binding.
+    public static final class StreamMetaBinding {
+        public final String hiddenName;
+        public final StreamMetaKind kind;
+        public final String key; // header/property key, else null
+        public final Type type;
+
+        StreamMetaBinding(String hiddenName, StreamMetaKind kind, String key, Type type) {
+            this.hiddenName = hiddenName;
+            this.kind = kind;
+            this.key = key;
+            this.type = type;
+        }
+    }
+
+    // Deep copy of the column mappings so planning can rewrite expr trees in place without touching the
+    // job's persisted ImportColumnDesc/Expr objects (which SHOW CREATE ROUTINE LOAD renders).
+    public static List<ImportColumnDesc> deepCopyColumnDescs(List<ImportColumnDesc> columnExprs) {
+        List<ImportColumnDesc> copy = Lists.newArrayList();
+        for (ImportColumnDesc desc : columnExprs) {
+            if (desc.getExpr() != null) {
+                copy.add(new ImportColumnDesc(desc.getColumnName(), desc.getExpr().clone(),
+                        desc.isMaterialized(), desc.getPos()));
+            } else {
+                copy.add(new ImportColumnDesc(desc.getColumnName(), desc.isMaterialized()));
+            }
+        }
+        return copy;
+    }
+
+    // Lowers metadata function calls in `columnExprs` (which must already be deep-copied -- the rewrite
+    // mutates expr trees in place) to hidden source columns: each distinct (source, kind, key) gets one
+    // generated hidden column whose name cannot collide with a user column, the call is replaced by a
+    // SlotRef to it, and a bare ImportColumnDesc is appended so a source slot is created. Returns the
+    // bindings so the caller can type the slots and emit TRoutineLoadMetaColumn descriptors. `tbl` seeds
+    // the collision set with the destination schema so a generated name can never equal a real table
+    // column (which initColumns would otherwise type from the table, not as metadata).
+    public static List<StreamMetaBinding> lowerStreamMetaFunctions(List<ImportColumnDesc> columnExprs, Table tbl) {
+        Map<String, StreamMetaBinding> bySignature = Maps.newLinkedHashMap();
+        Set<String> usedNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        for (ImportColumnDesc desc : columnExprs) {
+            usedNames.add(desc.getColumnName());
+        }
+        if (tbl != null) {
+            for (Column column : tbl.getFullSchema()) {
+                usedNames.add(column.getName());
+            }
+        }
+        for (int i = 0; i < columnExprs.size(); i++) {
+            ImportColumnDesc desc = columnExprs.get(i);
+            Expr expr = desc.getExpr();
+            if (expr == null) {
+                continue;
+            }
+            Expr rewritten = rewriteStreamMetaCalls(expr, bySignature, usedNames);
+            if (rewritten != expr) {
+                // The call was at the expression root, so replace the whole mapping expr.
+                columnExprs.set(i, new ImportColumnDesc(desc.getColumnName(), rewritten,
+                        desc.isMaterialized(), desc.getPos()));
+            }
+        }
+        List<StreamMetaBinding> bindings = Lists.newArrayList(bySignature.values());
+        for (StreamMetaBinding b : bindings) {
+            columnExprs.add(new ImportColumnDesc(b.hiddenName));
+        }
+        return bindings;
+    }
+
+    private static Expr rewriteStreamMetaCalls(Expr expr, Map<String, StreamMetaBinding> bySignature,
+                                               Set<String> usedNames) {
+        if (expr instanceof FunctionCallExpr) {
+            StreamMetaFunc spec = streamMetaFuncOf((FunctionCallExpr) expr);
+            if (spec != null) {
+                String key = null;
+                if (spec.takesKey && !expr.getChildren().isEmpty() && expr.getChild(0) instanceof StringLiteral) {
+                    key = ((StringLiteral) expr.getChild(0)).getValue();
+                }
+                String signature = spec.source + ":" + spec.kind + ":" + (key == null ? "" : key);
+                StreamMetaBinding b = bySignature.get(signature);
+                if (b == null) {
+                    String hiddenName = generateHiddenMetaName(usedNames, bySignature.size());
+                    usedNames.add(hiddenName);
+                    b = new StreamMetaBinding(hiddenName, spec.kind, key, spec.type);
+                    bySignature.put(signature, b);
+                }
+                return new SlotRef(null, b.hiddenName);
+            }
+        }
+        for (int i = 0; i < expr.getChildren().size(); i++) {
+            Expr child = expr.getChild(i);
+            Expr rewritten = rewriteStreamMetaCalls(child, bySignature, usedNames);
+            if (rewritten != child) {
+                expr.setChild(i, rewritten);
+            }
+        }
+        return expr;
+    }
+
+    // Internal hidden-column name (user cannot reference it) that is guaranteed not to collide with any
+    // existing column name (case-insensitive, matching the load column maps).
+    private static String generateHiddenMetaName(Set<String> usedNames, int seq) {
+        String name;
+        do {
+            name = "__starrocks_rl_meta_" + seq;
+            seq++;
+        } while (usedNames.contains(name));
+        return name;
+    }
+
+    private static TStreamSourceMetaKind toTStreamSourceMetaKind(StreamMetaKind kind) {
+        switch (kind) {
+            case TOPIC:
+                return TStreamSourceMetaKind.TOPIC;
+            case PARTITION:
+                return TStreamSourceMetaKind.PARTITION;
+            case OFFSET:
+                return TStreamSourceMetaKind.OFFSET;
+            case MESSAGE_ID:
+                return TStreamSourceMetaKind.MESSAGE_ID;
+            case TIMESTAMP:
+                return TStreamSourceMetaKind.TIMESTAMP;
+            case EVENT_TIME:
+                return TStreamSourceMetaKind.EVENT_TIME;
+            case KEY:
+                return TStreamSourceMetaKind.KEY;
+            case HEADER:
+                return TStreamSourceMetaKind.HEADER;
+            case HEADERS:
+                return TStreamSourceMetaKind.HEADERS;
+            default:
+                throw new IllegalStateException("unknown stream meta kind: " + kind);
+        }
+    }
+
     // load job meta
     private LoadErrorHub.Param loadErrorHubParam = new LoadErrorHub.Param();
 
@@ -305,7 +593,7 @@ public class Load {
                                    List<String> columnsFromPath, boolean isLoadJson) throws StarRocksException {
         initColumns(tbl, columnExprs, columnToHadoopFunction, exprsByName, descriptorTable,
                 srcTupleDesc, slotDescByName, params, needInitSlotAndAnalyzeExprs, useVectorizedLoad,
-                columnsFromPath, isLoadJson, false);
+                columnsFromPath, isLoadJson, false, null);
     }
 
     public static void initColumns(Table tbl, List<ImportColumnDesc> columnExprs,
@@ -314,7 +602,7 @@ public class Load {
                                    Map<String, SlotDescriptor> slotDescByName, TBrokerScanRangeParams params,
                                    boolean needInitSlotAndAnalyzeExprs, boolean useVectorizedLoad,
                                    List<String> columnsFromPath, boolean isLoadJson,
-                                   boolean partialUpdate) throws StarRocksException {
+                                   boolean partialUpdate, String routineLoadSourceType) throws StarRocksException {
         // check mapping column exist in schema
         // !! all column mappings are in columnExprs !!
         Set<String> importColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
@@ -365,8 +653,12 @@ public class Load {
         }
 
         // We make a copy of the columnExprs so that our subsequent changes
-        // to the columnExprs will not affect the original columnExprs.
-        List<ImportColumnDesc> copiedColumnExprs = Lists.newArrayList(columnExprs);
+        // to the columnExprs will not affect the original columnExprs. Routine load rewrites mapping
+        // exprs in place (metadata-function lowering, __op reset), so it needs a deep copy; otherwise
+        // SHOW CREATE ROUTINE LOAD -- which renders the job's shared ImportColumnDesc/Expr objects --
+        // would display the lowered hidden slots instead of the user's kafka_topic() text.
+        List<ImportColumnDesc> copiedColumnExprs = routineLoadSourceType != null
+                ? deepCopyColumnDescs(columnExprs) : Lists.newArrayList(columnExprs);
 
         // If user does not specify the file field names, generate it by using base schema of table.
         // So that the following process can be unified
@@ -416,6 +708,20 @@ public class Load {
                 // 2. __op is not specified
                 copiedColumnExprs.add(new ImportColumnDesc(Load.LOAD_OP_COLUMN,
                         isLoadJson ? null : new IntLiteral(TOpType.UPSERT.getValue())));
+            }
+        }
+
+        // Lower routine-load metadata function calls (kafka_topic(), kafka_header('k'), ...) in the
+        // mapping exprs to hidden source columns the BE scanner fills from the message metadata; the
+        // hidden bare columns are appended last so they sit after the jsonpath-covered columns. Only for
+        // routine load; elsewhere a metadata-function name is left alone and fails normal function
+        // resolution ("No matching function"), which is the desired "not supported here".
+        List<StreamMetaBinding> metaBindings = Lists.newArrayList();
+        Map<String, StreamMetaBinding> metaByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        if (routineLoadSourceType != null) {
+            metaBindings = lowerStreamMetaFunctions(copiedColumnExprs, tbl);
+            for (StreamMetaBinding b : metaBindings) {
+                metaByName.put(b.hiddenName, b);
             }
         }
 
@@ -523,6 +829,14 @@ public class Load {
             }
         }
 
+        // Hidden source-metadata columns have a fixed type assigned below; exclude them from expr-driven
+        // type inference (replaceSrcSlotDescType) so a MAP/INT/BIGINT metadata slot keeps its type.
+        for (ImportColumnDesc importColumnDesc : copiedColumnExprs) {
+            if (importColumnDesc.isColumn() && metaByName.containsKey(importColumnDesc.getColumnName())) {
+                varcharColumns.add(importColumnDesc.getColumnName());
+            }
+        }
+
         // init slot desc add expr map, also transform hadoop functions
         // if use vectorized load, set src slot desc type with starrocks schema if source column is in starrocks table
         // else set varchar firstly, and try to set specific type later after expr analyzed.
@@ -558,6 +872,14 @@ public class Load {
                         slotDesc.setType(IntegerType.TINYINT);
                         slotDesc.setColumn(new Column(columnName, IntegerType.TINYINT));
                         slotDesc.setIsMaterialized(true);
+                    } else if (metaByName.containsKey(columnName)) {
+                        // Hidden source-metadata column (lowered from kafka_topic() etc.). Fix the type
+                        // (INT/BIGINT/VARCHAR/MAP) here, before expression analysis, so kafka_headers()['k']
+                        // sees a MAP child.
+                        Type metaType = metaByName.get(columnName).type;
+                        slotDesc.setType(metaType);
+                        slotDesc.setColumn(new Column(columnName, metaType));
+                        slotDesc.setIsMaterialized(true);
                     } else {
                         slotDesc.setType(VarcharType.VARCHAR);
                         slotDesc.setColumn(new Column(columnName, VarcharType.VARCHAR));
@@ -581,6 +903,23 @@ public class Load {
                 slotDescByName.put(columnName, slotDesc);
             }
         }
+
+        // Emit a TRoutineLoadMetaColumn for each hidden metadata slot so the BE scanner fills it from the
+        // message metadata by slot id (never by name, so payload fields are not shadowed).
+        for (StreamMetaBinding b : metaBindings) {
+            SlotDescriptor metaSlot = slotDescByName.get(b.hiddenName);
+            if (metaSlot == null) {
+                continue;
+            }
+            TRoutineLoadMetaColumn metaDesc = new TRoutineLoadMetaColumn();
+            metaDesc.setSlot_id(metaSlot.getId().asInt());
+            metaDesc.setKind(toTStreamSourceMetaKind(b.kind));
+            if (b.key != null) {
+                metaDesc.setKey(b.key);
+            }
+            params.addToStream_source_meta_columns(metaDesc);
+        }
+
         /*
          * The extension column of the materialized view is added to the expression evaluation of load
          * To avoid nested expressions. eg : column(a, tmp_c, c = expr(tmp_c)) ,
@@ -852,8 +1191,11 @@ public class Load {
             }
 
             // check if contain aggregation
+            // collectAll (not collect): collect() stops at the first matching node and does not descend,
+            // so it would miss a metadata call nested inside another function, e.g.
+            // from_unixtime(kafka_timestamp_ms()/1000).
             List<FunctionCallExpr> funcs = Lists.newArrayList();
-            expr.collect(FunctionCallExpr.class, funcs);
+            expr.collectAll((Predicate<Expr>) e -> e instanceof FunctionCallExpr, funcs);
             for (FunctionCallExpr fn : funcs) {
                 if (fn.isAggregateFunction()) {
                     throw new StarRocksException("Don't support aggregation function in load expression");
@@ -889,8 +1231,11 @@ public class Load {
             expr = ExprUtils.analyzeAndCastFold(expr);
 
             // check if contain aggregation
+            // collectAll (not collect): collect() stops at the first matching node and does not descend,
+            // so it would miss a metadata call nested inside another function, e.g.
+            // from_unixtime(kafka_timestamp_ms()/1000).
             List<FunctionCallExpr> funcs = Lists.newArrayList();
-            expr.collect(FunctionCallExpr.class, funcs);
+            expr.collectAll((Predicate<Expr>) e -> e instanceof FunctionCallExpr, funcs);
             for (FunctionCallExpr fn : funcs) {
                 if (fn.isAggregateFunction()) {
                     throw new StarRocksException("Don't support aggregation function in load expression");

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -270,6 +270,31 @@ public class Load {
         return !collectStreamMetaKinds(columnDescs).isEmpty();
     }
 
+    // Column names fed by a stream-metadata function (kafka_offset() etc.) rather than the payload. A writer
+    // field colliding with one of these can't be auto-evolved (the slot is filled by message id, not the
+    // payload), so Avro schema evolution PAUSEs on the clash. Case-insensitive, matching column resolution.
+    public static Set<String> collectStreamMetaColumnNames(List<ImportColumnDesc> columnDescs) {
+        Set<String> names = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        if (columnDescs == null) {
+            return names;
+        }
+        for (ImportColumnDesc desc : columnDescs) {
+            Expr expr = desc.getExpr();
+            if (expr == null) {
+                continue;
+            }
+            List<FunctionCallExpr> funcs = Lists.newArrayList();
+            expr.collectAll((Predicate<Expr>) e -> e instanceof FunctionCallExpr, funcs);
+            for (FunctionCallExpr fn : funcs) {
+                if (streamMetaFuncOf(fn) != null) {
+                    names.add(desc.getColumnName());
+                    break;
+                }
+            }
+        }
+        return names;
+    }
+
     // A hidden source column synthesized for one distinct metadata function call, plus its BE binding.
     public static final class StreamMetaBinding {
         public final String hiddenName;

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/AvroSchemaEvolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/AvroSchemaEvolver.java
@@ -1,0 +1,421 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.routineload;
+
+import com.google.common.collect.Sets;
+import com.starrocks.authorization.PrivilegeBuiltinConstants;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.SchemaChangeTypeCompatibility;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.AutoHeavySchemaChangeForbiddenException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.AddColumnClause;
+import com.starrocks.sql.ast.AddFieldClause;
+import com.starrocks.sql.ast.AlterClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.ModifyColumnClause;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.StructFieldDesc;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.expression.TypeDef;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.thrift.TColumn;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+
+// Turns the writer schema the BE shipped (the full record, not a diff) into the ALTER clauses needed to make
+// the table accommodate it. The BE escalated because something did not fit; the FE re-diffs the whole schema
+// against the live table and decides, per field:
+//   - name with no column                        -> ADD COLUMN (the writer type verbatim, nullable, no default)
+//   - existing struct column with a new subfield -> ADD FIELD
+//   - existing column whose type does not fit but the change is legal -> MODIFY (safe widening, possibly a
+//     heavy rewrite if the table is not fast-schema-evolution)
+//   - unresolvable -> a pause reason: a metadata-column clash, a case-only name difference, a key column, or
+//     a type change the engine cannot perform (e.g. scalar to struct)
+//
+// Most fields in the shipped schema already fit (the BE sends everything, not just the offender), so the
+// "does the column already hold the writer type" predicate is load-bearing: it must agree with the BE's
+// avro_scalar_fits/avro_field_covered, or detection would loop (FE skips a field the BE keeps escalating) or
+// over-alter. The writer types here are already StarRocks types the BE mapped from Avro (unions/enums
+// collapsed), so this is a StarRocks-type-to-StarRocks-type comparison.
+//
+// Partial batch: resolvable clauses are returned to apply even when other fields are unresolvable; the caller
+// applies the clauses and then pauses with the returned pause reason.
+public class AvroSchemaEvolver {
+
+    // The clauses to apply and, if any field could not be resolved, the reason to pause the job afterwards.
+    public static class Plan {
+        private final List<AlterClause> clauses;
+        private final String pauseReason;
+
+        Plan(List<AlterClause> clauses, String pauseReason) {
+            this.clauses = clauses;
+            this.pauseReason = pauseReason;
+        }
+
+        public List<AlterClause> getClauses() {
+            return clauses;
+        }
+
+        public String getPauseReason() {
+            return pauseReason;
+        }
+
+        public boolean shouldPause() {
+            return pauseReason != null;
+        }
+    }
+
+    private AvroSchemaEvolver() {
+    }
+
+    public static Plan plan(OlapTable table, PendingSchemaChange pending, Set<String> metaColumnNames) {
+        List<AlterClause> clauses = new ArrayList<>();
+        List<String> pauseReasons = new ArrayList<>();
+
+        if (pending.getSchemaColumns() != null) {
+            for (TColumn tcol : pending.getSchemaColumns()) {
+                if (!tcol.isSetType_desc()) {
+                    continue;
+                }
+                String name = tcol.getColumn_name();
+                Type writerType = TypeDeserializer.fromThrift(tcol.getType_desc());
+
+                if (metaColumnNames.contains(name)) {
+                    pauseReasons.add("field '" + name + "' collides with a metadata column; rename one");
+                    continue;
+                }
+                Column liveCol = table.getColumn(name);
+                if (liveCol == null) {
+                    clauses.add(buildAddColumn(name, writerType));
+                    continue;
+                }
+                // getColumn is case-insensitive; StarRocks forbids two columns differing only in case, so a
+                // case-only mismatch can never be resolved by ADD and must be raised to the user.
+                if (!liveCol.getName().equals(name)) {
+                    pauseReasons.add("field '" + name + "' differs only in case from column '"
+                            + liveCol.getName() + "'; rename one");
+                    continue;
+                }
+                // Load planning creates no source slot for generated/auto-increment columns, so the BE
+                // keeps escalating a same-named writer field as uncovered no matter how well the type
+                // fits; treating it as covered here would loop. Only a rename resolves the clash.
+                if (liveCol.isGeneratedColumn() || liveCol.isAutoIncrement()) {
+                    pauseReasons.add("field '" + name + "' collides with "
+                            + (liveCol.isGeneratedColumn() ? "generated" : "auto-increment")
+                            + " column '" + liveCol.getName()
+                            + "', which is never loaded from the payload; rename the field");
+                    continue;
+                }
+                Type colType = liveCol.getType();
+                if (columnAccommodates(colType, writerType)) {
+                    continue;
+                }
+                // The column would have to change to hold the writer type, but it is a key column. A key
+                // type change affects sort/distribution, so it is not auto-evolved; pause for the user. (A
+                // key column that already fits was skipped above -- the writer schema carries every field,
+                // key columns included, and an unchanged key must not pause the job.)
+                if (liveCol.isKey()) {
+                    pauseReasons.add("key column '" + name + "' would need a type change to hold the new Avro "
+                            + "type (" + writerType + "), which is not auto-evolved");
+                    continue;
+                }
+                // DECIMALV2 is deprecated and the native avro reader has no V2 path, so a writer decimal
+                // never fits a V2 column. Its only lossless v3 form is DECIMAL128(27, 9) (the single legal
+                // V2 -> v3 conversion the engine allows); migrate to it when that form holds the writer so
+                // the reader can read the field. A string writer routes through the generic path below
+                // (V2 -> VARCHAR is legal and holds anything); a writer beyond V2's capacity falls through
+                // to a pause.
+                if (colType.isDecimalV2()) {
+                    Type v3 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 9);
+                    if (columnAccommodates(v3, writerType)) {
+                        clauses.add(buildModify(name, v3, liveCol.isAllowNull()));
+                        continue;
+                    }
+                }
+                if (colType.isStructType() && writerType.isStructType()) {
+                    diffStruct(name, new ArrayList<>(), (StructType) colType, (StructType) writerType,
+                            clauses, pauseReasons);
+                } else if (colType.isScalarType() && writerType.isScalarType()
+                        && SchemaChangeTypeCompatibility.isSchemaChangeAllowed(colType, writerType)) {
+                    clauses.add(buildModify(name, writerType, liveCol.isAllowNull()));
+                } else {
+                    pauseReasons.add("column '" + name + "' (" + colType + ") cannot hold the new Avro type ("
+                            + writerType + ")");
+                }
+            }
+        }
+
+        if (pending.getWidenColumns() != null) {
+            for (String name : pending.getWidenColumns()) {
+                Column liveCol = table.getColumn(name);
+                if (liveCol == null) {
+                    continue;
+                }
+                Type colType = liveCol.getType();
+                if (!colType.isScalarType()) {
+                    continue;
+                }
+                // The BE only flags a length-limited varchar/varbinary (len < the max width). A column
+                // already at the max -- or unbounded (len < 0) -- needs no widen; emitting the MODIFY
+                // anyway would be a no-op the next daemon tick reads as "did not converge", pausing the job.
+                int len = ((ScalarType) colType).getLength();
+                if (len < 0 || len >= StringType.MAX_STRING_LENGTH) {
+                    continue;
+                }
+                // Widen to the bounded max width -- the same length the BE treats as "no overflow possible"
+                // (TypeDescriptor::MAX_VARCHAR_LENGTH) -- so the widened column never re-triggers detection.
+                Type target = colType.isBinaryType()
+                        ? TypeFactory.createVarbinary(StringType.MAX_STRING_LENGTH)
+                        : TypeFactory.createVarcharType(StringType.MAX_STRING_LENGTH);
+                clauses.add(buildModify(liveCol.getName(), target, liveCol.isAllowNull()));
+            }
+        }
+
+        String pauseReason = pauseReasons.isEmpty() ? null : String.join("; ", pauseReasons);
+        return new Plan(clauses, pauseReason);
+    }
+
+    // Applies the planned clauses under a root inner context (the caller runs this off the txn thread and
+    // holding no routine-load lock). Returns the descriptions of changes that were refused because they need
+    // a full table rewrite, so the caller can pause and name them.
+    //
+    // allowHeavyRewrite=true: all clauses go in one ALTER. A fast-schema-evolution change takes effect
+    // synchronously; a heavy one runs as a background AlterJobV2. Always returns an empty list.
+    //
+    // allowHeavyRewrite=false: the engine is told to refuse heavy changes (forbidAutoHeavySchemaChange).
+    // Clauses are applied one at a time so a refused (heavy) clause is identified exactly while the light
+    // ones still take effect; the refused clauses' descriptions are returned.
+    public static List<String> applyClauses(String dbName, String tableName, List<AlterClause> clauses,
+                                            boolean allowHeavyRewrite) throws Exception {
+        ConnectContext context = ConnectContext.buildInner();
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        try (ConnectContext.ScopeGuard guard = context.bindScope()) {
+            if (allowHeavyRewrite) {
+                applyOne(context, dbName, tableName, clauses);
+                return new ArrayList<>();
+            }
+            context.setForbidAutoHeavySchemaChange(true);
+            List<String> refused = new ArrayList<>();
+            for (AlterClause clause : clauses) {
+                try {
+                    applyOne(context, dbName, tableName, Collections.singletonList(clause));
+                } catch (AutoHeavySchemaChangeForbiddenException e) {
+                    refused.add(describeClause(clause));
+                }
+            }
+            return refused;
+        }
+    }
+
+    private static void applyOne(ConnectContext context, String dbName, String tableName, List<AlterClause> clauses)
+            throws Exception {
+        QualifiedName qualifiedName =
+                QualifiedName.of(Arrays.asList(DEFAULT_INTERNAL_CATALOG_NAME, dbName, tableName));
+        TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+        AlterTableStmt stmt = new AlterTableStmt(tableRef, clauses);
+        Analyzer.analyze(stmt, context);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(context, stmt);
+    }
+
+    // A short, human-readable rendering of a planned clause for a pause message, so the operator sees the
+    // exact change to run by hand.
+    public static String describeClause(AlterClause clause) {
+        if (clause instanceof AddColumnClause) {
+            ColumnDef def = ((AddColumnClause) clause).getColumnDef();
+            return "ADD COLUMN " + def.getName() + " " + def.getTypeDef().toSql();
+        }
+        if (clause instanceof ModifyColumnClause) {
+            ColumnDef def = ((ModifyColumnClause) clause).getColumnDef();
+            return "MODIFY COLUMN " + def.getName() + " " + def.getTypeDef().toSql();
+        }
+        if (clause instanceof AddFieldClause) {
+            AddFieldClause add = (AddFieldClause) clause;
+            return "MODIFY COLUMN " + add.getColName() + " ADD FIELD " + add.getFieldDesc().getFieldName();
+        }
+        return clause.toString();
+    }
+
+    // Walks an existing struct column against the writer struct: a missing subfield becomes an ADD FIELD (at
+    // its nested path); a present-but-wider subfield recurses (nested struct) or, if its type changed
+    // incompatibly, becomes a pause reason (a struct subfield type cannot be auto-evolved).
+    private static void diffStruct(String topColName, List<String> parentPath, StructType colStruct,
+                                   StructType writerStruct, List<AlterClause> clauses, List<String> pauseReasons) {
+        for (StructField wf : writerStruct.getFields()) {
+            StructField cf = colStruct.getField(wf.getName());
+            if (cf == null) {
+                StructFieldDesc desc = new StructFieldDesc(wf.getName(), new ArrayList<>(parentPath),
+                        new TypeDef(wf.getType()), null);
+                clauses.add(new AddFieldClause(topColName, desc, new HashMap<>()));
+            } else if (!cf.getName().equals(wf.getName())) {
+                // getField matched case-insensitively. Subfield names are unique ignoring case, so ADD
+                // FIELD cannot resolve this; raise it to the user like the top-level case-only mismatch.
+                String path = parentPath.isEmpty() ? wf.getName()
+                        : String.join(".", parentPath) + "." + wf.getName();
+                pauseReasons.add("struct column '" + topColName + "' subfield '" + path
+                        + "' differs only in case from '" + cf.getName() + "'; rename one");
+            } else if (columnAccommodates(cf.getType(), wf.getType())) {
+                continue;
+            } else if (cf.getType().isStructType() && wf.getType().isStructType()) {
+                List<String> childPath = new ArrayList<>(parentPath);
+                childPath.add(wf.getName());
+                diffStruct(topColName, childPath, (StructType) cf.getType(), (StructType) wf.getType(),
+                        clauses, pauseReasons);
+            } else {
+                String path = parentPath.isEmpty() ? wf.getName()
+                        : String.join(".", parentPath) + "." + wf.getName();
+                pauseReasons.add("struct column '" + topColName + "' subfield '" + path
+                        + "' type change is not auto-evolved");
+            }
+        }
+    }
+
+    // True if column type `col` already holds writer type `writer` without an ALTER. Mirrors the BE
+    // avro_field_covered/avro_scalar_fits: a string/binary column holds anything; struct/array/map recurse;
+    // a scalar must be the same or a wider type in the same family.
+    private static boolean columnAccommodates(Type col, Type writer) {
+        if (writer.isStructType()) {
+            if (!col.isStructType()) {
+                return col.isStringType() || col.isBinaryType();
+            }
+            StructType cs = (StructType) col;
+            for (StructField wf : ((StructType) writer).getFields()) {
+                StructField cf = cs.getField(wf.getName());
+                // getField matches case-insensitively but the BE matches subfield names exactly, so a
+                // case-only match is NOT covered — or the BE would keep escalating what we skip.
+                if (cf == null || !cf.getName().equals(wf.getName())
+                        || !columnAccommodates(cf.getType(), wf.getType())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (writer.isArrayType()) {
+            if (!col.isArrayType()) {
+                return col.isStringType() || col.isBinaryType();
+            }
+            return columnAccommodates(((ArrayType) col).getItemType(), ((ArrayType) writer).getItemType());
+        }
+        if (writer.isMapType()) {
+            if (!col.isMapType()) {
+                return col.isStringType() || col.isBinaryType();
+            }
+            // Avro map keys are always strings; mirror the BE: only a string/binary key column holds
+            // them (the map reader appends raw key bytes into a binary key column).
+            Type colKey = ((MapType) col).getKeyType();
+            if (!colKey.isStringType() && !colKey.isBinaryType()) {
+                return false;
+            }
+            return columnAccommodates(((MapType) col).getValueType(), ((MapType) writer).getValueType());
+        }
+        if (col.isScalarType() && writer.isScalarType()) {
+            return scalarAccommodates((ScalarType) col, (ScalarType) writer);
+        }
+        // Writer is a scalar but the column is complex: not representable.
+        return false;
+    }
+
+    private static boolean scalarAccommodates(ScalarType col, ScalarType writer) {
+        if (col.isStringType() || col.isBinaryType()) {
+            return true;
+        }
+        // Only decimal v3 columns, mirroring the BE is_decimalv3_field_type: a writer decimal always maps
+        // to v3 (get_avro_type), so a v3 column holds it when its precision/scale are wide enough. A legacy
+        // DECIMALV2 column falls through to the exact-match below (v3 != v2 -> escalate), keeping FE and BE
+        // in lockstep so detection neither loops nor over-alters.
+        if (col.isDecimalV3()) {
+            if (writer.isDecimalV3()) {
+                return col.getScalarPrecision() >= writer.getScalarPrecision()
+                        && col.getScalarScale() >= writer.getScalarScale();
+            }
+            PrimitiveType wp = writer.getPrimitiveType();
+            // An integer/float into a decimal column is cast with a per-value overflow check by the reader.
+            return isIntegerType(wp) || isFloatType(wp);
+        }
+        PrimitiveType cp = col.getPrimitiveType();
+        PrimitiveType wp = writer.getPrimitiveType();
+        if (isIntegerType(cp)) {
+            return isIntegerType(wp) && numericRank(cp) >= numericRank(wp);
+        }
+        if (isFloatType(cp)) {
+            if (isIntegerType(wp)) {
+                return true;
+            }
+            return isFloatType(wp) && numericRank(cp) >= numericRank(wp);
+        }
+        return cp == wp;
+    }
+
+    private static boolean isIntegerType(PrimitiveType t) {
+        return t == PrimitiveType.TINYINT || t == PrimitiveType.SMALLINT || t == PrimitiveType.INT
+                || t == PrimitiveType.BIGINT || t == PrimitiveType.LARGEINT;
+    }
+
+    private static boolean isFloatType(PrimitiveType t) {
+        return t == PrimitiveType.FLOAT || t == PrimitiveType.DOUBLE;
+    }
+
+    // Byte-width rank within the integer and float families, matching the BE numeric_rank.
+    private static int numericRank(PrimitiveType t) {
+        switch (t) {
+            case TINYINT:
+                return 1;
+            case SMALLINT:
+                return 2;
+            case INT:
+            case FLOAT:
+                return 4;
+            case BIGINT:
+            case DOUBLE:
+                return 8;
+            case LARGEINT:
+                return 16;
+            default:
+                return 0;
+        }
+    }
+
+    private static AlterClause buildAddColumn(String name, Type type) {
+        ColumnDef def = new ColumnDef(name, new TypeDef(type), true);
+        return new AddColumnClause(def, null, null, new HashMap<>());
+    }
+
+    private static AlterClause buildModify(String name, Type type, boolean nullable) {
+        ColumnDef def = new ColumnDef(name, new TypeDef(type), nullable);
+        return new ModifyColumnClause(def, null, null, new HashMap<>());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -43,8 +43,10 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadTask;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TKafkaLoadInfo;
@@ -58,6 +60,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.starrocks.common.ErrorCode.ERR_ROUTINE_LOAD_OFFSET_INVALID;
@@ -192,6 +195,15 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         if ((routineLoadJob).getConfluentSchemaRegistryUrl() != null) {
             tKafkaLoadInfo.setConfluent_schema_registry_url((routineLoadJob).getConfluentSchemaRegistryUrl());
         }
+        // Attach per-message source metadata only when the COLUMNS clause references a metadata column;
+        // otherwise the BE leaves the buffer metadata-free and reads every field from the payload.
+        // key/headers are gated more narrowly.
+        List<ImportColumnDesc> columnDescs = routineLoadJob.getColumnDescs();
+        Set<Load.StreamMetaKind> metaKinds = Load.collectStreamMetaKinds(columnDescs);
+        tKafkaLoadInfo.setNeed_source_metadata(!metaKinds.isEmpty());
+        tKafkaLoadInfo.setNeed_message_key(metaKinds.contains(Load.StreamMetaKind.KEY));
+        tKafkaLoadInfo.setNeed_message_headers(
+                metaKinds.contains(Load.StreamMetaKind.HEADER) || metaKinds.contains(Load.StreamMetaKind.HEADERS));
         tRoutineLoadTask.setKafka_load_info(tKafkaLoadInfo);
         tRoutineLoadTask.setType(TLoadSourceType.KAFKA);
         tRoutineLoadTask.setParams(plan(routineLoadJob));

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -222,6 +222,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         } else {
             tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_CSV_PLAIN);
         }
+        // Turn on BE-side writer-schema detection only when the job opted in and the configuration can act
+        // on the signal (native avro reader, no jsonpaths); the gate lives in isAvroSchemaEvolutionEnabled.
+        if (routineLoadJob.isAvroSchemaEvolutionEnabled()) {
+            tRoutineLoadTask.setEnable_schema_evolution(true);
+        }
         if (Math.abs(routineLoadJob.getMaxFilterRatio() - 1) > 0.001) {
             tRoutineLoadTask.setMax_filter_ratio(routineLoadJob.getMaxFilterRatio());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PendingSchemaChange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PendingSchemaChange.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.routineload;
+
+import com.starrocks.thrift.TColumn;
+
+import java.util.List;
+
+// Runtime-only record that a routine-load task hit an Avro writer schema the table does not yet cover. Set
+// on the job by RoutineLoadJob.afterAborted from the BE rollback attachment and cleared by the
+// schema-evolution daemon once the resulting ALTER resolves. While a job holds one, the task scheduler
+// defers dispatching its tasks, so they do not re-abort against the not-yet-evolved table.
+//
+// The BE ships the full writer schema, not a diff: schemaColumns carries every top-level field (name + full
+// nested type, nullable, no default); the FE diffs it against the live table and picks ADD COLUMN / ADD
+// FIELD / MODIFY. widenColumns names existing varchar/varbinary columns an over-length value overran (widen
+// to the type's max length). The two are independent; either may be empty.
+//
+// Not persisted: after a leader failover this is simply re-derived from the next BE signal.
+public class PendingSchemaChange {
+    private final int schemaId;
+    private final List<TColumn> schemaColumns;
+    private final List<String> widenColumns;
+    // Set once the daemon has applied the ALTER. On a later tick, if the table still does not cover the
+    // schema and no ALTER is running, the change is treated as failed (job paused) rather than re-applied,
+    // so a cancelled/ineffective ALTER cannot loop.
+    private boolean applied = false;
+
+    public PendingSchemaChange(int schemaId, List<TColumn> schemaColumns, List<String> widenColumns) {
+        this.schemaId = schemaId;
+        this.schemaColumns = schemaColumns;
+        this.widenColumns = widenColumns;
+    }
+
+    public boolean isApplied() {
+        return applied;
+    }
+
+    public void setApplied(boolean applied) {
+        this.applied = applied;
+    }
+
+    public int getSchemaId() {
+        return schemaId;
+    }
+
+    public List<TColumn> getSchemaColumns() {
+        return schemaColumns;
+    }
+
+    public List<String> getWidenColumns() {
+        return widenColumns;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -25,7 +25,9 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PulsarUtil;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.load.Load;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TLoadSourceType;
@@ -35,6 +37,7 @@ import com.starrocks.thrift.TUniqueId;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class PulsarTaskInfo extends RoutineLoadTaskInfo {
@@ -131,6 +134,15 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
             tPulsarLoadInfo.setInitial_positions(getInitialPositions());
         }
         tPulsarLoadInfo.setProperties(routineLoadJob.getConvertedCustomProperties());
+        // Attach per-message source metadata only when the COLUMNS clause references a metadata column;
+        // otherwise the BE leaves the buffer metadata-free and reads every field from the payload.
+        // key/headers are gated more narrowly.
+        List<ImportColumnDesc> columnDescs = routineLoadJob.getColumnDescs();
+        Set<Load.StreamMetaKind> metaKinds = Load.collectStreamMetaKinds(columnDescs);
+        tPulsarLoadInfo.setNeed_source_metadata(!metaKinds.isEmpty());
+        tPulsarLoadInfo.setNeed_message_key(metaKinds.contains(Load.StreamMetaKind.KEY));
+        tPulsarLoadInfo.setNeed_message_headers(
+                metaKinds.contains(Load.StreamMetaKind.HEADER) || metaKinds.contains(Load.StreamMetaKind.HEADERS));
         tRoutineLoadTask.setPulsar_load_info(tPulsarLoadInfo);
         tRoutineLoadTask.setType(TLoadSourceType.PULSAR);
         tRoutineLoadTask.setParams(plan(routineLoadJob));

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
@@ -35,10 +35,13 @@
 package com.starrocks.load.routineload;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TRLTaskTxnCommitAttachment;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TxnCommitAttachment;
+
+import java.util.List;
 
 // {"progress": "", "backendId": "", "taskSignature": "", "numOfErrorData": "",
 // "numOfTotalData": "", "taskId": "", "jobId": ""}
@@ -63,6 +66,15 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     private String errorLogUrl;
     private long loadedBytes;
     private boolean nonRetryable = false;
+
+    // Avro schema evolution: set by the BE on the rollback attachment when a message's writer schema is
+    // not yet covered by the table. detectedSchemaColumns is the full writer schema (each top-level field
+    // as name + full type, nullable, no default); detectedWidenColumns names varchar/varbinary columns an
+    // over-length value overran. Consumed in afterAborted; not persisted or replayed.
+    private boolean schemaChangeNeeded = false;
+    private int detectedSchemaId = -1;
+    private List<TColumn> detectedSchemaColumns;
+    private List<String> detectedWidenColumns;
 
     public RLTaskTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK);
@@ -99,6 +111,18 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
         }
         if (rlTaskTxnCommitAttachment.isSetNonRetryable()) {
             this.nonRetryable = rlTaskTxnCommitAttachment.isNonRetryable();
+        }
+        if (rlTaskTxnCommitAttachment.isSetSchemaChangeNeeded()) {
+            this.schemaChangeNeeded = rlTaskTxnCommitAttachment.isSchemaChangeNeeded();
+        }
+        if (rlTaskTxnCommitAttachment.isSetDetectedSchemaId()) {
+            this.detectedSchemaId = rlTaskTxnCommitAttachment.getDetectedSchemaId();
+        }
+        if (rlTaskTxnCommitAttachment.isSetDetectedSchemaColumns()) {
+            this.detectedSchemaColumns = rlTaskTxnCommitAttachment.getDetectedSchemaColumns();
+        }
+        if (rlTaskTxnCommitAttachment.isSetDetectedWidenColumns()) {
+            this.detectedWidenColumns = rlTaskTxnCommitAttachment.getDetectedWidenColumns();
         }
     }
 
@@ -152,6 +176,22 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
     public boolean isNonRetryable() {
         return nonRetryable;
+    }
+
+    public boolean isSchemaChangeNeeded() {
+        return schemaChangeNeeded;
+    }
+
+    public int getDetectedSchemaId() {
+        return detectedSchemaId;
+    }
+
+    public List<TColumn> getDetectedSchemaColumns() {
+        return detectedSchemaColumns;
+    }
+
+    public List<String> getDetectedWidenColumns() {
+        return detectedWidenColumns;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -121,6 +121,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -247,6 +248,19 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     // or a job persisted before this field existed.
     @SerializedName("nar")
     private Boolean useNativeAvroReader;
+    // null/false = schema evolution disabled (opt-in via avro.enable_schema_evolution). Resolved once at
+    // job creation, like useNativeAvroReader.
+    @SerializedName("ase")
+    private Boolean enableAvroSchemaEvolution;
+    // null = default true. When false, schema evolution auto-applies only metadata-only fast changes; a
+    // change needing a full table rewrite pauses the job, naming the ALTER to run by hand.
+    @SerializedName("ahs")
+    private Boolean allowHeavySchemaChange;
+    // Avro schema evolution: non-null while a task reported a writer schema the table does not yet cover and
+    // the resulting ALTER has not resolved. Runtime-only (no @SerializedName): re-derived from BE signals
+    // after a leader failover. Set in afterAborted; cleared by the schema-evolution daemon. While set, the
+    // task scheduler holds this job's tasks.
+    private volatile PendingSchemaChange pendingSchemaChange;
 
     protected int currentTaskConcurrentNum;
     @SerializedName("p")
@@ -449,6 +463,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
             }
             this.confluentSchemaRegistryUrl = stmt.getConfluentSchemaRegistryUrl();
             this.useNativeAvroReader = stmt.getUseNativeAvroReader();
+            this.enableAvroSchemaEvolution = stmt.getEnableAvroSchemaEvolution();
+            this.allowHeavySchemaChange = stmt.getAllowHeavySchemaChange();
         } else {
             throw new StarRocksException("Invalid format type.");
         }
@@ -509,6 +525,123 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     public Boolean getUseNativeAvroReader() {
         return useNativeAvroReader;
+    }
+
+    public Boolean getEnableAvroSchemaEvolution() {
+        return enableAvroSchemaEvolution;
+    }
+
+    public Boolean getAllowHeavySchemaChange() {
+        return allowHeavySchemaChange;
+    }
+
+    // Default true when unset (job created before the property existed, or older persisted state).
+    public boolean isHeavySchemaChangeAllowed() {
+        return !Boolean.FALSE.equals(allowHeavySchemaChange);
+    }
+
+    // True only when the job opted in AND the configuration can actually act on it: the native avro reader
+    // is active and no jsonpaths are set. jsonpaths are excluded because routine-load avro never had a
+    // working jsonpath->column mapping, so that path carries no by-name field->column binding for
+    // evolution to build on. Mirrors the BE detection gate.
+    public boolean isAvroSchemaEvolutionEnabled() {
+        return Boolean.TRUE.equals(enableAvroSchemaEvolution)
+                && "avro".equalsIgnoreCase(getFormat())
+                && Boolean.TRUE.equals(useNativeAvroReader)
+                && Strings.isNullOrEmpty(getJsonPaths());
+    }
+
+    public PendingSchemaChange getPendingSchemaChange() {
+        return pendingSchemaChange;
+    }
+
+    public void setPendingSchemaChange(PendingSchemaChange pendingSchemaChange) {
+        this.pendingSchemaChange = pendingSchemaChange;
+    }
+
+    public boolean hasPendingSchemaChange() {
+        return pendingSchemaChange != null;
+    }
+
+    // Called by the RoutineLoad scheduler daemon (off the txn thread, holding no routine-load lock) when this
+    // job has a pending Avro schema change. Diffs the writer schema against the live table and applies the
+    // ALTER, then either clears the marker (the table now covers the schema, so the held tasks resume) or
+    // pauses the job. Idempotent across ticks: while an ALTER is in flight it waits; once applied it verifies
+    // coverage rather than re-applying, so a cancelled or ineffective ALTER pauses instead of looping.
+    public void tryEvolveSchema() throws StarRocksException {
+        PendingSchemaChange pending = pendingSchemaChange;
+        if (pending == null) {
+            return;
+        }
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(getDbId());
+        Table table = db == null ? null
+                : GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(getDbId(), getTableId());
+        if (!(table instanceof OlapTable)) {
+            // Table dropped or not OLAP: drop the marker so the held tasks resume and fail through normal paths.
+            pendingSchemaChange = null;
+            return;
+        }
+        OlapTable olapTable = (OlapTable) table;
+
+        // An ALTER (ours from a previous tick, or another) is still running on this table: wait for it.
+        if (!GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                .getUnfinishedAlterJobV2ByTableId(olapTable.getId()).isEmpty()) {
+            return;
+        }
+
+        Set<String> metaNames = Load.collectStreamMetaColumnNames(getColumnDescs());
+        AvroSchemaEvolver.Plan plan = AvroSchemaEvolver.plan(olapTable, pending, metaNames);
+
+        if (plan.getClauses().isEmpty()) {
+            // Nothing more to apply: the table already covers the schema, or only unresolvable fields remain.
+            if (plan.shouldPause()) {
+                updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.INTERNAL_ERR,
+                        "Avro schema evolution: " + plan.getPauseReason()));
+            }
+            pendingSchemaChange = null;
+            return;
+        }
+
+        if (pending.isApplied()) {
+            // Applied on an earlier tick, nothing running, yet the table still does not cover the schema: the
+            // ALTER did not converge (e.g. it was cancelled). Pause instead of re-applying in a loop.
+            updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.INTERNAL_ERR,
+                    "Avro schema evolution did not converge for table " + olapTable.getName()));
+            pendingSchemaChange = null;
+            return;
+        }
+
+        List<String> heavyRefused;
+        try {
+            heavyRefused = AvroSchemaEvolver.applyClauses(db.getFullName(), olapTable.getName(),
+                    plan.getClauses(), isHeavySchemaChangeAllowed());
+            pending.setApplied(true);
+        } catch (Exception e) {
+            updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.INTERNAL_ERR,
+                    "Avro schema evolution ALTER failed: " + e.getMessage()));
+            pendingSchemaChange = null;
+            return;
+        }
+
+        // Applied what we could. Pause if any field was unresolvable, or if a needed change was refused
+        // because it requires a full table rewrite (allow_heavy off) -- naming the exact ALTERs so the
+        // operator can run them by hand or enable the property. Otherwise the next tick confirms coverage
+        // (sync fast schema evolution is immediate; a heavy rewrite finishes asynchronously) and clears the
+        // marker, resuming the held tasks.
+        List<String> pauseReasons = new ArrayList<>();
+        if (plan.shouldPause()) {
+            pauseReasons.add(plan.getPauseReason());
+        }
+        if (!heavyRefused.isEmpty()) {
+            pauseReasons.add("the following changes require a full table rewrite and "
+                    + CreateRoutineLoadStmt.AVRO_ALLOW_HEAVY_SCHEMA_CHANGE
+                    + " is false; run them manually or enable the property: " + String.join(", ", heavyRefused));
+        }
+        if (!pauseReasons.isEmpty()) {
+            updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.INTERNAL_ERR,
+                    "Avro schema evolution: " + String.join("; ", pauseReasons)));
+            pendingSchemaChange = null;
+        }
     }
 
     @Override
@@ -1262,6 +1395,20 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                 return;
             }
 
+            // Avro schema evolution: the BE shipped the writer schema the table does not yet cover. Record it
+            // so the schema-evolution daemon can ALTER the table and resume; the task scheduler holds this
+            // job's tasks while the marker is set. The task is still renewed below and waits in the queue.
+            // A late abort carrying the same schema id must not replace an existing marker: that would reset
+            // the daemon's "already applied" flag and could re-apply an in-flight ALTER. A different schema id
+            // does replace it (a newer writer schema supersedes the old one).
+            if (rlAttachment != null && rlAttachment.isSchemaChangeNeeded()) {
+                PendingSchemaChange existing = getPendingSchemaChange();
+                if (existing == null || existing.getSchemaId() != rlAttachment.getDetectedSchemaId()) {
+                    setPendingSchemaChange(new PendingSchemaChange(rlAttachment.getDetectedSchemaId(),
+                            rlAttachment.getDetectedSchemaColumns(), rlAttachment.getDetectedWidenColumns()));
+                }
+            }
+
             // step2: commit task , update progress, maybe create a new task
             executeTaskOnTxnStatusChanged(routineLoadTaskInfo, txnState, TransactionStatus.ABORTED,
                     txnStatusChangeReasonString);
@@ -1812,6 +1959,16 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         if ("avro".equalsIgnoreCase(getFormat())) {
             sb.append("\"").append(CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER).append("\"=\"");
             sb.append(useNativeAvroReader != null ? useNativeAvroReader : Boolean.FALSE).append("\",\n");
+        }
+
+        if (enableAvroSchemaEvolution != null) {
+            sb.append("\"").append(CreateRoutineLoadStmt.AVRO_ENABLE_SCHEMA_EVOLUTION).append("\"=\"");
+            sb.append(enableAvroSchemaEvolution).append("\",\n");
+        }
+
+        if (allowHeavySchemaChange != null) {
+            sb.append("\"").append(CreateRoutineLoadStmt.AVRO_ALLOW_HEAVY_SCHEMA_CHANGE).append("\"=\"");
+            sb.append(allowHeavySchemaChange).append("\",\n");
         }
 
         if (!Strings.isNullOrEmpty(getEnvelope())) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -243,6 +243,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     protected long maxBatchSizeBytes = Config.max_routine_load_batch_size;
 
     private String confluentSchemaRegistryUrl;
+    // Resolved at job creation for Avro jobs (never null for them); null means a non-Avro job
+    // or a job persisted before this field existed.
+    @SerializedName("nar")
+    private Boolean useNativeAvroReader;
 
     protected int currentTaskConcurrentNum;
     @SerializedName("p")
@@ -444,6 +448,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                 jobProperties.put(CreateRoutineLoadStmt.JSONPATHS, "");
             }
             this.confluentSchemaRegistryUrl = stmt.getConfluentSchemaRegistryUrl();
+            this.useNativeAvroReader = stmt.getUseNativeAvroReader();
         } else {
             throw new StarRocksException("Invalid format type.");
         }
@@ -500,6 +505,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public Boolean getUseNativeAvroReader() {
+        return useNativeAvroReader;
     }
 
     @Override
@@ -1796,6 +1805,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
         sb.append("\"").append(CreateRoutineLoadStmt.JSONROOT).append("\"=\"");
         sb.append(getJsonRoot()).append("\",\n");
+
+        // For an Avro job persisted before this field existed (null), emit "false" rather than nothing:
+        // such a job runs the legacy reader, and replaying the shown DDL must keep doing so even if the
+        // FE-wide default config has been flipped to the native reader since.
+        if ("avro".equalsIgnoreCase(getFormat())) {
+            sb.append("\"").append(CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER).append("\"=\"");
+            sb.append(useNativeAvroReader != null ? useNativeAvroReader : Boolean.FALSE).append("\",\n");
+        }
 
         if (!Strings.isNullOrEmpty(getEnvelope())) {
             sb.append("\"").append(CreateRoutineLoadStmt.ENVELOPE).append("\"=\"");

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1886,6 +1886,15 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                           Map<String, String> jobProperties,
                           RoutineLoadDataSourceProperties dataSourceProperties,
                           OriginStatementInfo originStatement) throws DdlException {
+        // ALTER can replace the COLUMNS clause, so re-check that any metadata functions apply to this
+        // job's source (e.g. reject kafka_offset() on a Pulsar job). CREATE is validated in
+        // CreateRoutineLoadAnalyzer; this covers the ALTER path.
+        List<ImportColumnDesc> metaColumnDescs =
+                (routineLoadDesc != null && routineLoadDesc.getColumnsInfo() != null)
+                        ? routineLoadDesc.getColumnsInfo().getColumns()
+                        : null;
+        Load.validateStreamMetaFunctions(metaColumnDescs, getDataSourceTypeName(), getFormat(),
+                getUseNativeAvroReader());
         if (jobProperties != null) {
             checkCommonJobProperties(jobProperties);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
@@ -133,6 +133,28 @@ public class RoutineLoadScheduler extends LeaderDaemon {
 
         // check timeout tasks
         routineLoadManager.processTimeoutTasks();
+
+        // apply any pending Avro schema evolutions detected by routine-load tasks
+        processPendingSchemaChanges();
+    }
+
+    // Apply pending Avro schema evolutions: a job whose task reported an uncovered writer schema holds a
+    // marker (set on the txn thread in RoutineLoadJob.afterAborted). Here, off that thread and holding no job
+    // lock, each such job ALTERs its table and then resumes or pauses. Runs RUNNING jobs only; the marker is
+    // transient runtime state.
+    private void processPendingSchemaChanges() {
+        List<RoutineLoadJob> jobs = routineLoadManager.getRoutineLoadJobByState(
+                Sets.newHashSet(RoutineLoadJob.JobState.RUNNING));
+        for (RoutineLoadJob job : jobs) {
+            if (!job.hasPendingSchemaChange()) {
+                continue;
+            }
+            try {
+                job.tryEvolveSchema();
+            } catch (Exception e) {
+                LOG.warn("failed to evolve Avro schema for routine load job {}", job.getId(), e);
+            }
+        }
     }
 
     private List<RoutineLoadJob> getNeedScheduleRoutineJobs() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -271,6 +271,15 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
             return;
         }
 
+        // Hold this job's tasks while an Avro schema evolution is pending: the schema-evolution daemon is
+        // altering the table, and dispatching now would just re-abort against the not-yet-evolved schema. No
+        // BE slot is taken yet (allocated below), so deferring here leaks nothing.
+        RoutineLoadJob pendingJob = routineLoadManager.getJob(routineLoadTaskInfo.getJobId());
+        if (pendingJob != null && pendingJob.hasPendingSchemaChange()) {
+            delayPutToQueue(routineLoadTaskInfo, "waiting for Avro schema evolution to complete");
+            return;
+        }
+
         try {
             // for kafka/pulsar routine load, readyToExecute means there is new data in kafka/pulsar stream
             if (!routineLoadTaskInfo.readyToExecute()) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -90,6 +90,10 @@ public class StreamLoadInfo {
     private int loadParallelRequestNum = 0;
     private boolean enableReplicatedStorage = false;
     private String confluentSchemaRegistryUrl;
+    // null = not set; the choice is resolved on the FE (from the FE config
+    // enable_routine_load_native_avro_reader default) and carried to the BE, which falls back to the
+    // legacy avro scanner when it is unset.
+    private Boolean useNativeAvroReader;
     private long logRejectedRecordNum = 0;
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
     private ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
@@ -123,6 +127,10 @@ public class StreamLoadInfo {
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public Boolean getUseNativeAvroReader() {
+        return useNativeAvroReader;
     }
 
     public TUniqueId getId() {
@@ -473,6 +481,7 @@ public class StreamLoadInfo {
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
         }
         confluentSchemaRegistryUrl = routineLoadJob.getConfluentSchemaRegistryUrl();
+        useNativeAvroReader = routineLoadJob.getUseNativeAvroReader();
         trimSpace = routineLoadJob.isTrimspace();
         enclose = routineLoadJob.getEnclose();
         escape = routineLoadJob.getEscape();

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -94,6 +94,9 @@ public class StreamLoadInfo {
     // enable_routine_load_native_avro_reader default) and carried to the BE, which falls back to the
     // legacy avro scanner when it is unset.
     private Boolean useNativeAvroReader;
+    // "KAFKA"/"PULSAR" for routine load, null otherwise. Enables (and scopes) the source-metadata
+    // functions in the COLUMNS clause; null means a metadata function is rejected as unknown.
+    private String routineLoadSourceType;
     private long logRejectedRecordNum = 0;
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
     private ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
@@ -131,6 +134,10 @@ public class StreamLoadInfo {
 
     public Boolean getUseNativeAvroReader() {
         return useNativeAvroReader;
+    }
+
+    public String getRoutineLoadSourceType() {
+        return routineLoadSourceType;
     }
 
     public TUniqueId getId() {
@@ -486,6 +493,7 @@ public class StreamLoadInfo {
         enclose = routineLoadJob.getEnclose();
         escape = routineLoadJob.getEscape();
         computeResource = routineLoadJob.getComputeResource();
+        routineLoadSourceType = routineLoadJob.getDataSourceTypeName();
     }
 
     // used for stream load

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -272,7 +272,8 @@ public class StreamLoadScanNode extends LoadScanNode {
         Load.initColumns(dstTable, streamLoadInfo.getColumnExprDescs(), null /* no hadoop function */,
                 exprsByName, descriptorTable, paramCreateContext.tupleDescriptor, slotDescByName,
                 paramCreateContext.params, true, useVectorizedLoad, Lists.newArrayList(),
-                streamLoadInfo.getFormatType() == TFileFormatType.FORMAT_JSON, streamLoadInfo.isPartialUpdate());
+                streamLoadInfo.getFormatType() == TFileFormatType.FORMAT_JSON, streamLoadInfo.isPartialUpdate(),
+                streamLoadInfo.getRoutineLoadSourceType());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -257,6 +257,12 @@ public class StreamLoadScanNode extends LoadScanNode {
         if (streamLoadInfo.getConfluentSchemaRegistryUrl() != null) {
             params.setConfluent_schema_registry_url(streamLoadInfo.getConfluentSchemaRegistryUrl());
         }
+        // Resolved once at job creation (CreateRoutineLoadStmt) and persisted, so it is uniform across
+        // all BE nodes and stable across FE-config changes. null = a job created before this feature
+        // (or a non-avro job) -> leave unset, BE falls back to the legacy scanner.
+        if (streamLoadInfo.getUseNativeAvroReader() != null) {
+            params.setUse_native_avro_reader(streamLoadInfo.getUseNativeAvroReader());
+        }
         initColumns();
         initWhereExpr(streamLoadInfo.getWhereExpr());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -284,6 +284,20 @@ public class ConnectContext {
     // Track if current write is CTAS (Create Table As Select)
     private boolean isCTAS = false;
 
+    // When set, schema change refuses any change that needs a full table rewrite (not fast schema
+    // evolution), throwing AutoHeavySchemaChangeForbiddenException instead of creating a heavy AlterJobV2.
+    // Used by automatic drivers (Avro routine-load schema evolution) to skip and report heavy changes;
+    // off for normal user-issued ALTERs.
+    private boolean forbidAutoHeavySchemaChange = false;
+
+    public boolean isForbidAutoHeavySchemaChange() {
+        return forbidAutoHeavySchemaChange;
+    }
+
+    public void setForbidAutoHeavySchemaChange(boolean forbidAutoHeavySchemaChange) {
+        this.forbidAutoHeavySchemaChange = forbidAutoHeavySchemaChange;
+    }
+
     public void setTxnId(long txnId) {
         this.txnId = txnId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateRoutineLoadAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateRoutineLoadAnalyzer.java
@@ -18,11 +18,16 @@ import com.google.common.base.Strings;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.load.Load;
+import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.LabelName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.List;
 
 public class CreateRoutineLoadAnalyzer {
 
@@ -53,6 +58,13 @@ public class CreateRoutineLoadAnalyzer {
             statement.setRoutineLoadDesc(CreateRoutineLoadStmt.buildLoadDesc(statement.getLoadPropertyList()));
             statement.checkJobProperties();
             statement.checkDataSourceProperties();
+            RoutineLoadDesc routineLoadDesc = statement.getRoutineLoadDesc();
+            List<ImportColumnDesc> metaColumnDescs =
+                    (routineLoadDesc != null && routineLoadDesc.getColumnsInfo() != null)
+                            ? routineLoadDesc.getColumnsInfo().getColumns()
+                            : null;
+            Load.validateStreamMetaFunctions(metaColumnDescs, statement.getTypeName(), statement.getFormat(),
+                    statement.getUseNativeAvroReader());
         } catch (StarRocksException e) {
             LOG.error(e.getMessage(), e);
             throw new SemanticException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateRoutineLoadAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateRoutineLoadAnalyzer.java
@@ -65,6 +65,17 @@ public class CreateRoutineLoadAnalyzer {
                             : null;
             Load.validateStreamMetaFunctions(metaColumnDescs, statement.getTypeName(), statement.getFormat(),
                     statement.getUseNativeAvroReader());
+            // Schema evolution maps payload fields to columns by name. A plain column list in COLUMNS
+            // pins the loaded column set instead, so an added column would never start loading and the
+            // BE would re-escalate the same schema forever. Expression mappings pin nothing: the
+            // payload columns still come from the live table schema.
+            if (Boolean.TRUE.equals(statement.getEnableAvroSchemaEvolution()) && metaColumnDescs != null
+                    && metaColumnDescs.stream().anyMatch(ImportColumnDesc::isColumn)) {
+                throw new StarRocksException(CreateRoutineLoadStmt.AVRO_ENABLE_SCHEMA_EVOLUTION
+                        + " maps payload fields to columns by name and cannot be combined with an explicit"
+                        + " column list in COLUMNS; use one or the other (expression mappings in COLUMNS"
+                        + " are still allowed)");
+            }
         } catch (StarRocksException e) {
             LOG.error(e.getMessage(), e);
             throw new SemanticException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -133,6 +133,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String KAFKA_DEFAULT_OFFSETS = "kafka_default_offsets";
     // optional
     public static final String CONFLUENT_SCHEMA_REGISTRY_URL = "confluent.schema.registry.url";
+    // optional: per-job override to use the avrocpp-based reader (STRUCT/MAP support) for avro.
+    // When unset, the FE config enable_routine_load_native_avro_reader supplies the default, resolved
+    // once at job creation.
+    public static final String AVRO_USE_NATIVE_READER = "avro.use_native_reader";
 
     // pulsar type properties
     public static final String PULSAR_SERVICE_URL_PROPERTY = "pulsar_service_url";
@@ -171,6 +175,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(TASK_CONSUME_SECOND)
             .add(TASK_TIMEOUT_SECOND)
             .add(PropertyAnalyzer.PROPERTIES_WAREHOUSE)
+            .add(AVRO_USE_NATIVE_READER)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -190,6 +195,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .build();
 
     private String confluentSchemaRegistryUrl;
+    // For Avro jobs, resolved at analyze time: the job property if set, otherwise the FE config
+    // default. Stays null for non-Avro formats.
+    private Boolean useNativeAvroReader;
     private LabelName labelName;
     private final String tableName;
     private final List<ParseNode> loadPropertyList;
@@ -285,6 +293,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public Boolean getUseNativeAvroReader() {
+        return useNativeAvroReader;
     }
 
     public long getTaskConsumeSecond() {
@@ -621,6 +633,11 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             } else if (format.equalsIgnoreCase("avro")) {
                 format = "avro";
                 jsonPaths = jobProperties.get(JSONPATHS);
+                // Resolve the reader choice once, at creation time, so flipping the FE-wide default
+                // later only affects newly created jobs and never existing ones.
+                useNativeAvroReader = Util.getBooleanPropertyOrDefault(jobProperties.get(AVRO_USE_NATIVE_READER),
+                        Config.enable_routine_load_native_avro_reader,
+                        AVRO_USE_NATIVE_READER + " should be a boolean");
             } else {
                 throw new StarRocksException("Format type is invalid. format=`" + format + "`");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -137,6 +137,15 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     // When unset, the FE config enable_routine_load_native_avro_reader supplies the default, resolved
     // once at job creation.
     public static final String AVRO_USE_NATIVE_READER = "avro.use_native_reader";
+    // optional: per-job opt-in to Avro schema evolution. When true, and the native avro reader is active
+    // and no jsonpaths are set, the BE detects writer-schema changes the table does not yet cover and the
+    // FE evolves the table (ADD COLUMN / ADD FIELD / MODIFY) and retries. Defaults to false.
+    public static final String AVRO_ENABLE_SCHEMA_EVOLUTION = "avro.enable_schema_evolution";
+    // optional: when Avro schema evolution is on, whether to auto-apply changes that need a full table
+    // rewrite (heavy AlterJobV2) -- e.g. an int->varchar type change, a decimal grow, or any change on a
+    // non-fast-schema-evolution table. When false, only metadata-only fast changes are auto-applied and a
+    // heavy change pauses the job, naming the ALTER to run manually. Defaults to true.
+    public static final String AVRO_ALLOW_HEAVY_SCHEMA_CHANGE = "avro.schema_evolution_allow_heavy_alter";
 
     // pulsar type properties
     public static final String PULSAR_SERVICE_URL_PROPERTY = "pulsar_service_url";
@@ -176,6 +185,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(TASK_TIMEOUT_SECOND)
             .add(PropertyAnalyzer.PROPERTIES_WAREHOUSE)
             .add(AVRO_USE_NATIVE_READER)
+            .add(AVRO_ENABLE_SCHEMA_EVOLUTION)
+            .add(AVRO_ALLOW_HEAVY_SCHEMA_CHANGE)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -198,6 +209,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     // For Avro jobs, resolved at analyze time: the job property if set, otherwise the FE config
     // default. Stays null for non-Avro formats.
     private Boolean useNativeAvroReader;
+    // null = not set by the user; defaults to false (schema evolution is opt-in).
+    private Boolean enableAvroSchemaEvolution;
+    // null = not set by the user; defaults to true (auto-apply heavy schema changes when evolving).
+    private Boolean allowHeavySchemaChange;
     private LabelName labelName;
     private final String tableName;
     private final List<ParseNode> loadPropertyList;
@@ -297,6 +312,14 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public Boolean getUseNativeAvroReader() {
         return useNativeAvroReader;
+    }
+
+    public Boolean getEnableAvroSchemaEvolution() {
+        return enableAvroSchemaEvolution;
+    }
+
+    public Boolean getAllowHeavySchemaChange() {
+        return allowHeavySchemaChange;
     }
 
     public long getTaskConsumeSecond() {
@@ -638,6 +661,12 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                 useNativeAvroReader = Util.getBooleanPropertyOrDefault(jobProperties.get(AVRO_USE_NATIVE_READER),
                         Config.enable_routine_load_native_avro_reader,
                         AVRO_USE_NATIVE_READER + " should be a boolean");
+                enableAvroSchemaEvolution = Util.getBooleanPropertyOrDefault(
+                        jobProperties.get(AVRO_ENABLE_SCHEMA_EVOLUTION), false,
+                        AVRO_ENABLE_SCHEMA_EVOLUTION + " should be a boolean");
+                allowHeavySchemaChange = Util.getBooleanPropertyOrDefault(
+                        jobProperties.get(AVRO_ALLOW_HEAVY_SCHEMA_CHANGE), true,
+                        AVRO_ALLOW_HEAVY_SCHEMA_CHANGE + " should be a boolean");
             } else {
                 throw new StarRocksException("Format type is invalid. format=`" + format + "`");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -229,6 +229,41 @@ public class CreateRoutineLoadStmtTest {
     }
 
     @Test
+    public void testSchemaEvolutionRejectsExplicitColumnList() {
+        String sql = "CREATE ROUTINE LOAD job ON tbl " +
+                "COLUMNS(`a`, `b`) " +
+                "PROPERTIES (\"format\"=\"avro\", \"avro.use_native_reader\"=\"true\", " +
+                "\"avro.enable_schema_evolution\"=\"true\") " +
+                "FROM KAFKA (\"kafka_broker_list\" = \"kafkahost1:9092\", " +
+                "\"confluent.schema.registry.url\" = \"https://confluent.west.us\", " +
+                "\"kafka_topic\" = \"topictest\")";
+        List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
+        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) stmts.get(0);
+        try {
+            CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+            Assertions.fail("expected the explicit column list to be rejected");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("cannot be combined with an explicit column list"));
+        }
+    }
+
+    @Test
+    public void testSchemaEvolutionAllowsExpressionOnlyColumns() {
+        // Expression mappings pin no payload column set, so they are compatible with schema evolution.
+        String sql = "CREATE ROUTINE LOAD job ON tbl " +
+                "COLUMNS(`c` = 1) " +
+                "PROPERTIES (\"format\"=\"avro\", \"avro.use_native_reader\"=\"true\", " +
+                "\"avro.enable_schema_evolution\"=\"true\") " +
+                "FROM KAFKA (\"kafka_broker_list\" = \"kafkahost1:9092\", " +
+                "\"confluent.schema.registry.url\" = \"https://confluent.west.us\", " +
+                "\"kafka_topic\" = \"topictest\")";
+        List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
+        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) stmts.get(0);
+        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+        Assertions.assertTrue(createRoutineLoadStmt.getEnableAvroSchemaEvolution());
+    }
+
+    @Test
     public void testLoadPropertiesContexts() {
         String sql = "CREATE ROUTINE LOAD testdb.routine_name ON table1"
                 + " PROPERTIES( \"desired_concurrent_number\"=\"3\",\n"

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -617,7 +617,7 @@ public class LoadTest {
                 "missing dependency column for generated column c3",
                 () -> Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable,
                         localSrcTupleDesc, localSlotDescByName, new TBrokerScanRangeParams(), true, true,
-                        Lists.newArrayList(), false, true));
+                        Lists.newArrayList(), false, true, null));
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/load/StreamMetaFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/StreamMetaFunctionTest.java
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.ast.ImportColumnDesc;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class StreamMetaFunctionTest {
+
+    private static FunctionCallExpr call(String name, Expr... args) {
+        return new FunctionCallExpr(name, Lists.newArrayList(args));
+    }
+
+    @Test
+    public void testStreamMetaFuncOf() {
+        Load.StreamMetaFunc topic = Load.streamMetaFuncOf(call("kafka_topic"));
+        Assertions.assertNotNull(topic);
+        Assertions.assertEquals("KAFKA", topic.source);
+        Assertions.assertEquals(Load.StreamMetaKind.TOPIC, topic.kind);
+
+        Load.StreamMetaFunc header = Load.streamMetaFuncOf(call("kafka_header", new StringLiteral("k")));
+        Assertions.assertNotNull(header);
+        Assertions.assertTrue(header.takesKey);
+
+        // Name matching is case-insensitive; a regular (non-metadata) function -> null.
+        Assertions.assertNotNull(Load.streamMetaFuncOf(call("KAFKA_TOPIC")));
+        Assertions.assertNull(Load.streamMetaFuncOf(call("from_unixtime")));
+    }
+
+    @Test
+    public void testValidateSourceMatch() {
+        // kafka_offset() only for KAFKA.
+        List<ImportColumnDesc> kafkaOffset = Lists.newArrayList(new ImportColumnDesc("c", call("kafka_offset")));
+        Assertions.assertThrows(DdlException.class,
+                () -> Load.validateStreamMetaFunctions(kafkaOffset, "PULSAR", "json", true));
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(kafkaOffset, "KAFKA", "json", true));
+
+        // pulsar_message_id() only for PULSAR.
+        List<ImportColumnDesc> pulsarMid = Lists.newArrayList(new ImportColumnDesc("c", call("pulsar_message_id")));
+        Assertions.assertThrows(DdlException.class,
+                () -> Load.validateStreamMetaFunctions(pulsarMid, "KAFKA", "json", true));
+    }
+
+    @Test
+    public void testValidateFormat() {
+        // Metadata functions require JSON or Avro; CSV (empty format) is rejected.
+        List<ImportColumnDesc> descs = Lists.newArrayList(new ImportColumnDesc("c", call("kafka_topic")));
+        Assertions.assertThrows(DdlException.class, () -> Load.validateStreamMetaFunctions(descs, "KAFKA", "", true));
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(descs, "KAFKA", "json", true));
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(descs, "KAFKA", "avro", true));
+    }
+
+    @Test
+    public void testValidateAvroRequiresNativeReader() {
+        List<ImportColumnDesc> descs = Lists.newArrayList(new ImportColumnDesc("c", call("kafka_topic")));
+        // Avro without the native reader is rejected (the non-native AvroScanner does not fill metadata).
+        Assertions.assertThrows(DdlException.class,
+                () -> Load.validateStreamMetaFunctions(descs, "KAFKA", "avro", false));
+        Assertions.assertThrows(DdlException.class,
+                () -> Load.validateStreamMetaFunctions(descs, "KAFKA", "avro", null));
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(descs, "KAFKA", "avro", true));
+        // JSON ignores the reader flag.
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(descs, "KAFKA", "json", false));
+    }
+
+    @Test
+    public void testValidateAvroRejectedForPulsar() {
+        // Pulsar tasks send non-JSON data to the BE as CSV, so Avro metadata extraction can never work.
+        List<ImportColumnDesc> descs = Lists.newArrayList(new ImportColumnDesc("c", call("pulsar_topic")));
+        Assertions.assertThrows(DdlException.class,
+                () -> Load.validateStreamMetaFunctions(descs, "PULSAR", "avro", true));
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(descs, "PULSAR", "json", null));
+    }
+
+    @Test
+    public void testValidateArityAndKey() {
+        // header lookup requires a single string-literal key.
+        List<ImportColumnDesc> noArg = Lists.newArrayList(new ImportColumnDesc("c", call("kafka_header")));
+        Assertions.assertThrows(DdlException.class, () -> Load.validateStreamMetaFunctions(noArg, "KAFKA", "json", true));
+
+        List<ImportColumnDesc> nonLiteral =
+                Lists.newArrayList(new ImportColumnDesc("c", call("kafka_header", new SlotRef(null, "x"))));
+        Assertions.assertThrows(DdlException.class, () -> Load.validateStreamMetaFunctions(nonLiteral, "KAFKA", "json", true));
+
+        List<ImportColumnDesc> ok =
+                Lists.newArrayList(new ImportColumnDesc("c", call("kafka_header", new StringLiteral("trace-id"))));
+        Assertions.assertDoesNotThrow(() -> Load.validateStreamMetaFunctions(ok, "KAFKA", "json", true));
+
+        // scalar functions take no arguments.
+        List<ImportColumnDesc> extraArg =
+                Lists.newArrayList(new ImportColumnDesc("c", call("kafka_topic", new StringLiteral("x"))));
+        Assertions.assertThrows(DdlException.class, () -> Load.validateStreamMetaFunctions(extraArg, "KAFKA", "json", true));
+    }
+
+    @Test
+    public void testCollectKinds() {
+        List<ImportColumnDesc> descs = Lists.newArrayList(
+                new ImportColumnDesc("a", call("kafka_topic")),
+                new ImportColumnDesc("b", call("kafka_header", new StringLiteral("h"))),
+                new ImportColumnDesc("plain", call("from_unixtime")));
+        Set<Load.StreamMetaKind> kinds = Load.collectStreamMetaKinds(descs);
+        Assertions.assertTrue(kinds.contains(Load.StreamMetaKind.TOPIC));
+        Assertions.assertTrue(kinds.contains(Load.StreamMetaKind.HEADER));
+        Assertions.assertFalse(kinds.contains(Load.StreamMetaKind.KEY));
+    }
+
+    @Test
+    public void testLowerRootAndNested() {
+        // root call: t = kafka_topic(); nested call: ts = from_unixtime(kafka_timestamp_ms()).
+        ImportColumnDesc tDesc = new ImportColumnDesc("t", call("kafka_topic"));
+        ImportColumnDesc tsDesc = new ImportColumnDesc("ts", call("from_unixtime", call("kafka_timestamp_ms")));
+        List<ImportColumnDesc> descs = Lists.newArrayList(tDesc, tsDesc);
+
+        List<Load.StreamMetaBinding> bindings = Load.lowerStreamMetaFunctions(descs, null);
+
+        Assertions.assertEquals(2, bindings.size());
+        // Two hidden bare columns appended.
+        Assertions.assertEquals(4, descs.size());
+        Assertions.assertTrue(descs.get(2).isColumn());
+        Assertions.assertTrue(descs.get(3).isColumn());
+
+        // Root rewritten to a SlotRef to the hidden topic column.
+        Expr rewrittenRoot = descs.get(0).getExpr();
+        Assertions.assertTrue(rewrittenRoot instanceof SlotRef);
+
+        // Nested call's child rewritten to a SlotRef; the outer function stays.
+        Expr rewrittenNested = descs.get(1).getExpr();
+        Assertions.assertTrue(rewrittenNested instanceof FunctionCallExpr);
+        Assertions.assertTrue(rewrittenNested.getChild(0) instanceof SlotRef);
+    }
+
+    @Test
+    public void testLowerDedup() {
+        // Two identical kafka_topic() calls collapse to one hidden column.
+        List<ImportColumnDesc> descs = Lists.newArrayList(
+                new ImportColumnDesc("a", call("kafka_topic")),
+                new ImportColumnDesc("b", call("kafka_topic")));
+        List<Load.StreamMetaBinding> bindings = Load.lowerStreamMetaFunctions(descs, null);
+
+        Assertions.assertEquals(1, bindings.size());
+        Assertions.assertEquals(3, descs.size()); // a, b, one hidden column
+        SlotRef refA = (SlotRef) descs.get(0).getExpr();
+        SlotRef refB = (SlotRef) descs.get(1).getExpr();
+        Assertions.assertEquals(refA.getColumnName(), refB.getColumnName());
+        Assertions.assertEquals(bindings.get(0).hiddenName, refA.getColumnName());
+    }
+
+    @Test
+    public void testLowerNameCollisionAvoided() {
+        // An existing column named like the first generated hidden name forces the generator to skip it
+        // (the same mechanism seeds destination-table column names, preventing table-column collisions).
+        List<ImportColumnDesc> descs = Lists.newArrayList(
+                new ImportColumnDesc("__starrocks_rl_meta_0"),
+                new ImportColumnDesc("t", call("kafka_topic")));
+        List<Load.StreamMetaBinding> bindings = Load.lowerStreamMetaFunctions(descs, null);
+        Assertions.assertEquals(1, bindings.size());
+        Assertions.assertNotEquals("__starrocks_rl_meta_0", bindings.get(0).hiddenName);
+    }
+
+    @Test
+    public void testLowerNoMetaUnchanged() {
+        // No metadata function -> nothing rewritten, no hidden column.
+        List<ImportColumnDesc> descs = Lists.newArrayList(
+                new ImportColumnDesc("a"),
+                new ImportColumnDesc("b", call("from_unixtime", new SlotRef(null, "x"))));
+        List<Load.StreamMetaBinding> bindings = Load.lowerStreamMetaFunctions(descs, null);
+        Assertions.assertTrue(bindings.isEmpty());
+        Assertions.assertEquals(2, descs.size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/AvroSchemaEvolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/AvroSchemaEvolverTest.java
@@ -1,0 +1,492 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.routineload;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.ast.AddColumnClause;
+import com.starrocks.sql.ast.AddFieldClause;
+import com.starrocks.sql.ast.ModifyColumnClause;
+import com.starrocks.thrift.TColumn;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.FloatType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
+import com.starrocks.type.TypeSerializer;
+import com.starrocks.type.VarbinaryType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Set;
+
+// Covers AvroSchemaEvolver.plan: it diffs the full writer schema the BE ships against the live table and
+// decides, per field, ADD COLUMN / ADD FIELD / MODIFY / skip / PAUSE. The plan only reads table.getColumn,
+// so the table is a mock; writer columns are real TColumns carrying a serialized type, exactly as the BE
+// builds them. Exercises every fit-predicate family and every pause reason.
+public class AvroSchemaEvolverTest {
+
+    private static final Set<String> NO_META = Collections.emptySet();
+
+    // A writer field as the BE ships it: name + serialized type, nullable, no default.
+    private static TColumn writer(String name, Type type) {
+        TColumn tc = new TColumn();
+        tc.setColumn_name(name);
+        tc.setType_desc(TypeSerializer.toThrift(type));
+        return tc;
+    }
+
+    private static PendingSchemaChange schema(TColumn... cols) {
+        return new PendingSchemaChange(1, Lists.newArrayList(cols), Collections.emptyList());
+    }
+
+    private static StructType struct(StructField... fields) {
+        return new StructType(Lists.newArrayList(fields));
+    }
+
+    private static OlapTable tableWith(Column... columns) {
+        OlapTable table = Mockito.mock(OlapTable.class);
+        for (Column c : columns) {
+            Mockito.when(table.getColumn(c.getName())).thenReturn(c);
+        }
+        return table;
+    }
+
+    private static AvroSchemaEvolver.Plan plan(OlapTable table, PendingSchemaChange pending) {
+        return AvroSchemaEvolver.plan(table, pending, NO_META);
+    }
+
+    @Test
+    public void addNewColumn() {
+        AvroSchemaEvolver.Plan plan = plan(tableWith(), schema(writer("c", IntegerType.INT)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        AddColumnClause add = (AddColumnClause) plan.getClauses().get(0);
+        Assertions.assertEquals("c", add.getColumnDef().getName());
+        Assertions.assertEquals(PrimitiveType.INT, add.getColumnDef().getType().getPrimitiveType());
+        Assertions.assertTrue(add.getColumnDef().isAllowNull());
+    }
+
+    @Test
+    public void skipExactType() {
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", IntegerType.INT)),
+                schema(writer("c", IntegerType.INT)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void skipWhenColumnIsWider() {
+        // int writer into a BIGINT column already fits.
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", IntegerType.BIGINT)),
+                schema(writer("c", IntegerType.INT)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void skipVarcharHoldsAnything() {
+        // A varchar column holds any value, including a record (the reader JSON-encodes it).
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", VarcharType.VARCHAR)),
+                schema(writer("c", struct(new StructField("a", IntegerType.INT)))));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void modifyIntToBigint() {
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", IntegerType.INT)),
+                schema(writer("c", IntegerType.BIGINT)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        ModifyColumnClause mod = (ModifyColumnClause) plan.getClauses().get(0);
+        Assertions.assertEquals("c", mod.getColumnDef().getName());
+        Assertions.assertEquals(PrimitiveType.BIGINT, mod.getColumnDef().getType().getPrimitiveType());
+    }
+
+    @Test
+    public void modifyFloatToDouble() {
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", FloatType.FLOAT)),
+                schema(writer("c", FloatType.DOUBLE)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        ModifyColumnClause mod = (ModifyColumnClause) plan.getClauses().get(0);
+        Assertions.assertEquals(PrimitiveType.DOUBLE, mod.getColumnDef().getType().getPrimitiveType());
+    }
+
+    @Test
+    public void skipIntegerIntoFloatColumn() {
+        // An integer always fits a float/double column.
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", FloatType.DOUBLE)),
+                schema(writer("c", IntegerType.INT)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void skipDecimalShrink() {
+        Type col = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        Type writer = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 8, 2);
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", col)), schema(writer("c", writer)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void modifyDecimalGrow() {
+        Type col = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        Type writer = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 2);
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", col)), schema(writer("c", writer)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        Assertions.assertInstanceOf(ModifyColumnClause.class, plan.getClauses().get(0));
+    }
+
+    @Test
+    public void migrateDecimalV2ColumnToV3() {
+        // A writer decimal always maps to v3 (get_avro_type) and the native reader has no V2 path, so a
+        // DECIMALV2 column never holds it unchanged. It is migrated to its lossless v3 form DECIMAL128(27, 9)
+        // -- the single legal V2 -> v3 conversion -- so the reader can read the field.
+        Type col = TypeFactory.createDecimalV2Type(27, 9);
+        Type writer = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", col)), schema(writer("c", writer)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        ModifyColumnClause mod = (ModifyColumnClause) plan.getClauses().get(0);
+        ScalarType target = (ScalarType) mod.getColumnDef().getType();
+        Assertions.assertEquals(PrimitiveType.DECIMAL128, target.getPrimitiveType());
+        Assertions.assertEquals(27, target.getScalarPrecision());
+        Assertions.assertEquals(9, target.getScalarScale());
+    }
+
+    @Test
+    public void pauseDecimalV2ColumnWriterBeyondCapacity() {
+        // A writer decimal wider than V2's (27, 9) capacity cannot be migrated (the engine only allows
+        // V2 -> the exact (27, 9) v3 form), so it pauses for the operator.
+        Type col = TypeFactory.createDecimalV2Type(27, 9);
+        Type writer = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 30, 4);
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", col)), schema(writer("c", writer)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+        Assertions.assertTrue(plan.getPauseReason().contains("c"));
+    }
+
+    @Test
+    public void pauseScalarColumnRecordWriter() {
+        // Column is a scalar, the field became a record: not representable, pause.
+        AvroSchemaEvolver.Plan plan = plan(tableWith(new Column("c", IntegerType.BIGINT)),
+                schema(writer("c", struct(new StructField("a", IntegerType.INT)))));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseStructColumnScalarWriter() {
+        AvroSchemaEvolver.Plan plan = plan(
+                tableWith(new Column("c", struct(new StructField("a", IntegerType.INT)))),
+                schema(writer("c", IntegerType.BIGINT)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseCaseOnlyNameDifference() {
+        // Live column is "foo"; getColumn is case-insensitive, so the writer field "Foo" resolves to it.
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getColumn("Foo")).thenReturn(new Column("foo", IntegerType.INT));
+        AvroSchemaEvolver.Plan plan = plan(table, schema(writer("Foo", IntegerType.INT)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseKeyColumn() {
+        Column key = new Column("k", IntegerType.INT);
+        key.setIsKey(true);
+        AvroSchemaEvolver.Plan plan = plan(tableWith(key), schema(writer("k", IntegerType.BIGINT)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void skipKeyColumnThatFits() {
+        // The writer schema carries every field, key columns included. A key column the writer value still
+        // fits must not pause the job; only the genuinely new field is added.
+        Column key = new Column("k", IntegerType.BIGINT);
+        key.setIsKey(true);
+        AvroSchemaEvolver.Plan plan = plan(tableWith(key),
+                schema(writer("k", IntegerType.BIGINT), writer("v", IntegerType.INT)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        AddColumnClause add = (AddColumnClause) plan.getClauses().get(0);
+        Assertions.assertEquals("v", add.getColumnDef().getName());
+    }
+
+    @Test
+    public void pauseMetadataColumnCollision() {
+        AvroSchemaEvolver.Plan plan = AvroSchemaEvolver.plan(tableWith(), schema(writer("off", IntegerType.BIGINT)),
+                Sets.newHashSet("off"));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void addFieldToStruct() {
+        Column c = new Column("c", struct(new StructField("a", IntegerType.INT)));
+        StructType writerType = struct(new StructField("a", IntegerType.INT), new StructField("b", IntegerType.INT));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c), schema(writer("c", writerType)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        AddFieldClause add = (AddFieldClause) plan.getClauses().get(0);
+        Assertions.assertEquals("c", add.getColName());
+        Assertions.assertEquals("b", add.getFieldDesc().getFieldName());
+        Assertions.assertTrue(add.getFieldDesc().getNestedParentFieldNames().isEmpty());
+    }
+
+    @Test
+    public void addFieldToNestedStruct() {
+        Column c = new Column("c", struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("s", struct(new StructField("x", IntegerType.INT)))));
+        StructType writerType = struct(
+                new StructField("a", IntegerType.INT),
+                new StructField("s", struct(new StructField("x", IntegerType.INT),
+                        new StructField("y", IntegerType.INT))));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c), schema(writer("c", writerType)));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        AddFieldClause add = (AddFieldClause) plan.getClauses().get(0);
+        Assertions.assertEquals("c", add.getColName());
+        Assertions.assertEquals("y", add.getFieldDesc().getFieldName());
+        Assertions.assertEquals(Lists.newArrayList("s"), add.getFieldDesc().getNestedParentFieldNames());
+    }
+
+    @Test
+    public void widenColumnToVarcharMax() {
+        Column v = new Column("v", new VarcharType(10));
+        PendingSchemaChange pending = new PendingSchemaChange(1, Collections.emptyList(), Lists.newArrayList("v"));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(v), pending);
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        ModifyColumnClause mod = (ModifyColumnClause) plan.getClauses().get(0);
+        Assertions.assertEquals("v", mod.getColumnDef().getName());
+        Assertions.assertEquals(StringType.MAX_STRING_LENGTH,
+                ((ScalarType) mod.getColumnDef().getType()).getLength());
+    }
+
+    @Test
+    public void skipArrayColumnThatFits() {
+        // ARRAY<BIGINT> already holds an ARRAY<INT> writer (the element widens), so no change.
+        Column c = new Column("c", new ArrayType(IntegerType.BIGINT));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c), schema(writer("c", new ArrayType(IntegerType.INT))));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseArrayElementTypeChange() {
+        // An ARRAY element type that no longer fits cannot be evolved (there is no per-element MODIFY); pause.
+        Column c = new Column("c", new ArrayType(IntegerType.INT));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c), schema(writer("c", new ArrayType(IntegerType.BIGINT))));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void skipMapColumnThatFits() {
+        // Only the map value side is judged; an INT value into a BIGINT-valued map fits.
+        Column c = new Column("c", new MapType(VarcharType.VARCHAR, IntegerType.BIGINT));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c),
+                schema(writer("c", new MapType(VarcharType.VARCHAR, IntegerType.INT))));
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseMapValueTypeChange() {
+        Column c = new Column("c", new MapType(VarcharType.VARCHAR, IntegerType.INT));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c),
+                schema(writer("c", new MapType(VarcharType.VARCHAR, IntegerType.BIGINT))));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseMapNonStringKeyColumn() {
+        // Avro map keys are always strings; a MAP<INT,...> column cannot take them even though the
+        // value side fits. Mirrors the BE coverage check, which escalates this.
+        Column c = new Column("c", new MapType(IntegerType.INT, IntegerType.BIGINT));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c),
+                schema(writer("c", new MapType(VarcharType.VARCHAR, IntegerType.INT))));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseCaseOnlyStructSubfield() {
+        // The live struct has subfield "Foo"; the writer carries "foo". The BE matches subfield names
+        // exactly and keeps escalating, and ADD FIELD cannot resolve it (subfield names are unique
+        // ignoring case), so the planner must pause instead of treating the column as covered.
+        Column c = new Column("c", struct(new StructField("Foo", IntegerType.INT)));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c),
+                schema(writer("c", struct(new StructField("foo", IntegerType.INT)))));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseGeneratedColumnCollision() {
+        Column gen = Mockito.mock(Column.class);
+        Mockito.when(gen.getName()).thenReturn("g");
+        Mockito.when(gen.getType()).thenReturn(IntegerType.INT);
+        Mockito.when(gen.isGeneratedColumn()).thenReturn(true);
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getColumn("g")).thenReturn(gen);
+
+        AvroSchemaEvolver.Plan plan = plan(table, schema(writer("g", IntegerType.INT)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void pauseAutoIncrementColumnCollision() {
+        Column autoInc = Mockito.mock(Column.class);
+        Mockito.when(autoInc.getName()).thenReturn("id");
+        Mockito.when(autoInc.getType()).thenReturn(IntegerType.BIGINT);
+        Mockito.when(autoInc.isAutoIncrement()).thenReturn(true);
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getColumn("id")).thenReturn(autoInc);
+
+        AvroSchemaEvolver.Plan plan = plan(table, schema(writer("id", IntegerType.BIGINT)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+    }
+
+    @Test
+    public void widenVarbinaryColumnToMax() {
+        Column v = new Column("v", TypeFactory.createVarbinary(16));
+        PendingSchemaChange pending = new PendingSchemaChange(1, Collections.emptyList(), Lists.newArrayList("v"));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(v), pending);
+
+        Assertions.assertFalse(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        ModifyColumnClause mod = (ModifyColumnClause) plan.getClauses().get(0);
+        Assertions.assertEquals(PrimitiveType.VARBINARY, mod.getColumnDef().getType().getPrimitiveType());
+        Assertions.assertEquals(StringType.MAX_STRING_LENGTH,
+                ((ScalarType) mod.getColumnDef().getType()).getLength());
+    }
+
+    @Test
+    public void skipAlreadyWidenedColumn() {
+        // A widen column already at the max width (or an unbounded varbinary) produces no clause, so the
+        // daemon re-tick after the widen ALTER has landed sees an empty plan and converges, instead of
+        // re-emitting a no-op MODIFY that it would read as "did not converge" and pause the job on.
+        Column varcharAtMax = new Column("s", new VarcharType(StringType.MAX_STRING_LENGTH));
+        Column varbinaryUnbounded = new Column("b", new VarbinaryType());
+        PendingSchemaChange pending =
+                new PendingSchemaChange(1, Collections.emptyList(), Lists.newArrayList("s", "b"));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(varcharAtMax, varbinaryUnbounded), pending);
+
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+        Assertions.assertFalse(plan.shouldPause());
+    }
+
+    @Test
+    public void pauseNestedStructSubfieldTypeChange() {
+        // A subfield whose type changed -- not a new field to add, not a nested struct to recurse into --
+        // cannot be evolved (a struct subfield type is not modifiable via ALTER), so it pauses.
+        Column c = new Column("c", struct(new StructField("a",
+                struct(new StructField("x", IntegerType.INT)))));
+        StructType writerType = struct(new StructField("a",
+                struct(new StructField("x", VarcharType.VARCHAR))));
+        AvroSchemaEvolver.Plan plan = plan(tableWith(c), schema(writer("c", writerType)));
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertTrue(plan.getClauses().isEmpty());
+        Assertions.assertTrue(plan.getPauseReason().contains("x"));
+    }
+
+    @Test
+    public void partialBatchAppliesResolvableThenPauses() {
+        // One new field (resolvable -> ADD COLUMN) plus one incompatible field (pause).
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getColumn("b")).thenReturn(new Column("b", IntegerType.BIGINT));
+        PendingSchemaChange pending = schema(
+                writer("a", IntegerType.INT),
+                writer("b", struct(new StructField("x", IntegerType.INT))));
+        AvroSchemaEvolver.Plan plan = plan(table, pending);
+
+        Assertions.assertTrue(plan.shouldPause());
+        Assertions.assertEquals(1, plan.getClauses().size());
+        Assertions.assertInstanceOf(AddColumnClause.class, plan.getClauses().get(0));
+        Assertions.assertTrue(plan.getPauseReason().contains("b"));
+    }
+
+    @Test
+    public void describeClauseRendersReadableAlter() {
+        // The pause message for a refused heavy change names the exact ALTER; check each clause kind renders.
+        Assertions.assertTrue(AvroSchemaEvolver.describeClause(
+                        plan(tableWith(), schema(writer("c", IntegerType.INT))).getClauses().get(0))
+                .startsWith("ADD COLUMN c"));
+        Assertions.assertTrue(AvroSchemaEvolver.describeClause(
+                        plan(tableWith(new Column("c", IntegerType.INT)), schema(writer("c", IntegerType.BIGINT)))
+                                .getClauses().get(0))
+                .startsWith("MODIFY COLUMN c"));
+        Column s = new Column("s", struct(new StructField("a", IntegerType.INT)));
+        StructType w = struct(new StructField("a", IntegerType.INT), new StructField("b", IntegerType.INT));
+        Assertions.assertTrue(AvroSchemaEvolver.describeClause(
+                        plan(tableWith(s), schema(writer("s", w))).getClauses().get(0))
+                .contains("ADD FIELD b"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -584,6 +584,22 @@ public class KafkaRoutineLoadJobTest {
     }
 
     @Test
+    public void testJobPropertiesToSqlWithNativeAvroReader() {
+        RoutineLoadJob job = new KafkaRoutineLoadJob(1L, "routine_load", 1L, 1L, "127.0.0.1:9020", "topic1");
+        // Non-avro job: the property is not emitted at all.
+        Assertions.assertFalse(job.jobPropertiesToSql().contains(CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER));
+        // Avro job with the field unset (persisted by an older FE): an explicit "false", so replaying
+        // the DDL keeps the legacy reader regardless of the current FE-wide default.
+        Map<String, String> jobProperties = Deencapsulation.getField(job, "jobProperties");
+        jobProperties.put(CreateRoutineLoadStmt.FORMAT, "avro");
+        Assertions.assertTrue(job.jobPropertiesToSql()
+                .contains("\"" + CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER + "\"=\"false\""));
+        Deencapsulation.setField(job, "useNativeAvroReader", true);
+        Assertions.assertTrue(job.jobPropertiesToSql()
+                .contains("\"" + CreateRoutineLoadStmt.AVRO_USE_NATIVE_READER + "\"=\"true\""));
+    }
+
+    @Test
     public void testGetStatistic() {
         RoutineLoadJob job = new KafkaRoutineLoadJob(1L, "routine_load", 1L, 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(job, "receivedBytes", 10);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -600,6 +600,20 @@ public class KafkaRoutineLoadJobTest {
     }
 
     @Test
+    public void testJobPropertiesToSqlWithAvroSchemaEvolution() {
+        RoutineLoadJob job = new KafkaRoutineLoadJob(1L, "routine_load", 1L, 1L, "127.0.0.1:9020", "topic1");
+        String sql = job.jobPropertiesToSql();
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.AVRO_ENABLE_SCHEMA_EVOLUTION));
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.AVRO_ALLOW_HEAVY_SCHEMA_CHANGE));
+
+        Deencapsulation.setField(job, "enableAvroSchemaEvolution", true);
+        Deencapsulation.setField(job, "allowHeavySchemaChange", false);
+        sql = job.jobPropertiesToSql();
+        Assertions.assertTrue(sql.contains("\"" + CreateRoutineLoadStmt.AVRO_ENABLE_SCHEMA_EVOLUTION + "\"=\"true\""));
+        Assertions.assertTrue(sql.contains("\"" + CreateRoutineLoadStmt.AVRO_ALLOW_HEAVY_SCHEMA_CHANGE + "\"=\"false\""));
+    }
+
+    @Test
     public void testGetStatistic() {
         RoutineLoadJob job = new KafkaRoutineLoadJob(1L, "routine_load", 1L, 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(job, "receivedBytes", 10);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -828,7 +828,7 @@ public class StreamLoadScanNodeTest {
             List<ImportColumnDesc> columnExprs = Lists.newArrayList();
             columnExprs.add(new ImportColumnDesc("c3", new FunctionCallExpr("func", Lists.newArrayList())));
             Load.initColumns(table, columnExprs, null, null, null, null, null, null, true, false, Lists.newArrayList(),
-                    false, false);
+                    false, false, null);
         });
     }
 }

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -65,6 +65,15 @@ struct TKafkaLoadInfo {
     3: required map<i32, i64> partition_begin_offset;
     4: optional map<string, string> properties;
     5: optional string confluent_schema_registry_url;
+    // Whether the job's COLUMNS clause references any source-metadata function (kafka_topic(),
+    // kafka_partition(), ...). The consumer attaches the extended per-message metadata
+    // (topic/timestamp/key/headers) to the buffer only when this is set.
+    8: optional bool need_source_metadata;
+    // Finer gates within need_source_metadata: only extract the (potentially large) message key/headers
+    // when the job references kafka_key() / kafka_header()/kafka_headers(). Scalar metadata is cheap and
+    // not separately gated.
+    6: optional bool need_message_key;
+    7: optional bool need_message_headers;
 }
 
 struct TPulsarLoadInfo {
@@ -74,6 +83,12 @@ struct TPulsarLoadInfo {
     4: required list<string> partitions;
     5: optional map<string, i64> initial_positions;
     6: optional map<string, string> properties;
+    // Like TKafkaLoadInfo, except that for Pulsar need_source_metadata gates attaching per-message
+    // metadata at all; the other two gate extraction of the message key (partition key) / headers
+    // (properties).
+    9: optional bool need_source_metadata;
+    7: optional bool need_message_key;
+    8: optional bool need_message_headers;
 }
 
 struct TRoutineLoadTask {

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -108,6 +108,10 @@ struct TRoutineLoadTask {
     14: optional PlanNodes.TFileFormatType format
     15: optional TPulsarLoadInfo pulsar_load_info
     16: optional double max_filter_ratio
+    // When true (Avro routine load only), the aggregator stops a batch at a Confluent
+    // schema-id boundary so messages written under the old schema commit cleanly before
+    // the new schema triggers an ALTER. FE resolves this per job; unset = legacy behavior.
+    17: optional bool enable_schema_evolution
 }
 
 struct TKafkaMetaProxyRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1092,6 +1092,17 @@ struct TRLTaskTxnCommitAttachment {
     12: optional TPulsarRLTaskProgress pulsarRLTaskProgress
     // If true, the error is non-retryable and routine load job should be paused
     13: optional bool nonRetryable
+    // Avro schema evolution: set when the task was aborted because a message carried a schema the table
+    // does not yet cover. detectedSchemaColumns is the full writer schema (every top-level field as name +
+    // type_desc + is_allow_null), not a diff: the FE diffs it against the live table and decides the DDL
+    // (ADD COLUMN / ADD FIELD / MODIFY) or fails the job on a metadata-column collision, then resubmits the
+    // task from the same offset. detectedWidenColumns names varchar/varbinary columns an over-length value
+    // overran (length is not in the avro schema, so it is detected per value): the FE widens them to the
+    // varchar max. The two lists are independent; either may be set.
+    14: optional bool schemaChangeNeeded
+    15: optional i32 detectedSchemaId
+    16: optional list<Descriptors.TColumn> detectedSchemaColumns
+    17: optional list<string> detectedWidenColumns
 }
 
 struct TMiniLoadTxnCommitAttachment {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -398,6 +398,11 @@ struct TQueryOptions {
   // hardcoded "stream-load-pipe" filename. Optional and unused for
   // non-routine-load query paths.
   218: optional string routine_load_source_info;
+
+  // Avro routine load only: when true, the Avro scanner detects message fields that have no
+  // matching table column and fails the task with the new-column list so FE can ALTER and retry.
+  // Threaded from TRoutineLoadTask.enable_schema_evolution by the routine load task executor.
+  219: optional bool enable_avro_schema_evolution = false;
 }
 
 // A scan range plus the parameters needed to execute that scan.

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -303,6 +303,11 @@ struct TBrokerScanRangeParams {
     32: optional bool flexible_column_mapping
     33: optional TFileScanType file_scan_type
     34: optional bool schema_sample_types = true
+    // Per-job choice for avro routine load: use the avrocpp-based scanner (STRUCT/MAP support). The FE
+    // resolves this at job creation (from the avro.use_native_reader property, defaulting to the FE
+    // config enable_avro_routine_load_native_reader) and sets it here. If unset (e.g. an older FE), the
+    // BE falls back to the legacy avro scanner.
+    35: optional bool use_native_avro_reader
 }
 
 // Broker scan range

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -239,6 +239,31 @@ enum TFileScanType {
     FILES_QUERY
 }
 
+// Which per-message metadata field a routine-load source-metadata slot is bound to. The FE lowers
+// metadata functions in the COLUMNS clause (kafka_topic(), kafka_header('k'), pulsar_message_id(),
+// ...) into hidden source slots described by TRoutineLoadMetaColumn, so the BE scanner fills the slot
+// from the Kafka/Pulsar message rather than the payload. TIMESTAMP is the Kafka record timestamp /
+// Pulsar publish time; EVENT_TIME is the Pulsar event time. HEADER selects one header/property by key
+// (last-wins); HEADERS is the whole map.
+enum TStreamSourceMetaKind {
+    TOPIC = 0,
+    PARTITION = 1,
+    OFFSET = 2,
+    MESSAGE_ID = 3,
+    TIMESTAMP = 4,
+    EVENT_TIME = 5,
+    KEY = 6,
+    HEADER = 7,
+    HEADERS = 8
+}
+
+struct TRoutineLoadMetaColumn {
+    1: optional Types.TSlotId slot_id
+    2: optional TStreamSourceMetaKind kind
+    // For HEADER: the header/property key to look up. Unused for the other kinds.
+    3: optional string key
+}
+
 struct TBrokerScanRangeParams {
     1: required i8 column_separator;
     2: required i8 row_delimiter;
@@ -308,6 +333,9 @@ struct TBrokerScanRangeParams {
     // config enable_avro_routine_load_native_reader) and sets it here. If unset (e.g. an older FE), the
     // BE falls back to the legacy avro scanner.
     35: optional bool use_native_avro_reader
+    // Routine-load source-metadata slots: each binds a hidden source slot to a per-message metadata
+    // field. Empty for non-routine-load and for jobs that use no metadata function.
+    36: optional list<TRoutineLoadMetaColumn> stream_source_meta_columns
 }
 
 // Broker scan range

--- a/test/sql/test_mixed_schema_change/R/test_mixed_schema_change
+++ b/test/sql/test_mixed_schema_change/R/test_mixed_schema_change
@@ -1,0 +1,40 @@
+-- name: test_mixed_schema_change_clauses
+create database test_mixed_schema_change;
+-- result:
+-- !result
+use test_mixed_schema_change;
+-- result:
+-- !result
+CREATE TABLE `t` (
+  `k` int(11) NULL,
+  `n` int(11) NULL,
+  `s` struct<a int>
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"fast_schema_evolution" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+alter table t add column c2 varchar(32), modify column s add field b int, modify column n bigint;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t values (1, 10, row(100, 101), 'x');
+-- result:
+-- !result
+select * from t;
+-- result:
+1	10	{"a":100,"b":101}	x
+-- !result
+drop table t;
+-- result:
+-- !result
+drop database test_mixed_schema_change;
+-- result:
+-- !result

--- a/test/sql/test_mixed_schema_change/T/test_mixed_schema_change
+++ b/test/sql/test_mixed_schema_change/T/test_mixed_schema_change
@@ -1,0 +1,20 @@
+-- name: test_mixed_schema_change_clauses
+create database test_mixed_schema_change;
+use test_mixed_schema_change;
+CREATE TABLE `t` (
+  `k` int(11) NULL,
+  `n` int(11) NULL,
+  `s` struct<a int>
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"fast_schema_evolution" = "true",
+"replication_num" = "1"
+);
+alter table t add column c2 varchar(32), modify column s add field b int, modify column n bigint;
+function: wait_alter_table_finish()
+insert into t values (1, 10, row(100, 101), 'x');
+select * from t;
+drop table t;
+drop database test_mixed_schema_change;

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -61,6 +61,7 @@ PROPERTIES
 "jsonpaths"="",
 "strip_outer_array"="false",
 "json_root"="",
+"avro.use_native_reader"="false",
 "strict_mode"="false",
 "pause_on_fatal_parse_error"="false",
 "timezone"="Asia/Shanghai",

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -62,6 +62,8 @@ PROPERTIES
 "strip_outer_array"="false",
 "json_root"="",
 "avro.use_native_reader"="false",
+"avro.enable_schema_evolution"="false",
+"avro.schema_evolution_allow_heavy_alter"="true",
 "strict_mode"="false",
 "pause_on_fatal_parse_error"="false",
 "timezone"="Asia/Shanghai",


### PR DESCRIPTION
## Why I'm doing:

Routine Load ingesting Avro from Kafka fails the job the moment a producer evolves
its writer schema — adds a field, adds a `record` subfield, or widens a type. New
data silently stops landing until someone manually `ALTER`s the table. We want the
common, safe evolutions (the ones fast schema evolution already supports) to be
applied automatically so external data keeps flowing and no new columns are lost.

## What I'm doing:

Opt-in per job via `"avro.enable_schema_evolution" = "true"` (default `false`;
requires the native Avro reader and no `jsonpaths`). When enabled:

**BE — detect & escalate (classifier only).** The native Avro scanner compares each
message's writer schema against the destination tuple. The fit predicate
(`avro_field_covered`/`avro_scalar_fits`) recurses through struct/array/map and
treats a varchar/binary column as holding anything. On the first message of a new
Confluent schema id that the table does not cover, the task is failed and the
**full writer schema** (every top-level field with its complete nested type) is
shipped to the FE on the rollback attachment — the BE computes no diff and picks no
DDL.

**Aggregator — clean cutover (no double-load).** With evolution on, the consumer
group ends the batch *before* the first message of a new Confluent schema id. The
old-schema messages already appended commit atomically with their offsets, as on the
normal path. The schema-changed message is never appended in this batch, so it is
never committed — it is consumed for the first time by the next task once the table
has been evolved. No committed message is re-read and the boundary message is not
double-loaded; the existing delivery guarantee is unchanged.

**FE — diff & apply, reusing fast schema evolution.** A `PendingSchemaChange` marker
is recorded (runtime-only; re-derived after failover). A scheduler daemon, off the
txn thread and holding no job lock, diffs the writer schema against the live table
and emits `ADD COLUMN` / `ADD FIELD` (nested) / `MODIFY` clauses. The FE fit
predicate mirrors the BE's exactly so detection neither loops nor over-alters. While
the marker is set, the task scheduler holds the job's tasks; once the table covers
the schema the tasks resume, otherwise the job pauses with the reason. The daemon is
idempotent and convergence-checked, so a cancelled/ineffective ALTER pauses rather
than loops.

**Heavy vs. light, gated.** On fast-schema-evolution tables most changes (ADD COLUMN,
ADD FIELD, int/float widening, varchar length grow) are metadata-only and immediate;
a few need a full table rewrite (decimal precision/scale grow, type→VARCHAR, anything
on a non-FSE table). `"avro.schema_evolution_allow_heavy_alter"` (default `true`)
controls them; when `false`, only metadata-only changes apply automatically and a
heavy change pauses the job naming the exact `ALTER TABLE` to run by hand. Heaviness
is decided by the engine (a `ConnectContext` flag makes `SchemaChangeHandler` refuse
heavy changes), not re-derived in the FE, so the two cannot drift.

**Pauses for what cannot be auto-evolved:** metadata-column collision, case-only name
difference, key-column type change, scalar→struct, struct-subfield type change.
A length-limited `VARCHAR`/`VARBINARY` overrun is detected per value (Avro carries no
length) and the column is widened to max — a separate channel from the schema diff.
A legacy DECIMALV2 column is migrated to DECIMAL128(27,9) (the only lossless V2→v3)
since the native reader has no V2 path.

Stacked on #73821 (avrocpp scanner) and #73840 (source-metadata functions); review
the top commits — the rest belong to those PRs.

Tested: BE UT (detection / struct-map / confluent decoder), FE UT
(`AvroSchemaEvolverTest`), and an SQL e2e for a mixed-clause schema change — all green.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5