### PR TITLE
[UT] Stabilize and speed up CreateMaterializedViewTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -47,7 +47,6 @@ import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
-import com.starrocks.common.util.ThreadUtil;
 import com.starrocks.persist.CreateTableInfo;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
@@ -56,6 +55,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.SubmitResult;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -96,16 +96,16 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -121,6 +121,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
@@ -361,20 +363,33 @@ public class CreateMaterializedViewTest extends MVTestBase {
         stmtExecutor.execute();
     }
 
-    private List<TaskRunStatus> waitingTaskFinish() {
+    private List<TaskRunStatus> waitingTaskFinish(String mvTaskName) {
+        // Poll the task-run state for THIS task only, up to 15s with a 500ms interval.
+        // The previous version captured getMatchedTaskRunStatus(null) once at the start
+        // and then re-checked taskRuns.get(0) in a loop. That had two bugs:
+        //   1. The list was a snapshot - new pending/running runs submitted after the
+        //      first call were invisible, so the loop could return immediately by
+        //      seeing only an old, already-finished history entry.
+        //   2. Filter was null, so the "first" run might belong to any task in the
+        //      database, not the one the caller cares about.
+        // Both bugs were masked at the call sites by an unconditional Thread.sleep(4000L)
+        // inside getMaterializedViewChecked() that gave the periodic refresh task time
+        // to fire and reach a quiescent state before this method was even invoked.
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        List<TaskRunStatus> taskRuns = taskManager.getMatchedTaskRunStatus(null);
-        int retryCount = 0, maxRetry = 50;
-        while (retryCount < maxRetry) {
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(200L);
-            Constants.TaskRunState state = taskRuns.get(0).getState();
-            if (state.isFinishState()) {
-                break;
-            }
-            retryCount++;
-            LOG.info("waiting for TaskRunState retryCount:" + retryCount);
-        }
-        return taskRuns;
+        TGetTasksParams params = new TGetTasksParams();
+        params.setTask_name(mvTaskName);
+        Awaitility.await()
+                .atMost(15, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    List<TaskRunStatus> runs = taskManager.getMatchedTaskRunStatus(params);
+                    // At least one run must exist (covers the initial periodic-fire wait)
+                    // AND no pending/running runs may remain for this task name (so any
+                    // executeTask() submission made just before this call has drained).
+                    return !runs.isEmpty()
+                            && runs.stream().allMatch(r -> r.getState().isFinishState());
+                });
+        return taskManager.getMatchedTaskRunStatus(params);
     }
 
     // ========== full test ==========
@@ -446,7 +461,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
 
     public void testFullCreateSync(MaterializedView materializedView, Table baseTable) throws Exception {
         String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
-        List<TaskRunStatus> taskRuns = waitingTaskFinish();
+        List<TaskRunStatus> taskRuns = waitingTaskFinish(mvTaskName);
         Assertions.assertEquals(Constants.TaskRunState.SKIPPED, taskRuns.get(0).getState());
 
         validatePartitionSync(baseTable, materializedView);
@@ -466,7 +481,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
         StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
         new StmtExecutor(connectContext, statement).execute();
         GlobalStateMgr.getCurrentState().getTaskManager().executeTask(mvTaskName);
-        waitingTaskFinish();
+        waitingTaskFinish(mvTaskName);
     }
 
     @Test
@@ -3145,14 +3160,42 @@ public class CreateMaterializedViewTest extends MVTestBase {
         }
     }
 
