### PR TITLE
[BugFix] rewrite string date-column predicates to date-only string compare for consistent lake pushdown/pruning on current_date

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1005,6 +1005,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_COUNT_STAR_OPTIMIZATION = "enable_count_star_optimization";
 
+    // Rewrites comparisons between a STRING date column (canonical 'yyyy-MM-dd' values) and a temporal
+    // constant into a pure string-domain comparison, so connector push-down and partition pruning behave
+    // consistently for current_date() / current_date()-interval predicates. Disable for string columns
+    // that store non-canonical date formats or genuine datetime strings.
+    public static final String ENABLE_REWRITE_STRING_DATE_PREDICATE = "enable_rewrite_string_date_predicate";
+
     public static final String ENABLE_PARTITION_COLUMN_VALUE_ONLY_OPTIMIZATION =
             "enable_partition_column_value_only_optimization";
 
@@ -3073,6 +3079,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_COUNT_STAR_OPTIMIZATION, flag = VariableMgr.INVISIBLE)
     private boolean enableCountStarOptimization = true;
+
+    @VarAttr(name = ENABLE_REWRITE_STRING_DATE_PREDICATE)
+    private boolean enableRewriteStringDatePredicate = true;
 
     @VarAttr(name = ENABLE_MIN_MAX_OPTIMIZATION)
     private boolean enableMinMaxOptimization = true;
@@ -5650,6 +5659,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableCountStarOptimization(boolean v) {
         enableCountStarOptimization = v;
+    }
+
+    public boolean isEnableRewriteStringDatePredicate() {
+        return enableRewriteStringDatePredicate;
+    }
+
+    public void setEnableRewriteStringDatePredicate(boolean v) {
+        enableRewriteStringDatePredicate = v;
     }
 
     public boolean isEnableMinMaxOptimization() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedDateColumnPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedStringDatePredicateRule;
 
 import java.util.List;
 import java.util.Map;
