### PR TITLE
[Enhancement] Introduce per-rowset uid (stable rowset identity)

### DIFF
--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -19,6 +19,7 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "runtime/exec_env.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
 
@@ -105,6 +106,12 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
             to_file_meta_pb(writer->lcrm_file(), op_compaction->mutable_lcrm_file());
         }
     }
+    // Fresh uid: a compaction output is a new logical rowset and must not dedup
+    // with the input rowsets it supersedes (it leaves their split family). Use
+    // set_ (always re-mint), not ensure_ (mint-if-absent): the output is derived
+    // from inputs, so it must never alias an input's uid even if one is ever
+    // copied in. Matches tablet_parallel_compaction_manager's merged output.
+    tablet_reshard_helper::set_rowset_uid(op_compaction->mutable_output_rowset());
     return Status::OK();
 }
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -45,6 +45,7 @@
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
@@ -820,6 +821,10 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     op_write->mutable_rowset()->set_num_rows(_tablet_writer->num_rows());
     op_write->mutable_rowset()->set_data_size(_tablet_writer->data_size());
     op_write->mutable_rowset()->set_overlapped(op_write->rowset().segment_metas_size() > 1);
+    // Mint the rowset's global uid here so it lives in the txn log and is inherited
+    // identically by every split child this write may be cross-published to. This is a
+    // freshly built op_write (no uid to inherit), so always assign one.
+    tablet_reshard_helper::set_rowset_uid(op_write->mutable_rowset());
 
     // Column-mode PCU combined with condition update requires the condition column to be part of
     // the partial update column set: the handler compares old vs new values from the partial chunk

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -36,6 +36,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/primitive/primary_key_encoding_types.h"
 #include "storage/segment_stream_converter.h"
 #include "storage/tablet_schema.h"
@@ -690,6 +691,9 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
         auto new_rowset_meta = new_metadata->add_rowsets();
         new_rowset_meta->CopyFrom(src_rowset_meta);
         new_rowset_meta->mutable_del_files()->Clear();
+        // Replication produces a target-local rowset; any source-cluster uid carried by
+        // CopyFrom belongs to a different uid space, so mint a fresh target uid.
+        tablet_reshard_helper::set_rowset_uid(new_rowset_meta);
 
         // Convert rowset metadata. The copied segment_metas carry over per-segment attributes
         // (size, sort keys, num_rows, vector_index_ids, ...); rewrite only filename/encryption_meta.

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -50,6 +50,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/vacuum.h"
 #include "storage/protobuf_file.h"
 #include "storage/replication_utils.h"
@@ -506,6 +507,8 @@ Status ReplicationTxnManager::convert_rowset_meta(
         }
     }
 
+    // Fresh uid for the replicated rowset.
+    tablet_reshard_helper::set_rowset_uid(rowset_metadata);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -31,6 +31,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/metadata_util.h"
@@ -170,6 +171,9 @@ private:
 
 Status LinkedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_metadata) {
     new_rowset_metadata->CopyFrom(rowset->metadata());
+    // Linked SC reuses the source segments, so it inherits the source uid; mint one
+    // only if the source predates the uid feature (set-if-absent).
+    tablet_reshard_helper::ensure_rowset_uid(new_rowset_metadata);
     return Status::OK();
 }
 
@@ -253,6 +257,8 @@ Status DirectSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
     new_rowset_metadata->set_num_rows(writer->num_rows());
     new_rowset_metadata->set_data_size(writer->data_size());
     new_rowset_metadata->set_overlapped(rowset->is_overlapped());
+    // Fresh uid: a converted (rewritten) rowset is new data, distinct from its base.
+    tablet_reshard_helper::set_rowset_uid(new_rowset_metadata);
     _next_rowset_id += get_rowset_id_step(*new_rowset_metadata);
     return Status::OK();
 }
@@ -344,6 +350,8 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
     new_rowset_metadata->set_data_size(writer->data_size());
     // TODO: support writer final merge
     new_rowset_metadata->set_overlapped(true);
+    // Fresh uid: a converted (rewritten) rowset is new data, distinct from its base.
+    tablet_reshard_helper::set_rowset_uid(new_rowset_metadata);
     _next_rowset_id += get_rowset_id_step(*new_rowset_metadata);
     return Status::OK();
 }

