### PR TITLE
[Enhancement] Backfill v1 metadata when light_weight_tablet_creation is altered to false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1155,6 +1155,16 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             metaChanged = true;
         }
 
+        // The light_weight_tablet_creation snapshot from the lock-free phase decides whether
+        // the loop in buildPartitions sends CreateReplicaTask. If a concurrent ALTER flipped
+        // this property between the snapshot and the commit, the lock-free phase used a stale
+        // value and the new partition would land without v1 metadata under a table that now
+        // claims it has v1 in object storage - which silently undermines the downgrade
+        // backfill in alterLightWeightTabletCreation. Treat this as a meta change and retry.
+        if (olapTable.isLightWeightTabletCreation() != copiedTable.isLightWeightTabletCreation()) {
+            metaChanged = true;
+        }
+
         if (metaChanged) {
             throw new DdlException("Table[" + tableName + "]'s meta has been changed. try again.");
         }
@@ -2018,6 +2028,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
     void buildPartitions(Database db, OlapTable table, List<PhysicalPartition> partitions,
                          ComputeResource computeResource) throws DdlException {
+        buildPartitions(db, table, partitions, computeResource, false);
+    }
+
+    void buildPartitions(Database db, OlapTable table, List<PhysicalPartition> partitions,
+                         ComputeResource computeResource, boolean backfill) throws DdlException {
         if (partitions.isEmpty()) {
             return;
         }
@@ -2033,7 +2048,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 }
             }
         }
