### PR TITLE
[Enhancement] Check operator finished status defensively

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -558,10 +558,10 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
             if (is_precondition_block()) {
                 set_driver_state(DriverState::PRECONDITION_BLOCK);
                 COUNTER_UPDATE(_block_by_precondition_counter, 1);
-            } else if (!sink_operator()->is_finished() && !sink_operator()->need_input()) {
+            } else if (!sink_operator()->need_input() && !sink_operator()->is_finished()) {
                 set_driver_state(DriverState::OUTPUT_FULL);
                 COUNTER_UPDATE(_block_by_output_full_counter, 1);
-            } else if (!source_operator()->is_finished() && !source_operator()->has_output()) {
+            } else if (!source_operator()->has_output() && !source_operator()->is_finished()) {
                 if (source_operator()->is_mutable()) {
                     set_driver_state(DriverState::LOCAL_WAITING);
                     COUNTER_UPDATE(_yield_by_local_wait_counter, 1);

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -427,13 +427,13 @@ public:
         }
 
         // OUTPUT_FULL
-        if (!sink_operator()->need_input()) {
+        if (!sink_operator()->need_input() && !sink_operator()->is_finished()) {
             set_driver_state(DriverState::OUTPUT_FULL);
             return false;
         }
 
         // INPUT_EMPTY
-        if (!source_operator()->is_finished() && !source_operator()->has_output()) {
+        if (!source_operator()->has_output() && !source_operator()->is_finished()) {
             set_driver_state(DriverState::INPUT_EMPTY);
             return false;
         }
@@ -463,13 +463,13 @@ public:
         }
 
         // OUTPUT_FULL
-        if (!sink_operator()->need_input()) {
+        if (!sink_operator()->need_input() && !sink_operator()->is_finished()) {
             set_driver_state(DriverState::OUTPUT_FULL);
             return false;
         }
 
         // INPUT_EMPTY
-        if (!source_operator()->is_finished() && !source_operator()->has_output()) {
+        if (!source_operator()->has_output() && !source_operator()->is_finished()) {
             set_driver_state(DriverState::INPUT_EMPTY);
             return false;
         }


### PR DESCRIPTION
## Why I'm doing:

The driver went into this state because there's race condition when it's evaluating this line [!sink_operator()->is_finished() && !sink_operator()->need_input()](https://github.com/StarRocks/starrocks/blob/67838f4264543e250a4b2e6c89e10fa025f48ede/be/src/exec/pipeline/pipeline_driver.cpp#L561):
1. It first checked whether the sink operator is finished, and found it to be **not finished**.
2. Some other thread (driver with the source operator) flipped the aggregator finished state, making the sink operator **finished**.
3. It then checked whether the sink operator needs input, and found it to be false because the sink operator has actually finished.

Reordering `!sink_operator()->is_finished() && !sink_operator()->need_input()` to be `!sink_operator()->need_input() && !sink_operator()->is_finished()` can actually avoid the driver to go into an invalid state. The new order is **robust to flip-in-the-middle situations**.

Changes in other places have the same idea. The source operator related changes may not be really necessary but they can make the code more consistent.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
