### PR TITLE
[BugFix] Notify sink when distinct aggregate source finishes

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -27,6 +27,7 @@ bool AggregateDistinctBlockingSourceOperator::is_finished() const {
 }
 
 Status AggregateDistinctBlockingSourceOperator::set_finished(RuntimeState* state) {
+    auto notify = _aggregator->defer_notify_sink();
     return _aggregator->set_finished();
 }
 


### PR DESCRIPTION
## Why I'm doing:
We have a **flaky integration test** which **hangs randomly**. (sometimes it succeeds, sometimes it hangs) We found it might be due to a race condition in the driver execution part.

When the hang happens, if we query the BE `pipeline_blocking_drivers` endpoint, we get
```
curl -s "http://127.0.0.1:8040/api/pipeline_blocking_drivers/stat"
{
    "queries_in_workgroup": [
        {
            "query_id": "e8efe893-5aab-11f1-bb33-c6d4eface3ce",
            "fragments": [
                {
                    "fragment_id": "e8efe893-5aab-11f1-bb33-c6d4eface3d0",
                    "fragment_status": "OK",
                    "drivers": [
                        {
                            "driver_id": 10,
                            "state": "OUTPUT_FULL",
                            "driver_desc": "query_id=e8efe893-5aab-11f1-bb33-c6d4eface3ce fragment_id=e8efe893-5aab-11f1-bb33-c6d4eface3d0 driver=driver_2_10 addr=0xfffe74d30510, status=OUTPUT_FULL, operator-chain: [local_exchange_source_2_0xfffe759d9c10(X) { has_output:false} -> aggregate_distinct_blocking_sink_2_0xfffeb48ebd10(X)]"
                        }
                    ]
                }
            ]
        }
    ]
}
```

This driver's state is invalid in two aspects:
- It has two operators `local_exchange_source` and `aggregate_distinct_blocking_sink`. Both of them are finished (marked with `(X)`). But the driver is in `OUTPUT_FULL` state instead of the `FINISH` state.
- Actually the driver should **never** go into the `OUTPUT_FULL` state. It can only go into the OUTPUT_FULL state when there's a race condition when evaluating this line [!sink_operator()->is_finished() && !sink_operator()->need_input()](https://github.com/StarRocks/starrocks/blob/67838f4264543e250a4b2e6c89e10fa025f48ede/be/src/exec/pipeline/pipeline_driver.cpp#L561). Specifically, `!is_finished()` and `!need_input()` can never be true at the same time for [aggregate_distinct_blocking_sink_operator.cpp](https://github.com/StarRocks/starrocks/blob/67838f4264543e250a4b2e6c89e10fa025f48ede/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp). The reason we saw the `OUTPUT_FULL` state was that between evaluating !is_finished()` and `!need_input()`, the source operator's driver thread flipped the finished flag.

## What I'm doing:

We found that this commit can fix the timeout/deadlock issue mentioned above.

It doesn't fix the real race condition issue. But the notification would _**wake up**_ the blocked driver with the sink operator.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
