### PR TITLE
[Enhancement] Open all partitions for LIST tables in OlapTableSink

### DIFF
--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -1069,7 +1069,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: The upper bound on how many partitions a load can open up front. The value is used as a cap in two scenarios: (1) for LIST-partitioned tables (which open all partitions by default) and (2) for RANGE-partitioned tables loaded via INSERT / Broker Load / Spark Load (which also open all partitions by default). Stream Load and Routine Load on RANGE-partitioned tables ignore this cap and keep the conservative latest-32 default. The per-table property `load_initial_open_partition_number` overrides this value, bypasses this cap, and is the highest-priority setting. From v3.6 onwards, the default value is increased from 32 to 4096.
+- Description: The upper bound on how many partitions a load can open up front. The value is used as a cap in two scenarios: (1) for LIST-partitioned tables (which open all partitions by default) and (2) for RANGE-partitioned tables loaded via INSERT / Broker Load / Spark Load (which also open all partitions by default). Stream Load and Routine Load on RANGE-partitioned tables ignore this cap and keep the conservative latest-32 default. The per-table property `load_initial_open_partition_number` overrides this value, bypasses this cap, and is the highest-priority setting. From v4.0 onwards, the default value is increased from 32 to 4096.
 - Introduced in: -
 
 ### `max_load_timeout_second`

--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -1063,6 +1063,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The maximum number of concurrent Broker Load jobs allowed within the StarRocks cluster. This parameter is valid only for Broker Load. The value of this parameter must be less than the value of `max_running_txn_num_per_db`. From v2.5 onwards, the default value is changed from `10` to `5`.
 - Introduced in: -
 
+### `max_load_initial_open_partition_number`
+
+- Default: 4096
+- Type: Long
+- Unit: -
+- Is mutable: Yes
+- Description: The upper bound on how many partitions a load can open up front. The value is used as a cap in two scenarios: (1) for LIST-partitioned tables (which open all partitions by default) and (2) for RANGE-partitioned tables loaded via INSERT / Broker Load / Spark Load (which also open all partitions by default). Stream Load and Routine Load on RANGE-partitioned tables ignore this cap and keep the conservative latest-32 default. The per-table property `load_initial_open_partition_number` overrides this value, bypasses this cap, and is the highest-priority setting. From v3.6 onwards, the default value is increased from 32 to 4096.
+- Introduced in: -
+
 ### `max_load_timeout_second`
 
 - Default: 259200

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -1069,7 +1069,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Long
 - 单位: -
 - 是否可变: Yes
-- 描述: 单次导入开始时最多预先打开的分区数。该值在以下两种场景作为上限生效:(1) LIST 分区表(默认全部打开);(2) RANGE 分区表通过 INSERT / Broker Load / Spark Load 导入(默认全部打开)。Stream Load 与 Routine Load 写入 RANGE 分区表时不受该上限限制,保留更保守的「最新 32」默认行为。表属性 `load_initial_open_partition_number` 优先级最高,可覆盖该值并突破此上限。从 v3.6 起,默认值从 32 调整为 4096。
+- 描述: 单次导入开始时最多预先打开的分区数。该值在以下两种场景作为上限生效:(1) LIST 分区表(默认全部打开);(2) RANGE 分区表通过 INSERT / Broker Load / Spark Load 导入(默认全部打开)。Stream Load 与 Routine Load 写入 RANGE 分区表时不受该上限限制,保留更保守的「最新 32」默认行为。表属性 `load_initial_open_partition_number` 优先级最高,可覆盖该值并突破此上限。从 v4.0 起,默认值从 32 调整为 4096。
 - 引入版本: -
 
 ### `max_load_timeout_second`

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -1063,6 +1063,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: StarRocks 集群中允许的最大并发 Broker Load 作业数。此参数仅对 Broker Load 有效。此参数的值必须小于 `max_running_txn_num_per_db` 的值。从 v2.5 开始，默认值从 `10` 更改为 `5`。
 - 引入版本: -
 
