### PR TITLE
[Refactor] FeNameFormat: extract shared checkName to dedup empty/format checks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -80,37 +80,31 @@ public class FeNameFormat {
                 "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,254}$";
     }
 
+    // Shared validation for identifier names: rejects empty or characters not matching the format regex.
+    // The format regex also encodes the length bound, so callers do not pass a separate length.
+    // wrongNameArgs are the message args for wrongNameError.
+    private static void checkName(String name, String regex,
+                                  ErrorCode wrongNameError, Object... wrongNameArgs) {
+        if (Strings.isNullOrEmpty(name) || !name.matches(regex)) {
+            ErrorReport.reportSemanticException(wrongNameError, wrongNameArgs);
+        }
+    }
+
     // The length of db name is 256.
     public static void checkDbName(String dbName) {
-        if (Strings.isNullOrEmpty(dbName)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
-        }
-
-        if (!dbName.matches(DB_NAME_REGEX)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
-        }
+        checkName(dbName, DB_NAME_REGEX, ErrorCode.ERR_WRONG_DB_NAME, dbName);
     }
 
     public static void checkNamespace(String dbName) {
-        if (Strings.isNullOrEmpty(dbName)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
-        }
-
-        if (!dbName.matches(ICEBERG_NAMESPACE_REGEX)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
-        }
+        checkName(dbName, ICEBERG_NAMESPACE_REGEX, ErrorCode.ERR_WRONG_DB_NAME, dbName);
     }
 
     public static void checkTableName(String tableName) {
-        if (Strings.isNullOrEmpty(tableName) || !tableName.matches(TABLE_NAME_REGEX)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_TABLE_NAME, tableName);
-        }
+        checkName(tableName, TABLE_NAME_REGEX, ErrorCode.ERR_WRONG_TABLE_NAME, tableName);
     }
 
     public static void checkPartitionName(String partitionName) throws AnalysisException {
-        if (Strings.isNullOrEmpty(partitionName) || !partitionName.matches(COMMON_NAME_REGEX)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_PARTITION_NAME, partitionName);
-        }
+        checkName(partitionName, COMMON_NAME_REGEX, ErrorCode.ERR_WRONG_PARTITION_NAME, partitionName);
 
         if (partitionName.startsWith(FORBIDDEN_PARTITION_NAME)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_PARTITION_NAME, partitionName);
@@ -122,19 +116,9 @@ public class FeNameFormat {
     }
 
     public static void checkColumnName(String columnName, boolean isPartitionColumn) {
-        if (Strings.isNullOrEmpty(columnName)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
-        }
-        String pattern;
-        if (RunMode.isSharedNothingMode()) {
-            pattern = SHARED_NOTHING_COLUMN_NAME_REGEX;
-        } else {
-            pattern = SHARED_DATE_COLUMN_NAME_REGEX;
-        }
-
-        if (!columnName.matches(pattern)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
-        }
+        String pattern = RunMode.isSharedNothingMode()
+                ? SHARED_NOTHING_COLUMN_NAME_REGEX : SHARED_DATE_COLUMN_NAME_REGEX;
+        checkName(columnName, pattern, ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
 
         if (columnName.startsWith(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
@@ -193,8 +177,6 @@ public class FeNameFormat {
     }
 
     public static void checkCommonName(String type, String name) {
-        if (Strings.isNullOrEmpty(name) || !name.matches(COMMON_NAME_REGEX)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
-        }
+        checkName(name, COMMON_NAME_REGEX, ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
@@ -108,6 +108,16 @@ public class FeNameFormatTest {
     }
 
     @Test
+    public void testCheckTableName() {
+        // length boundary: 1024 chars is accepted, 1025 is rejected
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkTableName("a".repeat(1024)));
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkTableName("my_table"));
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkTableName("a".repeat(1025)));
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkTableName(""));
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkTableName("ab\0c"));
+    }
+
+    @Test
     public void testCheckNamespace() {
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("abc"));
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("ns1.ns2"));


### PR DESCRIPTION
## Why I'm doing:

The identifier validators in `FeNameFormat` (`checkDbName`, `checkNamespace`, `checkTableName`, `checkPartitionName`, `checkColumnName`, `checkCommonName`) each repeated the same "reject empty, then reject characters not matching the format regex" boilerplate. The duplication is verbose and easy to let drift out of sync.

## What I'm doing:

Extract a single private `checkName(name, regex, errorCode, args...)` helper and route all six validators through it. This is a pure refactor with no behavior change:

- Each call site keeps its original regex (length bounds stay encoded in the pattern, e.g. `{1,1024}`, `{0,255}`) and its original error code/args.
- `ErrorReport.reportSemanticException` always throws, so collapsing the prior two sequential `if` checks (same error code + args) into one `||` condition is semantically identical.

Also adds `testCheckTableName` to lock the existing length / empty / null-byte behavior.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5