### PR TITLE
[Enhancement] Allow MODIFY COLUMN to change a value column's default

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -546,7 +546,7 @@ Status SegmentMetaCollecter::_append_default_column_value(ColumnId cid, Column* 
         column->append_nulls(1);
         return Status::OK();
     }
-    if (!tablet_column->has_default_value()) {
+    if (!tablet_column->has_backfill_default_value()) {
         column->append_nulls(1);
         return Status::OK();
     }
@@ -561,12 +561,17 @@ Status SegmentMetaCollecter::_append_default_column_value(ColumnId cid, Column* 
 
 Status SegmentMetaCollecter::_collect_count_for_default_column(ColumnId cid, Column* column) {
     ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
-    if (!tablet_column->has_default_value() && !tablet_column->is_nullable()) {
+    if (!tablet_column->has_backfill_default_value() && !tablet_column->is_nullable()) {
         return Status::InternalError(
                 fmt::format("invalid nonexistent column({}) without default value.", tablet_column->name()));
     }
 
-    bool is_null_default = !tablet_column->has_default_value();
+    // Match the read path (DefaultValueColumnIterator): missing-column rows take the frozen origin
+    // default (falling back to default_value), which is NULL when there is no backfill default or
+    // the value is the "NULL" sentinel. Counting by the current default_value alone would
+    // over-count rows that read as NULL after a default change.
+    bool is_null_default =
+            !tablet_column->has_backfill_default_value() || tablet_column->backfill_default_value() == "NULL";
     column->append_datum(int64_t(is_null_default ? 0 : _segment->num_rows()));
     return Status::OK();
 }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -233,6 +233,19 @@ Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnP
                          << "': " << converted.status().to_string();
         }
     }
+    // Frozen backfill default for rows older than this column (see Descriptors.thrift / ColumnPB).
+    if (t_column.__isset.origin_default_value) {
+        column_pb->set_origin_default_value(t_column.origin_default_value);
+    } else if (t_column.__isset.origin_default_expr) {
+        // Complex (array/map/struct) origin: evaluate to JSON, same as default_expr -> default_value.
+        auto converted = convert_default_expr_to_json_string(t_column.origin_default_expr);
+        if (converted.ok()) {
+            column_pb->set_origin_default_value(converted.value());
+        } else {
+            LOG(WARNING) << "Failed to convert origin_default_expr to JSON String for column '" << t_column.column_name
+                         << "': " << converted.status().to_string();
+        }
+    }
     if (t_column.__isset.is_bloom_filter_column) {
         column_pb->set_is_bf_column(t_column.is_bloom_filter_column);
     }
@@ -528,6 +541,16 @@ Status preprocess_default_expr_for_tcolumns(std::vector<TColumn>& columns) {
                 column.__isset.default_value = true;
             } else {
                 LOG(ERROR) << "Failed to convert default_expr to JSON String for column '" << column.column_name
+                           << "': " << result.status().to_string();
+            }
+        }
+        if (column.__isset.origin_default_expr && !column.__isset.origin_default_value) {
+            auto result = convert_default_expr_to_json_string(column.origin_default_expr);
+            if (result.ok()) {
+                column.origin_default_value = result.value();
+                column.__isset.origin_default_value = true;
+            } else {
+                LOG(ERROR) << "Failed to convert origin_default_expr to JSON String for column '" << column.column_name
                            << "': " << result.status().to_string();
             }
         }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -775,14 +775,16 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_create_merge_struct_ite
             ASSIGN_OR_RETURN(auto iter, (*_sub_readers)[iter->second]->new_iterator(child_paths[i], sub_column));
             field_iters.emplace_back(std::move(iter));
         } else {
-            if (!sub_column->has_default_value() && !sub_column->is_nullable()) {
+            if (!sub_column->has_backfill_default_value() && !sub_column->is_nullable()) {
                 return Status::InternalError(
                         fmt::format("invalid nonexistent column({}) without default value.", sub_column->name()));
             } else {
+                // Prefer the frozen origin default (falls back to default_value) for struct
+                // fields that are absent from this segment.
                 const TypeInfoPtr& type_info = get_type_info(*sub_column);
                 auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
-                        sub_column->has_default_value(), sub_column->default_value(), sub_column->is_nullable(),
-                        type_info, sub_column->length(), num_rows(), child_paths[i]);
+                        sub_column->has_backfill_default_value(), sub_column->backfill_default_value(),
+                        sub_column->is_nullable(), type_info, sub_column->length(), num_rows(), child_paths[i]);
                 ColumnIteratorOptions iter_opts;
                 RETURN_IF_ERROR(default_value_iter->init(iter_opts));
                 field_iters.emplace_back(std::move(default_value_iter));

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -516,14 +516,16 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_defaul
         return _new_extended_column_iterator(column, path);
     }
 
