### PR TITLE
[BugFix] Prevent StarMgrMetaSyncer from reaping range-colocate PACK shard groups

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -116,8 +116,7 @@ public class ColocateChecker {
      * every peer GroupId stable in lock-step.
      */
     private void processGroup(ColocateTableIndex colocateTableIndex, long colocateGroupId) {
-        List<ColocateRange> expectedRanges =
-                colocateTableIndex.getColocateRangeMgr().getColocateRanges(colocateGroupId);
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(colocateGroupId);
         if (expectedRanges.isEmpty()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -614,7 +614,7 @@ public class SplitTabletJob extends TabletReshardJob {
         }
         long grpId = groupId.grpId;
         int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
-        List<ColocateRange> currentRanges = colocateTableIndex.getColocateRangeMgr().getColocateRanges(grpId);
+        List<ColocateRange> currentRanges = colocateTableIndex.getColocateRanges(grpId);
 
         Set<Tuple> canonicalLowers = new LinkedHashSet<>();
         boolean oldStradlesBoundary = false;
@@ -840,7 +840,7 @@ public class SplitTabletJob extends TabletReshardJob {
         // Snapshot colocate ranges once: the createShard RPCs in the inner loop only ever
         // read the same grpId, and the ranges list is stable for the duration of this DDL.
         List<ColocateRange> colocateRanges = rangeColocateGroupId == null ? null
-                : colocateTableIndex.getColocateRangeMgr().getColocateRanges(rangeColocateGroupId.grpId);
+                : colocateTableIndex.getColocateRanges(rangeColocateGroupId.grpId);
         int colocateColumnCount = rangeColocateGroupId == null ? 0
                 : colocateTableIndex.getGroupSchema(rangeColocateGroupId).getColocateColumnCount();
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -406,7 +406,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         if (groupId == null) {
             return;
         }
-        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
+        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
         int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
         for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
             for (ReshardingMaterializedIndex reshardingIndex

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
@@ -19,11 +19,12 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Range;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Manages colocate ranges for range distribution colocate groups.
@@ -136,20 +137,29 @@ public class ColocateRangeMgr {
     }
 
     /**
-     * Returns all PACK shard group ids currently tracked across every colocate group.
+     * Returns the PACK shard group ids tracked for the given colocate groups.
      *
-     * <p>These PACK shard groups are created by FE but are not attached to any
+     * <p>PACK shard groups are created by FE but are not attached to any
      * {@code PhysicalPartition}, so callers that build the set of FE-known shard groups
-     * from partitions alone must union this in (e.g. {@code StarMgrMetaSyncer}); otherwise
+     * from partitions alone must union these in (e.g. {@code StarMgrMetaSyncer}); otherwise
      * a live PACK shard group would be misclassified as an orphan and reaped.
      *
+     * <p>The caller passes the colocate group ids that are still live (referenced by the
+     * colocate table index). Restricting to those ids skips stale range entries that can
+     * linger after a crash between the range-update and add-table journal records, so a
+     * genuinely orphaned PACK shard group is still eligible for cleanup.
+     *
+     * @param colocateGroupIds the live colocate group ids to collect PACK shard groups for
      * @return a new set of PACK shard group ids (empty if none); never null
      */
-    public Set<Long> getAllPackShardGroupIds() {
-        return colocateGroupToRanges.values().stream()
-                .flatMap(List::stream)
-                .map(ColocateRange::getShardGroupId)
-                .collect(Collectors.toSet());
+    public Set<Long> getPackShardGroupIds(Collection<Long> colocateGroupIds) {
+        Set<Long> packShardGroupIds = new HashSet<>();
+        for (Long colocateGroupId : colocateGroupIds) {
+            for (ColocateRange range : colocateGroupToRanges.getOrDefault(colocateGroupId, Collections.emptyList())) {
+                packShardGroupIds.add(range.getShardGroupId());
+            }
+        }
+        return packShardGroupIds;
     }
 
     // ---- Initialize ----

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Manages colocate ranges for range distribution colocate groups.
@@ -131,6 +133,23 @@ public class ColocateRangeMgr {
      */
     public boolean containsColocateGroup(long colocateGroupId) {
         return colocateGroupToRanges.containsKey(colocateGroupId);
+    }
+
+    /**
+     * Returns all PACK shard group ids currently tracked across every colocate group.
+     *
+     * <p>These PACK shard groups are created by FE but are not attached to any
+     * {@code PhysicalPartition}, so callers that build the set of FE-known shard groups
+     * from partitions alone must union this in (e.g. {@code StarMgrMetaSyncer}); otherwise
+     * a live PACK shard group would be misclassified as an orphan and reaped.
+     *
+     * @return a new set of PACK shard group ids (empty if none); never null
+     */
+    public Set<Long> getAllPackShardGroupIds() {
+        return colocateGroupToRanges.values().stream()
+                .flatMap(List::stream)
+                .map(ColocateRange::getShardGroupId)
+                .collect(Collectors.toSet());
     }
 
     // ---- Initialize ----

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
@@ -19,12 +19,11 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Range;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Manages colocate ranges for range distribution colocate groups.
@@ -137,29 +136,20 @@ public class ColocateRangeMgr {
     }
 
     /**
-     * Returns the PACK shard group ids tracked for the given colocate groups.
+     * Returns all PACK shard group ids currently tracked across every colocate group.
      *
-     * <p>PACK shard groups are created by FE but are not attached to any
+     * <p>These PACK shard groups are created by FE but are not attached to any
      * {@code PhysicalPartition}, so callers that build the set of FE-known shard groups
-     * from partitions alone must union these in (e.g. {@code StarMgrMetaSyncer}); otherwise
+     * from partitions alone must union this in (e.g. {@code StarMgrMetaSyncer}); otherwise
      * a live PACK shard group would be misclassified as an orphan and reaped.
      *
-     * <p>The caller passes the colocate group ids that are still live (referenced by the
-     * colocate table index). Restricting to those ids skips stale range entries that can
-     * linger after a crash between the range-update and add-table journal records, so a
-     * genuinely orphaned PACK shard group is still eligible for cleanup.
-     *
-     * @param colocateGroupIds the live colocate group ids to collect PACK shard groups for
      * @return a new set of PACK shard group ids (empty if none); never null
      */
-    public Set<Long> getPackShardGroupIds(Collection<Long> colocateGroupIds) {
-        Set<Long> packShardGroupIds = new HashSet<>();
-        for (Long colocateGroupId : colocateGroupIds) {
-            for (ColocateRange range : colocateGroupToRanges.getOrDefault(colocateGroupId, Collections.emptyList())) {
-                packShardGroupIds.add(range.getShardGroupId());
-            }
-        }
-        return packShardGroupIds;
+    public Set<Long> getAllPackShardGroupIds() {
+        return colocateGroupToRanges.values().stream()
+                .flatMap(List::stream)
+                .map(ColocateRange::getShardGroupId)
+                .collect(Collectors.toSet());
     }
 
     // ---- Initialize ----

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -186,24 +186,18 @@ public class ColocateTableIndex implements Writable {
     }
 
     /**
-     * Returns the PACK shard group ids of all live range-colocate groups.
+     * Returns all PACK shard group ids tracked by the range-colocate metadata.
      *
      * <p>PACK shard groups are created by FE but not attached to any {@code PhysicalPartition},
      * so {@code StarMgrMetaSyncer} must union these into its FE-known shard group set to avoid
-     * reaping live PACK shard groups as orphans. Only groups still present in {@code group2Schema}
-     * are included, so a stale range entry left by a crash between the range-update and add-table
-     * journal records does not pin a genuinely orphaned PACK shard group forever.
+     * reaping live PACK shard groups as orphans.
      *
      * @return a new set of PACK shard group ids (empty if none); never null
      */
     public Set<Long> getAllPackShardGroupIds() {
         readLock();
         try {
-            Set<Long> liveColocateGroupIds = new HashSet<>();
-            for (GroupId groupId : group2Schema.keySet()) {
-                liveColocateGroupIds.add(groupId.grpId);
-            }
-            return colocateRangeMgr.getPackShardGroupIds(liveColocateGroupIds);
+            return colocateRangeMgr.getAllPackShardGroupIds();
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -164,6 +164,24 @@ public class ColocateTableIndex implements Writable {
         return colocateRangeMgr;
     }
 
+    /**
+     * Returns all PACK shard group ids tracked by the range-colocate metadata.
+     *
+     * <p>PACK shard groups are created by FE but not attached to any {@code PhysicalPartition},
+     * so {@code StarMgrMetaSyncer} must union these into its FE-known shard group set to avoid
+     * reaping live PACK shard groups as orphans.
+     *
+     * @return a new set of PACK shard group ids (empty if none); never null
+     */
+    public Set<Long> getAllPackShardGroupIds() {
+        readLock();
+        try {
+            return colocateRangeMgr.getAllPackShardGroupIds();
+        } finally {
+            readUnlock();
+        }
+    }
+
     public static String getFullGroupName(long dbId, String colocateGroup) {
         return dbId + "_" + ColocatePropertyInfo.getColocateGroupName(colocateGroup);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -160,23 +161,49 @@ public class ColocateTableIndex implements Writable {
 
     }
 
+    @VisibleForTesting
     public ColocateRangeMgr getColocateRangeMgr() {
         return colocateRangeMgr;
     }
 
     /**
-     * Returns all PACK shard group ids tracked by the range-colocate metadata.
+     * Returns the colocate ranges of the given range-colocate group.
+     *
+     * <p>Delegates to {@link ColocateRangeMgr} under this index's read lock and returns an
+     * immutable snapshot, so callers cannot mutate the range list or read it without holding
+     * the lock. {@link ColocateRangeMgr} itself is not synchronized; all access goes through
+     * this index, which owns the lock.
+     *
+     * @return an immutable copy of the colocate ranges (empty if the group is unknown)
+     */
+    public List<ColocateRange> getColocateRanges(long colocateGroupId) {
+        readLock();
+        try {
+            return List.copyOf(colocateRangeMgr.getColocateRanges(colocateGroupId));
+        } finally {
+            readUnlock();
+        }
+    }
+
+    /**
+     * Returns the PACK shard group ids of all live range-colocate groups.
      *
      * <p>PACK shard groups are created by FE but not attached to any {@code PhysicalPartition},
      * so {@code StarMgrMetaSyncer} must union these into its FE-known shard group set to avoid
-     * reaping live PACK shard groups as orphans.
+     * reaping live PACK shard groups as orphans. Only groups still present in {@code group2Schema}
+     * are included, so a stale range entry left by a crash between the range-update and add-table
+     * journal records does not pin a genuinely orphaned PACK shard group forever.
      *
      * @return a new set of PACK shard group ids (empty if none); never null
      */
     public Set<Long> getAllPackShardGroupIds() {
         readLock();
         try {
-            return colocateRangeMgr.getAllPackShardGroupIds();
+            Set<Long> liveColocateGroupIds = new HashSet<>();
+            for (GroupId groupId : group2Schema.keySet()) {
+                liveColocateGroupIds.add(groupId.grpId);
+            }
+            return colocateRangeMgr.getPackShardGroupIds(liveColocateGroupIds);
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2759,8 +2759,7 @@ public class OlapTable extends Table {
             // which is harmless because the next create on the same colocate_with name allocates a
             // new grpId via getNextId().
             if (colocateTableIndex.isRangeColocateGroup(groupId)) {
-                List<ColocateRange> ranges = colocateTableIndex.getColocateRangeMgr()
-                        .getColocateRanges(groupId.grpId);
+                List<ColocateRange> ranges = colocateTableIndex.getColocateRanges(groupId.grpId);
                 if (!ranges.isEmpty()) {
                     GlobalStateMgr.getCurrentState().getEditLog().logColocateRangeUpdate(
                             ColocateRangePersistInfo.create(groupId.grpId, ranges));

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -146,6 +146,11 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 }
             }
         }
+        // Range-colocate PACK shard groups live in ColocateRangeMgr, not on any
+        // PhysicalPartition. Without unioning them in, deleteUnusedShardAndShardGroup would
+        // treat a live PACK shard group as an orphan and reap it (along with its live tablets).
+        groupIds.addAll(GlobalStateMgr.getCurrentState().getColocateTableIndex().getAllPackShardGroupIds());
+
         long elapsedMs = System.currentTimeMillis() - startMs;
         if (elapsedMs > SLOW_COLLECTION_WARN_THRESHOLD_MS) {
             LOG.warn("getAllPartitionShardGroupId is slow: elapsed={}ms, dbCount={}, groupCount={}",

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -109,7 +109,7 @@ public final class RangeColocateScanDispatch {
      * {@code bucketSeq < bucketNum} invariant requires.
      */
     public int bucketCount() {
-        int count = colocateTableIndex.getColocateRangeMgr().getColocateRanges(colocateGroupId).size();
+        int count = colocateTableIndex.getColocateRanges(colocateGroupId).size();
         // ColocateRangeMgr always seeds a group with the [MIN, MAX) range,
         // so a registered group has at least one entry.
         Preconditions.checkState(count > 0,
@@ -274,8 +274,7 @@ public final class RangeColocateScanDispatch {
      */
     @Nullable
     public Map<Long, Integer> computeBucketSeq(MaterializedIndex selectedIndex) {
-        ColocateRangeMgr colocateRangeMgr = colocateTableIndex.getColocateRangeMgr();
-        List<ColocateRange> colocateRanges = colocateRangeMgr.getColocateRanges(colocateGroupId);
+        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRanges(colocateGroupId);
         Preconditions.checkState(!colocateRanges.isEmpty(),
                 "range colocate group %s has no colocate ranges", colocateGroupId);
         List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(olapTable);
@@ -296,7 +295,7 @@ public final class RangeColocateScanDispatch {
                     tabletId, colocateGroupId);
             Range<Tuple> tabletRange = tablet.getRange().getRange();
             Tuple prefix = ColocateRangeUtils.extractColocatePrefix(tabletRange, colocateColumnCount);
-            int bucketSeq = colocateRangeMgr.getColocateRangeIndex(colocateGroupId, prefix);
+            int bucketSeq = ColocateRangeMgr.indexOf(colocateRanges, prefix);
             if (bucketSeq < 0) {
                 return null; // tablet prefix does not match any ColocateRange
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2314,8 +2314,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                                                  ColocateTableIndex.GroupId groupId)
             throws DdlException {
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRangeMgr()
-                .getColocateRanges(groupId.grpId);
+        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
         if (colocateRanges.isEmpty()) {
             throw new DdlException("Colocate range metadata is missing for group '"
                     + table.getColocateGroup() + "', cannot create range colocate tablets");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
@@ -303,39 +303,42 @@ public class ColocateRangeMgrTest {
         Assertions.assertEquals(2001L, found2.getShardGroupId());
     }
 
-    // ---- getAllPackShardGroupIds ----
+    // ---- getPackShardGroupIds ----
 
     @Test
-    public void testGetAllPackShardGroupIdsEmpty() {
-        Assertions.assertTrue(colocateRangeMgr.getAllPackShardGroupIds().isEmpty());
+    public void testGetPackShardGroupIdsEmpty() {
+        Assertions.assertTrue(colocateRangeMgr.getPackShardGroupIds(Set.of()).isEmpty());
+        // An unknown colocate group id contributes nothing.
+        Assertions.assertTrue(colocateRangeMgr.getPackShardGroupIds(Set.of(COLOCATE_GROUP_ID)).isEmpty());
     }
 
     @Test
-    public void testGetAllPackShardGroupIdsSingleGroup() {
+    public void testGetPackShardGroupIdsSingleGroup() {
         colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
-        Assertions.assertEquals(Set.of(1001L), colocateRangeMgr.getAllPackShardGroupIds());
+        Assertions.assertEquals(Set.of(1001L), colocateRangeMgr.getPackShardGroupIds(Set.of(COLOCATE_GROUP_ID)));
     }
 
     @Test
-    public void testGetAllPackShardGroupIdsMultiRange() {
+    public void testGetPackShardGroupIdsMultiRange() {
         List<ColocateRange> ranges = Arrays.asList(
                 new ColocateRange(Range.lt(makeTuple(100)), 1001L),
                 new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
                 new ColocateRange(Range.ge(makeTuple(200)), 1003L));
         colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
-        Assertions.assertEquals(Set.of(1001L, 1002L, 1003L), colocateRangeMgr.getAllPackShardGroupIds());
+        Assertions.assertEquals(Set.of(1001L, 1002L, 1003L),
+                colocateRangeMgr.getPackShardGroupIds(Set.of(COLOCATE_GROUP_ID)));
     }
 
     @Test
-    public void testGetAllPackShardGroupIdsMultiGroup() {
+    public void testGetPackShardGroupIdsMultiGroup() {
         colocateRangeMgr.initColocateGroup(100L, 1001L);
         colocateRangeMgr.setColocateRanges(200L, Arrays.asList(
                 new ColocateRange(Range.lt(makeTuple(50)), 2001L),
                 new ColocateRange(Range.ge(makeTuple(50)), 2002L)));
-        Assertions.assertEquals(Set.of(1001L, 2001L, 2002L), colocateRangeMgr.getAllPackShardGroupIds());
+        Assertions.assertEquals(Set.of(1001L, 2001L, 2002L),
+                colocateRangeMgr.getPackShardGroupIds(Set.of(100L, 200L)));
 
-        // After removing one group, only the other group's PACK ids remain.
-        colocateRangeMgr.removeColocateGroup(100L);
-        Assertions.assertEquals(Set.of(2001L, 2002L), colocateRangeMgr.getAllPackShardGroupIds());
+        // Only the requested groups contribute: excluding group 100 drops its PACK id.
+        Assertions.assertEquals(Set.of(2001L, 2002L), colocateRangeMgr.getPackShardGroupIds(Set.of(200L)));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class ColocateRangeMgrTest {
 
@@ -300,5 +301,41 @@ public class ColocateRangeMgrTest {
         // Find in group 2
         ColocateRange found2 = colocateRangeMgr.getColocateRange(groupId2, makeTuple(100));
         Assertions.assertEquals(2001L, found2.getShardGroupId());
+    }
+
+    // ---- getAllPackShardGroupIds ----
+
+    @Test
+    public void testGetAllPackShardGroupIdsEmpty() {
+        Assertions.assertTrue(colocateRangeMgr.getAllPackShardGroupIds().isEmpty());
+    }
+
+    @Test
+    public void testGetAllPackShardGroupIdsSingleGroup() {
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+        Assertions.assertEquals(Set.of(1001L), colocateRangeMgr.getAllPackShardGroupIds());
+    }
+
+    @Test
+    public void testGetAllPackShardGroupIdsMultiRange() {
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1003L));
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+        Assertions.assertEquals(Set.of(1001L, 1002L, 1003L), colocateRangeMgr.getAllPackShardGroupIds());
+    }
+
+    @Test
+    public void testGetAllPackShardGroupIdsMultiGroup() {
+        colocateRangeMgr.initColocateGroup(100L, 1001L);
+        colocateRangeMgr.setColocateRanges(200L, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(50)), 2001L),
+                new ColocateRange(Range.ge(makeTuple(50)), 2002L)));
+        Assertions.assertEquals(Set.of(1001L, 2001L, 2002L), colocateRangeMgr.getAllPackShardGroupIds());
+
+        // After removing one group, only the other group's PACK ids remain.
+        colocateRangeMgr.removeColocateGroup(100L);
+        Assertions.assertEquals(Set.of(2001L, 2002L), colocateRangeMgr.getAllPackShardGroupIds());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
@@ -303,42 +303,39 @@ public class ColocateRangeMgrTest {
         Assertions.assertEquals(2001L, found2.getShardGroupId());
     }
 
-    // ---- getPackShardGroupIds ----
+    // ---- getAllPackShardGroupIds ----
 
     @Test
-    public void testGetPackShardGroupIdsEmpty() {
-        Assertions.assertTrue(colocateRangeMgr.getPackShardGroupIds(Set.of()).isEmpty());
-        // An unknown colocate group id contributes nothing.
-        Assertions.assertTrue(colocateRangeMgr.getPackShardGroupIds(Set.of(COLOCATE_GROUP_ID)).isEmpty());
+    public void testGetAllPackShardGroupIdsEmpty() {
+        Assertions.assertTrue(colocateRangeMgr.getAllPackShardGroupIds().isEmpty());
     }
 
     @Test
-    public void testGetPackShardGroupIdsSingleGroup() {
+    public void testGetAllPackShardGroupIdsSingleGroup() {
         colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
-        Assertions.assertEquals(Set.of(1001L), colocateRangeMgr.getPackShardGroupIds(Set.of(COLOCATE_GROUP_ID)));
+        Assertions.assertEquals(Set.of(1001L), colocateRangeMgr.getAllPackShardGroupIds());
     }
 
     @Test
-    public void testGetPackShardGroupIdsMultiRange() {
+    public void testGetAllPackShardGroupIdsMultiRange() {
         List<ColocateRange> ranges = Arrays.asList(
                 new ColocateRange(Range.lt(makeTuple(100)), 1001L),
                 new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
                 new ColocateRange(Range.ge(makeTuple(200)), 1003L));
         colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
-        Assertions.assertEquals(Set.of(1001L, 1002L, 1003L),
-                colocateRangeMgr.getPackShardGroupIds(Set.of(COLOCATE_GROUP_ID)));
+        Assertions.assertEquals(Set.of(1001L, 1002L, 1003L), colocateRangeMgr.getAllPackShardGroupIds());
     }
 
     @Test
-    public void testGetPackShardGroupIdsMultiGroup() {
+    public void testGetAllPackShardGroupIdsMultiGroup() {
         colocateRangeMgr.initColocateGroup(100L, 1001L);
         colocateRangeMgr.setColocateRanges(200L, Arrays.asList(
                 new ColocateRange(Range.lt(makeTuple(50)), 2001L),
                 new ColocateRange(Range.ge(makeTuple(50)), 2002L)));
-        Assertions.assertEquals(Set.of(1001L, 2001L, 2002L),
-                colocateRangeMgr.getPackShardGroupIds(Set.of(100L, 200L)));
+        Assertions.assertEquals(Set.of(1001L, 2001L, 2002L), colocateRangeMgr.getAllPackShardGroupIds());
 
-        // Only the requested groups contribute: excluding group 100 drops its PACK id.
-        Assertions.assertEquals(Set.of(2001L, 2002L), colocateRangeMgr.getPackShardGroupIds(Set.of(200L)));
+        // After removing one group, only the other group's PACK ids remain.
+        colocateRangeMgr.removeColocateGroup(100L);
+        Assertions.assertEquals(Set.of(2001L, 2002L), colocateRangeMgr.getAllPackShardGroupIds());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.staros.proto.PlacementPolicy;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.StarOSAgent;
@@ -1116,5 +1117,18 @@ public class ColocateTableIndexTest {
         ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
         ColocateTableIndex.GroupId unknown = new ColocateTableIndex.GroupId(1L, 2L);
         Assertions.assertFalse(colocateTableIndex.isRangeColocateGroup(unknown));
+    }
+
+    @Test
+    public void testGetAllPackShardGroupIdsExcludesOrphanRangeEntries() {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+        // Seed a range entry for a grpId that has no live colocate group (not in group2Schema),
+        // mimicking the crash window between the range-update and add-table journal records.
+        long orphanGrpId = 9999L;
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(orphanGrpId,
+                List.of(new ColocateRange(Range.all(), 4787L)));
+        // The orphaned PACK shard group must not be reported as FE-known, so StarMgrMetaSyncer
+        // can still reap it once it is genuinely unused.
+        Assertions.assertTrue(colocateTableIndex.getAllPackShardGroupIds().isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -16,7 +16,6 @@ package com.starrocks.catalog;
 
 import com.staros.proto.PlacementPolicy;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.Range;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.StarOSAgent;
@@ -1117,18 +1116,5 @@ public class ColocateTableIndexTest {
         ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
         ColocateTableIndex.GroupId unknown = new ColocateTableIndex.GroupId(1L, 2L);
         Assertions.assertFalse(colocateTableIndex.isRangeColocateGroup(unknown));
-    }
-
-    @Test
-    public void testGetAllPackShardGroupIdsExcludesOrphanRangeEntries() {
-        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
-        // Seed a range entry for a grpId that has no live colocate group (not in group2Schema),
-        // mimicking the crash window between the range-update and add-table journal records.
-        long orphanGrpId = 9999L;
-        colocateTableIndex.getColocateRangeMgr().setColocateRanges(orphanGrpId,
-                List.of(new ColocateRange(Range.all(), 4787L)));
-        // The orphaned PACK shard group must not be reported as FE-known, so StarMgrMetaSyncer
-        // can still reap it once it is genuinely unused.
-        Assertions.assertTrue(colocateTableIndex.getAllPackShardGroupIds().isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -920,7 +920,8 @@ public class StarMgrMetaSyncerTest {
     // and never reaped by deleteUnusedShardAndShardGroup, even when older than the threshold.
     @Test
     public void testPackShardGroupNotReapedWhenStillReferenced() {
-        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
+        boolean oldForceDelete = Config.meta_sync_force_delete_shard_meta;
+        long oldCleanThreshold = Config.shard_group_clean_threshold_sec;
         Config.meta_sync_force_delete_shard_meta = false;
         Config.shard_group_clean_threshold_sec = 0;
 
@@ -963,7 +964,8 @@ public class StarMgrMetaSyncerTest {
         Assertions.assertFalse(deletedGroups.contains(packGroupId));
         Assertions.assertEquals(1, shardGroupInfos.size());
 
-        Config.meta_sync_force_delete_shard_meta = oldValue;
+        Config.meta_sync_force_delete_shard_meta = oldForceDelete;
+        Config.shard_group_clean_threshold_sec = oldCleanThreshold;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -127,6 +127,10 @@ public class StarMgrMetaSyncerTest {
     private ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
     private StorageVolumeMgr storageVolumeMgr = new SharedDataStorageVolumeMgr();
 
+    // PACK shard group ids surfaced by ColocateRangeMgr. Tests mutate this to register
+    // live PACK groups that must not be reaped.
+    private Set<Long> packShardGroupIds = new HashSet<>();
+
     private StarMgrMetaSyncer starMgrMetaSyncer;
 
     long shardGroupId = 12L;
@@ -184,6 +188,21 @@ public class StarMgrMetaSyncerTest {
                 globalStateMgr.getStorageVolumeMgr();
                 minTimes = 0;
                 result = storageVolumeMgr;
+
+                globalStateMgr.getColocateTableIndex();
+                minTimes = 0;
+                result = colocateTableIndex;
+            }
+        };
+
+        // PACK shard groups live in ColocateRangeMgr, surfaced via getAllPackShardGroupIds().
+        // Default to an empty set so getAllPartitionShardGroupId() does not NPE on addAll(null);
+        // tests mutate packShardGroupIds to register live PACK groups.
+        new Expectations() {
+            {
+                colocateTableIndex.getAllPackShardGroupIds();
+                minTimes = 0;
+                result = packShardGroupIds;
             }
         };
 
@@ -892,6 +911,57 @@ public class StarMgrMetaSyncerTest {
         };
         Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
         Assertions.assertEquals(0, shardGroupInfos.size());
+
+        Config.meta_sync_force_delete_shard_meta = oldValue;
+    }
+
+    // A range-colocate PACK shard group lives in ColocateRangeMgr (surfaced via
+    // getAllPackShardGroupIds), not on any PhysicalPartition. It must be reported as FE-known
+    // and never reaped by deleteUnusedShardAndShardGroup, even when older than the threshold.
+    @Test
+    public void testPackShardGroupNotReapedWhenStillReferenced() {
+        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
+        Config.meta_sync_force_delete_shard_meta = false;
+        Config.shard_group_clean_threshold_sec = 0;
+
+        long packGroupId = 7777L;
+        packShardGroupIds.add(packGroupId);
+
+        // The PACK group id must be part of the FE-known shard group set.
+        Set<Long> feKnown = Deencapsulation.invoke(starMgrMetaSyncer, "getAllPartitionShardGroupId");
+        Assertions.assertTrue(feKnown.contains(packGroupId));
+
+        // An old PACK group present in StarOS must NOT be selected for deletion.
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        shardGroupInfos.add(ShardGroupInfo.newBuilder()
+                .setGroupId(packGroupId)
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(0L))
+                .putLabels("indexId", String.valueOf(0L))
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .build());
+        List<Long> deletedGroups = new ArrayList<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public StarOSAgent.ListShardGroupResult listShardGroup(long startGroupId) {
+                return new StarOSAgent.ListShardGroupResult(shardGroupInfos, 0L);
+            }
+
+            @Mock
+            public List<Long> listShard(long groupId) {
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public void deleteShardGroup(List<Long> groupIds) {
+                deletedGroups.addAll(groupIds);
+            }
+        };
+
+        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+        Assertions.assertFalse(deletedGroups.contains(packGroupId));
+        Assertions.assertEquals(1, shardGroupInfos.size());
 
         Config.meta_sync_force_delete_shard_meta = oldValue;
     }


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, range-distribution colocate creates a **PACK shard group** per colocate range. This PACK shard group is tracked only in `ColocateRangeMgr` and is **not attached to any `PhysicalPartition`** (unlike the per-partition SPREAD shard groups).

`StarMgrMetaSyncer.deleteUnusedShardAndShardGroup()` reaps StarOS shard groups that are absent from its "FE-known" set, which it builds solely from `PhysicalPartition.getShardGroupIds()` via `getAllPartitionShardGroupId()`. Because PACK shard groups never appear in that set, they were misclassified as orphans and permanently deleted once older than `shard_group_clean_threshold_sec` (default 3600s) — and `cleanOneGroup()` first deleted the live tablets that are dual members of `[SPREAD, PACK]`.

After deletion, `ColocateRangeMgr` still references the now-deleted PACK shard group, so subsequent `createShards` / `createShardsForSplit` fail with `NOT_EXIST: shard group <id> not exist`, surfacing on both `CREATE TABLE` (joining an existing colocate group) and tablet reshard split jobs.

## What I'm doing:

**Primary fix — recognize PACK shard groups as FE-known:**

- `ColocateRangeMgr.getAllPackShardGroupIds()` enumerates the PACK shard group ids across colocate groups.
- `ColocateTableIndex.getAllPackShardGroupIds()` exposes them under the index read lock.
- `StarMgrMetaSyncer.getAllPartitionShardGroupId()` unions them into the FE-known set.

This only enlarges the protected set, so it can only prevent erroneous deletions; genuine-orphan cleanup behavior is unchanged.

**Encapsulate `ColocateRangeMgr` behind `ColocateTableIndex` (review feedback):**

- All production access now goes through the lock-guarded `ColocateTableIndex.getColocateRanges()`, which returns an immutable snapshot, so callers can neither mutate the range list nor read it lock-free.
- Migrated the 6 former direct callers — `ColocateChecker`, `SplitTabletJobFactory`, `SplitTabletJob`, `RangeColocateScanDispatch`, `OlapTable`, `LocalMetastore`.
- `getColocateRangeMgr()` is now `@VisibleForTesting` (zero production callers; remaining users are cross-package tests).

**Note on orphaned range entries:** a crash between the range-update and add-table journal records can leave a `ColocateRangeMgr` entry with no live colocate group. Such a PACK shard group is intentionally kept protected (a benign leak — the `grpId` is never reused via `getNextId()`) rather than reaped, because reaping it without a per-shard liveness check could delete the half-created table's live tablets.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5