### PR TITLE
[BugFix] Add decorrelated jitter to lake vacuum retry backoff

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/vacuum.h"
 
+#include <butil/fast_rand.h>
 #include <butil/time.h>
 #include <bvar/bvar.h>
 
@@ -99,6 +100,29 @@ static bvar::PassiveStatus<int> g_queued_delete_file_tasks("lake_vacuum_queued_d
                                                            get_num_delete_file_queued_tasks, nullptr);
 static bvar::PassiveStatus<int> g_active_delete_file_tasks("lake_vacuum_active_delete_file_tasks",
                                                            get_num_active_file_queued_tasks, nullptr);
+
+// Decorrelated jitter (AWS Architecture Blog "Exponential Backoff And Jitter"):
+//   next_delay = min(cap, rand([base, last_delay * 3]))
+// where cap = base * 2^max_retries.
+//
+// Pure helper: all knobs (base, max_retries) are passed in by the caller so the function has no
+// hidden dependencies on global config and is trivial to unit-test. Caller passes
+// last_delay (= base on the first attempt) and feeds the returned value back on the next call.
+//
+// Compared to deterministic backoff, retry timestamps of independent CNs grow decorrelated over
+// successive attempts even when they all start throttled at the same moment, keeping the
+// per-prefix request rate below the remote storage's limit. The returned value is always
+// in [base, cap], so the caller-configured minimum delay is preserved as a floor.
+int64_t calculate_retry_delay(int64_t last_delay, int64_t base, int64_t max_retries) {
+    int64_t cap = base * (1L << max_retries);
+    int64_t upper = std::min(cap, last_delay * 3);
+    if (upper <= base) {
+        return base;
+    }
+    int64_t range = upper - base + 1;
+    return base + static_cast<int64_t>(butil::fast_rand_less_than(range));
+}
+
 namespace {
 
 // Delete .vi files for segments in a rowset using segment_metas metadata.
@@ -135,18 +159,16 @@ bool should_retry(const Status& st, int64_t attempted_retries) {
     return MatchPattern(message, config::lake_vacuum_retry_pattern.value());
 }
 
-int64_t calculate_retry_delay(int64_t attempted_retries) {
-    int64_t min_delay = config::lake_vacuum_retry_min_delay_ms;
-    return min_delay * (1 << attempted_retries);
-}
-
 Status delete_files_with_retry(FileSystem* fs, std::span<const std::string> paths) {
+    const int64_t base = config::lake_vacuum_retry_min_delay_ms;
+    const int64_t max_retries = config::lake_vacuum_retry_max_attempts;
+    int64_t last_delay = base;
     for (int64_t attempted_retries = 0; /**/; attempted_retries++) {
         auto st = fs->delete_files(paths);
         if (!st.ok() && should_retry(st, attempted_retries)) {
-            int64_t delay = calculate_retry_delay(attempted_retries);
-            LOG(WARNING) << "Fail to delete: " << st << " will retry after " << delay << "ms";
-            std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+            last_delay = calculate_retry_delay(last_delay, base, max_retries);
+            LOG(WARNING) << "Fail to delete: " << st << " will retry after " << last_delay << "ms";
+            std::this_thread::sleep_for(std::chrono::milliseconds(last_delay));
         } else {
             return st;
         }

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -42,6 +42,9 @@
 
 namespace starrocks::lake {
 
+// Forward-declare internal helper exposed for testing (defined in vacuum.cpp).
+int64_t calculate_retry_delay(int64_t last_delay, int64_t base, int64_t max_retries);
+
 struct VacuumTestArg {
     int64_t min_batch_size;
 };
@@ -3520,6 +3523,49 @@ TEST(LakeVacuumTest2, test_delete_files_retry4) {
     ASSERT_TRUE(future.get().ok());
     ASSERT_FALSE(fs::path_exist("test_vacuum_delete_files_retry.txt"));
     EXPECT_GT(attempts, 1);
+}
+
+TEST(LakeVacuumTest2, test_calculate_retry_delay_jitter) {
+    // Pure helper: no global config dependency. All knobs passed in.
+    const int64_t base = 100;
+    const int64_t max_retries = 5;
+    const int64_t cap = base * (1L << max_retries); // = 3200
+    constexpr int kSamples = 200;
+
+    // 1. First call: last_delay = base. Window is [base, min(cap, base*3)] = [100, 300].
+    {
+        std::set<int64_t> observed;
+        for (int i = 0; i < kSamples; ++i) {
+            int64_t delay = calculate_retry_delay(base, base, max_retries);
+            EXPECT_GE(delay, base) << "delay=" << delay;
+            EXPECT_LE(delay, std::min(cap, base * 3)) << "delay=" << delay;
+            observed.insert(delay);
+        }
+        EXPECT_GT(observed.size(), 1U) << "first-call jitter inactive";
+    }
+
+    // 2. Cap clamping: once last_delay * 3 exceeds cap, delays must not exceed cap.
+    {
+        int64_t large_last = cap; // last_delay already at cap
+        std::set<int64_t> observed;
+        for (int i = 0; i < kSamples; ++i) {
+            int64_t delay = calculate_retry_delay(large_last, base, max_retries);
+            EXPECT_GE(delay, base);
+            EXPECT_LE(delay, cap) << "cap not enforced, delay=" << delay;
+            observed.insert(delay);
+        }
+        EXPECT_GT(observed.size(), 1U) << "cap-clamped jitter inactive";
+    }
+
+    // 3. Simulated retry chain: feed last_delay back; every step stays in [base, cap].
+    {
+        int64_t last_delay = base;
+        for (int step = 0; step < 20; ++step) {
+            last_delay = calculate_retry_delay(last_delay, base, max_retries);
+            EXPECT_GE(last_delay, base) << "step=" << step;
+            EXPECT_LE(last_delay, cap) << "step=" << step;
+        }
+    }
 }
 
 TEST_P(LakeVacuumTest, test_vacuum_bundle_metadata) {


### PR DESCRIPTION
## Why I'm doing:

`calculate_retry_delay()` in `be/src/storage/lake/vacuum.cpp` currently
returns a fully deterministic exponential backoff
(`min_delay * 2^attempted_retries`). When multiple CNs hit the same S3
throttling (`Please reduce your request rate`) at the same time, they
all back off by the same amount and retry in lockstep, which keeps the
prefix-level QPS high and prolongs the throttled state.

Decorrelated jitter spreads retries across a wider, ever-growing
window, and each CN's window diverges from the others over successive
attempts.

### Example: 100 CN concurrently throttled, base = 100ms

| | First retry timing | First retry concurrent rate |
| --- | --- | --- |
| **Before** (deterministic) | all 100 CN retry at exactly 100ms | ∞ instantaneously (all 100 in a single instant) |
| **After** (decorrelated jitter) | uniformly distributed in `[100, 300]ms` | ~500 QPS (100 CN spread over a 200ms window) |

S3 per-prefix DELETE rate limit is 3500 QPS, so the post-change rate
comfortably stays well below it. Successive retries de-correlate
further: each CN's `last_delay` diverges from the others, so the
window each CN samples from on the next iteration is different.

## What I'm doing:

- Move `calculate_retry_delay()` out of the anonymous namespace in
  `vacuum.cpp` into `starrocks::lake` so it can be reached from the
  unit test via a forward declaration without exposing it in
  `vacuum.h`.
- Replace the deterministic backoff with **decorrelated jitter** (AWS
  Architecture Blog "Exponential Backoff And Jitter"):
  `next_delay = min(cap, rand([base, last_delay * 3]))`, where
  `base = lake_vacuum_retry_min_delay_ms` and
  `cap = base * 2^lake_vacuum_retry_max_attempts`. Caller passes
  `last_delay` (= `base` on the first attempt) and feeds the returned
  value back on the next call.
- Update `delete_files_with_retry()` to track `last_delay` across loop
  iterations.
- Use `butil::fast_rand_less_than()` (brpc thread-local PRNG) instead
  of `std::rand()` to avoid contention on the global rand state.
- Switch the shift expressions to `1L << ...` to avoid signed-int
  shift narrowing if `lake_vacuum_retry_max_attempts` is raised in
  the future.
- Add `LakeVacuumTest2.test_calculate_retry_delay_jitter` covering:
  - first-call window `[base, min(cap, base*3)]` with 200 samples;
  - cap clamping (delays must not exceed cap when `last_delay * 3`
    overflows the cap);
  - a 20-step simulated retry chain stays within `[base, cap]`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

