### PR TITLE
[Enhancement] Add global shuffle for Hive connector sink

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -4680,7 +4680,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
-        ConnectorSinkShuffleMode mode = ConnectorSinkShuffleMode.fromName(this.connectorSinkShuffleMode);
+        return ConnectorSinkShuffleMode.fromName(this.connectorSinkShuffleMode);
+    }
+
+    public ConnectorSinkShuffleMode getIcebergConnectorSinkShuffleMode() {
+        ConnectorSinkShuffleMode mode = getConnectorSinkShuffleMode();
         // Backward compatibility: legacy iceberg-only boolean implies FORCE when new mode stays at default AUTO.
         if (mode == ConnectorSinkShuffleMode.AUTO && enableIcebergSinkGlobalShuffle) {
             return ConnectorSinkShuffleMode.FORCE;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -22,8 +22,6 @@ import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.Function;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -36,14 +34,10 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.connector.ConnectorSinkShuffleMode;
-import com.starrocks.connector.ConnectorSinkSortScope;
-import com.starrocks.connector.iceberg.IcebergPartitionTransform;
 import com.starrocks.connector.iceberg.IcebergRowLineageUtils;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
@@ -78,7 +72,6 @@ import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.DefaultValueExpr;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
@@ -92,17 +85,16 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.ConnectorSinkShuffleSpec;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.EmptyDistributionProperty;
 import com.starrocks.sql.optimizer.base.GatherDistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
-import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.base.RoundRobinDistributionSpec;
 import com.starrocks.sql.optimizer.base.SortProperty;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -119,19 +111,12 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.iceberg.NullOrder;
-import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.SortDirection;
-import org.apache.iceberg.SortField;
-import org.apache.iceberg.SortOrder;
-import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -621,40 +606,16 @@ public class InsertPlanner {
                                                                  LogicalPlan logicalPlan) {
         OptExpression root = logicalPlan.getRoot();
         ColumnRefSet requiredColumns = new ColumnRefSet(logicalPlan.getOutputColumn());
-        if (!(targetTable instanceof IcebergTable icebergTable) ||
-                !shouldPlanIcebergShuffle(insertStmt, icebergTable, sessionVariable)) {
+        Optional<ConnectorSinkShuffleSpec> spec = ConnectorSinkShuffleSpec.forTable(targetTable);
+        if (spec.isEmpty() || !spec.get().shouldShuffle(insertStmt, sessionVariable)) {
             return new PreOptimizePlanContext(root, requiredColumns, null);
         }
-
-        Pair<List<Integer>, Map<ColumnRefOperator, ScalarOperator>> result =
-                buildIcebergPartitionShuffleColumns(icebergTable, outputColumns, columnRefFactory);
-        Map<ColumnRefOperator, ScalarOperator> transformProjection = result.second;
-        if (transformProjection.isEmpty()) {
-            return new PreOptimizePlanContext(root, requiredColumns, result.first);
-        }
-
-        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
-        for (ColumnRefOperator col : outputColumns) {
-            projectionMap.put(col, col);
-        }
-        projectionMap.putAll(transformProjection);
-        for (ColumnRefOperator transformCol : transformProjection.keySet()) {
-            requiredColumns.union(transformCol.getId());
-        }
-        root = OptExpression.create(new LogicalProjectOperator(projectionMap), root);
-        return new PreOptimizePlanContext(root, requiredColumns, result.first);
+        ConnectorSinkShuffleSpec.PreOptimizeResult r = spec.get()
+                .prepare(insertStmt, outputColumns, columnRefFactory, root, requiredColumns);
+        return new PreOptimizePlanContext(r.root, r.requiredColumns, r.partitionColumnIDs);
     }
 
-    private boolean shouldPlanIcebergShuffle(InsertStmt insertStmt, IcebergTable icebergTable,
-                                             SessionVariable sessionVariable) {
-        ConnectorSinkShuffleMode shuffleMode = sessionVariable.getConnectorSinkShuffleMode();
-        if (shuffleMode == ConnectorSinkShuffleMode.NEVER || icebergTable.getPartitionColumns().isEmpty()) {
-            return false;
-        }
-        return shuffleMode == ConnectorSinkShuffleMode.FORCE ||
-                (shuffleMode == ConnectorSinkShuffleMode.AUTO &&
-                        shouldEnableAdaptiveGlobalShuffle(insertStmt, icebergTable, sessionVariable));
-    }
+
 
     private void castLiteralToTargetColumnsType(InsertStmt insertStatement) {
         Preconditions.checkState(insertStatement.getQueryStatement().getQueryRelation() instanceof ValuesRelation,
@@ -957,159 +918,6 @@ public class InsertPlanner {
         return root.withNewRoot(new LogicalProjectOperator(new HashMap<>(columnRefMap)));
     }
 
-    /**
-     * Build partition shuffle columns for Iceberg tables with partition transforms.
-     * For identity transforms, uses the source column ref directly.
-     * For non-identity transforms (year, month, day, hour, bucket, truncate), creates
-     * CallOperator expressions so shuffle happens on transformed values.
-     *
-     * @return Pair of (partition column IDs for hash distribution, projection map for transform expressions)
-     */
-    private Pair<List<Integer>, Map<ColumnRefOperator, ScalarOperator>> buildIcebergPartitionShuffleColumns(
-            IcebergTable icebergTable, List<ColumnRefOperator> outputColumns, ColumnRefFactory columnRefFactory) {
-        List<Integer> partitionColumnIDs = new ArrayList<>();
-        Map<ColumnRefOperator, ScalarOperator> transformProjection = new HashMap<>();
-
-        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
-        PartitionSpec spec = nativeTable.spec();
-
-        // For unpartitioned tables or identity-only partitions, fall back to source column indexes
-        if (spec.isUnpartitioned()) {
-            List<Integer> fallbackIDs = icebergTable.partitionColumnIndexes().stream()
-                    .filter(x -> x >= 0 && x < outputColumns.size())
-                    .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-            return Pair.create(fallbackIDs, transformProjection);
-        }
-
-        boolean allIdentity = spec.fields().stream().allMatch(f -> f.transform().isIdentity());
-        if (allIdentity) {
-            List<Integer> fallbackIDs = icebergTable.partitionColumnIndexes().stream()
-                    .filter(x -> x >= 0 && x < outputColumns.size())
-                    .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-            return Pair.create(fallbackIDs, transformProjection);
-        }
-
-        org.apache.iceberg.Schema icebergSchema = nativeTable.schema();
-        List<Column> fullSchema = icebergTable.getFullSchema();
-
-        for (PartitionField field : spec.fields()) {
-            String sourceColumnName = icebergSchema.findColumnName(field.sourceId());
-            boolean isTimestampWithZone =
-                    icebergSchema.findType(field.sourceId()).equals(Types.TimestampType.withZone());
-            int sourceColumnIndex = -1;
-            for (int i = 0; i < fullSchema.size(); i++) {
-                if (fullSchema.get(i).getName().equalsIgnoreCase(sourceColumnName)) {
-                    sourceColumnIndex = i;
-                    break;
-                }
-            }
-            if (sourceColumnIndex < 0 || sourceColumnIndex >= outputColumns.size()) {
-                continue;
-            }
-
-            ColumnRefOperator sourceRef = outputColumns.get(sourceColumnIndex);
-            IcebergPartitionTransform transform =
-                    IcebergPartitionTransform.fromString(field.transform().toString());
-
-            switch (transform) {
-                case IDENTITY:
-                    partitionColumnIDs.add(sourceRef.getId());
-                    break;
-                case YEAR:
-                case MONTH:
-                case DAY:
-                case HOUR: {
-                    String funcName = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX +
-                            (isTimestampWithZone ? "timestamptz_" : "") + transform.name().toLowerCase();
-                    Type[] argTypes = new Type[] {sourceRef.getType()};
-                    Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
-                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-                    if (fn == null) {
-                        // Fallback to source column if function not found
-                        partitionColumnIDs.add(sourceRef.getId());
-                        break;
-                    }
-                    Type returnType = fn.getReturnType();
-                    CallOperator callOp = new CallOperator(funcName, returnType, Lists.newArrayList(sourceRef), fn);
-                    ColumnRefOperator transformRef = columnRefFactory.create(
-                            funcName, returnType, true);
-                    transformProjection.put(transformRef, callOp);
-                    partitionColumnIDs.add(transformRef.getId());
-                    break;
-                }
-                case BUCKET: {
-                    int numBuckets = extractTransformParam(field.transform().toString());
-                    if (numBuckets <= 0) {
-                        partitionColumnIDs.add(sourceRef.getId());
-                        break;
-                    }
-                    String funcName = isTimestampWithZone
-                            ? FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "timestamptz_bucket"
-                            : FunctionSet.ICEBERG_TRANSFORM_BUCKET;
-                    Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
-                    Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
-                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-                    if (fn == null) {
-                        partitionColumnIDs.add(sourceRef.getId());
-                        break;
-                    }
-                    Type returnType = fn.getReturnType();
-                    CallOperator callOp = new CallOperator(funcName, returnType,
-                            Lists.newArrayList(sourceRef, ConstantOperator.createInt(numBuckets)), fn);
-                    ColumnRefOperator transformRef = columnRefFactory.create(
-                            funcName, returnType, true);
-                    transformProjection.put(transformRef, callOp);
-                    partitionColumnIDs.add(transformRef.getId());
-                    break;
-                }
-                case TRUNCATE: {
-                    int width = extractTransformParam(field.transform().toString());
-                    if (width <= 0) {
-                        partitionColumnIDs.add(sourceRef.getId());
-                        break;
-                    }
-                    String funcName = FunctionSet.ICEBERG_TRANSFORM_TRUNCATE;
-                    Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
-                    Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
-                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-                    if (fn == null) {
-                        partitionColumnIDs.add(sourceRef.getId());
-                        break;
-                    }
-                    // For truncate, the return type matches the source column type (mirrors FunctionAnalyzer).
-                    // fn.getReturnType() returns a generic DECIMAL type for decimal columns (wildcard
-                    // precision/scale), which would produce incorrect shuffle hash keys.
-                    Type returnType = sourceRef.getType();
-                    CallOperator callOp = new CallOperator(funcName, returnType,
-                            Lists.newArrayList(sourceRef, ConstantOperator.createInt(width)), fn);
-                    ColumnRefOperator transformRef = columnRefFactory.create(
-                            funcName, returnType, true);
-                    transformProjection.put(transformRef, callOp);
-                    partitionColumnIDs.add(transformRef.getId());
-                    break;
-                }
-                case UNKNOWN:
-                default:
-                    // Skip void/unknown transforms
-                    break;
-            }
-        }
-
-        return Pair.create(partitionColumnIDs, transformProjection);
-    }
-
-    private static int extractTransformParam(String transform) {
-        int l = transform.indexOf('[');
-        int r = transform.indexOf(']');
-        if (l >= 0 && r > l) {
-            try {
-                return Integer.parseInt(transform.substring(l + 1, r));
-            } catch (NumberFormatException ignore) {
-                // fall through
-            }
-        }
-        return 0;
-    }
 
     private static final class PreOptimizePlanContext {
         private final OptExpression root;
@@ -1142,49 +950,16 @@ public class InsertPlanner {
         }
 
         Table targetTable = insertStmt.getTargetTable();
-        if (targetTable instanceof IcebergTable) {
-            IcebergTable icebergTable = (IcebergTable) targetTable;
-
-            // Create distribution property if global shuffle is enabled
-            DistributionProperty distributionProperty = EmptyDistributionProperty.INSTANCE;
-
-            if (preComputedPartitionColumnIDs != null && !preComputedPartitionColumnIDs.isEmpty()) {
-                // Use pre-computed partition column IDs (which may include transform expressions).
-                // If preComputedPartitionColumnIDs is null, shouldPlanIcebergShuffle already decided
-                // not to shuffle, so we skip redundant re-evaluation.
-                distributionProperty = createDistributionPropertyFromPartitions(preComputedPartitionColumnIDs);
-            }
-
-            // Check if we should use host-level sorting for connector sink
-            ConnectorSinkSortScope sortScope = ConnectorSinkSortScope.fromName(session.getConnectorSinkSortScope());
-            boolean useHostLevelSort = (sortScope == ConnectorSinkSortScope.HOST);
-
-            // Get sort order info from Iceberg table
-            List<Ordering> sortOrderings = new ArrayList<>();
-            if (useHostLevelSort) {
-                org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
-                SortOrder sortOrder = nativeTable.sortOrder();
-                if (sortOrder != null && sortOrder.isSorted()) {
-                    List<Integer> sortKeyIndexes = icebergTable.getSortKeyIndexes();
-                    for (int idx = 0; idx < sortKeyIndexes.size(); ++idx) {
-                        int sortKeyIndex = sortKeyIndexes.get(idx);
-                        SortField sortField = sortOrder.fields().get(idx);
-                        // Skip non-identity transforms
-                        if (!sortField.transform().isIdentity()) {
-                            continue;
-                        }
-                        boolean isAsc = sortField.direction() == SortDirection.ASC;
-                        boolean isNullFirst = sortField.nullOrder() == NullOrder.NULLS_FIRST;
-                        sortOrderings.add(new Ordering(outputColumns.get(sortKeyIndex), isAsc, isNullFirst));
-                    }
-                }
-            }
-
-            // Create sort property if host-level sorting is enabled and sort order exists
-            SortProperty sortProperty = SortProperty.createProperty(sortOrderings);
-
-            // Return property set with both distribution and sort properties
-            // These properties also can be empty.
+        Optional<ConnectorSinkShuffleSpec> connectorSpec = ConnectorSinkShuffleSpec.forTable(targetTable);
+        if (connectorSpec.isPresent()) {
+            // preComputedPartitionColumnIDs is non-null iff the spec decided to shuffle
+            // (set in preparePreOptimizePlanContext). When non-empty, create the hash
+            // distribution; otherwise leave the property set distribution-less.
+            DistributionProperty distributionProperty =
+                    (preComputedPartitionColumnIDs != null && !preComputedPartitionColumnIDs.isEmpty())
+                            ? createDistributionPropertyFromPartitions(preComputedPartitionColumnIDs)
+                            : EmptyDistributionProperty.INSTANCE;
+            SortProperty sortProperty = connectorSpec.get().computeSortProperty(session, outputColumns);
             return new PhysicalPropertySet(distributionProperty, sortProperty);
         }
 
@@ -1370,84 +1145,5 @@ public class InsertPlanner {
         return true;
     }
 
-    /**
-     * Judge whether adaptive global shuffle should be enabled based on partition count and backend count.
-     * <p>
-     * Decision criteria (configurable via session variables):
-     * 1. Enable when estimated partition count >= backend count * ratio
-     * 2. OR when estimated partition count >= absolute threshold
-     *
-     * @param insertStmt   INSERT statement
-     * @param icebergTable target Iceberg table
-     * @param session      Session variable
-     * @return whether to enable global shuffle
-     */
-    private boolean shouldEnableAdaptiveGlobalShuffle(InsertStmt insertStmt,
-                                                      IcebergTable icebergTable,
-                                                      SessionVariable session) {
-        // Get the number of alive BE nodes and CN nodes in the cluster
-        SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        int aliveBackendNum = clusterInfo.getAliveBackendNumber();
-        int totalComputeNodeNum = clusterInfo.getTotalComputeNodeNumber();
-        int totalWorkerNum = aliveBackendNum + totalComputeNodeNum;
 
-        // Don't enable global shuffle if we have only 1 or 0 worker nodes
-        if (totalWorkerNum <= 1) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Disable adaptive global shuffle for connector table {}.{}: " +
-                                "total worker nodes ({}) <= 1",
-                        icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(),
-                        totalWorkerNum);
-            }
-            return false;
-        }
-
-        // Estimate the number of partitions that may be involved in this insert
-        long estimatedPartitionCount = estimatePartitionCountForInsert(insertStmt, icebergTable);
-
-        // Don't enable global shuffle if unable to estimate partition count or only writing to 1 partition
-        // estimatedPartitionCount <= 1 covers:
-        // - -1: unable to estimate (users typically write to only the latest partition)
-        // - 0 or 1: only writing to one partition
-        if (estimatedPartitionCount <= 1) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Disable adaptive global shuffle for connector table {}.{}: " +
-                                "estimated partition count ({}) <= 1",
-                        icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(),
-                        estimatedPartitionCount);
-            }
-            return false;
-        }
-
-        // Get configured thresholds from connector variables
-        long partitionCountThreshold = session.getConnectorSinkShufflePartitionThreshold();
-        double partitionCountNodeRatio = session.getConnectorSinkShufflePartitionNodeRatio();
-
-        // Decision logic:
-        // 1. estimated partitions >= total worker count * ratio coefficient
-        // 2. OR estimated partitions >= absolute threshold
-        boolean shouldEnable = estimatedPartitionCount >= (long) (totalWorkerNum * partitionCountNodeRatio)
-                || estimatedPartitionCount >= partitionCountThreshold;
-
-        if (shouldEnable && LOG.isDebugEnabled()) {
-            LOG.debug("Enable adaptive global shuffle for connector table {}.{}: " +
-                            "estimated partitions={}, total workers={}, threshold={}, ratio={}",
-                    icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(),
-                    estimatedPartitionCount, totalWorkerNum,
-                    partitionCountThreshold, partitionCountNodeRatio);
-        }
-
-        return shouldEnable;
-    }
-
-    /**
-     * Estimate the number of partitions that may be involved in this INSERT operation.
-     *
-     * @param insertStmt   INSERT statement
-     * @param icebergTable target Iceberg table
-     * @return estimated partition count
-     */
-    private long estimatePartitionCountForInsert(InsertStmt insertStmt, IcebergTable icebergTable) {
-        return InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ConnectorSinkShuffleSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ConnectorSinkShuffleSpec.java
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.InsertPartitionEstimator;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.system.SystemInfoService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Per-connector strategy that decides whether to plan a global shuffle before
+ * a connector sink, and computes the partition column IDs used as the hash key.
+ *
+ * <p>Iceberg and Hive share the same decision rule (mode + partitions + AUTO
+ * adaptive check on cluster worker count and partition cardinality) — provided
+ * as default methods here — but differ in how they materialize partition column
+ * IDs:
+ *
+ * <ul>
+ *   <li><b>Iceberg</b>: may inject transform projection columns (bucket/truncate/
+ *       year/month/day/hour) and use their virtual column refs as the hash key.</li>
+ *   <li><b>Hive</b>: identity columns only, hash key is the partition column
+ *       refs directly.</li>
+ * </ul>
+ *
+ * <p>InsertPlanner dispatches via {@link #forTable(Table)}; non-eligible tables
+ * (OlapTable, TableFunctionTable, Paimon, ...) return {@link Optional#empty()}
+ * and the planner falls back to its existing connector-specific code paths.
+ */
+public interface ConnectorSinkShuffleSpec {
+
+    Logger LOG = LogManager.getLogger(ConnectorSinkShuffleSpec.class);
+
+    /** The connector sink target this spec wraps. */
+    Table table();
+
+    /**
+     * Compute partition column IDs and (optionally) rewrite the logical plan to
+     * inject transform projection columns. Hive returns identity column IDs and
+     * leaves the plan unchanged; Iceberg may add a {@code LogicalProjectOperator}
+     * for non-identity transforms.
+     */
+    PreOptimizeResult prepare(InsertStmt insertStmt,
+                              List<ColumnRefOperator> outputColumns,
+                              ColumnRefFactory columnRefFactory,
+                              OptExpression root,
+                              ColumnRefSet requiredColumns);
+
+    /**
+     * Optional sort property override (Iceberg may want host-level sort by the
+     * table's native sort order). Default: no sort.
+     */
+    default SortProperty computeSortProperty(SessionVariable session,
+                                             List<ColumnRefOperator> outputColumns) {
+        return SortProperty.createProperty(java.util.Collections.emptyList());
+    }
+
+    /**
+     * Connector-agnostic decision: mode NEVER / unpartitioned → no shuffle;
+     * FORCE → always; AUTO → delegate to {@link #shouldEnableAdaptiveGlobalShuffle}.
+     */
+    default boolean shouldShuffle(InsertStmt insertStmt, SessionVariable sv) {
+        ConnectorSinkShuffleMode mode = effectiveShuffleMode(sv);
+        if (mode == ConnectorSinkShuffleMode.NEVER || table().getPartitionColumns().isEmpty()) {
+            return false;
+        }
+        return mode == ConnectorSinkShuffleMode.FORCE
+                || (mode == ConnectorSinkShuffleMode.AUTO
+                        && shouldEnableAdaptiveGlobalShuffle(insertStmt, sv));
+    }
+
+    /**
+     * The shuffle mode used by {@link #shouldShuffle}. Connectors override this
+     * only when they need a connector-specific view of the mode (e.g. Iceberg
+     * honours the legacy {@code enable_iceberg_sink_global_shuffle} boolean).
+     */
+    default ConnectorSinkShuffleMode effectiveShuffleMode(SessionVariable sv) {
+        return sv.getConnectorSinkShuffleMode();
+    }
+
+    /**
+     * AUTO-mode adaptive check, identical to the previous Iceberg-only logic:
+     * enable shuffle when worker count > 1 AND
+     *   (estimated partitions >= workerCount * ratio
+     *    OR estimated partitions >= absolute threshold).
+     *
+     * <p>Uses {@link SystemInfoService} worker counts and {@link InsertPartitionEstimator}
+     * — both already work on the generic {@link Table} type.
+     */
+    default boolean shouldEnableAdaptiveGlobalShuffle(InsertStmt insertStmt, SessionVariable sv) {
+        SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        int totalWorkerNum = clusterInfo.getAliveBackendNumber() + clusterInfo.getTotalComputeNodeNumber();
+        if (totalWorkerNum <= 1) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Disable adaptive global shuffle for connector table {}.{}: " +
+                                "total worker nodes ({}) <= 1",
+                        table().getCatalogDBName(), table().getCatalogTableName(), totalWorkerNum);
+            }
+            return false;
+        }
+
+        long estimatedPartitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, table());
+        if (estimatedPartitionCount <= 1) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Disable adaptive global shuffle for connector table {}.{}: " +
+                                "estimated partition count ({}) <= 1",
+                        table().getCatalogDBName(), table().getCatalogTableName(), estimatedPartitionCount);
+            }
+            return false;
+        }
+
+        long partitionCountThreshold = sv.getConnectorSinkShufflePartitionThreshold();
+        double partitionCountNodeRatio = sv.getConnectorSinkShufflePartitionNodeRatio();
+        boolean shouldEnable = estimatedPartitionCount >= (long) (totalWorkerNum * partitionCountNodeRatio)
+                || estimatedPartitionCount >= partitionCountThreshold;
+
+        if (shouldEnable && LOG.isDebugEnabled()) {
+            LOG.debug("Enable adaptive global shuffle for connector table {}.{}: " +
+                            "estimated partitions={}, total workers={}, threshold={}, ratio={}",
+                    table().getCatalogDBName(), table().getCatalogTableName(),
+                    estimatedPartitionCount, totalWorkerNum,
+                    partitionCountThreshold, partitionCountNodeRatio);
+        }
+        return shouldEnable;
+    }
+
+    /** Factory: returns the spec for connector-sink-eligible tables, else empty. */
+    static Optional<ConnectorSinkShuffleSpec> forTable(Table table) {
+        if (table instanceof IcebergTable) {
+            return Optional.of(new IcebergSinkShuffleSpec((IcebergTable) table));
+        }
+        if (table instanceof HiveTable) {
+            return Optional.of(new HiveSinkShuffleSpec((HiveTable) table));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Result of plan preparation. {@code root} may differ from the original (Iceberg
+     * transform projection); {@code requiredColumns} may carry newly-introduced
+     * column refs; {@code partitionColumnIDs} are the hash key.
+     */
+    final class PreOptimizeResult {
+        public final OptExpression root;
+        public final ColumnRefSet requiredColumns;
+        public final List<Integer> partitionColumnIDs;
+
+        public PreOptimizeResult(OptExpression root,
+                                 ColumnRefSet requiredColumns,
+                                 List<Integer> partitionColumnIDs) {
+            this.root = root;
+            this.requiredColumns = requiredColumns;
+            this.partitionColumnIDs = partitionColumnIDs;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HiveSinkShuffleSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HiveSinkShuffleSpec.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+
+import java.util.List;
+
+/**
+ * Hive {@link ConnectorSinkShuffleSpec}. Hive supports only identity partition
+ * columns (no transforms), so {@link #prepare} computes hash key IDs directly
+ * from {@code outputFullSchema.indexOf(column)} and never rewrites the plan.
+ */
+public class HiveSinkShuffleSpec implements ConnectorSinkShuffleSpec {
+
+    private final HiveTable hiveTable;
+
+    public HiveSinkShuffleSpec(HiveTable hiveTable) {
+        this.hiveTable = hiveTable;
+    }
+
+    @Override
+    public Table table() {
+        return hiveTable;
+    }
+
+    @Override
+    public PreOptimizeResult prepare(InsertStmt insertStmt,
+                                     List<ColumnRefOperator> outputColumns,
+                                     ColumnRefFactory columnRefFactory,
+                                     OptExpression root,
+                                     ColumnRefSet requiredColumns) {
+        List<Column> outputFullSchema = insertStmt.getTargetTable().getBaseSchema();
+        List<Integer> partitionColumnIds = Lists.newArrayList();
+        for (Column column : hiveTable.getPartitionColumns()) {
+            int index = outputFullSchema.indexOf(column);
+            Preconditions.checkState(index >= 0,
+                    "Hive partition column not found in output schema: " + column.getName());
+            partitionColumnIds.add(outputColumns.get(index).getId());
+        }
+        // No plan rewrite for Hive (identity-only partition columns).
+        return new PreOptimizeResult(root, requiredColumns, partitionColumnIds);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/IcebergSinkShuffleSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/IcebergSinkShuffleSpec.java
@@ -1,0 +1,274 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
+import com.starrocks.connector.ConnectorSinkSortScope;
+import com.starrocks.connector.iceberg.IcebergPartitionTransform;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.Type;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.types.Types;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Iceberg {@link ConnectorSinkShuffleSpec}. Handles partition transforms (identity /
+ * bucket / truncate / year / month / day / hour) by injecting a transform projection
+ * column for non-identity cases, and uses the virtual column refs as the hash key.
+ * Also supports host-level sort property derived from the table's native sort order.
+ */
+public class IcebergSinkShuffleSpec implements ConnectorSinkShuffleSpec {
+
+    private final IcebergTable icebergTable;
+
+    public IcebergSinkShuffleSpec(IcebergTable icebergTable) {
+        this.icebergTable = icebergTable;
+    }
+
+    @Override
+    public Table table() {
+        return icebergTable;
+    }
+
+    @Override
+    public ConnectorSinkShuffleMode effectiveShuffleMode(SessionVariable sv) {
+        return sv.getIcebergConnectorSinkShuffleMode();
+    }
+
+    @Override
+    public PreOptimizeResult prepare(InsertStmt insertStmt,
+                                     List<ColumnRefOperator> outputColumns,
+                                     ColumnRefFactory columnRefFactory,
+                                     OptExpression root,
+                                     ColumnRefSet requiredColumns) {
+        Pair<List<Integer>, Map<ColumnRefOperator, ScalarOperator>> result =
+                buildIcebergPartitionShuffleColumns(outputColumns, columnRefFactory);
+        Map<ColumnRefOperator, ScalarOperator> transformProjection = result.second;
+
+        if (transformProjection.isEmpty()) {
+            // All-identity partitions: no plan rewrite needed
+            return new PreOptimizeResult(root, requiredColumns, result.first);
+        }
+
+        // Inject transform projection columns into the logical plan and extend requiredColumns
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        for (ColumnRefOperator col : outputColumns) {
+            projectionMap.put(col, col);
+        }
+        projectionMap.putAll(transformProjection);
+        for (ColumnRefOperator transformCol : transformProjection.keySet()) {
+            requiredColumns.union(transformCol.getId());
+        }
+        OptExpression newRoot = OptExpression.create(new LogicalProjectOperator(projectionMap), root);
+        return new PreOptimizeResult(newRoot, requiredColumns, result.first);
+    }
+
+    @Override
+    public SortProperty computeSortProperty(SessionVariable session, List<ColumnRefOperator> outputColumns) {
+        ConnectorSinkSortScope sortScope = ConnectorSinkSortScope.fromName(session.getConnectorSinkSortScope());
+        if (sortScope != ConnectorSinkSortScope.HOST) {
+            return SortProperty.createProperty(java.util.Collections.emptyList());
+        }
+
+        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+        SortOrder sortOrder = nativeTable.sortOrder();
+        List<com.starrocks.sql.optimizer.base.Ordering> sortOrderings = new ArrayList<>();
+        if (sortOrder != null && sortOrder.isSorted()) {
+            List<Integer> sortKeyIndexes = icebergTable.getSortKeyIndexes();
+            for (int idx = 0; idx < sortKeyIndexes.size(); ++idx) {
+                int sortKeyIndex = sortKeyIndexes.get(idx);
+                SortField sortField = sortOrder.fields().get(idx);
+                // Skip non-identity transforms
+                if (!sortField.transform().isIdentity()) {
+                    continue;
+                }
+                boolean isAsc = sortField.direction() == SortDirection.ASC;
+                boolean isNullFirst = sortField.nullOrder() == NullOrder.NULLS_FIRST;
+                sortOrderings.add(new com.starrocks.sql.optimizer.base.Ordering(
+                        outputColumns.get(sortKeyIndex), isAsc, isNullFirst));
+            }
+        }
+        return SortProperty.createProperty(sortOrderings);
+    }
+
+    /**
+     * Compute partition column IDs, optionally adding transform projection columns.
+     * Mirrors the logic previously in {@code InsertPlanner.buildIcebergPartitionShuffleColumns}.
+     */
+    private Pair<List<Integer>, Map<ColumnRefOperator, ScalarOperator>>
+            buildIcebergPartitionShuffleColumns(List<ColumnRefOperator> outputColumns,
+                                                ColumnRefFactory columnRefFactory) {
+        List<Integer> partitionColumnIDs = new ArrayList<>();
+        Map<ColumnRefOperator, ScalarOperator> transformProjection = new HashMap<>();
+
+        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+        PartitionSpec spec = nativeTable.spec();
+
+        // Unpartitioned / identity-only: fall back to source column indexes
+        if (spec.isUnpartitioned()) {
+            List<Integer> fallbackIDs = icebergTable.partitionColumnIndexes().stream()
+                    .filter(x -> x >= 0 && x < outputColumns.size())
+                    .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
+            return Pair.create(fallbackIDs, transformProjection);
+        }
+        boolean allIdentity = spec.fields().stream().allMatch(f -> f.transform().isIdentity());
+        if (allIdentity) {
+            List<Integer> fallbackIDs = icebergTable.partitionColumnIndexes().stream()
+                    .filter(x -> x >= 0 && x < outputColumns.size())
+                    .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
+            return Pair.create(fallbackIDs, transformProjection);
+        }
+
+        org.apache.iceberg.Schema icebergSchema = nativeTable.schema();
+        List<Column> fullSchema = icebergTable.getFullSchema();
+
+        for (PartitionField field : spec.fields()) {
+            String sourceColumnName = icebergSchema.findColumnName(field.sourceId());
+            boolean isTimestampWithZone =
+                    icebergSchema.findType(field.sourceId()).equals(Types.TimestampType.withZone());
+            int sourceColumnIndex = -1;
+            for (int i = 0; i < fullSchema.size(); i++) {
+                if (fullSchema.get(i).getName().equalsIgnoreCase(sourceColumnName)) {
+                    sourceColumnIndex = i;
+                    break;
+                }
+            }
+            if (sourceColumnIndex < 0 || sourceColumnIndex >= outputColumns.size()) {
+                continue;
+            }
+
+            ColumnRefOperator sourceRef = outputColumns.get(sourceColumnIndex);
+            IcebergPartitionTransform transform =
+                    IcebergPartitionTransform.fromString(field.transform().toString());
+
+            switch (transform) {
+                case IDENTITY:
+                    partitionColumnIDs.add(sourceRef.getId());
+                    break;
+                case YEAR:
+                case MONTH:
+                case DAY:
+                case HOUR: {
+                    String funcName = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX +
+                            (isTimestampWithZone ? "timestamptz_" : "") + transform.name().toLowerCase();
+                    Type[] argTypes = new Type[] {sourceRef.getType()};
+                    com.starrocks.catalog.Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
+                            com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    if (fn == null) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    Type returnType = fn.getReturnType();
+                    CallOperator callOp = new CallOperator(funcName, returnType, Lists.newArrayList(sourceRef), fn);
+                    ColumnRefOperator transformRef = columnRefFactory.create(funcName, returnType, true);
+                    transformProjection.put(transformRef, callOp);
+                    partitionColumnIDs.add(transformRef.getId());
+                    break;
+                }
+                case BUCKET: {
+                    int numBuckets = extractTransformParam(field.transform().toString());
+                    if (numBuckets <= 0) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    String funcName = isTimestampWithZone
+                            ? FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "timestamptz_bucket"
+                            : FunctionSet.ICEBERG_TRANSFORM_BUCKET;
+                    Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
+                    com.starrocks.catalog.Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
+                            com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    if (fn == null) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    Type returnType = fn.getReturnType();
+                    CallOperator callOp = new CallOperator(funcName, returnType,
+                            Lists.newArrayList(sourceRef, ConstantOperator.createInt(numBuckets)), fn);
+                    ColumnRefOperator transformRef = columnRefFactory.create(funcName, returnType, true);
+                    transformProjection.put(transformRef, callOp);
+                    partitionColumnIDs.add(transformRef.getId());
+                    break;
+                }
+                case TRUNCATE: {
+                    int width = extractTransformParam(field.transform().toString());
+                    if (width <= 0) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    String funcName = FunctionSet.ICEBERG_TRANSFORM_TRUNCATE;
+                    Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
+                    com.starrocks.catalog.Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
+                            com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    if (fn == null) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    // Truncate's return type matches the source column type
+                    // (fn.getReturnType() returns wildcard DECIMAL for decimal cols, wrong hash key).
+                    Type returnType = sourceRef.getType();
+                    CallOperator callOp = new CallOperator(funcName, returnType,
+                            Lists.newArrayList(sourceRef, ConstantOperator.createInt(width)), fn);
+                    ColumnRefOperator transformRef = columnRefFactory.create(funcName, returnType, true);
+                    transformProjection.put(transformRef, callOp);
+                    partitionColumnIDs.add(transformRef.getId());
+                    break;
+                }
+                case UNKNOWN:
+                default:
+                    // Skip void/unknown transforms
+                    break;
+            }
+        }
+        return Pair.create(partitionColumnIDs, transformProjection);
+    }
+
+    private static int extractTransformParam(String transform) {
+        int l = transform.indexOf('[');
+        int r = transform.indexOf(']');
+        if (l >= 0 && r > l) {
+            try {
+                return Integer.parseInt(transform.substring(l + 1, r));
+            } catch (NumberFormatException ignore) {
+                // fall through
+            }
+        }
+        return 0;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -103,17 +103,17 @@ public class SessionVariableTest {
 
         // Default mode is AUTO
         Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.AUTO,
-                sessionVariable.getConnectorSinkShuffleMode());
+                sessionVariable.getIcebergConnectorSinkShuffleMode());
 
         // Backward compatibility: enableIcebergSinkGlobalShuffle implies FORCE when mode stays at default AUTO.
         com.starrocks.common.jmockit.Deencapsulation.setField(sessionVariable, "enableIcebergSinkGlobalShuffle", true);
         Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.FORCE,
-                sessionVariable.getConnectorSinkShuffleMode());
+                sessionVariable.getIcebergConnectorSinkShuffleMode());
 
         // Explicitly set mode to NEVER should not be affected by legacy boolean.
         com.starrocks.common.jmockit.Deencapsulation.setField(sessionVariable, "connectorSinkShuffleMode", "never");
         Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.NEVER,
-                sessionVariable.getConnectorSinkShuffleMode());
+                sessionVariable.getIcebergConnectorSinkShuffleMode());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerTest.java
@@ -17,7 +17,6 @@ package com.starrocks.sql;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -34,6 +33,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.InPredicate;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.optimizer.base.ConnectorSinkShuffleSpec;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.StatisticStorage;
 import com.starrocks.system.SystemInfoService;
@@ -88,8 +88,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertTrue(enabled);
     }
 
@@ -108,8 +108,8 @@ public class InsertPlannerTest {
             setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                     queryStatement, selectRelation, 10, 0, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-            boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                    insertStmt, icebergTable, sessionVariable);
+            boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
             assertTrue(enabled);
         } finally {
             setInsertPlannerLoggerLevel(Level.INFO);
@@ -134,8 +134,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 1500, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertTrue(enabled);
     }
 
@@ -157,8 +157,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 5, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertFalse(enabled);
     }
 
