### PR TITLE
[Enhancement] Record per-file size of lake DCG .cols files to skip stat on open

### DIFF
--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -142,6 +142,9 @@ Status DeltaColumnGroup::load(int64_t version, const DeltaColumnGroupVerPB& dcg_
     for (const auto& encryption_meta : dcg_ver_pb.encryption_metas()) {
         _encryption_metas.push_back(encryption_meta);
     }
+    for (const auto& column_file_size : dcg_ver_pb.column_file_sizes()) {
+        _column_file_sizes.push_back(column_file_size);
+    }
     for (const auto& ucids : dcg_ver_pb.unique_column_ids()) {
         _column_uids.emplace_back();
         for (const auto& cid : ucids.column_ids()) {

--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -105,6 +105,10 @@ public:
 
     const std::vector<std::string>& encryption_metas() const { return _encryption_metas; }
 
+    // Per-file size of each `.cols` file, 1:1 with relative_column_files(). May be empty (and
+    // individual entries may be 0) for data written before the size field existed.
+    const std::vector<int64_t>& column_file_sizes() const { return _column_file_sizes; }
+
     int64_t file_size() const { return _file_size; }
 
 private:
@@ -115,6 +119,7 @@ private:
     std::vector<std::vector<ColumnUID>> _column_uids;
     std::vector<std::string> _column_files;
     std::vector<std::string> _encryption_metas;
+    std::vector<int64_t> _column_file_sizes; // per-file size, 1:1 with _column_files; 0/empty = unknown
     size_t _memory_usage = 0;
     int64_t _file_size = 0; // file size of all column files
 };

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -533,7 +533,7 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
     // 4 generate delta columngroup
     for (const auto& each : rss_upt_id_to_rowid_pairs) {
         builder->append_dcg(each.first, dcg_column_file_with_encryption_metas[each.first], dcg_column_ids[each.first],
-                             dcg_column_file_sizes[each.first]);
+                            dcg_column_file_sizes[each.first]);
     }
     builder->apply_column_mode_partial_update(params.op_write);
 

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -416,6 +416,9 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
     // It means column_1 and column_2 are stored in aaa.cols, and column_3 and column_4 are stored in bbb.cols
     std::map<uint32_t, std::vector<std::vector<ColumnUID>>> dcg_column_ids;
     std::map<uint32_t, std::vector<std::pair<std::string, std::string>>> dcg_column_file_with_encryption_metas;
+    // Parallel to dcg_column_file_with_encryption_metas: byte size of each `.cols` file,
+    // captured from finalize() so readers can avoid a stat/HeadObject when opening the segment.
+    std::map<uint32_t, std::vector<int64_t>> dcg_column_file_sizes;
     // 3. read from raw segment file and update file, and generate `.col` files
     // The inner segment loop is parallelized: each (column_batch, rssid) combination is independent
     // since they read different source segments and write to different .col files (UUID-based names).
@@ -456,7 +459,8 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
 
             auto func = [this, &params, &partial_schema, &partial_tschema, &selective_unique_update_column_ids, rssid,
                          upt_pairs_ptr, condition_idx_in_partial_schema, &dcg_column_ids,
-                         &dcg_column_file_with_encryption_metas, &result_mutex, &shared_status]() {
+                         &dcg_column_file_with_encryption_metas, &dcg_column_file_sizes, &result_mutex,
+                         &shared_status]() {
                 // 3.3 read from source segment
                 auto source_chunk_or = _read_from_source_segment(params, partial_schema, rssid);
                 if (!source_chunk_or.ok()) {
@@ -505,6 +509,7 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                     dcg_column_file_with_encryption_metas[rssid].emplace_back(
                             file_name(delta_column_group_writer->segment_path()),
                             delta_column_group_writer->encryption_meta());
+                    dcg_column_file_sizes[rssid].push_back(static_cast<int64_t>(segment_file_size));
                 }
                 TRACE_COUNTER_INCREMENT("pcu_handle_cnt", 1);
             };
@@ -527,7 +532,8 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
     }
     // 4 generate delta columngroup
     for (const auto& each : rss_upt_id_to_rowid_pairs) {
-        builder->append_dcg(each.first, dcg_column_file_with_encryption_metas[each.first], dcg_column_ids[each.first]);
+        builder->append_dcg(each.first, dcg_column_file_with_encryption_metas[each.first], dcg_column_ids[each.first],
+                             dcg_column_file_sizes[each.first]);
     }
     builder->apply_column_mode_partial_update(params.op_write);
 

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -112,15 +112,19 @@ void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment
 
 void MetaFileBuilder::append_dcg(uint32_t rssid,
                                  const std::vector<std::pair<std::string, std::string>>& file_with_encryption_metas,
-                                 const std::vector<std::vector<ColumnUID>>& unique_column_id_list) {
+                                 const std::vector<std::vector<ColumnUID>>& unique_column_id_list,
+                                 const std::vector<int64_t>& file_sizes) {
     DeltaColumnGroupVerPB& dcg_ver = (*_tablet_meta->mutable_dcg_meta()->mutable_dcgs())[rssid];
     DeltaColumnGroupVerPB new_dcg_ver;
     std::unordered_set<ColumnUID> need_to_remove_cuids_filter;
 
     // 1. append new dcgs
     DCHECK(file_with_encryption_metas.size() == unique_column_id_list.size());
+    DCHECK(file_with_encryption_metas.size() == file_sizes.size());
     for (int i = 0; i < file_with_encryption_metas.size(); i++) {
         new_dcg_ver.add_column_files(file_with_encryption_metas[i].first);
+        // Keep column_file_sizes strictly 1:1 with column_files so readers can index by position.
+        new_dcg_ver.add_column_file_sizes(file_sizes[i]);
         if (!file_with_encryption_metas[i].second.empty()) {
             new_dcg_ver.add_encryption_metas(file_with_encryption_metas[i].second);
         }
@@ -144,6 +148,9 @@ void MetaFileBuilder::append_dcg(uint32_t rssid,
         if (!mcids->empty()) {
             new_dcg_ver.add_unique_column_ids()->CopyFrom(dcg_ver.unique_column_ids(i));
             new_dcg_ver.add_column_files(dcg_ver.column_files(i));
+            // Carry forward the old size, or 0 (unknown) for data written before this field existed,
+            // so column_file_sizes stays aligned with column_files.
+            new_dcg_ver.add_column_file_sizes(i < dcg_ver.column_file_sizes_size() ? dcg_ver.column_file_sizes(i) : 0);
             new_dcg_ver.add_versions(dcg_ver.versions(i));
             if (i < dcg_ver.encryption_metas_size()) {
                 new_dcg_ver.add_encryption_metas(dcg_ver.encryption_metas(i));

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -53,7 +53,8 @@ public:
     void append_delvec(const DelVectorPtr& delvec, uint32_t segment_id);
     // append delta column group to builder
     void append_dcg(uint32_t rssid, const std::vector<std::pair<std::string, std::string>>& file_with_encryption_metas,
-                    const std::vector<std::vector<ColumnUID>>& unique_column_id_list);
+                    const std::vector<std::vector<ColumnUID>>& unique_column_id_list,
+                    const std::vector<int64_t>& file_sizes);
     // handle txn log
     void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
                        const std::vector<FileMetaPB>& orphan_files);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -502,7 +502,8 @@ Status validate_dcg_shape(const DeltaColumnGroupVerPB& dcg) {
         return Status::Corruption("DCG shape invalid: column_files/unique_column_ids/versions size mismatch");
     }
     // Optional fields must not exceed column_files length
-    if (dcg.encryption_metas_size() > dcg.column_files_size() || dcg.shared_files_size() > dcg.column_files_size()) {
+    if (dcg.encryption_metas_size() > dcg.column_files_size() || dcg.shared_files_size() > dcg.column_files_size() ||
+        dcg.column_file_sizes_size() > dcg.column_files_size()) {
         return Status::Corruption("DCG shape invalid: optional fields exceed column_files size");
     }
     // No duplicate column UIDs across entries
@@ -523,6 +524,11 @@ void normalize_dcg_optional_fields(DeltaColumnGroupVerPB* dcg) {
     }
     while (dcg->shared_files_size() < dcg->column_files_size()) {
         dcg->add_shared_files(false);
+    }
+    // Pad with 0 (unknown) so column_file_sizes stays 1:1 with column_files; readers
+    // treat 0 as "size unknown" and fall back to stat/HeadObject.
+    while (dcg->column_file_sizes_size() < dcg->column_files_size()) {
+        dcg->add_column_file_sizes(0);
     }
 }
 
@@ -638,6 +644,8 @@ DeltaColumnGroupVerPB make_single_entry_dcg(const DeltaColumnGroupVerPB& source,
     out.add_versions(source.versions(entry_index));
     out.add_encryption_metas(source.encryption_metas(entry_index));
     out.add_shared_files(source.shared_files(entry_index));
+    // source is normalized before this call, so column_file_sizes is 1:1 with column_files.
+    out.add_column_file_sizes(source.column_file_sizes(entry_index));
     return out;
 }
 
@@ -1111,6 +1119,8 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
     rebuilt.add_versions(new_version);
     rebuilt.add_encryption_metas(segment_writer->encryption_meta());
     rebuilt.add_shared_files(false);
+    // Record the size of the freshly written .cols file so readers can skip a stat/HeadObject.
+    rebuilt.add_column_file_sizes(static_cast<int64_t>(written_file_size));
     return rebuilt;
 }
 
@@ -1154,6 +1164,7 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
             final_dcg.add_versions(entry.single_entry.versions(0));
             final_dcg.add_encryption_metas(entry.single_entry.encryption_metas(0));
             final_dcg.add_shared_files(entry.single_entry.shared_files(0));
+            final_dcg.add_column_file_sizes(entry.single_entry.column_file_sizes(0));
         }
 
         bool any_entry_is_conflicting = false;
@@ -1193,6 +1204,7 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
             final_dcg.add_versions(rebuilt_entry.versions(0));
             final_dcg.add_encryption_metas(rebuilt_entry.encryption_metas(0));
             final_dcg.add_shared_files(rebuilt_entry.shared_files(0));
+            final_dcg.add_column_file_sizes(rebuilt_entry.column_file_sizes(0));
             g_tablet_merge_dcg_rebuild_total << 1;
         }
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -646,6 +646,11 @@ StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGro
     }
     ASSIGN_OR_RETURN(auto filepath, dcg.column_file_by_idx(parent_name(_segment_file_info.path), idx));
     FileInfo info{.path = filepath};
