### PR TITLE
[Feature] Accept and ignore precision argument on DATETIME(p)/TIME(p)

### DIFF
--- a/docs/en/sql-reference/data-types/date-types/DATETIME.md
+++ b/docs/en/sql-reference/data-types/date-types/DATETIME.md
@@ -15,4 +15,4 @@ The form of printing is `YYYY-MM-DD HH:MM:SS`.
 
 From v3.3.5, DATETIME supports millisecond and microsecond precision. The form of printing is `YYYY-MM-DD HH:MM:SS.ffffff`.
 
-For MySQL compatibility, StarRocks also accepts an optional fractional-seconds precision argument, `DATETIME(p)`, where `p` ranges from 0 to 6. This syntax is accepted in column definitions and `CAST` expressions (for example, `CAST(now() AS DATETIME(3))`), which lets generated SQL from MySQL ecosystem tools run unchanged. The precision argument is ignored: values are always stored at microsecond precision.
+For MySQL compatibility, StarRocks also accepts an optional fractional-seconds precision argument, `DATETIME(p)`, where `p` ranges from 0 to 6. This syntax is accepted in column definitions and `CAST` expressions (for example, `CAST(now() AS DATETIME(3))`), which lets generated SQL from MySQL ecosystem tools run unchanged. The precision argument is ignored: values are always stored at microsecond precision. For more information, see the [cast](../../sql-functions/cast.md) function.

