### PR TITLE
[Tool] Add doc-code sync tooling for tech writer workflow

### DIFF
--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -88,13 +88,16 @@ jobs:
           printf "%b" "$change_types" > /tmp/change_types.txt
           echo "saved to /tmp/change_types.txt"
 
-      # Run the extraction script against the merged commit to find new undocumented params
+      # Run the extraction script against the merged commit to find new undocumented params.
+      # The merge commit is already checked out; diff against its first parent (HEAD^1).
+      # set +e so the step continues even when the script exits 1 (gaps found).
       - name: Detect new undocumented parameters
         id: params
-        # The merge commit is already checked out; diff against its first parent
         run: |
+          set +e
           python3 build-support/extract_and_diff_params.py \
             --new-params-only \
+            --diff-base HEAD^1 \
             --output json \
             > /tmp/param_drift.json 2>&1
           echo "exitcode=$?" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -1,0 +1,189 @@
+name: CI Doc Needs Update
+
+# When a PR merges to main and declares a behavior change but documentation
+# was not added, opens a GitHub issue labeled 'docs-maintainer' so the
+# tech writer's weekly workflow picks it up automatically.
+#
+# The issue body includes:
+#   - PR metadata (title, number, URL, author)
+#   - The behavior-change type checkboxes that were checked
+#   - A table of any new config parameters / session variables detected in the
+#     diff that have no corresponding documentation entry
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  doc-needed-check:
+    runs-on: ubuntu-latest
+    name: Open doc-needed issue
+    # Fire only on merged PRs that declared a behavior change but did not check
+    # the "I have added documentation" box. Doc PRs themselves are excluded.
+    if: >
+      github.event.pull_request.merged == true &&
+      github.base_ref == 'main' &&
+      github.repository == 'StarRocks/starrocks' &&
+      !startsWith(github.event.pull_request.title, '[Doc]') &&
+      contains(toJson(github.event.pull_request.body), '[x] Yes, this PR will result in a change in behavior.') &&
+      contains(toJson(github.event.pull_request.body), '[ ] I have added documentation for my new feature or new function')
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Checkout the merged commit so we can run the diff script
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Ensure the docs-maintainer label exists (idempotent)
+      - name: Ensure labels exist
+        run: |
+          gh label create "docs-maintainer" \
+            --description "Picked up by the weekly docs triage workflow" \
+            --color "0075ca" --force || true
+          gh label create "documentation" \
+            --description "Documentation changes" \
+            --color "0075ca" --force || true
+
+      # Extract which behavior-change type boxes were checked
+      - name: Extract change types
+        id: changetype
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          change_types=""
+          while IFS= read -r phrase; do
+            if echo "$PR_BODY" | grep -qF "[x] ${phrase}"; then
+              change_types="${change_types}- ${phrase}\n"
+            fi
+          done << 'EOF'
+          Interface/UI changes: syntax, type conversion, expression evaluation, display information
+          Parameter changes: default values, similar parameters but with different default values
+          Policy changes: use new policy to replace old one, functionality automatically enabled
+          Feature removed
+          Miscellaneous: upgrade & downgrade compatibility, etc.
+          EOF
+          if [ -z "$change_types" ]; then
+            change_types="- (no specific type checked)\n"
+          fi
+          # Store as a file to preserve newlines
+          printf "%b" "$change_types" > /tmp/change_types.txt
+          echo "saved to /tmp/change_types.txt"
+
+      # Run the extraction script against the merged commit to find new undocumented params
+      - name: Detect new undocumented parameters
+        id: params
+        # The merge commit is already checked out; diff against its first parent
+        run: |
+          python3 build-support/extract_and_diff_params.py \
+            --new-params-only \
+            --output json \
+            > /tmp/param_drift.json 2>&1
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+
+      # Build the issue body from the collected data
+      - name: Build issue body
+        id: issuebody
+        run: |
+          python3 - << 'PYEOF'
+          import json, os, sys
+
+          pr_number = os.environ["PR_NUMBER"]
+          pr_title = os.environ["PR_TITLE"]
+          pr_url = os.environ["PR_URL"]
+          pr_author = os.environ["PR_AUTHOR"]
+
+          with open("/tmp/change_types.txt") as f:
+              change_types = f.read().strip()
+
+          # Load param drift data (may be empty or have gaps)
+          try:
+              with open("/tmp/param_drift.json") as f:
+                  drift = json.load(f)
+          except Exception:
+              drift = {}
+
+          lines = [
+              "## Documentation needed for merged PR",
+              "",
+              f"PR #{pr_number} was merged and declared a behavior change, "
+              "but documentation was not added. Please review and update the docs.",
+              "",
+              f"**PR:** [{pr_title}]({pr_url})",
+              f"**Author:** @{pr_author}",
+              f"**Behavior change types declared:**",
+              change_types,
+          ]
+
+          # Emit per-param tables if any gaps were detected
+          sections = [
+              ("FE Configuration", drift.get("fe_config", {}).get("missing_from_docs", []),
+               "docs/en/administration/management/FE_parameters/"),
+              ("BE Configuration", drift.get("be_config", {}).get("missing_from_docs", []),
+               "docs/en/administration/management/BE_parameters/"),
+              ("Session / Global Variables", drift.get("session_var", {}).get("missing_from_docs", []),
+               "docs/en/sql-reference/System_variable.md"),
+          ]
+
+          any_params = any(rows for _, rows, _ in sections)
+          if any_params:
+              lines.append("## New parameters detected with no documentation entry")
+              lines.append("")
+              for title, rows, doc_path in sections:
+                  if not rows:
+                      continue
+                  lines.append(f"### {title}")
+                  lines.append("")
+                  lines.append("| Parameter | Type | Default | Mutable | Description | Suggested doc |")
+                  lines.append("|-----------|------|---------|---------|-------------|---------------|")
+                  for p in sorted(rows, key=lambda x: x["name"]):
+                      desc = p.get("description") or "—"
+                      mut = "Yes" if p.get("mutable") else "No"
+                      lines.append(
+                          f"| `{p['name']}` | {p.get('code_type','')} | "
+                          f"`{p.get('default','')}` | {mut} | {desc} | {doc_path} |"
+                      )
+                  lines.append("")
+
+          lines += [
+              "## Action required",
+              "",
+              "- [ ] Review the PR diff and update the relevant documentation",
+              "- [ ] Close this issue when documentation is published",
+              "",
+              "_Auto-generated by `ci-doc-needs-update.yml`_",
+          ]
+
+          body = "\n".join(lines)
+          # Write to file so gh can read it (avoids shell quoting issues)
+          with open("/tmp/issue_body.md", "w") as f:
+              f.write(body)
+
+          print("Issue body written to /tmp/issue_body.md")
+          PYEOF
+
+      - name: Create doc-needed issue
+        run: |
+          gh issue create \
+            --title "Docs needed: ${PR_TITLE}" \
+            --label "documentation,docs-maintainer" \
+            --body-file /tmp/issue_body.md \
+            --repo ${{ github.repository }}

