### PR TITLE
[BugFix] Sum composite-rowset stats when batching op_writes in PK multi-statement

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -971,6 +971,19 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
                     _pending_rowset_data.assigned_segment_idx + get_segment_idx(rowset_pb, i));
         }
     } else {
+        // The first op_write was CopyFrom'd above (carrying its num_rows/data_size/num_dels);
+        // subsequent op_writes only append their segments below, so their row/size/del counts
+        // must be SUMMED into the composite rowset. Otherwise the rowset keeps just the first
+        // op_write's counts while holding every op_write's segments — a multi-statement / batch
+        // (incl. cross-publish) PK txn would then report e.g. num_rows=1 for a 10001-row rowset,
+        // corrupting reads until compaction rewrites the rowset. A composite spanning multiple
+        // op_writes can also carry overlapping keys, so mark it overlapped (as the non-PK batch
+        // path does via set_overlapped(all_segments.size() > 1)).
+        _pending_rowset_data.rowset_pb.set_num_rows(_pending_rowset_data.rowset_pb.num_rows() + rowset_pb.num_rows());
+        _pending_rowset_data.rowset_pb.set_data_size(_pending_rowset_data.rowset_pb.data_size() +
+                                                     rowset_pb.data_size());
+        _pending_rowset_data.rowset_pb.set_num_dels(_pending_rowset_data.rowset_pb.num_dels() + rowset_pb.num_dels());
+        _pending_rowset_data.rowset_pb.set_overlapped(true);
         // Merge segments
         for (int i = 0; i < rowset_pb.segments_size(); i++) {
             _pending_rowset_data.rowset_pb.add_segments(rowset_pb.segments(i));

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -111,6 +111,46 @@ TEST_F(MetaFileTest, test_meta_rw) {
     ASSIGN_OR_ABORT(auto metadata2, _tablet_manager->get_tablet_metadata(tablet_id, 10));
 }
 
+// Regression: when add_rowset accumulates multiple op_writes into ONE composite rowset
+// (a multi-statement / batch / cross-publish PK txn), it must SUM num_rows/data_size/num_dels,
+// not keep only the first op_write's counts. The bug left e.g. num_rows=1 on a rowset whose
+// segments hold 1 + 10000 = 10001 rows, corrupting reads until compaction rewrote the rowset.
+TEST_F(MetaFileTest, test_add_rowset_sums_composite_stats) {
+    const int64_t tablet_id = 10050;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(2);
+    metadata->set_next_rowset_id(1);
+    MetaFileBuilder builder(*tablet, metadata);
+
+    RowsetMetadataPB rs_tiny; // first op_write: 1 row, 1 segment
+    rs_tiny.set_num_rows(1);
+    rs_tiny.set_data_size(100);
+    rs_tiny.set_overlapped(false);
+    rs_tiny.add_segments("seg_tiny.dat");
+    rs_tiny.add_segment_size(100);
+    builder.add_rowset(rs_tiny, {}, {}, {});
+
+    RowsetMetadataPB rs_large; // second op_write: 10000 rows, 1 segment
+    rs_large.set_num_rows(10000);
+    rs_large.set_data_size(50000);
+    rs_large.set_overlapped(false);
+    rs_large.add_segments("seg_large.dat");
+    rs_large.add_segment_size(50000);
+    builder.add_rowset(rs_large, {}, {}, {});
+
+    ASSERT_OK(builder.set_final_rowset());
+
+    ASSERT_EQ(1, metadata->rowsets_size());
+    const auto& rs = metadata->rowsets(0);
+    EXPECT_EQ(2, rs.segments_size());
+    EXPECT_EQ(2, rs.segment_size_size());
+    EXPECT_EQ(1 + 10000, rs.num_rows());    // before the fix: 1 (first op_write only)
+    EXPECT_EQ(100 + 50000, rs.data_size()); // before the fix: 100
+    EXPECT_TRUE(rs.overlapped());           // composite spanning >1 op_write
+}
+
 TEST_F(MetaFileTest, test_merge_delvec_files_empty) {
     std::vector<DelvecFileInfo> old_delvec_files;
     FileMetaPB new_delvec_file;


### PR DESCRIPTION
## Why I'm doing:

`MetaFileBuilder::add_rowset` accumulates the op_writes of a multi-statement / batch transaction into a single composite rowset. It merges their segments (and segment sizes, metas, encryption metas, shared flags, bundle offsets) but **never sums `num_rows`, `data_size`, or `num_dels`** — the first op_write's values (from the initial `CopyFrom`) survive. So the composite rowset reports only the first statement's counts while physically holding every statement's segments (e.g. `num_rows=1` for a rowset whose segments contain `1 + 10000 = 10001` rows).

On a **PRIMARY KEY** table this corrupts the read path — rows in the under-counted segments become unreadable and range scans miscount — until a later compaction rewrites the rowset and recomputes `num_rows`. It is reached by any PK multi-statement / batch transaction (`PrimaryKeyTxnLogApplier::apply(TxnLogVector)`); a write cross-published to split children during a tablet reshard is one trigger. The non-PK batch path already sums correctly, so only PK tables are affected.

Surfaced while end-to-end testing concurrent multi-statement writes during a tablet split (reshard work, #74013), but the bug is **pre-existing and broader than reshard**. Confirmed by decoding the on-disk `TabletMetadataPB`: a composite rowset with `num_rows=1` over two segments whose `segment_metas` hold `1` and `10000` rows.

## What I'm doing:

In the accumulation branch of `add_rowset`, sum `num_rows`/`data_size`/`num_dels` into the pending composite rowset, and mark it `overlapped` (a composite spanning multiple op_writes may carry overlapping keys — matching the non-PK batch path's `set_overlapped(all_segments.size() > 1)`).

Adds `MetaFileTest.test_add_rowset_sums_composite_stats`, which builds a composite rowset from a 1-row + 10000-row op_write and asserts the summed `num_rows`/`data_size` (it fails on the pre-fix first-op-write-only behavior).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: data-correctness fix (composite-rowset row/size counts on PK tables)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
