### PR TITLE
[BugFix] Treat now(N)/current_timestamp(N) defaults as stable consts

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -80,13 +80,13 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.starrocks.catalog.DefaultExpr.isEmptyDefaultTimeFunction;
 import static com.starrocks.catalog.DefaultExpr.isValidDefaultTimeFunction;
 import static com.starrocks.common.util.DateUtils.DATE_TIME_FORMATTER;
 
@@ -753,7 +753,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public DefaultValueType getDefaultValueType() {
         if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
+            if (defaultExpr.isTimeFunction()) {
+                // now() / now(N) / current_timestamp(N): stable within a statement, materializes to
+                // a single value, so it is a const default - the precision argument does not make it volatile.
                 return DefaultValueType.CONST;
             } else if (defaultExpr.hasExprObject()) {
                 return DefaultValueType.CONST;
@@ -773,15 +775,18 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // If the default value is uuid(), this function is not suitable.
     public String calculatedDefaultValue() {
         if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
-                // current transaction time
+            if (defaultExpr.isTimeFunction()) {
+                int scale = defaultExpr.getTimeFunctionScale();
+                // current transaction time; use the full start Instant (microsecond precision), not
+                // getStartTime() which truncates to epoch milliseconds and would drop the sub-millisecond
+                // digits of CURRENT_TIMESTAMP(4..6) that BE's now(N) keeps via query_globals timestamp_us.
                 if (ConnectContext.get() != null) {
-                    LocalDateTime localDateTime = Instant.ofEpochMilli(ConnectContext.get().getStartTime())
+                    LocalDateTime localDateTime = ConnectContext.get().getStartTimeInstant()
                             .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
-                    return localDateTime.format(DATE_TIME_FORMATTER);
+                    return formatDateTimeWithScale(localDateTime, scale);
                 } else {
                     // should not run up here
-                    return LocalDateTime.now().format(DATE_TIME_FORMATTER);
+                    return formatDateTimeWithScale(LocalDateTime.now(), scale);
                 }
             }
         }
@@ -793,6 +798,20 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return null;
     }
 
+    // Format a timestamp into a time-function default literal honoring its fractional-second scale.
+    // scale 0 -> "yyyy-MM-dd HH:mm:ss"; scale N -> N fractional digits. DATETIME stores microseconds,
+    // so the frozen literal must carry the precision or now(N) would silently collapse to seconds.
+    private static String formatDateTimeWithScale(LocalDateTime dateTime, int scale) {
+        if (scale <= 0) {
+            return dateTime.format(DATE_TIME_FORMATTER);
+        }
+        StringBuilder pattern = new StringBuilder("yyyy-MM-dd HH:mm:ss.");
+        for (int i = 0; i < scale; i++) {
+            pattern.append('S');
+        }
+        return dateTime.format(DateTimeFormatter.ofPattern(pattern.toString()));
+    }
+
     // if the column have a default value or default expr can be calculated like now(). return calculated value
     // else for a batch of every row different like uuid(). return null
     // require specify currentTimestamp. this will get the default value of the incoming time
@@ -801,10 +820,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // If the default value is uuid(), this function is not suitable.
     public String calculatedDefaultValueWithTime(long currentTimestamp) {
         if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
+            if (defaultExpr.isTimeFunction()) {
                 LocalDateTime localDateTime = Instant.ofEpochMilli(currentTimestamp)
                         .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
-                return localDateTime.format(DATE_TIME_FORMATTER);
+                return formatDateTimeWithScale(localDateTime, defaultExpr.getTimeFunctionScale());
             } else if (defaultExpr.hasExprObject()) {
                 // For expr object type default expressions, return null
                 // The actual default value will be evaluated in BE from TExpr
@@ -823,11 +842,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         // Generator expressions must win over any materialized defaultValue: schema-change paths freeze
         // ALTER-time into defaultValue so BE can backfill existing rows, but metadata callers (DESCRIBE,
         // information_schema.columns) must still report the generator, not the frozen literal.
-        if (defaultExpr != null && isEmptyDefaultTimeFunction(defaultExpr)) {
+        if (defaultExpr != null && defaultExpr.isTimeFunction()) {
             if (extras != null) {
                 extras.add("DEFAULT_GENERATED");
             }
-            return "CURRENT_TIMESTAMP";
+            int scale = defaultExpr.getTimeFunctionScale();
+            return scale > 0 ? "CURRENT_TIMESTAMP(" + scale + ")" : "CURRENT_TIMESTAMP";
         }
         if (defaultValue != null) {
             return defaultValue;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
@@ -43,13 +43,16 @@ import java.util.regex.Pattern;
 public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(DefaultExpr.class);
 
+    // Captures the fractional-second scale from a time-function default, e.g. "now(3)" -> 3.
+    private static final Pattern TIME_FUNCTION_SCALE_PATTERN = Pattern.compile("\\(\\s*(\\d+)\\s*\\)");
+
     @SerializedName("expr")
     private String expr;
 
     // StarRocks Gson skips fields without @SerializedName (see HiddenAnnotationExclusionStrategy).
-    // Without persistence this flag flipped to false after FE restart / edit-log replay, which made
-    // isEmptyDefaultTimeFunction misclassify "current_timestamp(N)" as the empty form and silently
-    // dropped its precision argument.
+    // Without persistence this flag flipped to false after FE restart / edit-log replay, which lost
+    // the distinction between the bare now() / current_timestamp() form and the precision-bearing
+    // now(N) form when rendering the default back to SQL (toSql / SHOW CREATE TABLE).
     @SerializedName("hasArguments")
     private boolean hasArguments;
 
@@ -150,9 +153,24 @@ public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
         return matcher.matches();
     }
 
-    public static boolean isEmptyDefaultTimeFunction(DefaultExpr expr) {
-        return expr.getExprObject() == null && expr.getExpr() != null &&
-                isValidDefaultTimeFunction(expr.getExpr()) && !expr.hasArgs();
+    // A stable time-function default: now() / now(N) / current_timestamp() / current_timestamp(N).
+    // These are constant within a statement, so they materialize to a single value at a given time
+    // (with fractional-second scale N). They are NOT volatile - unlike uuid(), every row of one
+    // statement sees the same value. Classification is by function identity, not by whether the
+    // precision argument is present.
+    public boolean isTimeFunction() {
+        return !hasExprObject() && expr != null && isValidDefaultTimeFunction(expr);
+    }
+
+    // Fractional-second scale of a time-function default (e.g. now(3) -> 3); 0 for the bare
+    // now() / current_timestamp() form. Read straight from the canonical expr string so it never
+    // depends on the historically-fragile hasArguments flag.
+    public int getTimeFunctionScale() {
+        if (!isTimeFunction()) {
+            return 0;
+        }
+        Matcher matcher = TIME_FUNCTION_SCALE_PATTERN.matcher(expr);
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
     }
 
     public Expr obtainExpr() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
@@ -99,9 +99,10 @@ public class ColumnGsonSerializationTest {
         Assertions.assertNotNull(restored.getDefaultExpr());
         Assertions.assertTrue(restored.getDefaultExpr().hasArgs(),
                 "hasArguments must persist across Gson roundtrip");
-        // VARY rather than CONST: precision-bearing time functions are not 'empty' generators.
-        Assertions.assertEquals(Column.DefaultValueType.VARY, restored.getDefaultValueType(),
-                "current_timestamp(N) must stay classified as VARY after roundtrip");
+        // CONST, not VARY: precision-bearing time functions are stable within a statement (every row
+        // sees the same value), so the precision argument does not make them volatile.
+        Assertions.assertEquals(Column.DefaultValueType.CONST, restored.getDefaultValueType(),
+                "current_timestamp(N) must be classified as CONST after roundtrip");
     }
 
     @Test
@@ -123,7 +124,7 @@ public class ColumnGsonSerializationTest {
         Assertions.assertEquals("current_timestamp(3)", restored.getDefaultExpr().getExpr());
         Assertions.assertTrue(restored.getDefaultExpr().hasArgs(),
                 "legacy persisted current_timestamp(3) must recover hasArguments via gsonPostProcess");
-        Assertions.assertEquals(Column.DefaultValueType.VARY, restored.getDefaultValueType());
+        Assertions.assertEquals(Column.DefaultValueType.CONST, restored.getDefaultValueType());
 
         // An empty-arg form persisted under the same legacy schema must stay empty.
         FunctionCallExpr emptyExpr = new FunctionCallExpr("current_timestamp", Lists.newArrayList());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -44,6 +45,7 @@ import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnDef.DefaultValueDef;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.thrift.TColumn;
@@ -320,5 +322,51 @@ public class ColumnTest {
         String toSql = column.toSqlWithoutAggregateTypeName(null);
 
         Assertions.assertEquals("`col` json NULL COMMENT \"{\\\"id\\\":\\\"0\\\",\\\"value\\\":\\\"1\\\"}\"", toSql);
+    }
+
+    @Test
+    public void testTimeFunctionDefaultIsConstWithPrecision() {
+        // now(N)/current_timestamp(N) are stable within a statement, so they are CONST (not volatile),
+        // and the materialized literal keeps the N fractional-second digits (DATETIME stores microseconds).
+        // Fractional digits are timezone-invariant, so we can assert on them without pinning a time zone.
+        long ts = 1_000_000_000_789L; // ...789 milliseconds since epoch
+
+        Column ctsN = timeFunctionColumn("current_timestamp", 3);
+        Assertions.assertTrue(ctsN.getDefaultExpr().isTimeFunction());
+        Assertions.assertEquals(Column.DefaultValueType.CONST, ctsN.getDefaultValueType());
+        Assertions.assertEquals(3, ctsN.getDefaultExpr().getTimeFunctionScale());
+        String v3 = ctsN.calculatedDefaultValueWithTime(ts);
+        Assertions.assertTrue(v3.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}"),
+                "now(3) default must carry exactly 3 fractional digits, got: " + v3);
+        Assertions.assertTrue(v3.endsWith(".789"), "fractional part must be preserved, got: " + v3);
+        // Metadata reports the generator (with precision), never the frozen literal.
+        Assertions.assertEquals("CURRENT_TIMESTAMP(3)", ctsN.getMetaDefaultValue(new ArrayList<>()));
+
+        Column now6 = timeFunctionColumn("now", 6);
+        Assertions.assertEquals(Column.DefaultValueType.CONST, now6.getDefaultValueType());
+        Assertions.assertEquals(6, now6.getDefaultExpr().getTimeFunctionScale());
+        Assertions.assertTrue(now6.calculatedDefaultValueWithTime(ts).endsWith(".789000"),
+                "now(6) pads a millisecond-resolution source out to 6 digits");
+
+        Column nowEmpty = timeFunctionColumn("now", -1);
+        Assertions.assertEquals(Column.DefaultValueType.CONST, nowEmpty.getDefaultValueType());
+        Assertions.assertEquals(0, nowEmpty.getDefaultExpr().getTimeFunctionScale());
+        Assertions.assertFalse(nowEmpty.calculatedDefaultValueWithTime(ts).contains("."),
+                "bare now() stays at second granularity");
+        Assertions.assertEquals("CURRENT_TIMESTAMP", nowEmpty.getMetaDefaultValue(new ArrayList<>()));
+
+        Column uuidCol = new Column("u", VarcharType.VARCHAR, false, null, true,
+                new DefaultValueDef(true, false, new FunctionCallExpr("uuid", Lists.newArrayList())), "");
+        Assertions.assertFalse(uuidCol.getDefaultExpr().isTimeFunction());
+        Assertions.assertEquals(Column.DefaultValueType.VARY, uuidCol.getDefaultValueType(),
+                "uuid() is genuinely per-row volatile and stays VARY");
+    }
+
+    private static Column timeFunctionColumn(String fn, int scale) {
+        FunctionCallExpr expr = scale >= 0
+                ? new FunctionCallExpr(fn, Lists.newArrayList(new IntLiteral(scale, IntegerType.INT)))
+                : new FunctionCallExpr(fn, Lists.newArrayList());
+        return new Column("ts", DateType.DATETIME, false, null, true,
+                new DefaultValueDef(true, scale >= 0, expr), "");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableColumnAlterInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableColumnAlterInfoTest.java
@@ -78,7 +78,9 @@ public class TableColumnAlterInfoTest {
         Assertions.assertNotNull(replayedTs.getDefaultExpr());
         Assertions.assertTrue(replayedTs.getDefaultExpr().hasArgs(),
                 "edit-log replay must preserve hasArguments for current_timestamp(3)");
-        Assertions.assertEquals(Column.DefaultValueType.VARY, replayedTs.getDefaultValueType());
+        // Stable within a statement, hence CONST (not volatile) - the precision argument is preserved
+        // for rendering but does not change the default-value classification.
+        Assertions.assertEquals(Column.DefaultValueType.CONST, replayedTs.getDefaultValueType());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1554,7 +1554,10 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     public static boolean hasMicroseconds(String plan) {
-        Pattern pattern = Pattern.compile("<slot 2>\\s*:\\s*'\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}'");
+        // current_timestamp(N) is a stable const default: it freezes to a single literal (in slot 3, like the
+        // no-precision form), and the plan renders the fractional part with significant digits only, so the
+        // matcher is slot-agnostic and accepts 1-6 fractional digits rather than a fixed six.
+        Pattern pattern = Pattern.compile("'\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{1,6}'");
         Matcher matcher = pattern.matcher(plan);
         return matcher.find();
     }

--- a/test/sql/test_default_now_precision/R/test_default_now_precision
+++ b/test/sql/test_default_now_precision/R/test_default_now_precision
@@ -1,0 +1,88 @@
+-- name: test_add_column_default_now_precision
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column c DATETIME DEFAULT now(3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where c is NULL;
+-- result:
+0
+-- !result
+select count(distinct c) from t where id in (1, 2);
+-- result:
+1
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+-- result:
+CURRENT_TIMESTAMP(3)
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_add_column_default_current_timestamp_precision_not_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column c DATETIME NOT NULL DEFAULT current_timestamp(6);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where c is NULL;
+-- result:
+0
+-- !result
+select count(distinct c) from t where id in (1, 2);
+-- result:
+1
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+-- result:
+CURRENT_TIMESTAMP(6)
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_default_now_precision/T/test_default_now_precision
+++ b/test/sql/test_default_now_precision/T/test_default_now_precision
@@ -1,0 +1,61 @@
+-- name: test_add_column_default_now_precision
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+-- two rows written before column c exists: they physically lack c and are backfilled on read
+insert into t values (1), (2);
+
+-- now(3) is a precision-bearing time function: stable within a statement (NOT volatile like uuid),
+-- so ADD COLUMN must accept it (it was previously rejected as "unsupported default expr") and freeze
+-- a single ALTER-time value for the pre-existing rows.
+alter table t add column c DATETIME DEFAULT now(3);
+function: wait_alter_table_finish()
+
+-- row written after the column was added gets the current statement's now(3)
+insert into t (id) values (3);
+
+-- pre-existing rows are backfilled non-null
+select count(*) from t where c is NULL;
+
+-- id=1 and id=2 both predate c, so they share the SAME frozen ALTER-time value (one distinct)
+select count(distinct c) from t where id in (1, 2);
+
+-- the metadata default reports the generator with its precision, not the frozen literal
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+
+drop database db_${uuid0};
+
+
+-- name: test_add_column_default_current_timestamp_precision_not_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+insert into t values (1), (2);
+
+-- same stable time function with microsecond precision, NOT NULL: still accepted and backfilled
+alter table t add column c DATETIME NOT NULL DEFAULT current_timestamp(6);
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+select count(*) from t where c is NULL;
+select count(distinct c) from t where id in (1, 2);
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`now(N)` / `current_timestamp(N)` column defaults were classified as `VARY`
(per-row volatile) only because the default-kind check special-cased the
no-argument form (`isEmptyDefaultTimeFunction` required `!hasArgs()`). They are
stable within a statement, exactly like `now()` — the precision argument only
changes the fractional-second digits, not the volatility.

This misclassification meant:
- `ADD COLUMN ... DEFAULT now(N)` was rejected with `unsupported default expr`,
  even though `DEFAULT now()` / `DEFAULT current_timestamp` work.
- Several INSERT / load paths threw on `now(N)` defaults (e.g. the INSERT-VALUES
  path raised `unsupported default value`).
- It was papered over by keeping them `VARY` so the seconds-only freeze
  formatter would not drop the precision.

## What I'm doing:

Fixes #74062

Make `DefaultExpr` the single source of truth for the default kind:
- `isTimeFunction()` classifies `now()` / `now(N)` / `current_timestamp()` /
  `current_timestamp(N)` by function identity, not by whether the precision
  argument is present.
- `getTimeFunctionScale()` reads `N` from the canonical expr string,
  independent of the historically-fragile `hasArguments` flag.

Consequences:
- `now(N)` / `current_timestamp(N)` are now `CONST`. `ADD COLUMN` accepts them
  and freezes a single ALTER-time value for pre-existing rows, with no
  special-casing in `SchemaChangeHandler` — the existing CONST freeze path just
  works once the classification is correct.
- The materialized literal preserves the `N` fractional-second digits (DATETIME
  stores microseconds) instead of collapsing to seconds.
- Metadata reports `CURRENT_TIMESTAMP(N)` (the generator), never the frozen literal.
- `uuid()` / `uuid_numeric()` remain `VARY` (genuinely per-row).

BE needs no change: the DATETIME default backfill already parses fractional
seconds via `TimestampValue::from_string`.

Tests:
- `ColumnTest`: classification (`now(3)`→CONST scale 3, `now(6)`, bare `now()`,
  `uuid()`→VARY) and precision-preserving materialization + metadata.
- `ColumnGsonSerializationTest` / `TableColumnAlterInfoTest`: updated the
  assertions that locked in the old `VARY` classification (the `hasArguments`
  round-trip coverage is kept).
- e2e `test/sql/test_default_now_precision`: `ADD COLUMN now(3)` /
  `current_timestamp(6) NOT NULL` accepted; pre-existing rows backfilled
  non-null and share one frozen value; `column_default` reports
  `CURRENT_TIMESTAMP(N)`. Validated on a live cluster.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
