### PR TITLE
[BugFix] Archive force-killed task runs and honor session-prefixed task-run timeouts

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -296,7 +296,7 @@ public class AlterJobMgr {
                             "mv status:" + materializedView.getName());
                 }
                 try {
-                    taskRunManager.killTaskRun(currentTask.getId(), true);
+                    taskRunManager.killTaskRun(currentTask.getId(), true, "killed by ALTER MATERIALIZED VIEW");
                 } finally {
                     taskRunManager.taskRunUnlock();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -301,13 +301,15 @@ public class TaskManager implements MemoryTrackable {
             return false;
         }
         try {
-            taskRunScheduler.removePendingTask(task);
-        } catch (Exception ex) {
-            LOG.warn("failed to kill task.", ex);
+            try {
+                taskRunScheduler.removePendingTask(task);
+            } catch (Exception ex) {
+                LOG.warn("failed to kill task.", ex);
+            }
+            taskRunManager.killTaskRun(task.getId(), force, "killed by DROP TASK or manual cancel");
         } finally {
             taskRunManager.taskRunUnlock();
         }
-        taskRunManager.killTaskRun(task.getId(), force);
         return true;
     }
 
@@ -1245,6 +1247,10 @@ public class TaskManager implements MemoryTrackable {
     }
 
     private void removeTimeoutTaskRuns() {
+        // timeout cleanup is a leader responsibility; followers obtain the FAILED record via replay
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            return;
+        }
         // cancel long-running task runs to avoid resource waste
         long currentTimeMs = System.currentTimeMillis();
         Set<TaskRun> runningTaskRuns = taskRunManager.getTaskRunScheduler().getCopiedRunningTaskRuns();