-        if (numAliveNodes == 0 && !table.isLightWeightTabletCreation()) {
+        if (numAliveNodes == 0 && (backfill || !table.isLightWeightTabletCreation())) {
             if (RunMode.isSharedDataMode()) {
                 throw new DdlException("no alive compute nodes");
             } else {
@@ -2053,6 +2068,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         option.setEnableTabletCreationOptimization(table.isCloudNativeTableOrMaterializedView()
                 && (Config.lake_enable_tablet_creation_optimization || table.isFileBundling()));
         option.setGtid(GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid());
+        option.setBackfill(backfill);
 
         try {
             GlobalStateMgr.getCurrentState().getConsistencyChecker().addCreatingTableId(table.getId());
@@ -4132,7 +4148,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
-    private void alterLightWeightTabletCreation(OlapTable table,
+    private void alterLightWeightTabletCreation(Database db, OlapTable table,
                                                 Map<String, String> properties,
                                                 List<Runnable> appliers) throws DdlException {
         if (!table.isCloudNativeTable()) {
@@ -4149,7 +4165,34 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                     " must be bool type(false/true)");
         }
         boolean newValue = Boolean.parseBoolean(value);
+        // true -> false: tablets that never published (visibleVersion == 1) have no v1
+        // metadata or schema file in object storage. Re-dispatch CreateReplicaTask for those
+        // tablets so that downgrade to a version without the CN-side fallback can read v1
+        // from object storage.
+        if (table.isLightWeightTabletCreation() && !newValue) {
+            backfillLightWeightTabletMetadata(db, table);
+        }
         appliers.add(() -> table.setLightWeightTabletCreation(newValue));
+    }
+
+    private void backfillLightWeightTabletMetadata(Database db, OlapTable table) throws DdlException {
+        ConnectContext ctx = ConnectContext.get();
+        ComputeResource computeResource = ctx != null ? ctx.getCurrentComputeResource()
+                                                      : WarehouseManager.DEFAULT_RESOURCE;
+        List<PhysicalPartition> partitionsToBackfill = new ArrayList<>();
+        for (Partition partition : table.getPartitions()) {
+            for (PhysicalPartition pp : partition.getSubPartitions()) {
+                if (pp.getVisibleVersion() == PhysicalPartition.PARTITION_INIT_VERSION) {
+                    partitionsToBackfill.add(pp);
+                }
+            }
+        }
+        if (partitionsToBackfill.isEmpty()) {
+            return;
+        }
+        LOG.info("backfilling tablet metadata for table {}.{}: {} physical partitions",
+                db.getFullName(), table.getName(), partitionsToBackfill.size());
+        buildPartitions(db, table, partitionsToBackfill, computeResource, true /* backfill */);
     }
 
     private void alterTableQueryTimeout(OlapTable table,
@@ -4254,7 +4297,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             alterLakeCompactionMaxParallel(table, properties, appliers);
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION)) {
-            alterLightWeightTabletCreation(table, properties, appliers);
+            alterLightWeightTabletCreation(db, table, properties, appliers);
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
             alterTableQueryTimeout(table, properties, appliers);

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -68,6 +68,10 @@ public class TabletTaskExecutor {
     public static class CreateTabletOption {
         private boolean enableTabletCreationOptimization;
         private long gtid;
+        // When true, this is a backfill of v1 metadata + schema file for an existing table
+        // (e.g. light_weight_tablet_creation = true -> false). Bypasses the light-weight
+        // early-return so CreateReplicaTask is actually dispatched.
+        private boolean backfill;
 
         public boolean isEnableTabletCreationOptimization() {
             return enableTabletCreationOptimization;
@@ -84,6 +88,14 @@ public class TabletTaskExecutor {
         public void setGtid(long gtid) {
             this.gtid = gtid;
         }
+
+        public boolean isBackfill() {
+            return backfill;
+        }
+
+        public void setBackfill(boolean backfill) {
+            this.backfill = backfill;
+        }
     }
 
     public static void buildPartitionsSequentially(long dbId, OlapTable table, List<PhysicalPartition> partitions,
@@ -91,7 +103,7 @@ public class TabletTaskExecutor {
                                                    int numBackends,
                                                    ComputeResource computeResource,
                                                    CreateTabletOption option) throws DdlException {
-        if (table.isLightWeightTabletCreation()) {
+        if (table.isLightWeightTabletCreation() && !option.isBackfill()) {
             return;
         }
         // Try to bundle at least 200 CreateReplicaTask's in a single AgentBatchTask.
@@ -125,7 +137,7 @@ public class TabletTaskExecutor {
                                                    int numBackends,
                                                    ComputeResource computeResource,
                                                    CreateTabletOption option) throws DdlException {
-        if (table.isLightWeightTabletCreation()) {
+        if (table.isLightWeightTabletCreation() && !option.isBackfill()) {
             return;
         }
         long start = System.currentTimeMillis();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -67,6 +67,13 @@ import java.util.Objects;
 public class CreateLakeTableTest {
     private static ConnectContext connectContext;
 
+    // Shared by the @Mock static methods below: a static mock method cannot reference a
+    // test-method local, so these live at class scope. Each test resets them at the start.
+    private static java.util.concurrent.atomic.AtomicBoolean backfillSeen =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+    private static java.util.concurrent.atomic.AtomicInteger partitionsBackfilled =
+            new java.util.concurrent.atomic.AtomicInteger(0);
+
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
@@ -894,5 +901,86 @@ public class CreateLakeTableTest {
         // Invalid value rejected by analyzer.
         ExceptionChecker.expectThrowsWithMsg(Exception.class, "must be bool type", () -> alterTable(
                 "alter table lake_test.alter_lw set ('light_weight_tablet_creation' = 'maybe')"));
+    }
+
+    @Test
+    public void testAlterLightWeightTabletCreationTrueToFalseTriggersBackfill() throws Exception {
+        backfillSeen.set(false);
+        partitionsBackfilled.set(0);
+        new MockUp<com.starrocks.task.TabletTaskExecutor>() {
+            @Mock
+            public static void buildPartitionsSequentially(long dbId,
+                                                           com.starrocks.catalog.OlapTable t,
+                                                           List<com.starrocks.catalog.PhysicalPartition> partitions,
+                                                           int numReplicas,
+                                                           int numBackends,
+                                                           com.starrocks.warehouse.cngroup.ComputeResource cr,
+                                                           com.starrocks.task.TabletTaskExecutor.CreateTabletOption option) {
+                if (option.isBackfill()) {
+                    backfillSeen.set(true);
+                    partitionsBackfilled.set(partitions.size());
+                }
+            }
+
+            @Mock
+            public static void buildPartitionsConcurrently(long dbId,
+                                                           com.starrocks.catalog.OlapTable t,
+                                                           List<com.starrocks.catalog.PhysicalPartition> partitions,
+                                                           int numReplicas,
+                                                           int numBackends,
+                                                           com.starrocks.warehouse.cngroup.ComputeResource cr,
+                                                           com.starrocks.task.TabletTaskExecutor.CreateTabletOption option) {
+                if (option.isBackfill()) {
+                    backfillSeen.set(true);
+                    partitionsBackfilled.set(partitions.size());
+                }
+            }
+        };
+
+        createTable("create table lake_test.alter_lw_bf (c0 int) duplicate key(c0)\n" +
+                "distributed by hash(c0) buckets 2\n" +
+                "properties('light_weight_tablet_creation' = 'true')");
+        LakeTable table = getLakeTable("lake_test", "alter_lw_bf");
+        Assertions.assertTrue(table.isLightWeightTabletCreation());
+
+        // true -> false: backfill triggered, all PhysicalPartitions with visibleVersion == 1.
+        alterTable("alter table lake_test.alter_lw_bf set ('light_weight_tablet_creation' = 'false')");
+        Assertions.assertFalse(table.isLightWeightTabletCreation());
+        Assertions.assertTrue(backfillSeen.get(),
+                "buildPartitions[Sequentially|Concurrently] must be called with option.backfill = true");
+        Assertions.assertEquals(1, partitionsBackfilled.get(),
+                "the single unpublished physical partition should be backfilled");
+    }
+
+    @Test
+    public void testAlterLightWeightTabletCreationFalseToTrueSkipsBackfill() throws Exception {
+        backfillSeen.set(false);
+        partitionsBackfilled.set(0);
+        new MockUp<com.starrocks.task.TabletTaskExecutor>() {
+            @Mock
+            public static void buildPartitionsSequentially(long dbId,
+                                                           com.starrocks.catalog.OlapTable t,
+                                                           List<com.starrocks.catalog.PhysicalPartition> partitions,
+                                                           int numReplicas,
+                                                           int numBackends,
+                                                           com.starrocks.warehouse.cngroup.ComputeResource cr,
+                                                           com.starrocks.task.TabletTaskExecutor.CreateTabletOption option) {
+                if (option.isBackfill()) {
+                    backfillSeen.set(true);
+                }
+            }
+        };
+
+        createTable("create table lake_test.alter_lw_no_bf (c0 int) duplicate key(c0)\n" +
+                "distributed by hash(c0) buckets 2\n" +
+                "properties('light_weight_tablet_creation' = 'false')");
+        LakeTable table = getLakeTable("lake_test", "alter_lw_no_bf");
+        Assertions.assertFalse(table.isLightWeightTabletCreation());
+
+        // false -> true: no backfill needed; v1 metadata is already in object storage.
+        alterTable("alter table lake_test.alter_lw_no_bf set ('light_weight_tablet_creation' = 'true')");
+        Assertions.assertTrue(table.isLightWeightTabletCreation());
+        Assertions.assertFalse(backfillSeen.get(),
+                "false -> true must not trigger backfill");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Build on #73422 / #73845. When a table has `light_weight_tablet_creation` flipped from `true` to `false`, every PhysicalPartition that has never been published (visibleVersion == 1) lacks the v1 metadata and schema file in object storage. A downgrade target that does not include the CN-side fallback would fail to read those tablets. Backfill those files at ALTER time so the table behaves identically to a table that was created without the property.

## What I'm doing:

**Mechanics**
* `TabletTaskExecutor.CreateTabletOption` gains a `backfill` flag. The light-weight early-return in `buildPartitionsSequentially` / `buildPartitionsConcurrently` is relaxed so a backfill caller can drive `CreateReplicaTask` dispatch even while the table still reports `isLightWeightTabletCreation() == true`.
* `LocalMetastore.buildPartitions` exposes an overload with the backfill flag. When set, the alive-node precheck always throws on zero alive nodes (backfill needs CNs).
* `LocalMetastore.alterLightWeightTabletCreation` detects the `true -> false` transition, filters PhysicalPartitions to those with `visibleVersion == PARTITION_INIT_VERSION` (already-published partitions have v2+ in object storage and need no v1), and runs the backfill synchronously under the caller's existing table WRITE lock. If backfill throws, the edit log is not written and the property stays `true`. Empty tables short-circuit without dispatch.

**Tests**
* `CreateLakeTableTest.testAlterLightWeightTabletCreationTrueToFalseTriggersBackfill`: a freshly created light-weight table altered to `false` invokes `TabletTaskExecutor` with `option.backfill = true` for its unpublished partition.
* `CreateLakeTableTest.testAlterLightWeightTabletCreationFalseToTrueSkipsBackfill`: `false -> true` must not trigger backfill.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [ ] Policy changes
- [ ] Feature removed
- [ ] Miscellaneous: ALTER on an opt-in property; only takes effect when a user explicitly flips the property from `true` to `false`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4