-    @Test
-    public void testCreateAsync_Deferred(@Mocked TaskManager taskManager) throws Exception {
-        new Expectations() {
-            {
-                taskManager.executeTask((String) any);
-                times = 0;
+    // Counts invocations of TaskManager.executeTask(String). Used by the three
+    // testCreateAsync_* tests below in place of @Mocked TaskManager.
+    //
+    // Why a targeted MockUp instead of @Mocked TaskManager:
+    //   @Mocked TaskManager replaces every public method body of the class with a
+    //   JMockit stub for the duration of the test method. TaskManager.taskUnlock()
+    //   is public; tryTaskLock()/takeTaskLock() are private and therefore NOT
+    //   stubbed. If the TaskCleaner daemon happens to be inside one of the public
+    //   task-locked methods (e.g. removeExpiredTasks) when the test starts, the
+    //   real tryLock has already incremented the hold count - but the finally's
+    //   taskUnlock() call lands in the JMockit stub instead of taskLock.unlock().
+    //   The hold count never returns to zero, TaskCleaner becomes the perpetual
+    //   fair-lock owner, and every later test that drops a real-task MV wedges
+    //   in @AfterEach -> dropMaterializedView -> TaskManager.getTask ->
+    //   takeTaskLock. Observed as a flaky 1+ hour CI hang, reproduced twice
+    //   (2026-05-13 and 2026-05-29) with identical 2:06 elapsed-time fingerprint.
+    //   See trouble-shoot/fe-ut-timeout/findings-v2.html for the full write-up.
+    //
+    // The targeted MockUp only stubs the single public method we care about
+    // (executeTask(String)), so taskUnlock() and other TaskManager methods keep
+    // their real bodies and the strike window disappears.
+    private AtomicInteger installExecuteTaskCounter() {
+        AtomicInteger calls = new AtomicInteger();
+        new MockUp<TaskManager>() {
+            @Mock
+            public SubmitResult executeTask(String taskName) {
+                calls.incrementAndGet();
+                return new SubmitResult(null, SubmitResult.SubmitStatus.SUBMITTED);
             }
         };
+        return calls;
+    }
+
+    @Test
+    public void testCreateAsync_Deferred() throws Exception {
+        AtomicInteger executeTaskCalls = installExecuteTaskCounter();
         starRocksAssert.withMaterializedView(
                 "create materialized view deferred_async " +
                         "refresh deferred async distributed by hash(c_1_9) as" +
@@ -3165,16 +3208,12 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "create materialized view deferred_scheduled " +
                         "refresh deferred async every(interval 1 day) distributed by hash(c_1_9) as" +
                         " select c_1_9, c_1_4 from t1");
+        Assertions.assertEquals(0, executeTaskCalls.get());
     }
 
     @Test
-    public void testCreateAsync_Immediate(@Mocked TaskManager taskManager) throws Exception {
-        new Expectations() {
-            {
-                taskManager.executeTask((String) any);
-                times = 3;
-            }
-        };
+    public void testCreateAsync_Immediate() throws Exception {
+        AtomicInteger executeTaskCalls = installExecuteTaskCounter();
         starRocksAssert.withMaterializedView(
                 "create materialized view async_immediate " +
                         "refresh immediate async distributed by hash(c_1_9) as" +
@@ -3187,16 +3226,12 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "create materialized view schedule_immediate " +
                         "refresh immediate async every(interval 1 day) distributed by hash(c_1_9) as" +
                         " select c_1_9, c_1_4 from t1");
+        Assertions.assertEquals(3, executeTaskCalls.get());
     }
 
     @Test
-    public void testCreateAsync_Immediate_Implicit(@Mocked TaskManager taskManager) throws Exception {
-        new Expectations() {
-            {
-                taskManager.executeTask((String) any);
-                times = 3;
-            }
-        };
+    public void testCreateAsync_Immediate_Implicit() throws Exception {
+        AtomicInteger executeTaskCalls = installExecuteTaskCounter();
         starRocksAssert.withMaterializedView(
                 "create materialized view async_immediate_implicit " +
                         "refresh async distributed by hash(c_1_9) as" +
@@ -3209,6 +3244,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "create materialized view schedule_immediate_implicit " +
                         "refresh async every(interval 1 day) distributed by hash(c_1_9) as" +
                         " select c_1_9, c_1_4 from t1");
+        Assertions.assertEquals(3, executeTaskCalls.get());
     }
 
     private void testMVColumnAlias(String expr) throws Exception {
@@ -3931,12 +3967,21 @@ public class CreateMaterializedViewTest extends MVTestBase {
                     (CreateMaterializedViewStatement) statementBase;
 
             currentState.getLocalMetastore().createMaterializedView(createMaterializedViewStatement);
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
 
             TableName mvName = com.starrocks.catalog.TableName.fromTableRef(createMaterializedViewStatement.getTableRef());
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), mvName.getTbl());
-            Assertions.assertNotNull(table);
-            Assertions.assertTrue(table instanceof MaterializedView);
+            String mvTableName = mvName.getTbl();
+            // Poll for the named MV to appear in the local metastore, up to 5s with a
+            // 200ms interval. createMaterializedView is synchronous so the MV is normally
+            // visible immediately; polling tolerates any async registration delay.
+            // Periodic-refresh callers (e.g. testFullCreate) no longer rely on a fixed
+            // sleep here - the per-task-name waitingTaskFinish(mvTaskName) helper now
+            // waits for the first task run to reach a finish state instead.
+            Awaitility.await()
+                    .atMost(5, TimeUnit.SECONDS)
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .until(() -> GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(testDb.getFullName(), mvTableName) instanceof MaterializedView);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), mvTableName);
             return (MaterializedView) table;
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
@@ -3952,14 +3997,26 @@ public class CreateMaterializedViewTest extends MVTestBase {
                     (CreateMaterializedViewStatement) statementBase;
 
             currentState.getLocalMetastore().createMaterializedView(createMaterializedViewStatement);
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
 
             TableName mvTableName = com.starrocks.catalog.TableName.fromTableRef(createMaterializedViewStatement.getTableRef());
             mvName = mvTableName.getTbl();
 
+            // Poll for the named MV to appear in the local metastore, up to 5s with a 200ms
+            // interval. Replaces an unconditional Thread.sleep(4000L) that this helper used
+            // to do after createMaterializedView. The sleep was originally added in PR
+            // #9233 (Jul 2022) for one test that needed a periodic-refresh task to fire at
+            // least once; a subsequent refactor inherited it into this helper used by
+            // ~20 tests that only read the MV schema (no periodic refresh involved). The
+            // polling form costs ~0ms when the MV is already visible (the typical case,
+            // since createMaterializedView is synchronous) while still tolerating any
+            // future async registration delay.
+            String finalMvName = mvName;
+            Awaitility.await()
+                    .atMost(5, TimeUnit.SECONDS)
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .until(() -> GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(testDb.getFullName(), finalMvName) instanceof MaterializedView);
             Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), mvName);
-            Assertions.assertNotNull(table);
-            Assertions.assertTrue(table instanceof MaterializedView);
             MaterializedView mv = (MaterializedView) table;
 
             return mv.getFullSchema().stream().filter(Column::isKey).collect(Collectors.toList());


### PR DESCRIPTION
Combines two changes against the same test file:

1. Fix the flaky hang caused by @Mocked TaskManager racing TaskCleaner.

The three testCreateAsync_* tests used @Mocked TaskManager, which makes
JMockit replace every public method body with a class-wide stub for the
duration of the test. TaskManager.taskUnlock() is public;
tryTaskLock()/takeTaskLock() are private and therefore left untouched.
If the TaskCleaner daemon was inside removeExpiredTasks (the real
tryLock had already incremented the hold count) when the test method
started, the finally's taskUnlock() landed in the JMockit stub instead
of taskLock.unlock(). The hold count never returned to zero,
TaskCleaner became the perpetual fair-lock owner, and every later test
that dropped a real-task MV wedged in @AfterEach ->
dropMaterializedView -> TaskManager.getTask -> takeTaskLock for the
rest of the JVM.

Replace with a narrow MockUp<TaskManager> that only stubs the public
executeTask(String) overload these tests actually verify;
taskUnlock() and the other TaskManager methods keep their real bodies
and the strike window disappears. Reproduced twice (2026-05-13,
2026-05-29) with identical 2:06 elapsed-time fingerprint. See
trouble-shoot/fe-ut-timeout/findings-v2.html for the full diagnosis.

2. Replace two unconditional Thread.sleep(4000L) calls with Awaitility
polls and harden waitingTaskFinish().

The sleeps trace back to PR #9233 (Jul 2022) where one test needed a
periodic-refresh task to fire at least once; later refactors folded
the sleep into two helpers now used by ~24 callers, almost none of
which need to wait at all.

  getMaterializedViewKeysChecked()  -- 20 callers, schema-only
    poll: await up to 5s, interval 200ms, until MV is visible as
    a MaterializedView in LocalMetastore

  getMaterializedViewChecked()      -- 3 callers
    poll: same MV-visible condition, 5s / 200ms

The MV-visible poll is near-zero cost in the common case because
createMaterializedView is synchronous and the MV is already in
nameToTable by the time the helper looks.
Removing the second sleep also exposed a pre-existing race in
waitingTaskFinish(): it captured getMatchedTaskRunStatus(null) once
at the start and then re-checked taskRuns.get(0), so the loop could
return immediately by observing a stale, already-finished history
entry that belonged to some unrelated task. Harden the helper:

  - take an mvTaskName parameter and pass it to the task-name filter
    in TGetTasksParams, so only this MV's task runs are considered
  - poll (Awaitility, atMost 15s, interval 500ms) until at least one
    matching run exists AND all matching runs are in a finish state,
    so any pending/running submission drains before we return
  - return a freshly re-fetched list (not the stale snapshot)

Both call sites updated to pass the task name.

Result on local ./run-fe-ut.sh --test CreateMaterializedViewTest:
  Surefire time elapsed: 112.0 s -> 28.0 s (-75%)
  Wall clock:            3:00   -> 1:08    (-62%)
  Pass/fail:             201/0  -> 201/0   (unchanged)
  4s-plateau tests:      24     -> 0       (no fixed sleeps remain)

## Why I'm doing:

Introduced in #31258

```
2026-05-29T10:28:25.3058656Z 2026-05-29 18:28:24 [main] WARN  TaskManager:860 - task lock is held by: {"id":78,"name":"TaskCleaner","stack":["java.base@17.0.8/java.lang.Thread.sleep(Native Method)","app//com.starrocks.common.util.Daemon.run(Daemon.java:104)"]}
2026-05-29T10:28:25.3060607Z 2026-05-29 18:28:24 [main] WARN  TaskManager:879 - fail to get TaskManager lock after retry 1 times
2026-05-29T10:28:32.2939484Z 2026-05-29 18:28:29 [main] WARN  TaskManager:860 - task lock is held by: {"id":78,"name":"TaskCleaner","stack":["java.base@17.0.8/java.lang.Thread.sleep(Native Method)","app//com.starrocks.common.util.Daemon.run(Daemon.java:104)"]}
2026-05-29T10:28:32.2940748Z 2026-05-29 18:28:29 [main] WARN  TaskManager:879 - fail to get TaskManager lock after retry 2 times
2026-05-29T10:28:35.3007306Z 2026-05-29 18:28:34 [main] WARN  TaskManager:860 - task lock is held by: {"id":78,"name":"TaskCleaner","stack":["java.base@17.0.8/java.lang.Thread.sleep(Native Method)","app//com.starrocks.common.util.Daemon.run(Daemon.java:104)"]}

...

2026-05-29T11:40:18.3396721Z 2026-05-29 19:40:10 [main] WARN  TaskManager:879 - fail to get TaskManager lock after retry 862 times
2026-05-29T11:40:18.3397705Z 2026-05-29 19:40:15 [main] WARN  TaskManager:860 - task lock is held by: {"id":78,"name":"TaskCleaner","stack":["java.base@17.0.8/java.lang.Thread.sleep(Native Method)","app//com.starrocks.common.util.Daemon.run(Daemon.java:104)"]}
2026-05-29T11:40:18.3398631Z 2026-05-29 19:40:15 [main] WARN  TaskManager:879 - fail to get TaskManager lock after retry 863 times
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