@@ -180,8 +180,7 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 100, 100L, 2.0, true, partitionRef, null, false, nodeMgr, clusterInfo);
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         assertEquals(1L, partitionCount);
     }
 
@@ -202,8 +201,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 0, 0, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertFalse(enabled);
     }
 
@@ -224,8 +223,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 1, 0, 1000, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertFalse(enabled);
     }
 
@@ -244,8 +243,8 @@ public class InsertPlannerTest {
             setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                     queryStatement, selectRelation, 1, 0, 1000, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-            boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                    insertStmt, icebergTable, sessionVariable);
+            boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
             assertFalse(enabled);
         } finally {
             setInsertPlannerLoggerLevel(Level.INFO);
@@ -269,8 +268,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 1, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertFalse(enabled);
     }
 
@@ -289,8 +288,8 @@ public class InsertPlannerTest {
             setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                     queryStatement, selectRelation, 10, 0, 1, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-            boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                    insertStmt, icebergTable, sessionVariable);
+            boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
             assertFalse(enabled);
         } finally {
             setInsertPlannerLoggerLevel(Level.INFO);
@@ -369,14 +368,13 @@ public class InsertPlannerTest {
             }
         };
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         // Empty partition list returns 0 (new table with no partitions yet)
         // This correctly disables shuffle since estimatedPartitionCount (0) <= 1
         assertEquals(0L, partitionCount);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertFalse(enabled);
     }
 