--- a/docs/en/sql-reference/data-types/date-types/DATETIME.md
+++ b/docs/en/sql-reference/data-types/date-types/DATETIME.md
@@ -14,3 +14,5 @@ Date and time type. The value range is ['0000-01-01 00:00:00', '9999-12-31 23:59
 The form of printing is `YYYY-MM-DD HH:MM:SS`.
 
 From v3.3.5, DATETIME supports millisecond and microsecond precision. The form of printing is `YYYY-MM-DD HH:MM:SS.ffffff`.
+
+For MySQL compatibility, StarRocks also accepts an optional fractional-seconds precision argument, `DATETIME(p)`, where `p` ranges from 0 to 6. This syntax is accepted in column definitions and `CAST` expressions (for example, `CAST(now() AS DATETIME(3))`), which lets generated SQL from MySQL ecosystem tools run unchanged. The precision argument is ignored: values are always stored at microsecond precision.

--- a/docs/ja/sql-reference/data-types/date-types/DATETIME.md
+++ b/docs/ja/sql-reference/data-types/date-types/DATETIME.md
@@ -14,4 +14,4 @@ import DateTip from '../../../_assets/commonMarkdown/dateTimeTip.mdx'
 
 バージョン v3.3.5 から、DATETIME はミリ秒およびマイクロ秒の精度をサポートしています。出力形式は `YYYY-MM-DD HH:MM:SS.ffffff` です。
 
-MySQL との互換性のため、StarRocks はオプションの小数秒精度引数 `DATETIME(p)`（`p` は 0 から 6）も受け付けます。この構文は列定義や `CAST` 式（例: `CAST(now() AS DATETIME(3))`）で使用でき、MySQL エコシステムのツールが生成した SQL をそのまま実行できます。精度引数は無視され、値は常にマイクロ秒精度で格納されます。
+MySQL との互換性のため、StarRocks はオプションの小数秒精度引数 `DATETIME(p)`（`p` は 0 から 6）も受け付けます。この構文は列定義や `CAST` 式（例: `CAST(now() AS DATETIME(3))`）で使用でき、MySQL エコシステムのツールが生成した SQL をそのまま実行できます。精度引数は無視され、値は常にマイクロ秒精度で格納されます。詳細については、[cast](../../sql-functions/cast.md) 関数を参照してください。

--- a/docs/ja/sql-reference/data-types/date-types/DATETIME.md
+++ b/docs/ja/sql-reference/data-types/date-types/DATETIME.md
@@ -13,3 +13,5 @@ import DateTip from '../../../_assets/commonMarkdown/dateTimeTip.mdx'
 出力形式は `YYYY-MM-DD HH:MM:SS` です。
 
 バージョン v3.3.5 から、DATETIME はミリ秒およびマイクロ秒の精度をサポートしています。出力形式は `YYYY-MM-DD HH:MM:SS.ffffff` です。
+
+MySQL との互換性のため、StarRocks はオプションの小数秒精度引数 `DATETIME(p)`（`p` は 0 から 6）も受け付けます。この構文は列定義や `CAST` 式（例: `CAST(now() AS DATETIME(3))`）で使用でき、MySQL エコシステムのツールが生成した SQL をそのまま実行できます。精度引数は無視され、値は常にマイクロ秒精度で格納されます。

--- a/docs/zh/sql-reference/data-types/date-types/DATETIME.md
+++ b/docs/zh/sql-reference/data-types/date-types/DATETIME.md
@@ -14,6 +14,8 @@ import DateTip from '../../../_assets/commonMarkdown/dateTimeTip.mdx'
 
 从 v3.3.5 起，DATETIME 支持毫秒和微秒精度。打印形式为 `YYYY-MM-DD HH:MM:SS.fffffff`
 
+为兼容 MySQL，StarRocks 还接受可选的小数秒精度参数 `DATETIME(p)`，其中 `p` 的取值范围为 0 到 6。该语法可用于列定义和 `CAST` 表达式（例如 `CAST(now() AS DATETIME(3))`），使 MySQL 生态工具生成的 SQL 无需修改即可运行。该精度参数会被忽略：数据始终以微秒精度存储。
+
 ## 示例
 
 创建表时指定字段类型为 DATETIME。

--- a/docs/zh/sql-reference/data-types/date-types/DATETIME.md
+++ b/docs/zh/sql-reference/data-types/date-types/DATETIME.md
@@ -14,7 +14,7 @@ import DateTip from '../../../_assets/commonMarkdown/dateTimeTip.mdx'
 
 从 v3.3.5 起，DATETIME 支持毫秒和微秒精度。打印形式为 `YYYY-MM-DD HH:MM:SS.fffffff`
 
-为兼容 MySQL，StarRocks 还接受可选的小数秒精度参数 `DATETIME(p)`，其中 `p` 的取值范围为 0 到 6。该语法可用于列定义和 `CAST` 表达式（例如 `CAST(now() AS DATETIME(3))`），使 MySQL 生态工具生成的 SQL 无需修改即可运行。该精度参数会被忽略：数据始终以微秒精度存储。
+为兼容 MySQL，StarRocks 还接受可选的小数秒精度参数 `DATETIME(p)`，其中 `p` 的取值范围为 0 到 6。该语法可用于列定义和 `CAST` 表达式（例如 `CAST(now() AS DATETIME(3))`），使 MySQL 生态工具生成的 SQL 无需修改即可运行。该精度参数会被忽略：数据始终以微秒精度存储。更多信息，参见 [cast](../../sql-functions/cast.md) 函数。
 
 ## 示例
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/TypeParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/TypeParser.java
@@ -50,6 +50,10 @@ import static com.starrocks.sql.parser.AstBuilderUtils.getIdentifier;
 import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
 
 public class TypeParser {
+    // MySQL accepts a fractional-seconds precision argument in range [0, 6] for DATETIME(p)/TIME(p).
+    private static final int MIN_FRACTIONAL_SECONDS_PRECISION = 0;
+    private static final int MAX_FRACTIONAL_SECONDS_PRECISION = 6;
+
     public static Type getType(com.starrocks.sql.parser.StarRocksParser.TypeContext context) {
         if (context.baseType() != null) {
             return getBaseType(context.baseType());
@@ -82,9 +86,27 @@ public class TypeParser {
             return HLLType.HLL;
         } else if (context.BINARY() != null || context.VARBINARY() != null) {
             return TypeFactory.createVarbinary(length);
+        } else if (context.DATETIME() != null || context.TIME() != null) {
+            // MySQL ecosystem tools emit DATETIME(p)/TIME(p) with a fractional-seconds precision
+            // argument. StarRocks always stores microsecond precision internally, so the argument is
+            // accepted (validated against MySQL's 0-6 range) and then ignored.
+            if (context.typeParameter() != null) {
+                checkFractionalSecondsPrecision(length, context);
+            }
+            return context.DATETIME() != null ? DateType.DATETIME : DateType.TIME;
         } else {
             String typeStr = context.getChild(0).getText();
             return getTypeByName(typeStr);
+        }
+    }
+
+    private static void checkFractionalSecondsPrecision(int precision,
+            com.starrocks.sql.parser.StarRocksParser.BaseTypeContext context) {
+        if (precision < MIN_FRACTIONAL_SECONDS_PRECISION || precision > MAX_FRACTIONAL_SECONDS_PRECISION) {
+            throw new ParsingException(
+                    String.format("fractional seconds precision must be in range [%d, %d], but got %d",
+                            MIN_FRACTIONAL_SECONDS_PRECISION, MAX_FRACTIONAL_SECONDS_PRECISION, precision),
+                    createPos(context));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -313,6 +313,41 @@ class ParserTest {
     }
 
     @Test
+    void testDatetimePrecisionArgumentMysqlCompatibility() {
+        // MySQL ecosystem tools routinely emit DATETIME(p)/TIME(p) with a fractional-seconds
+        // precision argument. StarRocks stores microsecond precision internally, so it accepts
+        // the argument (validated against MySQL's 0-6 range) and ignores its value.
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        sessionVariable.setSqlDialect("sr");
+
+        // CAST positions: precision argument accepted and ignored, resolved type unchanged.
+        QueryStatement datetimeStmt =
+                (QueryStatement) SqlParser.parse("select cast('2020-01-01 00:00:00' as datetime(3))",
+                        sessionVariable).get(0);
+        Analyzer.analyze(datetimeStmt, ctx);
+        Assertions.assertTrue(datetimeStmt.getQueryRelation().getOutputExpression().get(0).getType().isDatetime());
+
+        // TIME(p) is accepted by the parser as well (the precision argument is validated and ignored).
+        SqlParser.parse("select cast('12:00:00' as time(6))", sessionVariable);
+
+        // Boundary values 0 and 6 are accepted.
+        SqlParser.parse("select cast('2020-01-01 00:00:00' as datetime(0))", sessionVariable);
+        SqlParser.parse("select cast('2020-01-01 00:00:00' as datetime(6))", sessionVariable);
+
+        // Column-definition positions also accept the precision argument.
+        SqlParser.parse("create table t (k int, dt datetime(3)) duplicate key(k) "
+                + "distributed by hash(k) buckets 1", sessionVariable);
+
+        // Out-of-range precision is rejected with a clear message.
+        ParsingException e = Assertions.assertThrows(ParsingException.class,
+                () -> SqlParser.parse("select cast('2020-01-01 00:00:00' as datetime(7))", sessionVariable));
+        Assertions.assertTrue(e.getMessage().contains("fractional seconds precision"),
+                "unexpected message: " + e.getMessage());
+    }
+
+    @Test
     void testTypeCast() {
         SessionVariable sessionVariable = new SessionVariable();
         sessionVariable.setSqlDialect("sr");

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -3222,8 +3222,8 @@ baseType
     | FLOAT
     | DOUBLE
     | DATE
-    | DATETIME
-    | TIME
+    | DATETIME typeParameter?
+    | TIME typeParameter?
     | CHAR typeParameter?
     | VARCHAR typeParameter?
     | STRING


### PR DESCRIPTION
## Why I'm doing:

StarRocks' parser rejects `DATETIME(p)` / `TIME(p)` with a fractional-seconds precision argument, which is standard MySQL 5.6+ syntax. Tools in the MySQL ecosystem (BI products, ORMs, dbt adapters) routinely emit this in generated casts and column definitions, so queries such as `CAST(now() AS DATETIME(3))` fail against StarRocks even though bare `DATETIME` works.

## What I'm doing:

Accept an optional precision argument on `DATETIME(p)` / `TIME(p)` in the grammar's shared `type` rule, so it is honored in both `CAST` expressions and column-type positions. The argument is validated against MySQL's accepted range `[0, 6]` (a clear `ParsingException` is raised otherwise) and then ignored — StarRocks already stores microsecond precision internally.

Scope is intentionally limited to `DATETIME`/`TIME`: bare `TIMESTAMP` is not currently a StarRocks type, so introducing `TIMESTAMP(p)` would mean adding a new type alias and is left out of this change.

- `fe/fe-grammar/.../StarRocks.g4`: `DATETIME typeParameter?` / `TIME typeParameter?`.
- `fe/fe-core/.../parser/TypeParser.java`: validate the precision to `[0, 6]`, then ignore it.
- `fe/fe-core/.../parser/ParserTest.java`: `testDatetimePrecisionArgumentMysqlCompatibility`.
- `docs/{en,zh,ja}/sql-reference/data-types/date-types/DATETIME.md`: MySQL-compatibility note.

Fixes #74011

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)