### PR TITLE
[Draft][Refactor] Confine WITH_TENANN guards to the vector-index subsystem

### DIFF
--- a/be/src/storage/index/vector/empty_index_reader.h
+++ b/be/src/storage/index/vector/empty_index_reader.h
@@ -28,13 +28,13 @@ public:
         return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 
-    Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
-                  tenann::IdFilter* id_filter = nullptr) override {
+    Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
+                  uint8_t* result_distances, const SparseRange<>& scan_range) override {
         return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 
-    Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,
-                        std::vector<float>* result_distances, tenann::IdFilter* id_filter, float range,
+    Status range_search(const float* query_vector, size_t query_size, int k, std::vector<int64_t>* result_ids,
+                        std::vector<float>* result_distances, const SparseRange<>& scan_range, float range,
                         int order) override {
         return Status::NotSupported("EmptyIndexReader does not support this operation");
     }

--- a/be/src/storage/index/vector/empty_index_reader.h
+++ b/be/src/storage/index/vector/empty_index_reader.h
@@ -28,8 +28,8 @@ public:
         return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 
-    Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
-                  uint8_t* result_distances, const SparseRange<>& scan_range) override {
+    Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids, uint8_t* result_distances,
+                  const SparseRange<>& scan_range) override {
         return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -69,7 +69,7 @@ Status TenAnnIndexBuilderProxy::init() {
         // Use tenann file writer for remote FS (S3/HDFS) in shared-data mode
         if (_file_writer != nullptr) {
             _index_builder->index_writer()->SetFileWriter(
-                    std::shared_ptr<tenann::IndexFileWriter>(_file_writer, [](tenann::IndexFileWriter*) {}));
+                    std::shared_ptr<tenann::IndexFileWriter>(_file_writer.get(), [](tenann::IndexFileWriter*) {}));
         }
         if (_is_element_nullable) {
             _index_builder->EnableCustomRowId();

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.h
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.h
@@ -30,18 +30,12 @@ namespace starrocks {
 class TenAnnIndexBuilderProxy final : public VectorIndexBuilder {
 public:
     TenAnnIndexBuilderProxy(std::shared_ptr<TabletIndex> tablet_index, std::string segment_index_path,
-                            bool is_element_nullable, int omp_threads)
+                            bool is_element_nullable, int omp_threads,
+                            std::unique_ptr<VectorIndexFileWriter> file_writer)
             : VectorIndexBuilder(std::move(tablet_index), std::move(segment_index_path)),
               _is_element_nullable(is_element_nullable),
               _omp_threads(omp_threads),
-              _file_writer(nullptr) {}
-
-    TenAnnIndexBuilderProxy(std::shared_ptr<TabletIndex> tablet_index, std::string segment_index_path,
-                            bool is_element_nullable, int omp_threads, VectorIndexFileWriter* file_writer)
-            : VectorIndexBuilder(std::move(tablet_index), std::move(segment_index_path)),
-              _is_element_nullable(is_element_nullable),
-              _omp_threads(omp_threads),
-              _file_writer(file_writer) {}
+              _file_writer(std::move(file_writer)) {}
 
     // proxy should not clean index builder resource
     ~TenAnnIndexBuilderProxy() override { (void)close(); };
@@ -60,7 +54,7 @@ private:
 
     const bool _is_element_nullable;
     const int _omp_threads;
-    VectorIndexFileWriter* _file_writer = nullptr;
+    std::unique_ptr<VectorIndexFileWriter> _file_writer;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -44,6 +44,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
+#include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_file_reader.h"
 #include "tenann/common/error.h"
@@ -149,22 +150,30 @@ Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::str
     return init_searcher(adapted_meta, index_path, fs);
 }
 
-Status TenANNReader::search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids,
-                            uint8_t* result_distances, tenann::IdFilter* id_filter) {
+Status TenANNReader::search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
+                            uint8_t* result_distances, const SparseRange<>& scan_range) {
+    DelIdFilter del_id_filter(scan_range);
+    auto query_view = tenann::PrimitiveSeqView{.data = reinterpret_cast<uint8_t*>(const_cast<float*>(query_vector)),
+                                               .size = static_cast<uint32_t>(query_size),
+                                               .elem_type = tenann::PrimitiveType::kFloatType};
     try {
-        _searcher->AnnSearch(query_vector, k, result_ids, result_distances, id_filter);
+        _searcher->AnnSearch(query_view, k, result_ids, result_distances, &del_id_filter);
     } catch (tenann::Error& e) {
         return Status::InternalError(e.what());
     }
     return Status::OK();
 };
 
-Status TenANNReader::range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,
-                                  std::vector<float>* result_distances, tenann::IdFilter* id_filter, float range,
-                                  int order) {
+Status TenANNReader::range_search(const float* query_vector, size_t query_size, int k,
+                                  std::vector<int64_t>* result_ids, std::vector<float>* result_distances,
+                                  const SparseRange<>& scan_range, float range, int order) {
+    DelIdFilter del_id_filter(scan_range);
+    auto query_view = tenann::PrimitiveSeqView{.data = reinterpret_cast<uint8_t*>(const_cast<float*>(query_vector)),
+                                               .size = static_cast<uint32_t>(query_size),
+                                               .elem_type = tenann::PrimitiveType::kFloatType};
     try {
-        _searcher->RangeSearch(query_vector, range, k, tenann::AnnSearcher::ResultOrder(order), result_ids,
-                               result_distances, id_filter);
+        _searcher->RangeSearch(query_view, range, k, tenann::AnnSearcher::ResultOrder(order), result_ids,
+                               result_distances, &del_id_filter);
     } catch (tenann::Error& e) {
         return Status::InternalError(e.what());
     }

--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -164,9 +164,9 @@ Status TenANNReader::search(const float* query_vector, size_t query_size, int k,
     return Status::OK();
 };
 
-Status TenANNReader::range_search(const float* query_vector, size_t query_size, int k,
-                                  std::vector<int64_t>* result_ids, std::vector<float>* result_distances,
-                                  const SparseRange<>& scan_range, float range, int order) {
+Status TenANNReader::range_search(const float* query_vector, size_t query_size, int k, std::vector<int64_t>* result_ids,
+                                  std::vector<float>* result_distances, const SparseRange<>& scan_range, float range,
+                                  int order) {
     DelIdFilter del_id_filter(scan_range);
     auto query_view = tenann::PrimitiveSeqView{.data = reinterpret_cast<uint8_t*>(const_cast<float*>(query_vector)),
                                                .size = static_cast<uint32_t>(query_size),

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -42,8 +42,8 @@ public:
     Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
                          size_t segment_num_rows, int query_k, bool user_set_ef) override;
 
-    Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
-                  uint8_t* result_distances, const SparseRange<>& scan_range) override;
+    Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids, uint8_t* result_distances,
+                  const SparseRange<>& scan_range) override;
     Status range_search(const float* query_vector, size_t query_size, int k, std::vector<int64_t>* result_ids,
                         std::vector<float>* result_distances, const SparseRange<>& scan_range, float range,
                         int order) override;

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -42,10 +42,10 @@ public:
     Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
                          size_t segment_num_rows, int query_k, bool user_set_ef) override;
 
-    Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
-                  tenann::IdFilter* id_filter = nullptr) override;
-    Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,
-                        std::vector<float>* result_distances, tenann::IdFilter* id_filter, float range,
+    Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
+                  uint8_t* result_distances, const SparseRange<>& scan_range) override;
+    Status range_search(const float* query_vector, size_t query_size, int k, std::vector<int64_t>* result_ids,
+                        std::vector<float>* result_distances, const SparseRange<>& scan_range, float range,
                         int order) override;
 
 private:

--- a/be/src/storage/index/vector/vector_index_builder_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_builder_factory.cpp
@@ -22,13 +22,19 @@ namespace starrocks {
 // =============== IndexBuilderFactory =============
 StatusOr<std::unique_ptr<VectorIndexBuilder>> VectorIndexBuilderFactory::create_index_builder(
         const std::shared_ptr<TabletIndex>& tablet_index, const std::string& segment_index_path,
-        const IndexBuilderType index_builder_type, const bool is_element_nullable, [[maybe_unused]] int omp_threads,
-        [[maybe_unused]] VectorIndexFileWriter* file_writer) {
+        const IndexBuilderType index_builder_type, const bool is_element_nullable, [[maybe_unused]] int omp_threads) {
     switch (index_builder_type) {
     case TEN_ANN:
 #ifdef WITH_TENANN
+    {
+        // Bridge tenann's file IO through StarRocks FS so remote schemes (staros://, s3://,
+        // hdfs://) work in shared-data mode. The builder owns the writer for its full lifetime,
+        // so the proxy's Close() (which finalizes remote uploads) runs before the writer dies.
+        ASSIGN_OR_RETURN(auto wfile, fs::new_writable_file(segment_index_path));
+        auto file_writer = std::make_unique<VectorIndexFileWriter>(std::move(wfile));
         return std::make_unique<TenAnnIndexBuilderProxy>(tablet_index, segment_index_path, is_element_nullable,
-                                                         omp_threads, file_writer);
+                                                         omp_threads, std::move(file_writer));
+    }
 #else
         return std::make_unique<EmptyVectorIndexBuilder>(tablet_index, segment_index_path);
 #endif

--- a/be/src/storage/index/vector/vector_index_builder_factory.h
+++ b/be/src/storage/index/vector/vector_index_builder_factory.h
@@ -23,20 +23,16 @@
 
 namespace starrocks {
 
-class VectorIndexFileWriter;
-
 class VectorIndexBuilderFactory {
 public:
     // omp_threads: number of OpenMP threads passed down to the TenANN builder.
     //   Caller owns the policy (e.g. a CPU-budget split for lake builds, or the raw config value
     //   for local writes); the builder itself does not reach into ExecEnv or config.
-    // file_writer: optional, for remote FS (S3/HDFS) in shared-data mode. In non-TenANN
-    //   builds VectorIndexFileWriter is a stub class (vector_index_file_writer.h) and the
-    //   argument is ignored, so the strongly-typed pointer compiles in both configurations.
+    // The builder bridges its file IO through StarRocks FS internally so remote schemes
+    // (staros://, s3://, hdfs://) work in shared-data mode; callers pass only the path.
     static StatusOr<std::unique_ptr<VectorIndexBuilder>> create_index_builder(
             const std::shared_ptr<TabletIndex>& tablet_index, const std::string& segment_index_path,
-            const IndexBuilderType index_builder_type, const bool is_element_nullable, int omp_threads,
-            [[maybe_unused]] VectorIndexFileWriter* file_writer = nullptr);
+            const IndexBuilderType index_builder_type, const bool is_element_nullable, int omp_threads);
 
     static StatusOr<IndexBuilderType> get_index_builder_type_from_config(
             const std::shared_ptr<TabletIndex>& _tablet_index) {

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -71,9 +71,9 @@ public:
     // caller-owned and must be sized to at least k.
     virtual Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
                           uint8_t* result_distances, const SparseRange<>& scan_range) = 0;
-    virtual Status range_search(const float* query_vector, size_t query_size, int k,
-                                std::vector<int64_t>* result_ids, std::vector<float>* result_distances,
-                                const SparseRange<>& scan_range, float range, int order) = 0;
+    virtual Status range_search(const float* query_vector, size_t query_size, int k, std::vector<int64_t>* result_ids,
+                                std::vector<float>* result_distances, const SparseRange<>& scan_range, float range,
+                                int order) = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -34,10 +34,13 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "common/status.h"
+#include "storage/primitive/range.h"
 #ifdef WITH_TENANN
-#include "tenann/common/seq_view.h"
-#include "tenann/searcher/id_filter.h"
 #include "tenann/store/index_meta.h"
 #endif
 
@@ -60,13 +63,17 @@ public:
                                  size_t segment_num_rows, int query_k, bool user_set_ef) {
         return init_searcher(meta, index_path, fs);
     }
-
-    virtual Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
-                          tenann::IdFilter* id_filter = nullptr) = 0;
-    virtual Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,
-                                std::vector<float>* result_distances, tenann::IdFilter* id_filter, float range,
-                                int order) = 0;
 #endif