@@ -1265,15 +1271,15 @@ public class TaskManager implements MemoryTrackable {
             LOG.warn("task run [{}] has been running for a long time, cancel it," +
                     " created(ms):{}, timeout(s):{}", taskRun, taskRunCreatedTime, taskRunTimeout);
 
-            if (!tryTaskLock()) {
+            if (!taskRunManager.tryTaskRunLock()) {
                 continue;
             }
             try {
-                taskRunManager.killRunningTaskRun(taskRun, true);
+                taskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
             } catch (Exception e) {
                 LOG.warn("failed to cancel long-running task run: {}", taskRun, e);
             } finally {
-                taskUnlock();
+                taskRunManager.taskRunUnlock();
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -212,8 +212,13 @@ public class TaskRun implements Comparable<TaskRun> {
         int defaultTimeoutS = Config.task_runs_timeout_second;
         if (properties != null) {
             for (Map.Entry<String, String> entry : properties.entrySet()) {
-                if (entry.getKey().equalsIgnoreCase(SessionVariable.QUERY_TIMEOUT)
-                        || entry.getKey().equalsIgnoreCase(SessionVariable.INSERT_TIMEOUT)) {
+                String key = entry.getKey();
+                // session variables are stored with a "session." prefix; strip it before matching
+                if (key.startsWith(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX)) {
+                    key = key.substring(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
+                }
+                if (key.equalsIgnoreCase(SessionVariable.QUERY_TIMEOUT)
+                        || key.equalsIgnoreCase(SessionVariable.INSERT_TIMEOUT)) {
                     try {
                         int timeout = Integer.parseInt(entry.getValue());
                         if (timeout > 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -95,6 +95,10 @@ public class TaskRunManager implements MemoryTrackable {
      * NOTE: This method is not thread safe, the caller should ensure the thread safety.
      */
     public boolean killRunningTaskRun(TaskRun taskRun, boolean force) {
+        return killRunningTaskRun(taskRun, force, "killed manually");
+    }
+
+    public boolean killRunningTaskRun(TaskRun taskRun, boolean force, String errorMessage) {
         if (taskRun == null) {
             return false;
         }
@@ -117,10 +121,86 @@ public class TaskRunManager implements MemoryTrackable {
         } finally {
             // if it's force, remove it from running TaskRun map no matter it's killed or not
             if (force) {
-                // remove it from running TaskRun map
-                taskRunScheduler.removeRunningTask(taskRun.getTaskId());
+                archiveForceKilledTaskRun(taskRun, errorMessage);
             }
         }
+    }
+
+    /**
+     * Archive a force-killed running task run so its history is not lost. This mirrors
+     * {@link #checkRunningTaskRun()}'s WAL archive but is triggered by the kill path, which would
+     * otherwise just drop the run from the running map.
+     *
+     * The caller must hold taskRunLock so this is atomic against checkRunningTaskRun. We first verify
+     * (identity check) that this exact run is still the one in the running map, because the caller may
+     * be iterating a stale snapshot; only then do we remove/archive by taskId.
+     *
+     * Three cases (leader only, after the identity check):
+     *  - Already archived (defense-in-depth: checkRunningTaskRun handled it): just remove.
+     *  - Already in a finish state but not yet archived (the run completed naturally before we killed
+     *    it; its executor set a finish state (SUCCESS/FAILED/SKIPPED)): archive with that real terminal
+     *    state, not FAILED, so a completed run is never lost or mislabeled.
+     *  - Still RUNNING (the actual force kill): archive as FAILED with the kill reason.
+     *
+     * Followers must not write edit logs; they obtain the record by replaying the leader's
+     * RUNNING->finish edit log (see TaskManager#replayUpdateTaskRun).
+     *
+     * The run's executor thread may still be alive after a force kill and could later mutate the live
+     * TaskRunStatus, so we archive a deep-copy snapshot (not the live reference) and do NOT mutate the
+     * live status here. History/scheduler mutation happens only inside the WAL callback so an edit-log
+     * failure leaves memory unchanged.
+     */
+    private void archiveForceKilledTaskRun(TaskRun taskRun, String errorMessage) {
+        long taskId = taskRun.getTaskId();
+        // Identity check (the caller must hold taskRunLock): removeTimeoutTaskRuns iterates a snapshot
+        // taken before locking, so by now checkRunningTaskRun may have archived this run AND a newer
+        // run for the same taskId may have been scheduled. Only act if this exact run is still the
+        // running one; otherwise removeRunningTask(taskId) would drop the newer run.
+        if (taskRunScheduler.getRunningTaskRun(taskId) != taskRun) {
+            LOG.info("skip archiving force-killed task run, it is no longer the running task run for taskId:{}, queryId:{}",
+                    taskId, taskRun.getStatus() == null ? null : taskRun.getStatus().getQueryId());
+            return;
+        }
+        TaskRunStatus status = taskRun.getStatus();
+        if (status == null || !GlobalStateMgr.getCurrentState().isLeader()
+                || taskRunHistory.getTask(status.getQueryId()) != null) {
+            // cannot archive (no status), follower (archives via replay), or already archived
+            // (defense-in-depth): just remove. Identity already verified above, so this is safe.
+            taskRunScheduler.removeRunningTask(taskId);
+            return;
+        }
+        // If the run was still RUNNING when we killed it, record it as FAILED with the kill reason.
+        // If it had already reached a finish state on its own (its executor set SUCCESS/FAILED/SKIPPED
+        // before checkRunningTaskRun archived it), keep that real terminal state, error, and finish
+        // time -- we must never relabel a naturally finished run with the kill reason.
+        final boolean killedWhileRunning = !status.getState().isFinishState();
+        final Constants.TaskRunState finalState =
+                killedWhileRunning ? Constants.TaskRunState.FAILED : status.getState();
+        final long finishTime = (!killedWhileRunning && status.getFinishTime() > 0)
+                ? status.getFinishTime() : System.currentTimeMillis();
+
+        // Archive a deep-copy snapshot rather than the live status, because the executor thread may
+        // still mutate the live status concurrently. The snapshot already carries the natural
+        // terminal state, error, and finish time; only a run we killed while still running overrides
+        // them with the kill reason. The edit-log change is then derived from this snapshot so the
+        // journal (used for follower replay) and the in-memory history carry identical values.
+        TaskRunStatus archivedStatus = TaskRunStatus.fromJson(status.toJSON());
+        archivedStatus.setState(finalState);
+        archivedStatus.setFinishTime(finishTime);
+        if (killedWhileRunning) {
+            archivedStatus.setErrorCode(-1);
+            archivedStatus.setErrorMessage(errorMessage);
+        }
+        TaskRunStatusChange statusChange = new TaskRunStatusChange(taskId, archivedStatus,
+                Constants.TaskRunState.RUNNING, finalState);
+        LOG.info("archive force-killed task run from state RUNNING to {}, queryId:{}, taskId:{}",
+                finalState, archivedStatus.getQueryId(), taskId);
+        GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
+            // Mutate shared state only inside the WAL callback, so an edit-log failure leaves memory
+            // unchanged.
+            taskRunScheduler.removeRunningTask(taskId);
+            taskRunHistory.addHistory(archivedStatus);
+        });
     }
 
     /**
@@ -145,6 +225,10 @@ public class TaskRunManager implements MemoryTrackable {
      * NOTE: This method is not thread safe, caller should take lock if necessary.
      */
     public boolean killTaskRun(Long taskId, boolean force) {
+        return killTaskRun(taskId, force, "killed manually");
+    }
+
+    public boolean killTaskRun(Long taskId, boolean force, String errorMessage) {
         // kill all pending task runs of the task id
         killPendingTaskRuns(taskId);
         // kill the running task run
@@ -152,7 +236,7 @@ public class TaskRunManager implements MemoryTrackable {
         if (taskRun == null) {
             return false;
         }
-        return killRunningTaskRun(taskRun, force);
+        return killRunningTaskRun(taskRun, force, errorMessage);
     }
 
     // At present, only the manual and automatic tasks of the materialized view have different priorities.

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -983,15 +983,19 @@ public class TaskManagerTest {
                 return ImmutableSet.of(taskRun);
             }
         };
+        final String[] capturedReason = {null};
         new MockUp<TaskRunManager>() {
             @Mock
-            void killRunningTaskRun(TaskRun taskRun, boolean force) {
+            boolean killRunningTaskRun(TaskRun taskRun, boolean force, String errorMessage) {
                 assertEquals(status, taskRun.getStatus());
+                capturedReason[0] = errorMessage;
+                return true;
             }
         };
 
         TaskManager taskManager = new TaskManager();
         taskManager.removeExpiredTaskRuns(false);
+        assertEquals("killed by TaskCleaner due to timeout", capturedReason[0]);
     }
 
     @Test
@@ -1020,8 +1024,9 @@ public class TaskManagerTest {
         };
         new MockUp<TaskRunManager>() {
             @Mock
-            void killRunningTaskRun(TaskRun taskRun, boolean force) {
+            boolean killRunningTaskRun(TaskRun taskRun, boolean force, String errorMessage) {
                 Assertions.fail("Task without timeout should not be canceled");
+                return true;
             }
         };
 
@@ -1054,8 +1059,9 @@ public class TaskManagerTest {
         };
         new MockUp<TaskRunManager>() {
             @Mock
-            void killRunningTaskRun(TaskRun taskRun, boolean force) {
+            boolean killRunningTaskRun(TaskRun taskRun, boolean force, String errorMessage) {
                 Assertions.fail("Non-expired task should not be canceled");
+                return true;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerKillArchiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerKillArchiveTest.java
@@ -1,0 +1,353 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class TaskRunManagerKillArchiveTest {
+    private TaskManager masterTaskManager;
+    private TaskRunManager masterTaskRunManager;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        masterTaskManager = new TaskManager();
+        masterTaskRunManager = masterTaskManager.getTaskRunManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private TaskRun addRunningTaskRun(TaskManager taskManager, String taskName, long taskId,
+                                      String queryId, Constants.TaskRunState state) {
+        Task task = new Task(taskName);
+        task.setId(taskId);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        taskManager.replayCreateTask(task);
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+        taskRun.getStatus().setState(state);
+        taskManager.getTaskRunScheduler().addRunningTaskRun(taskRun);
+        return taskRun;
+    }
+
+    // A-1: on the leader, force kill of a RUNNING task run archives it as FAILED + writes edit log.
+    @Test
+    public void testForceKillArchivesAsFailedOnLeader() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1001L;
+        String queryId = "kill_archive_q1";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_leader", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+
+        masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
+
+        // master: removed from running, archived as FAILED
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        TaskRunStatus archived = masterTaskRunManager.getTaskRunHistory().getTask(queryId);
+        Assertions.assertNotNull(archived);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, archived.getState());
+        Assertions.assertEquals(-1, archived.getErrorCode());
+        Assertions.assertEquals("killed by TaskCleaner due to timeout", archived.getErrorMessage());
+
+        // edit log emitted as RUNNING -> FAILED
+        TaskRunStatusChange change = (TaskRunStatusChange) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        Assertions.assertNotNull(change);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, change.getToStatus());
+        Assertions.assertEquals(queryId, change.getQueryId());
+        Assertions.assertEquals(-1, change.getErrorCode());
+
+        // follower replays the edit log -> FAILED appears in follower history
+        TaskManager followerTaskManager = new TaskManager();
+        addRunningTaskRun(followerTaskManager, "kill_archive_leader", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+        followerTaskManager.replayUpdateTaskRun(change);
+        Assertions.assertEquals(0, followerTaskManager.getTaskRunScheduler().getRunningTaskCount());
+        TaskRunStatus followerArchived = followerTaskManager.getTaskRunHistory().getTask(queryId);
+        Assertions.assertNotNull(followerArchived);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, followerArchived.getState());
+    }
+
+    // A-2: a run that finished naturally (SUCCESS) but is not yet archived must be archived with its
+    // real terminal state (SUCCESS), never relabeled FAILED, and never dropped.
+    @Test
+    public void testForceKillPreservesNaturalFinishState() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1002L;
+        String queryId = "kill_archive_q2";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_success", taskId, queryId,
+                Constants.TaskRunState.SUCCESS);
+
+        masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
+
+        // archived as SUCCESS (not FAILED), removed from running map
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        TaskRunStatus archived = masterTaskRunManager.getTaskRunHistory().getTask(queryId);
+        Assertions.assertNotNull(archived);
+        Assertions.assertEquals(Constants.TaskRunState.SUCCESS, archived.getState());
+
+        // journal carries RUNNING -> SUCCESS
+        TaskRunStatusChange change = (TaskRunStatusChange) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        Assertions.assertEquals(Constants.TaskRunState.SUCCESS, change.getToStatus());
+    }
+
+    // A-2b: a run already present in history (e.g. checkRunningTaskRun archived it; we hold a stale
+    // snapshot ref) must not be re-archived or overwritten to FAILED.
+    @Test
+    public void testForceKillDoesNotOverwriteAlreadyArchivedRun() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1007L;
+        String queryId = "kill_archive_q7";
+        // run still shows RUNNING in our stale ref, but a SUCCESS record already exists in history
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_already", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+        TaskRunStatus alreadyArchived = TaskRunStatus.fromJson(taskRun.getStatus().toJSON());
+        alreadyArchived.setState(Constants.TaskRunState.SUCCESS);
+        masterTaskRunManager.getTaskRunHistory().addHistory(alreadyArchived);
+
+        masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
+
+        // history record untouched (still SUCCESS, not overwritten to FAILED), run removed
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertEquals(Constants.TaskRunState.SUCCESS,
+                masterTaskRunManager.getTaskRunHistory().getTask(queryId).getState());
+    }
+
+    // A-2c: a run that FAILED naturally (its own error) but is not yet archived keeps its own error
+    // code/message — it must not be relabeled with the kill reason.
+    @Test
+    public void testForceKillPreservesNaturalFailureError() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1009L;
+        String queryId = "kill_archive_q9";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_natfail", taskId, queryId,
+                Constants.TaskRunState.FAILED);
+        taskRun.getStatus().setErrorCode(1064);
+        taskRun.getStatus().setErrorMessage("syntax error from the query itself");
+
+        masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
+
+        TaskRunStatus archived = masterTaskRunManager.getTaskRunHistory().getTask(queryId);
+        Assertions.assertNotNull(archived);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, archived.getState());
+        Assertions.assertEquals(1064, archived.getErrorCode());
+        Assertions.assertEquals("syntax error from the query itself", archived.getErrorMessage());
+    }
+
+    // A-3: on a follower, force kill removes the run but writes no edit log / history (replay does that).
+    @Test
+    public void testForceKillOnFollowerDoesNotArchive() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+        };
+        long taskId = 1003L;
+        String queryId = "kill_archive_q3";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_follower", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+
+        masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
+
+        // removed from running map, but NOT archived and state untouched (waits for replay)
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertNull(masterTaskRunManager.getTaskRunHistory().getTask(queryId));
+        Assertions.assertEquals(Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());
+    }
+
+    // A-4: edit-log failure during force kill leaves memory unchanged (run stays RUNNING in the map,
+    // nothing archived); recovery is left to the next cleaner tick.
+    @Test
+    public void testForceKillEditLogFailureLeavesMemoryUnchanged() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1004L;
+        String queryId = "kill_archive_q4";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_editlog_fail", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logUpdateTaskRun(any(TaskRunStatusChange.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout"));
+
+        // run still in running map, still RUNNING, not archived
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertEquals(Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());
+        Assertions.assertNull(masterTaskRunManager.getTaskRunHistory().getTask(queryId));
+    }
+
+    // A-5: the archived record is a snapshot — a later mutation of the live status (simulating the
+    // still-running executor thread) must NOT change the FAILED history record.
+    @Test
+    public void testArchivedRecordIsSnapshotImmuneToLateMutation() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1005L;
+        String queryId = "kill_archive_q5";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_snapshot", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+
+        masterTaskRunManager.killRunningTaskRun(taskRun, true, "killed by TaskCleaner due to timeout");
+
+        TaskRunStatus archived = masterTaskRunManager.getTaskRunHistory().getTask(queryId);
+        Assertions.assertNotNull(archived);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, archived.getState());
+
+        // executor thread finishes late and flips the LIVE status to SUCCESS
+        taskRun.getStatus().setState(Constants.TaskRunState.SUCCESS);
+
+        // history record is a snapshot, unaffected
+        Assertions.assertEquals(Constants.TaskRunState.FAILED,
+                masterTaskRunManager.getTaskRunHistory().getTask(queryId).getState());
+    }
+
+    // A-6: a stale snapshot ref (the run was already archived+removed and a NEW run for the same
+    // taskId scheduled) must NOT cause removal/archival of the newer run.
+    @Test
+    public void testForceKillStaleRefDoesNotTouchNewerRun() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        long taskId = 1008L;
+        Task task = new Task("kill_archive_stale");
+        task.setId(taskId);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        masterTaskManager.replayCreateTask(task);
+
+        // stale reference (simulating the cleaner's pre-lock snapshot)
+        TaskRun staleTaskRun = TaskRunBuilder.newBuilder(task).build();
+        staleTaskRun.setTaskId(taskId);
+        staleTaskRun.initStatus("stale_query_id", System.currentTimeMillis());
+        staleTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        masterTaskRunManager.getTaskRunScheduler().addRunningTaskRun(staleTaskRun);
+
+        // simulate checkRunningTaskRun: the stale run is archived + removed, then a newer run for the
+        // same taskId is scheduled
+        masterTaskRunManager.getTaskRunScheduler().removeRunningTask(taskId);
+        TaskRun newerTaskRun = TaskRunBuilder.newBuilder(task).build();
+        newerTaskRun.setTaskId(taskId);
+        newerTaskRun.initStatus("newer_query_id", System.currentTimeMillis());
+        newerTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        masterTaskRunManager.getTaskRunScheduler().addRunningTaskRun(newerTaskRun);
+
+        // force-kill the STALE reference
+        masterTaskRunManager.killRunningTaskRun(staleTaskRun, true, "killed by TaskCleaner due to timeout");
+
+        // the newer run must be untouched: still the running run for taskId, not archived
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertSame(newerTaskRun, masterTaskRunManager.getTaskRunScheduler().getRunningTaskRun(taskId));
+        Assertions.assertNull(masterTaskRunManager.getTaskRunHistory().getTask("newer_query_id"));
+    }
+
+    // A-1b: end-to-end — removeExpiredTaskRuns on the leader archives a timed-out run as FAILED.
+    @Test
+    public void testRemoveExpiredTaskRunsArchivesTimedOutRunAsFailed() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        new MockUp<TaskRun>() {
+            @Mock
+            public int getExecuteTimeoutS() {
+                return 1;
+            }
+        };
+        long taskId = 1006L;
+        String queryId = "kill_archive_q6";
+        TaskRun taskRun = addRunningTaskRun(masterTaskManager, "kill_archive_e2e", taskId, queryId,
+                Constants.TaskRunState.RUNNING);
+        // createTime well in the past so (now - createTime) > getExecuteTimeoutS()*1000
+        taskRun.getStatus().setCreateTime(System.currentTimeMillis() - 5000);
+
+        masterTaskManager.removeExpiredTaskRuns(false);
+
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        TaskRunStatus archived = masterTaskRunManager.getTaskRunHistory().getTask(queryId);
+        Assertions.assertNotNull(archived);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, archived.getState());
+
+        TaskRunStatusChange change = (TaskRunStatusChange) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        Assertions.assertNotNull(change);
+        Assertions.assertEquals(Constants.TaskRunState.FAILED, change.getToStatus());
+        Assertions.assertEquals(queryId, change.getQueryId());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,5 +121,50 @@ public class TaskRunTest {
         assertEquals("PARTITION_START", TaskRun.PARTITION_START);
         assertEquals("PARTITION_END", TaskRun.PARTITION_END);
         assertEquals("FORCE", TaskRun.FORCE);
+    }
+
+    @Test
+    public void testSessionPrefixedInsertTimeoutProperty() {
+        int oldTtl = Config.task_ttl_second;
+        Config.task_ttl_second = 300000;
+        try {
+            Map<String, String> props = new HashMap<>();
+            // session variables are stored with a "session." prefix
+            props.put(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.INSERT_TIMEOUT, "259200");
+            taskRun.setProperties(props);
+            // Before the fix this returned task_runs_timeout_second (14400) because the
+            // prefixed key never matched; after the fix it honors 259200 (capped by ttls).
+            assertEquals(Math.min(259200, Config.task_runs_ttl_second), taskRun.getExecuteTimeoutS());
+        } finally {
+            Config.task_ttl_second = oldTtl;
+        }
+    }
+
+    @Test
+    public void testSessionPrefixedQueryTimeoutProperty() {
+        int oldTtl = Config.task_ttl_second;
+        Config.task_ttl_second = 300000;
+        try {
+            Map<String, String> props = new HashMap<>();
+            props.put(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.QUERY_TIMEOUT, "259200");
+            taskRun.setProperties(props);
+            assertEquals(Math.min(259200, Config.task_runs_ttl_second), taskRun.getExecuteTimeoutS());
+        } finally {
+            Config.task_ttl_second = oldTtl;
+        }
+    }
+
+    @Test
+    public void testBareInsertTimeoutStillWorks() {
+        int oldTtl = Config.task_ttl_second;
+        Config.task_ttl_second = 300000;
+        try {
+            Map<String, String> props = new HashMap<>();
+            props.put(SessionVariable.INSERT_TIMEOUT, "259200");
+            taskRun.setProperties(props);
+            assertEquals(Math.min(259200, Config.task_runs_ttl_second), taskRun.getExecuteTimeoutS());
+        } finally {
+            Config.task_ttl_second = oldTtl;
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`SUBMIT TASK` run history could vanish completely. When `TaskCleaner` timed out a long-running task run it force-killed it via `TaskRunManager.killRunningTaskRun(taskRun, force=true)`, whose `finally` only called `removeRunningTask` and never archived the run. The sole normal archive path, `checkRunningTaskRun()`, requires the run to still be in the running map — but `force` removed it first — so no `FAILED`/finished record was ever written. The records disappeared from `information_schema.task_runs` and `_statistics_.task_run_history` with no trace. The same gap affected the ALTER MV and DROP/CANCEL force-kill paths.

A second, related defect made runs hit the 4h default timeout unexpectedly: `TaskRun.getExecuteTimeoutS()` compared the raw property key against `query_timeout`/`insert_timeout`, but session properties are stored with a `session.` prefix, so `session.insert_timeout` never matched and fell back to `task_runs_timeout_second` (4h).

## What I'm doing:

- **Archive force-killed runs (root cause).** `killRunningTaskRun` now archives the run on the force-kill path via a new leader-gated helper `archiveForceKilledTaskRun`:
  - Leader-only writes the edit log; followers obtain the record by replaying `RUNNING -> finishState` in `replayUpdateTaskRun`.
  - An identity check (`getRunningTaskRun(taskId) == taskRun`) prevents a stale snapshot from dropping a newer run scheduled for the same `taskId`.
  - A run still `RUNNING` is archived as `FAILED` with the kill reason; a run that finished naturally just before the kill keeps its real terminal state, error, and finish time.
  - The archived record is a deep-copy snapshot, so the still-running executor thread cannot mutate it; shared-state mutation happens only inside the WAL callback, so an edit-log failure leaves memory unchanged.
- **Lock/leader wiring.** `removeTimeoutTaskRuns` now runs only on the leader and holds `taskRunLock` (the same lock as `checkRunningTaskRun`); `killTask` holds `taskRunLock` around the kill. Each caller passes a descriptive kill reason (timeout cleanup / ALTER MV / DROP or manual cancel).
- **Honor session-prefixed timeouts.** `getExecuteTimeoutS()` strips the `session.` prefix before matching `query_timeout`/`insert_timeout`, so a user-set `session.insert_timeout` is respected. The existing `Math.min(.., task_runs_ttl_second, task_ttl_second)` cap is unchanged — operators who need longer task runs must also raise `task_ttl_second`/`task_runs_ttl_second`.

Scope: this fixes the running-task-run kill path only. The in-memory-only archive limitation / cluster-wide archive stall and pending-task-run kill archival are tracked separately.

Tests: new `TaskRunManagerKillArchiveTest` (leader archive + follower replay, natural-finish preservation, already-archived no-overwrite, natural-FAILED error preservation, follower no-archive, edit-log-failure atomicity, snapshot immunity, stale-ref safety, end-to-end timeout); `TaskRunTest` prefix cases; updated `TaskManagerTest` wiring guards.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)