### PR TITLE
[BugFix] Backfill uncollected external table columns on partial ANALYZE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -25,7 +25,6 @@ import com.google.common.cache.RemovalCause;
 import com.google.common.cache.RemovalListener;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.BasicTable;
 import com.starrocks.catalog.Column;
@@ -762,62 +761,35 @@ public class MetadataMgr {
         // Get basic/histogram stats from internal statistics.
         Statistics internalStatistics = FeConstants.runningUnitTest ? null :
                 getTableStatisticsFromInternalStatistics(table, columns);
-        if (internalStatistics == null ||
-                internalStatistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::isUnknown)) {
-            // Get basic stats from connector metadata.
-            session.setObtainedFromInternalStatistics(false);
-            // Avoid `analyze table` to collect table statistics from metadata.
-            if (StatisticUtils.statisticTableBlackListCheck(table.getId())) {
-                return internalStatistics;
-            } else if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() &&
-                    session.getSourceTablesCount() == 1) {
-                return StatisticsUtils.buildDefaultStatistics(columns.keySet());
-            } else {
-                Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-                Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
-                        session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);
-                if (connectorBasicStats != null && internalStatistics != null &&
-                        internalStatistics.getColumnStatistics().values().stream().anyMatch(
-                                columnStatistic -> columnStatistic.getHistogram() != null)) {
-                    // combine connector metadata basic stats and histogram from internal stats
-                    Map<ColumnRefOperator, ColumnStatistic> internalColumnStatsMap = internalStatistics.getColumnStatistics();
-                    Map<ColumnRefOperator, ColumnStatistic> combinedColumnStatsMap = Maps.newHashMap();
-                    connectorBasicStats.getColumnStatistics().forEach((key, value) -> {
-                        if (internalColumnStatsMap.containsKey(key)) {
-                            combinedColumnStatsMap.put(key, ColumnStatistic.buildFrom(value).
-                                    setHistogram(internalColumnStatsMap.get(key).getHistogram()).build());
-                        } else {
-                            combinedColumnStatsMap.put(key, value);
-                        }
-                    });
+        boolean hasInternalStats = internalStatistics != null &&
+                internalStatistics.getColumnStatistics().values().stream().anyMatch(stat -> !stat.isUnknown());
+        session.setObtainedFromInternalStatistics(hasInternalStats);
 
-                    return Statistics.builder().addColumnStatistics(combinedColumnStatsMap).
-                            setOutputRowCount(connectorBasicStats.getOutputRowCount()).build();
-                } else {
-                    return connectorBasicStats;
-                }
-            }
-        } else {
-            session.setObtainedFromInternalStatistics(true);
-            // Internal stats can mix collected columns with uncollected ones, which are left unknown here.
-            // Those unknown columns would otherwise carry no min/max at all - worse than the connector/manifest
-            // min/max they inherit when there are no internal stats. Backfill them from connector metadata,
-            // respecting the same guards that gate metadata access in the branch above.
-            boolean hasUnknownColumn = internalStatistics.getColumnStatistics().values().stream()
-                    .anyMatch(ColumnStatistic::isUnknown);
-            boolean metadataStatsAllowed = !StatisticUtils.statisticTableBlackListCheck(table.getId()) &&
-                    !(session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() &&
-                            session.getSourceTablesCount() == 1);
-            if (hasUnknownColumn && metadataStatsAllowed) {
-                Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-                Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
-                        session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);
-                if (connectorBasicStats != null) {
-                    return backfillUnknownColumnsFromConnector(internalStatistics, connectorBasicStats);
-                }
-            }
+        // Fast path: every requested column is covered by internal stats, no need to touch connector metadata.
+        if (hasInternalStats && internalStatistics.getColumnStatistics().values().stream()
+                .noneMatch(ColumnStatistic::isUnknown)) {
             return internalStatistics;
         }