+
+    // Search the index for the k nearest neighbors of a float query vector. query_size is the
+    // number of float elements (the vector dimension). scan_range carries the still-live row
+    // ids; the implementation builds the per-query id filter from it. Result buffers are
+    // caller-owned and must be sized to at least k.
+    virtual Status search(const float* query_vector, size_t query_size, int k, int64_t* result_ids,
+                          uint8_t* result_distances, const SparseRange<>& scan_range) = 0;
+    virtual Status range_search(const float* query_vector, size_t query_size, int k,
+                                std::vector<int64_t>* result_ids, std::vector<float>* result_distances,
+                                const SparseRange<>& scan_range, float range, int order) = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_reader_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_reader_factory.cpp
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef WITH_TENANN
 #include "storage/index/vector/vector_index_reader_factory.h"
+
+#ifdef WITH_TENANN
+#include <boost/algorithm/string/predicate.hpp>
 
 #include "fs/fs.h"
 #include "storage/index/vector/empty_index_reader.h"
+#include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/tenann_index_reader.h"
 #include "storage/index/vector/vector_index_reader.h"
 #include "tenann/index/index_cache.h"
+#endif
 
 namespace starrocks {
+
+#ifdef WITH_TENANN
 
 static Status create_from_file_impl(const std::string& index_path,
                                     const std::shared_ptr<tenann::IndexMeta>& /*index_meta*/,
@@ -84,5 +90,38 @@ Status VectorIndexReaderFactory::create_from_file(const std::string& index_path,
     return create_from_file_impl(index_path, index_meta, vector_index_reader, fs);
 }
 
-} // namespace starrocks
+Status VectorIndexReaderFactory::create_and_init(const std::string& index_path,
+                                                 const std::shared_ptr<TabletIndex>& tablet_index,
+                                                 const std::map<std::string, std::string>& query_params, FileSystem* fs,
+                                                 size_t segment_num_rows, int query_k,
+                                                 std::shared_ptr<VectorIndexReader>* reader) {
+    ASSIGN_OR_RETURN(auto meta, get_vector_meta(tablet_index, query_params));
+    auto index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
+    RETURN_IF_ERROR(create_from_file(index_path, index_meta, reader, fs));
+    // Enable per-segment adaptive ef_search. query_params carries a user-explicit efSearch iff the
+    // user set one via query hint / session var; that disables adaptive scaling so user intent is
+    // honored. FE preserves the user-typed key casing (e.g. "efsearch", "EFSEARCH"), so the check
+    // must be case-insensitive.
+    bool user_set_ef = false;
+    for (const auto& entry : query_params) {
+        if (boost::iequals(entry.first, starrocks::index::vector::EF_SEARCH)) {
+            user_set_ef = true;
+            break;
+        }
+    }
+    return (*reader)->init_searcher(*index_meta, index_path, fs, segment_num_rows, query_k, user_set_ef);
+}
+
+#else // !WITH_TENANN
+
+Status VectorIndexReaderFactory::create_and_init(const std::string& /*index_path*/,
+                                                 const std::shared_ptr<TabletIndex>& /*tablet_index*/,
+                                                 const std::map<std::string, std::string>& /*query_params*/,
+                                                 FileSystem* /*fs*/, size_t /*segment_num_rows*/, int /*query_k*/,
+                                                 std::shared_ptr<VectorIndexReader>* /*reader*/) {
+    return Status::NotSupported("vector index requires the TENANN build");
+}
+
 #endif
+
+} // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_reader_factory.h
+++ b/be/src/storage/index/vector/vector_index_reader_factory.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
+#include <string>
+
 #include "fmt/format.h"
 #include "fs/fs_util.h"
 #include "storage/index/index_descriptor.h"
