### PR TITLE
[Enhancement] Materialize volatile column defaults per row on ADD COLUMN

### DIFF
--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -386,6 +386,46 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
     return true;
 }
 
+// Place an evaluated generated/default column value into the destination chunk slot, honoring the
+// destination column's nullability. A generated column is always nullable, but a volatile default
+// (uuid()/uuid_numeric()) can be added to a NOT NULL column; since the expr engine marks even never-null
+// functions as nullable, a non-nullable destination unwraps the data column. A genuine null reaching a
+// NOT NULL column violates the constraint and is reported as an error.
+static Status assign_generated_column_value(Chunk* chunk, size_t idx, ColumnPtr tmp, size_t num_rows) {
+    // Mutating ops need the raw mutable column; the chunk slot (ColumnPtr) is only swapped, never mutated.
+    Column* dst = chunk->get_column_raw_ptr_by_index(idx);
+    if (dst->is_nullable()) {
+        if (tmp->only_null()) {
+            // Only null column maybe lost type info, we append null for the chunk instead of swapping.
+            dst->reset_column();
+            dst->append_nulls(num_rows);
+        } else if (tmp->is_nullable()) {
+            chunk->get_column_by_index(idx).swap(tmp);
+        } else {
+            // Non-nullable result (e.g. a const column) into a nullable destination: unpack and graft.
+            ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(num_rows, tmp);
+            down_cast<NullableColumn*>(dst)->swap_by_data_column(output_column);
+        }
+        return Status::OK();
+    }
+    // Destination is NOT NULL.
+    if (tmp->only_null()) {
+        return Status::InternalError("NOT NULL column got a NULL value from its default expression");
+    }
+    if (tmp->is_nullable()) {
+        const auto* nullable = down_cast<const NullableColumn*>(tmp.get());
+        if (nullable->null_count() != 0) {
+            return Status::InternalError("NOT NULL column got a NULL value from its default expression");
+        }
+        ColumnPtr data = nullable->data_column();
+        chunk->get_column_by_index(idx).swap(data);
+    } else {
+        ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(num_rows, tmp);
+        chunk->get_column_by_index(idx).swap(output_column);
+    }
+    return Status::OK();
+}
+
 Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
     if (_gc_exprs.size() == 0) {
         return Status::OK();
@@ -398,22 +438,8 @@ Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
 
     for (auto it : _gc_exprs) {
         ASSIGN_OR_RETURN(ColumnPtr tmp, it.second->evaluate(new_chunk.get()));
-        if (tmp->only_null()) {
-            // Only null column maybe lost type info, we append null
-            // for the chunk instead of swapping the tmp column.
-            auto* col = new_chunk->get_column_raw_ptr_by_index(it.first);
-            col->reset_column();
-            col->append_nulls(new_chunk->num_rows());
-        } else if (tmp->is_nullable()) {
-            new_chunk->get_column_by_index(it.first).swap(tmp);
-        } else {
-            // generated column must be a nullable column. If tmp is not nullable column,
-            // it maybe a constant column or some other column type.
-            // Unpack normal const column
-            ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(new_chunk->num_rows(), tmp);
-            auto* col = down_cast<NullableColumn*>(new_chunk->get_column_raw_ptr_by_index(it.first));
-            col->swap_by_data_column(output_column);
-        }
+        RETURN_IF_ERROR(
+                assign_generated_column_value(new_chunk.get(), it.first, std::move(tmp), new_chunk->num_rows()));
     }
 
     // reset the slot-index map for compatibility
@@ -496,22 +522,8 @@ Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& ne
         // cid for new partial schema
         int cid = it.first - base_schema_columns;
         ASSIGN_OR_RETURN(ColumnPtr tmp, it.second->evaluate(read_chunk.get()));
-        if (tmp->only_null()) {
-            // Only null column maybe lost type info, we append null
-            // for the chunk instead of swapping the tmp column.
-            auto* col = down_cast<NullableColumn*>(tmp_new_chunk->get_column_raw_ptr_by_index(cid));
-            col->reset_column();
-            col->append_nulls(read_chunk->num_rows());
-        } else if (tmp->is_nullable()) {
-            tmp_new_chunk->get_column_by_index(cid).swap(tmp);
-        } else {
-            // generated column must be a nullable column. If tmp is not nullable column,
-            // it maybe a constant column or some other column type
-            // Unpack normal const column
-            ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(read_chunk->num_rows(), tmp);
-            auto* col = down_cast<NullableColumn*>(tmp_new_chunk->get_column_raw_ptr_by_index(cid));
-            col->swap_by_data_column(output_column);
-        }
+        RETURN_IF_ERROR(
+                assign_generated_column_value(tmp_new_chunk.get(), cid, std::move(tmp), read_chunk->num_rows()));
     }
 
     // append into the new_chunk

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -571,6 +571,9 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                     boolean hasNewGeneratedColumn = false;
                     List<Column> diffGeneratedColumnSchema = Lists.newArrayList();
