### PR TITLE
[Enhancement] Fail load writes fast instead of exiting BE on delta writer hang

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -627,8 +627,21 @@ CONF_mInt64(max_queueing_memtable_per_tablet, "2");
 // 0 means disable
 CONF_mInt64(stale_memtable_flush_time_sec, "0");
 
-// delta writer hang after this time, be will exit since storage is in error state
+// The async delta writer thread pool is treated as "hung" once it stays saturated
+// (queue full and no task completes) for longer than this many seconds, which usually
+// indicates a slow or stuck disk.
+// - When enable_load_fail_fast_when_disk_write_hang is true (default), new load writes
+//   are failed fast with a retryable error after this timeout.
+// - When it is false, the BE keeps the legacy behavior and exits the process after this
+//   timeout so the storage error becomes visible.
 CONF_Int32(be_exit_after_disk_write_hang_second, "60");
+
+// When the async delta writer thread pool stays saturated for longer than
+// be_exit_after_disk_write_hang_second (typically a slow or hung disk), fail new load
+// writes fast with a retryable error instead of exiting the whole BE process. This keeps
+// the node serving the other (healthy) disks and lets the FE retry or reroute the load.
+// Set to false to restore the legacy behavior of exiting the BE on a disk write hang.
+CONF_mBool(enable_load_fail_fast_when_disk_write_hang, "true");
 
 // Automatically detect whether a char/varchar column to use dictionary encoding
 // If the number of keys in a dictionary is greater than this fraction of the total number of rows

--- a/be/src/common/config_diagnostic_fwd.h
+++ b/be/src/common/config_diagnostic_fwd.h
@@ -41,8 +41,21 @@ CONF_Bool(sys_log_timezone, "false");
 // The maximum number of bytes to display on the debug webserver's log page.
 CONF_Int64(web_log_bytes, "1048576");
 
-// delta writer hang after this time, be will exit since storage is in error state
+// The async delta writer thread pool is treated as "hung" once it stays saturated
+// (queue full and no task completes) for longer than this many seconds, which usually
+// indicates a slow or stuck disk.
+// - When enable_load_fail_fast_when_disk_write_hang is true (default), new load writes
+//   are failed fast with a retryable error after this timeout.
+// - When it is false, the BE keeps the legacy behavior and exits the process after this
+//   timeout so the storage error becomes visible.
 CONF_Int32(be_exit_after_disk_write_hang_second, "60");
+
+// When the async delta writer thread pool stays saturated for longer than
+// be_exit_after_disk_write_hang_second (typically a slow or hung disk), fail new load
+// writes fast with a retryable error instead of exiting the whole BE process. This keeps
+// the node serving the other (healthy) disks and lets the FE retry or reroute the load.
+// Set to false to restore the legacy behavior of exiting the BE on a disk write hang.
+CONF_mBool(enable_load_fail_fast_when_disk_write_hang, "true");
 
 #ifdef __x86_64__
 // Enable genearate minidump for crash.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -913,6 +913,7 @@
       "path": "be/src/common/config_diagnostic_fwd.h",
       "configs": [
         "be_exit_after_disk_write_hang_second",
+        "enable_load_fail_fast_when_disk_write_hang",
         "jaeger_endpoint",
         "web_log_bytes",
         "sys_log_verbose_level",

--- a/be/src/common/thread/threadpool.h
+++ b/be/src/common/thread/threadpool.h
@@ -280,6 +280,10 @@ public:
         return _total_queued_tasks;
     }
 