--- a/be/src/storage/lake/spark_load.cpp
+++ b/be/src/storage/lake/spark_load.cpp
@@ -22,6 +22,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/push_utils.h"
 #include "storage/storage_engine.h"
@@ -125,6 +126,8 @@ Status SparkLoadHandler::_load_convert(VersionedTablet& cur_tablet) {
     op_write->mutable_rowset()->set_num_rows(writer->num_rows());
     op_write->mutable_rowset()->set_data_size(writer->data_size());
     op_write->mutable_rowset()->set_overlapped(false);
+    // Fresh uid for the (newly built) bulk-load rowset.
+    tablet_reshard_helper::set_rowset_uid(op_write->mutable_rowset());
     RETURN_IF_ERROR(cur_tablet.tablet_manager()->put_txn_log(std::move(txn_log)));
 
     _write_bytes += static_cast<int64_t>(writer->data_size());

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -27,6 +27,7 @@
 #include "storage/lake/pk_tablet_writer.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/txn_log.h"
 #include "storage/rowset/segment.h"
 
@@ -182,6 +183,12 @@ Status Tablet::delete_data(int64_t txn_id, const DeletePredicatePB& delete_predi
     rowset->set_num_rows(0);
     rowset->set_data_size(0);
     rowset->mutable_delete_predicate()->CopyFrom(delete_predicate);
+    // A delete-predicate rowset still needs a uid to satisfy the reshard-merge
+    // invariant (every rowset must carry one). The uid is per-tablet and independent
+    // across siblings; MERGE dedups predicate rowsets by version (one txn == one
+    // predicate), not uid, so independent per-tablet deletes still collapse to one.
+    // This is a freshly built delete-predicate rowset, so always assign a uid.
+    tablet_reshard_helper::set_rowset_uid(rowset);
     return put_txn_log(std::move(txn_log));
 }
 

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -33,6 +33,7 @@
 #include "storage/lake/filenames.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/memtable_flush_executor.h"
@@ -1036,6 +1037,9 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                 // next_compaction_offset must only be set > 0 when overlapped=true.
                 // For non-overlapped range-split output, leave it unset (defaults to 0).
                 merged_output->clear_next_compaction_offset();
+                // Fresh uid: the manager-assembled merged compaction output is a new
+                // logical rowset distinct from the per-subtask outputs it concatenates.
+                tablet_reshard_helper::set_rowset_uid(merged_output);
             }
 
             op_parallel->set_is_range_split(true);
@@ -1273,6 +1277,9 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                     merged_output->set_data_size(total_data_size);
                     merged_output->set_overlapped(true);
                     merged_output->set_next_compaction_offset(merged_output->segment_metas_size());
+                    // Fresh uid: the manager-assembled merged compaction output is a new
+                    // logical rowset distinct from the per-subtask outputs it concatenates.
+                    tablet_reshard_helper::set_rowset_uid(merged_output);
                 }
 
                 // Log segment file names for debugging data consistency

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -17,11 +17,41 @@
 #include <algorithm>
 #include <numeric>
 
