### PR TITLE
[UT] Resolve mockDML targets against analyzed db, not hardcoded "test"

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -91,6 +91,7 @@ public class AnalyzeMgrTest {
     @Test
     public void testAnalyzeMgrBasicStatsPersist() throws Exception {
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap().clear();
         Table table =
                 connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1461,10 +1461,10 @@ public class UtFrameUtils {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = com.starrocks.catalog.TableName.fromTableRef(insertStmt.getTableRef());
-                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-                    OlapTable tbl = ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(testDb.getFullName(), tableName.getTbl()));
-                    if (tbl != null) {
+                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(tableName.getDb(), tableName.getTbl());
+                    if (table instanceof OlapTable) {
+                        OlapTable tbl = (OlapTable) table;
                         for (Long partitionId : insertStmt.getTargetPartitionIds()) {
                             Partition partition = tbl.getPartition(partitionId);
                             setPartitionVersion(partition, partition.getDefaultPhysicalPartition().getVisibleVersion() + 1);
@@ -1473,10 +1473,11 @@ public class UtFrameUtils {
                 } else if (stmt instanceof DeleteStmt) {
                     DeleteStmt delete = (DeleteStmt) stmt;
                     TableName tableName = com.starrocks.catalog.TableName.fromTableRef(delete.getTableRef());
-                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-                    OlapTable tbl = ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(testDb.getFullName(), tableName.getTbl()));
-                    tbl.setHasDelete();
+                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(tableName.getDb(), tableName.getTbl());
+                    if (table instanceof OlapTable) {
+                        ((OlapTable) table).setHasDelete();
+                    }
                 }
             }
         };


### PR DESCRIPTION
Both branches of UtFrameUtils.mockDML() looked the target table up under a hardcoded literal "test" db, ignoring whatever db the statement was actually analyzed against. The DeleteStmt branch crashed with NPE; the InsertStmt branch silently early-returned via if (tbl != null).

Symptom (InsertStmt): same hardcoded "test" lookup, but the existing null guard turned the failure into a silent skip - the partition-version bump the mock is supposed to simulate did not run for any INSERT whose real target db was not "test" (including the periodic stats INSERTs into _statistics_.column_statistics fired by the same daemon).

## Why I'm doing:

```
2026-05-29T11:39:28.3325967Z 2026-05-29 19:39:22 [predicate-columns-daemon-thread] WARN  StmtExecutor:1282 - execute Exception, sql: DELETE FROM _statistics_.predicate_columns WHERE fe_id='127.0.0.1_9010_1780050378892' AND last_used < '2026-05-28 19:39:22'
2026-05-29T11:39:28.3327014Z java.lang.NullPointerException: Cannot invoke "com.starrocks.catalog.OlapTable.setHasDelete()" because "tbl" is null
2026-05-29T11:39:28.3327742Z    at com.starrocks.utframe.UtFrameUtils$8.handleDMLStmt(UtFrameUtils.java:1508) ~[test-classes/:?]
2026-05-29T11:39:28.3328344Z    at jdk.internal.reflect.GeneratedMethodAccessor31.invoke(Unknown Source) ~[?:?]
2026-05-29T11:39:28.3328995Z    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
2026-05-29T11:39:28.3329627Z    at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
2026-05-29T11:39:28.3330274Z    at mockit.internal.reflection.MethodReflection.invokeWithCheckedThrows(MethodReflection.java:123) ~[jmockit-1.49.4.jar:1.49.4]
2026-05-29T11:39:28.3331171Z    at mockit.internal.reflection.MethodReflection.invokeWithCheckedThrows(MethodReflection.java:28) ~[jmockit-1.49.4.jar:1.49.4]
2026-05-29T11:39:28.3332042Z    at mockit.internal.faking.FakeMethodBridge.executeSimpleFakeMethod(FakeMethodBridge.java:72) ~[jmockit-1.49.4.jar:1.49.4]
2026-05-29T11:39:28.3332817Z    at mockit.internal.faking.FakeMethodBridge.callFake(FakeMethodBridge.java:49) ~[jmockit-1.49.4.jar:1.49.4]
2026-05-29T11:39:28.3333516Z    at mockit.internal.faking.FakeMethodBridge.invoke(FakeMethodBridge.java:38) ~[jmockit-1.49.4.jar:1.49.4]
2026-05-29T11:39:28.3334127Z    at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java) ~[classes/:?]
2026-05-29T11:39:28.3334767Z    at com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:3070) ~[classes/:?]
2026-05-29T11:39:28.3335391Z    at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:1162) ~[classes/:?]
2026-05-29T11:39:28.3335960Z    at com.starrocks.qe.SimpleExecutor.executeDMLOrControl(SimpleExecutor.java:111) ~[classes/:?]
2026-05-29T11:39:28.3336597Z    at com.starrocks.qe.SimpleExecutor.executeDML(SimpleExecutor.java:89) ~[classes/:?]
2026-05-29T11:39:28.3337323Z    at com.starrocks.statistic.columns.PredicateColumnsStorage.vacuum(PredicateColumnsStorage.java:284) ~[classes/:?]
2026-05-29T11:39:28.3338121Z    at com.starrocks.statistic.columns.PredicateColumnsStorage.vacuum(PredicateColumnsStorage.java:270) ~[classes/:?]
2026-05-29T11:39:28.3338890Z    at com.starrocks.statistic.columns.PredicateColumnsMgr.vacuum(PredicateColumnsMgr.java:192) ~[classes/:?]
2026-05-29T11:39:28.3339720Z    at com.starrocks.statistic.columns.PredicateColumnsMgr$DaemonThread.runAfterCatalogReady(PredicateColumnsMgr.java:243) ~[classes/:?]
2026-05-29T11:39:28.3340511Z    at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:78) ~[classes/:?]
2026-05-29T11:39:28.3341067Z    at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[classes/:?]
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
