### PR TITLE
[Refactor] Extract SegmentPKIterator into its own file

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -262,6 +262,7 @@ set(STORAGE_FILES
     lake/spark_load.cpp
     lake/update_manager.cpp
     lake/rowset_update_state.cpp
+    lake/segment_pk_iterator.cpp
     lake/meta_file.cpp
     lake/lake_primary_index.cpp
     lake/versioned_tablet.cpp

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -20,7 +20,6 @@
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/raw_data_visitor.h"
-#include "common/config_primary_key_fwd.h"
 #include "common/stack_util.h"
 #include "common/tracer.h"
 #include "fs/fs_factory.h"
@@ -39,123 +38,6 @@
 #include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
-
-Status SegmentPKIterator::_load() {
-    TRY_CATCH_BAD_ALLOC(_pk_column_chunk = ChunkFactory::new_chunk(_pkey_schema, 4096));
-    auto chunk_container = _pk_column_chunk->clone_empty();
-    if (_iter != nullptr) {
-        while (true) {
-            chunk_container->reset();
-            Status st;
-            // Capture the segment-wide physical rowid base (= iterator's range_start)
-            // from the first non-empty emit only. Subsequent emits use the plain form
-            // since the base is already known and contiguity is structurally guaranteed
-            // by get_each_segment_iterator (no delvec / predicates / sparse ranges).
-            if (!_physical_rowid_base.has_value()) {
-                std::vector<uint32_t> rowid_buffer;
-                {
-                    TRACE_COUNTER_SCOPE_LATENCY_US("segment_get_next_us");
-                    st = _iter->get_next(chunk_container.get(), &rowid_buffer);
-                }
-                if (st.ok() && !rowid_buffer.empty()) {
-                    _physical_rowid_base = rowid_buffer.front();
-                }
-            } else {
-                TRACE_COUNTER_SCOPE_LATENCY_US("segment_get_next_us");
-                st = _iter->get_next(chunk_container.get());
-            }
-            if (st.is_end_of_file()) {
-                break;
-            }
-            if (!st.ok()) {
-                return st;
-            }
-            TRY_CATCH_BAD_ALLOC(_pk_column_chunk->append(*chunk_container));
-            if (_lazy_load && (_pk_column_chunk->memory_usage() >= config::pk_column_lazy_load_threshold_bytes ||
-                               _pk_column_chunk->num_rows() >= config::pk_index_parallel_execution_min_rows)) {
-                break;
-            }
-        }
-    }
-    if (!_lazy_load && _standalone_pk_column == nullptr) {
-        // In some place, like partial update handler, we need to get standalone pk column,
-        // so we can't use lazy load mode.
-        ASSIGN_OR_RETURN(_standalone_pk_column, encoded_pk_column(_pk_column_chunk.get()));
-    }
-    if (_pk_column_chunk->num_rows() == 0) {
-        return Status::OK();
-    }
-    _current_rows += _pk_column_chunk->num_rows();
-    _begin_rowid_offsets.push_back(_current_rows);
-    return Status::OK();
-}
-
-Status SegmentPKIterator::init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool lazy_load,
-                               PrimaryKeyEncodingType encoding_type, bool defer_data_load) {
-    _iter = iter;
-    _pkey_schema = pkey_schema;
-    _lazy_load = lazy_load;
-    _defer_data_load = defer_data_load;
-    _begin_rowid_offsets.push_back(0);
-    RETURN_IF(encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE,
-              Status::InvalidArgument("PK_ENCODING_TYPE_NONE is not a valid encoding type"));
-    _encoding_type = encoding_type;
-    if (!_defer_data_load) {
-        _status = _load();
-        if (_status.ok()) {
-            _memory_usage = _pk_column_chunk->memory_usage() +
-                            (_standalone_pk_column ? _standalone_pk_column->memory_usage() : 0);
-        }
-    }
-    return _status;
-}
-
-bool SegmentPKIterator::done() {
-    // Deferred first load: trigger on first done() call
-    if (_defer_data_load) {
-        _defer_data_load = false;
-        _status = _load();
-        if (_status.ok() && _pk_column_chunk != nullptr) {
-            _memory_usage = _pk_column_chunk->memory_usage() +
-                            (_standalone_pk_column ? _standalone_pk_column->memory_usage() : 0);
-        }
-    }
-    return (_pk_column_chunk == nullptr || _pk_column_chunk->is_empty()) || !_status.ok();
-}
-
-Status SegmentPKIterator::status() {
-    return _status;
-}
-
-void SegmentPKIterator::next() {
-    _status = _load();
-    if (_status.ok()) {
-        _current_pk_column_idx++;
-    }
-}
-
-SegmentPKChunkRef SegmentPKIterator::current() {
-    SegmentPKChunkRef ref;
-    const size_t logical_rowid_offset = _begin_rowid_offsets[_current_pk_column_idx];
-    ref.physical_rowid_offset = _physical_rowid_base.value_or(0) + static_cast<uint32_t>(logical_rowid_offset);
-    ref.chunk = std::move(_pk_column_chunk);
-    return ref;
-}
-
-StatusOr<MutableColumnPtr> SegmentPKIterator::encoded_pk_column(const Chunk* chunk) {
-    TRACE_COUNTER_SCOPE_LATENCY_US("pk_encode_us");
-    MutableColumnPtr pk_column;
-    RETURN_IF(_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE,
-              Status::InvalidArgument("PK_ENCODING_TYPE_NONE is not a valid encoding type"));
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(_pkey_schema, &pk_column, _encoding_type));
-    TRY_CATCH_BAD_ALLOC(
-            PrimaryKeyEncoder::encode(_pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(), _encoding_type));
-    return std::move(pk_column);
-}
-
-void SegmentPKIterator::close() {
-    _iter->close();
-}
 
 RowsetUpdateState::RowsetUpdateState() = default;
 

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -15,12 +15,12 @@
 #pragma once
 
 #include <atomic>