+#include "base/uid_util.h"
 #include "common/logging.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/tablet_range.h"
 
 namespace starrocks::lake::tablet_reshard_helper {
+
+// Generates a fresh, non-zero global rowset uid (a 128-bit PUniqueId).
+PUniqueId make_rowset_uid() {
+    return UniqueId(generate_uuid()).to_proto();
+}
+
+// Mints the rowset's global `uid` if absent; idempotent so an inherited uid
+// (CopyFrom from split / cross-publish) is preserved.
+void ensure_rowset_uid(RowsetMetadataPB* rowset_metadata) {
+    if (has_valid_uid(*rowset_metadata)) {
+        return;
+    }
+    rowset_metadata->mutable_uid()->CopyFrom(make_rowset_uid());
+}
+
+// Unconditionally assigns a fresh uid, replacing any existing one.
+void set_rowset_uid(RowsetMetadataPB* rowset_metadata) {
+    rowset_metadata->mutable_uid()->CopyFrom(make_rowset_uid());
+}
+
+// True iff the rowset carries a usable uid (present and non-zero).
+bool has_valid_uid(const RowsetMetadataPB& rowset_metadata) {
+    return rowset_metadata.has_uid() && (rowset_metadata.uid().hi() != 0 || rowset_metadata.uid().lo() != 0);
+}
+
+// True iff both rowsets carry the same valid uid (the same logical rowset).
+bool same_rowset_uid(const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
+    return has_valid_uid(a) && has_valid_uid(b) && UniqueId(a.uid()) == UniqueId(b.uid());
+}
 
 void allocate_proportionally(int64_t total, const std::vector<int64_t>& weights, std::vector<int64_t>* out) {
     DCHECK(out != nullptr);

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -29,6 +29,27 @@ class TabletManager;
 
 namespace starrocks::lake::tablet_reshard_helper {
 
+// Generates a fresh, non-zero global rowset uid (a 128-bit PUniqueId).
+PUniqueId make_rowset_uid();
+
+// Mints the rowset's global `uid` if absent. Called at every rowset-creation
+// site so that every RowsetMetadataPB carries a uid; idempotent (set-if-absent)
+// so an inherited uid (CopyFrom from split / cross-publish) is preserved.
+void ensure_rowset_uid(RowsetMetadataPB* rowset_metadata);
+
+// Unconditionally assigns a fresh uid, replacing any existing one. Used when a
+// publish physically rewrites a rowset's segments (replace_segments), so a
+// per-tablet-private rewrite cannot alias the cross-published sibling it came from.
+void set_rowset_uid(RowsetMetadataPB* rowset_metadata);
+
+// True iff the rowset carries a usable uid (present and non-zero). A zero or
+// absent uid is treated as non-dedupable by MERGE rather than aliasing.
+bool has_valid_uid(const RowsetMetadataPB& rowset_metadata);
+
+// True iff both rowsets carry the same valid uid, i.e. they are the same logical
+// rowset across split siblings. The single source of truth for MERGE dedup.
+bool same_rowset_uid(const RowsetMetadataPB& a, const RowsetMetadataPB& b);
+
 void set_all_data_files_shared(RowsetMetadataPB* rowset_metadata);
 void set_all_data_files_shared(TxnLogPB* txn_log);
 void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs = false);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -44,6 +44,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_compaction_state.h"
 #include "storage/persistent_index_parallel_publish_context.h"
 #include "storage/primary_key_encoder.h"
@@ -844,6 +845,25 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
         new_rows_op.add_dels_meta()->CopyFrom(del_meta);
     }
     if (new_rows_op.rowset().segment_metas_size() > 0 || new_rows_op.dels_meta_size() > 0) {
+        // Give the synthesized new_rows rowset a uid. In COLUMN_UPSERT_MODE the
+        // original op_write.rowset() never enters tablet metadata as a top-level
+        // rowset: its partial-column segments become DCG entries on existing rowsets
+        // (apply_column_mode_partial_update orphans them into orphan_files for GC), and
+        // only this new_rows_op is added via apply_opwrite below. So the uid here can't
+        // collide with any concurrent top-level rowset in this metadata.
+        if (tablet_reshard_helper::has_valid_uid(op_write.rowset())) {
+            // Reuse op_write.uid (minted by delta_writer at write time, preserved
+            // verbatim across cross-publish by proto CopyFrom) so every split sibling
+            // that re-runs this publish converges on the same identity.
+            new_rows_op.mutable_rowset()->mutable_uid()->CopyFrom(op_write.rowset().uid());
+        } else {
+            // A legacy in-flight COLUMN_UPSERT_MODE op_write written before the uid
+            // field existed (rolling upgrade / BE restart with pending txn logs) carries
+            // no uid. Such a write is never range-distributed (range distribution is a
+            // new, post-uid feature) and therefore never cross-published, so mint a
+            // fresh uid rather than hard-failing the in-flight transaction.
+            tablet_reshard_helper::set_rowset_uid(new_rows_op.mutable_rowset());
+        }
         builder->apply_opwrite(new_rows_op, {}, {});
         if (!segment_id_to_add_dels_new_acc.empty()) {
             (void)builder->update_num_del_stat(segment_id_to_add_dels_new_acc);

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -32,6 +32,45 @@ using namespace tablet_reshard_helper;
 
 class TabletReshardHelperTest : public ::testing::Test {};
 
+// Exercises the per-rowset uid helpers introduced for the reshard MERGE identity.
+TEST_F(TabletReshardHelperTest, RowsetUidHelpers) {
+    // make_rowset_uid: fresh, non-zero, and distinct across calls.
+    auto a = make_rowset_uid();
+    auto b = make_rowset_uid();
+    EXPECT_TRUE(a.hi() != 0 || a.lo() != 0);
+    EXPECT_FALSE(a.hi() == b.hi() && a.lo() == b.lo());
+
+    RowsetMetadataPB rs;
+    EXPECT_FALSE(has_valid_uid(rs)); // absent => invalid
+
+    ensure_rowset_uid(&rs); // mints when absent
+    EXPECT_TRUE(has_valid_uid(rs));
+    auto minted = rs.uid();
+
+    ensure_rowset_uid(&rs); // idempotent: preserves the existing uid
+    EXPECT_EQ(minted.hi(), rs.uid().hi());
+    EXPECT_EQ(minted.lo(), rs.uid().lo());
+
+    set_rowset_uid(&rs); // always re-mints (replaces)
+    EXPECT_TRUE(has_valid_uid(rs));
+    EXPECT_FALSE(rs.uid().hi() == minted.hi() && rs.uid().lo() == minted.lo());
+
+    // same_rowset_uid: equal valid uids match; differing uids do not.
+    RowsetMetadataPB x;
+    RowsetMetadataPB y;
+    x.mutable_uid()->CopyFrom(a);
+    y.mutable_uid()->CopyFrom(a);
+    EXPECT_TRUE(same_rowset_uid(x, y));
+    y.mutable_uid()->CopyFrom(b);
+    EXPECT_FALSE(same_rowset_uid(x, y));
+
+    // A present-but-zero uid is not valid and never matches.
+    RowsetMetadataPB z;
+    z.mutable_uid();
+    EXPECT_FALSE(has_valid_uid(z));
+    EXPECT_FALSE(same_rowset_uid(x, z));
+}
+
 namespace {
 
 int64_t sum_of(const std::vector<int64_t>& v) {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -206,6 +206,12 @@ message RowsetMetadataPB {
     repeated SegmentMetadataPB segment_metas = 17;
     // Indicates the effective sort key range of this rowset for range distribution table.
     optional TabletRangePB range = 18;
+    // Global unique id of this rowset's DATA, alongside the per-tablet local `id`.
+    // Minted once at rowset creation and carried verbatim by CopyFrom across SPLIT,
+    // cross-publish, linked schema change, and replication, so that siblings produced
+    // from the same logical rowset compare equal. MERGE dedups rowsets by uid equality.
+    // Optional => backward compatible; legacy rowsets are backfilled at split time.
+    optional PUniqueId uid = 19;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,


### PR DESCRIPTION
## Why I'm doing:

Groundwork for uid-based MERGE dedup in shared-data tablet reshard. Introduces a stable per-rowset data identity (`RowsetMetadataPB.uid`) so that rowsets produced from the same logical rowset (split siblings, cross-publish) compare equal.

This PR is **inert on its own** — nothing reads the uid yet. The follow-up split/merge PR (#74013, stacked on this one) consumes it as the MERGE dedup identity (replacing `split_origin`).

## What I'm doing:

- Add optional `uid` (`PUniqueId`) to `RowsetMetadataPB` (field 19; optional => backward compatible).
- Add uid helpers in `tablet_reshard_helper`: `make_rowset_uid` / `ensure_rowset_uid` / `set_rowset_uid` / `has_valid_uid` / `same_rowset_uid`.
- Mint the uid at every rowset producer: delta_writer, compaction, spark_load, (linked/converted/sorted) schema change, replication (lake + non-lake), parallel compaction, delete-predicate (`tablet.cpp`), and column-mode partial update (`update_manager`).
- Add a unit test for the helpers.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5