+
+        // Some or all columns are unknown: pull connector/manifest stats and backfill the unknown columns.
+        // Avoid `analyze table` collecting table statistics from metadata.
+        if (StatisticUtils.statisticTableBlackListCheck(table.getId())) {
+            return internalStatistics;
+        }
+        if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() &&
+                session.getSourceTablesCount() == 1) {
+            return hasInternalStats ? internalStatistics : StatisticsUtils.buildDefaultStatistics(columns.keySet());
+        }
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
+                session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);
+        if (connectorBasicStats == null) {
+            return hasInternalStats ? internalStatistics : null;
+        }
+        if (internalStatistics == null) {
+            return connectorBasicStats;
+        }
+        return backfillUnknownColumnsFromConnector(internalStatistics, connectorBasicStats);
     }
 
     // Partial ANALYZE leaves uncollected columns as unknown in the internal stats. Without backfill they carry

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -15,6 +15,7 @@
 package com.starrocks.server;
 
 import com.google.api.client.util.Lists;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
@@ -798,8 +799,50 @@ public class MetadataMgr {
             }
         } else {
             session.setObtainedFromInternalStatistics(true);
+            // Internal stats can mix collected columns with uncollected ones, which are left unknown here.
+            // Those unknown columns would otherwise carry no min/max at all - worse than the connector/manifest
+            // min/max they inherit when there are no internal stats. Backfill them from connector metadata,
+            // respecting the same guards that gate metadata access in the branch above.
+            boolean hasUnknownColumn = internalStatistics.getColumnStatistics().values().stream()
+                    .anyMatch(ColumnStatistic::isUnknown);
+            boolean metadataStatsAllowed = !StatisticUtils.statisticTableBlackListCheck(table.getId()) &&
+                    !(session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() &&
+                            session.getSourceTablesCount() == 1);
+            if (hasUnknownColumn && metadataStatsAllowed) {
+                Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+                Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
+                        session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);
+                if (connectorBasicStats != null) {
+                    return backfillUnknownColumnsFromConnector(internalStatistics, connectorBasicStats);
+                }
+            }
             return internalStatistics;
         }
