### PR TITLE
[Enhancement] Use multi-column combined NDV for composite equi-join cardinality

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -48,6 +48,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.MaxLiteral;
@@ -1727,11 +1728,79 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         if (eqOnPredicates.isEmpty()) {
             return statistics;
         }
+        double mcRowCount = estimateInnerRowCountByMultiColumnNDV(statistics, eqOnPredicates);
+        if (mcRowCount >= 0) {
+            return statistics.withOutputRowCount(Math.max(1, mcRowCount));
+        }
         if (ConnectContext.get().getSessionVariable().isUseCorrelatedJoinEstimate()) {
             return estimatedInnerJoinStatisticsAssumeCorrelated(statistics, eqOnPredicates);
         } else {
             return statistics.withOutputRowCount(estimateInnerRowCountMiddleGround(statistics, eqOnPredicates));
         }
+    }
+
+    // Estimate inner-join row count from the multi-column combined NDV of the join key:
+    // |t1 join t2| ~= crossRows / max(ndv(leftKeyCols), ndv(rightKeyCols)), where ndv(cols) is the number of
+    // distinct value-combinations across that side's key columns (the combined NDV of the column set, not a single
+    // scalar key). The per-predicate heuristic instead derives the denominator from single-column NDV (the driving
+    // predicate plus a fixed auxiliary coefficient, or sqrt damping), never from the number of distinct key
+    // combinations, so it drifts on composite keys. Returns -1 when not applicable so the caller falls back to
+    // that heuristic. Restricted to the safe case: every equi-predicate is a plain '=' column-to-column comparison
+    // (null-safe '<=>' is left to the per-predicate path, which keeps NULL-matching rows), the key spans exactly two
+    // relations, and each relation's full key is covered by a combined-NDV statistic, so max() needs no independence
+    // guess.
+    private double estimateInnerRowCountByMultiColumnNDV(Statistics statistics,
+                                                         List<BinaryPredicateOperator> eqOnPredicates) {
+        if (eqOnPredicates.size() < 2 || columnRefFactory == null) {
+            return -1;
+        }
+        // Group join-key columns by their source relation rather than by predicate side: the equi-predicate
+        // operands are not normalized to (left-table, right-table) order, so child(0) may come from either side.
+        // A clean two-table composite key yields exactly two groups, each holding one table's key columns.
+        Map<Integer, Set<ColumnRefOperator>> relationToKeyColumns = new HashMap<>();
+        for (BinaryPredicateOperator predicate : eqOnPredicates) {
+            // Only plain '=' is safe here. Null-safe '<=>' (EQ_FOR_NULL) matches NULL key values, so the NULL
+            // discount applied below would drop those matches; leave it to the per-predicate estimator.
+            if (predicate.getBinaryType() != BinaryType.EQ) {
+                return -1;
+            }
+            for (ScalarOperator child : predicate.getChildren()) {
+                if (!(child instanceof ColumnRefOperator)) {
+                    return -1;
+                }
+                int relationId = columnRefFactory.getRelationId(((ColumnRefOperator) child).getId());
+                if (relationId == -1) {
+                    return -1;
+                }
+                relationToKeyColumns.computeIfAbsent(relationId, k -> new HashSet<>()).add((ColumnRefOperator) child);
+            }
+        }
+        if (relationToKeyColumns.size() != 2) {
+            return -1;
+        }
+
+        double ndv = 1.0;
+        double nonNullFactor = 1.0;
+        for (Set<ColumnRefOperator> keyColumns : relationToKeyColumns.values()) {
+            Pair<Set<ColumnRefOperator>, MultiColumnCombinedStats> mc = statistics.getLargestSubsetMCStats(keyColumns);
+            if (mc == null || mc.first.size() != keyColumns.size()) {
+                // this relation's full key is not covered by a combined-NDV statistic
+                return -1;
+            }
+            ndv = Math.max(ndv, mc.second.getNdv());
+            // NULLs never satisfy an equi-join, so discount the most NULL-heavy key column on this side,
+            // mirroring estimateColumnEqualToColumn's single-column (1 - nullsFraction) factor.
+            nonNullFactor *= (1.0 - maxNullsFraction(statistics, keyColumns));
+        }
+        return statistics.getOutputRowCount() / ndv * nonNullFactor;
+    }
+
+    private static double maxNullsFraction(Statistics statistics, Set<ColumnRefOperator> columns) {
+        return columns.stream()
+                .map(statistics::getColumnStatistic)
+                .mapToDouble(ColumnStatistic::getNullsFraction)
+                .max()
+                .orElse(0.0);
     }
 
     // The implementation here refers to Presto

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinMultiColumnNDVCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinMultiColumnNDVCardinalityTest.java
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.MultiColumnCombinedStatistics;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import mockit.Expectations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JoinMultiColumnNDVCardinalityTest extends PlanWithCostTestBase {
+    private OlapTable t0;
+    private OlapTable t1;
+
+    @BeforeEach
+    public void before() {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+        // crossRows = 1000 * 1000 = 1,000,000
+        setTableStatistics(t0, 1000);
+        setTableStatistics(t1, 1000);
+
+        StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
+        new Expectations(ss) {
+            {
+                // single-column distinct count 100 for every key column (min/max/nulls/avgSize/ndv)
+                ss.getColumnStatistic(t0, "v1");
+                result = new ColumnStatistic(0, 1000, 0, 8, 100);
+                minTimes = 0;
+                ss.getColumnStatistic(t0, "v2");
+                result = new ColumnStatistic(0, 1000, 0, 8, 100);
+                minTimes = 0;
+                ss.getColumnStatistic(t0, "v3");
+                result = new ColumnStatistic(0, 1000, 0, 8, 100);
+                minTimes = 0;
+                ss.getColumnStatistic(t1, "v4");
+                result = new ColumnStatistic(0, 1000, 0, 8, 100);
+                minTimes = 0;
+                ss.getColumnStatistic(t1, "v5");
+                result = new ColumnStatistic(0, 1000, 0, 8, 100);
+                minTimes = 0;
+                ss.getColumnStatistic(t1, "v6");
+                result = new ColumnStatistic(0, 1000, 0, 8, 100);
+                minTimes = 0;
+            }
+        };
+    }
+
+    private void mockCombinedStatsOnBothSides() {
+        StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
+        new Expectations(ss) {
+            {
+                ss.getMultiColumnCombinedStatistics(t0.getId());
+                result = new MultiColumnCombinedStatistics(
+                        Sets.newHashSet(t0.getColumn("v1").getUniqueId(), t0.getColumn("v2").getUniqueId()), 200);
+                minTimes = 0;
+                ss.getMultiColumnCombinedStatistics(t1.getId());
+                result = new MultiColumnCombinedStatistics(
+                        Sets.newHashSet(t1.getColumn("v4").getUniqueId(), t1.getColumn("v5").getUniqueId()), 100);
+                minTimes = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testCompositeKeyUsesCombinedNDV() throws Exception {
+        mockCombinedStatsOnBothSides();
+        // 1,000,000 / max(ndv(v1,v2)=200, ndv(v4,v5)=100) = 5000
+        String plan = getCostExplain("select * from t0 join t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5");
+        assertContains(plan, "cardinality: 5000");
+    }
+
+    @Test
+    public void testCombinedNDVIndependentOfPredicateOperandOrder() throws Exception {
+        mockCombinedStatsOnBothSides();
+        // operands not normalized to (left-table, right-table): the second predicate is written reversed.
+        // Grouping key columns by relation (not by predicate side) must still find both per-table keys.
+        String plan = getCostExplain("select * from t0 join t1 on t0.v1 = t1.v4 and t1.v5 = t0.v2");
+        assertContains(plan, "cardinality: 5000");
+    }
+
+    @Test
+    public void testFallsBackWhenOneSideUncovered() throws Exception {
+        StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
+        new Expectations(ss) {
+            {
+                // only t0 has a combined-NDV stat; t1's composite key is uncovered
+                ss.getMultiColumnCombinedStatistics(t0.getId());
+                result = new MultiColumnCombinedStatistics(
+                        Sets.newHashSet(t0.getColumn("v1").getUniqueId(), t0.getColumn("v2").getUniqueId()), 200);
+                minTimes = 0;
+                ss.getMultiColumnCombinedStatistics(t1.getId());
+                result = MultiColumnCombinedStatistics.EMPTY;
+                minTimes = 0;
+            }
+        };
+        // falls back to the per-predicate driving heuristic: 1,000,000 / 100 * 0.9 = 9000, not 5000
+        String plan = getCostExplain("select * from t0 join t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5");
+        assertContains(plan, "cardinality: 9000");
+        assertNotContains(plan, "cardinality: 5000");
+    }
+
+    @Test
+    public void testNullSafeEqualFallsBackToPerPredicate() throws Exception {
+        mockCombinedStatsOnBothSides();
+        // '<=>' matches NULL key values, so the combined-NDV path must not apply (it discounts NULLs). Falls back
+        // to the per-predicate heuristic: 1,000,000 / 100 * 0.9 = 9000, not the combined 5000.
+        String plan = getCostExplain("select * from t0 join t1 on t0.v1 <=> t1.v4 and t0.v2 <=> t1.v5");
+        assertContains(plan, "cardinality: 9000");
+        assertNotContains(plan, "cardinality: 5000");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Inner-join cardinality on a composite equi-key (e.g. `t0.a = t1.a AND t0.b = t1.b`)
is estimated from single-column NDV only. The default driving-predicate path keeps
the most selective `1/max(ndv(leftCol), ndv(rightCol))` factor and discounts the
rest by a fixed auxiliary coefficient; the middle-ground path uses sqrt damping.
Neither uses the number of distinct key-column *combinations*, so the row-count
estimate drifts on composite keys — it overestimates rows when the key columns are
largely independent (high combined NDV) and can underestimate when they are
correlated. This skews join-order and broadcast/shuffle decisions even when an
exact multi-column NDV statistic has already been collected for the key.

## What I'm doing:

When a multi-column combined-NDV statistic covers the full join key on both sides,
estimate the inner join directly as `crossRows / max(ndv(leftKeyCols), ndv(rightKeyCols))`,
where `ndv(cols)` is the combined NDV (number of distinct value-combinations) of
that side's key columns — not a single scalar key.

It applies only in the safe case and otherwise returns the existing heuristic
unchanged:
- every equi-predicate is a plain column-to-column comparison,
- the join key spans exactly two relations,
- each side's full key is covered by a combined-NDV statistic (so `max()` needs no
  independence guess).

Key columns are grouped by source relation rather than by predicate side, so the
estimate does not depend on operand ordering in the `ON` clause. NULLs are
discounted per side, mirroring the single-column equi-join factor. Multi-column
stats are loaded only for native tables, so external/lake tables are unaffected.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5