+                    // New columns whose default is volatile (uuid()/uuid_numeric()): BE materializes them per
+                    // pre-existing row during the rewrite, reusing the generated-column expr machinery.
+                    List<Column> diffDefaultExprColumns = Lists.newArrayList();
                     if (originIndexMetaId == table.getBaseIndexMetaId()) {
                         List<String> originSchema = table.getSchemaByIndexMetaId(originIndexMetaId).stream().map(col ->
                                 new String(col.getName())).collect(Collectors.toList());
@@ -579,9 +582,14 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                         if (originSchema.size() != 0 && newSchema.size() != 0) {
                             for (String colNameInNewSchema : newSchema) {
-                                if (!originSchema.contains(colNameInNewSchema) &&
-                                        table.getColumn(colNameInNewSchema).isGeneratedColumn()) {
-                                    diffGeneratedColumnSchema.add(table.getColumn(colNameInNewSchema));
+                                if (originSchema.contains(colNameInNewSchema)) {
+                                    continue;
+                                }
+                                Column newCol = table.getColumn(colNameInNewSchema);
+                                if (newCol.isGeneratedColumn()) {
+                                    diffGeneratedColumnSchema.add(newCol);
+                                } else if (newCol.getDefaultValueType() == Column.DefaultValueType.VARY) {
+                                    diffDefaultExprColumns.add(newCol);
                                 }
                             }
                         }
@@ -658,7 +666,21 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                             mcExprs.put(columnIndex, ExprToThrift.treeToThrift(generatedColumnExpr));
                         }
-                        // we need this thing, otherwise some expr evalution will fail in BE
+                    }
+                    // A volatile default has no column references, so it skips the slot-ref rewriting above and
+                    // goes straight to its materialization expr, keyed by the same full-schema column index.
+                    for (Column defaultExprColumn : diffDefaultExprColumns) {
+                        int columnIndex;
+                        if (defaultExprColumn.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
+                            String originName = Column.removeNamePrefix(defaultExprColumn.getName());
+                            columnIndex = table.getFullSchema().indexOf(table.getColumn(originName));
+                        } else {
+                            columnIndex = table.getFullSchema().indexOf(defaultExprColumn);
+                        }
+                        mcExprs.put(columnIndex, defaultExprColumn.getMaterializedDefaultThriftExpr());
+                    }
+                    if (!mcExprs.isEmpty()) {
+                        // BE needs the query globals/options to evaluate the materialization exprs in the rewrite.
                         TQueryGlobals queryGlobals = new TQueryGlobals();
                         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
                         queryGlobals.setNow_string(dateFormat.format(new Date()));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1180,13 +1180,23 @@ public class SchemaChangeHandler extends AlterHandler {
                                       Set<String> newColNameSet) throws DdlException {
 
         Column.DefaultValueType defaultValueType = newColumn.getDefaultValueType();
-        if (defaultValueType != Column.DefaultValueType.CONST && defaultValueType != Column.DefaultValueType.NULL) {
+        // A volatile (VARY) default such as uuid() / uuid_numeric() gives every row its own value, so the
+        // single-value fast-schema-evolution backfill cannot represent it for pre-existing rows. It is still
+        // addable by forcing a real rewrite that evaluates the default per row (same path as generated columns).
+        boolean varyDefaultRewrite = false;
+        if (defaultValueType == Column.DefaultValueType.VARY) {
+            if (newColumn.getDefaultExpr().obtainExpr() == null) {
+                throw new DdlException("unsupported default expr:" + newColumn.getDefaultExpr().getExpr());
+            }
+            varyDefaultRewrite = true;
+        } else if (defaultValueType != Column.DefaultValueType.CONST && defaultValueType != Column.DefaultValueType.NULL) {
             throw new DdlException("unsupported default expr:" + newColumn.getDefaultExpr().getExpr());
         }
 
         boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
-        // if column is generated column, need to rewrite table data, so we can not use light schema change
-        if (newColumn.isAutoIncrement() || newColumn.isGeneratedColumn()) {
+        // if column is generated column or has a volatile default, need to rewrite table data,
+        // so we can not use light schema change
+        if (newColumn.isAutoIncrement() || newColumn.isGeneratedColumn() || varyDefaultRewrite) {
             fastSchemaEvolution = false;
         }
 
@@ -1304,6 +1314,22 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException(
                     "Can not add column which already exists in column id: " + newColName
                             + ", you can remove " + foundColumn.get() + " and try again.");
+        }
+
+        // A volatile default is materialized per row only for the base table. A rollup task reads its own old
+        // index version, not the materialized base, so a column added to a rollup (or a key column propagated to
+        // every index on a unique-key table) falls back to the single-value default path (NULL/empty) for
+        // pre-existing rows; re-evaluating the expr per index instead would make a rollup's value disagree with
+        // the base row. Until the value can be derived consistently across indexes, restrict it to the base table.
+        if (varyDefaultRewrite) {
+            boolean addsToNonBaseIndex = targetIndexMetaId != -1L
+                    || (KeysType.UNIQUE_KEYS == olapTable.getKeysType() && newColumn.isKey()
+                            && indexMetaIdToSchema.size() > 1);
+            if (addsToNonBaseIndex) {
+                throw new DdlException("A volatile default (uuid()/uuid_numeric()) can only be added to the base "
+                        + "table; adding column '" + newColName + "' to a rollup or as a key column propagated to "
+                        + "all indexes is not supported.");
+            }
         }
 
         /*

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -638,6 +638,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                     boolean hasNewGeneratedColumn = false;
                     List<Column> diffGeneratedColumnSchema = Lists.newArrayList();
+                    // New columns whose default is volatile (uuid()/uuid_numeric()): BE materializes them per
+                    // pre-existing row during the rewrite, reusing the generated-column expr machinery.
+                    List<Column> diffDefaultExprColumns = Lists.newArrayList();
                     if (originIdxMetaId == tbl.getBaseIndexMetaId()) {
                         List<String> originSchema = tbl.getSchemaByIndexMetaId(originIdxMetaId).stream().map(col ->
                                 new String(col.getName())).collect(Collectors.toList());
@@ -646,9 +649,14 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                         if (originSchema.size() != 0 && newSchema.size() != 0) {
                             for (String colNameInNewSchema : newSchema) {
-                                if (!originSchema.contains(colNameInNewSchema) &&
-                                        tbl.getColumn(colNameInNewSchema).isGeneratedColumn()) {
-                                    diffGeneratedColumnSchema.add(tbl.getColumn(colNameInNewSchema));
+                                if (originSchema.contains(colNameInNewSchema)) {
+                                    continue;
+                                }
+                                Column newCol = tbl.getColumn(colNameInNewSchema);
+                                if (newCol.isGeneratedColumn()) {
+                                    diffGeneratedColumnSchema.add(newCol);
+                                } else if (newCol.getDefaultValueType() == Column.DefaultValueType.VARY) {
+                                    diffDefaultExprColumns.add(newCol);
                                 }
                             }
                         }
@@ -726,7 +734,21 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                             mcExprs.put(columnIndex, ExprToThrift.treeToThrift(generatedColumnExpr));
                         }
-                        // we need this thing, otherwise some expr evalution will fail in BE
+                    }
+                    // A volatile default has no column references, so it skips the slot-ref rewriting above and
+                    // goes straight to its materialization expr, keyed by the same full-schema column index.
+                    for (Column defaultExprColumn : diffDefaultExprColumns) {
+                        int columnIndex;
+                        if (defaultExprColumn.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
+                            String originName = Column.removeNamePrefix(defaultExprColumn.getName());
+                            columnIndex = tbl.getFullSchema().indexOf(tbl.getColumn(originName));
+                        } else {
+                            columnIndex = tbl.getFullSchema().indexOf(defaultExprColumn);
+                        }
+                        mcExprs.put(columnIndex, defaultExprColumn.getMaterializedDefaultThriftExpr());
+                    }
+                    if (!mcExprs.isEmpty()) {
+                        // BE needs the query globals/options to evaluate the materialization exprs in the rewrite.
                         TQueryGlobals queryGlobals = new TQueryGlobals();
                         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
                         queryGlobals.setNow_string(dateFormat.format(new Date()));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -57,6 +57,7 @@ import com.starrocks.sql.ast.expression.ArrayExpr;
 import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
+import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.MapExpr;
 import com.starrocks.sql.ast.expression.NullLiteral;
@@ -66,6 +67,7 @@ import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.thrift.TAggStateDesc;
 import com.starrocks.thrift.TAggregationType;
 import com.starrocks.thrift.TColumn;
+import com.starrocks.thrift.TExpr;
 import com.starrocks.type.AggStateDesc;
 import com.starrocks.type.NullType;
 import com.starrocks.type.PrimitiveType;
@@ -766,6 +768,25 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             return DefaultValueType.CONST;
         }
         return DefaultValueType.NULL;
+    }
+
+    // Build the per-row materialization expr for a volatile (VARY) default such as uuid() / uuid_numeric().
+    // A schema-change rewrite evaluates it once per pre-existing row so each row gets its own value, exactly
+    // as an INSERT evaluates the default per row. CONST defaults (literals, now(N)) freeze a single value and
+    // never reach here. Returns null when there is no obtainable default expr.
+    public TExpr getMaterializedDefaultThriftExpr() {
+        if (defaultExpr == null) {
+            return null;
+        }
+        Expr expr = defaultExpr.obtainExpr();
+        if (expr == null) {
+            return null;
+        }
+        if (!expr.getType().equals(getType())) {
+            expr = new CastExpr(getType(), expr);
+        }
+        expr = ExprUtils.analyzeAndCastFold(expr);
+        return ExprToThrift.treeToThrift(expr);
     }
 
     // if the column have a default value or default expr can be calculated like now(). return calculated value

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -80,13 +80,13 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.starrocks.catalog.DefaultExpr.isEmptyDefaultTimeFunction;
 import static com.starrocks.catalog.DefaultExpr.isValidDefaultTimeFunction;
 import static com.starrocks.common.util.DateUtils.DATE_TIME_FORMATTER;
 
@@ -753,7 +753,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public DefaultValueType getDefaultValueType() {
         if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
+            if (defaultExpr.isTimeFunction()) {
+                // now() / now(N) / current_timestamp(N): stable within a statement, materializes to
+                // a single value, so it is a const default - the precision argument does not make it volatile.
                 return DefaultValueType.CONST;
             } else if (defaultExpr.hasExprObject()) {
                 return DefaultValueType.CONST;
@@ -773,15 +775,18 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // If the default value is uuid(), this function is not suitable.
     public String calculatedDefaultValue() {
         if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
-                // current transaction time
+            if (defaultExpr.isTimeFunction()) {
+                int scale = defaultExpr.getTimeFunctionScale();
+                // current transaction time; use the full start Instant (microsecond precision), not
+                // getStartTime() which truncates to epoch milliseconds and would drop the sub-millisecond
+                // digits of CURRENT_TIMESTAMP(4..6) that BE's now(N) keeps via query_globals timestamp_us.
                 if (ConnectContext.get() != null) {
-                    LocalDateTime localDateTime = Instant.ofEpochMilli(ConnectContext.get().getStartTime())
+                    LocalDateTime localDateTime = ConnectContext.get().getStartTimeInstant()
                             .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
-                    return localDateTime.format(DATE_TIME_FORMATTER);
+                    return formatDateTimeWithScale(localDateTime, scale);
                 } else {
                     // should not run up here
-                    return LocalDateTime.now().format(DATE_TIME_FORMATTER);
+                    return formatDateTimeWithScale(LocalDateTime.now(), scale);
                 }
             }
         }
@@ -793,6 +798,20 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return null;
     }
 
+    // Format a timestamp into a time-function default literal honoring its fractional-second scale.
+    // scale 0 -> "yyyy-MM-dd HH:mm:ss"; scale N -> N fractional digits. DATETIME stores microseconds,
+    // so the frozen literal must carry the precision or now(N) would silently collapse to seconds.
+    private static String formatDateTimeWithScale(LocalDateTime dateTime, int scale) {
+        if (scale <= 0) {
+            return dateTime.format(DATE_TIME_FORMATTER);
+        }
+        StringBuilder pattern = new StringBuilder("yyyy-MM-dd HH:mm:ss.");
+        for (int i = 0; i < scale; i++) {
+            pattern.append('S');
+        }
+        return dateTime.format(DateTimeFormatter.ofPattern(pattern.toString()));
+    }
+
     // if the column have a default value or default expr can be calculated like now(). return calculated value
     // else for a batch of every row different like uuid(). return null
     // require specify currentTimestamp. this will get the default value of the incoming time
@@ -801,10 +820,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // If the default value is uuid(), this function is not suitable.
     public String calculatedDefaultValueWithTime(long currentTimestamp) {
         if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
+            if (defaultExpr.isTimeFunction()) {
                 LocalDateTime localDateTime = Instant.ofEpochMilli(currentTimestamp)
                         .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
-                return localDateTime.format(DATE_TIME_FORMATTER);
+                return formatDateTimeWithScale(localDateTime, defaultExpr.getTimeFunctionScale());
             } else if (defaultExpr.hasExprObject()) {
                 // For expr object type default expressions, return null
                 // The actual default value will be evaluated in BE from TExpr
@@ -823,11 +842,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         // Generator expressions must win over any materialized defaultValue: schema-change paths freeze
         // ALTER-time into defaultValue so BE can backfill existing rows, but metadata callers (DESCRIBE,
         // information_schema.columns) must still report the generator, not the frozen literal.
-        if (defaultExpr != null && isEmptyDefaultTimeFunction(defaultExpr)) {
+        if (defaultExpr != null && defaultExpr.isTimeFunction()) {
             if (extras != null) {
                 extras.add("DEFAULT_GENERATED");
             }
-            return "CURRENT_TIMESTAMP";
+            int scale = defaultExpr.getTimeFunctionScale();
+            return scale > 0 ? "CURRENT_TIMESTAMP(" + scale + ")" : "CURRENT_TIMESTAMP";
         }
         if (defaultValue != null) {
             return defaultValue;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
@@ -43,13 +43,16 @@ import java.util.regex.Pattern;
 public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(DefaultExpr.class);
 
+    // Captures the fractional-second scale from a time-function default, e.g. "now(3)" -> 3.
+    private static final Pattern TIME_FUNCTION_SCALE_PATTERN = Pattern.compile("\\(\\s*(\\d+)\\s*\\)");
+
     @SerializedName("expr")
     private String expr;
 
     // StarRocks Gson skips fields without @SerializedName (see HiddenAnnotationExclusionStrategy).
-    // Without persistence this flag flipped to false after FE restart / edit-log replay, which made
-    // isEmptyDefaultTimeFunction misclassify "current_timestamp(N)" as the empty form and silently
-    // dropped its precision argument.
+    // Without persistence this flag flipped to false after FE restart / edit-log replay, which lost
+    // the distinction between the bare now() / current_timestamp() form and the precision-bearing
+    // now(N) form when rendering the default back to SQL (toSql / SHOW CREATE TABLE).
     @SerializedName("hasArguments")
     private boolean hasArguments;
 
@@ -150,9 +153,24 @@ public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
         return matcher.matches();
     }
 
-    public static boolean isEmptyDefaultTimeFunction(DefaultExpr expr) {
-        return expr.getExprObject() == null && expr.getExpr() != null &&
-                isValidDefaultTimeFunction(expr.getExpr()) && !expr.hasArgs();
+    // A stable time-function default: now() / now(N) / current_timestamp() / current_timestamp(N).
+    // These are constant within a statement, so they materialize to a single value at a given time
+    // (with fractional-second scale N). They are NOT volatile - unlike uuid(), every row of one
+    // statement sees the same value. Classification is by function identity, not by whether the
+    // precision argument is present.
+    public boolean isTimeFunction() {
+        return !hasExprObject() && expr != null && isValidDefaultTimeFunction(expr);
+    }
+
+    // Fractional-second scale of a time-function default (e.g. now(3) -> 3); 0 for the bare
+    // now() / current_timestamp() form. Read straight from the canonical expr string so it never
+    // depends on the historically-fragile hasArguments flag.
+    public int getTimeFunctionScale() {
+        if (!isTimeFunction()) {
+            return 0;
+        }
+        Matcher matcher = TIME_FUNCTION_SCALE_PATTERN.matcher(expr);
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
     }
 
     public Expr obtainExpr() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
@@ -99,9 +99,10 @@ public class ColumnGsonSerializationTest {
         Assertions.assertNotNull(restored.getDefaultExpr());
         Assertions.assertTrue(restored.getDefaultExpr().hasArgs(),
                 "hasArguments must persist across Gson roundtrip");
-        // VARY rather than CONST: precision-bearing time functions are not 'empty' generators.
-        Assertions.assertEquals(Column.DefaultValueType.VARY, restored.getDefaultValueType(),
-                "current_timestamp(N) must stay classified as VARY after roundtrip");
+        // CONST, not VARY: precision-bearing time functions are stable within a statement (every row
+        // sees the same value), so the precision argument does not make them volatile.
+        Assertions.assertEquals(Column.DefaultValueType.CONST, restored.getDefaultValueType(),
+                "current_timestamp(N) must be classified as CONST after roundtrip");
     }
 
     @Test
@@ -123,7 +124,7 @@ public class ColumnGsonSerializationTest {
         Assertions.assertEquals("current_timestamp(3)", restored.getDefaultExpr().getExpr());
         Assertions.assertTrue(restored.getDefaultExpr().hasArgs(),
                 "legacy persisted current_timestamp(3) must recover hasArguments via gsonPostProcess");
-        Assertions.assertEquals(Column.DefaultValueType.VARY, restored.getDefaultValueType());
+        Assertions.assertEquals(Column.DefaultValueType.CONST, restored.getDefaultValueType());
 
         // An empty-arg form persisted under the same legacy schema must stay empty.
         FunctionCallExpr emptyExpr = new FunctionCallExpr("current_timestamp", Lists.newArrayList());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -44,6 +45,7 @@ import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnDef.DefaultValueDef;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.thrift.TColumn;
@@ -320,5 +322,51 @@ public class ColumnTest {
         String toSql = column.toSqlWithoutAggregateTypeName(null);
 
         Assertions.assertEquals("`col` json NULL COMMENT \"{\\\"id\\\":\\\"0\\\",\\\"value\\\":\\\"1\\\"}\"", toSql);
+    }
+
+    @Test
+    public void testTimeFunctionDefaultIsConstWithPrecision() {
+        // now(N)/current_timestamp(N) are stable within a statement, so they are CONST (not volatile),
+        // and the materialized literal keeps the N fractional-second digits (DATETIME stores microseconds).
+        // Fractional digits are timezone-invariant, so we can assert on them without pinning a time zone.
+        long ts = 1_000_000_000_789L; // ...789 milliseconds since epoch
+
+        Column ctsN = timeFunctionColumn("current_timestamp", 3);
+        Assertions.assertTrue(ctsN.getDefaultExpr().isTimeFunction());
+        Assertions.assertEquals(Column.DefaultValueType.CONST, ctsN.getDefaultValueType());
+        Assertions.assertEquals(3, ctsN.getDefaultExpr().getTimeFunctionScale());
+        String v3 = ctsN.calculatedDefaultValueWithTime(ts);
+        Assertions.assertTrue(v3.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}"),
+                "now(3) default must carry exactly 3 fractional digits, got: " + v3);
+        Assertions.assertTrue(v3.endsWith(".789"), "fractional part must be preserved, got: " + v3);
+        // Metadata reports the generator (with precision), never the frozen literal.
+        Assertions.assertEquals("CURRENT_TIMESTAMP(3)", ctsN.getMetaDefaultValue(new ArrayList<>()));
+
+        Column now6 = timeFunctionColumn("now", 6);
+        Assertions.assertEquals(Column.DefaultValueType.CONST, now6.getDefaultValueType());
+        Assertions.assertEquals(6, now6.getDefaultExpr().getTimeFunctionScale());
+        Assertions.assertTrue(now6.calculatedDefaultValueWithTime(ts).endsWith(".789000"),
+                "now(6) pads a millisecond-resolution source out to 6 digits");
+
+        Column nowEmpty = timeFunctionColumn("now", -1);
+        Assertions.assertEquals(Column.DefaultValueType.CONST, nowEmpty.getDefaultValueType());
+        Assertions.assertEquals(0, nowEmpty.getDefaultExpr().getTimeFunctionScale());
+        Assertions.assertFalse(nowEmpty.calculatedDefaultValueWithTime(ts).contains("."),
+                "bare now() stays at second granularity");
+        Assertions.assertEquals("CURRENT_TIMESTAMP", nowEmpty.getMetaDefaultValue(new ArrayList<>()));
+
+        Column uuidCol = new Column("u", VarcharType.VARCHAR, false, null, true,
+                new DefaultValueDef(true, false, new FunctionCallExpr("uuid", Lists.newArrayList())), "");
+        Assertions.assertFalse(uuidCol.getDefaultExpr().isTimeFunction());
+        Assertions.assertEquals(Column.DefaultValueType.VARY, uuidCol.getDefaultValueType(),
+                "uuid() is genuinely per-row volatile and stays VARY");
+    }
+
+    private static Column timeFunctionColumn(String fn, int scale) {
+        FunctionCallExpr expr = scale >= 0
+                ? new FunctionCallExpr(fn, Lists.newArrayList(new IntLiteral(scale, IntegerType.INT)))
+                : new FunctionCallExpr(fn, Lists.newArrayList());
+        return new Column("ts", DateType.DATETIME, false, null, true,
+                new DefaultValueDef(true, scale >= 0, expr), "");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableColumnAlterInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableColumnAlterInfoTest.java
@@ -78,7 +78,9 @@ public class TableColumnAlterInfoTest {
         Assertions.assertNotNull(replayedTs.getDefaultExpr());
         Assertions.assertTrue(replayedTs.getDefaultExpr().hasArgs(),
                 "edit-log replay must preserve hasArguments for current_timestamp(3)");
-        Assertions.assertEquals(Column.DefaultValueType.VARY, replayedTs.getDefaultValueType());
+        // Stable within a statement, hence CONST (not volatile) - the precision argument is preserved
+        // for rendering but does not change the default-value classification.
+        Assertions.assertEquals(Column.DefaultValueType.CONST, replayedTs.getDefaultValueType());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1554,7 +1554,10 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     public static boolean hasMicroseconds(String plan) {
-        Pattern pattern = Pattern.compile("<slot 2>\\s*:\\s*'\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}'");
+        // current_timestamp(N) is a stable const default: it freezes to a single literal (in slot 3, like the
+        // no-precision form), and the plan renders the fractional part with significant digits only, so the
+        // matcher is slot-agnostic and accepts 1-6 fractional digits rather than a fixed six.
+        Pattern pattern = Pattern.compile("'\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{1,6}'");
         Matcher matcher = pattern.matcher(plan);
         return matcher.find();
     }

--- a/test/sql/test_default_now_precision/R/test_default_now_precision
+++ b/test/sql/test_default_now_precision/R/test_default_now_precision
@@ -1,0 +1,88 @@
+-- name: test_add_column_default_now_precision
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column c DATETIME DEFAULT now(3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where c is NULL;
+-- result:
+0
+-- !result
+select count(distinct c) from t where id in (1, 2);
+-- result:
+1
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+-- result:
+CURRENT_TIMESTAMP(3)
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_add_column_default_current_timestamp_precision_not_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column c DATETIME NOT NULL DEFAULT current_timestamp(6);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where c is NULL;
+-- result:
+0
+-- !result
+select count(distinct c) from t where id in (1, 2);
+-- result:
+1
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+-- result:
+CURRENT_TIMESTAMP(6)
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_default_now_precision/T/test_default_now_precision
+++ b/test/sql/test_default_now_precision/T/test_default_now_precision
@@ -1,0 +1,61 @@
+-- name: test_add_column_default_now_precision
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+-- two rows written before column c exists: they physically lack c and are backfilled on read
+insert into t values (1), (2);
+
+-- now(3) is a precision-bearing time function: stable within a statement (NOT volatile like uuid),
+-- so ADD COLUMN must accept it (it was previously rejected as "unsupported default expr") and freeze
+-- a single ALTER-time value for the pre-existing rows.
+alter table t add column c DATETIME DEFAULT now(3);
+function: wait_alter_table_finish()
+
+-- row written after the column was added gets the current statement's now(3)
+insert into t (id) values (3);
+
+-- pre-existing rows are backfilled non-null
+select count(*) from t where c is NULL;
+
+-- id=1 and id=2 both predate c, so they share the SAME frozen ALTER-time value (one distinct)
+select count(distinct c) from t where id in (1, 2);
+
+-- the metadata default reports the generator with its precision, not the frozen literal
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+
+drop database db_${uuid0};
+
+
+-- name: test_add_column_default_current_timestamp_precision_not_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+insert into t values (1), (2);
+
+-- same stable time function with microsecond precision, NOT NULL: still accepted and backfilled
+alter table t add column c DATETIME NOT NULL DEFAULT current_timestamp(6);
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+select count(*) from t where c is NULL;
+select count(distinct c) from t where id in (1, 2);
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'c';
+
+drop database db_${uuid0};

--- a/test/sql/test_default_volatile_materialization/R/test_default_volatile_materialization
+++ b/test/sql/test_default_volatile_materialization/R/test_default_volatile_materialization
@@ -1,0 +1,192 @@
+-- name: test_add_column_default_uuid
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column u VARCHAR(36) DEFAULT (uuid());
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where u is NULL;
+-- result:
+0
+-- !result
+select count(distinct u) from t where id in (1, 2);
+-- result:
+2
+-- !result
+select count(distinct u) from t;
+-- result:
+3
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+-- result:
+uuid()
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_add_column_default_uuid_numeric
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column u LARGEINT DEFAULT (uuid_numeric());
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where u is NULL;
+-- result:
+0
+-- !result
+select count(distinct u) from t where id in (1, 2);
+-- result:
+2
+-- !result
+select count(distinct u) from t;
+-- result:
+3
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+-- result:
+uuid_numeric()
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_add_column_default_uuid_not_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column u VARCHAR(36) NOT NULL DEFAULT (uuid());
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where u is NULL;
+-- result:
+0
+-- !result
+select count(distinct u) from t where id in (1, 2);
+-- result:
+2
+-- !result
+select count(distinct u) from t;
+-- result:
+3
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+-- result:
+uuid()
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_add_column_default_uuid_numeric_not_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1), (2);
+-- result:
+-- !result
+alter table t add column u LARGEINT NOT NULL DEFAULT (uuid_numeric());
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select count(*) from t where u is NULL;
+-- result:
+0
+-- !result
+select count(distinct u) from t where id in (1, 2);
+-- result:
+2
+-- !result
+select count(distinct u) from t;
+-- result:
+3
+-- !result
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+-- result:
+uuid_numeric()
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_default_volatile_materialization/T/test_default_volatile_materialization
+++ b/test/sql/test_default_volatile_materialization/T/test_default_volatile_materialization
@@ -1,0 +1,122 @@
+-- name: test_add_column_default_uuid
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+-- two rows written before column u exists: they physically lack u and are backfilled during the rewrite
+insert into t values (1), (2);
+
+-- uuid() is a volatile default: every row gets its own value, which the single-value fast-schema-evolution
+-- backfill cannot represent, so ADD COLUMN forces a real rewrite that evaluates uuid() per pre-existing row
+-- (it was previously rejected as "unsupported default expr").
+alter table t add column u VARCHAR(36) DEFAULT (uuid());
+function: wait_alter_table_finish()
+
+-- row written after the column was added gets its own uuid()
+insert into t (id) values (3);
+
+-- every row (pre-existing + new) is non-null
+select count(*) from t where u is NULL;
+
+-- the two pre-existing rows got DISTINCT materialized values, NOT one frozen value (this is what
+-- separates a volatile default from a const default such as now(N), which would share one value)
+select count(distinct u) from t where id in (1, 2);
+
+-- all three rows hold distinct uuids
+select count(distinct u) from t;
+
+-- the metadata default reports the generator
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+
+drop database db_${uuid0};
+
+
+-- name: test_add_column_default_uuid_numeric
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+insert into t values (1), (2);
+
+-- uuid_numeric() is the LARGEINT volatile default: same per-row materialization for pre-existing rows
+alter table t add column u LARGEINT DEFAULT (uuid_numeric());
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+select count(*) from t where u is NULL;
+select count(distinct u) from t where id in (1, 2);
+select count(distinct u) from t;
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+
+drop database db_${uuid0};
+
+
+-- name: test_add_column_default_uuid_not_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+insert into t values (1), (2);
+
+-- NOT NULL volatile default: uuid() never returns null, so the rewrite materializes a non-null value per
+-- pre-existing row even though the column rejects nulls (the destination is non-nullable in the rewrite)
+alter table t add column u VARCHAR(36) NOT NULL DEFAULT (uuid());
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+select count(*) from t where u is NULL;
+select count(distinct u) from t where id in (1, 2);
+select count(distinct u) from t;
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+
+drop database db_${uuid0};
+
+
+-- name: test_add_column_default_uuid_numeric_not_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true", "replication_num" = "1");
+
+insert into t values (1), (2);
+
+alter table t add column u LARGEINT NOT NULL DEFAULT (uuid_numeric());
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+select count(*) from t where u is NULL;
+select count(distinct u) from t where id in (1, 2);
+select count(distinct u) from t;
+select column_default from information_schema.columns
+where table_schema = 'db_${uuid0}' and table_name = 't' and column_name = 'u';
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`ALTER TABLE ... ADD COLUMN ... DEFAULT (uuid())` / `DEFAULT (uuid_numeric())` is
rejected with `unsupported default expr`, even though `CREATE TABLE` accepts the
same volatile defaults. A volatile (VARY) default gives every row its own value,
and the single-value fast-schema-evolution backfill cannot represent that for
pre-existing rows, so the operation was blocked outright instead of materializing
per row. Same CREATE-vs-ADD-COLUMN asymmetry as precision time-function defaults,
but for genuinely per-row functions.

## What I'm doing:

Route a volatile default through the generated-column materialization path so the
schema-change rewrite evaluates the default once per pre-existing row (a distinct
value per row), matching CREATE TABLE and PostgreSQL's volatile-default rewrite.

- `Column.getMaterializedDefaultThriftExpr()` builds the per-row materialization expr.
- `SchemaChangeHandler.addColumnInternal` forces a real rewrite for a VARY default
  (the `fastSchemaEvolution = false` path generated columns already take) instead
  of rejecting it.
- `SchemaChangeJobV2` / `LakeTableSchemaChangeJob` feed the default expr into the
  existing `mc_exprs` map; BE evaluates it per row — no new BE machinery, the
  zero-column-reference expr (uuid() reads nothing) is already supported there.
- BE `assign_generated_column_value` honors the destination column's nullability. A
  generated column is always nullable, but a volatile default can be `NOT NULL`;
  since the expr engine marks even never-null functions like uuid() as nullable, a
  non-nullable destination unwraps the data column, and a genuine null reaching a
  NOT NULL column is reported as an error.

Consequences:
- `ADD COLUMN ... DEFAULT (uuid())` / `(uuid_numeric())` — nullable and `NOT NULL`
  — are accepted; pre-existing rows get distinct, stable, materialized values
  (frozen once at ALTER time, read back thereafter, not recomputed per read).
- Metadata reports the generator (`uuid()` / `uuid_numeric()`), never a frozen literal.
- `now()` / `now(N)` / `current_timestamp(N)` stay CONST (single frozen value) —
  they are not volatile.
- Materialization is for the base table only. Adding a volatile default to a rollup
  (`ADD COLUMN ... DEFAULT (uuid()) TO <rollup>`), or as a key column propagated to
  every index on a unique-key table, is rejected with a clear error: a rollup task
  reads its own old index version, not the materialized base, so the per-row value
  cannot be kept consistent across indexes. A plain add to the base works even when
  the table has rollups (the column does not enter the rollups).

Validated on a live cluster (DUPLICATE table, fast schema evolution): all four of
uuid()/uuid_numeric() × nullable/NOT NULL accepted; pre-existing rows non-null with
distinct per-row values (`count(distinct)=2` for the two old rows vs the `1` a
frozen const would give).

Depends on #74061. This branch is stacked on it; the precision-time-function commit
collapses out of the diff once #74061 merges.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