+    // Supplying the known size lets the segment open path skip a stat/HeadObject. A size of 0 means
+    // unknown (old data lacking column_file_sizes), in which case we fall back to discovering it.
+    if (idx < dcg.column_file_sizes().size() && dcg.column_file_sizes()[idx] > 0) {
+        info.size = dcg.column_file_sizes()[idx];
+    }
     if (idx < dcg.encryption_metas().size()) {
         info.encryption_meta = dcg.encryption_metas()[idx];
     }

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -346,7 +346,8 @@ TEST_F(MetaFileTest, test_dcg) {
         std::vector<std::vector<ColumnUID>> unique_column_id_list;
         unique_column_id_list.push_back({3, 4, 5});
         unique_column_id_list.push_back({6, 7, 8});
-        builder.append_dcg(110, filenames, unique_column_id_list);
+        std::vector<int64_t> file_sizes{111, 222};
+        builder.append_dcg(110, filenames, unique_column_id_list, file_sizes);
         builder.apply_column_mode_partial_update(op_write);
         Status st = builder.finalize(next_id());
         EXPECT_TRUE(st.ok());
@@ -364,7 +365,8 @@ TEST_F(MetaFileTest, test_dcg) {
         filenames.emplace_back("ccc.cols", "");
         std::vector<std::vector<ColumnUID>> unique_column_id_list;
         unique_column_id_list.push_back({4, 7});
-        builder.append_dcg(110, filenames, unique_column_id_list);
+        std::vector<int64_t> file_sizes{333};
+        builder.append_dcg(110, filenames, unique_column_id_list, file_sizes);
         builder.apply_column_mode_partial_update(op_write);
         Status st = builder.finalize(next_id());
         EXPECT_TRUE(st.ok());
@@ -383,7 +385,8 @@ TEST_F(MetaFileTest, test_dcg) {
         filenames.emplace_back("ddd.cols", "");
         std::vector<std::vector<ColumnUID>> unique_column_id_list;
         unique_column_id_list.push_back({3, 5});
-        builder.append_dcg(110, filenames, unique_column_id_list);
+        std::vector<int64_t> file_sizes{444};
+        builder.append_dcg(110, filenames, unique_column_id_list, file_sizes);
         builder.apply_column_mode_partial_update(op_write);
         Status st = builder.finalize(next_id());
         EXPECT_TRUE(st.ok());
@@ -392,6 +395,16 @@ TEST_F(MetaFileTest, test_dcg) {
         EXPECT_TRUE(dcg_ver_iter->second.versions_size() == 3);
         EXPECT_TRUE(dcg_ver_iter->second.column_files_size() == 3);
         EXPECT_TRUE(dcg_ver_iter->second.unique_column_ids_size() == 3);
+        // column_file_sizes stays 1:1 with column_files, and carries forward the size
+        // of each retained `.cols` file regardless of how entries are reordered.
+        EXPECT_TRUE(dcg_ver_iter->second.column_file_sizes_size() == 3);
+        std::map<std::string, int64_t> file_to_size;
+        for (int i = 0; i < dcg_ver_iter->second.column_files_size(); i++) {
+            file_to_size[dcg_ver_iter->second.column_files(i)] = dcg_ver_iter->second.column_file_sizes(i);
+        }
+        EXPECT_EQ(444, file_to_size["ddd.cols"]);
+        EXPECT_EQ(222, file_to_size["bbb.cols"]);
+        EXPECT_EQ(333, file_to_size["ccc.cols"]);
         // <3, 5> -> ddd.cols
         // <6, 8> -> bbb.cols
         // <4, 7> -> ccc.cols

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -100,6 +100,10 @@ message DeltaColumnGroupVerPB {
     repeated bytes encryption_metas = 4;
     // Whether files are shared by multiple tablets
     repeated bool shared_files = 5;
+    // Per-file size of each `.cols` file, strictly 1:1 with column_files.
+    // 0 means unknown (data written before this field existed); readers then
+    // fall back to stat/HeadObject to discover the file size.
+    repeated int64 column_file_sizes = 6 [packed = true];
 }
 
 message DeltaColumnGroupMetadataPB {


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, each delta-column-group (DCG) `.cols` file is itself a full segment, so its byte length is recoverable from the segment trailer at read time. However, unlike regular segments — whose size is persisted in `RowsetMetadataPB.segment_size` and threaded through `FileInfo.size` so that opening the segment can skip a stat/`HeadObject` — `DeltaColumnGroupVerPB` stored no size at all. As a result `Segment::new_dcg_segment()` constructed a `FileInfo` without `.size`, and every open of a `.cols` segment paid an extra `HeadObject` RPC against object storage (non-trivial latency on S3/OSS/OBS, etc.).

## What I'm doing:

Carry the already-computed `.cols` file size through to the reader so the optimization that regular segments enjoy also applies to DCG files:

- `gensrc/proto/lake_types.proto`: add `repeated int64 column_file_sizes = 6 [packed]` to `DeltaColumnGroupVerPB`, strictly 1:1 with `column_files`.
- `be/src/storage/lake/meta_file.{h,cpp}`: `MetaFileBuilder::append_dcg` takes a parallel `file_sizes` vector, writes one size per file, and carries forward old sizes (or `0` = unknown) when retaining existing entries so the array stays aligned with `column_files`.
- `be/src/storage/lake/column_mode_partial_update_handler.cpp`: collect `segment_file_size` (already produced by `SegmentWriter::finalize()`) and pass it to `append_dcg`.
- `be/src/storage/delta_column_group.{h,cpp}`: new `_column_file_sizes` member + accessor; lake `load()` reads the field.
- `be/src/storage/rowset/segment.cpp`: `new_dcg_segment` sets `FileInfo.size` when the recorded size is `> 0`, otherwise falls back to discovering it.

**Backward compatibility:** a size of `0` (or an absent `column_file_sizes`, e.g. data written before this field existed) is treated as "unknown" and transparently falls back to the previous stat/`HeadObject` behavior. No migration required.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5