@@ -398,8 +396,8 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 5, 5, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertTrue(enabled);
     }
 
@@ -454,8 +452,7 @@ public class InsertPlannerTest {
             }
         };
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         // Empty partition list returns 0 (new table with no partitions yet)
         assertEquals(0L, partitionCount);
     }
@@ -503,8 +500,7 @@ public class InsertPlannerTest {
             }
         };
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         assertEquals(-1L, partitionCount);
     }
 
@@ -613,8 +609,7 @@ public class InsertPlannerTest {
             }
         };
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         assertEquals(50L, partitionCount);
     }
 
@@ -640,8 +635,7 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 100, 200L, 10.0, false, null, predicate, true, nodeMgr, clusterInfo);
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         assertEquals(2L, partitionCount);
     }
 
@@ -673,12 +667,11 @@ public class InsertPlannerTest {
         setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
                 queryStatement, selectRelation, 10, 0, 200, 100L, 2.0, false, null, predicate, true, nodeMgr, clusterInfo);
 
-        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
-                insertStmt, icebergTable);
+        long partitionCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
         assertEquals(-1L, partitionCount);
 
-        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
-                insertStmt, icebergTable, sessionVariable);
+        boolean enabled = ConnectorSinkShuffleSpec.forTable(icebergTable).get()
+                    .shouldEnableAdaptiveGlobalShuffle(insertStmt, sessionVariable);
         assertFalse(enabled);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.plan;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