+    // Maximum number of tasks that can be queued before submit() starts returning
+    // ServiceUnavailable. Immutable after the pool is built, so no lock is needed.
+    int max_queue_size() const { return _max_queue_size; }
+
     MonoTime last_active_timestamp() const {
         std::lock_guard l(_lock);
         return _last_active_timestamp;

--- a/be/src/common/util/bthreads/executor.cpp
+++ b/be/src/common/util/bthreads/executor.cpp
@@ -33,20 +33,50 @@ int ThreadPoolExecutor::submit(void* (*fn)(void*), void* args) {
         // 1. The first scenario is that there is a lot of concurrency and tablet,
         //    write speed is slower than send speed,
         //    so that we can sleep here back pressure sender(rpc request memory consume will trace by MemTrack)
-        // 2. The second scenrio is that storage hang, task will be blocked continuously
-        //    We will log FATAL after be_exit_after_disk_write_hang_second,
-        //    eliminate the long tail of writes while keeping users aware of storage failures
+        // 2. The second scenrio is that storage hang, task will be blocked continuously,
+        //    in which case we stop retrying after be_exit_after_disk_write_hang_second.
         MonoTime now_timestamp = MonoTime::Now();
         if (now_timestamp.GetDeltaSince(_thread_pool->last_active_timestamp())
                     .MoreThan(MonoDelta::FromSeconds(starrocks::config::be_exit_after_disk_write_hang_second))) {
-            LOG(WARNING) << "write hang after " << starrocks::config::be_exit_after_disk_write_hang_second << " second";
+            LOG(WARNING) << "async_delta_writer thread pool hang after "
+                         << starrocks::config::be_exit_after_disk_write_hang_second << " second, err=" << st;
             break;
         }
-        LOG(INFO) << "async_delta_writer is busy, retry after " << _busy_sleep_ms << "ms";
+        VLOG(2) << "async_delta_writer is busy, retry after " << _busy_sleep_ms << "ms";
         bthread_usleep(_busy_sleep_ms * 1000);
     }
-    LOG_IF(FATAL, !st.ok()) << "BE exit since submit write fail err=" << st;
-    return st.ok() ? 0 : -1;
+    if (!st.ok()) {
+        if (starrocks::config::enable_load_fail_fast_when_disk_write_hang) {
+            // The thread pool is saturated, most likely because of a slow or hung disk.
+            // Instead of taking the whole BE down (which kills writes/queries on every
+            // healthy disk too), run the task inline so the already-queued work still
+            // makes progress, matching brpc's own fallback when it fails to offload
+            // _execute_tasks. New writes are shed earlier via is_overloaded() in the
+            // load write path, so they fail fast with a retryable error rather than
+            // piling up here.
+            fn(args);
+        } else {
+            // Legacy behavior: a long disk write hang is treated as fatal so the storage
+            // error becomes visible and the long tail of writes is eliminated.
+            LOG(FATAL) << "BE exit since submit write fail err=" << st;
+        }
+    }
+    return 0;
+}
+
+bool ThreadPoolExecutor::is_overloaded() const {
+    if (!starrocks::config::enable_load_fail_fast_when_disk_write_hang || _thread_pool == nullptr) {
+        return false;
+    }
+    // Only treat the pool as overloaded once the queue is full: a non-full queue can still
+    // accept work, and an idle pool (a stale last_active_timestamp with an empty queue) must
+    // not be mistaken for a hang.
+    if (_thread_pool->num_queued_tasks() < _thread_pool->max_queue_size()) {
+        return false;
+    }
+    return MonoTime::Now()
+            .GetDeltaSince(_thread_pool->last_active_timestamp())
+            .MoreThan(MonoDelta::FromSeconds(starrocks::config::be_exit_after_disk_write_hang_second));
 }
 
 } // namespace starrocks::bthreads

--- a/be/src/common/util/bthreads/executor.h
+++ b/be/src/common/util/bthreads/executor.h
@@ -61,6 +61,14 @@ public:
 
     int submit(void* (*fn)(void*), void* args) override;
 
+    // Returns true when the underlying thread pool looks stuck on a slow/hung disk:
+    // the task queue is full AND no task has completed for at least
+    // be_exit_after_disk_write_hang_second. Used by the load write path to shed load
+    // (fail fast with a retryable error) instead of buffering until the pool is at
+    // capacity. Always returns false when enable_load_fail_fast_when_disk_write_hang
+    // is disabled.
+    bool is_overloaded() const;
+
 private:
     ThreadPool* _thread_pool;
     Ownership _ownership;

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -16,12 +16,27 @@
 
 #include <fmt/format.h>
 
