### PR TITLE
[Refactor] Remove workgroup executor manager back-reference

### DIFF
--- a/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
@@ -15,23 +15,18 @@
 #include "exec/workgroup/pipeline_executor_set_manager.h"
 
 #include "common/thread/thread.h"
-#include "exec/workgroup/work_group_manager.h"
+#include "exec/workgroup/work_group.h"
 
 namespace starrocks::workgroup {
 
-ExecutorsManager::ExecutorsManager(WorkGroupManager* parent, PipelineExecutorSetConfig conf)
-        : _parent(parent),
-          _conf(std::move(conf)),
+ExecutorsManager::ExecutorsManager(PipelineExecutorSetConfig conf)
+        : _conf(std::move(conf)),
           _shared_executors(std::make_unique<PipelineExecutorSet>(_conf, "com", _conf.total_cpuids,
                                                                   std::vector<CpuUtil::CpuIds>{})) {
     _wg_to_cpuids[COMMON_WORKGROUP] = _conf.total_cpuids;
     for (auto cpuid : _conf.total_cpuids) {
         _cpu_owners[cpuid].set_wg(COMMON_WORKGROUP);
     }
-}
-
-void ExecutorsManager::close() const {
-    for_each_executors([](auto& executors) { executors.close(); });
 }
 
 Status ExecutorsManager::start_shared_executors_unlocked() const {
@@ -138,14 +133,14 @@ std::unique_ptr<PipelineExecutorSet> ExecutorsManager::maybe_create_exclusive_ex
     return executors;
 }
 
-void ExecutorsManager::change_num_connector_scan_threads(uint32_t num_connector_scan_threads) {
+bool ExecutorsManager::change_num_connector_scan_threads(uint32_t num_connector_scan_threads) {
     const auto prev_val = _conf.num_total_connector_scan_threads;
     _conf.num_total_connector_scan_threads = num_connector_scan_threads;
     if (_conf.num_total_connector_scan_threads == prev_val) {
-        return;
+        return false;
     }
 
-    for_each_executors([](const auto& executors) { executors.notify_num_total_connector_scan_threads_changed(); });
+    return true;
 }
 
 void ExecutorsManager::change_enable_resource_group_cpu_borrowing(bool val) {
@@ -156,31 +151,6 @@ void ExecutorsManager::change_enable_resource_group_cpu_borrowing(bool val) {
     _conf.enable_cpu_borrowing = new_val;
 
     update_shared_executors();
-}
-
-void ExecutorsManager::change_exec_state_report_max_threads(int max_threads) {
-    for_each_executors([max_threads](const auto& executors) {
-        auto st = executors.update_exec_state_report_max_threads(max_threads);
-        LOG_IF(WARNING, !st.ok()) << "[WORKGROUP] change exec_state_report_max_threads failed: " << st;
-    });
-}
-
-void ExecutorsManager::change_priority_exec_state_report_max_threads(int max_threads) {
-    for_each_executors([max_threads](const auto& executors) {
-        auto st = executors.update_priority_exec_state_report_max_threads(max_threads);
-        LOG_IF(WARNING, !st.ok()) << "[WORKGROUP] change priority_exec_state_report_max_threads failed: " << st;
-    });
-}
-
-void ExecutorsManager::for_each_executors(const ExecutorsConsumer& consumer) const {
-    for (const auto& [_, wg] : _parent->_workgroups) {
-        if (wg != nullptr && wg->exclusive_executors() != nullptr) {
-            consumer(*wg->exclusive_executors());
-        }
-    }
-    if (_shared_executors) {
-        consumer(*_shared_executors);
-    }
 }
 
 bool ExecutorsManager::should_yield(const WorkGroup* wg) const {

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.h
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 #include "common/thread/cpu_util.h"
 #include "exec/workgroup/pipeline_executor_set.h"
@@ -43,9 +44,7 @@ namespace starrocks::workgroup {
 /// with `unlocked` suffix. And the methods with `unlocked`suffix should not call other protected methods.
 class ExecutorsManager {
 public:
-    ExecutorsManager(WorkGroupManager* parent, PipelineExecutorSetConfig conf);
-
-    void close() const;
+    explicit ExecutorsManager(PipelineExecutorSetConfig conf);
 
     Status start_shared_executors_unlocked() const;
     void update_shared_executors() const;
@@ -58,13 +57,10 @@ public:
     std::unique_ptr<PipelineExecutorSet> maybe_create_exclusive_executors_unlocked(WorkGroup* wg,
                                                                                    const CpuUtil::CpuIds& cpuids) const;
 
-    void change_num_connector_scan_threads(uint32_t num_connector_scan_threads);
+    bool change_num_connector_scan_threads(uint32_t num_connector_scan_threads);
     void change_enable_resource_group_cpu_borrowing(bool val);
-    void change_exec_state_report_max_threads(int max_threads);
-    void change_priority_exec_state_report_max_threads(int max_threads);
 
     using ExecutorsConsumer = std::function<void(PipelineExecutorSet&)>;
-    void for_each_executors(const ExecutorsConsumer& consumer) const;
 
     /// Whether the task running on the borrowed CPU should yield the CPU, that is,
     /// the task of the owner resource group of the borrowed CPU has arrived.
@@ -73,7 +69,6 @@ public:
 private:
     static constexpr WorkGroup* COMMON_WORKGROUP = nullptr;
 
-    WorkGroupManager* const _parent;
     PipelineExecutorSetConfig _conf;
     std::unordered_map<WorkGroup*, CpuUtil::CpuIds> _wg_to_cpuids;
     const std::unique_ptr<PipelineExecutorSet> _shared_executors;

--- a/be/src/exec/workgroup/work_group_manager.cpp
+++ b/be/src/exec/workgroup/work_group_manager.cpp
@@ -56,7 +56,7 @@ struct WorkGroupMetrics {
 // ------------------------------------------------------------------------------------
 
 WorkGroupManager::WorkGroupManager(PipelineExecutorSetConfig executors_manager_conf, MetricRegistry* metrics)
-        : _executors_manager(this, std::move(executors_manager_conf)),
+        : _executors_manager(std::move(executors_manager_conf)),
           _metrics(metrics),
           _shared_mem_tracker_manager(metrics) {}
 
@@ -442,7 +442,7 @@ Status WorkGroupManager::start() {
 
 void WorkGroupManager::close() {
     std::unique_lock write_lock(_mutex);
-    _executors_manager.close();
+    for_each_executors_unlocked([](auto& executors) { executors.close(); });
 }
 
 bool WorkGroupManager::should_yield(const WorkGroup* wg) const {
@@ -451,12 +451,15 @@ bool WorkGroupManager::should_yield(const WorkGroup* wg) const {
 
 void WorkGroupManager::for_each_executors(const ExecutorsManager::ExecutorsConsumer& consumer) const {
     std::shared_lock read_lock(_mutex);
-    _executors_manager.for_each_executors(consumer);
+    for_each_executors_unlocked(consumer);
 }
 
 void WorkGroupManager::change_num_connector_scan_threads(uint32_t num_connector_scan_threads) {
     std::unique_lock write_lock(_mutex);
-    _executors_manager.change_num_connector_scan_threads(num_connector_scan_threads);
+    if (_executors_manager.change_num_connector_scan_threads(num_connector_scan_threads)) {
+        for_each_executors_unlocked(
+                [](auto& executors) { executors.notify_num_total_connector_scan_threads_changed(); });
+    }
 }
 
 void WorkGroupManager::change_enable_resource_group_cpu_borrowing(const bool val) {
@@ -466,17 +469,34 @@ void WorkGroupManager::change_enable_resource_group_cpu_borrowing(const bool val
 
 void WorkGroupManager::change_exec_state_report_max_threads(int max_threads) {
     std::shared_lock read_lock(_mutex);
-    _executors_manager.change_exec_state_report_max_threads(max_threads);
+    for_each_executors_unlocked([max_threads](auto& executors) {
+        auto st = executors.update_exec_state_report_max_threads(max_threads);
+        LOG_IF(WARNING, !st.ok()) << "[WORKGROUP] change exec_state_report_max_threads failed: " << st;
+    });
 }
 
 void WorkGroupManager::change_priority_exec_state_report_max_threads(int max_threads) {
     std::shared_lock read_lock(_mutex);
-    _executors_manager.change_priority_exec_state_report_max_threads(max_threads);
+    for_each_executors_unlocked([max_threads](auto& executors) {
+        auto st = executors.update_priority_exec_state_report_max_threads(max_threads);
+        LOG_IF(WARNING, !st.ok()) << "[WORKGROUP] change priority_exec_state_report_max_threads failed: " << st;
+    });
 }
 
 void WorkGroupManager::set_workgroup_expiration_time(const std::chrono::seconds value) {
     std::unique_lock write_lock(_mutex);
     _workgroup_expiration_time = value;
+}
+
+void WorkGroupManager::for_each_executors_unlocked(const ExecutorsManager::ExecutorsConsumer& consumer) const {
+    for (const auto& [_, wg] : _workgroups) {
+        if (wg != nullptr && wg->exclusive_executors() != nullptr) {
+            consumer(*wg->exclusive_executors());
+        }
+    }
+    if (_executors_manager.shared_executors() != nullptr) {
+        consumer(*_executors_manager.shared_executors());
+    }
 }
 
 // ------------------------------------------------------------------------------------

--- a/be/src/exec/workgroup/work_group_manager.h
+++ b/be/src/exec/workgroup/work_group_manager.h
@@ -95,11 +95,10 @@ private:
     void delete_workgroup_unlocked(const WorkGroupPtr& wg);
     void add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockType& unique_lock);
     void update_metrics_unlocked();
+    void for_each_executors_unlocked(const ExecutorsManager::ExecutorsConsumer& consumer) const;
     WorkGroupPtr get_default_workgroup_unlocked();
 
 private:
-    friend class ExecutorsManager;
-
     mutable std::shared_mutex _mutex;
     // Place it before _workgroups to ensure the shared executors is destructed after all the dedicated executors for
     // workgroups, since _executors_manager owns the shared executors, and WorkGroup owns the dedicated executors.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