@@ -83,6 +84,7 @@ public class ScalarOperatorRewriter {
             new SimplifiedScanColumnRule(),
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
+            new SimplifiedStringDatePredicateRule(),
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedStringDatePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedStringDatePredicateRule.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.Lists;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.type.Type;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Normalizes comparisons between a STRING date column (canonical 'yyyy-MM-dd' values, common for
+ * lake/partition columns such as datestr / datestr_ist) and a temporal constant into a pure
+ * string-domain comparison, so that connector predicate push-down and partition pruning work
+ * consistently.
+ *
+ * <p>Background: {@code current_date()} folds to a DATE constant, while {@code current_date() - interval
+ * '1' day} folds to a DATETIME constant (the analyzer casts the interval-arithmetic operand to
+ * DATETIME). When such a constant is compared with a string column, the optimizer either wraps the
+ * column in {@code CAST(col AS DATETIME)} (equality path) or renders the constant to a string via the
+ * IN/BETWEEN common-type path. A DATETIME constant always renders with a time component
+ * ('2026-05-30 00:00:00'), which never string-matches a stored 'yyyy-MM-dd' value, producing empty
+ * results and inconsistent behaviour between '=', 'IN', and ranges.
+ *
+ * <p>This rule runs after constant folding and rewrites, only when the constant time-of-day is
+ * midnight (always true for current_date()/current_date()-interval):
+ * <pre>
+ *   CAST(strcol AS DATE|DATETIME) op '2026-05-30 00:00:00'  -> strcol op '2026-05-30'
+ *   strcol op '2026-05-30 00:00:00'                         -> strcol op '2026-05-30'
+ *   strcol IN ('2026-05-30', '2026-05-18 00:00:00')         -> strcol IN ('2026-05-30', '2026-05-18')
+ * </pre>
+ *
+ * <p>Soundness: relies on the string column storing canonical zero-padded 'yyyy-MM-dd' values, for
+ * which lexicographic order equals chronological order. Gated by the session variable
+ * {@code enable_rewrite_string_date_predicate}; disable it for string columns that store
+ * non-canonical date formats or genuine datetime strings.
+ */
+public class SimplifiedStringDatePredicateRule extends BottomUpScalarOperatorRewriteRule {
+    // 'yyyy-MM-dd HH:mm:ss' with midnight time, optional fractional seconds (also all-zero).
+    private static final Pattern MIDNIGHT_DATETIME_STRING =
+            Pattern.compile("(\\d{4}-\\d{2}-\\d{2}) 00:00:00(?:\\.0+)?");
+    // 'yyyy-MM-dd'
+    private static final Pattern DATE_STRING = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
+    private static boolean enabled() {
+        return ConnectContext.get() == null
+                || ConnectContext.get().getSessionVariable().isEnableRewriteStringDatePredicate();
+    }
+
+    @Override
+    public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate,
+                                               ScalarOperatorRewriteContext context) {
+        if (!enabled()) {
+            return predicate;
+        }
+        BinaryType type = predicate.getBinaryType();
+        // Only equality and range comparisons; for canonical 'yyyy-MM-dd' strings lexicographic order
+        // matches chronological order, so ranges remain correct.
+        if (!(type.isEqual() || type == BinaryType.NE || type.isRange())) {
+            return predicate;
+        }
+
+        ScalarOperator column = extractStringDateColumn(predicate.getChild(0));
+        if (column == null) {
+            return predicate;
+        }
+        Optional<ConstantOperator> dateString = toDateOnlyString(predicate.getChild(1));
+        if (dateString.isEmpty()) {
+            return predicate;
+        }
+        // Idempotency: if neither side changed, return the original so the rewriter reaches a fixpoint.
+        // toDateOnlyString() returns the same constant instance when it is already a canonical date string.
+        if (column == predicate.getChild(0) && dateString.get() == predicate.getChild(1)) {
+            return predicate;
+        }
+        return new BinaryPredicateOperator(type, column, dateString.get());
+    }
+
+    @Override
+    public ScalarOperator visitInPredicate(InPredicateOperator predicate, ScalarOperatorRewriteContext context) {
+        if (!enabled() || predicate.isSubquery()) {
+            return predicate;
+        }
+        ScalarOperator column = extractStringDateColumn(predicate.getChild(0));
+        if (column == null) {
+            return predicate;
+        }
+
+        List<ScalarOperator> newChildren = Lists.newArrayList();
+        newChildren.add(column);
+        boolean changed = column != predicate.getChild(0);
+        for (ScalarOperator value : predicate.getListChildren()) {
+            Optional<ConstantOperator> dateString = toDateOnlyString(value);
+            if (dateString.isEmpty()) {
+                return predicate;
+            }
+            changed |= dateString.get() != value;
+            newChildren.add(dateString.get());
+        }
+        // Idempotency: only rebuild when something actually changed, so the rewriter reaches a fixpoint.
+        if (!changed) {
+            return predicate;
+        }
+        return new InPredicateOperator(predicate.isNotIn(), newChildren);
+    }
+
+    // Returns the bare string column if the operator is a string column, or CAST(stringColumn AS DATE|DATETIME).
+    private static ScalarOperator extractStringDateColumn(ScalarOperator op) {
+        if (op.isColumnRef() && op.getType().isStringType()) {
+            return op;
+        }
+        if (op instanceof CastOperator
+                && (op.getType().isDate() || op.getType().isDatetime())) {
+            ScalarOperator child = op.getChild(0);
+            if (child.isColumnRef() && child.getType().isStringType()) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    // Renders a temporal/date-string constant to a canonical 'yyyy-MM-dd' varchar constant, but only
+    // when it has no (non-midnight) time component. Returns empty otherwise.
+    private static Optional<ConstantOperator> toDateOnlyString(ScalarOperator op) {
+        if (!op.isConstantRef()) {
+            return Optional.empty();
+        }
+        ConstantOperator constant = (ConstantOperator) op;
+        if (constant.isNull()) {
+            return Optional.empty();
+        }
+        Type type = constant.getType();
+        if (type.isDate()) {
+            return Optional.of(ConstantOperator.createVarchar(toDateString(constant.getDate())));
+        }
+        if (type.isDatetime()) {
+            LocalDateTime dt = constant.getDatetime();
+            if (!dt.toLocalTime().equals(LocalTime.MIDNIGHT)) {
+                return Optional.empty();
+            }
+            return Optional.of(ConstantOperator.createVarchar(toDateString(dt)));
+        }
+        if (type.isStringType()) {
+            String value = constant.getVarchar();
+            if (DATE_STRING.matcher(value).matches()) {
+                return Optional.of(constant);
+            }
+            java.util.regex.Matcher m = MIDNIGHT_DATETIME_STRING.matcher(value);
+            if (m.matches()) {
+                return Optional.of(ConstantOperator.createVarchar(m.group(1)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static String toDateString(LocalDateTime dateTime) {
+        return dateTime.toLocalDate().toString(); // ISO-8601 -> yyyy-MM-dd
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedStringDatePredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedStringDatePredicateRuleTest.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.DateType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+public class SimplifiedStringDatePredicateRuleTest {
+    private final SimplifiedStringDatePredicateRule rule = new SimplifiedStringDatePredicateRule();
+
+    private static ColumnRefOperator stringColumn() {
+        return new ColumnRefOperator(1, VarcharType.VARCHAR, "datestr", true);
+    }
+
+    // CAST(strcol AS DATETIME) = datetime '2026-05-30 00:00:00' -> strcol = '2026-05-30'
+    @Test
+    public void testEqualityCastColumnDatetimeMidnight() {
+        ScalarOperator castColumn = new CastOperator(DateType.DATETIME, stringColumn());
+        ConstantOperator midnight =
+                ConstantOperator.createDatetime(LocalDateTime.of(2026, 5, 30, 0, 0, 0));
+        ScalarOperator result = rule.apply(new BinaryPredicateOperator(BinaryType.EQ, castColumn, midnight), null);
+        Assertions.assertEquals("1: datestr = 2026-05-30", result.toString());
+    }
+
+    // bare DATE constant: CAST(strcol AS DATE) = date '2026-05-30' -> strcol = '2026-05-30'
+    @Test
+    public void testEqualityCastColumnDate() {
+        ScalarOperator castColumn = new CastOperator(DateType.DATE, stringColumn());
+        ConstantOperator date = ConstantOperator.createDate(LocalDateTime.of(2026, 5, 30, 0, 0, 0));
+        ScalarOperator result = rule.apply(new BinaryPredicateOperator(BinaryType.EQ, castColumn, date), null);
+        Assertions.assertEquals("1: datestr = 2026-05-30", result.toString());
+    }
+
+    // range comparison preserved (lexicographic == chronological for canonical yyyy-MM-dd)
+    @Test
+    public void testRangeCastColumn() {
+        ScalarOperator castColumn = new CastOperator(DateType.DATETIME, stringColumn());
+        ConstantOperator midnight =
+                ConstantOperator.createDatetime(LocalDateTime.of(2026, 5, 29, 0, 0, 0));
+        ScalarOperator result = rule.apply(new BinaryPredicateOperator(BinaryType.GE, castColumn, midnight), null);
+        Assertions.assertEquals("1: datestr >= 2026-05-29", result.toString());
+    }
+
+    // datetime constant with a real time component must NOT be rewritten (would lose precision).
+    @Test
+    public void testNonMidnightDatetimeNotRewritten() {
+        ScalarOperator castColumn = new CastOperator(DateType.DATETIME, stringColumn());
+        ConstantOperator noon = ConstantOperator.createDatetime(LocalDateTime.of(2026, 5, 30, 12, 0, 0));
+        BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, castColumn, noon);
+        ScalarOperator result = rule.apply(predicate, null);
+        Assertions.assertSame(predicate, result);
+    }
+
+    // string column directly compared to a varchar datetime-midnight literal -> date-only.
+    @Test
+    public void testBareStringColumnMidnightStringLiteral() {
+        ConstantOperator midnightString = ConstantOperator.createVarchar("2026-05-30 00:00:00");
+        ScalarOperator result =
+                rule.apply(new BinaryPredicateOperator(BinaryType.EQ, stringColumn(), midnightString), null);
+        Assertions.assertEquals("1: datestr = 2026-05-30", result.toString());
+    }
+
+    // IN with mixed-format render: ('2026-05-30', '2026-05-18 00:00:00') -> both date-only.
+    @Test
+    public void testInPredicateMixedFormat() {
+        InPredicateOperator in = new InPredicateOperator(false, ImmutableList.of(
+                stringColumn(),
+                ConstantOperator.createVarchar("2026-05-30"),
+                ConstantOperator.createVarchar("2026-05-18 00:00:00")));
+        ScalarOperator result = rule.apply(in, null);
+        Assertions.assertEquals("1: datestr IN (2026-05-30, 2026-05-18)", result.toString());
+    }
+
+    // IN with a temporal constant element (DATETIME midnight) -> date-only string.
+    @Test
+    public void testInPredicateDatetimeConstant() {
+        InPredicateOperator in = new InPredicateOperator(false, ImmutableList.of(
+                stringColumn(),
+                ConstantOperator.createDate(LocalDateTime.of(2026, 5, 30, 0, 0, 0)),
+                ConstantOperator.createDatetime(LocalDateTime.of(2026, 5, 18, 0, 0, 0))));
+        ScalarOperator result = rule.apply(in, null);
+        Assertions.assertEquals("1: datestr IN (2026-05-30, 2026-05-18)", result.toString());
+    }
+
+    // non-string column is untouched.
+    @Test
+    public void testNonStringColumnNotRewritten() {
+        ColumnRefOperator dateColumn = new ColumnRefOperator(1, DateType.DATE, "dt", true);
+        ConstantOperator date = ConstantOperator.createDate(LocalDateTime.of(2026, 5, 30, 0, 0, 0));
+        BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, dateColumn, date);
+        ScalarOperator result = rule.apply(predicate, null);
+        Assertions.assertSame(predicate, result);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Querying a **STRING** date-partition column (e.g. `datestr`, `datestr_ist`, canonical `yyyy-MM-dd`) with `current_date()` / `current_date() - interval ...` returned **empty results** or behaved inconsistently across `=`, `IN`, and range comparisons, and across Iceberg / Delta / partitioned / unpartitioned tables.

Example (Delta, partitioned):

```sql
-- works
select distinct datestr from catalog.database.order where datestr >= current_date() - interval '1' day;
-- empty (bug)
select distinct datestr from catalog.database.order where datestr  = current_date() - interval '1' day;
```

Plan of the failing query:

```
0:DeltaLakeScanNode
   PARTITION PREDICATES: CAST(94: datestr AS DATETIME) = '2026-05-29 00:00:00'
   partitions=0/1788          <-- all partitions pruned away
```

### Root cause

A temporal constant's **string rendering is type-driven**, not value-driven:

- `current_date()` folds to a **DATE** constant → renders `'2026-05-30'`
- `current_date() - interval '1' day` folds to a **DATETIME** constant (analyzer casts the interval-arithmetic operand to DATETIME, `ExpressionAnalyzer#visitTimestampArithmeticExpr`) → renders `'2026-05-30 00:00:00'` (always carries a time component)

When compared with a STRING column, two different type-coercion paths produce two different shapes:

| Path | Coercion function | Result |
|------|-------------------|--------|
| `=` / range | `TypeManager.getCompatibleTypeForBinary` (string ⨯ date → **DATETIME**) | wraps column: `CAST(datestr AS DATETIME) = '... 00:00:00'` |
| `IN` / `BETWEEN` | `TypeManager.getCompatibleTypeForBetweenAndIn` (→ **VARCHAR**) | renders constants to string; DATETIME element keeps `00:00:00` |

Visible in a mixed `IN` list:

```
PARTITION PREDICATES: 83: datestr IN ('2026-05-30', '2026-05-18 00:00:00')
                                      ^date-only       ^datetime (interval branch)
```

Lake connector predicate converters (`ScalarOperatorToIcebergExpr`, `ScalarOperationToDeltaLakeExpr`) **strip the cast** (`ExtractColumnName.visitCastOperator` recurses through it) and compare the literal against the **physical STRING** column values. Stored `'2026-05-30'` vs `'2026-05-30 00:00:00'` in the **string domain** → never matches → empty. `>=` survives only by lexicographic accident; equality cannot. OLAP/internal tables are unaffected (they keep the predicate as a per-row residual filter evaluated by `TimestampValue::from_string`, not a cast-stripped pushdown).

## What I'm doing:

New scan-predicate rewrite rule **`SimplifiedStringDatePredicateRule`** (runs after constant folding, in `DEFAULT_REWRITE_SCAN_PREDICATE_RULES`). For a STRING column (bare or wrapped in `CAST(strcol AS DATE|DATETIME)`) compared to a temporal/date-string constant, it normalizes to a pure **string-domain, date-only** comparison — **only when the constant has no non-midnight time component**:

```
CAST(datestr AS DATETIME) =  '2026-05-30 00:00:00'   ->  datestr =  '2026-05-30'
datestr                   >= '2026-05-29 00:00:00'   ->  datestr >= '2026-05-29'
datestr IN ('2026-05-30', '2026-05-18 00:00:00')     ->  datestr IN ('2026-05-30', '2026-05-18')
```

Collapses every permutation (`=` / `IN` / range × DATE / DATETIME × `current_date()` / `- interval`) onto a single shape that both connector push-down and partition pruner handle natively. Connector-agnostic: fixes Iceberg + Delta (any string-partition lake table), partitioned and unpartitioned.

**Correctness / assumptions:**
- Canonical zero-padded `yyyy-MM-dd` strings: lexicographic order == chronological order, so ranges stay correct.
- A DATETIME constant with a real, non-midnight time (`= '2026-05-30 12:00:00'`) is **not** rewritten — datetime semantics preserved, no silent precision loss.
- Rule is **idempotent** (returns the original operator instance when nothing changes) so the fixpoint rewriter terminates.

**Safety / config:** This layer has no partition metadata, so it cannot distinguish a string column holding dates from one holding arbitrary text. A column storing literal `'yyyy-MM-dd 00:00:00'` values would be truncated to date-only. Escape hatch — disable per-session or globally:

```sql
SET enable_rewrite_string_date_predicate = false;   -- default: true
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
    - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [x] 3.5