@@ -1294,6 +1295,130 @@ public class InsertPlanTest extends PlanTestBase {
                 Lists.newArrayList(data, k2), Lists.newArrayList(data), Arrays.asList(0),
                 "select data, id from iceberg_shuffle_src");
         assertHashPartitionedByExpression(actualRes, "__iceberg_transform_truncate");
+    }
+
+    @Test
+    public void testInsertHiveWithGlobalShuffle() throws Exception {
+        Column c1 = new Column("c1", IntegerType.INT);
+        Column p1 = new Column("p1", IntegerType.INT);
+        String actualRes = getHiveInsertExecPlanWithGlobalShuffle(
+                "hive_catalog_shuffle", "hive_table",
+                Lists.newArrayList(c1, p1),
+                Lists.newArrayList("p1"),
+                "select 1, 2 from t0",
+                ConnectorSinkShuffleMode.FORCE);
+        // FORCE mode + partitioned hive ⇒ HASH_PARTITIONED by partition column p1
+        Assertions.assertTrue(actualRes.contains("HASH_PARTITIONED:") && actualRes.contains("p1"),
+                "Expected HASH_PARTITIONED by p1, got:\n" + actualRes);
+        Assertions.assertTrue(actualRes.contains("Hive TABLE SINK"),
+                "Expected Hive TABLE SINK, got:\n" + actualRes);
+    }
+
+    @Test
+    public void testInsertHiveNeverModeNoShuffle() throws Exception {
+        Column c1 = new Column("c1", IntegerType.INT);
+        Column p1 = new Column("p1", IntegerType.INT);
+        String actualRes = getHiveInsertExecPlanWithGlobalShuffle(
+                "hive_catalog_never", "hive_table",
+                Lists.newArrayList(c1, p1),
+                Lists.newArrayList("p1"),
+                "select 1, 2 from t0",
+                ConnectorSinkShuffleMode.NEVER);
+        // NEVER mode ⇒ no global shuffle, single fragment co-located with scan
+        Assertions.assertFalse(actualRes.contains("HASH_PARTITIONED:"),
+                "NEVER mode should not produce HASH_PARTITIONED, got:\n" + actualRes);
+    }
+
+    @Test
+    public void testInsertHiveUnpartitionedNoShuffle() throws Exception {
+        Column c1 = new Column("c1", IntegerType.INT);
+        Column c2 = new Column("c2", IntegerType.INT);
+        String actualRes = getHiveInsertExecPlanWithGlobalShuffle(
+                "hive_catalog_unpart", "hive_table",
+                Lists.newArrayList(c1, c2),
+                Lists.newArrayList(),       // empty partition columns
+                "select 1, 2 from t0",
+                ConnectorSinkShuffleMode.FORCE);
+        // Even with FORCE, no partition columns ⇒ no shuffle (hashing key would be empty)
+        Assertions.assertFalse(actualRes.contains("HASH_PARTITIONED:"),
+                "Unpartitioned hive should not produce HASH_PARTITIONED, got:\n" + actualRes);
+    }
+
+    private String getHiveInsertExecPlanWithGlobalShuffle(String catalogName, String tableName,
+                                                          List<Column> fullSchema,
+                                                          List<String> partitionColumnNames,
+                                                          String selectSql,
+                                                          ConnectorSinkShuffleMode mode) throws Exception {
+        String createHiveCatalogStmt = String.format(
+                "create external catalog %s properties (\"type\"=\"hive\", " +
+                        "\"hive.metastore.uris\"=\"thrift://hms:9083\")", catalogName);
+        starRocksAssert.withCatalog(createHiveCatalogStmt);
+
+        List<String> dataColumnNames = fullSchema.stream()
+                .map(Column::getName)
+                .filter(n -> !partitionColumnNames.contains(n))
+                .collect(java.util.stream.Collectors.toList());
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setId(com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong())
+                .setTableName(tableName)
+                .setCatalogName(catalogName)
+                .setResourceName(com.starrocks.server.CatalogMgr.ResourceMappingCatalog
+                        .toResourceName(catalogName, "hive"))
+                .setHiveDbName("hive_db")
+                .setHiveTableName(tableName)
+                .setPartitionColumnNames(partitionColumnNames)
+                .setDataColumnNames(dataColumnNames)
+                .setFullSchema(fullSchema)
+                .setTableLocation("hdfs://fake_location/" + tableName)
+                .setProperties(new HashMap<>())
+                .setStorageFormat(com.starrocks.connector.hive.HiveStorageFormat.PARQUET)
+                .setCreateTime(System.currentTimeMillis())
+                .build();
+
+        MetadataMgr metadata = starRocksAssert.getCtx().getGlobalStateMgr().getMetadataMgr();
+        long tableId = hiveTable.getId();
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, catalogName, "hive_db");
+                result = new Database(tableId, "hive_db");
+                minTimes = 0;
+
+                metadata.getTable((ConnectContext) any, catalogName, "hive_db", tableName);
+                result = hiveTable;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<SessionVariable>() {
+            @Mock
+            public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
+                return mode;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Database getDatabase(String currentCatalogName, String dbName) {
+                return new Database(tableId, "hive_db");
+            }
+
+            @Mock
+            public com.starrocks.catalog.Table getSessionAwareTable(
+                    ConnectContext context, Database database, TableName currentTableName) {
+                return hiveTable;
+            }
+        };
+
+        boolean enableMaterializedViewRewrite =
+                connectContext.getSessionVariable().isEnableMaterializedViewRewrite();
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
+        try {
+            return getInsertExecPlan(String.format(
+                    "explain insert into %s.hive_db.%s %s", catalogName, tableName, selectSql));
+        } finally {
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(enableMaterializedViewRewrite);
+        }
     }
 
     private String getIcebergInsertExecPlanWithGlobalShuffle(String catalogName, String tableName, long tableId,


### PR DESCRIPTION
## Why I'm doing:
     
Iceberg sink already supports tri-state global shuffle via
`connector_sink_shuffle_mode` (NEVER/AUTO/FORCE). Hive sink has no
equivalent — INSERT always runs co-located with scan, which blocks
cross-node rebalancing of hot partitions and leaves no hook for a
future partition-skew rebalancer.

## What I'm doing:

- Extend `connector_sink_shuffle_mode` to HiveTable.
- Abstract the per-connector decision into `ConnectorSinkShuffleSpec`
  with `IcebergSinkShuffleSpec` and `HiveSinkShuffleSpec` impls. The
  mode + adaptive worker/partition-count check lives as default
  methods; connectors implement only the partition-column-ID
  computation (Iceberg adds transform projection; Hive uses identity
  columns directly).
- `InsertPlanner` is shorter by ~220 lines: removed
  `buildIcebergPartitionShuffleColumns`, `extractTransformParam`,
  `shouldEnableAdaptiveGlobalShuffle`, `shouldPlanIcebergShuffle`; the
  `IcebergTable` and `HiveTable` branches in
  `createPhysicalPropertySet` collapse into one spec dispatch.
- No new session variables; reuses
  `connector_sink_shuffle_mode` +
  `connector_sink_shuffle_partition_threshold` +
  `connector_sink_shuffle_partition_node_ratio`.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