+### `max_load_initial_open_partition_number`
+
+- 默认值: 4096
+- 类型: Long
+- 单位: -
+- 是否可变: Yes
+- 描述: 单次导入开始时最多预先打开的分区数。该值在以下两种场景作为上限生效:(1) LIST 分区表(默认全部打开);(2) RANGE 分区表通过 INSERT / Broker Load / Spark Load 导入(默认全部打开)。Stream Load 与 Routine Load 写入 RANGE 分区表时不受该上限限制,保留更保守的「最新 32」默认行为。表属性 `load_initial_open_partition_number` 优先级最高,可覆盖该值并突破此上限。从 v3.6 起,默认值从 32 调整为 4096。
+- 引入版本: -
+
 ### `max_load_timeout_second`
 
 - 默认值: 259200

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -574,6 +574,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         GlobalStateMgr.getCurrentState().getLocalMetastore().modifyTableReplicationNum(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER)) {
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2270,6 +2270,16 @@ public class OlapTable extends Table {
         return tableProperty.enableLoadProfile();
     }
 
+    public int getLoadInitialOpenPartitionNumber() {
+        return tableProperty == null ? TableProperty.INVALID : tableProperty.getLoadInitialOpenPartitionNumber();
+    }
+
+    public void setLoadInitialOpenPartitionNumber(int n) {
+        tableProperty.modifyTableProperties(
+                PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER, String.valueOf(n));
+        tableProperty.buildLoadInitialOpenPartitionNumber();
+    }
+
     public void setEnableLoadProfile(boolean enableLoadProfile) {
         tableProperty
                 .modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_LOAD_PROFILE,
@@ -3035,6 +3045,13 @@ public class OlapTable extends Table {
         String partitionLiveNumber = tableProperties.get(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER);
         if (partitionLiveNumber != null) {
             properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER, partitionLiveNumber);
+        }
+
+        // load initial open partition number
+        String loadInitialOpenPartitionNumber =
+                tableProperties.get(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER);
+        if (loadInitialOpenPartitionNumber != null) {
+            properties.put(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER, loadInitialOpenPartitionNumber);
         }
 
         // partition ttl

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -292,6 +292,11 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     private boolean enableLoadProfile = false;
 
+    // Per-table override for OlapTableSink.getOpenPartitions().
+    // INVALID (default) means use the partition-type aware default plus global Config fallback.
+    // 0 opens all partitions; positive N opens the latest N partitions.
+    private int loadInitialOpenPartitionNumber = INVALID;
+
     private String baseCompactionForbiddenTimeRanges = "";
 
     // 1. This table has been deleted. if hasDelete is false, the BE segment must don't have deleteConditions.
@@ -395,6 +400,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.bucketSize = other.bucketSize;
         this.mutableBucketNum = other.mutableBucketNum;
         this.enableLoadProfile = other.enableLoadProfile;
+        this.loadInitialOpenPartitionNumber = other.loadInitialOpenPartitionNumber;
         this.baseCompactionForbiddenTimeRanges = other.baseCompactionForbiddenTimeRanges;
         this.hasDelete = other.hasDelete;
         this.hasForbiddenGlobalDict = other.hasForbiddenGlobalDict;
@@ -504,6 +510,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildLakeCompactionMaxParallel();
                 buildTableQueryTimeout();
                 buildDataCacheEnable();
+                buildLoadInitialOpenPartitionNumber();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -640,6 +647,22 @@ public class TableProperty implements Writable, GsonPostProcessable {
             partitionTTLNumber = Integer.parseInt(properties.get(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER));
         }
         return this;
+    }
+
+    public TableProperty buildLoadInitialOpenPartitionNumber() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER)) {
+            try {
+                loadInitialOpenPartitionNumber = Integer.parseInt(
+                        properties.get(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER));
+            } catch (NumberFormatException e) {
+                loadInitialOpenPartitionNumber = INVALID;
+            }
+        }
+        return this;
+    }
+
+    public int getLoadInitialOpenPartitionNumber() {
+        return loadInitialOpenPartitionNumber;
     }
 
     public TableProperty buildAutoRefreshPartitionsLimit() {
@@ -1453,6 +1476,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildFileBundling();
         buildMutableBucketNum();
         buildCompactionStrategy();
+        buildLoadInitialOpenPartitionNumber();
         // NOTE: new properties should not be built here, just add SerializedName to the field.
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2682,7 +2682,7 @@ public class Config extends ConfigBase {
      * Used to limit num of partition for load open partition number
      */
     @ConfField(mutable = true)
-    public static long max_load_initial_open_partition_number = 32;
+    public static long max_load_initial_open_partition_number = 4096;
 
     /**
      * enable automatic bucket for random distribution table

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -211,6 +211,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_PARTITION_LIVE_NUMBER = "partition_live_number";
     public static final String PROPERTIES_PARTITION_RETENTION_CONDITION = "partition_retention_condition";
     public static final String PROPERTIES_TIME_DRIFT_CONSTRAINT = "time_drift_constraint";
+    public static final String PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER = "load_initial_open_partition_number";
 
     // default: same as cluster query_timeout
     public static final String PROPERTIES_TABLE_QUERY_TIMEOUT = "table_query_timeout";
@@ -478,6 +479,25 @@ public class PropertyAnalyzer {
             }
         }
         return partitionLiveNumber;
+    }
+
+    public static int analyzeLoadInitialOpenPartitionNumber(Map<String, String> properties, boolean removeProperties) {
+        int value = INVALID;
+        if (properties != null && properties.containsKey(PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER)) {
+            try {
+                value = Integer.parseInt(properties.get(PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER));
+            } catch (NumberFormatException e) {
+                throw new SemanticException(PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER + ": " + e.getMessage());
+            }
+            if (value < 0) {
+                throw new SemanticException("Illegal " + PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER + ": " + value
+                        + ". Use 0 to open all partitions, or a positive integer to open the latest N partitions.");
+            }
+            if (removeProperties) {
+                properties.remove(PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER);
+            }
+        }
+        return value;
     }
 
     public static String analyzePartitionRetentionCondition(Database db,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -61,6 +61,7 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -289,15 +290,34 @@ public class OlapTableSink extends DataSink {
             return new ArrayList<>(Collections.singletonList(
                     dstTable.getPartition(ExpressionRangePartitionInfo.AUTOMATIC_SHADOW_PARTITION_NAME).getId()));
         }
-        if (isFromOverwrite || !enableAutomaticPartition || Config.max_load_initial_open_partition_number <= 0
-                || partitionIds.size() < Config.max_load_initial_open_partition_number) {
+        if (isFromOverwrite || !enableAutomaticPartition) {
             return partitionIds;
         }
-        // bigger partition id means newer partition
-        // open last max_load_initial_open_partition_number partitions
+
+        // Resolve the initial-open limit:
+        //   1. Table property load_initial_open_partition_number wins when set.
+        //   2. LIST-partitioned tables default to opening all partitions because partition ids
+        //      carry no time/access-locality signal (e.g. tenant_id), so "latest N" degenerates
+        //      to random sampling and causes incremental_open churn.
+        //   3. Everything else falls back to the global Config.max_load_initial_open_partition_number.
+        int limit;
+        int tableLimit = dstTable.getLoadInitialOpenPartitionNumber();
+        if (tableLimit != TableProperty.INVALID) {
+            limit = tableLimit;
+        } else if (dstTable.getPartitionInfo().isListPartition()) {
+            return partitionIds;
+        } else {
+            limit = (int) Config.max_load_initial_open_partition_number;
+        }
+
+        if (limit <= 0 || partitionIds.size() < limit) {
+            return partitionIds;
+        }
+
+        // bigger partition id means newer partition; open the newest `limit` partitions
         Set<Long> openPartitionIds = partitionIds.stream().collect(
                 Collectors.toCollection(() -> new TreeSet<>(Collections.reverseOrder())))
-                .stream().limit(Config.max_load_initial_open_partition_number).collect(Collectors.toSet());;
+                .stream().limit(limit).collect(Collectors.toSet());
         if (!dstTable.getDoubleWritePartitions().isEmpty()) {
             openPartitionIds.addAll(dstTable.getDoubleWritePartitions().keySet());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -163,6 +163,11 @@ public class OlapTableSink extends DataSink {
     private boolean enableDynamicOverwrite = false;
     private boolean isFromOverwrite = false;
     private boolean isMultiStatementTxn = false;
+    private boolean isStreamingLoad = false;
+
+    // Conservative default for RANGE-partitioned tables under stream / routine load.
+    // Stream and routine load both go through StreamLoadPlanner and call setIsStreamingLoad(true).
+    private static final int STREAM_LOAD_DEFAULT_OPEN_PARTITION_NUMBER = 32;
 
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
                          TWriteQuorumType writeQuorum, boolean enableReplicatedStorage,
@@ -271,6 +276,10 @@ public class OlapTableSink extends DataSink {
         this.isMultiStatementTxn = isMultiStatementTxn;
     }
 
+    public void setIsStreamingLoad(boolean isStreamingLoad) {
+        this.isStreamingLoad = isStreamingLoad;
+    }
+
     public void complete(String mergeCondition) throws StarRocksException {
         TOlapTableSink tSink = tDataSink.getOlap_table_sink();
         if (mergeCondition != null && !mergeCondition.isEmpty()) {
@@ -294,20 +303,37 @@ public class OlapTableSink extends DataSink {
             return partitionIds;
         }
 
-        // Resolve the initial-open limit:
-        //   1. Table property load_initial_open_partition_number wins when set.
-        //   2. LIST-partitioned tables default to opening all partitions because partition ids
-        //      carry no time/access-locality signal (e.g. tenant_id), so "latest N" degenerates
-        //      to random sampling and causes incremental_open churn.
-        //   3. Everything else falls back to the global Config.max_load_initial_open_partition_number.
-        int limit;
+        // Resolve the initial-open limit. Priority:
+        //   1. Table property `load_initial_open_partition_number` — highest; bypasses the
+        //      global Config.max_load_initial_open_partition_number ceiling.
+        //   2. LIST partition: open all, capped by max_load_initial_open_partition_number.
+        //   3. RANGE partition:
+        //        - Stream / routine load: keep the conservative 32 (id ordering correlates
+        //          well with write recency for time-based ranges, and large fan-out hurts
+        //          continuous-ingest paths).
+        //        - Other load types: open all, capped by max_load_initial_open_partition_number.
         int tableLimit = dstTable.getLoadInitialOpenPartitionNumber();
+        int limit;
+        boolean capByGlobalMax;
         if (tableLimit != TableProperty.INVALID) {
             limit = tableLimit;
+            capByGlobalMax = false;
         } else if (dstTable.getPartitionInfo().isListPartition()) {
-            return partitionIds;
+            limit = 0;
+            capByGlobalMax = true;
+        } else if (isStreamingLoad) {
+            limit = STREAM_LOAD_DEFAULT_OPEN_PARTITION_NUMBER;
+            capByGlobalMax = false;
         } else {
-            limit = (int) Config.max_load_initial_open_partition_number;
+            limit = 0;
+            capByGlobalMax = true;
+        }
+
+        if (capByGlobalMax) {
+            int globalMax = (int) Config.max_load_initial_open_partition_number;
+            if (globalMax > 0 && (limit <= 0 || limit > globalMax)) {
+                limit = globalMax;
+            }
         }
 
         if (limit <= 0 || partitionIds.size() < limit) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -166,7 +166,9 @@ public class OlapTableSink extends DataSink {
     private boolean isStreamingLoad = false;
 
     // Conservative default for RANGE-partitioned tables under stream / routine load.
-    // Stream and routine load both go through StreamLoadPlanner and call setIsStreamingLoad(true).
+    // Both planner paths flag streaming ingest via setIsStreamingLoad(true): StreamLoadPlanner
+    // (legacy stream load and routine load) and LoadPlanner (transaction stream load and batch
+    // write), the latter gated on EtlJobType.STREAM_LOAD / ROUTINE_LOAD.
     private static final int STREAM_LOAD_DEFAULT_OPEN_PARTITION_NUMBER = 32;
 
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
@@ -313,7 +315,9 @@ public class OlapTableSink extends DataSink {
         //          continuous-ingest paths).
         //        - Other load types: open all, capped by max_load_initial_open_partition_number.
         int tableLimit = dstTable.getLoadInitialOpenPartitionNumber();
-        int limit;
+        // Keep the limit a long: Config.max_load_initial_open_partition_number is a long, so a
+        // narrowing (int) cast would wrap values above Integer.MAX_VALUE (e.g. 4294967297 -> 1).
+        long limit;
         boolean capByGlobalMax;
         if (tableLimit != TableProperty.INVALID) {
             limit = tableLimit;
@@ -330,7 +334,7 @@ public class OlapTableSink extends DataSink {
         }
 
         if (capByGlobalMax) {
-            int globalMax = (int) Config.max_load_initial_open_partition_number;
+            long globalMax = Config.max_load_initial_open_partition_number;
             if (globalMax > 0 && (limit <= 0 || limit > globalMax)) {
                 limit = globalMax;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -214,6 +214,7 @@ public class StreamLoadPlanner {
         OlapTableSink olapTableSink = new OlapTableSink(destTable, tupleDesc, partitionIds, writeQuorum,
                 destTable.enableReplicatedStorage(), scanNode.nullExprInAutoIncrement(),
                 enableAutomaticPartition, computeResource);
+        olapTableSink.setIsStreamingLoad(true);
         if (missAutoIncrementColumn.size() == 1 && missAutoIncrementColumn.get(0) == Boolean.TRUE) {
             olapTableSink.setMissAutoIncrementColumn();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3970,6 +3970,18 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         });
     }
 
+    private void alterLoadInitialOpenPartitionNumber(OlapTable table,
+                                                     Map<String, String> properties,
+                                                     List<Runnable> appliers) {
+        int value = PropertyAnalyzer.analyzeLoadInitialOpenPartitionNumber(properties, true);
+        TableProperty tableProperty = table.getTableProperty();
+        appliers.add(() -> {
+            tableProperty.modifyTableProperties(
+                    PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER, String.valueOf(value));
+            tableProperty.buildLoadInitialOpenPartitionNumber();
+        });
+    }
+
     private void alterStorageMedium(OlapTable table,
                                     Map<String, String> properties,
                                     List<Runnable> appliers) throws DdlException {
@@ -4200,6 +4212,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         List<Runnable> appliers = new ArrayList<>();
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
             alterPartitionLiveNumber(db, table, properties, appliers);
+        }
+        if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER)) {
+            alterLoadInitialOpenPartitionNumber(table, properties, appliers);
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
             alterStorageMedium(table, properties,  appliers);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -753,6 +753,14 @@ public class OlapTableFactory implements AbstractTableFactory {
                 table.setPartitionLiveNumber(partitionLiveNumber);
             }
 
+            // load initial open partition number
+            if (properties != null
+                    && properties.containsKey(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER)) {
+                int loadInitialOpenPartitionNumber =
+                        PropertyAnalyzer.analyzeLoadInitialOpenPartitionNumber(properties, true);
+                table.setLoadInitialOpenPartitionNumber(loadInitialOpenPartitionNumber);
+            }
+
             // analyze partition ttl duration
             if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
                 Pair<String, PeriodDuration> ttlDuration = PropertyAnalyzer.analyzePartitionTTL(properties, true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -498,6 +498,12 @@ public class LoadPlanner {
             dataSink = new OlapTableSink(olapTable, tupleDesc, partitionIds,
                     olapTable.writeQuorum(), forceReplicatedStorage ? true : ((OlapTable) destTable).enableReplicatedStorage(),
                     checkNullExprInAutoIncrement(), enableAutomaticPartition, computeResource);
+            // Stream/routine loads planned through LoadPlanner (transaction stream load via
+            // StreamLoadTask, batch write via MergeCommitTask) must be flagged as streaming so
+            // OlapTableSink applies the conservative initial-open-partition default, matching the
+            // StreamLoadPlanner path. Broker load (EtlJobType.BROKER) is intentionally excluded.
+            ((OlapTableSink) dataSink).setIsStreamingLoad(
+                    this.etlJobType == EtlJobType.STREAM_LOAD || this.etlJobType == EtlJobType.ROUTINE_LOAD);
             if (this.missAutoIncrementColumn == Boolean.TRUE) {
                 ((OlapTableSink) dataSink).setMissAutoIncrementColumn();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -253,6 +253,8 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             // do nothing, dynamic properties will be analyzed in SchemaChangeHandler.process
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
             PropertyAnalyzer.analyzePartitionLiveNumber(properties, false);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER)) {
+            PropertyAnalyzer.analyzeLoadInitialOpenPartitionNumber(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
             PropertyAnalyzer.analyzePartitionTTL(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -258,6 +258,71 @@ public class AlterTableTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testLoadInitialOpenPartitionNumberProperty() throws Exception {
+        starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_load_initial_open_partition_number (\n" +
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "    \"replication_num\" = \"1\",\n" +
+                    "    \"load_initial_open_partition_number\" = \"5\"\n" +
+                    ");");
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getFullName();
+
+        // CREATE path: OlapTableFactory -> PropertyAnalyzer.analyzeLoadInitialOpenPartitionNumber
+        //              -> OlapTable.setLoadInitialOpenPartitionNumber -> TableProperty.build/get.
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(dbName, "test_load_initial_open_partition_number");
+        Assertions.assertEquals(5, table.getLoadInitialOpenPartitionNumber());
+        // OlapTable.getProperties() round-trips the persisted value.
+        Assertions.assertEquals("5",
+                    table.getProperties().get(PropertyAnalyzer.PROPERTIES_LOAD_INITIAL_OPEN_PARTITION_NUMBER));
+
+        // ALTER path: AlterTableClauseAnalyzer -> LocalMetastore.alterLoadInitialOpenPartitionNumber.
+        String alterSql = "ALTER TABLE test_load_initial_open_partition_number " +
+                    "SET(\"load_initial_open_partition_number\" = \"10\");";
+        AlterTableStmt alterStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql, ctx);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterStmt);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(dbName, "test_load_initial_open_partition_number");
+        Assertions.assertEquals(10, table.getLoadInitialOpenPartitionNumber());
+
+        // 0 is a valid value meaning "open all partitions".
+        String openAllSql = "ALTER TABLE test_load_initial_open_partition_number " +
+                    "SET(\"load_initial_open_partition_number\" = \"0\");";
+        AlterTableStmt openAllStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(openAllSql, ctx);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, openAllStmt);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(dbName, "test_load_initial_open_partition_number");
+        Assertions.assertEquals(0, table.getLoadInitialOpenPartitionNumber());
+
+        // Negative values are rejected by PropertyAnalyzer.analyzeLoadInitialOpenPartitionNumber
+        // (at analysis time or in LocalMetastore.alterLoadInitialOpenPartitionNumber).
+        String negativeSql = "ALTER TABLE test_load_initial_open_partition_number " +
+                    "SET(\"load_initial_open_partition_number\" = \"-1\");";
+        assertThrows(AnalysisException.class, () -> {
+            AlterTableStmt bad = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(negativeSql, ctx);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, bad);
+        });
+
+        // Non-numeric values are rejected too.
+        String nonNumericSql = "ALTER TABLE test_load_initial_open_partition_number " +
+                    "SET(\"load_initial_open_partition_number\" = \"abc\");";
+        assertThrows(AnalysisException.class, () -> {
+            AlterTableStmt bad = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(nonNumericSql, ctx);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, bad);
+        });
+    }
+
+    @Test
     public void testAlterTablePartitionStorageMedium() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_partition_storage_medium (\n" +
                     "event_day DATE,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
@@ -598,6 +599,88 @@ public class OlapTableSinkTest {
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
 
         Config.max_load_initial_open_partition_number = 32;
+    }
+
+    @Test
+    public void testGetOpenPartitionsListPartitionOpensAll(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
+        ListPartitionInfo listInfo = new ListPartitionInfo(PartitionType.LIST, Lists.newArrayList());
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = TableProperty.INVALID;
+            mockTable.getPartitionInfo();
+            result = listInfo;
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+
+        long savedConfig = Config.max_load_initial_open_partition_number;
+        Config.max_load_initial_open_partition_number = 2;
+        try {
+            List<Long> open = sink.getOpenPartitions();
+            Assertions.assertEquals(Sets.newHashSet(ids), Sets.newHashSet(open),
+                    "LIST partition table should open all partitions regardless of latest-N config");
+        } finally {
+            Config.max_load_initial_open_partition_number = savedConfig;
+        }
+    }
+
+    @Test
+    public void testGetOpenPartitionsTablePropertyOverrides(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = 2;
+            mockTable.getDoubleWritePartitions();
+            result = Maps.newHashMap();
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+
+        List<Long> open = sink.getOpenPartitions();
+        Assertions.assertEquals(2, open.size(),
+                "Table property load_initial_open_partition_number should cap the open set");
+        Assertions.assertEquals(Sets.newHashSet(40L, 50L), Sets.newHashSet(open),
+                "When capped, the two newest (largest id) partitions should be opened");
+    }
+
+    @Test
+    public void testGetOpenPartitionsRangePartitionKeepsLatestN(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
+        RangePartitionInfo rangeInfo = new RangePartitionInfo();
+        Deencapsulation.setField(rangeInfo, "type", PartitionType.RANGE);
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = TableProperty.INVALID;
+            mockTable.getPartitionInfo();
+            result = rangeInfo;
+            mockTable.getDoubleWritePartitions();
+            result = Maps.newHashMap();
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+
+        long savedConfig = Config.max_load_initial_open_partition_number;
+        Config.max_load_initial_open_partition_number = 3;
+        try {
+            List<Long> open = sink.getOpenPartitions();
+            Assertions.assertEquals(Sets.newHashSet(30L, 40L, 50L), Sets.newHashSet(open),
+                    "RANGE partition should preserve the latest-N config behavior");
+        } finally {
+            Config.max_load_initial_open_partition_number = savedConfig;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -92,6 +92,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -588,21 +589,23 @@ public class OlapTableSinkTest {
             }
         };
 
+        long savedMax = Config.max_load_initial_open_partition_number;
         Config.max_load_initial_open_partition_number = 1;
-
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L),
-                TWriteQuorumType.MAJORITY, false, false, true);
-        sink.setAutomaticBucketSize(1);
-        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.complete();
-        LOG.info("sink is {}", sink.toThrift());
-        LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
-
-        Config.max_load_initial_open_partition_number = 32;
+        try {
+            OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L),
+                    TWriteQuorumType.MAJORITY, false, false, true);
+            sink.setAutomaticBucketSize(1);
+            sink.init(new TUniqueId(1, 2), 3, 4, 1000);
+            sink.complete();
+            LOG.info("sink is {}", sink.toThrift());
+            LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
+        } finally {
+            Config.max_load_initial_open_partition_number = savedMax;
+        }
     }
 
     @Test
-    public void testGetOpenPartitionsListPartitionOpensAll(@Mocked OlapTable mockTable) {
+    public void testGetOpenPartitionsListOpensAllUnderLargeGlobalCap(@Mocked OlapTable mockTable) {
         List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
         ListPartitionInfo listInfo = new ListPartitionInfo(PartitionType.LIST, Lists.newArrayList());
 
@@ -619,18 +622,48 @@ public class OlapTableSinkTest {
                 TWriteQuorumType.MAJORITY, false, false, true);
 
         long savedConfig = Config.max_load_initial_open_partition_number;
-        Config.max_load_initial_open_partition_number = 2;
+        Config.max_load_initial_open_partition_number = 4096;
         try {
             List<Long> open = sink.getOpenPartitions();
             Assertions.assertEquals(Sets.newHashSet(ids), Sets.newHashSet(open),
-                    "LIST partition table should open all partitions regardless of latest-N config");
+                    "LIST should open all partitions when count is below the global cap");
         } finally {
             Config.max_load_initial_open_partition_number = savedConfig;
         }
     }
 
     @Test
-    public void testGetOpenPartitionsTablePropertyOverrides(@Mocked OlapTable mockTable) {
+    public void testGetOpenPartitionsListCappedByGlobalMax(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
+        ListPartitionInfo listInfo = new ListPartitionInfo(PartitionType.LIST, Lists.newArrayList());
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = TableProperty.INVALID;
+            mockTable.getPartitionInfo();
+            result = listInfo;
+            mockTable.getDoubleWritePartitions();
+            result = Maps.newHashMap();
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+
+        long savedConfig = Config.max_load_initial_open_partition_number;
+        Config.max_load_initial_open_partition_number = 2;
+        try {
+            List<Long> open = sink.getOpenPartitions();
+            Assertions.assertEquals(Sets.newHashSet(40L, 50L), Sets.newHashSet(open),
+                    "LIST should be capped by max_load_initial_open_partition_number when partitions exceed it");
+        } finally {
+            Config.max_load_initial_open_partition_number = savedConfig;
+        }
+    }
+
+    @Test
+    public void testGetOpenPartitionsTablePropertyCapsTheSet(@Mocked OlapTable mockTable) {
         List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
 
         new Expectations() {{
@@ -646,14 +679,107 @@ public class OlapTableSinkTest {
                 TWriteQuorumType.MAJORITY, false, false, true);
 
         List<Long> open = sink.getOpenPartitions();
-        Assertions.assertEquals(2, open.size(),
-                "Table property load_initial_open_partition_number should cap the open set");
         Assertions.assertEquals(Sets.newHashSet(40L, 50L), Sets.newHashSet(open),
-                "When capped, the two newest (largest id) partitions should be opened");
+                "Table property load_initial_open_partition_number should cap the open set to the newest N");
     }
 
     @Test
-    public void testGetOpenPartitionsRangePartitionKeepsLatestN(@Mocked OlapTable mockTable) {
+    public void testGetOpenPartitionsTablePropertyBypassesGlobalCap(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = 5;
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+
+        long savedConfig = Config.max_load_initial_open_partition_number;
+        Config.max_load_initial_open_partition_number = 2;
+        try {
+            List<Long> open = sink.getOpenPartitions();
+            Assertions.assertEquals(Sets.newHashSet(ids), Sets.newHashSet(open),
+                    "Table property should bypass the global cap and open all 5 partitions");
+        } finally {
+            Config.max_load_initial_open_partition_number = savedConfig;
+        }
+    }
+
+    @Test
+    public void testGetOpenPartitionsRangeStreamingLoadKeeps32(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList();
+        for (long i = 1; i <= 40; i++) {
+            ids.add(i);
+        }
+        RangePartitionInfo rangeInfo = new RangePartitionInfo();
+        Deencapsulation.setField(rangeInfo, "type", PartitionType.RANGE);
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = TableProperty.INVALID;
+            mockTable.getPartitionInfo();
+            result = rangeInfo;
+            mockTable.getDoubleWritePartitions();
+            result = Maps.newHashMap();
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+        sink.setIsStreamingLoad(true);
+
+        long savedConfig = Config.max_load_initial_open_partition_number;
+        Config.max_load_initial_open_partition_number = 4096;
+        try {
+            List<Long> open = sink.getOpenPartitions();
+            Assertions.assertEquals(32, open.size(),
+                    "RANGE + streaming load should keep the conservative latest-32 cap");
+            Set<Long> expected = Sets.newHashSet();
+            for (long i = 9; i <= 40; i++) {
+                expected.add(i);
+            }
+            Assertions.assertEquals(expected, Sets.newHashSet(open),
+                    "RANGE + streaming load should open the newest 32 partition ids");
+        } finally {
+            Config.max_load_initial_open_partition_number = savedConfig;
+        }
+    }
+
+    @Test
+    public void testGetOpenPartitionsRangeNonStreamingOpensAll(@Mocked OlapTable mockTable) {
+        List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
+        RangePartitionInfo rangeInfo = new RangePartitionInfo();
+        Deencapsulation.setField(rangeInfo, "type", PartitionType.RANGE);
+
+        new Expectations() {{
+            mockTable.getState();
+            result = OlapTable.OlapTableState.NORMAL;
+            mockTable.getLoadInitialOpenPartitionNumber();
+            result = TableProperty.INVALID;
+            mockTable.getPartitionInfo();
+            result = rangeInfo;
+        }};
+
+        OlapTableSink sink = new OlapTableSink(mockTable, getTuple(), ids,
+                TWriteQuorumType.MAJORITY, false, false, true);
+
+        long savedConfig = Config.max_load_initial_open_partition_number;
+        Config.max_load_initial_open_partition_number = 4096;
+        try {
+            List<Long> open = sink.getOpenPartitions();
+            Assertions.assertEquals(Sets.newHashSet(ids), Sets.newHashSet(open),
+                    "RANGE + non-streaming load should open all partitions when below the global cap");
+        } finally {
+            Config.max_load_initial_open_partition_number = savedConfig;
+        }
+    }
+
+    @Test
+    public void testGetOpenPartitionsRangeNonStreamingCappedByGlobalMax(@Mocked OlapTable mockTable) {
         List<Long> ids = Lists.newArrayList(10L, 20L, 30L, 40L, 50L);
         RangePartitionInfo rangeInfo = new RangePartitionInfo();
         Deencapsulation.setField(rangeInfo, "type", PartitionType.RANGE);
@@ -677,7 +803,7 @@ public class OlapTableSinkTest {
         try {
             List<Long> open = sink.getOpenPartitions();
             Assertions.assertEquals(Sets.newHashSet(30L, 40L, 50L), Sets.newHashSet(open),
-                    "RANGE partition should preserve the latest-N config behavior");
+                    "RANGE + non-streaming load should respect the global cap when set lower");
         } finally {
             Config.max_load_initial_open_partition_number = savedConfig;
         }


### PR DESCRIPTION
## Why I'm doing:
OlapTableSink.getOpenPartitions() opens at most the latest N partitions up front (N = Config.max_load_initial_open_partition_number, default 32). The latest-N heuristic assumes partition-id order correlates with write probability — true for RANGE-by-date, but broken in common cases:

LIST tables (multi-tenant, partition key = tenant_id, etc.): id order carries no time/access-locality signal, so latest-N degenerates to random sampling. Most senders fall back to incremental_open / createPartition on first write, amplifying FE load.
RANGE tables under INSERT / Broker / Spark Load: target partition set is already known after planner pruning. Opening only 32 forces unnecessary incremental opens.
Default too low for modern deployments with thousands of partitions.
No per-table knob: users can't dial this per table without touching cluster config.

## What I'm doing:
Restructure the open-partition resolution by partition type × load type, and add a per-table override.
Priority (highest first)
Table property load_initial_open_partition_number (new) — bypasses the global cap. 0 means open all.
LIST partition — open all, capped by max_load_initial_open_partition_number.
RANGE + Stream / Routine Load — keep the conservative latest-32 default.
RANGE + other load (INSERT / Broker / Spark) — open all, capped by max_load_initial_open_partition_number.
Key changes
Config.max_load_initial_open_partition_number: default 32 → 4096.
New table property load_initial_open_partition_number (CREATE / ALTER / SHOW CREATE).
OlapTableSink: new isStreamingLoad flag + setter; getOpenPartitions() rewritten by the priority above.
StreamLoadPlanner calls setIsStreamingLoad(true), covering Stream Load + Routine Load.
7 new OlapTableSinkTest cases covering every branch.

### Usage
```
-- Open all partitions on this table, ignoring the global cap
ALTER TABLE account_base SET ("load_initial_open_partition_number" = "0");

-- Cap a specific table at 100
ALTER TABLE huge_log SET ("load_initial_open_partition_number" = "100");
```

### Compatibility
RANGE + Stream/Routine Load: unchanged (still latest-32).
RANGE + INSERT/Broker/Spark: previously capped at 32, now opens all up to 4096.
LIST: previously sampled (latest-N), now opens all up to 4096.



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
