### PR TITLE
[BugFix] Fix datetime prepared parameter parsing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -36,7 +36,6 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.DateUtils;
@@ -491,8 +490,6 @@ public class DateLiteral extends LiteralExpr {
                 }
                 if (len > 7) {
                     microsecond = data.getInt();
-                    // choose the highest scale to keep microsecond value
-                    type = ScalarType.createDecimalV2Type(6);
                 }
             } else {
                 copy(MIN_DATETIME);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.analysis;
 
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.PrepareStmtContext;
@@ -31,6 +32,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -129,6 +133,32 @@ public class PreparedStmtTest{
         Assertions.assertEquals(false, stmt.getParameters().get(0).equals(stmt.getParameters().get(1)));
         Assertions.assertEquals(false, stmt.getParameters().get(1).equals(stmt.getParameters().get(2)));
         Assertions.assertEquals(false, stmt.getParameters().get(0).equals(stmt.getParameters().get(2)));
+    }
+
+    @Test
+    public void testParseDatetimeParamWithMicrosecond() throws Exception {
+        LiteralExpr literal = LiteralExpr.parseLiteral(12);
+        literal.parseMysqlParam(mysqlDatetimeParam(2026, 5, 28, 14, 57, 39, 621441));
+
+        Assertions.assertTrue(literal instanceof DateLiteral);
+        assertEquals(Type.DATETIME, literal.getType());
+        assertEquals("2026-05-28 14:57:39.621441", literal.getStringValue());
+        assertEquals(LocalDateTime.of(2026, 5, 28, 14, 57, 39, 621441000), literal.getRealObjectValue());
+    }
+
+    private ByteBuffer mysqlDatetimeParam(int year, int month, int day, int hour, int minute, int second,
+                                          int microsecond) {
+        ByteBuffer buffer = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+        buffer.put((byte) 11);
+        buffer.putChar((char) year);
+        buffer.put((byte) month);
+        buffer.put((byte) day);
+        buffer.put((byte) hour);
+        buffer.put((byte) minute);
+        buffer.put((byte) second);
+        buffer.putInt(microsecond);
+        buffer.flip();
+        return buffer;
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`branch-3.5` can fail when executing a prepared statement through the MySQL binary protocol with a DATETIME parameter that includes microseconds. `DateLiteral.parseMysqlParam()` reads the microsecond field and then incorrectly changes the literal type to `DECIMAL(6,0)`, which later fails in planning with `Invalid date type: DECIMAL(6,0)`.

`main` and `branch-4.1` already parse prepared statement parameters through `MysqlParamParser` and do not have this invalid type mutation. This PR applies the minimal fix for `branch-3.5`.

Fixes #issue

## What I'm doing:

Remove the invalid conversion from DATETIME to DECIMAL when parsing MySQL binary DATETIME parameters with microseconds.

Add a regression test that constructs a MySQL binary DATETIME parameter for `2026-05-28 14:57:39.621441` and verifies it remains a DATETIME literal with the correct value.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

## Testing:

```
git diff --check

docker exec -w /home/disk2/owen/code/starrocks-fix-35-datetime-param-20260602 \
  owen-dev-main ./run-fe-ut.sh --test com.starrocks.analysis.PreparedStmtTest
```

Result:

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