+    }
+
+    // Partial ANALYZE leaves uncollected columns as unknown in the internal stats. Without backfill they carry
+    // no min/max, which is worse than the connector/manifest min/max they would inherit with no internal stats
+    // at all. Take the row count and the unknown columns from the connector stats (the queried snapshot), keep
+    // collected columns as-is, and preserve any histogram already attached to a backfilled column.
+    @VisibleForTesting
+    static Statistics backfillUnknownColumnsFromConnector(Statistics internalStatistics,
+                                                          Statistics connectorStatistics) {
+        Map<ColumnRefOperator, ColumnStatistic> connectorColumnStats = connectorStatistics.getColumnStatistics();
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(connectorStatistics.getOutputRowCount());
+        internalStatistics.getColumnStatistics().forEach((columnRef, columnStatistic) -> {
+            ColumnStatistic connectorStat = connectorColumnStats.get(columnRef);
+            if (columnStatistic.isUnknown() && connectorStat != null) {
+                if (columnStatistic.getHistogram() != null) {
+                    connectorStat = ColumnStatistic.buildFrom(connectorStat)
+                            .setHistogram(columnStatistic.getHistogram()).build();
+                }
+                builder.addColumnStatistic(columnRef, connectorStat);
+            } else {
+                builder.addColumnStatistic(columnRef, columnStatistic);
+            }
+        });
+        return builder.build();
     }
 
     public Statistics getTableStatistics(OptimizerContext session,

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -33,6 +33,10 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -500,6 +504,49 @@ public class MetadataMgrTest {
         Assertions.assertFalse(MetadataTableName.isMetadataTable("table$"));
         Assertions.assertFalse(MetadataTableName.isMetadataTable("table$unknown_type"));
         Assertions.assertTrue(MetadataTableName.isMetadataTable("table$logical_iceberg_metadata"));
+    }
+
+    @Test
+    public void testBackfillUnknownColumnsFromConnector() {
+        ColumnRefOperator collected = new ColumnRefOperator(1, IntegerType.INT, "collected", true);
+        ColumnRefOperator uncollected = new ColumnRefOperator(2, IntegerType.INT, "uncollected", true);
+
+        // Internal stats from a partial ANALYZE: one collected column, one left unknown.
+        ColumnStatistic collectedStat = ColumnStatistic.builder()
+                .setMinValue(1).setMaxValue(100).setNullsFraction(0.0).setAverageRowSize(4)
+                .setDistinctValuesCount(50).build();
+        Statistics internal = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(collected, collectedStat)
+                .addColumnStatistic(uncollected, ColumnStatistic.unknown())
+                .build();
+
+        // Connector/manifest stats: fresher row count plus min/max for both columns.
+        ColumnStatistic connectorCollected = ColumnStatistic.builder()
+                .setMinValue(0).setMaxValue(9).setNullsFraction(0.0).setAverageRowSize(4)
+                .setDistinctValuesCount(5).build();
+        ColumnStatistic connectorUncollected = ColumnStatistic.builder()
+                .setMinValue(5).setMaxValue(500).setNullsFraction(0.0).setAverageRowSize(4)
+                .setDistinctValuesCount(200).build();
+        Statistics connector = Statistics.builder()
+                .setOutputRowCount(999999)
+                .addColumnStatistic(collected, connectorCollected)
+                .addColumnStatistic(uncollected, connectorUncollected)
+                .build();
+
+        Statistics merged = MetadataMgr.backfillUnknownColumnsFromConnector(internal, connector);
+
+        // Collected column keeps its collected stats, not the connector's.
+        Assertions.assertFalse(merged.getColumnStatistic(collected).isUnknown());
+        Assertions.assertEquals(100, merged.getColumnStatistic(collected).getMaxValue(), 0.001);
+        Assertions.assertEquals(50, merged.getColumnStatistic(collected).getDistinctValuesCount(), 0.001);
+
+        // Uncollected column is backfilled from the connector instead of staying unknown.
+        Assertions.assertFalse(merged.getColumnStatistic(uncollected).isUnknown());
+        Assertions.assertEquals(500, merged.getColumnStatistic(uncollected).getMaxValue(), 0.001);
+
+        // Row count comes from the connector (queried snapshot), not the stale collected stats.
+        Assertions.assertEquals(999999, merged.getOutputRowCount(), 0.001);
     }
 
     private void dropCatalogIfExists(String catalogName) {


### PR DESCRIPTION
## Why I'm doing:

`MetadataMgr#getTableStatistics` merges internal (collected via `ANALYZE`)
statistics with connector/manifest statistics for external tables. That
merge is all-or-nothing over the set of requested columns:

- **No stats collected** → every column is unknown, the method falls back
  to connector/manifest stats, so columns inherit manifest min/max. Fine.
- **Stats collected for *some* columns** (a partial `ANALYZE`) → the method
  returns the internal stats as-is. Collected columns are fine, but the
  *uncollected* columns stay `unknown` and the connector/manifest fallback
  is skipped for the whole table.

So a partial `ANALYZE` leaves the uncollected columns with no min/max at
all — strictly worse than collecting nothing, where those same columns
would have inherited manifest min/max. The fallback only kicks in when
*every* column is unknown.

## What I'm doing:

**Commit 1 (BugFix):** when internal stats cover only part of the requested
columns, fetch connector metadata and backfill the `unknown` columns from
it. The row count is also taken from the connector (the queried snapshot)
so it stays consistent with the backfilled columns; collected columns and
any histogram already attached to a backfilled column are preserved. Adds a
unit test for the merge helper.

**Commit 2 (Refactor):** the fix exposed three near-duplicate column-merge
branches in `getTableStatistics` (histogram-over-connector combine, the new
partial backfill, and the histogram attach in
`getTableStatisticsFromInternalStatistics`). Collapse the method into one
flat path — fast-return when every column is collected, otherwise fetch
connector metadata once and reuse the backfill helper for both the
all-unknown and partially-collected cases. Behavior across the previous
fallback / single-table / blacklist / null-connector branches is preserved.

The two commits are kept separate on purpose: the BugFix is self-contained
and cherry-pick friendly for backports, the Refactor is main-only. Happy to
split into two PRs if maintainers prefer.

**User-visible behavior change:** for external tables with a *partial*
`ANALYZE` (statistics collected for only some of the queried columns), the
uncollected columns now contribute connector/manifest min/max to the
optimizer instead of being treated as unknown, and the table row count for
that estimate now comes from connector metadata rather than from the
collected stats. Consequently, cardinality estimates — and therefore query
plans (join order, runtime filter generation, broadcast vs. shuffle, …) —
can change for such tables. Estimates are generally more accurate; tables
that were fully analyzed, or had no statistics at all, are unaffected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
