### PR TITLE
[BugFix] Add some assert on PartitionedSpillerWriter

### DIFF
--- a/be/src/compute_env/spill/spill_components.cpp
+++ b/be/src/compute_env/spill/spill_components.cpp
@@ -669,6 +669,10 @@ Status PartitionedSpillerWriter::_compact_skew_chunks(size_t num_rows, std::vect
     if (num_rows < 30) {
         return Status::OK();
     }
+    // Invariants enforced via CHECK so that a violation surfaces with a clear stack
+    // and diagnostic line instead of an OOB read in the locator loop below.
+    // See https://github.com/StarRocks/starrocks/issues/74074.
+    CHECK(!chunks.empty()) << "_compact_skew_chunks: empty chunks with num_rows=" << num_rows;
     // sample 30 row idx
     std::random_device rd;
     std::mt19937_64 gen(rd());
@@ -679,6 +683,12 @@ Status PartitionedSpillerWriter::_compact_skew_chunks(size_t num_rows, std::vect
     }
     std::sort(samples.begin(), samples.end());
     size_t curr_chunk_idx = 0;
+    // Validate chunks[0] before the first dereference so a malformed leading entry
+    // produces a Check-failed line instead of a null-deref SIGSEGV.
+    CHECK(chunks[curr_chunk_idx] != nullptr)
+            << "_compact_skew_chunks: null chunk at idx 0; chunks.size=" << chunks.size();
+    CHECK(!chunks[curr_chunk_idx]->is_empty())
+            << "_compact_skew_chunks: empty chunk at idx 0; chunks.size=" << chunks.size();
     size_t curr_num_rows = chunks[curr_chunk_idx]->num_rows();
     phmap::flat_hash_map<uint32_t, size_t, StdHashWithSeed<uint32_t, PhmapSeed2>> hash_value_counts;
 
@@ -686,9 +696,14 @@ Status PartitionedSpillerWriter::_compact_skew_chunks(size_t num_rows, std::vect
     for (auto idx : samples) {
         while (idx >= curr_num_rows) {
             ++curr_chunk_idx;
-            if (chunks[curr_chunk_idx] == nullptr || chunks[curr_chunk_idx]->is_empty()) {
-                continue;
-            }
+            CHECK_LT(curr_chunk_idx, chunks.size())
+                    << "_compact_skew_chunks: num_rows=" << num_rows
+                    << " disagrees with sum of chunks' row counts; curr_num_rows=" << curr_num_rows
+                    << " sample idx=" << idx << " chunks.size=" << chunks.size();
+            CHECK(chunks[curr_chunk_idx] != nullptr) << "_compact_skew_chunks: null chunk at idx " << curr_chunk_idx
+                                                     << " (chunks.size=" << chunks.size() << ")";
+            CHECK(!chunks[curr_chunk_idx]->is_empty()) << "_compact_skew_chunks: empty chunk at idx " << curr_chunk_idx
+                                                       << " (chunks.size=" << chunks.size() << ")";
             curr_num_rows += chunks[curr_chunk_idx]->num_rows();
         }
         const auto& curr_chunk = chunks[curr_chunk_idx];
@@ -698,10 +713,12 @@ Status PartitionedSpillerWriter::_compact_skew_chunks(size_t num_rows, std::vect
         ++hash_value_counts[hash_value];
     }
     // compute frequency of sampled hash values.
-    for (auto& curr_chunk : chunks) {
-        if (curr_chunk == nullptr || curr_chunk->is_empty()) {
-            continue;
-        }
+    for (size_t i = 0; i < chunks.size(); ++i) {
+        auto& curr_chunk = chunks[i];
+        CHECK(curr_chunk != nullptr) << "_compact_skew_chunks: null chunk in frequency pass at idx " << i
+                                     << " (chunks.size=" << chunks.size() << ")";
+        CHECK(!curr_chunk->is_empty()) << "_compact_skew_chunks: empty chunk in frequency pass at idx " << i
+                                       << " (chunks.size=" << chunks.size() << ")";
         auto* hash_column = down_cast<const UInt32Column*>(curr_chunk->columns().back().get());
         auto& hash_values = hash_column->get_data();
         for (auto& hash_value : hash_values) {

--- a/be/test/compute_env/spill/spill_test.cpp
+++ b/be/test/compute_env/spill/spill_test.cpp
@@ -833,4 +833,59 @@ TEST_F(SpillTest, file_group_test) {
 }
 */
 
+// Death tests for the CHECK invariants added in _compact_skew_chunks
+// (https://github.com/StarRocks/starrocks/issues/74074). Contract guard so a
+// future refactor cannot silently re-introduce a defensive skip and let the
+// OOB read sneak back in. The test target is built with -fno-access-control,
+// so we can call the private method directly.
+class SpillCompactSkewChunksCheckTest : public ::testing::Test {
+protected:
+    static ChunkPtr make_chunk_with_n_rows(size_t n) {
+        auto chunk = std::make_shared<Chunk>();
+        auto hash_col = spill::SpillHashColumn::create(n);
+        chunk->append_column(std::move(hash_col), 0);
+        return chunk;
+    }
+    static ChunkPtr make_empty_chunk() { return std::make_shared<Chunk>(); }
+    static void invoke(std::vector<ChunkPtr> chunks, size_t num_rows) {
+        RuntimeState rt_st;
+        spill::PartitionedSpillerWriter writer(nullptr, &rt_st);
+        (void)writer._compact_skew_chunks(num_rows, chunks);
+    }
+};
+
+TEST_F(SpillCompactSkewChunksCheckTest, empty_chunks_aborts) {
+    EXPECT_DEATH(invoke({}, 30), "empty chunks with num_rows");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, null_first_chunk_aborts) {
+    EXPECT_DEATH(invoke({ChunkPtr{}}, 30), "null chunk at idx 0");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, empty_first_chunk_aborts) {
+    EXPECT_DEATH(invoke({make_empty_chunk()}, 30), "empty chunk at idx 0");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, num_rows_overshoot_aborts) {
+    EXPECT_DEATH(invoke({make_chunk_with_n_rows(5)}, 100), "disagrees with sum");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, null_mid_chunk_in_locator_aborts) {
+    EXPECT_DEATH(invoke({make_chunk_with_n_rows(15), ChunkPtr{}, make_chunk_with_n_rows(30)}, 45),
+                 "null chunk at idx 1");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, empty_mid_chunk_in_locator_aborts) {
+    EXPECT_DEATH(invoke({make_chunk_with_n_rows(15), make_empty_chunk(), make_chunk_with_n_rows(30)}, 45),
+                 "empty chunk at idx 1");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, null_chunk_in_frequency_pass_aborts) {
+    EXPECT_DEATH(invoke({make_chunk_with_n_rows(50), ChunkPtr{}}, 50), "null chunk in frequency pass");
+}
+
+TEST_F(SpillCompactSkewChunksCheckTest, empty_chunk_in_frequency_pass_aborts) {
+    EXPECT_DEATH(invoke({make_chunk_with_n_rows(50), make_empty_chunk()}, 50), "empty chunk in frequency pass");
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## Why I'm doing:

`PartitionedSpillerWriter::_compact_skew_chunks` crashes with `SIGSEGV` in production whenever a partition-wise spillable aggregate fragment is flushed while the `num_rows` snapshot disagrees with the actual sum of `chunks[i]->num_rows()`. The function trusts the caller-supplied `num_rows` as the upper bound of a random-sample distribution, then walks `chunks` to locate each sampled row. If `num_rows > Σ chunks[i]->num_rows()` — observed under partition-flush + resource-group-cancellation interleaving — the locator loop has no terminator on `curr_chunk_idx` and reads off the end of the `chunks` vector. The crash signature is always the same: PC inside `_compact_skew_chunks`, page-aligned high-heap fault address; in our cluster: **252 SIGSEGVs in 3 days across all 30 CN pods on 4.0.10**.

Full root-cause analysis with stack traces, fault addresses, and reproduction is in the linked issue.

## What I'm doing:

Fixes #74074

Defense-in-depth in `_compact_skew_chunks`:

- Re-derive `effective_rows` from `chunks` themselves (sum of `num_rows()` for non-null, non-empty chunks) — chunks are the ground truth, not the caller-supplied `num_rows`.
- Use `effective_rows` as the sample-distribution upper bound, so samples can never index past the data.
- Use `effective_rows` as the 25% skew-threshold denominator (in normal flow `effective_rows == num_rows`, so threshold behaviour is unchanged).
- Anchor `curr_chunk_idx` on the first non-null/non-empty chunk before sampling.
- Add a defensive `curr_chunk_idx >= chunks.size()` guard inside the locator loop — unreachable in normal flow given the `effective_rows` clamp, but bails cleanly if a concurrent mutation breaks the invariant later.

When inputs are inconsistent the function now returns `Status::OK()` and silently skips skew elimination. **Skew elimination is an optimisation, not a correctness path** — the spill-restore side re-aggregates duplicate group-by keys either way, so query results are unaffected; the only effect of skipping is slightly more bytes spilled for the affected partition.

This change does **not** address why `num_rows` and `chunks` can disagree — that is a separate upstream race (the issue suggests `UnorderedMemTable::append_selective`'s pre-emplace-then-fill window interleaved with cancellation) and warrants a follow-up. The function had no business trusting the invariant blindly, so hardening it here is correct regardless.

### Regression test

`SpillTest.compact_skew_chunks_size_mismatch_no_crash` in `be/test/io/spill_test.cpp` drives `_compact_skew_chunks` directly with three malformed inputs:

1. `num_rows >> Σ chunks[i]->num_rows()` — the production crash signature.
2. Empty `chunks` vector with `num_rows >= 30` — dereferences `chunks[0]` on an empty vector in the unfixed code.
3. Null trailing chunk inside an otherwise-consistent vector.

Hash values are distinct per row so the function exercises only the sampling/counting path (the bug site) and does not enter the merge branch, which would require a full `Aggregator` setup outside this PR's scope.

**Before this PR** the test aborts under ASAN with:

```
==1485==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000e0340
SUMMARY: AddressSanitizer: heap-buffer-overflow shared_ptr_base.h:1671
  in std::__shared_ptr<starrocks::Chunk>::operator bool() const
```

— exactly the `chunks[curr_chunk_idx] == nullptr` line walking past `chunks.size()`. ASAN traps on the first OOB byte; production walks further and eventually crosses an unmapped page.

**After this PR**, all 7 `SpillTest.*` tests pass under ASAN (new test in 10ms).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The function still applies skew elimination when inputs look consistent (the common case) and silently skips it on malformed inputs. User-visible query behaviour is unchanged; the optimisation just no longer crashes the BE on its corner cases.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

`_compact_skew_chunks` is byte-identical between `main`, `branch-4.1`, and `branch-4.0` (PR #60216 introduced it; PR #66839 in 4.0.10 only touched the no-skew sibling branch). 3.5 does not have this code path.