+#include "common/util/bthreads/executor.h"
 #include "runtime/current_thread.h"
 #include "storage/segment_flush_executor.h"
 #include "storage/storage_engine.h"
 #include "storage/storage_metrics.h"
 
 namespace starrocks {
+
+namespace {
+// Returns true when the shared async delta writer thread pool is saturated and has made
+// no progress for be_exit_after_disk_write_hang_second (a slow or hung disk). Used to fail
+// load writes fast with a retryable error instead of letting them pile up in the queue.
+bool async_delta_writer_overloaded() {
+    auto* engine = StorageEngine::instance();
+    if (engine == nullptr) {
+        return false;
+    }
+    auto* executor = static_cast<bthreads::ThreadPoolExecutor*>(engine->async_delta_writer_executor());
+    return executor != nullptr && executor->is_overloaded();
+}
+} // namespace
 
 AsyncDeltaWriter::~AsyncDeltaWriter() {
     _close();
@@ -124,6 +139,15 @@ Status AsyncDeltaWriter::_init() {
 
 void AsyncDeltaWriter::write(const AsyncDeltaWriterRequest& req, AsyncDeltaWriterCallback* cb) {
     DCHECK(cb != nullptr);
+    if (async_delta_writer_overloaded()) {
+        LOG_EVERY_N(WARNING, 100) << "Reject write because async delta writer thread pool is overloaded, tablet_id: "
+                                  << _writer->tablet()->tablet_id();
+        FailedRowsetInfo failed_info{.tablet_id = _writer->tablet()->tablet_id(), .replicate_token = nullptr};
+        cb->run(Status::ServiceUnavailable("async delta writer thread pool is overloaded, the disk may be slow or "
+                                           "hung; please retry the load"),
+                nullptr, &failed_info);
+        return;
+    }
     Task task;
     task.chunk = req.chunk;
     task.indexes = req.indexes;
@@ -159,6 +183,15 @@ void AsyncDeltaWriter::write_segment(const AsyncDeltaWriterSegmentRequest& req) 
 
 void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     DCHECK(cb != nullptr);
+    if (async_delta_writer_overloaded()) {
+        LOG_EVERY_N(WARNING, 100) << "Reject commit because async delta writer thread pool is overloaded, tablet_id: "
+                                  << _writer->tablet()->tablet_id();
+        FailedRowsetInfo failed_info{.tablet_id = _writer->tablet()->tablet_id(), .replicate_token = nullptr};
+        cb->run(Status::ServiceUnavailable("async delta writer thread pool is overloaded, the disk may be slow or "
+                                           "hung; please retry the load"),
+                nullptr, &failed_info);
+        return;
+    }
     Task task;
     task.chunk = nullptr;
     task.indexes = nullptr;

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -22,6 +22,7 @@
 
 #include "base/testutil/sync_point.h"
 #include "common/compiler_util.h"
+#include "common/util/bthreads/executor.h"
 #include "common/util/stack_trace_mutex.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/load_spill_block_manager.h"
@@ -29,6 +30,20 @@
 #include "storage/storage_metrics.h"
 
 namespace starrocks::lake {
+
+namespace {
+// Returns true when the shared async delta writer thread pool is saturated and has made
+// no progress for be_exit_after_disk_write_hang_second (a slow or hung disk). Used to fail
+// load writes fast with a retryable error instead of letting them pile up in the queue.
+bool async_delta_writer_overloaded() {
+    auto* engine = StorageEngine::instance();
+    if (engine == nullptr) {
+        return false;
+    }
+    auto* executor = static_cast<bthreads::ThreadPoolExecutor*>(engine->async_delta_writer_executor());
+    return executor != nullptr && executor->is_overloaded();
+}
+} // namespace
 
 class AsyncDeltaWriterImpl {
     friend class MergeBlockTask;
@@ -297,6 +312,13 @@ inline Status AsyncDeltaWriterImpl::do_open() {
 
 inline void AsyncDeltaWriterImpl::write(const Chunk* chunk, const uint32_t* indexes, uint32_t indexes_size,
                                         Callback cb) {
+    if (async_delta_writer_overloaded()) {
+        LOG_EVERY_N(WARNING, 100) << "Reject write because async delta writer thread pool is overloaded, tablet_id: "
+                                  << _writer->tablet_id();
+        cb(Status::ServiceUnavailable(
+                "async delta writer thread pool is overloaded, the disk may be slow or hung; please retry the load"));
+        return;
+    }
     auto task = std::make_shared<WriteTask>();
     task->chunk = chunk;
     task->indexes = indexes;
@@ -317,6 +339,13 @@ inline void AsyncDeltaWriterImpl::flush(Callback cb) {
 }
 
 inline void AsyncDeltaWriterImpl::finish(DeltaWriterFinishMode mode, FinishCallback cb) {
+    if (async_delta_writer_overloaded()) {
+        LOG_EVERY_N(WARNING, 100) << "Reject finish because async delta writer thread pool is overloaded, tablet_id: "
+                                  << _writer->tablet_id();
+        cb(Status::ServiceUnavailable(
+                "async delta writer thread pool is overloaded, the disk may be slow or hung; please retry the load"));
+        return;
+    }
     auto task = std::make_shared<FinishTask>();
     task->cb = std::move(cb); // Do NOT touch |cb| since here
     task->finish_mode = mode;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -166,6 +166,12 @@ StorageEngine::~StorageEngine() {
 #endif
 }
 
+std::unique_ptr<bthread::Executor> StorageEngine::TEST_swap_async_delta_writer_executor(
+        std::unique_ptr<bthread::Executor> executor) {
+    _async_delta_writer_executor.swap(executor);
+    return executor;
+}
+
 void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
     std::vector<std::thread> threads;
     threads.reserve(data_dirs.size());

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -236,6 +236,15 @@ public:
 
     bthread::Executor* async_delta_writer_executor() { return _async_delta_writer_executor.get(); }
 
+    // Test only: replace the async delta writer executor so unit tests can install a saturated
+    // thread pool and exercise the overload/fail-fast reject paths. Returns the previously
+    // installed executor (ownership transferred to the caller) so the test can restore it.
+    std::unique_ptr<bthread::Executor> TEST_swap_async_delta_writer_executor(
+            std::unique_ptr<bthread::Executor> executor) {
+        _async_delta_writer_executor.swap(executor);
+        return executor;
+    }
+
     LoadSpillBlockMergeExecutor* load_spill_block_merge_executor() { return _load_spill_block_merge_executor.get(); }
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -239,11 +239,9 @@ public:
     // Test only: replace the async delta writer executor so unit tests can install a saturated
     // thread pool and exercise the overload/fail-fast reject paths. Returns the previously
     // installed executor (ownership transferred to the caller) so the test can restore it.
+    // Defined out-of-line because bthread::Executor is only forward-declared here.
     std::unique_ptr<bthread::Executor> TEST_swap_async_delta_writer_executor(
-            std::unique_ptr<bthread::Executor> executor) {
-        _async_delta_writer_executor.swap(executor);
-        return executor;
-    }
+            std::unique_ptr<bthread::Executor> executor);
 
     LoadSpillBlockMergeExecutor* load_spill_block_merge_executor() { return _load_spill_block_merge_executor.get(); }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXEC_FILES
         ./column/object_column_test.cpp
         ./column/column_cow_test.cpp
         ./common/uri_test.cpp
+        ./common/util/bthreads/executor_test.cpp
         ./connector/file_scan_metrics_test.cpp
         ./connector/file_connector_rejected_record_test.cpp
         ./connector/hive_connector_test.cpp

--- a/be/test/common/util/bthreads/executor_test.cpp
+++ b/be/test/common/util/bthreads/executor_test.cpp
@@ -43,12 +43,7 @@ protected:
     // far-past default value, keeping the "not hung yet" assertions independent of uptime.
     std::unique_ptr<ThreadPool> build_saturated_pool(const std::string& name, std::atomic<bool>* release) {
         std::unique_ptr<ThreadPool> pool;
-        CHECK(ThreadPoolBuilder(name)
-                      .set_min_threads(1)
-                      .set_max_threads(1)
-                      .set_max_queue_size(1)
-                      .build(&pool)
-                      .ok());
+        CHECK(ThreadPoolBuilder(name).set_min_threads(1).set_max_threads(1).set_max_queue_size(1).build(&pool).ok());
 
         // Stamp last_active_timestamp() to ~now by running one task to completion.
         MonoTime before = MonoTime::Now();
@@ -64,8 +59,7 @@ protected:
                       while (!release->load()) {
                           std::this_thread::sleep_for(std::chrono::milliseconds(1));
                       }
-                  })
-                      .ok());
+                  }).ok());
         while (!started->load()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }

--- a/be/test/common/util/bthreads/executor_test.cpp
+++ b/be/test/common/util/bthreads/executor_test.cpp
@@ -138,4 +138,58 @@ TEST_F(ThreadPoolExecutorTest, submit_runs_inline_instead_of_crashing) {
     pool->shutdown();
 }
 
+TEST_F(ThreadPoolExecutorTest, submit_retries_while_busy_then_succeeds) {
+    std::atomic<bool> release{false};
+    auto pool = build_saturated_pool("test_retry", &release);
+    ThreadPoolExecutor executor(pool.get(), kDontTakeOwnership);
+
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+    // A large threshold keeps the pool in the "busy, back off and retry" branch rather than
+    // the "hung, give up" branch, so submit() exercises the retry loop instead of bailing out.
+    config::be_exit_after_disk_write_hang_second = 100000;
+
+    // Release the blocked worker shortly after submit() starts spinning so the queue drains
+    // and the retry loop eventually succeeds in offloading the task to the pool.
+    std::thread releaser([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        release.store(true);
+    });
+
+    std::atomic<int> ran{0};
+    auto fn = [](void* arg) -> void* {
+        static_cast<std::atomic<int>*>(arg)->fetch_add(1);
+        return nullptr;
+    };
+    int rc = executor.submit(fn, &ran);
+    ASSERT_EQ(0, rc);
+
+    releaser.join();
+    // The task was offloaded to the pool (not run inline / crashed); draining the pool runs it.
+    pool->shutdown();
+    ASSERT_EQ(1, ran.load());
+}
+
+// Death tests fork; TSAN dies on thread creation after fork, so skip it there (matching
+// the convention in threadpool_test.cpp). The saturated pool is built in the parent so the
+// forked child only hits do_submit()'s capacity check (which returns ServiceUnavailable
+// without spawning a worker) before reaching LOG(FATAL).
+#ifndef THREAD_SANITIZER
+TEST_F(ThreadPoolExecutorTest, submit_crashes_when_fail_fast_disabled) {
+    std::atomic<bool> release{false};
+    auto pool = build_saturated_pool("test_fatal", &release);
+    ThreadPoolExecutor executor(pool.get(), kDontTakeOwnership);
+
+    // Legacy behavior: with fail-fast disabled, a hung pool takes the whole BE down so the
+    // storage error is surfaced instead of being swallowed.
+    config::enable_load_fail_fast_when_disk_write_hang = false;
+    config::be_exit_after_disk_write_hang_second = 0;
+
+    auto fn = [](void*) -> void* { return nullptr; };
+    ASSERT_DEATH({ executor.submit(fn, nullptr); }, "BE exit since submit write fail");
+
+    release.store(true);
+    pool->shutdown();
+}
+#endif
+
 } // namespace starrocks::bthreads

--- a/be/test/common/util/bthreads/executor_test.cpp
+++ b/be/test/common/util/bthreads/executor_test.cpp
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/util/bthreads/executor.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "common/config_diagnostic_fwd.h"
+#include "common/thread/threadpool.h"
+
+namespace starrocks::bthreads {
+
+class ThreadPoolExecutorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _saved_fail_fast = config::enable_load_fail_fast_when_disk_write_hang;
+        _saved_hang_second = config::be_exit_after_disk_write_hang_second;
+    }
+    void TearDown() override {
+        config::enable_load_fail_fast_when_disk_write_hang = _saved_fail_fast;
+        config::be_exit_after_disk_write_hang_second = _saved_hang_second;
+    }
+
+    // Builds a pool with a single worker and a single queue slot, then blocks the worker
+    // and fills the queue so the pool is saturated (mirrors the "40960/40960 queued" state).
+    // A task is run to completion first so last_active_timestamp() is recent rather than the
+    // far-past default value, keeping the "not hung yet" assertions independent of uptime.
+    std::unique_ptr<ThreadPool> build_saturated_pool(const std::string& name, std::atomic<bool>* release) {
+        std::unique_ptr<ThreadPool> pool;
+        CHECK(ThreadPoolBuilder(name)
+                      .set_min_threads(1)
+                      .set_max_threads(1)
+                      .set_max_queue_size(1)
+                      .build(&pool)
+                      .ok());
+
+        // Stamp last_active_timestamp() to ~now by running one task to completion.
+        MonoTime before = MonoTime::Now();
+        CHECK(pool->submit_func([]() {}).ok());
+        while (pool->last_active_timestamp().GetDeltaSince(before).ToNanoseconds() < 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
+        // Occupy the single worker so queued tasks cannot make progress.
+        auto started = std::make_shared<std::atomic<bool>>(false);
+        CHECK(pool->submit_func([started, release]() {
+                      started->store(true);
+                      while (!release->load()) {
+                          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                      }
+                  })
+                      .ok());
+        while (!started->load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        // Fill the only queue slot; the blocked worker can never drain it.
+        CHECK(pool->submit_func([]() {}).ok());
+        CHECK_EQ(pool->max_queue_size(), pool->num_queued_tasks());
+        return pool;
+    }
+
+    bool _saved_fail_fast{};
+    int32_t _saved_hang_second{};
+};
+
+TEST_F(ThreadPoolExecutorTest, is_overloaded) {
+    std::atomic<bool> release{false};
+    auto pool = build_saturated_pool("test_overload", &release);
+    ThreadPoolExecutor executor(pool.get(), kDontTakeOwnership);
+
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+    config::be_exit_after_disk_write_hang_second = 0;
+
+    // Full queue and no task completing for >= the (zero) timeout => overloaded.
+    ASSERT_TRUE(executor.is_overloaded());
+
+    // The feature flag gates the behavior entirely.
+    config::enable_load_fail_fast_when_disk_write_hang = false;
+    ASSERT_FALSE(executor.is_overloaded());
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+
+    // A large hang threshold means the pool is just busy, not hung yet.
+    config::be_exit_after_disk_write_hang_second = 100000;
+    ASSERT_FALSE(executor.is_overloaded());
+
+    release.store(true);
+    pool->shutdown();
+}
+
+TEST_F(ThreadPoolExecutorTest, is_not_overloaded_when_pool_has_capacity) {
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_TRUE(ThreadPoolBuilder("test_idle")
+                        .set_min_threads(1)
+                        .set_max_threads(2)
+                        .set_max_queue_size(16)
+                        .build(&pool)
+                        .ok());
+    ThreadPoolExecutor executor(pool.get(), kDontTakeOwnership);
+
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+    // Even with a zero timeout, an idle/non-full pool must never be treated as hung.
+    config::be_exit_after_disk_write_hang_second = 0;
+    ASSERT_FALSE(executor.is_overloaded());
+
+    pool->shutdown();
+}
+
+TEST_F(ThreadPoolExecutorTest, submit_runs_inline_instead_of_crashing) {
+    std::atomic<bool> release{false};
+    auto pool = build_saturated_pool("test_inline", &release);
+    ThreadPoolExecutor executor(pool.get(), kDontTakeOwnership);
+
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+    config::be_exit_after_disk_write_hang_second = 0;
+
+    // The pool is saturated and "hung". submit() must run the task inline and report
+    // success instead of taking the whole process down with LOG(FATAL).
+    std::atomic<int> ran{0};
+    auto fn = [](void* arg) -> void* {
+        static_cast<std::atomic<int>*>(arg)->fetch_add(1);
+        return nullptr;
+    };
+    int rc = executor.submit(fn, &ran);
+    ASSERT_EQ(0, rc);
+    ASSERT_EQ(1, ran.load());
+
+    release.store(true);
+    pool->shutdown();
+}
+
+} // namespace starrocks::bthreads

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -18,6 +18,9 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <atomic>
+#include <chrono>
+#include <memory>
 #include <random>
 #include <thread>
 
@@ -31,8 +34,11 @@
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "column/vectorized_fwd.h"
+#include "common/config_diagnostic_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/logging.h"
+#include "common/thread/threadpool.h"
+#include "common/util/bthreads/executor.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "runtime/descriptors.h"
@@ -44,12 +50,37 @@
 #include "storage/load_spill_block_manager.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
+#include "storage/storage_engine.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 
 namespace starrocks::lake {
 
 using namespace starrocks;
+
+namespace {
+// Builds a single-worker, single-slot pool, blocks the worker, and fills the only queue slot so
+// the pool reports as saturated/hung. With be_exit_after_disk_write_hang_second=0 this makes
+// ThreadPoolExecutor::is_overloaded() return true, which drives the load-fail-fast reject paths.
+std::unique_ptr<ThreadPool> build_saturated_pool(const std::string& name, std::atomic<bool>* release) {
+    std::unique_ptr<ThreadPool> pool;
+    CHECK(ThreadPoolBuilder(name).set_min_threads(1).set_max_threads(1).set_max_queue_size(1).build(&pool).ok());
+
+    auto started = std::make_shared<std::atomic<bool>>(false);
+    CHECK(pool->submit_func([started, release]() {
+                  started->store(true);
+                  while (!release->load()) {
+                      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                  }
+              }).ok());
+    while (!started->load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    // Fill the only queue slot; the blocked worker can never drain it.
+    CHECK(pool->submit_func([]() {}).ok());
+    return pool;
+}
+} // namespace
 
 class LakeAsyncDeltaWriterTest : public TestBase {
 public:
@@ -1294,6 +1325,74 @@ TEST_F(LakeAsyncDeltaWriterTest, test_concurrent_cancel_and_close) {
     auto t2 = std::thread([&]() { delta_writer->close(); });
     t1.join();
     t2.join();
+}
+
+// When the async delta writer thread pool is saturated by a slow/hung disk, write() and finish()
+// must shed load by rejecting the request fast with a retryable ServiceUnavailable error instead
+// of piling up in the queue.
+TEST_F(LakeAsyncDeltaWriterTest, write_and_finish_reject_when_overloaded) {
+    auto saved_fail_fast = config::enable_load_fail_fast_when_disk_write_hang;
+    auto saved_hang_second = config::be_exit_after_disk_write_hang_second;
+
+    // Open the writer with the real executor before swapping in the saturated one, so its
+    // execution queue keeps pointing at the live original executor.
+    auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
+    ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+
+    std::atomic<bool> release{false};
+    auto pool = build_saturated_pool("lake_async_reject", &release);
+    auto saturated = std::make_unique<bthreads::ThreadPoolExecutor>(pool.get(), kDontTakeOwnership);
+    auto original = StorageEngine::instance()->TEST_swap_async_delta_writer_executor(std::move(saturated));
+
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+    config::be_exit_after_disk_write_hang_second = 0;
+
+    static const int kChunkSize = 16;
+    auto chunk = generate_data(kChunkSize);
+    std::vector<uint32_t> indexes(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    {
+        Status write_status;
+        bool called = false;
+        delta_writer->write(&chunk, indexes.data(), indexes.size(), [&](const Status& st) {
+            write_status = st;
+            called = true;
+        });
+        ASSERT_TRUE(called);
+        ASSERT_TRUE(write_status.is_service_unavailable()) << write_status.to_string();
+    }
+    {
+        Status finish_status;
+        bool called = false;
+        delta_writer->finish([&](StatusOr<TxnLogPtr> res) {
+            finish_status = res.status();
+            called = true;
+        });
+        ASSERT_TRUE(called);
+        ASSERT_TRUE(finish_status.is_service_unavailable()) << finish_status.to_string();
+    }
+
+    // Restore the real executor before any teardown, then release and drain the saturated pool.
+    StorageEngine::instance()->TEST_swap_async_delta_writer_executor(std::move(original));
+    release.store(true);
+    pool->shutdown();
+
+    delta_writer->close();
+
+    config::enable_load_fail_fast_when_disk_write_hang = saved_fail_fast;
+    config::be_exit_after_disk_write_hang_second = saved_hang_second;
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -18,13 +18,18 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
+#include <memory>
 #include <thread>
 #include <utility>
 
 #include "base/testutil/assert.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
+#include "common/config_diagnostic_fwd.h"
 #include "common/config_exec_fwd.h"
+#include "common/thread/threadpool.h"
+#include "common/util/bthreads/executor.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "gutil/walltime.h"
@@ -46,6 +51,41 @@
 #include "storage/txn_manager.h"
 
 namespace starrocks {
+
+namespace {
+// Builds a single-worker, single-slot pool, blocks the worker, and fills the only queue slot so
+// the pool reports as saturated/hung. With be_exit_after_disk_write_hang_second=0 this makes
+// ThreadPoolExecutor::is_overloaded() return true, which drives the load-fail-fast reject paths.
+std::unique_ptr<ThreadPool> build_saturated_pool(const std::string& name, std::atomic<bool>* release) {
+    std::unique_ptr<ThreadPool> pool;
+    CHECK(ThreadPoolBuilder(name).set_min_threads(1).set_max_threads(1).set_max_queue_size(1).build(&pool).ok());
+
+    auto started = std::make_shared<std::atomic<bool>>(false);
+    CHECK(pool->submit_func([started, release]() {
+                  started->store(true);
+                  while (!release->load()) {
+                      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                  }
+              }).ok());
+    while (!started->load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    // Fill the only queue slot; the blocked worker can never drain it.
+    CHECK(pool->submit_func([]() {}).ok());
+    return pool;
+}
+
+// Captures the Status delivered to AsyncDeltaWriter::write()/commit().
+class CapturingCallback : public AsyncDeltaWriterCallback {
+public:
+    void run(const Status& st, const CommittedRowsetInfo* /*info*/, const FailedRowsetInfo* /*failed_info*/) override {
+        status = st;
+        called = true;
+    }
+    Status status;
+    bool called = false;
+};
+} // namespace
 
 class SegmentFlushExecutorTest : public ::testing::Test {
 public:
@@ -410,6 +450,51 @@ TEST_F(SegmentFlushExecutorTest, test_duplicate_commit_after_committed_returns_o
     ASSERT_EQ(kCommitted, delta_writer->get_state());
 
     ASSERT_OK(StorageEngine::instance()->txn_manager()->delete_txn(_partition_id, _tablet, delta_writer->txn_id()));
+}
+
+// When the async delta writer thread pool is saturated by a slow/hung disk, write() and commit()
+// must shed load by rejecting the request fast with a retryable ServiceUnavailable error instead
+// of piling up in the queue.
+TEST_F(SegmentFlushExecutorTest, write_and_commit_reject_when_overloaded) {
+    auto saved_fail_fast = config::enable_load_fail_fast_when_disk_write_hang;
+    auto saved_hang_second = config::be_exit_after_disk_write_hang_second;
+
+    // Open the writer with the real executor before swapping in the saturated one, so its
+    // execution queue keeps pointing at the live original executor.
+    std::shared_ptr<AsyncDeltaWriter> async_delta_writer =
+            create_delta_writer(_tablet->tablet_id(), _tablet->schema_hash(), _mem_tracker.get());
+
+    std::atomic<bool> release{false};
+    auto pool = build_saturated_pool("seg_flush_reject", &release);
+    auto saturated = std::make_unique<bthreads::ThreadPoolExecutor>(pool.get(), kDontTakeOwnership);
+    auto original = StorageEngine::instance()->TEST_swap_async_delta_writer_executor(std::move(saturated));
+
+    config::enable_load_fail_fast_when_disk_write_hang = true;
+    config::be_exit_after_disk_write_hang_second = 0;
+
+    {
+        CapturingCallback cb;
+        AsyncDeltaWriterRequest req; // contents are unused on the reject path
+        async_delta_writer->write(req, &cb);
+        ASSERT_TRUE(cb.called);
+        ASSERT_TRUE(cb.status.is_service_unavailable()) << cb.status.to_string();
+    }
+    {
+        CapturingCallback cb;
+        async_delta_writer->commit(&cb);
+        ASSERT_TRUE(cb.called);
+        ASSERT_TRUE(cb.status.is_service_unavailable()) << cb.status.to_string();
+    }
+
+    // Restore the real executor before any teardown, then release and drain the saturated pool.
+    StorageEngine::instance()->TEST_swap_async_delta_writer_executor(std::move(original));
+    release.store(true);
+    pool->shutdown();
+
+    async_delta_writer->abort();
+
+    config::enable_load_fail_fast_when_disk_write_hang = saved_fail_fast;
+    config::be_exit_after_disk_write_hang_second = saved_hang_second;
 }
 
 } // namespace starrocks

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -175,7 +175,7 @@ This topic introduces the following types of BE configurations:
 - Type: Int
 - Unit: Seconds
 - Is mutable: No
-- Description: The length of time that the BE waits to exit after the disk hangs.
+- Description: The amount of time the async delta writer thread pool can stay saturated (typically caused by a slow or hung disk) before the BE reacts. When `enable_load_fail_fast_when_disk_write_hang` is `true` (default), load writes are failed fast with a retryable error after this timeout. When `enable_load_fail_fast_when_disk_write_hang` is `false`, the BE exits the process after this timeout instead.
 - Introduced in: -
 
 ### be_http_num_workers

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -894,6 +894,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The number of tablet writer threads used in ingestion, such as Stream Load, Broker Load and Insert. When the parameter is set to less than or equal to 0, the system uses half of the number of CPU cores, with a minimum of 16. When the parameter is set to greater than 0, the system uses that value. This configuration is changed to dynamic from v3.1.7 onwards.
 - Introduced in: -
 
+### enable_load_fail_fast_when_disk_write_hang
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to fail load writes fast with a retryable error when the async delta writer thread pool stays saturated (its queue is full and no task completes) for longer than `be_exit_after_disk_write_hang_second`, which usually indicates a slow or hung disk. When set to `true`, the BE keeps serving the other healthy disks and lets the FE retry or reroute the load. When set to `false`, the BE keeps the legacy behavior and exits the process after the timeout.
+- Introduced in: -
+
 ### push_worker_count_high_priority
 
 - Default: 3

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -147,7 +147,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - タイプ: Int
 - 単位: 秒
 - 変更可能: いいえ
-- 説明: ディスクがハングした後、BE が終了するまでの待機時間。
+- 説明: async delta writer スレッドプールが（通常はディスクの低速またはハングにより）飽和状態を維持できる、BE が反応するまでの時間。`enable_load_fail_fast_when_disk_write_hang` が `true`（デフォルト）の場合、このタイムアウト後に取り込みの書き込みを再試行可能なエラーで即座に失敗させます。`enable_load_fail_fast_when_disk_write_hang` が `false` の場合、このタイムアウト後に BE はプロセスを終了します。
 - 導入バージョン: -
 
 ### be_http_num_workers

--- a/docs/ja/administration/management/BE_parameters/query_loading.md
+++ b/docs/ja/administration/management/BE_parameters/query_loading.md
@@ -777,6 +777,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: Stream Load、Broker Load、Insertなどの取り込みで使用されるタブレットライタースレッドの数。パラメータが0以下に設定されている場合、システムはCPUコア数の半分を使用し、最小値は16です。パラメータが0より大きい値に設定されている場合、システムはその値を使用します。この設定はv3.1.7以降、動的に変更されました。
 - 導入バージョン: -
 
+### enable_load_fail_fast_when_disk_write_hang
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: async delta writer スレッドプールが `be_exit_after_disk_write_hang_second` を超えて飽和状態（キューが満杯でタスクが完了しない、通常はディスクの低速またはハングを示す）が続いた場合に、取り込みの書き込みを再試行可能なエラーで即座に失敗させるかどうか。`true` に設定すると、BE は他の正常なディスクへのサービスを継続し、FE が取り込みを再試行または再ルーティングできるようにします。`false` に設定すると、BE は従来の動作を維持し、タイムアウト後にプロセスを終了します。
+- 導入バージョン: -
+
 ### push_worker_count_high_priority
 
 - デフォルト: 3

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -162,7 +162,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 类型：Int
 - 单位：秒
 - 是否动态：否
-- 描述：磁盘挂起后触发 BE 进程退出的等待时间。
+- 描述：async delta writer 线程池在 BE 做出反应前允许持续饱和（通常由磁盘变慢或挂起引起）的时长。当 `enable_load_fail_fast_when_disk_write_hang` 为 `true`（默认）时，超过该时长后对导入写入快速失败并返回可重试的错误；当 `enable_load_fail_fast_when_disk_write_hang` 为 `false` 时，超过该时长后 BE 退出进程。
 - 引入版本：-
 
 ### be_http_num_workers

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -896,6 +896,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：导入用的 tablet writer 线程数, 用于 Stream Load、Broker Load、Insert 等。当参数设置为小于等于 0 时，系统使用 CPU 核数的二分之一，最小为 16。当参数设置为大于 0 时，系统使用该值。自 v3.1.7 起变为动态参数。
 - 引入版本：-
 
+### enable_load_fail_fast_when_disk_write_hang
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：当 async delta writer 线程池持续饱和（队列写满且没有任务完成）的时间超过 `be_exit_after_disk_write_hang_second`（通常意味着磁盘变慢或挂起）时，是否对导入写入快速失败并返回可重试的错误。设置为 `true` 时，BE 会继续为其他健康磁盘提供服务，并让 FE 重试或重新路由该导入。设置为 `false` 时，BE 保持旧行为，在超时后退出进程。
+- 引入版本：-
+
 ### push_worker_count_high_priority
 
 - 默认值：3


### PR DESCRIPTION


## Why I'm doing:
When the shared async delta writer thread pool is saturated because of a slow or hung disk, ThreadPoolExecutor::submit() used to call LOG(FATAL) and take the whole BE down, killing writes and queries on every healthy disk too.

## What I'm doing:
Instead, shed load gracefully:
- submit() no longer crashes; on give-up it runs the consumer inline (matching brpc's own fallback) so already-queued work still makes progress.
- AsyncDeltaWriter::write()/commit() and lake::AsyncDeltaWriter write()/finish() reject new work with a retryable ServiceUnavailable error once the pool stays full with no progress for be_exit_after_disk_write_hang_second, so loads fail fast and the FE can retry or reroute.

The legacy exit behavior is preserved behind the new mutable config enable_load_fail_fast_when_disk_write_hang (default true); set it to false to restore exiting the BE on a disk write hang.

Add ThreadPoolExecutor::is_overloaded(), a ThreadPool::max_queue_size() getter, unit tests, and BE config docs (en/zh/ja).


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5