-    if (!column.has_default_value() && !column.is_nullable()) {
+    if (!column.has_backfill_default_value() && !column.is_nullable()) {
         return Status::InternalError(
                 fmt::format("invalid nonexistent column({}) without default value.", column.name()));
     } else {
+        // Use the frozen origin default (falls back to default_value) so rows older than this
+        // column keep the default in effect when it was added, not a later MODIFY DEFAULT value.
         const TypeInfoPtr& type_info = get_type_info(column);
         auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
-                column.has_default_value(), column.default_value(), column.is_nullable(), type_info, column.length(),
-                num_rows(), path);
+                column.has_backfill_default_value(), column.backfill_default_value(), column.is_nullable(), type_info,
+                column.length(), num_rows(), path);
         return default_value_iter;
     }
 }
@@ -545,9 +547,9 @@ StatusOr<ColumnIteratorUPtr> Segment::_new_extended_column_iterator(const Tablet
         // The root column does not exist in this segment (e.g., added by schema change later).
         // Fall back to column default/nullability.
         const TypeInfoPtr& type_info = get_type_info(column);
-        auto default_iter = std::make_unique<DefaultValueColumnIterator>(column.has_default_value(),
-                                                                         column.default_value(), column.is_nullable(),
-                                                                         type_info, column.length(), num_rows());
+        auto default_iter = std::make_unique<DefaultValueColumnIterator>(
+                column.has_backfill_default_value(), column.backfill_default_value(), column.is_nullable(), type_info,
+                column.length(), num_rows());
         VLOG(2) << "root column '" << col_name << "' not found in segment, return default for path: " << full_path;
         return default_iter;
     }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1546,11 +1546,22 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                         }
                     }
                 }
