### PR TITLE
[Enhancement] Arrow Flight SQL: implement metadata getStream* handlers to unblock ADBC GetObjects

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1112,6 +1112,7 @@ under the License.
                         -Xmx4096m
                         -XX:TieredStopAtLevel=1 -XX:CICompilerCount=1 -XX:-BackgroundCompilation -XX:+UseSerialGC
                         -Duser.timezone=Asia/Shanghai
+                        --add-opens=java.base/java.nio=ALL-UNNAMED
                         -Djacoco-agent.destfile=${project.build.directory}/jacoco.exec
                     </argLine>
                     <!-- Set maven to use independent class loading to avoid unit test failure due to the early shutdown of the JVM -->

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlMetadataHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlMetadataHandler.java
@@ -1,0 +1,460 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.PatternMatcher;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.ast.KeysType;
+import org.apache.arrow.flight.sql.FlightSqlProducer.Schemas;
+import org.apache.arrow.flight.sql.impl.FlightSql;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.DatabaseMetaData;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * Builds Arrow {@link VectorSchemaRoot}s for the Flight SQL metadata commands
+ * ({@code GetCatalogs}, {@code GetDbSchemas}, {@code GetTables}, ...), backed by the FE's in-memory
+ * catalog/database/table metadata.
+ *
+ * <p>The roots produced here conform exactly to the {@code FlightSqlProducer.Schemas.GET_*_SCHEMA}
+ * definitions, which are the schemas advertised by the matching {@code getFlightInfo*} handlers in
+ * {@link ArrowFlightSqlServiceImpl}. Each builder maps StarRocks' three-level
+ * {@code catalog -> database -> table} namespace onto Flight SQL's
+ * {@code catalog_name -> db_schema_name -> table_name} columns.
+ *
+ * <p>The caller owns the returned root and must {@link VectorSchemaRoot#close()} it after streaming.
+ */
+public final class ArrowFlightSqlMetadataHandler {
+    private static final Logger LOG = LogManager.getLogger(ArrowFlightSqlMetadataHandler.class);
+
+    private ArrowFlightSqlMetadataHandler() {
+    }
+
+    // ------------------------------------------------------------------
+    // Catalogs
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildCatalogs(BufferAllocator allocator) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_CATALOGS_SCHEMA, allocator);
+        VarCharVector catalogVector = (VarCharVector) root.getVector("catalog_name");
+        catalogVector.allocateNew();
+
+        int row = 0;
+        for (String catalog : listCatalogNames()) {
+            setVarChar(catalogVector, row++, catalog);
+        }
+        root.setRowCount(row);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // DB schemas
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildSchemas(FlightSql.CommandGetDbSchemas command, BufferAllocator allocator,
+                                                 ConnectContext context) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_SCHEMAS_SCHEMA, allocator);
+        VarCharVector catalogVector = (VarCharVector) root.getVector("catalog_name");
+        VarCharVector dbSchemaVector = (VarCharVector) root.getVector("db_schema_name");
+        catalogVector.allocateNew();
+        dbSchemaVector.allocateNew();
+
+        PatternMatcher dbPattern = createPattern(
+                command.hasDbSchemaFilterPattern() ? command.getDbSchemaFilterPattern() : null);
+
+        int row = 0;
+        for (String catalog : catalogsForCommand(command.hasCatalog() ? command.getCatalog() : null)) {
+            for (String db : listDbNames(context, catalog)) {
+                if (dbPattern != null && !dbPattern.match(db)) {
+                    continue;
+                }
+                setVarChar(catalogVector, row, catalog);
+                setVarChar(dbSchemaVector, row, db);
+                row++;
+            }
+        }
+        root.setRowCount(row);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // Tables
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildTables(FlightSql.CommandGetTables command, BufferAllocator allocator,
+                                               ConnectContext context) {
+        boolean includeSchema = command.getIncludeSchema();
+        Schema arrowSchema = includeSchema ? Schemas.GET_TABLES_SCHEMA : Schemas.GET_TABLES_SCHEMA_NO_SCHEMA;
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+
+        VarCharVector catalogVector = (VarCharVector) root.getVector("catalog_name");
+        VarCharVector dbSchemaVector = (VarCharVector) root.getVector("db_schema_name");
+        VarCharVector tableNameVector = (VarCharVector) root.getVector("table_name");
+        VarCharVector tableTypeVector = (VarCharVector) root.getVector("table_type");
+        VarBinaryVector tableSchemaVector = includeSchema ? (VarBinaryVector) root.getVector("table_schema") : null;
+        for (Field field : arrowSchema.getFields()) {
+            root.getVector(field.getName()).allocateNew();
+        }
+
+        PatternMatcher dbPattern = createPattern(
+                command.hasDbSchemaFilterPattern() ? command.getDbSchemaFilterPattern() : null);
+        PatternMatcher tablePattern = createPattern(
+                command.hasTableNameFilterPattern() ? command.getTableNameFilterPattern() : null);
+        List<String> tableTypeFilter = command.getTableTypesList();
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        int row = 0;
+        for (String catalog : catalogsForCommand(command.hasCatalog() ? command.getCatalog() : null)) {
+            for (String db : listDbNames(context, catalog)) {
+                if (dbPattern != null && !dbPattern.match(db)) {
+                    continue;
+                }
+                for (String tableName : listTableNames(context, catalog, db)) {
+                    if (tablePattern != null && !tablePattern.match(tableName)) {
+                        continue;
+                    }
+                    Table table;
+                    try {
+                        table = metadataMgr.getTable(context, catalog, db, tableName);
+                    } catch (Exception e) {
+                        LOG.warn("[ARROW] Failed to load table {}.{}.{} for GetTables, skipping",
+                                catalog, db, tableName, e);
+                        continue;
+                    }
+                    if (table == null) {
+                        continue;
+                    }
+                    String tableType = table.getMysqlType();
+                    if (!tableTypeFilter.isEmpty() && !tableTypeFilter.contains(tableType)) {
+                        continue;
+                    }
+
+                    setVarChar(catalogVector, row, catalog);
+                    setVarChar(dbSchemaVector, row, db);
+                    setVarChar(tableNameVector, row, tableName);
+                    setVarChar(tableTypeVector, row, tableType);
+                    if (tableSchemaVector != null) {
+                        tableSchemaVector.setSafe(row, serializeTableSchema(table));
+                    }
+                    row++;
+                }
+            }
+        }
+        root.setRowCount(row);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // Table types
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildTableTypes(BufferAllocator allocator) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_TABLE_TYPES_SCHEMA, allocator);
+        VarCharVector tableTypeVector = (VarCharVector) root.getVector("table_type");
+        tableTypeVector.allocateNew();
+
+        // The distinct set of values that Table#getMysqlType() can emit.
+        String[] tableTypes = {"BASE TABLE", "VIEW", "SYSTEM VIEW"};
+        for (int i = 0; i < tableTypes.length; i++) {
+            setVarChar(tableTypeVector, i, tableTypes[i]);
+        }
+        root.setRowCount(tableTypes.length);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // Primary keys
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildPrimaryKeys(FlightSql.CommandGetPrimaryKeys command, BufferAllocator allocator,
+                                                    ConnectContext context) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_PRIMARY_KEYS_SCHEMA, allocator);
+        VarCharVector catalogVector = (VarCharVector) root.getVector("catalog_name");
+        VarCharVector dbSchemaVector = (VarCharVector) root.getVector("db_schema_name");
+        VarCharVector tableNameVector = (VarCharVector) root.getVector("table_name");
+        VarCharVector columnNameVector = (VarCharVector) root.getVector("column_name");
+        IntVector keySequenceVector = (IntVector) root.getVector("key_sequence");
+        VarCharVector keyNameVector = (VarCharVector) root.getVector("key_name");
+        for (Field field : Schemas.GET_PRIMARY_KEYS_SCHEMA.getFields()) {
+            root.getVector(field.getName()).allocateNew();
+        }
+
+        String catalog = command.hasCatalog() ? command.getCatalog() : InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+        String db = command.hasDbSchema() ? command.getDbSchema() : null;
+        String tableName = command.getTable();
+
+        int row = 0;
+        for (Column column : primaryKeyColumns(context, catalog, db, tableName)) {
+            setVarChar(catalogVector, row, catalog);
+            setVarChar(dbSchemaVector, row, db);
+            setVarChar(tableNameVector, row, tableName);
+            setVarChar(columnNameVector, row, column.getName());
+            keySequenceVector.setSafe(row, row + 1);
+            keyNameVector.setNull(row);
+            row++;
+        }
+        root.setRowCount(row);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // Imported / exported / cross-reference keys
+    //
+    // StarRocks does not model foreign-key relationships, so these always return an empty stream that
+    // still conforms to the (shared) imported/exported/cross-reference key schema.
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildImportedKeys(BufferAllocator allocator) {
+        return emptyRoot(Schemas.GET_IMPORTED_KEYS_SCHEMA, allocator);
+    }
+
+    public static VectorSchemaRoot buildExportedKeys(BufferAllocator allocator) {
+        return emptyRoot(Schemas.GET_EXPORTED_KEYS_SCHEMA, allocator);
+    }
+
+    public static VectorSchemaRoot buildCrossReference(BufferAllocator allocator) {
+        return emptyRoot(Schemas.GET_CROSS_REFERENCE_SCHEMA, allocator);
+    }
+
+    // ------------------------------------------------------------------
+    // XDBC type info
+    // ------------------------------------------------------------------
+
+    public static VectorSchemaRoot buildTypeInfo(FlightSql.CommandGetXdbcTypeInfo command, BufferAllocator allocator) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_TYPE_INFO_SCHEMA, allocator);
+        for (Field field : Schemas.GET_TYPE_INFO_SCHEMA.getFields()) {
+            root.getVector(field.getName()).allocateNew();
+        }
+
+        VarCharVector typeNameVector = (VarCharVector) root.getVector("type_name");
+        IntVector dataTypeVector = (IntVector) root.getVector("data_type");
+        IntVector columnSizeVector = (IntVector) root.getVector("column_size");
+        VarCharVector literalPrefixVector = (VarCharVector) root.getVector("literal_prefix");
+        VarCharVector literalSuffixVector = (VarCharVector) root.getVector("literal_suffix");
+        ListVector createParamsVector = (ListVector) root.getVector("create_params");
+        IntVector nullableVector = (IntVector) root.getVector("nullable");
+        BitVector caseSensitiveVector = (BitVector) root.getVector("case_sensitive");
+        IntVector searchableVector = (IntVector) root.getVector("searchable");
+        BitVector unsignedVector = (BitVector) root.getVector("unsigned_attribute");
+        BitVector fixedPrecScaleVector = (BitVector) root.getVector("fixed_prec_scale");
+        BitVector autoIncrementVector = (BitVector) root.getVector("auto_increment");
+        VarCharVector localTypeNameVector = (VarCharVector) root.getVector("local_type_name");
+        IntVector minScaleVector = (IntVector) root.getVector("minimum_scale");
+        IntVector maxScaleVector = (IntVector) root.getVector("maximum_scale");
+        IntVector sqlDataTypeVector = (IntVector) root.getVector("sql_data_type");
+        IntVector datetimeSubcodeVector = (IntVector) root.getVector("datetime_subcode");
+        IntVector numPrecRadixVector = (IntVector) root.getVector("num_prec_radix");
+        IntVector intervalPrecisionVector = (IntVector) root.getVector("interval_precision");
+
+        Integer dataTypeFilter = command.hasDataType() ? command.getDataType() : null;
+
+        int row = 0;
+        for (TypeInfo type : STARROCKS_TYPE_INFO) {
+            if (dataTypeFilter != null && dataTypeFilter != type.jdbcType) {
+                continue;
+            }
+            setVarChar(typeNameVector, row, type.name);
+            dataTypeVector.setSafe(row, type.jdbcType);
+            if (type.columnSize == null) {
+                columnSizeVector.setNull(row);
+            } else {
+                columnSizeVector.setSafe(row, type.columnSize);
+            }
+            setVarChar(literalPrefixVector, row, type.stringType ? "'" : null);
+            setVarChar(literalSuffixVector, row, type.stringType ? "'" : null);
+            // create_params is informational; StarRocks does not surface it, so leave it null.
+            createParamsVector.setNull(row);
+            nullableVector.setSafe(row, DatabaseMetaData.typeNullable);
+            caseSensitiveVector.setSafe(row, type.stringType ? 1 : 0);
+            searchableVector.setSafe(row, DatabaseMetaData.typeSearchable);
+            unsignedVector.setSafe(row, 0);
+            fixedPrecScaleVector.setSafe(row, 0);
+            autoIncrementVector.setNull(row);
+            setVarChar(localTypeNameVector, row, type.name);
+            minScaleVector.setNull(row);
+            maxScaleVector.setNull(row);
+            sqlDataTypeVector.setSafe(row, type.jdbcType);
+            datetimeSubcodeVector.setNull(row);
+            numPrecRadixVector.setSafe(row, 10);
+            intervalPrecisionVector.setNull(row);
+            row++;
+        }
+        root.setRowCount(row);
+        return root;
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static VectorSchemaRoot emptyRoot(Schema schema, BufferAllocator allocator) {
+        VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+        root.setRowCount(0);
+        return root;
+    }
+
+    /**
+     * The internal {@code default_catalog} plus every registered external catalog, sorted for a stable order.
+     * {@link CatalogMgr#getCatalogs()} only returns external catalogs, so the internal one is added explicitly.
+     */
+    private static List<String> listCatalogNames() {
+        TreeSet<String> catalogs = new TreeSet<>();
+        catalogs.add(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+        catalogs.addAll(GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogs().keySet());
+        return new ArrayList<>(catalogs);
+    }
+
+    /**
+     * Resolve the catalogs a command should enumerate: the single requested catalog when {@code catalog} is set,
+     * otherwise every catalog. A {@code null} value means "no filter" in the Flight SQL protocol.
+     */
+    private static List<String> catalogsForCommand(String catalog) {
+        if (catalog == null) {
+            return listCatalogNames();
+        }
+        return Lists.newArrayList(catalog);
+    }
+
+    private static List<String> listDbNames(ConnectContext context, String catalog) {
+        try {
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().listDbNames(context, catalog);
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to list databases for catalog {}, skipping", catalog, e);
+            return Lists.newArrayList();
+        }
+    }
+
+    private static List<String> listTableNames(ConnectContext context, String catalog, String db) {
+        try {
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().listTableNames(context, catalog, db);
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to list tables for {}.{}, skipping", catalog, db, e);
+            return Lists.newArrayList();
+        }
+    }
+
+    /**
+     * Returns the primary-key columns of a table, or an empty list when the table is missing or is not a
+     * StarRocks PRIMARY KEY table (the only model that maps to a SQL primary key).
+     */
+    private static List<Column> primaryKeyColumns(ConnectContext context, String catalog, String db, String tableName) {
+        if (db == null || tableName == null || tableName.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        Table table;
+        try {
+            table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalog, db, tableName);
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to load table {}.{}.{} for GetPrimaryKeys", catalog, db, tableName, e);
+            return Lists.newArrayList();
+        }
+        if (!(table instanceof OlapTable)) {
+            return Lists.newArrayList();
+        }
+        OlapTable olapTable = (OlapTable) table;
+        if (olapTable.getKeysType() != KeysType.PRIMARY_KEYS) {
+            return Lists.newArrayList();
+        }
+        return olapTable.getKeyColumns();
+    }
+
+    private static PatternMatcher createPattern(String filterPattern) {
+        if (filterPattern == null || filterPattern.isEmpty()) {
+            return null;
+        }
+        // Database and table names are matched case-insensitively, consistent with SR's identifier handling.
+        return PatternMatcher.createMysqlPattern(filterPattern, false);
+    }
+
+    private static byte[] serializeTableSchema(Table table) {
+        List<Field> fields = Lists.newArrayList();
+        try {
+            for (Column column : table.getBaseSchema()) {
+                fields.add(ArrowUtils.convertToArrowType(column.getType(), column.getName(), column.isAllowNull()));
+            }
+        } catch (Exception e) {
+            // A single column with a type Arrow can't represent must not fail the whole GetTables stream;
+            // fall back to an empty schema for this table.
+            LOG.warn("[ARROW] Failed to convert schema of table {} for GetTables, emitting empty schema",
+                    table.getName(), e);
+            fields.clear();
+        }
+        return ArrowFlightSqlServiceImpl.serializeMetadata(new Schema(fields)).array();
+    }
+
+    private static void setVarChar(VarCharVector vector, int index, String value) {
+        if (value == null) {
+            vector.setNull(index);
+        } else {
+            vector.setSafe(index, value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private static final class TypeInfo {
+        private final String name;
+        private final int jdbcType;
+        private final Integer columnSize;
+        private final boolean stringType;
+
+        private TypeInfo(String name, int jdbcType, Integer columnSize, boolean stringType) {
+            this.name = name;
+            this.jdbcType = jdbcType;
+            this.columnSize = columnSize;
+            this.stringType = stringType;
+        }
+    }
+
+    // The set of StarRocks SQL types exposed to clients, mapped onto their closest JDBC type codes.
+    private static final List<TypeInfo> STARROCKS_TYPE_INFO = List.of(
+            new TypeInfo("BOOLEAN", Types.BOOLEAN, 1, false),
+            new TypeInfo("TINYINT", Types.TINYINT, 3, false),
+            new TypeInfo("SMALLINT", Types.SMALLINT, 5, false),
+            new TypeInfo("INT", Types.INTEGER, 10, false),
+            new TypeInfo("BIGINT", Types.BIGINT, 19, false),
+            new TypeInfo("LARGEINT", Types.DECIMAL, 39, false),
+            new TypeInfo("FLOAT", Types.REAL, 7, false),
+            new TypeInfo("DOUBLE", Types.DOUBLE, 15, false),
+            new TypeInfo("DECIMAL", Types.DECIMAL, 38, false),
+            new TypeInfo("CHAR", Types.CHAR, 255, true),
+            new TypeInfo("VARCHAR", Types.VARCHAR, 1048576, true),
+            new TypeInfo("STRING", Types.VARCHAR, 1048576, true),
+            new TypeInfo("JSON", Types.VARCHAR, null, true),
+            new TypeInfo("DATE", Types.DATE, 10, false),
+            new TypeInfo("DATETIME", Types.TIMESTAMP, 26, false),
+            new TypeInfo("VARBINARY", Types.VARBINARY, null, false));
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -439,7 +439,12 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     @Override
     public SchemaResult getSchemaStatement(FlightSql.CommandStatementQuery command, CallContext context,
                                            FlightDescriptor descriptor) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getSchemaStatement unimplemented").toRuntimeException();
+        // Only semantic analysis is needed to derive the result schema, which any FE can do locally from its
+        // catalog metadata. Unlike prepared statements, a raw statement query carries no FE-pinned state, so
+        // there is no need to forward to the issuing FE even when proxy is enabled.
+        ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(context.peerIdentity());
+        Schema schema = buildSchemaFromQuery(ctx, command.getQuery());
+        return new SchemaResult(schema);
     }
 
     @Override
@@ -463,60 +468,93 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     @Override
     public void getStreamTypeInfo(FlightSql.CommandGetXdbcTypeInfo command, CallContext context, ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamTypeInfo unimplemented").toRuntimeException();
+        streamMetadata(context, listener, (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildTypeInfo(command, allocator));
     }
 
     @Override
     public void getStreamCatalogs(CallContext context, ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamCatalogs unimplemented").toRuntimeException();
-
+        streamMetadata(context, listener, (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildCatalogs(allocator));
     }
 
     @Override
     public void getStreamSchemas(FlightSql.CommandGetDbSchemas command, CallContext context, ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamSchemas unimplemented").toRuntimeException();
-
+        streamMetadata(context, listener,
+                (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildSchemas(command, allocator, ctx));
     }
 
     @Override
     public void getStreamTables(FlightSql.CommandGetTables command, CallContext context, ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamTables unimplemented").toRuntimeException();
-
+        streamMetadata(context, listener,
+                (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildTables(command, allocator, ctx));
     }
 
     @Override
     public void getStreamTableTypes(CallContext context, ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamTableTypes unimplemented").toRuntimeException();
-
+        streamMetadata(context, listener, (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildTableTypes(allocator));
     }
 
     @Override
     public void getStreamPrimaryKeys(FlightSql.CommandGetPrimaryKeys command, CallContext context,
                                      ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamPrimaryKeys unimplemented").toRuntimeException();
+        streamMetadata(context, listener,
+                (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildPrimaryKeys(command, allocator, ctx));
     }
 
     @Override
     public void getStreamExportedKeys(FlightSql.CommandGetExportedKeys command, CallContext context,
                                       ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamExportedKeys unimplemented").toRuntimeException();
+        streamMetadata(context, listener, (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildExportedKeys(allocator));
     }
 
     @Override
     public void getStreamImportedKeys(FlightSql.CommandGetImportedKeys command, CallContext context,
                                       ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamImportedKeys unimplemented").toRuntimeException();
+        streamMetadata(context, listener, (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildImportedKeys(allocator));
     }
 
     @Override
     public void getStreamCrossReference(FlightSql.CommandGetCrossReference command, CallContext context,
                                         ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamCrossReference unimplemented").toRuntimeException();
+        streamMetadata(context, listener, (ctx, allocator) -> ArrowFlightSqlMetadataHandler.buildCrossReference(allocator));
     }
 
     @Override
     public void listFlights(CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("listFlights unimplemented").toRuntimeException();
+        // StarRocks does not expose a discoverable list of flights; metadata and statement flights are obtained
+        // through the dedicated getFlightInfo* commands. Return an empty list rather than failing the call so
+        // clients that probe listFlights on connect can proceed.
+        listener.onCompleted();
+    }
+
+    /**
+     * Build a metadata result locally from the FE's in-memory catalog state and stream it to the client.
+     *
+     * <p>The handler emits a single {@link VectorSchemaRoot} conforming to the matching
+     * {@code Schemas.GET_*_SCHEMA}. This service owns that root and closes it once streaming finishes.
+     * The {@link ConnectContext} is bound to the current thread for the duration of the build so metadata
+     * lookups that consult the thread-local context (e.g. external connectors, authorization) work correctly.
+     */
+    private void streamMetadata(CallContext context, ServerStreamListener listener,
+                                java.util.function.BiFunction<ArrowFlightSqlConnectContext,
+                                        BufferAllocator, VectorSchemaRoot> builder) {
+        ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(context.peerIdentity());
+        VectorSchemaRoot root = null;
+        try (var scope = ctx.bindScope()) {
+            root = builder.apply(ctx, rootAllocator);
+            listener.start(root);
+            listener.putNext();
+            listener.completed();
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to stream metadata", e);
+            listener.error(CallStatus.INTERNAL
+                    .withDescription("Failed to stream metadata: " + e.getMessage())
+                    .withCause(e)
+                    .toRuntimeException());
+        } finally {
+            if (root != null) {
+                root.close();
+            }
+        }
     }
 
     protected static ByteBuffer serializeMetadata(final Schema schema) {

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlMetadataHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlMetadataHandlerTest.java
@@ -1,0 +1,207 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.type.IntegerType;
+import org.apache.arrow.flight.sql.FlightSqlProducer;
+import org.apache.arrow.flight.sql.impl.FlightSql;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class ArrowFlightSqlMetadataHandlerTest {
+
+    private BufferAllocator allocator;
+    private ConnectContext context;
+    private MockedStatic<GlobalStateMgr> mockedGlobalState;
+    private MetadataMgr metadataMgr;
+    private CatalogMgr catalogMgr;
+
+    @BeforeEach
+    public void setUp() {
+        allocator = new RootAllocator(Long.MAX_VALUE);
+        context = mock(ConnectContext.class);
+
+        GlobalStateMgr globalStateMgr = mock(GlobalStateMgr.class);
+        metadataMgr = mock(MetadataMgr.class);
+        catalogMgr = mock(CatalogMgr.class);
+        when(globalStateMgr.getMetadataMgr()).thenReturn(metadataMgr);
+        when(globalStateMgr.getCatalogMgr()).thenReturn(catalogMgr);
+        when(catalogMgr.getCatalogs()).thenReturn(Map.of());
+
+        mockedGlobalState = mockStatic(GlobalStateMgr.class);
+        mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockedGlobalState.close();
+        allocator.close();
+    }
+
+    private static String str(VectorSchemaRoot root, String field, int row) {
+        VarCharVector vector = (VarCharVector) root.getVector(field);
+        return vector.isNull(row) ? null : vector.getObject(row).toString();
+    }
+
+    @Test
+    public void testBuildCatalogsIncludesInternalAndExternalSorted() {
+        Map<String, Catalog> catalogs = new LinkedHashMap<>();
+        catalogs.put("zeta_catalog", mock(Catalog.class));
+        catalogs.put("alpha_catalog", mock(Catalog.class));
+        when(catalogMgr.getCatalogs()).thenReturn(catalogs);
+
+        try (VectorSchemaRoot root = ArrowFlightSqlMetadataHandler.buildCatalogs(allocator)) {
+            assertEquals(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, root.getSchema());
+            assertEquals(3, root.getRowCount());
+            // TreeSet ordering: alpha_catalog, default_catalog, zeta_catalog
+            assertEquals("alpha_catalog", str(root, "catalog_name", 0));
+            assertEquals("default_catalog", str(root, "catalog_name", 1));
+            assertEquals("zeta_catalog", str(root, "catalog_name", 2));
+        }
+    }
+
+    @Test
+    public void testBuildSchemasFiltersByCatalogAndPattern() {
+        when(metadataMgr.listDbNames(any(), eq("default_catalog")))
+                .thenReturn(List.of("sales_db", "ops_db", "sandbox"));
+
+        FlightSql.CommandGetDbSchemas command = FlightSql.CommandGetDbSchemas.newBuilder()
+                .setCatalog("default_catalog")
+                .setDbSchemaFilterPattern("s%")
+                .build();
+
+        try (VectorSchemaRoot root = ArrowFlightSqlMetadataHandler.buildSchemas(command, allocator, context)) {
+            assertEquals(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA, root.getSchema());
+            // "sales_db" and "sandbox" match "s%"; "ops_db" does not.
+            assertEquals(2, root.getRowCount());
+            assertEquals("default_catalog", str(root, "catalog_name", 0));
+            assertEquals("sales_db", str(root, "db_schema_name", 0));
+            assertEquals("sandbox", str(root, "db_schema_name", 1));
+        }
+    }
+
+    @Test
+    public void testBuildTablesAppliesTypeFilterAndNamespaceColumns() {
+        when(metadataMgr.listDbNames(any(), eq("default_catalog"))).thenReturn(List.of("db1"));
+        when(metadataMgr.listTableNames(any(), eq("default_catalog"), eq("db1")))
+                .thenReturn(List.of("t_table", "t_view"));
+
+        Table baseTable = mock(Table.class);
+        when(baseTable.getMysqlType()).thenReturn("BASE TABLE");
+        Table viewTable = mock(Table.class);
+        when(viewTable.getMysqlType()).thenReturn("VIEW");
+        when(metadataMgr.getTable(any(), eq("default_catalog"), eq("db1"), eq("t_table"))).thenReturn(baseTable);
+        when(metadataMgr.getTable(any(), eq("default_catalog"), eq("db1"), eq("t_view"))).thenReturn(viewTable);
+
+        FlightSql.CommandGetTables command = FlightSql.CommandGetTables.newBuilder()
+                .setCatalog("default_catalog")
+                .addTableTypes("BASE TABLE")
+                .setIncludeSchema(false)
+                .build();
+
+        try (VectorSchemaRoot root = ArrowFlightSqlMetadataHandler.buildTables(command, allocator, context)) {
+            assertEquals(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA, root.getSchema());
+            assertEquals(1, root.getRowCount());
+            assertEquals("default_catalog", str(root, "catalog_name", 0));
+            assertEquals("db1", str(root, "db_schema_name", 0));
+            assertEquals("t_table", str(root, "table_name", 0));
+            assertEquals("BASE TABLE", str(root, "table_type", 0));
+        }
+    }
+
+    @Test
+    public void testBuildPrimaryKeysReturnsKeyColumnsForPrimaryKeyTable() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getKeysType()).thenReturn(KeysType.PRIMARY_KEYS);
+        Column id = new Column("id", IntegerType.BIGINT, true);
+        Column region = new Column("region", IntegerType.INT, true);
+        when(table.getKeyColumns()).thenReturn(List.of(id, region));
+        when(metadataMgr.getTable(any(), eq("default_catalog"), eq("db1"), eq("orders"))).thenReturn(table);
+
+        FlightSql.CommandGetPrimaryKeys command = FlightSql.CommandGetPrimaryKeys.newBuilder()
+                .setCatalog("default_catalog")
+                .setDbSchema("db1")
+                .setTable("orders")
+                .build();
+
+        try (VectorSchemaRoot root = ArrowFlightSqlMetadataHandler.buildPrimaryKeys(command, allocator, context)) {
+            assertEquals(FlightSqlProducer.Schemas.GET_PRIMARY_KEYS_SCHEMA, root.getSchema());
+            assertEquals(2, root.getRowCount());
+            assertEquals("orders", str(root, "table_name", 0));
+            assertEquals("id", str(root, "column_name", 0));
+            assertEquals(1, ((IntVector) root.getVector("key_sequence")).get(0));
+            assertEquals("region", str(root, "column_name", 1));
+            assertEquals(2, ((IntVector) root.getVector("key_sequence")).get(1));
+        }
+    }
+
+    @Test
+    public void testBuildPrimaryKeysEmptyForNonPrimaryKeyTable() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getKeysType()).thenReturn(KeysType.DUP_KEYS);
+        when(metadataMgr.getTable(any(), eq("default_catalog"), eq("db1"), eq("logs"))).thenReturn(table);
+
+        FlightSql.CommandGetPrimaryKeys command = FlightSql.CommandGetPrimaryKeys.newBuilder()
+                .setCatalog("default_catalog")
+                .setDbSchema("db1")
+                .setTable("logs")
+                .build();
+
+        try (VectorSchemaRoot root = ArrowFlightSqlMetadataHandler.buildPrimaryKeys(command, allocator, context)) {
+            assertEquals(0, root.getRowCount());
+        }
+    }
+
+    @Test
+    public void testBuildTypeInfoFilterByDataType() {
+        FlightSql.CommandGetXdbcTypeInfo command = FlightSql.CommandGetXdbcTypeInfo.newBuilder()
+                .setDataType(java.sql.Types.INTEGER)
+                .build();
+
+        try (VectorSchemaRoot root = ArrowFlightSqlMetadataHandler.buildTypeInfo(command, allocator)) {
+            assertEquals(FlightSqlProducer.Schemas.GET_TYPE_INFO_SCHEMA, root.getSchema());
+            assertEquals(1, root.getRowCount());
+            assertEquals("INT", str(root, "type_name", 0));
+            assertEquals(java.sql.Types.INTEGER, ((IntVector) root.getVector("data_type")).get(0));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -713,14 +713,9 @@ public class ArrowFlightSqlServiceImplTest {
 
     @Test
     public void testUnimplementedFlightSqlMethods() {
+        // acceptPut* remain unimplemented: the Flight SQL surface is read-only.
         FlightStream mockStream = mock(FlightStream.class);
-        FlightProducer.ServerStreamListener mockServerListener = mock(FlightProducer.ServerStreamListener.class);
         FlightProducer.StreamListener<PutResult> mockPutListener = mock(FlightProducer.StreamListener.class);
-        FlightDescriptor mockDescriptor = FlightDescriptor.command("SELECT 1".getBytes());
-        Criteria mockCriteria = mock(Criteria.class);
-
-        assertThrows(FlightRuntimeException.class, () -> service.getSchemaStatement(FlightSql.CommandStatementQuery
-                .getDefaultInstance(), mockCallContext, mockDescriptor));
 
         assertThrows(FlightRuntimeException.class, () -> service.acceptPutStatement(FlightSql.CommandStatementUpdate
                 .getDefaultInstance(), mockCallContext, mockStream, mockPutListener));
@@ -732,35 +727,70 @@ public class ArrowFlightSqlServiceImplTest {
         assertThrows(FlightRuntimeException.class,
                 () -> service.acceptPutPreparedStatementQuery(FlightSql.CommandPreparedStatementQuery
                         .getDefaultInstance(), mockCallContext, mockStream, mockPutListener));
+    }
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamTypeInfo(FlightSql.CommandGetXdbcTypeInfo
-                .getDefaultInstance(), mockCallContext, mockServerListener));
+    @Test
+    public void testListFlightsCompletesEmpty() {
+        Criteria mockCriteria = mock(Criteria.class);
+        FlightProducer.StreamListener<FlightInfo> listener = mock(FlightProducer.StreamListener.class);
+        service.listFlights(mockCallContext, mockCriteria, listener);
+        verify(listener).onCompleted();
+        verify(listener, org.mockito.Mockito.never()).onNext(any());
+    }
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamCatalogs(mockCallContext, mockServerListener));
+    @Test
+    public void testGetSchemaStatementReturnsSchema() {
+        ArrowFlightSqlConnectContext realContext = new ArrowFlightSqlConnectContext("token123");
+        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(realContext);
+        try {
+            org.apache.arrow.flight.SchemaResult result = service.getSchemaStatement(
+                    FlightSql.CommandStatementQuery.newBuilder().setQuery("SELECT 1 AS c1").build(),
+                    mockCallContext, FlightDescriptor.command("".getBytes()));
+            assertNotNull(result);
+            assertNotNull(result.getSchema());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamSchemas(FlightSql.CommandGetDbSchemas
-                .getDefaultInstance(), mockCallContext, mockServerListener));
+    @Test
+    public void testGetStreamTableTypesEmitsStaticTypes() {
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+        ArgumentCaptor<VectorSchemaRoot> rootCaptor = ArgumentCaptor.forClass(VectorSchemaRoot.class);
 
-        assertThrows(FlightRuntimeException.class,
-                () -> service.getStreamTables(FlightSql.CommandGetTables.getDefaultInstance(), mockCallContext,
-                        mockServerListener));
+        service.getStreamTableTypes(mockCallContext, listener);
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamTableTypes(mockCallContext, mockServerListener));
+        verify(listener).start(rootCaptor.capture());
+        verify(listener).putNext();
+        verify(listener).completed();
+        assertEquals(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA, rootCaptor.getValue().getSchema());
+        assertEquals(3, rootCaptor.getValue().getRowCount());
+    }
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamPrimaryKeys(FlightSql.CommandGetPrimaryKeys
-                .getDefaultInstance(), mockCallContext, mockServerListener));
+    @Test
+    public void testGetStreamTypeInfoEmitsTypeTable() {
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+        ArgumentCaptor<VectorSchemaRoot> rootCaptor = ArgumentCaptor.forClass(VectorSchemaRoot.class);
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamExportedKeys(FlightSql.CommandGetExportedKeys
-                .getDefaultInstance(), mockCallContext, mockServerListener));
+        service.getStreamTypeInfo(FlightSql.CommandGetXdbcTypeInfo.getDefaultInstance(), mockCallContext, listener);
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamImportedKeys(FlightSql.CommandGetImportedKeys
-                .getDefaultInstance(), mockCallContext, mockServerListener));
+        verify(listener).start(rootCaptor.capture());
+        verify(listener).completed();
+        assertEquals(FlightSqlProducer.Schemas.GET_TYPE_INFO_SCHEMA, rootCaptor.getValue().getSchema());
+        assertTrue(rootCaptor.getValue().getRowCount() > 0);
+    }
 
-        assertThrows(FlightRuntimeException.class, () -> service.getStreamCrossReference(FlightSql.CommandGetCrossReference
-                .getDefaultInstance(), mockCallContext, mockServerListener));
+    @Test
+    public void testGetStreamExportedKeysEmitsEmptyStream() {
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+        ArgumentCaptor<VectorSchemaRoot> rootCaptor = ArgumentCaptor.forClass(VectorSchemaRoot.class);
 
-        assertThrows(FlightRuntimeException.class,
-                () -> service.listFlights(mockCallContext, mockCriteria, mock(FlightProducer.StreamListener.class)));
+        service.getStreamExportedKeys(FlightSql.CommandGetExportedKeys.getDefaultInstance(), mockCallContext, listener);
+
+        verify(listener).start(rootCaptor.capture());
+        verify(listener).completed();
+        assertEquals(FlightSqlProducer.Schemas.GET_EXPORTED_KEYS_SCHEMA, rootCaptor.getValue().getSchema());
+        assertEquals(0, rootCaptor.getValue().getRowCount());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The Flight SQL service in FE wires up `getFlightInfo*` for every standard metadata command (catalogs, schemas, tables, table types, primary/imported/exported/cross-reference keys, XDBC type info), but every matching `getStream*` was stubbed with `CallStatus.UNIMPLEMENTED`. So the two-phase Flight RPC succeeded on phase 1 (`GetFlightInfo`) and failed on phase 2 (`DoGet`). This broke ADBC `GetObjects` — which most ADBC tooling (DataFusion, Polars, dbt-adbc, common BI clients) calls on connect to enumerate catalogs / db_schemas / tables. `getSchemaStatement` and `listFlights` were also unimplemented.

## What I'm doing:

Back the metadata streams with the FE's in-memory catalog/database/table state, emitting Arrow batches that conform to the advertised `FlightSqlProducer.Schemas.GET_*_SCHEMA`. StarRocks' three-level `catalog -> database -> table` namespace maps onto Flight SQL's `catalog_name -> db_schema_name -> table_name`.

New `ArrowFlightSqlMetadataHandler` builds each `VectorSchemaRoot`; `ArrowFlightSqlServiceImpl` binds the `ConnectContext` to the thread, streams the root, and closes it.

- `getStreamCatalogs`: `default_catalog` + external catalogs
- `getStreamSchemas`: databases per catalog, LIKE-filtered by `db_schema_filter_pattern`
- `getStreamTables`: tables per (catalog, db), filtered by name pattern and `table_types`; when `include_schema` is set, embeds the IPC-serialized per-table Arrow schema
- `getStreamTableTypes`: static `BASE TABLE` / `VIEW` / `SYSTEM VIEW`
- `getStreamPrimaryKeys`: key columns of PRIMARY KEY tables
- `getStream{Imported,Exported}Keys` / `getStreamCrossReference`: empty streams conforming to the shared keys schema (StarRocks has no foreign keys)
- `getStreamTypeInfo`: static StarRocks type table mapped to JDBC type codes
- `getSchemaStatement`: derives the result schema via local semantic analysis
- `listFlights`: completes with an empty list instead of failing

`acceptPutStatement` / `acceptPutPreparedStatement*` remain `UNIMPLEMENTED` (read-only Flight SQL surface).

Fixes #72298

## Verified

Built this FE from source in the `dev-env-ubuntu:4.1` image, deployed it onto a BE-backed allin1 cluster, enabled `arrow_flight_port`, and ran the ADBC `GetObjects` API via `adbc_driver_flightsql`:

```
CATALOGS: ['default_catalog']
DB_SCHEMAS (default_catalog): 4
TABLES (default_catalog): 82
   default_catalog.adbc_demo.orders [BASE TABLE]
   default_catalog.adbc_demo.v_orders [VIEW]
   default_catalog.information_schema.tables [SYSTEM VIEW]
orders COLUMNS: ['order_id', 'region', 'amount']   # include_schema path
TABLE_TYPES: ['BASE TABLE', 'VIEW', 'SYSTEM VIEW']
RESULT: ADBC GetObjects SUCCEEDED
```

Deployment note (pre-existing, not introduced here): enabling `arrow_flight_port` requires the FE JVM to be started with `--add-opens=java.base/java.nio=ALL-UNNAMED` for Arrow off-heap memory; otherwise Arrow allocation fails at `MemoryUtil.<clinit>`. This affects the existing V1 statement path too.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)