### PR TITLE
[BugFix] Reject HAVING with aggregates in incremental MV at create time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -44,6 +44,8 @@ import com.starrocks.sql.ast.expression.CaseWhenClause;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
 import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
+import com.starrocks.sql.ast.expression.ExprToSql;
+import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IsNullPredicate;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
@@ -262,6 +264,12 @@ public class IVMAnalyzer {
                 CollectionUtils.isNotEmpty(selectRelation.getOrderByExpressions())) {
             throw new SemanticException("IVMAnalyzer does not support order by clause, " +
                     "but got: %s", selectRelation.getOrderBy());
+        }
+        // Aggregate IVM is UPSERT-only: a group crossing the HAVING threshold across
+        // refreshes can't be added/removed, so reject instead of silently miscomputing.
+        if (selectRelation.getHaving() != null && ExprUtils.containsAggregate(selectRelation.getHaving())) {
+            throw new SemanticException("IVMAnalyzer does not support HAVING with aggregate functions, " +
+                    "but got: %s", ExprToSql.toSql(selectRelation.getHaving()));
         }
         boolean isRetractable = checkAggregate(selectRelation);
         Relation innerRelation = selectRelation.getRelation();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -128,6 +128,54 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * HAVING that references an aggregate must be rejected: aggregate IVM is UPSERT-only,
+     * so a group crossing the HAVING threshold across refreshes can't be maintained.
+     * Without this gate the rewrite failed with the opaque "__AGG_STATE__ columns size"
+     * mismatch because the HAVING aggregate survived un-rewritten.
+     */
+    @Test
+    public void testRejectHavingWithAggregate() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_having "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` "
+                + "GROUP BY id HAVING SUM(c1) > 10";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        SemanticException ex = assertThrows(SemanticException.class,
+                () -> analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL),
+                "INCREMENTAL refresh must reject HAVING that references an aggregate");
+        assertTrue(ex.getMessage().contains("does not support HAVING"),
+                "error message must mention HAVING rejection, got: " + ex.getMessage());
+    }
+
+    /**
+     * HAVING over only group-by keys (no aggregate) is equivalent to a post-aggregation
+     * filter on stable keys — no threshold crossing — so it must still be accepted.
+     */
+    @Test
+    public void testAcceptHavingOnGroupKey() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_having_key "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` "
+                + "GROUP BY id HAVING id > 0";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL);
+        assertTrue(result.isPresent(), "HAVING over only group-by keys must be accepted");
+    }
+
+    /**
      * {@code COUNT(*)} in an aggregate MV query must be accepted by IVMAnalyzer.
      *
      * <p>Regression: until the fix that allows 0-arg count combinators, {@code count(*)}

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_having_reject
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_having_reject
@@ -1,0 +1,57 @@
+-- name: test_ivm_having_reject
+create external catalog ivm_ice_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog ivm_ice_${uuid0};
+-- result:
+-- !result
+create database ivm_ice_db_${uuid0};
+-- result:
+-- !result
+use ivm_ice_db_${uuid0};
+-- result:
+-- !result
+create table base (region string, amount int, score int);
+-- result:
+-- !result
+insert into base values ('CN', 30, 1), ('CN', 40, 2), ('US', 5, 3);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_having
+DISTRIBUTED BY HASH(region) BUCKETS 1
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "INCREMENTAL")
+AS SELECT region, SUM(amount) AS s, COUNT(*) AS c
+FROM ivm_ice_${uuid0}.ivm_ice_db_${uuid0}.base
+GROUP BY region
+HAVING SUM(amount) > 10;
+-- result:
+[REGEX].*does not support HAVING with aggregate functions.*
+-- !result
+drop table ivm_ice_${uuid0}.ivm_ice_db_${uuid0}.base;
+-- result:
+-- !result
+drop database ivm_ice_${uuid0}.ivm_ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ivm_ice_${uuid0};
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_having_reject
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_having_reject
@@ -1,0 +1,30 @@
+-- name: test_ivm_having_reject
+-- HAVING that references an aggregate must be rejected at CREATE: aggregate IVM
+-- is UPSERT-only, so a group crossing the HAVING threshold can't be maintained.
+create external catalog ivm_ice_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ivm_ice_${uuid0};
+create database ivm_ice_db_${uuid0};
+use ivm_ice_db_${uuid0};
+create table base (region string, amount int, score int);
+insert into base values ('CN', 30, 1), ('CN', 40, 2), ('US', 5, 3);
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+CREATE MATERIALIZED VIEW mv_having
+DISTRIBUTED BY HASH(region) BUCKETS 1
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "INCREMENTAL")
+AS SELECT region, SUM(amount) AS s, COUNT(*) AS c
+FROM ivm_ice_${uuid0}.ivm_ice_db_${uuid0}.base
+GROUP BY region
+HAVING SUM(amount) > 10;
+drop table ivm_ice_${uuid0}.ivm_ice_db_${uuid0}.base;
+drop database ivm_ice_${uuid0}.ivm_ice_db_${uuid0};
+drop catalog ivm_ice_${uuid0};
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`CREATE MATERIALIZED VIEW ... PROPERTIES("refresh_mode" = "INCREMENTAL")` with a
`HAVING` that references an aggregate failed with an opaque internal error:

```
MV __AGG_STATE__ columns size N must match aggregate map size N+1
```

`IVMAnalyzer.checkAggregate` rewrites the SELECT list and output expressions
(each aggregate -> `state_merge` + an `__AGG_STATE__` column) but never rewrites
the `HAVING` predicate. The un-rewritten `HAVING` aggregate survives as a raw
aggregate, so the planned `LogicalAggregationOperator` has one more aggregation
than the MV has `__AGG_STATE__` columns, tripping the `Preconditions.checkState`
in `IvmDeltaAggregateRule`.

Making CREATE pass (by rewriting `HAVING` too) would only mask a deeper problem:
aggregate IVM output is UPSERT-only (`IvmDeltaAggregateRule` sets `__ACTION__ =
UPSERT`, no retraction). A group whose aggregate crosses the `HAVING` threshold
across refreshes can neither be added (its prior state isn't stored once filtered
out) nor removed (no delete is ever emitted), so incremental maintenance would
silently diverge from a full recompute. `HAVING` with aggregates is therefore not
maintainable under the current design.

## What I'm doing:

Reject `HAVING` that references an aggregate at CREATE time with a clear message,
alongside the existing window-function / `ORDER BY` rejections in
`IVMAnalyzer.checkSelectRelation`. A `HAVING` over only group-by keys (equivalent
to `WHERE`, no threshold crossing) is still accepted.

```
-- before
ERROR: MV __AGG_STATE__ columns size 2 must match aggregate map size 3
-- after
ERROR: IVMAnalyzer does not support HAVING with aggregate functions, but got: sum(...) > 10
```

Verified on a shared-nothing cluster over an Iceberg base table. `IVMAnalyzerTest`
passes 27/27 (including the two new cases), and the SQL regression
`test_materialized_view_ivm/test_ivm_having_reject` passes.

Fixes #issue: N/A — reported as CelerData internal issue #55849 (not in this repo).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