@@ -22,10 +26,20 @@
 namespace starrocks {
 
 class FileSystem;
+class TabletIndex;
 
 class VectorIndexReaderFactory {
-#ifdef WITH_TENANN
 public:
+    // Build a ready-to-search reader for the .vi file at index_path: derives the TenANN index meta
+    // from tablet_index + query_params, opens the reader, and initializes the searcher (including
+    // per-segment adaptive ef_search). Returns NotFound when the .vi file is absent and NotSupported
+    // when the index is an empty marker or the build has no TenANN; callers treat both as "fall back
+    // to brute force". Keeps callers free of any TenANN type.
+    static Status create_and_init(const std::string& index_path, const std::shared_ptr<TabletIndex>& tablet_index,
+                                  const std::map<std::string, std::string>& query_params, FileSystem* fs,
+                                  size_t segment_num_rows, int query_k, std::shared_ptr<VectorIndexReader>* reader);
+
+#ifdef WITH_TENANN
     static Status create_from_file(const std::string& index_path, const std::shared_ptr<tenann::IndexMeta>& index_meta,
                                    std::shared_ptr<VectorIndexReader>* vector_index_reader);
 

--- a/be/src/storage/index/vector/vector_index_writer.cpp
+++ b/be/src/storage/index/vector/vector_index_writer.cpp
@@ -23,7 +23,6 @@
 #include "fs/fs_util.h"
 #include "gutil/strings/substitute.h"
 #include "storage/index/index_descriptor.h"
-#include "storage/index/vector/vector_index_file_writer.h"
 
 namespace starrocks {
 
@@ -150,21 +149,11 @@ Status VectorIndexWriter::_prepare_index_builder() {
     ASSIGN_OR_RETURN(auto index_builder_type,
                      VectorIndexBuilderFactory::get_index_builder_type_from_config(_tablet_index));
     const int omp_threads = std::max(1, static_cast<int>(config::config_vector_index_build_concurrency));
-#ifdef WITH_TENANN
-    // Create VectorIndexFileWriter to support remote FS (S3/HDFS) in shared-data mode.
-    // TenANN doesn't understand staros:// scheme, so we create a WritableFile through
-    // StarRocks FS and bridge it to tenann via VectorIndexFileWriter.
-    ASSIGN_OR_RETURN(auto wfile, fs::new_writable_file(_vector_index_file_path));
-    auto file_writer = std::make_unique<VectorIndexFileWriter>(std::move(wfile));
-    ASSIGN_OR_RETURN(_index_builder, VectorIndexBuilderFactory::create_index_builder(
-                                             _tablet_index, _vector_index_file_path, index_builder_type,
-                                             _is_element_nullable, omp_threads, file_writer.get()));
-    _file_writer_holder = std::move(file_writer);
-#else
+    // The builder bridges its file IO through StarRocks FS internally (remote schemes in
+    // shared-data mode), so no VectorIndexFileWriter is constructed here.
     ASSIGN_OR_RETURN(_index_builder, VectorIndexBuilderFactory::create_index_builder(
                                              _tablet_index, _vector_index_file_path, index_builder_type,
                                              _is_element_nullable, omp_threads));
-#endif
     RETURN_IF_ERROR(_index_builder->init());
 
     if (_buffer_column != nullptr) {

--- a/be/src/storage/index/vector/vector_index_writer.h
+++ b/be/src/storage/index/vector/vector_index_writer.h
@@ -29,7 +29,6 @@
 namespace starrocks {
 
 class ArrayColumn;
-class VectorIndexFileWriter;
 
 // Validate an array column against the vector index parameters. Every caller
 // that feeds data into a vector index builder must call this first so the
@@ -65,11 +64,6 @@ public:
 private:
     std::shared_ptr<TabletIndex> _tablet_index;
     std::string _vector_index_file_path;
-    // Declared before _index_builder: TenAnnIndexBuilderProxy stores a raw pointer to this
-    // VectorIndexFileWriter. Members are destroyed in reverse declaration order, so the
-    // proxy's destructor (which calls close() -> _file_writer->Close()) must run BEFORE
-    // _file_writer_holder is freed, otherwise we get a use-after-free on teardown.
-    std::unique_ptr<VectorIndexFileWriter> _file_writer_holder;
     std::unique_ptr<VectorIndexBuilder> _index_builder;
 
     uint32_t _start_vector_index_build_threshold;

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -27,7 +27,6 @@
 #include "storage/chunk_helper.h"
 #include "storage/index/vector/vector_index_builder.h"
 #include "storage/index/vector/vector_index_builder_factory.h"
-#include "storage/index/vector/vector_index_file_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/olap_common.h"
@@ -298,16 +297,8 @@ Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const FileInfo& se
         ASSIGN_OR_RETURN(auto builder_type,
                          VectorIndexBuilderFactory::get_index_builder_type_from_config(tablet_index));
 
-#ifdef WITH_TENANN
-        ASSIGN_OR_RETURN(auto wfile, fs::new_writable_file(vi_path));
-        auto file_writer = std::make_unique<VectorIndexFileWriter>(std::move(wfile));
-        ASSIGN_OR_RETURN(auto builder,
-                         VectorIndexBuilderFactory::create_index_builder(tablet_index, vi_path, builder_type, true,
-                                                                         _omp_threads, file_writer.get()));
-#else
         ASSIGN_OR_RETURN(auto builder, VectorIndexBuilderFactory::create_index_builder(
                                                tablet_index, vi_path, builder_type, true, _omp_threads));
-#endif
         RETURN_IF_ERROR(builder->init());
 
         // Read column data in batches and add to builder

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -15,7 +15,6 @@
 #include "segment_iterator.h"
 
 #include <algorithm>
-#include <boost/algorithm/string/predicate.hpp>
 #include <cmath>
 #include <limits>
 #include <memory>
@@ -53,7 +52,6 @@
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
 #include "storage/index/index_descriptor.h"
-#include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_reader.h"
 #include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/lake/filenames.h"
@@ -304,10 +302,6 @@ private:
         ColumnId vector_data_column_id = 0;
         int32_t vector_data_column_uid = -1;
         bool added_vector_data_column = false; // true if we appended vector column to _schema
-
-#ifdef WITH_TENANN
-        std::shared_ptr<tenann::IndexMeta> index_meta;
-#endif
 
         std::shared_ptr<VectorIndexReader> ann_reader;
 
@@ -957,44 +951,21 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
                                                       const std::shared_ptr<TabletIndex>& tablet_index_meta,
                                                       const std::map<std::string, std::string>& query_params,
                                                       FileSystem* fs) {
-#ifdef WITH_TENANN
     if (!_vector_index_ctx) {
         return Status::OK();
     }
-    ASSIGN_OR_RETURN(auto meta, get_vector_meta(tablet_index_meta, query_params))
-    _vector_index_ctx->index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
-    auto create_st = VectorIndexReaderFactory::create_from_file(index_path, _vector_index_ctx->index_meta,
-                                                                &_vector_index_ctx->ann_reader, fs);
-    // .vi file not found — caller will set up brute-force fallback
-    if (create_st.is_not_found()) {
+    // The factory derives the TenANN index meta, opens the reader, and initializes the searcher
+    // (including per-segment adaptive ef_search) internally, so this stays tenann-free. NotFound
+    // (missing .vi file), NotSupported (empty-marker reader, or a build without TenANN) both mean
+    // "no ANN index here" — fall back to brute force.
+    auto st = VectorIndexReaderFactory::create_and_init(index_path, tablet_index_meta, query_params, fs,
+                                                        static_cast<size_t>(_segment->num_rows()),
+                                                        _vector_index_ctx->k, &_vector_index_ctx->ann_reader);
+    if (st.is_not_found() || st.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;
         return Status::OK();
     }
-    RETURN_IF_ERROR(create_st);
-    // Enable per-segment adaptive ef_search. query_params carries a user-explicit
-    // efSearch iff the user set one via query hint / session var; that disables
-    // adaptive scaling so user intent is honored. FE preserves the user-typed key
-    // casing for ann_params (e.g. "efsearch", "Efsearch", "EFSEARCH" are all
-    // valid), so the check must be case-insensitive.
-    bool user_set_ef = false;
-    for (const auto& entry : query_params) {
-        if (boost::iequals(entry.first, starrocks::index::vector::EF_SEARCH)) {
-            user_set_ef = true;
-            break;
-        }
-    }
-    Status status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs,
-                                                                 static_cast<size_t>(_segment->num_rows()),
-                                                                 _vector_index_ctx->k, user_set_ef);
-    // empty ann reader — caller will set up brute-force fallback
-    if (status.is_not_supported()) {
-        _vector_index_ctx->use_vector_index = false;
-        return Status::OK();
-    }
-    return status;
-#else
-    return Status::OK();
-#endif
+    return st;
 }
 
 // Sets up brute-force fallback state and ensures the vector data column is in _schema.
@@ -1106,7 +1077,6 @@ Status SegmentIterator::_init_ann_reader() {
         return Status::OK();
     }
 
-#ifdef WITH_TENANN
     {
         std::string index_path;
         if (_opts.belonged_to_cloud_native) {
@@ -1120,10 +1090,6 @@ Status SegmentIterator::_init_ann_reader() {
         FileSystem* vi_fs = _opts.belonged_to_cloud_native ? _segment->file_system() : nullptr;
         RETURN_IF_ERROR(_init_reader_from_file(index_path, tablet_index_meta, _vector_index_ctx->query_params, vi_fs));
     }
-#else
-    // Without TenANN, ANN index is not available — force brute-force
-    _vector_index_ctx->use_vector_index = false;
-#endif
 
     if (!_vector_index_ctx->use_vector_index && !_vector_index_ctx->use_ivfpq) {
         // .vi file not found, empty reader, or no TenANN support.

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -53,7 +53,6 @@
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
 #include "storage/index/index_descriptor.h"
-#include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_reader.h"
 #include "storage/index/vector/vector_index_reader_factory.h"
@@ -307,7 +306,6 @@ private:
         bool added_vector_data_column = false; // true if we appended vector column to _schema
 
 #ifdef WITH_TENANN
-        tenann::PrimitiveSeqView query_view;
         std::shared_ptr<tenann::IndexMeta> index_meta;
 #endif
 
@@ -821,12 +819,6 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema
         } else {
             _vector_index_ctx->k = _opts.vector_search_option->k * _opts.vector_search_option->k_factor;
         }
-#ifdef WITH_TENANN
-        _vector_index_ctx->query_view = tenann::PrimitiveSeqView{
-                .data = reinterpret_cast<uint8_t*>(_opts.vector_search_option->query_vector.data()),
-                .size = static_cast<uint32_t>(_opts.vector_search_option->query_vector.size()),
-                .elem_type = tenann::PrimitiveType::kFloatType};
-#endif
     }
     // For small segment file (the number of rows is less than chunk_size),
     // the segment iterator will reserve a large amount of memory,
@@ -1144,7 +1136,6 @@ Status SegmentIterator::_init_ann_reader() {
 }
 
 Status SegmentIterator::_get_row_ranges_by_vector_index() {
-#ifdef WITH_TENANN
     if (!_vector_index_ctx || !_vector_index_ctx->use_vector_index) {
         return Status::OK();
     }
@@ -1157,20 +1148,21 @@ Status SegmentIterator::_get_row_ranges_by_vector_index() {
     std::vector<int64_t> result_ids;
     std::vector<float> result_distances;
     std::vector<int64_t> filtered_result_ids;
-    DelIdFilter del_id_filter(_scan_range);
+    const auto& query_vector = _opts.vector_search_option->query_vector;
 
     {
         SCOPED_RAW_TIMER(&_opts.stats->vector_search_timer);
         if (_vector_index_ctx->vector_range >= 0) {
             st = _vector_index_ctx->ann_reader->range_search(
-                    _vector_index_ctx->query_view, _vector_index_ctx->k, &result_ids, &result_distances, &del_id_filter,
-                    static_cast<float>(_vector_index_ctx->vector_range), _vector_index_ctx->result_order);
+                    query_vector.data(), query_vector.size(), _vector_index_ctx->k, &result_ids, &result_distances,
+                    _scan_range, static_cast<float>(_vector_index_ctx->vector_range), _vector_index_ctx->result_order);
         } else {
             result_ids.resize(_vector_index_ctx->k);
             result_distances.resize(_vector_index_ctx->k);
-            st = _vector_index_ctx->ann_reader->search(
-                    _vector_index_ctx->query_view, _vector_index_ctx->k, (result_ids.data()),
-                    reinterpret_cast<uint8_t*>(result_distances.data()), &del_id_filter);
+            st = _vector_index_ctx->ann_reader->search(query_vector.data(), query_vector.size(), _vector_index_ctx->k,
+                                                       result_ids.data(),
+                                                       reinterpret_cast<uint8_t*>(result_distances.data()),
+                                                       _scan_range);
         }
     }
 
@@ -1206,9 +1198,6 @@ Status SegmentIterator::_get_row_ranges_by_vector_index() {
                 id2distance_map[filtered_result_ids[i]];
     }
     return Status::OK();
-#else
-    return Status::OK();
-#endif
 }
 
 Status SegmentIterator::_get_row_ranges_by_row_ids(std::vector<int64_t>* result_ids, SparseRange<>* r) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -959,8 +959,8 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
     // (missing .vi file), NotSupported (empty-marker reader, or a build without TenANN) both mean
     // "no ANN index here" — fall back to brute force.
     auto st = VectorIndexReaderFactory::create_and_init(index_path, tablet_index_meta, query_params, fs,
-                                                        static_cast<size_t>(_segment->num_rows()),
-                                                        _vector_index_ctx->k, &_vector_index_ctx->ann_reader);
+                                                        static_cast<size_t>(_segment->num_rows()), _vector_index_ctx->k,
+                                                        &_vector_index_ctx->ann_reader);
     if (st.is_not_found() || st.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;
         return Status::OK();
@@ -1125,10 +1125,9 @@ Status SegmentIterator::_get_row_ranges_by_vector_index() {
         } else {
             result_ids.resize(_vector_index_ctx->k);
             result_distances.resize(_vector_index_ctx->k);
-            st = _vector_index_ctx->ann_reader->search(query_vector.data(), query_vector.size(), _vector_index_ctx->k,
-                                                       result_ids.data(),
-                                                       reinterpret_cast<uint8_t*>(result_distances.data()),
-                                                       _scan_range);
+            st = _vector_index_ctx->ann_reader->search(
+                    query_vector.data(), query_vector.size(), _vector_index_ctx->k, result_ids.data(),
+                    reinterpret_cast<uint8_t*>(result_distances.data()), _scan_range);
         }
     }
 

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -185,15 +185,10 @@ TEST_F(VectorIndexSearchTest, test_search_vector_index) {
         std::vector<int64_t> result_ids(kTopK);
         std::vector<float> result_distances(kTopK);
         SparseRange<> scan_range;
-        DelIdFilter del_id_filter(scan_range);
         std::vector<float> query_vector = {1.0f, 2.0f, 3.0f};
-        tenann::PrimitiveSeqView query_view =
-                tenann::PrimitiveSeqView{.data = reinterpret_cast<uint8_t*>(query_vector.data()),
-                                         .size = static_cast<uint32_t>(3),
-                                         .elem_type = tenann::PrimitiveType::kFloatType};
 
-        st = ann_reader->search(query_view, kTopK, result_ids.data(),
-                                reinterpret_cast<uint8_t*>(result_distances.data()), &del_id_filter);
+        st = ann_reader->search(query_vector.data(), query_vector.size(), kTopK, result_ids.data(),
+                                reinterpret_cast<uint8_t*>(result_distances.data()), scan_range);
         CHECK_OK(st);
         ASSERT_EQ(result_ids.size(), kTopK);
     } catch (tenann::Error& e) {


### PR DESCRIPTION
## Why I'm doing:

TenANN (the optional vector-index library, prebuilt only for Linux x86_64/aarch64) is gated by `#ifdef WITH_TENANN`. Those guards had leaked out of the vector-index module into cross-cutting code — `storage/rowset/segment_iterator.cpp`, `storage/index/vector/vector_index_writer.cpp`, and `storage/lake/vector_index_build_task.cpp` — which had to name TenANN types (`tenann::PrimitiveSeqView`, `tenann::IndexMeta`, `tenann::IdFilter`) and carry `#ifdef`/`#else` branches. That clutters the hot scan/build path and makes the non-TenANN build (macOS, format-lib) easy to break.

## What I'm doing:

Push the TenANN dependency behind TenANN-free interfaces so the guards stay inside `be/src/storage/index/vector/`. `VectorIndexReader::search`/`range_search` now take `(const float* query, size_t dim, const SparseRange<>&)` and construct the `PrimitiveSeqView` and `DelIdFilter` inside `TenANNReader`. `VectorIndexBuilderFactory::create_index_builder` builds the FS-bridge `VectorIndexFileWriter` itself and sinks its ownership into `TenAnnIndexBuilderProxy` (removing the caller-held holder and its destruction-order workaround). A new `VectorIndexReaderFactory::create_and_init` derives the index meta, opens the reader, and runs adaptive-ef init behind a native signature, returning `NotSupported` in non-TenANN builds so callers fall back to brute force.

As a result `segment_iterator.cpp`, `vector_index_writer.cpp`, and `lake/vector_index_build_task.cpp` no longer contain any `#ifdef WITH_TENANN`. No behavior change.

Verified with `WITH_TENANN=ON` and `WITH_TENANN=OFF`; the vector UTs pass (72/72 across VectorIndexSearchTest, VectorIndexWriterTest, BruteForceVectorFallbackTest, AdaptiveEfSearchTest, ResolveBruteForceVectorColumnTest, SharedDataVectorIndexTest, SharedDataTabletWriterVITest).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5