--- a/.github/workflows/ci-doc-param-drift.yml
+++ b/.github/workflows/ci-doc-param-drift.yml
@@ -1,0 +1,95 @@
+name: CI Doc Param Drift
+
+# Runs when a PR modifies any of the config source-of-truth files.
+# Posts a PR comment listing any new parameters that have no documentation entry.
+# Does NOT block merge — the comment is informational only.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+      - 'branch*'
+    paths:
+      - 'fe/fe-core/src/main/java/com/starrocks/common/Config.java'
+      - 'fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java'
+      - 'fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java'
+      - 'be/src/common/config.h'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  param-drift-check:
+    runs-on: ubuntu-latest
+    name: Check new params for missing docs
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+
+    steps:
+      - name: Clean workspace
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: Record base branch
+        id: branch
+        run: echo "branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Check out the PR head merged with the base branch, matching the pattern
+      # used by ci-doc-checker.yml.
+      - name: Checkout PR
+        run: |
+          BRANCH=${{ steps.branch.outputs.branch }}
+          git config --global user.name "docs-automation[bot]"
+          git config --global user.email "docs-automation[bot]@starrocks.io"
+          git checkout $BRANCH
+          git pull
+          BRANCH_NAME="${BRANCH}-${PR_NUMBER}"
+          git fetch origin pull/${PR_NUMBER}/head:${BRANCH_NAME}
+          git checkout $BRANCH_NAME
+          git checkout -b merge_pr
+          git merge --squash --no-edit ${BRANCH} || \
+            (echo "::error::Merge conflict — cannot check param drift." && exit 1)
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run param drift check
+        id: drift
+        # Exit code 0 = no new undocumented params; 1 = gaps found.
+        # Continue so the comment step always runs (to clear stale comments).
+        continue-on-error: true
+        run: |
+          python3 build-support/extract_and_diff_params.py \
+            --new-params-only \
+            --output github-comment \
+            > drift_report.md 2>&1
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+
+      - name: Post or update PR comment (gaps found)
+        if: steps.drift.outputs.exitcode == '1'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: drift_report.md
+          comment_tag: param-drift
+          mode: upsert
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clear PR comment (no gaps)
+        if: steps.drift.outputs.exitcode != '1'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            No new undocumented parameters detected by the param-drift check.
+          comment_tag: param-drift
+          mode: upsert
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-doc-param-drift.yml
+++ b/.github/workflows/ci-doc-param-drift.yml
@@ -39,25 +39,19 @@ jobs:
         id: branch
         run: echo "branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
 
+      # Check out the base branch only. This is intentional: pull_request_target
+      # runs with a write-scoped token, so we must not execute scripts from the
+      # PR head (which is untrusted). We run the checker from the trusted base
+      # checkout and separately fetch the PR diff to identify new params.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
 
-      # Check out the PR head merged with the base branch, matching the pattern
-      # used by ci-doc-checker.yml.
-      - name: Checkout PR
+      # Fetch the PR head so git diff can compare against it
+      - name: Fetch PR head for diffing
         run: |
-          BRANCH=${{ steps.branch.outputs.branch }}
-          git config --global user.name "docs-automation[bot]"
-          git config --global user.email "docs-automation[bot]@starrocks.io"
-          git checkout $BRANCH
-          git pull
-          BRANCH_NAME="${BRANCH}-${PR_NUMBER}"
-          git fetch origin pull/${PR_NUMBER}/head:${BRANCH_NAME}
-          git checkout $BRANCH_NAME
-          git checkout -b merge_pr
-          git merge --squash --no-edit ${BRANCH} || \
-            (echo "::error::Merge conflict — cannot check param drift." && exit 1)
+          git fetch origin pull/${{ env.PR_NUMBER }}/head:pr-head
 
       - uses: actions/setup-python@v5
         with:
@@ -65,12 +59,11 @@ jobs:
 
       - name: Run param drift check
         id: drift
-        # Exit code 0 = no new undocumented params; 1 = gaps found.
-        # Continue so the comment step always runs (to clear stale comments).
-        continue-on-error: true
         run: |
+          set +e
           python3 build-support/extract_and_diff_params.py \
             --new-params-only \
+            --diff-base "origin/${{ steps.branch.outputs.branch }}" \
             --output github-comment \
             > drift_report.md 2>&1
           echo "exitcode=$?" >> $GITHUB_OUTPUT

