### PR TITLE
[BugFix] Use DB WRITE lock for RENAME and SWAP (table and materialized view)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -201,8 +201,27 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
 
             isSynchronous = false;
         } else {
-            for (AlterClause alterClause : statement.getAlterClauseList()) {
-                visit(alterClause, context);
+            // Same rule as ALTER MATERIALIZED VIEW (see visitAlterMaterializedViewStatement): RENAME and
+            // SWAP mutate the db's nameToTable/idToTable maps, so the operation must hold the DB WRITE
+            // lock here at the dispatcher; an intensive table lock (IX) would let a concurrent IS/IX
+            // holder observe a torn map. Other clauses touch only their own table and self-lock at the
+            // table level inside their handlers.
+            boolean dbLevelClause = statement.getAlterClauseList().stream()
+                    .anyMatch(c -> c instanceof TableRenameClause || c instanceof SwapTableClause);
+            if (dbLevelClause) {
+                Locker locker = new Locker();
+                locker.lockDatabase(db.getId(), LockType.WRITE);
+                try {
+                    for (AlterClause alterClause : statement.getAlterClauseList()) {
+                        visit(alterClause, context);
+                    }
+                } finally {
+                    locker.unLockDatabase(db.getId(), LockType.WRITE);
+                }
+            } else {
+                for (AlterClause alterClause : statement.getAlterClauseList()) {
+                    visit(alterClause, context);
+                }
             }
         }
         return null;
@@ -274,11 +293,36 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
         this.db = db;
         this.table = table;
 
+        // Locking rules for ALTER MATERIALIZED VIEW. This dispatcher acquires the metadata lock for the
+        // whole operation, picking the lock type from the clause; the clause handlers below run under
+        // that lock (some additionally take an intensive table lock on the same MV, which nests safely):
+        //   1. RENAME / SWAP drop and re-register the table(s) in the database's nameToTable/idToTable
+        //      maps -- DB-level state -- so they require the plain DB WRITE lock. An intensive table
+        //      lock only takes IX on the db, and IX is compatible with IS/IX, so a concurrent op holding
+        //      IS/IX (resolving a table by name, iterating db.getTables()) could observe a torn map.
+        //      DB WRITE must be taken here, not in the handler: the lock manager forbids upgrading this
+        //      dispatcher's IX to DB WRITE, and the SWAP handler is shared with ALTER TABLE.
+        //   2. Every other MV alter (refresh scheme, properties, status, add/drop column) mutates only
+        //      this MV's internal state, so it takes the lighter intensive table WRITE (IX on the db +
+        //      WRITE on this MV) to avoid blocking unrelated tables in the db.
+        //   3. The MV preconditions (INCREMENTAL, state == NORMAL) are validated up front, the same way
+        //      visitAlterTableStatement gates ALTER TABLE on table state.
+        // The matching replay paths must use the same lock type: AlterJobMgr.replaySwapTable /
+        // replayRenameMaterializedView take DB WRITE; the per-clause replays take the intensive lock.
+        AlterClause alterClause = stmt.getAlterTableClause();
+        boolean dbLevelClause = alterClause instanceof TableRenameClause || alterClause instanceof SwapTableClause;
+
         Locker locker = new Locker();
-        if (!locker.lockTableAndCheckDbExist(db, table.getId(), LockType.WRITE)) {
-            throw new AlterJobException("alter materialized failed. database:" + db.getFullName() + " not exist");
+        if (dbLevelClause) {
+            locker.lockDatabase(db.getId(), LockType.WRITE);
+        } else {
+            locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
         }
         try {
+            // re-check db existence under the lock (uniform for both lock types)
+            if (!db.isExist()) {
+                throw new AlterJobException("alter materialized failed. database:" + db.getFullName() + " not exist");
+            }
             MaterializedView materializedView = (MaterializedView) table;
             if (materializedView.getRefreshScheme().getType()
                     == com.starrocks.catalog.MaterializedViewRefreshType.INCREMENTAL) {
@@ -290,10 +334,14 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         + "Do not allow to do ALTER ops");
             }
 
-            visit(stmt.getAlterTableClause());
+            visit(alterClause);
             return null;
         } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
+            if (dbLevelClause) {
+                locker.unLockDatabase(db.getId(), LockType.WRITE);
+            } else {
+                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -63,7 +63,6 @@ import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.DataCacheInfo;
@@ -467,8 +466,13 @@ public class AlterJobMgr {
         MaterializedView oldMaterializedView = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(db.getId(), materializedViewId);
         if (oldMaterializedView != null) {
-            try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(),
-                    Lists.newArrayList(oldMaterializedView.getId()), LockType.WRITE)) {
+            // Rename drops and re-registers the MV in the db's nameToTable/idToTable maps (DB-level
+            // state), so it needs the DB WRITE lock, not an intensive table lock (IX is compatible with
+            // IS/IX and would let a follower query thread observe the torn maps). Mirrors the live
+            // rename lock and the existing replayRenameTable.
+            Locker locker = new Locker();
+            locker.lockDatabase(db.getId(), LockType.WRITE);
+            try {
                 db.dropTable(oldMaterializedView.getName());
                 oldMaterializedView.setName(newMaterializedViewName);
                 db.registerTableUnlocked(oldMaterializedView);
@@ -478,6 +482,8 @@ public class AlterJobMgr {
             } catch (Throwable e) {
                 oldMaterializedView.setInactiveAndReason("replay rename failed: " + e.getMessage());
                 LOG.warn("replay rename materialized-view failed: {}", oldMaterializedView.getName(), e);
+            } finally {
+                locker.unLockDatabase(db.getId(), LockType.WRITE);
             }
         }
     }
@@ -545,15 +551,26 @@ public class AlterJobMgr {
     }
 
     public void replaySwapTable(SwapTableOperationLog log) {
-        swapTableInternal(log);
         long dbId = log.getDbId();
         long origTblId = log.getOrigTblId();
         long newTblId = log.getNewTblId();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-        OlapTable origTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), origTblId);
-        OlapTable newTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), newTblId);
-        LOG.debug("finish replay swap table {}-{} with table {}-{}", origTblId, origTable.getName(), newTblId,
-                newTbl.getName());
+        // swapTableInternal drops and re-registers both tables in the db's nameToTable/idToTable maps
+        // (DB-level state), racing follower query threads, so hold the DB WRITE lock for the whole
+        // sequence (the live swap path also runs under DB WRITE).
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            swapTableInternal(log);
+            OlapTable origTable =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), origTblId);
+            OlapTable newTbl =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), newTblId);
+            LOG.debug("finish replay swap table {}-{} with table {}-{}", origTblId, origTable.getName(), newTblId,
+                    newTbl.getName());
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
+        }
     }
 
     /**


### PR DESCRIPTION
RENAME and SWAP drop and re-register tables in the database's
nameToTable/idToTable maps, i.e. they mutate DB-level state, but the
ALTER TABLE and ALTER MATERIALIZED VIEW paths held only an intensive
table lock (IX on the db + WRITE on the table). IX is compatible with
IS/IX, so a concurrent op holding IS/IX (resolving a table by name,
iterating db.getTables()) can run alongside the rename/swap and observe a
torn intermediate state where a name is briefly absent or points at the
wrong table object.

Take the plain DB WRITE lock for RENAME/SWAP clauses at the statement
dispatcher in both visitAlterTableStatement and
visitAlterMaterializedViewStatement, keeping the lighter intensive table
WRITE for every other alter clause (which mutate only their own table's
internal state). The lock is taken at the dispatcher rather than the
clause handler because the lock manager forbids upgrading the
dispatcher's IX to DB WRITE, and the SWAP handler is shared. A
locking-rules comment is added to visitAlterMaterializedViewStatement.

For the MV dispatcher, replace lockTableAndCheckDbExist with the plain
lockTableWithIntensiveDbLock and re-check db existence once under the
lock (uniform for both lock branches).

Fix the matching replay paths to the same lock type so followers do not
observe the torn maps during journal replay:
- AlterJobMgr.replayRenameMaterializedView: intensive -> DB WRITE.
- AlterJobMgr.replaySwapTable: add DB WRITE around swapTableInternal.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