-                // During linked schema change, the now() default value is stored in TabletMeta.
-                // When receiving a new schema change request, the last default value stored should be
-                // remained instead of changing.
-                if (old_column.has_default_value()) {
+                // During linked schema change the frozen default is stored as default_value in
+                // TabletMeta. Inherit it only when the request omits its own default (e.g. a
+                // now()/expr default materialized on the BE); when the request carries a
+                // default_value (e.g. MODIFY ... DEFAULT changed it), honor it so the new default
+                // reaches new writes instead of being reverted to the old one.
+                if (old_column.has_default_value() && !new_column.__isset.default_value) {
                     new_columns[new_col_idx].__set_default_value(old_column.default_value());
+                }
+                // The old tablet is authoritative for the frozen backfill default (origin): rows
+                // older than the column keep the default in effect when it was added, regardless of a
+                // later MODIFY. For schemas predating origin_default_value, the old default_value is
+                // that frozen value.
+                if (old_column.has_origin_default_value()) {
+                    new_columns[new_col_idx].__set_origin_default_value(old_column.origin_default_value());
+                } else if (old_column.has_default_value()) {
+                    new_columns[new_col_idx].__set_origin_default_value(old_column.default_value());
                 }
                 col_idx_to_unique_id[new_col_idx] = old_unique_id;
             } else {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -252,6 +252,11 @@ void TabletColumn::init_from_pb(const ColumnPB& column) {
         extra->has_default_value = true;
         extra->default_value = column.default_value();
     }
+    if (column.has_origin_default_value()) {
+        ExtraFields* extra = _get_or_alloc_extra_fields();
+        extra->has_origin_default_value = true;
+        extra->origin_default_value = column.origin_default_value();
+    }
     for (size_t i = 0; i < column.children_columns_size(); ++i) {
         TabletColumn sub_column;
         sub_column.init_from_pb(column.children_columns(i));
@@ -286,6 +291,9 @@ void TabletColumn::to_schema_pb(ColumnPB* column) const {
     column->set_is_auto_increment(is_auto_increment());
     if (has_default_value()) {
         column->set_default_value(default_value());
+    }
+    if (has_origin_default_value()) {
+        column->set_origin_default_value(origin_default_value());
     }
     if (has_precision()) {
         column->set_precision(_precision);

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -74,8 +74,11 @@ struct ExtendedColumnInfo {
 class TabletColumn {
     struct ExtraFields {
         std::string default_value;
+        // Frozen backfill default for rows that physically lack this column; see origin_default_value().
+        std::string origin_default_value;
         std::vector<TabletColumn> sub_columns;
         bool has_default_value = false;
+        bool has_origin_default_value = false;
         bool is_virtual_column = false;
     };
 
@@ -170,6 +173,30 @@ public:
         ExtraFields* ext = _get_or_alloc_extra_fields();
         ext->has_default_value = true;
         ext->default_value = std::move(value);
+    }
+
+    // Default frozen at column-add time, used to backfill rows that physically predate this
+    // column (added via fast schema evolution). Unlike default_value(), ALTER MODIFY DEFAULT
+    // does not change it, so older rows keep the default in effect when the column was added.
+    bool has_origin_default_value() const { return _extra_fields && _extra_fields->has_origin_default_value; }
+
+    const std::string& origin_default_value() const {
+        return _extra_fields ? _extra_fields->origin_default_value : kEmptyDefaultValue;
+    }
+
+    void set_origin_default_value(std::string value) {
+        ExtraFields* ext = _get_or_alloc_extra_fields();
+        ext->has_origin_default_value = true;
+        ext->origin_default_value = std::move(value);
+    }
+
+    // Default value to use when filling a column that is absent from a segment. Prefers the
+    // frozen origin default; falls back to default_value() for schemas written before the
+    // origin field existed.
+    bool has_backfill_default_value() const { return has_origin_default_value() || has_default_value(); }
+
+    const std::string& backfill_default_value() const {
+        return has_origin_default_value() ? origin_default_value() : default_value();
     }
 
     bool is_virtual_column() const { return _extra_fields && _extra_fields->is_virtual_column; }

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -164,6 +164,78 @@ TEST_F(TabletMgrTest, CreateTablet) {
     ASSERT_TRUE(create_st.ok());
 }
 
+// A MODIFY ... DEFAULT that runs as a linked/heavy schema change goes through
+// _create_tablet_meta_unlocked. The new-write default (default_value) must come from the request,
+// while the frozen backfill default (origin_default_value) for rows older than the column is
+// preserved from the base tablet. Regression guard: the old code unconditionally copied the base
+// default_value over the request, reverting the user's new default for BE-side default filling.
+TEST_F(TabletMgrTest, SchemaChangeKeepsModifiedDefault) {
+    std::vector<DataDir*> data_dirs;
+    data_dirs.push_back(_data_dirs[0]);
+
+    auto make_req = [](int64_t tablet_id, int32_t schema_hash, int32_t schema_version, const std::string& c_default) {
+        TColumnType key_type;
+        key_type.__set_type(TPrimitiveType::SMALLINT);
+        TColumn key;
+        key.__set_column_name("col1");
+        key.__set_column_type(key_type);
+        key.__set_is_key(true);
+
+        TColumnType val_type;
+        val_type.__set_type(TPrimitiveType::INT);
+        TColumn val;
+        val.__set_column_name("c");
+        val.__set_column_type(val_type);
+        val.__set_is_key(false);
+        val.__set_aggregation_type(TAggregationType::REPLACE);
+        val.__set_is_allow_null(true);
+        val.__set_default_value(c_default);
+
+        std::vector<TColumn> cols{key, val};
+        TTabletSchema schema;
+        schema.__set_short_key_column_count(1);
+        schema.__set_schema_hash(schema_hash);
+        schema.__set_schema_version(schema_version);
+        schema.__set_keys_type(TKeysType::AGG_KEYS);
+        schema.__set_storage_type(TStorageType::COLUMN);
+        schema.__set_columns(cols);
+
+        TCreateTabletReq req;
+        req.__set_tablet_schema(schema);
+        req.__set_tablet_id(tablet_id);
+        req.__set_version(2);
+        req.__set_version_hash(0);
+        return req;
+    };
+
+    // Base tablet: column c has add-time default "1".
+    TCreateTabletReq base_req = make_req(20001, 3333, 0, "1");
+    ASSERT_TRUE(_tablet_mgr->create_tablet(base_req, data_dirs).ok());
+
+    // Schema change: MODIFY c default 1 -> 2 (base_tablet_id set => linked/heavy path).
+    TCreateTabletReq sc_req = make_req(20002, 3334, 1, "2");
+    sc_req.__set_base_tablet_id(20001);
+    ASSERT_TRUE(_tablet_mgr->create_tablet(sc_req, data_dirs).ok());
+
+    TabletMetaSharedPtr meta(new TabletMeta());
+    ASSERT_TRUE(TabletMetaManager::get_tablet_meta(_data_dirs[0], 20002, 3334, meta.get()).ok());
+    const auto& tschema = meta->tablet_schema();
+    int c_idx = -1;
+    for (size_t i = 0; i < tschema.num_columns(); ++i) {
+        if (tschema.column(i).name() == "c") {
+            c_idx = static_cast<int>(i);
+            break;
+        }
+    }
+    ASSERT_GE(c_idx, 0);
+    const TabletColumn& c = tschema.column(c_idx);
+    // New writes get the modified default, not the reverted old one.
+    EXPECT_EQ("2", c.default_value());
+    // Rows older than the column keep the add-time default via the frozen origin.
+    ASSERT_TRUE(c.has_origin_default_value());
+    EXPECT_EQ("1", c.origin_default_value());
+}
+
 TEST_F(TabletMgrTest, DropTablet) {
     TCreateTabletReq create_tablet_req = get_create_tablet_request(111, 3333);
     std::vector<DataDir*> data_dirs;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -859,6 +859,11 @@ public class SchemaChangeHandler extends AlterHandler {
         modColumn.setName(oriColumn.getName());
         modColumn.setColumnId(oriColumn.getColumnId());
         modColumn.setUniqueId(oriColumn.getUniqueId());
+        // Carry over the frozen backfill default. MODIFY only changes the default for new
+        // writes (modColumn.defaultValue); rows older than the column must keep the default
+        // that was in effect when it was added, so origin is inherited, not taken from the clause.
+        modColumn.setOriginDefaultValue(oriColumn.getOriginDefaultValue());
+        modColumn.setOriginDefaultExpr(oriColumn.getOriginDefaultExpr());
 
         if (!oriColumn.isGeneratedColumn() && modColumn.isGeneratedColumn()) {
             throw new DdlException("Can not modify a non-generated column to a generated column");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -97,6 +97,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     private static final Logger LOG = LogManager.getLogger(Column.class);
 
     public static final String CAN_NOT_CHANGE_DEFAULT_VALUE = "Can not change default value";
+    // Sentinel stored in originDefaultValue meaning the column had no default when it was added,
+    // so rows older than it stay NULL even if a default is added later. Mirrors BE's "NULL"
+    // default_value convention (DefaultValueColumnIterator maps "NULL" to a null fill).
+    public static final String NULL_ORIGIN_DEFAULT_VALUE = "NULL";
     public static final int COLUMN_UNIQUE_ID_INIT_VALUE = -1;
 
     // logical name, rename will change this name.
@@ -141,6 +145,18 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     private boolean isAutoIncrement;
     @SerializedName(value = "defaultValue")
     private String defaultValue;
+    // Add-time default used to backfill rows that physically lack this column (added via fast
+    // schema evolution). Set when ALTER ... MODIFY ... DEFAULT changes the default: it freezes the
+    // pre-change (add-time) value here while |defaultValue| moves to the new default, so rows older
+    // than the column keep the default that was in effect when it was added. Null until then;
+    // getOriginDefaultValue() derives the add-time value from the current state in that case.
+    @SerializedName(value = "originDefaultValue")
+    private String originDefaultValue;
+    // Expression form of the add-time backfill default, used for complex (ARRAY/MAP/STRUCT) defaults
+    // whose materialized JSON only exists on the BE: MODIFY freezes the pre-change expression here,
+    // and the BE converts it to the origin JSON. Scalar defaults use |originDefaultValue| instead.
+    @SerializedName(value = "originDefaultExpr")
+    private DefaultExpr originDefaultExpr;
     // this handle function like now() or simple expression
     @SerializedName(value = "defaultExpr")
     private DefaultExpr defaultExpr;
@@ -295,6 +311,8 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.isKey = column.isKey();
         this.isAllowNull = column.isAllowNull();
         this.defaultValue = column.getDefaultValue();
+        this.originDefaultValue = column.originDefaultValue;
+        this.originDefaultExpr = column.originDefaultExpr;
         this.comment = column.getComment();
         this.defineExpr = column.getDefineExpr();
         this.defaultExpr = column.defaultExpr;
@@ -434,6 +452,52 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.defaultValue;
     }
 
+    public void setOriginDefaultValue(String originDefaultValue) {
+        this.originDefaultValue = originDefaultValue;
+    }
+
+    // Add-time backfill default for rows that physically lack this column. Returns the value
+    // frozen by a prior MODIFY ... DEFAULT once set; otherwise derives it from the current state,
+    // which equals the add-time default because a default can only be changed via MODIFY (which
+    // freezes it here), so an unfrozen column has never had its default changed. Complex
+    // (ARRAY/MAP/STRUCT) defaults return null here and carry their origin via getOriginDefaultExpr();
+    // a column with no backfillable literal returns null too. See the per-branch notes below.
+    public String getOriginDefaultValue() {
+        if (this.originDefaultValue != null) {
+            return this.originDefaultValue;
+        }
+        // Complex (ARRAY/MAP/STRUCT) defaults have no literal here — their add-time origin is carried
+        // in expression form via getOriginDefaultExpr() and materialized to JSON on the BE.
+        if (defaultExpr != null && defaultExpr.hasExprObject()) {
+            return null;
+        }
+        // A frozen literal (a literal default, or an ADD-time now()/current_timestamp) is what older
+        // rows read; anything not materialized into a literal (uuid(), current_timestamp(N), no
+        // default) leaves older rows reading SQL NULL.
+        if (defaultValue != null) {
+            return defaultValue;
+        }
+        return isAllowNull ? NULL_ORIGIN_DEFAULT_VALUE : null;
+    }
+
+    public void setOriginDefaultExpr(DefaultExpr originDefaultExpr) {
+        this.originDefaultExpr = originDefaultExpr;
+    }
+
+    // Add-time backfill default in expression form, for complex (ARRAY/MAP/STRUCT) defaults. Returns
+    // the value frozen by a prior MODIFY once set; otherwise the current complex default expression,
+    // which equals the add-time value (a default can only change via MODIFY, which freezes it). Null
+    // for non-complex columns (those use getOriginDefaultValue()).
+    public DefaultExpr getOriginDefaultExpr() {
+        if (this.originDefaultExpr != null) {
+            return this.originDefaultExpr;
+        }
+        if (defaultExpr != null && defaultExpr.hasExprObject()) {
+            return defaultExpr;
+        }
+        return null;
+    }
+
     public void setComment(String comment) {
         this.comment = comment;
     }
@@ -517,6 +581,18 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         } else if (this.defaultValue != null) {
             tColumn.setDefault_value(this.defaultValue);
         }
+        // Frozen backfill default for rows older than this column. Sent independently of
+        // default_value/default_expr so MODIFY DEFAULT does not retroactively change them.
+        String originDefault = getOriginDefaultValue();
+        if (originDefault != null) {
+            tColumn.setOrigin_default_value(originDefault);
+        }
+        // Complex (ARRAY/MAP/STRUCT) defaults carry their frozen origin in expression form; the BE
+        // converts it to the origin JSON, mirroring default_expr -> default_value.
+        DefaultExpr originExpr = getOriginDefaultExpr();
+        if (originExpr != null && originExpr.getExprObject() != null) {
+            tColumn.setOrigin_default_expr(ExprToThrift.treeToThrift(originExpr.getExprObject()));
+        }
 
         // The define expr does not need to be serialized here for now.
         // At present, only serialized(analyzed) define expr is directly used when creating a materialized view.
@@ -581,8 +657,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             throw new DdlException("Can not change from nullable to non-nullable");
         }
 
-        // Adding a default value to a column without a default value is not supported
-        if (!this.isSameDefaultValue(other)) {
+        // Allow changing the default for non-key value columns (see isDefaultValueChangeAllowed).
+        // The change is never retroactive: rows older than the column keep their add-time default
+        // via getOriginDefaultValue()/getOriginDefaultExpr() -- frozen on the first MODIFY, derived
+        // from the current (still add-time) default before that -- so even columns created before
+        // this feature keep their old rows' values; only new writes see the new default.
+        if (!this.isSameDefaultValue(other) && !this.isDefaultValueChangeAllowed()) {
             throw new DdlException(CAN_NOT_CHANGE_DEFAULT_VALUE);
         }
 
@@ -621,6 +701,19 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             }
         }
         return true;
+    }
+
+    // Whether MODIFY ... DEFAULT may change this column's default. Allowed for any non-key value
+    // column with a simple aggregation: scalar defaults keep the add-time value via
+    // getOriginDefaultValue(), complex (ARRAY/MAP/STRUCT) defaults via getOriginDefaultExpr(). Key
+    // columns and SUM/MIN/MAX/union aggregations (e.g. SUM requires a zero default) stay immutable.
+    private boolean isDefaultValueChangeAllowed() {
+        if (isKey) {
+            return false;
+        }
+        return aggregationType == null || aggregationType == AggregateType.NONE
+                || aggregationType == AggregateType.REPLACE
+                || aggregationType == AggregateType.REPLACE_IF_NOT_NULL;
     }
 
     public boolean nameEquals(String otherColName, boolean ignorePrefix) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaChangeTypeCompatibility.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaChangeTypeCompatibility.java
@@ -156,6 +156,14 @@ public class SchemaChangeTypeCompatibility {
     }
 
     public static boolean isSchemaChangeAllowed(Type lhs, Type rhs) {
+        // An identical type needs no conversion, so the change is always allowed -- this covers a
+        // MODIFY that only changes a column attribute such as the default. The matrix below encodes
+        // only scalar conversions, so without this complex types (ARRAY/MAP/STRUCT) could not be
+        // modified even to the same type. A genuine complex type change (e.g. ARRAY<INT> to
+        // ARRAY<BIGINT>) is not equal here and still falls through to the matrix, which rejects it.
+        if (lhs.equals(rhs)) {
+            return true;
+        }
         if (lhs.isDecimalV3() || rhs.isDecimalV3()) {
             return isSchemaChangeAllowedInvolvingDecimalV3(lhs, rhs);
         }

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -78,6 +78,12 @@ message ColumnPB {
     optional bool is_auto_increment = 18;
     // agg_state type
     optional AggStateDescPB agg_state_desc = 19;
+    // Default value used to backfill rows that physically lack this column (added via fast
+    // schema evolution). Frozen at column-add time; ALTER ... MODIFY ... DEFAULT does not
+    // change it. Distinct from |default_value| (field 7), which is the default for newly
+    // written rows. Absent for schemas written before this field existed; readers fall back
+    // to |default_value| in that case.
+    optional bytes origin_default_value = 20;
 }
 
 message TabletSchemaPB {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -276,6 +276,15 @@ struct TColumn {
     // If set, BE will evaluate this expression and convert to JSON string for storage.
     // For simple types, use |default_value| (field 6) instead.
     22: optional Exprs.TExpr default_expr
+    // Default value used to backfill rows that physically lack this column (added via fast
+    // schema evolution). Frozen at column-add time; ALTER ... MODIFY ... DEFAULT does not
+    // change it. Distinct from |default_value| (field 6), which is the default for newly
+    // written rows.
+    23: optional string origin_default_value
+    // Expression form of |origin_default_value| for complex (array/map/struct) defaults: the BE
+    // evaluates it and converts to the origin JSON, the same way |default_expr| feeds
+    // |default_value|. Set only when the frozen origin is a complex default.
+    24: optional Exprs.TExpr origin_default_expr
 }
 
 // Key information for locating a specific table schema version.

--- a/test/sql/test_modify_column_default/R/test_modify_column_default
+++ b/test/sql/test_modify_column_default/R/test_modify_column_default
@@ -1,0 +1,467 @@
+-- name: test_modify_column_default_retroactive
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT DEFAULT "1";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "2";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	1
+2	1
+3	2
+-- !result
+select count(c) from t;
+-- result:
+3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_add_default_keeps_old_rows_null
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "9";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	None
+2	None
+3	9
+-- !result
+select count(c) from t;
+-- result:
+1
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_complex_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c ARRAY<INT> DEFAULT [1,2,3];
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c ARRAY<INT> DEFAULT [4,5,6];
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	[1,2,3]
+2	[1,2,3]
+3	[4,5,6]
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_keeps_original_across_multiple_changes
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT DEFAULT "1";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "2";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+alter table t modify column c INT DEFAULT "3";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	1
+2	1
+3	3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_on_create_table_column
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT,
+    c INT DEFAULT "1"
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t (id) values (1);
+-- result:
+-- !result
+alter table t modify column c INT DEFAULT "2";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	1
+2	2
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_rejected_for_key_and_aggregate_columns
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table tk (
+    id INT DEFAULT "0",
+    v INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+alter table tk modify column id INT DEFAULT "1";
+-- result:
+E: (1064, 'No key column left. index[tk]')
+-- !result
+create table ta (
+    id INT,
+    s INT SUM
+)
+AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+alter table ta modify column s INT SUM DEFAULT "5";
+-- result:
+E: (1064, 'Can not change default value')
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_map_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c MAP<VARCHAR(10), INT> DEFAULT map{'a':1};
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c MAP<VARCHAR(10), INT> DEFAULT map{'b':2};
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	{"a":1}
+2	{"a":1}
+3	{"b":2}
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_struct_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(1, 'a');
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(2, 'b');
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	{"x":1,"y":"a"}
+2	{"x":1,"y":"a"}
+3	{"x":2,"y":"b"}
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_default_literal_to_current_timestamp
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c DATETIME DEFAULT "2020-01-01 00:00:00";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c DATETIME DEFAULT CURRENT_TIMESTAMP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select c from t where id in (1, 2) order by id;
+-- result:
+2020-01-01 00:00:00
+2020-01-01 00:00:00
+-- !result
+select count(c) from t;
+-- result:
+3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_modify_remove_default_keeps_old_rows
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+alter table t add column c INT NULL DEFAULT "5";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (2);
+-- result:
+-- !result
+alter table t modify column c INT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into t (id) values (3);
+-- result:
+-- !result
+select * from t order by id;
+-- result:
+1	5
+2	5
+3	None
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_modify_column_default/T/test_modify_column_default
+++ b/test/sql/test_modify_column_default/T/test_modify_column_default
@@ -1,0 +1,315 @@
+-- name: test_modify_column_default_retroactive
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- row written before column c exists: physically lacks c, backfilled on read
+insert into t values (1);
+
+-- add c with default 1 (fast schema evolution: metadata-only, no data rewrite)
+alter table t add column c INT DEFAULT "1";
+function: wait_alter_table_finish()
+
+-- row written while the default is 1: physically stores c=1
+insert into t (id) values (2);
+
+-- change the default to 2 (now allowed; old rows must keep the add-time default)
+alter table t modify column c INT DEFAULT "2";
+function: wait_alter_table_finish()
+
+-- row written after the change: physically stores c=2
+insert into t (id) values (3);
+
+-- id=1 predates the column, so it keeps 1 (default when c was added), not 2.
+-- id=2 stays 1, id=3 is 2.
+select * from t order by id;
+
+-- count must agree with the read path (all three rows are non-null)
+select count(c) from t;
+
+drop database db_${uuid0};
+
+
+-- name: test_add_default_keeps_old_rows_null
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- row written before column c exists
+insert into t values (1);
+
+-- add c with NO default (nullable): rows older than c read NULL
+alter table t add column c INT;
+function: wait_alter_table_finish()
+
+-- row written while c has no default: physically stores NULL
+insert into t (id) values (2);
+
+-- add a default where none existed: must NOT retroactively change older rows to 9
+alter table t modify column c INT DEFAULT "9";
+function: wait_alter_table_finish()
+
+-- row written after the default was added: physically stores c=9
+insert into t (id) values (3);
+
+-- id=1 and id=2 had no default when written, so they stay NULL; only id=3 is 9.
+select * from t order by id;
+
+-- count(c) must match: only id=3 is non-null (regression guard for the meta count fast path)
+select count(c) from t;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_complex_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- row written before column c exists
+insert into t values (1);
+
+-- add an ARRAY column with a complex default (constant literal)
+alter table t add column c ARRAY<INT> DEFAULT [1,2,3];
+function: wait_alter_table_finish()
+
+-- row written while the default is [1,2,3]: physically stores it
+insert into t (id) values (2);
+
+-- change the complex default; older rows must keep the add-time [1,2,3]
+alter table t modify column c ARRAY<INT> DEFAULT [4,5,6];
+function: wait_alter_table_finish()
+
+-- row written after the change: physically stores [4,5,6]
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time default [1,2,3]; only id=3 is [4,5,6]
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_keeps_original_across_multiple_changes
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c INT DEFAULT "1";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+alter table t modify column c INT DEFAULT "2";
+function: wait_alter_table_finish()
+
+alter table t modify column c INT DEFAULT "3";
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 keeps the ORIGINAL add-time default 1 across two changes (not 2); id=2 stays 1; id=3 is 3
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_on_create_table_column
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT,
+    c INT DEFAULT "1"
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t (id) values (1);
+
+-- c exists from CREATE TABLE, so changing its default is allowed too
+alter table t modify column c INT DEFAULT "2";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+-- c is always physical for CREATE-table columns: id=1 keeps 1, id=2 gets 2
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_rejected_for_key_and_aggregate_columns
+create database db_${uuid0};
+use db_${uuid0};
+
+create table tk (
+    id INT DEFAULT "0",
+    v INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- modifying the sole key column is rejected before the default check (no key column would remain)
+alter table tk modify column id INT DEFAULT "1";
+
+create table ta (
+    id INT,
+    s INT SUM
+)
+AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+-- SUM aggregate columns have a constrained default and stay immutable
+alter table ta modify column s INT SUM DEFAULT "5";
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_map_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c MAP<VARCHAR(10), INT> DEFAULT map{'a':1};
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+alter table t modify column c MAP<VARCHAR(10), INT> DEFAULT map{'b':2};
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time map; only id=3 is the new map
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_struct_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(1, 'a');
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+alter table t modify column c STRUCT<x INT, y VARCHAR(10)> DEFAULT row(2, 'b');
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time struct; only id=3 is the new struct
+select * from t order by id;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_default_literal_to_current_timestamp
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c DATETIME DEFAULT "2020-01-01 00:00:00";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+-- changing a literal default to now()/current_timestamp must be allowed
+alter table t modify column c DATETIME DEFAULT CURRENT_TIMESTAMP;
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- older rows keep the add-time literal (deterministic); the new now() value is not asserted
+select c from t where id in (1, 2) order by id;
+
+-- all three rows are non-null (id=3 got a now() value)
+select count(c) from t;
+
+drop database db_${uuid0};
+
+
+-- name: test_modify_remove_default_keeps_old_rows
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    id INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("fast_schema_evolution" = "true");
+
+insert into t values (1);
+
+alter table t add column c INT NULL DEFAULT "5";
+function: wait_alter_table_finish()
+
+insert into t (id) values (2);
+
+-- removing the default (MODIFY without DEFAULT) must keep older rows and only drop it for new writes
+alter table t modify column c INT NULL;
+function: wait_alter_table_finish()
+
+insert into t (id) values (3);
+
+-- id=1 and id=2 keep the add-time 5; id=3 has no default now, so it is NULL
+select * from t order by id;
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Changing a column's default used to require dropping and re-adding the column:
`ALTER TABLE ... MODIFY COLUMN ... DEFAULT` was hard-rejected with
"Can not change default value". The blocker was that StarRocks kept only a
single schema-level default per column, used both for new writes and to
backfill rows that physically lack the column (fast schema evolution). Changing
that one value would retroactively alter every pre-existing row, so the change
was forbidden outright.

## What I'm doing:

Allow `MODIFY COLUMN ... DEFAULT` for non-key value columns whose aggregation is
`NONE`, `REPLACE`, or `REPLACE_IF_NOT_NULL`. `SUM`/`MIN`/`MAX`/union-type
aggregate columns stay rejected (their default is constrained — e.g. a `SUM`
column must have a zero default, enforced at ADD COLUMN); a key column is
rejected independently, since the MODIFY would leave the table with no key.

The change is **not retroactive**: the new default applies only to new writes,
while rows older than the column keep the default that was in effect when it was
added — matching the intuitive, PostgreSQL-like semantics. This freezes an
**origin default** the first time MODIFY changes it:

- scalar defaults via `Column.originDefaultValue` → `TColumn.origin_default_value`;
- complex (ARRAY/MAP/STRUCT) defaults via `Column.originDefaultExpr` →
  `TColumn.origin_default_expr`, materialized to the origin JSON on the BE,
  mirroring `default_expr` → `default_value`.

The origin is derived lazily from the current default until that first freeze,
so columns created before this change keep correct backfill values.

Two changes make this work end to end:

- **Complex columns**: `MODIFY` on an ARRAY/MAP/STRUCT column was previously
  rejected outright (`Can not change ARRAY<INT> to ARRAY<INT>`), because the
  type-compatibility matrix only encodes scalar conversions.
  `SchemaChangeTypeCompatibility.isSchemaChangeAllowed` now short-circuits
  identical types (no conversion is needed), so a default-only MODIFY is
  allowed; a genuine complex type change (`ARRAY<INT>` → `ARRAY<BIGINT>`) is not
  equal and is still rejected.
- **Linked/heavy schema change** (`fast_schema_evolution=false`, or a default
  change combined with a type change) goes through
  `TabletManager::_create_tablet_meta_unlocked`, which used to copy the base
  column's `default_value` over the request — reverting a just-set default for
  BE-side default filling. It now keeps the request's `default_value` for new
  writes and preserves the frozen value as `origin_default_value` for older rows.

BE wires `origin_default_value`/`origin_default_expr` through the tablet schema
(proto + thrift), `tablet_manager`, segment and column readers, and the meta
reader, so the backfill and the meta-count fast path agree with the read path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