--- a/build-support/extract_and_diff_params.py
+++ b/build-support/extract_and_diff_params.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Compare StarRocks config parameters and session variables against documentation.
+
+Parses three source-of-truth files and compares their parameters against the
+hand-written Markdown documentation to find undocumented (missing) and removed
+(stale) entries.
+
+Usage:
+  # Full gap report — all undocumented params across all categories
+  python3 build-support/extract_and_diff_params.py
+
+  # Only report params added in the current git branch (for CI on PRs)
+  python3 build-support/extract_and_diff_params.py --new-params-only
+
+  # JSON output (used by ci-doc-needs-update.yml to build the issue body)
+  python3 build-support/extract_and_diff_params.py --output json
+
+  # GitHub-comment Markdown (used by ci-doc-param-drift.yml to post a PR comment)
+  python3 build-support/extract_and_diff_params.py --new-params-only --output github-comment
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# ── Source-of-truth paths ────────────────────────────────────────────────────
+
+FE_CONFIG_PATH = (
+    REPO_ROOT / "fe/fe-core/src/main/java/com/starrocks/common/Config.java"
+)
+SESSION_VAR_PATH = (
+    REPO_ROOT / "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+)
+GLOBAL_VAR_PATH = (
+    REPO_ROOT / "fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java"
+)
+BE_CONFIG_PATH = REPO_ROOT / "be/src/common/config.h"
+
+# ── Documentation paths ──────────────────────────────────────────────────────
+
+FE_PARAM_DOCS = [
+    REPO_ROOT / "docs/en/administration/management/FE_parameters/log_server_meta.md",
+    REPO_ROOT / "docs/en/administration/management/FE_parameters/user_query_loading.md",
+    REPO_ROOT / "docs/en/administration/management/FE_parameters/stats_storage.md",
+    REPO_ROOT / "docs/en/administration/management/FE_parameters/shared_lake_other.md",
+]
+BE_PARAM_DOCS = [
+    REPO_ROOT / "docs/en/administration/management/BE_parameters/log_server_meta.md",
+    REPO_ROOT / "docs/en/administration/management/BE_parameters/query_loading.md",
+    REPO_ROOT / "docs/en/administration/management/BE_parameters/stats_storage.md",
+    REPO_ROOT / "docs/en/administration/management/BE_parameters/shared_lake_other.md",
+]
+SESSION_VAR_DOCS = [
+    REPO_ROOT / "docs/en/sql-reference/System_variable.md",
+]
+
+ALL_SOURCE_PATHS = [FE_CONFIG_PATH, BE_CONFIG_PATH, SESSION_VAR_PATH, GLOBAL_VAR_PATH]
+
+
+# ── Data model ───────────────────────────────────────────────────────────────
+
+@dataclass
+class ParamInfo:
+    name: str
+    param_type: str       # 'fe_config' | 'be_config' | 'session_var'
+    code_type: str = ""   # Java type or C++ macro type suffix
+    default: str = ""
+    mutable: bool = False
+    description: str = ""
+    suggested_doc: str = ""
+
+
+# ── FE Config.java parser ────────────────────────────────────────────────────
+
+_FIELD_RE = re.compile(
+    r"public\s+static\s+(?:final\s+)?(\S+(?:\[\])?)\s+([a-z_][a-z0-9_]*)\s*="
+)
+
+
+def parse_fe_configs(path: Path) -> dict[str, ParamInfo]:
+    """
+    Extract @ConfField-annotated parameters from Config.java.
+
+    Handles:
+    - @ConfField with no args (immutable)
+    - @ConfField(mutable = true, comment = "...")
+    - @Deprecated @ConfField (excluded from output)
+    - Multi-line field initializers
+    """
+    params: dict[str, ParamInfo] = {}
+    lines = path.read_text().splitlines()
+    n = len(lines)
+    i = 0
+
+    while i < n:
+        stripped = lines[i].strip()
+
+        if not stripped.startswith("@ConfField"):
+            i += 1
+            continue
+
+        # Check if @Deprecated appears on the immediately preceding non-blank line
+        prev = i - 1
+        while prev >= 0 and not lines[prev].strip():
+            prev -= 1
+        deprecated = prev >= 0 and lines[prev].strip() == "@Deprecated"
+
+        # Collect full annotation (may span lines when it has arguments)
+        ann_text = stripped
+        while ann_text.count("(") > ann_text.count(")"):
+            i += 1
+            if i >= n:
+                break
+            ann_text += " " + lines[i].strip()
+
+        # Advance past any other annotations between @ConfField and the field declaration
+        i += 1
+        while i < n and lines[i].strip().startswith("@"):
+            i += 1
+
+        if i >= n:
+            break
+
+        # Collect field declaration (may span lines when the initializer is complex)
+        field_text = lines[i].strip()
+        while "public static" in field_text and ";" not in field_text:
+            i += 1
+            if i >= n:
+                break
+            field_text += " " + lines[i].strip()
+
+        if "public static" not in field_text:
+            i += 1
+            continue
+
+        m = _FIELD_RE.search(field_text)
+        if m and not deprecated:
+            code_type = m.group(1)
+            name = m.group(2)
+
+            # Simplified default extraction: everything between '=' and first ';'
+            default_m = re.search(r"=\s*(.+?)(?:\s*//.*)?;", field_text)
+            default = default_m.group(1).strip() if default_m else ""
+
+            comment_m = re.search(r'comment\s*=\s*"([^"]*)"', ann_text)
+            description = comment_m.group(1) if comment_m else ""
+
+            params[name] = ParamInfo(
+                name=name,
+                param_type="fe_config",
+                code_type=code_type,
+                default=default,
+                mutable=bool(re.search(r"mutable\s*=\s*true", ann_text)),
+                description=description,
+                suggested_doc="docs/en/administration/management/FE_parameters/",
+            )
+
+        i += 1
+
+    return params
+
+
+# ── BE config.h parser ───────────────────────────────────────────────────────
+
+_CONF_MACRO_RE = re.compile(
+    r'^\s*CONF_(m?)([A-Za-z0-9]+)\(\s*([a-z_][a-z0-9_]+)\s*,\s*"([^"]*)"\s*\)\s*;'
+)
+_INCLUDE_RE = re.compile(r'^\s*#include\s+"(config_[^"]+\.h)"\s*$')
+
+
+def _be_config_files(path: Path) -> list[Path]:
+    """Return config.h plus any local config_*.h includes (non-fwd)."""
+    files = [path]
+    for line in path.read_text().splitlines():
+        m = _INCLUDE_RE.match(line)
+        if m and not m.group(1).endswith("_fwd.h"):
+            candidate = path.parent / m.group(1)
+            if candidate.exists():
+                files.append(candidate)
+    return files
+
+
+def parse_be_configs(path: Path) -> dict[str, ParamInfo]:
+    """
+    Extract CONF_* macro parameters from config.h and its local includes.
+
+    The 'm' prefix on a macro (e.g. CONF_mBool vs CONF_Bool) indicates mutability.
+    """
+    params: dict[str, ParamInfo] = {}
+    for scan_path in _be_config_files(path):
+        for line in scan_path.read_text().splitlines():
+            m = _CONF_MACRO_RE.match(line)
+            if m:
+                mutable_flag, code_type, name, default = m.groups()
+                params[name] = ParamInfo(
+                    name=name,
+                    param_type="be_config",
+                    code_type=code_type,
+                    default=default,
+                    mutable=bool(mutable_flag),
+                    description="",
+                    suggested_doc="docs/en/administration/management/BE_parameters/",
+                )
+    return params
+
+
+# ── SessionVariable / GlobalVariable parser ──────────────────────────────────
+
+_CONST_RE = re.compile(
+    r'public\s+static\s+final\s+String\s+(\w+)\s*=\s*"([a-z][a-z0-9_]*)"'
+)
+_VARATTR_START_RE = re.compile(r'@(?:VarAttr|VariableMgr\.VarAttr)\s*\(')
+_FIELD_DECL_RE = re.compile(
+    r'(?:private|public|protected)\s+(?:static\s+)?(\w+(?:\[\])?)\s+\w+\s*=\s*(.+?)(?:;|$)'
+)
+
+
+def parse_session_vars(session_path: Path, global_path: Path) -> dict[str, ParamInfo]:
+    """
+    Extract annotated session and global variables from SessionVariable.java
+    and GlobalVariable.java.
+
+    Two-pass approach:
+      1. Build a dict of String constants (SCREAMING_SNAKE → 'actual_name').
+      2. For each @VarAttr annotation, resolve the name constant and record metadata.
+
+    Variables with flag = VariableMgr.INVISIBLE are internal and excluded.
+    """
+    params: dict[str, ParamInfo] = {}
+
+    for src_path in [session_path, global_path]:
+        lines = src_path.read_text().splitlines()
+        n = len(lines)
+
+        # Pass 1: String constants
+        const_map: dict[str, str] = {}
+        for line in lines:
+            m = _CONST_RE.search(line)
+            if m:
+                const_map[m.group(1)] = m.group(2)
+
+        # Pass 2: @VarAttr annotations
+        i = 0
+        while i < n:
+            stripped = lines[i].strip()
+
+            if not _VARATTR_START_RE.match(stripped):
+                i += 1
+                continue
+
+            # Collect multi-line annotation
+            ann_text = stripped
+            while ann_text.count("(") > ann_text.count(")") and i + 1 < n:
+                i += 1
+                ann_text += " " + lines[i].strip()
+
+            # Skip internal variables
+            if "INVISIBLE" in ann_text:
+                i += 1
+                continue
+
+            # Resolve name
+            name_m = re.search(r'\bname\s*=\s*(\w+|"[^"]+")', ann_text)
+            if not name_m:
+                i += 1
+                continue
+
+            raw = name_m.group(1)
+            if raw.startswith('"'):
+                var_name = raw.strip('"')
+            else:
+                # Constant reference: look up in const_map, fall back to lowercasing
+                var_name = const_map.get(raw, raw.lower())
+
+            # Skip names that look like class references or non-variable identifiers
+            if not re.fullmatch(r"[a-z_][a-z0-9_]*", var_name):
+                i += 1
+                continue
+
+            # Find the field declaration on the following lines
+            code_type = ""
+            default = ""
+            for j in range(i + 1, min(i + 6, n)):
+                fd = _FIELD_DECL_RE.search(lines[j].strip())
+                if fd:
+                    code_type = fd.group(1)
+                    default = fd.group(2).strip().rstrip(";")
+                    break
+
+            params[var_name] = ParamInfo(
+                name=var_name,
+                param_type="session_var",
+                code_type=code_type,
+                default=default,
+                mutable=True,
+                description="",
+                suggested_doc="docs/en/sql-reference/System_variable.md",
+            )
+            i += 1
+
+    return params
+
+
+# ── Documentation parser ─────────────────────────────────────────────────────
+
+# Matches:
+#   ### `param_name`        (FE params — backtick-wrapped)
+#   ### param_name          (BE params — plain)
+#   ### param_name (global) (session vars — with scope qualifier)
+_DOC_HEADING_RE = re.compile(r"^#{2,4}\s+[`']?([a-z_][a-z0-9_]*)[`']?")
+
+
+def parse_doc_params(doc_paths: list[Path]) -> set[str]:
+    """Extract documented parameter names from Markdown heading lines."""
+    names: set[str] = set()
+    for path in doc_paths:
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            m = _DOC_HEADING_RE.match(line)
+            if m:
+                names.add(m.group(1).lower())
+    return names
+
+
+# ── Git diff filter ───────────────────────────────────────────────────────────
+
+def get_new_param_names_from_diff(source_paths: list[Path]) -> set[str]:
+    """
+    Return parameter names that appear in the added lines (+) of
+    'git diff origin/main' for the given source files.
+
+    Used by --new-params-only to restrict the report to params
+    introduced in the current branch, avoiding noise from the pre-existing backlog.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "origin/main", "--"] + [str(p) for p in source_paths],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return set()
+
+    names: set[str] = set()
+    for line in result.stdout.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        # Java: public static [final] Type field_name =
+        for m in re.finditer(
+            r"public\s+static\s+(?:final\s+)?\S+\s+([a-z_][a-z0-9_]+)\s*=", line
+        ):
+            names.add(m.group(1))
+        # Java: String constant value = "actual_var_name"
+        for m in re.finditer(r'=\s*"([a-z_][a-z0-9_]+)"', line):
+            names.add(m.group(1))
+        # C++ CONF macro first argument
+        for m in re.finditer(
+            r"CONF_m?[A-Za-z0-9_]+\(\s*([a-z_][a-z0-9_]+)\s*,", line
+        ):
+            names.add(m.group(1))
+    return names
+
+
+# ── Output formatters ─────────────────────────────────────────────────────────
+
+def _fmt_text(
+    fe_missing: list[ParamInfo],
+    fe_stale: set[str],
+    be_missing: list[ParamInfo],
+    be_stale: set[str],
+    sv_missing: list[ParamInfo],
+    sv_stale: set[str],
+    new_params_only: bool,
+) -> str:
+    out: list[str] = []
+
+    def section(title: str, missing: list[ParamInfo], stale: set[str]) -> None:
+        out.append(f"\n=== {title} ===")
+        if missing:
+            out.append(
+                f"MISSING FROM DOCS ({len(missing)} in code, not documented):"
+            )
+            for p in sorted(missing, key=lambda x: x.name):
+                parts = [f"  {p.name}"]
+                if p.code_type:
+                    parts.append(f"[{p.code_type}]")
+                if p.default:
+                    parts.append(f"default={p.default!r}")
+                if p.mutable:
+                    parts.append("(mutable)")
+                if p.description:
+                    parts.append(f"— {p.description}")
+                out.append(" ".join(parts))
+        else:
+            out.append("MISSING FROM DOCS: none")
+
+        if not new_params_only:
+            if stale:
+                out.append(
+                    f"\nSTALE IN DOCS ({len(stale)} in docs, not in code):"
+                )
+                for name in sorted(stale):
+                    out.append(f"  {name}")
+            else:
+                out.append("\nSTALE IN DOCS: none")
+
+    section(
+        "FE Configuration  (Config.java → FE_parameters/)",
+        fe_missing,
+        fe_stale,
+    )
+    section(
+        "BE Configuration  (config.h → BE_parameters/)",
+        be_missing,
+        be_stale,
+    )
+    section(
+        "Session / Global Variables  (SessionVariable.java + GlobalVariable.java → System_variable.md)",
+        sv_missing,
+        sv_stale,
+    )
+    return "\n".join(out)
+
+
+def _fmt_github_comment(
+    fe_missing: list[ParamInfo],
+    be_missing: list[ParamInfo],
+    sv_missing: list[ParamInfo],
+) -> str:
+    total = len(fe_missing) + len(be_missing) + len(sv_missing)
+    if total == 0:
+        return ""
+
+    out: list[str] = [
+        "## New parameters without documentation",
+        "",
+        f"This PR introduces **{total} parameter(s)** not yet documented. "
+        "Please add entries before or shortly after merge.",
+        "",
+    ]
+
+    def section(title: str, params: list[ParamInfo]) -> None:
+        if not params:
+            return
+        out.append("<details>")
+        out.append(f"<summary>{title} — {len(params)} undocumented</summary>")
+        out.append("")
+        out.append(
+            "| Parameter | Type | Default | Mutable | Description | Suggested doc |"
+        )
+        out.append(
+            "|-----------|------|---------|---------|-------------|---------------|"
+        )
+        for p in sorted(params, key=lambda x: x.name):
+            desc = p.description or "—"
+            mut = "Yes" if p.mutable else "No"
+            out.append(
+                f"| `{p.name}` | {p.code_type} | `{p.default}` | {mut} | {desc} | {p.suggested_doc} |"
+            )
+        out.append("")
+        out.append("</details>")
+        out.append("")
+
+    section("FE Configuration", fe_missing)
+    section("BE Configuration", be_missing)
+    section("Session / Global Variables", sv_missing)
+
+    out.append(
+        "_Auto-generated by `build-support/extract_and_diff_params.py`. "
+        "See `docs/en/administration/management/` for the doc files to update._"
+    )
+    return "\n".join(out)
+
+
+def _fmt_json(
+    fe_missing: list[ParamInfo],
+    fe_stale: set[str],
+    be_missing: list[ParamInfo],
+    be_stale: set[str],
+    sv_missing: list[ParamInfo],
+    sv_stale: set[str],
+) -> str:
+    return json.dumps(
+        {
+            "fe_config": {
+                "missing_from_docs": [asdict(p) for p in fe_missing],
+                "stale_in_docs": sorted(fe_stale),
+            },
+            "be_config": {
+                "missing_from_docs": [asdict(p) for p in be_missing],
+                "stale_in_docs": sorted(be_stale),
+            },
+            "session_var": {
+                "missing_from_docs": [asdict(p) for p in sv_missing],
+                "stale_in_docs": sorted(sv_stale),
+            },
+        },
+        indent=2,
+    )
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Compare StarRocks source-code config params against documentation."
+    )
+    ap.add_argument(
+        "--new-params-only",
+        action="store_true",
+        help="Only report params added in the current git branch (CI mode)",
+    )
+    ap.add_argument(
+        "--output",
+        choices=["text", "json", "github-comment"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    ap.add_argument(
+        "--fe-config", type=Path, default=FE_CONFIG_PATH,
+        help="Path to Config.java",
+    )
+    ap.add_argument(
+        "--be-config", type=Path, default=BE_CONFIG_PATH,
+        help="Path to be/src/common/config.h",
+    )
+    ap.add_argument(
+        "--session-var", type=Path, default=SESSION_VAR_PATH,
+        help="Path to SessionVariable.java",
+    )
+    ap.add_argument(
+        "--global-var", type=Path, default=GLOBAL_VAR_PATH,
+        help="Path to GlobalVariable.java",
+    )
+    args = ap.parse_args()
+
+    # Extract from source code
+    fe_params = parse_fe_configs(args.fe_config)
+    be_params = parse_be_configs(args.be_config)
+    sv_params = parse_session_vars(args.session_var, args.global_var)
+
+    # Extract from documentation
+    fe_doc = parse_doc_params(FE_PARAM_DOCS)
+    be_doc = parse_doc_params(BE_PARAM_DOCS)
+    sv_doc = parse_doc_params(SESSION_VAR_DOCS)
+
+    # Compute gaps
+    fe_missing_names = set(fe_params) - fe_doc
+    fe_stale = fe_doc - set(fe_params)
+    be_missing_names = set(be_params) - be_doc
+    be_stale = be_doc - set(be_params)
+    sv_missing_names = set(sv_params) - sv_doc
+    sv_stale = sv_doc - set(sv_params)
+
+    # In --new-params-only mode, restrict to params visible in the current git diff
+    if args.new_params_only:
+        new_names = get_new_param_names_from_diff(
+            [args.fe_config, args.be_config, args.session_var, args.global_var]
+        )
+        fe_missing_names &= new_names
+        be_missing_names &= new_names
+        sv_missing_names &= new_names
+        fe_stale = set()
+        be_stale = set()
+        sv_stale = set()
+
+    fe_missing = sorted(
+        [fe_params[n] for n in fe_missing_names], key=lambda x: x.name
+    )
+    be_missing = sorted(
+        [be_params[n] for n in be_missing_names], key=lambda x: x.name
+    )
+    sv_missing = sorted(
+        [sv_params[n] for n in sv_missing_names], key=lambda x: x.name
+    )
+
+    has_gaps = bool(fe_missing or be_missing or sv_missing)
+
+    if args.output == "json":
+        print(
+            _fmt_json(
+                fe_missing, fe_stale,
+                be_missing, be_stale,
+                sv_missing, sv_stale,
+            )
+        )
+    elif args.output == "github-comment":
+        comment = _fmt_github_comment(fe_missing, be_missing, sv_missing)
+        if comment:
+            print(comment)
+            return 1
+        return 0
+    else:
+        print(
+            _fmt_text(
+                fe_missing, fe_stale,
+                be_missing, be_stale,
+                sv_missing, sv_stale,
+                args.new_params_only,
+            )
+        )
+        if not args.new_params_only:
+            print(
+                f"\nSummary: {len(fe_missing)} FE config, "
+                f"{len(be_missing)} BE config, "
+                f"{len(sv_missing)} session/global var missing from docs."
+            )
+
+    return 1 if has_gaps else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build-support/extract_and_diff_params.py
+++ b/build-support/extract_and_diff_params.py
@@ -349,17 +349,21 @@ def parse_doc_params(doc_paths: list[Path]) -> set[str]:
 
 # ── Git diff filter ───────────────────────────────────────────────────────────
 
-def get_new_param_names_from_diff(source_paths: list[Path]) -> set[str]:
+def get_new_param_names_from_diff(
+    source_paths: list[Path], diff_base: str = "origin/main"
+) -> set[str]:
     """
     Return parameter names that appear in the added lines (+) of
-    'git diff origin/main' for the given source files.
+    'git diff <diff_base>' for the given source files.
 
     Used by --new-params-only to restrict the report to params
     introduced in the current branch, avoiding noise from the pre-existing backlog.
+    Pass --diff-base to override the comparison ref (e.g. origin/branch-4.1 for
+    release-branch PRs, or HEAD^1 when running against a merge commit).
     """
     try:
         result = subprocess.run(
-            ["git", "diff", "origin/main", "--"] + [str(p) for p in source_paths],
+            ["git", "diff", diff_base, "--"] + [str(p) for p in source_paths],
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
@@ -544,6 +548,15 @@ def main() -> int:
         help="Output format (default: text)",
     )
     ap.add_argument(
+        "--diff-base",
+        default="origin/main",
+        help=(
+            "Git ref to diff against for --new-params-only "
+            "(default: origin/main). Use origin/<base_ref> for release-branch PRs "
+            "or HEAD^1 when running against a merge commit."
+        ),
+    )
+    ap.add_argument(
         "--fe-config", type=Path, default=FE_CONFIG_PATH,
         help="Path to Config.java",
     )
@@ -582,7 +595,8 @@ def main() -> int:
     # In --new-params-only mode, restrict to params visible in the current git diff
     if args.new_params_only:
         new_names = get_new_param_names_from_diff(
-            [args.fe_config, args.be_config, args.session_var, args.global_var]
+            [args.fe_config, args.be_config, args.session_var, args.global_var],
+            diff_base=args.diff_base,
         )
         fe_missing_names &= new_names
         be_missing_names &= new_names

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -1,0 +1,211 @@
+# Documentation Automation
+
+This file documents the tooling that helps keep StarRocks documentation in sync with the source code. These tools are designed to make the tech writer's workflow proactive — catching gaps when code changes merge rather than waiting for user reports.
+
+---
+
+## Overview
+
+Three sources of truth define documented behavior:
+
+| Source file | What it controls | Doc target |
+|---|---|---|
+| `fe/fe-core/src/main/java/com/starrocks/common/Config.java` | FE configuration parameters (`@ConfField`) | `docs/en/administration/management/FE_parameters/` |
+| `be/src/common/config.h` | BE configuration parameters (`CONF_*` macros) | `docs/en/administration/management/BE_parameters/` |
+| `fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java` + `GlobalVariable.java` | Session and global variables (`@VarAttr`) | `docs/en/sql-reference/System_variable.md` |
+
+All three are hand-documented Markdown. These tools detect when code and docs have diverged.
+
+---
+
+## Tools
+
+### `build-support/extract_and_diff_params.py`
+
+Compares parameters defined in source code against parameters documented in Markdown. Run this to find the full backlog of undocumented parameters or to check a specific area.
+
+**Run from the repo root:**
+
+```bash
+# Full gap report across all categories
+python3 build-support/extract_and_diff_params.py
+
+# Only params added in the current git branch (same mode used by CI)
+python3 build-support/extract_and_diff_params.py --new-params-only
+
+# Machine-readable output (JSON)
+python3 build-support/extract_and_diff_params.py --output json
+
+# Markdown formatted for a GitHub PR comment
+python3 build-support/extract_and_diff_params.py --new-params-only --output github-comment
+```
+
+**Sample text output:**
+
+```
+=== FE Configuration  (Config.java → FE_parameters/) ===
+MISSING FROM DOCS (304 in code, not documented):
+  audit_stmt_before_execute [boolean] default='false' (mutable)
+  enable_experimental_feature [boolean] default='false' (mutable)
+  ...
+
+STALE IN DOCS (5 in docs, not in code):
+  dump_log_dir
+  insert_load_default_timeout_second
+  ...
+
+Summary: 304 FE config, 373 BE config, 189 session/global var missing from docs.
+```
+
+**What it catches:**
+- Parameters added to code with no corresponding `###` heading in the doc files
+- Parameters removed from code whose doc entries still exist
+
+**What it cannot catch:**
+- A parameter present in both code and docs but with the wrong default value or outdated description
+- Renamed parameters (a rename looks like one deletion + one addition — requires human review)
+
+**As of the initial run (May 2026):** 304 FE config, 373 BE config, and 189 session/global variable entries exist in code with no documentation. This is the existing backlog to work through. The CI workflows use `--new-params-only` so they do not surface this backlog on every PR.
+
+---
+
+### `docs/scripts/extract_sql_samples.py`
+
+Walks `docs/en/`, finds all ` ```sql ` fenced code blocks, and reports how many are runnable (no placeholder patterns like `<table_name>`) versus illustrative.
+
+**Run from the repo root:**
+
+```bash
+# Summary report
+python3 docs/scripts/extract_sql_samples.py
+
+# Only show samples that look runnable
+python3 docs/scripts/extract_sql_samples.py --filter-runnable
+
+# Only show DDL and SELECT samples
+python3 docs/scripts/extract_sql_samples.py --filter-category DDL,SELECT
+
+# Export to CSV for a spreadsheet
+python3 docs/scripts/extract_sql_samples.py --format csv --output sql_samples.csv
+
+# Scan a subdirectory only
+python3 docs/scripts/extract_sql_samples.py --docs-root docs/en/sql-reference
+```
+
+**Sample output:**
+
+```
+SQL Sample Extraction Report
+============================================================
+Total SQL blocks found: 3624
+
+Category      Total  Runnable  Illustrative
+--------------------------------------------
+SELECT          536       486            50
+DDL            1257       885           372
+SHOW_ADMIN      435       316           119
+SET             127       103            24
+DML             235       173            62
+OTHER          1034       289           745
+```
+
+**As of the initial run (May 2026):** 3,624 SQL blocks in `docs/en/`, of which 2,252 are runnable and 1,372 are illustrative. This is a foundation for future SQL testing — the runnable samples can be executed against a live cluster to verify accuracy.
+
+---
+
+## CI Workflows
+
+### `ci-doc-param-drift.yml` — PR comment on config changes
+
+**Triggers:** Any PR that modifies `Config.java`, `SessionVariable.java`, `GlobalVariable.java`, or `config.h`.
+
+**What it does:** Runs `extract_and_diff_params.py --new-params-only --output github-comment` and posts the result as a comment on the PR. If no new undocumented params are detected, it posts a brief "no gaps found" message and clears any previous comment.
+
+**Does not block merge.** The comment is informational — engineers should not be blocked from shipping because docs haven't caught up yet.
+
+**Example comment (when gaps are found):**
+
+> ## New parameters without documentation
+>
+> This PR introduces **2 parameter(s)** not yet documented.
+>
+> | Parameter | Type | Default | Mutable | Description | Suggested doc |
+> |---|---|---|---|---|---|
+> | `enable_skew_join_v2` | boolean | `false` | Yes | — | docs/en/…/FE_parameters/ |
+
+---
+
+### `ci-doc-needs-update.yml` — Issue on behavior-changing merges
+
+**Triggers:** Any PR that merges to `main` with both of these conditions true:
+1. The `[x] Yes, this PR will result in a change in behavior.` checkbox is checked.
+2. The `[ ] I have added documentation for my new feature or new function` checkbox is **not** checked.
+
+Doc PRs (`[Doc]` prefix in title) are excluded.
+
+**What it does:**
+1. Runs `extract_and_diff_params.py --new-params-only --output json` on the merged commit.
+2. Opens a GitHub issue with:
+   - PR title, number, URL, and author
+   - The behavior-change type checkboxes that were checked
+   - A table of any newly undocumented parameters (if any were detected)
+   - Checklisted action items
+3. Labels the issue `documentation` and `docs-maintainer`.
+
+**The `docs-maintainer` label** is picked up by the weekly Sunday triage workflow alongside labeled PRs, so all documentation work appears in one queue.
+
+**Example issue body:**
+
+> ## Documentation needed for merged PR
+>
+> PR #73891 was merged and declared a behavior change, but documentation was not added.
+>
+> **PR:** [Feature] Add skew join v2 optimization hint (#73891)
+> **Author:** @some-engineer
+> **Behavior change types declared:**
+> - Policy changes: use new policy to replace old one, functionality automatically enabled
+>
+> ## New parameters detected with no documentation entry
+>
+> ### Session / Global Variables
+>
+> | Parameter | Type | Default | Mutable | Description | Suggested doc |
+> |---|---|---|---|---|---|
+> | `enable_optimize_skew_join_v2` | boolean | `false` | Yes | — | docs/en/sql-reference/System_variable.md |
+>
+> ## Action required
+> - [ ] Review the PR diff and update the relevant documentation
+> - [ ] Close this issue when documentation is published
+
+**Limitation:** This workflow fires only when the PR template is filled out following the convention. If a contributor replaces the template body entirely, the condition won't match and no issue will be opened.
+
+---
+
+## Working Through the Backlog
+
+To generate the full list of all undocumented parameters (not just new ones):
+
+```bash
+python3 build-support/extract_and_diff_params.py --output json > backlog.json
+```
+
+The JSON structure is:
+
+```json
+{
+  "fe_config": {
+    "missing_from_docs": [
+      { "name": "audit_stmt_before_execute", "code_type": "boolean",
+        "default": "false", "mutable": true, "description": "",
+        "suggested_doc": "docs/en/administration/management/FE_parameters/" }
+    ],
+    "stale_in_docs": ["dump_log_dir", "insert_load_default_timeout_second"]
+  },
+  "be_config": { ... },
+  "session_var": { ... }
+}
+```
+
+Each `missing_from_docs` entry has the parameter name, type, default value, mutability, any description extracted from the source annotation, and a suggested doc file to update.
+
+**Stale entries** (`stale_in_docs`) are parameter names that appear in the documentation but no longer exist in the source code. These should be removed or marked as deprecated in the docs.

--- a/docs/scripts/extract_sql_samples.py
+++ b/docs/scripts/extract_sql_samples.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Audit SQL code samples in the StarRocks English documentation.
+
+Walks docs/en/, finds all ```sql fenced blocks, extracts each sample with its
+source file and line number, categorizes by SQL statement type, and flags
+whether the sample looks runnable (no placeholder patterns) or illustrative.
+
+Usage:
+  python3 docs/scripts/extract_sql_samples.py
+  python3 docs/scripts/extract_sql_samples.py --format json
+  python3 docs/scripts/extract_sql_samples.py --format csv
+  python3 docs/scripts/extract_sql_samples.py --filter-runnable
+  python3 docs/scripts/extract_sql_samples.py --filter-category SELECT,DDL
+  python3 docs/scripts/extract_sql_samples.py --docs-root docs/en/sql-reference
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DOCS_ROOT = REPO_ROOT / "docs/en"
+
+# ── SQL category detection ───────────────────────────────────────────────────
+
+_CATEGORY_KEYWORDS: list[tuple[str, list[str]]] = [
+    ("DDL",        ["CREATE", "ALTER", "DROP", "TRUNCATE", "RENAME", "COMMENT"]),
+    ("DML",        ["INSERT", "UPDATE", "DELETE", "LOAD", "STREAM", "BROKER", "ROUTINE"]),
+    ("SHOW_ADMIN", ["SHOW", "ADMIN", "DESCRIBE", "DESC", "EXPLAIN", "ANALYZE"]),
+    ("SET",        ["SET"]),
+    ("SELECT",     ["SELECT", "WITH"]),
+]
+
+
+def _categorize(body: str) -> str:
+    first_line = ""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("--") and not stripped.startswith("#"):
+            first_line = stripped.upper()
+            break
+    for category, keywords in _CATEGORY_KEYWORDS:
+        for kw in keywords:
+            if first_line.startswith(kw):
+                return category
+    return "OTHER"
+
+
+# ── Runnability detection ────────────────────────────────────────────────────
+
+_PLACEHOLDER_RE = re.compile(r"<[a-zA-Z_][a-zA-Z0-9_ ]*>")
+_ELLIPSIS_RE = re.compile(r"^\s*\.\.\.\s*$", re.MULTILINE)
+_COMMENT_PLACEHOLDER_RE = re.compile(r"--\s*(add|insert|replace|your|todo|example)", re.IGNORECASE)
+
+
+def _is_runnable(body: str) -> bool:
+    if _PLACEHOLDER_RE.search(body):
+        return False
+    if _ELLIPSIS_RE.search(body):
+        return False
+    if _COMMENT_PLACEHOLDER_RE.search(body):
+        return False
+    # Must have at least one real statement token
+    return bool(re.search(r"\b(SELECT|CREATE|INSERT|ALTER|DROP|SET|SHOW|ADMIN|WITH|DELETE|UPDATE)\b", body, re.IGNORECASE))
+
+
+# ── Data model ───────────────────────────────────────────────────────────────
+
+@dataclass
+class SqlSample:
+    file: str         # relative to repo root
+    line_start: int   # 1-indexed line of the opening ```sql fence
+    category: str     # DDL | DML | SHOW_ADMIN | SET | SELECT | OTHER
+    runnable: bool    # True if no placeholder patterns detected
+    body: str         # raw SQL text
+
+
+# ── Extraction ───────────────────────────────────────────────────────────────
+
+_FENCE_OPEN_RE = re.compile(r"^```\s*sql\s*$", re.IGNORECASE)
+_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+
+
+def extract_samples(docs_root: Path) -> list[SqlSample]:
+    samples: list[SqlSample] = []
+    for path in sorted(docs_root.rglob("*.md")) + sorted(docs_root.rglob("*.mdx")):
+        rel = str(path.relative_to(REPO_ROOT))
+        lines = path.read_text(errors="replace").splitlines()
+        n = len(lines)
+        i = 0
+        while i < n:
+            if _FENCE_OPEN_RE.match(lines[i].strip()):
+                start = i + 1  # 1-indexed: fence is at line i, content starts at i+1
+                i += 1
+                body_lines: list[str] = []
+                while i < n and not _FENCE_CLOSE_RE.match(lines[i].strip()):
+                    body_lines.append(lines[i])
+                    i += 1
+                body = "\n".join(body_lines).strip()
+                if body:
+                    samples.append(
+                        SqlSample(
+                            file=rel,
+                            line_start=start,
+                            category=_categorize(body),
+                            runnable=_is_runnable(body),
+                            body=body,
+                        )
+                    )
+            i += 1
+    return samples
+
+
+# ── Output formatters ────────────────────────────────────────────────────────
+
+CATEGORIES = ["SELECT", "DDL", "SHOW_ADMIN", "SET", "DML", "OTHER"]
+
+
+def _fmt_text(samples: list[SqlSample]) -> str:
+    out: list[str] = []
+    out.append("SQL Sample Extraction Report")
+    out.append("=" * 60)
+    out.append(f"Total SQL blocks found: {len(samples)}")
+    out.append("")
+
+    # Summary table
+    out.append(f"{'Category':<12} {'Total':>6} {'Runnable':>9} {'Illustrative':>13}")
+    out.append("-" * 44)
+    for cat in CATEGORIES:
+        cat_samples = [s for s in samples if s.category == cat]
+        runnable = sum(1 for s in cat_samples if s.runnable)
+        out.append(
+            f"{cat:<12} {len(cat_samples):>6} {runnable:>9} {len(cat_samples) - runnable:>13}"
+        )
+    runnable_total = sum(1 for s in samples if s.runnable)
+    out.append(
+        f"{'TOTAL':<12} {len(samples):>6} {runnable_total:>9} {len(samples) - runnable_total:>13}"
+    )
+    out.append("")
+
+    # Top files by SQL block count
+    from collections import Counter
+    file_counts = Counter(s.file for s in samples)
+    out.append("Files with the most SQL blocks (top 10):")
+    for path, count in file_counts.most_common(10):
+        out.append(f"  {count:>4}  {path}")
+    out.append("")
+
+    # Sample runnable blocks (first 5)
+    runnable_samples = [s for s in samples if s.runnable]
+    if runnable_samples:
+        out.append(f"Runnable samples (first 5 of {len(runnable_samples)}):")
+        for s in runnable_samples[:5]:
+            out.append(f"  {s.file}:{s.line_start}  [{s.category}]")
+            for line in s.body.splitlines()[:3]:
+                out.append(f"    {line}")
+            if len(s.body.splitlines()) > 3:
+                out.append("    ...")
+            out.append("")
+
+    # Sample illustrative blocks (first 5)
+    illustrative = [s for s in samples if not s.runnable]
+    if illustrative:
+        out.append(f"Illustrative samples (first 5 of {len(illustrative)}):")
+        for s in illustrative[:5]:
+            out.append(f"  {s.file}:{s.line_start}  [{s.category}]")
+            for line in s.body.splitlines()[:3]:
+                out.append(f"    {line}")
+            if len(s.body.splitlines()) > 3:
+                out.append("    ...")
+            out.append("")
+
+    return "\n".join(out)
+
+
+def _fmt_json(samples: list[SqlSample]) -> str:
+    return json.dumps([asdict(s) for s in samples], indent=2)
+
+
+def _fmt_csv(samples: list[SqlSample]) -> str:
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=["file", "line_start", "category", "runnable", "body"],
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    for s in samples:
+        writer.writerow(asdict(s))
+    return buf.getvalue()
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Audit SQL code samples in StarRocks English documentation."
+    )
+    ap.add_argument(
+        "--docs-root",
+        type=Path,
+        default=DEFAULT_DOCS_ROOT,
+        help="Root directory to scan (default: docs/en/)",
+    )
+    ap.add_argument(
+        "--format",
+        choices=["text", "json", "csv"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    ap.add_argument(
+        "--filter-runnable",
+        action="store_true",
+        help="Only output runnable samples",
+    )
+    ap.add_argument(
+        "--filter-category",
+        help="Comma-separated list of categories to include (e.g. SELECT,DDL)",
+    )
+    ap.add_argument(
+        "--output",
+        type=Path,
+        help="Write output to this file instead of stdout",
+    )
+    args = ap.parse_args()
+
+    if not args.docs_root.exists():
+        print(f"error: docs root not found: {args.docs_root}", file=sys.stderr)
+        return 1
+
+    samples = extract_samples(args.docs_root)
+
+    # Apply filters
+    if args.filter_runnable:
+        samples = [s for s in samples if s.runnable]
+    if args.filter_category:
+        cats = {c.strip().upper() for c in args.filter_category.split(",")}
+        samples = [s for s in samples if s.category in cats]
+
+    # Format
+    if args.format == "json":
+        output = _fmt_json(samples)
+    elif args.format == "csv":
+        output = _fmt_csv(samples)
+    else:
+        output = _fmt_text(samples)
+
+    # Write
+    if args.output:
+        args.output.write_text(output)
+        print(f"Written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/scripts/extract_sql_samples.py
+++ b/docs/scripts/extract_sql_samples.py
@@ -113,7 +113,7 @@ def extract_samples(docs_root: Path) -> list[SqlSample]:
         i = 0
         while i < n:
             if _FENCE_OPEN_RE.match(lines[i].strip()):
-                start = i + 1  # 1-indexed: fence is at line i, content starts at i+1
+                start = i + 1  # 1-indexed line number of the opening fence
                 i += 1
                 body_lines: list[str] = []
                 while i < n and not _FENCE_CLOSE_RE.match(lines[i].strip()):


### PR DESCRIPTION
Adds scripts and CI workflows to proactively detect documentation gaps
instead of waiting for user reports:

- build-support/extract_and_diff_params.py: compares @ConfField, CONF_*
  macro, and @VarAttr parameters in source code against Markdown headings
  in FE_parameters/, BE_parameters/, and System_variable.md; supports
  --new-params-only and --output github-comment|json modes
- docs/scripts/extract_sql_samples.py: audits all ```sql blocks in
  docs/en/, categorizes by statement type, and flags runnable vs
  illustrative samples
- .github/workflows/ci-doc-param-drift.yml: posts a PR comment listing
  newly undocumented parameters when Config.java, config.h, or
  SessionVariable.java changes
- .github/workflows/ci-doc-needs-update.yml: opens a docs-maintainer-
  labeled issue when a behavior-changing PR merges without doc updates,
  including a table of newly undocumented parameters
- docs/AUTOMATION.md: reference guide for all tooling

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5