-#include <optional>
 #include <string>
 #include <unordered_map>
 
 #include "gutil/macros.h"
 #include "storage/lake/rowset.h"
+#include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/primitive/primary_key_encoding_types.h"
@@ -29,23 +29,6 @@
 namespace starrocks::lake {
 
 class RssidFileInfoContainer;
-
-// One chunk emitted by SegmentPKIterator::current(), carrying chunk[0]'s
-// position in the SOURCE SEGMENT FILE:
-//
-//   physical_rowid_offset — chunk[0]'s row position in the segment file;
-//   chunk[i]'s physical rowid = physical_rowid_offset + i. For shared
-//   (post-split) segments this skips the iterator's range_start; for
-//   non-shared segments it is 0.
-//
-// Used by PK-index upserts, delete-bitmap writers, and any consumer that reads
-// the full segment via Segment::open + fetch_values_by_rowid. The field is
-// by-value so the ref is async-capture safe — lambdas that outlive iter.next()
-// can rely on it without holding the iterator.
-struct SegmentPKChunkRef {
-    ChunkPtr chunk;
-    uint32_t physical_rowid_offset = 0;
-};
 
 struct PartialUpdateState {
     std::vector<uint64_t> src_rss_rowids;
@@ -101,81 +84,6 @@ struct RowsetUpdateStateParams {
     const Tablet* tablet;
     const RssidFileInfoContainer& container;
 };
-
-class SegmentPKIterator {
-public:
-    SegmentPKIterator() = default;
-    ~SegmentPKIterator() { close(); }
-    // If defer_data_load is true, only save parameters without loading the first chunk.
-    // The first chunk will be loaded lazily on the first done()/next() call.
-    // This avoids memory spikes when many iterators are created upfront.
-    Status init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool lazy_load,
-                PrimaryKeyEncodingType encoding_type, bool defer_data_load = false);
-    void next();
-    bool done();
-    Status status();
-    void close();
-    // Returns the most-recently-loaded chunk plus chunk[0]'s physical position
-    // in the source segment (see SegmentPKChunkRef doc). The returned chunk
-    // is moved out — done() will report empty until the next _load().
-    SegmentPKChunkRef current();
-
-    // The segment-wide physical rowid base: the first physical rowid the
-    // underlying iterator emits (= range_start for shared post-split segments,
-    // 0 otherwise, and 0 if the iterator emitted nothing). Constant — set once
-    // on the first non-empty emit and never changed thereafter, in contrast to
-    // the per-chunk SegmentPKChunkRef::physical_rowid_offset which advances by
-    // chunk. Lets callers translate a row's logical emit offset to its physical
-    // position in the segment file.
-    uint32_t physical_rowid_base() const { return _physical_rowid_base.value_or(0); }
-
-    // Return the memory usage of this encode pk column.
-    // If _lazy_load is true, return 0, because memory allocation is lazy.
-    size_t memory_usage() const { return _memory_usage; }
-
-    // Encode `pk_column_chunk` to the given |pk_column|
-    StatusOr<MutableColumnPtr> encoded_pk_column(const Chunk* chunk);
-
-    const MutableColumnPtr& standalone_pk_column() const { return _standalone_pk_column; }
-
-private:
-    Status _load();
-
-    // Iterator of this segment file.
-    ChunkIteratorPtr _iter;
-    // The PK schema of this segment file.
-    Schema _pkey_schema;
-    // status
-    Status _status = Status::OK();
-    // The current pk column index.
-    size_t _current_pk_column_idx = 0;
-    // The rowid offsets of each piece.
-    // E.g. if we have column vec : 100 rows, 101 rows, 200 rows,
-    // offset will be [0, 100, 201, 401]
-    std::vector<size_t> _begin_rowid_offsets;
-    // Current loaded row count of the segment.
-    size_t _current_rows = 0;
-    // If true, we will load segment peice by piece when needed.
-    bool _lazy_load = false;
-    // If true, first _load() is deferred until done() is first called.
-    bool _defer_data_load = false;
-    // If enable lazy load, `_memory_usage` will record first piece of pk column memory usage.
-    size_t _memory_usage = 0;
-    // For large segment, we need to load segment file piece by piece.
-    ChunkUniquePtr _pk_column_chunk;
-    // For no lazy load, we can load whole pk column and encode at once.
-    MutableColumnPtr _standalone_pk_column;
-    // First physical rowid emitted by the underlying iterator for this segment
-    // (= iterator's range_start). Set once on the first non-empty emit and never
-    // reset across subsequent _load() / next() calls. std::optional disambiguates
-    // "not yet set" from the legitimate value 0 (non-shared segment iterating from
-    // physical row 0).
-    std::optional<uint32_t> _physical_rowid_base;
-    // The encoding type of primary key.
-    PrimaryKeyEncodingType _encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
-};
-
-using SegmentPKIteratorPtr = std::unique_ptr<SegmentPKIterator>;
 
 class RowsetUpdateState {
 public:

--- a/be/src/storage/lake/segment_pk_iterator.cpp
+++ b/be/src/storage/lake/segment_pk_iterator.cpp
@@ -1,0 +1,142 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/segment_pk_iterator.h"
+
+#include "base/debug/trace.h"
+#include "column/chunk_factory.h"
+#include "common/config_primary_key_fwd.h"
+#include "runtime/current_thread.h"
+#include "storage/primary_key_encoder.h"
+
+namespace starrocks::lake {
+
+Status SegmentPKIterator::_load() {
+    TRY_CATCH_BAD_ALLOC(_pk_column_chunk = ChunkFactory::new_chunk(_pkey_schema, 4096));
+    auto chunk_container = _pk_column_chunk->clone_empty();
+    if (_iter != nullptr) {
+        while (true) {
+            chunk_container->reset();
+            Status st;
+            // Capture the segment-wide physical rowid base (= iterator's range_start)
+            // from the first non-empty emit only. Subsequent emits use the plain form
+            // since the base is already known and contiguity is structurally guaranteed
+            // by get_each_segment_iterator (no delvec / predicates / sparse ranges).
+            if (!_physical_rowid_base.has_value()) {
+                std::vector<uint32_t> rowid_buffer;
+                {
+                    TRACE_COUNTER_SCOPE_LATENCY_US("segment_get_next_us");
+                    st = _iter->get_next(chunk_container.get(), &rowid_buffer);
+                }
+                if (st.ok() && !rowid_buffer.empty()) {
+                    _physical_rowid_base = rowid_buffer.front();
+                }
+            } else {
+                TRACE_COUNTER_SCOPE_LATENCY_US("segment_get_next_us");
+                st = _iter->get_next(chunk_container.get());
+            }
+            if (st.is_end_of_file()) {
+                break;
+            }
+            if (!st.ok()) {
+                return st;
+            }
+            TRY_CATCH_BAD_ALLOC(_pk_column_chunk->append(*chunk_container));
+            if (_lazy_load && (_pk_column_chunk->memory_usage() >= config::pk_column_lazy_load_threshold_bytes ||
+                               _pk_column_chunk->num_rows() >= config::pk_index_parallel_execution_min_rows)) {
+                break;
+            }
+        }
+    }
+    if (!_lazy_load && _standalone_pk_column == nullptr) {
+        // In some place, like partial update handler, we need to get standalone pk column,
+        // so we can't use lazy load mode.
+        ASSIGN_OR_RETURN(_standalone_pk_column, encoded_pk_column(_pk_column_chunk.get()));
+    }
+    if (_pk_column_chunk->num_rows() == 0) {
+        return Status::OK();
+    }
+    _current_rows += _pk_column_chunk->num_rows();
+    _begin_rowid_offsets.push_back(_current_rows);
+    return Status::OK();
+}
+
+Status SegmentPKIterator::init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool lazy_load,
+                               PrimaryKeyEncodingType encoding_type, bool defer_data_load) {
+    _iter = iter;
+    _pkey_schema = pkey_schema;
+    _lazy_load = lazy_load;
+    _defer_data_load = defer_data_load;
+    _begin_rowid_offsets.push_back(0);
+    RETURN_IF(encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE,
+              Status::InvalidArgument("PK_ENCODING_TYPE_NONE is not a valid encoding type"));
+    _encoding_type = encoding_type;
+    if (!_defer_data_load) {
+        _status = _load();
+        if (_status.ok()) {
+            _memory_usage = _pk_column_chunk->memory_usage() +
+                            (_standalone_pk_column ? _standalone_pk_column->memory_usage() : 0);
+        }
+    }
+    return _status;
+}
+
+bool SegmentPKIterator::done() {
+    // Deferred first load: trigger on first done() call
+    if (_defer_data_load) {
+        _defer_data_load = false;
+        _status = _load();
+        if (_status.ok() && _pk_column_chunk != nullptr) {
+            _memory_usage = _pk_column_chunk->memory_usage() +
+                            (_standalone_pk_column ? _standalone_pk_column->memory_usage() : 0);
+        }
+    }
+    return (_pk_column_chunk == nullptr || _pk_column_chunk->is_empty()) || !_status.ok();
+}
+
+Status SegmentPKIterator::status() {
+    return _status;
+}
+
+void SegmentPKIterator::next() {
+    _status = _load();
+    if (_status.ok()) {
+        _current_pk_column_idx++;
+    }
+}
+
+SegmentPKChunkRef SegmentPKIterator::current() {
+    SegmentPKChunkRef ref;
+    const size_t logical_rowid_offset = _begin_rowid_offsets[_current_pk_column_idx];
+    ref.physical_rowid_offset = _physical_rowid_base.value_or(0) + static_cast<uint32_t>(logical_rowid_offset);
+    ref.chunk = std::move(_pk_column_chunk);
+    return ref;
+}
+
+StatusOr<MutableColumnPtr> SegmentPKIterator::encoded_pk_column(const Chunk* chunk) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("pk_encode_us");
+    MutableColumnPtr pk_column;
+    RETURN_IF(_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE,
+              Status::InvalidArgument("PK_ENCODING_TYPE_NONE is not a valid encoding type"));
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(_pkey_schema, &pk_column, _encoding_type));
+    TRY_CATCH_BAD_ALLOC(
+            PrimaryKeyEncoder::encode(_pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(), _encoding_type));
+    return std::move(pk_column);
+}
+
+void SegmentPKIterator::close() {
+    _iter->close();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/segment_pk_iterator.h
+++ b/be/src/storage/lake/segment_pk_iterator.h
@@ -1,0 +1,121 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "storage/primitive/chunk_iterator.h"
+#include "storage/primitive/primary_key_encoding_types.h"
+
+namespace starrocks::lake {
+
+// One chunk emitted by SegmentPKIterator::current(), carrying chunk[0]'s
+// position in the SOURCE SEGMENT FILE:
+//
+//   physical_rowid_offset — chunk[0]'s row position in the segment file;
+//   chunk[i]'s physical rowid = physical_rowid_offset + i. For shared
+//   (post-split) segments this skips the iterator's range_start; for
+//   non-shared segments it is 0.
+//
+// Used by PK-index upserts, delete-bitmap writers, and any consumer that reads
+// the full segment via Segment::open + fetch_values_by_rowid. The field is
+// by-value so the ref is async-capture safe — lambdas that outlive iter.next()
+// can rely on it without holding the iterator.
+struct SegmentPKChunkRef {
+    ChunkPtr chunk;
+    uint32_t physical_rowid_offset = 0;
+};
+
+class SegmentPKIterator {
+public:
+    SegmentPKIterator() = default;
+    ~SegmentPKIterator() { close(); }
+    // If defer_data_load is true, only save parameters without loading the first chunk.
+    // The first chunk will be loaded lazily on the first done()/next() call.
+    // This avoids memory spikes when many iterators are created upfront.
+    Status init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool lazy_load,
+                PrimaryKeyEncodingType encoding_type, bool defer_data_load = false);
+    void next();
+    bool done();
+    Status status();
+    void close();
+    // Returns the most-recently-loaded chunk plus chunk[0]'s physical position
+    // in the source segment (see SegmentPKChunkRef doc). The returned chunk
+    // is moved out — done() will report empty until the next _load().
+    SegmentPKChunkRef current();
+
+    // The segment-wide physical rowid base: the first physical rowid the
+    // underlying iterator emits (= range_start for shared post-split segments,
+    // 0 otherwise, and 0 if the iterator emitted nothing). Constant — set once
+    // on the first non-empty emit and never changed thereafter, in contrast to
+    // the per-chunk SegmentPKChunkRef::physical_rowid_offset which advances by
+    // chunk. Lets callers translate a row's logical emit offset to its physical
+    // position in the segment file.
+    uint32_t physical_rowid_base() const { return _physical_rowid_base.value_or(0); }
+
+    // Return the memory usage of this encode pk column.
+    // If _lazy_load is true, return 0, because memory allocation is lazy.
+    size_t memory_usage() const { return _memory_usage; }
+
+    // Encode `pk_column_chunk` to the given |pk_column|
+    StatusOr<MutableColumnPtr> encoded_pk_column(const Chunk* chunk);
+
+    const MutableColumnPtr& standalone_pk_column() const { return _standalone_pk_column; }
+
+private:
+    Status _load();
+
+    // Iterator of this segment file.
+    ChunkIteratorPtr _iter;
+    // The PK schema of this segment file.
+    Schema _pkey_schema;
+    // status
+    Status _status = Status::OK();
+    // The current pk column index.
+    size_t _current_pk_column_idx = 0;
+    // The rowid offsets of each piece.
+    // E.g. if we have column vec : 100 rows, 101 rows, 200 rows,
+    // offset will be [0, 100, 201, 401]
+    std::vector<size_t> _begin_rowid_offsets;
+    // Current loaded row count of the segment.
+    size_t _current_rows = 0;
+    // If true, we will load segment peice by piece when needed.
+    bool _lazy_load = false;
+    // If true, first _load() is deferred until done() is first called.
+    bool _defer_data_load = false;
+    // If enable lazy load, `_memory_usage` will record first piece of pk column memory usage.
+    size_t _memory_usage = 0;
+    // For large segment, we need to load segment file piece by piece.
+    ChunkUniquePtr _pk_column_chunk;
+    // For no lazy load, we can load whole pk column and encode at once.
+    MutableColumnPtr _standalone_pk_column;
+    // First physical rowid emitted by the underlying iterator for this segment
+    // (= iterator's range_start). Set once on the first non-empty emit and never
+    // reset across subsequent _load() / next() calls. std::optional disambiguates
+    // "not yet set" from the legitimate value 0 (non-shared segment iterating from
+    // physical row 0).
+    std::optional<uint32_t> _physical_rowid_base;
+    // The encoding type of primary key.
+    PrimaryKeyEncodingType _encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+};
+
+using SegmentPKIteratorPtr = std::unique_ptr<SegmentPKIterator>;
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

`SegmentPKIterator` (and its `SegmentPKChunkRef` return type) lived inside `rowset_update_state.{h,cpp}` alongside the much larger `RowsetUpdateState`. The iterator is a self-contained, independently testable unit (it already has its own `segment_pk_iterator_test.cpp`), so keeping it in the `RowsetUpdateState` files made both harder to navigate.

## What I'm doing:

Extract `SegmentPKIterator`, the `SegmentPKChunkRef` struct, and the `SegmentPKIteratorPtr` alias out of `rowset_update_state.{h,cpp}` into a dedicated `segment_pk_iterator.{h,cpp}`.

- `rowset_update_state.h` now `#include`s the new header, so every existing consumer keeps working unchanged.
- Removed includes orphaned by the move: `<optional>` from `rowset_update_state.h` and `common/config_primary_key_fwd.h` from `rowset_update_state.cpp`.
- Added `lake/segment_pk_iterator.cpp` to `be/src/storage/CMakeLists.txt`.

Pure code motion — no logic changes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
