### PR TITLE
[Doc] document ms precision for loads datetime fields

### DIFF
--- a/docs/en/sql-reference/information_schema/loads.md
+++ b/docs/en/sql-reference/information_schema/loads.md
@@ -28,14 +28,20 @@ The following fields are provided in `loads`:
 | UNSELECTED_ROWS      | The number of data rows that are filtered out due to the conditions specified in the WHERE clause. |
 | SINK_ROWS            | The number of data rows that are loaded.                     |
 | RUNTIME_DETAILS      | Load runtime metadata. For details, see [RUNTIME_DETAILS](#runtime_details). |
-| CREATE_TIME          | The time at which the load job was created. Format: `yyyy-MM-dd HH:mm:ss`. Example: `2023-07-24 14:58:58`. |
-| LOAD_START_TIME      | The start time of the LOADING stage of the load job. Format: `yyyy-MM-dd HH:mm:ss`. Example: `2023-07-24 14:58:58`. |
-| LOAD_COMMIT_TIME     | The time at which the loading transaction was committed. Format: `yyyy-MM-dd HH:mm:ss`. Example: `2023-07-24 14:58:58`. |
-| LOAD_FINISH_TIME     | The end time of the LOADING stage of the load job. Format: `yyyy-MM-dd HH:mm:ss`. Example: `2023-07-24 14:58:58`. |
+| CREATE_TIME          | The time at which the load job was created. Format: `yyyy-MM-dd HH:mm:ss.SSSSSS`. Example: `2023-07-24 14:58:58.123000`. |
+| LOAD_START_TIME      | The start time of the LOADING stage of the load job. Format: `yyyy-MM-dd HH:mm:ss.SSSSSS`. Example: `2023-07-24 14:58:58.123000`. |
+| LOAD_COMMIT_TIME     | The time at which the loading transaction was committed. Format: `yyyy-MM-dd HH:mm:ss.SSSSSS`. Example: `2023-07-24 14:58:58.123000`. |
+| LOAD_FINISH_TIME     | The end time of the LOADING stage of the load job. Format: `yyyy-MM-dd HH:mm:ss.SSSSSS`. Example: `2023-07-24 14:58:58.123000`. |
 | PROPERTIES           | The static properties of the load job. For details, see [PROPERTIES](#properties). |
 | ERROR_MSG            | The error message of the load job. If the load job did not encounter any error, `NULL` is returned. |
 | TRACKING_SQL         | The SQL statement that can be used to query the tracking log of the load job. A SQL statement is returned only when the load job involves unqualified data rows. If the load job does not involve any unqualified data rows, `NULL` is returned. |
 | REJECTED_RECORD_PATH | The path from which you can access all the unqualified data rows that are filtered out in the load job. The number of unqualified data rows logged is determined by the `log_rejected_record_num` parameter configured in the load job. You can use the `wget` command to access the path. If the load job does not involve any unqualified data rows, `NULL` is returned. |
+
+:::note
+
+From v4.2 onwards, `CREATE_TIME`, `LOAD_START_TIME`, `LOAD_COMMIT_TIME`, and `LOAD_FINISH_TIME` carry millisecond precision. The sub-second part is rendered as six fractional digits, of which the last three are always `0` (for example, `2023-07-24 14:58:58.123000`). Predicates on these fields, such as `LOAD_FINISH_TIME <= '2023-07-24 14:58:58'`, are also evaluated at millisecond precision. In earlier versions, these fields are second-precision (format `yyyy-MM-dd HH:mm:ss`).
+
+:::
 
 ## RUNTIME_DETAILS
 

--- a/docs/ja/sql-reference/information_schema/loads.md
+++ b/docs/ja/sql-reference/information_schema/loads.md
@@ -27,14 +27,20 @@ displayed_sidebar: docs
 | UNSELECTED_ROWS      | WHERE 句で指定された条件によりフィルタリングされたデータ行の数。 |
 | SINK_ROWS            | ロードされたデータ行の数。                     |
 | RUNTIME_DETAILS      | ロードの実行時メタデータ。詳細は [RUNTIME_DETAILS](#runtime_details) を参照。 |
-| CREATE_TIME          | ロードジョブが作成された時間。フォーマット: `yyyy-MM-dd HH:mm:ss`。例: `2023-07-24 14:58:58`。 |
-| LOAD_START_TIME      | ロードジョブの LOADING ステージの開始時間。フォーマット: `yyyy-MM-dd HH:mm:ss`。例: `2023-07-24 14:58:58`。 |
-| LOAD_COMMIT_TIME     | ロードトランザクションがコミットされた時間。フォーマット: `yyyy-MM-dd HH:mm:ss`。例: `2023-07-24 14:58:58`。 |
-| LOAD_FINISH_TIME     | ロードジョブの LOADING ステージの終了時間。フォーマット: `yyyy-MM-dd HH:mm:ss`。例: `2023-07-24 14:58:58`。 |
+| CREATE_TIME          | ロードジョブが作成された時間。フォーマット: `yyyy-MM-dd HH:mm:ss.SSSSSS`。例: `2023-07-24 14:58:58.123000`。 |
+| LOAD_START_TIME      | ロードジョブの LOADING ステージの開始時間。フォーマット: `yyyy-MM-dd HH:mm:ss.SSSSSS`。例: `2023-07-24 14:58:58.123000`。 |
+| LOAD_COMMIT_TIME     | ロードトランザクションがコミットされた時間。フォーマット: `yyyy-MM-dd HH:mm:ss.SSSSSS`。例: `2023-07-24 14:58:58.123000`。 |
+| LOAD_FINISH_TIME     | ロードジョブの LOADING ステージの終了時間。フォーマット: `yyyy-MM-dd HH:mm:ss.SSSSSS`。例: `2023-07-24 14:58:58.123000`。 |
 | PROPERTIES           | ロードジョブの静的プロパティ。詳細は [PROPERTIES](#properties) を参照。 |
 | ERROR_MSG            | ロードジョブのエラーメッセージ。エラーが発生しなかった場合、`NULL` が返されます。 |
 | TRACKING_SQL         | ロードジョブの追跡ログをクエリするために使用できる SQL ステートメント。ロードジョブが不適格なデータ行を含む場合にのみ SQL ステートメントが返されます。不適格なデータ行を含まない場合、`NULL` が返されます。 |
 | REJECTED_RECORD_PATH | ロードジョブでフィルタリングされたすべての不適格なデータ行にアクセスできるパス。ログに記録される不適格なデータ行の数は、ロードジョブで設定された `log_rejected_record_num` パラメータによって決まります。このパスにアクセスするには `wget` コマンドを使用できます。不適格なデータ行を含まない場合、`NULL` が返されます。 |
+
+:::note
+
+v4.2 以降、`CREATE_TIME`、`LOAD_START_TIME`、`LOAD_COMMIT_TIME`、`LOAD_FINISH_TIME` はミリ秒精度を持ちます。秒未満の部分は 6 桁の小数で表示され、そのうち末尾の 3 桁は常に `0` です（例: `2023-07-24 14:58:58.123000`）。これらのフィールドに対する述語（例: `LOAD_FINISH_TIME <= '2023-07-24 14:58:58'`）もミリ秒精度で評価されます。これより前のバージョンでは、これらのフィールドは秒精度（フォーマット `yyyy-MM-dd HH:mm:ss`）です。
+
+:::
 
 ## RUNTIME_DETAILS
 

--- a/docs/zh/sql-reference/information_schema/loads.md
+++ b/docs/zh/sql-reference/information_schema/loads.md
@@ -27,14 +27,20 @@ displayed_sidebar: docs
 | UNSELECTED_ROWS      | 由于 WHERE 子句中指定的条件而被过滤掉的数据行数。 |
 | SINK_ROWS            | 加载的数据行数。                     |
 | RUNTIME_DETAILS      | 加载运行时元数据。详情请参见 [RUNTIME_DETAILS](#runtime_details)。 |
-| CREATE_TIME          | 导入作业创建的时间。格式：`yyyy-MM-dd HH:mm:ss`。示例：`2023-07-24 14:58:58`。 |
-| LOAD_START_TIME      | 导入作业 LOADING 阶段的开始时间。格式：`yyyy-MM-dd HH:mm:ss`。示例：`2023-07-24 14:58:58`。 |
-| LOAD_COMMIT_TIME     | 加载事务提交的时间。格式：`yyyy-MM-dd HH:mm:ss`。示例：`2023-07-24 14:58:58`。 |
-| LOAD_FINISH_TIME     | 导入作业 LOADING 阶段的结束时间。格式：`yyyy-MM-dd HH:mm:ss`。示例：`2023-07-24 14:58:58`。 |
+| CREATE_TIME          | 导入作业创建的时间。格式：`yyyy-MM-dd HH:mm:ss.SSSSSS`。示例：`2023-07-24 14:58:58.123000`。 |
+| LOAD_START_TIME      | 导入作业 LOADING 阶段的开始时间。格式：`yyyy-MM-dd HH:mm:ss.SSSSSS`。示例：`2023-07-24 14:58:58.123000`。 |
+| LOAD_COMMIT_TIME     | 加载事务提交的时间。格式：`yyyy-MM-dd HH:mm:ss.SSSSSS`。示例：`2023-07-24 14:58:58.123000`。 |
+| LOAD_FINISH_TIME     | 导入作业 LOADING 阶段的结束时间。格式：`yyyy-MM-dd HH:mm:ss.SSSSSS`。示例：`2023-07-24 14:58:58.123000`。 |
 | PROPERTIES           | 导入作业的静态属性。详情请参见 [PROPERTIES](#properties)。 |
 | ERROR_MSG            | 导入作业的错误信息。如果导入作业未遇到任何错误，则返回 `NULL`。 |
 | TRACKING_SQL         | 可用于查询导入作业跟踪日志的 SQL 语句。仅当导入作业涉及不合格数据行时，才返回 SQL 语句。如果导入作业不涉及任何不合格数据行，则返回 `NULL`。 |
 | REJECTED_RECORD_PATH | 可以从中访问导入作业中过滤掉的所有不合格数据行的路径。记录的不合格数据行数由导入作业中配置的 `log_rejected_record_num` 参数决定。可以使用 `wget` 命令访问该路径。如果导入作业不涉及任何不合格数据行，则返回 `NULL`。 |
+
+:::note
+
+从 v4.2 版本开始，`CREATE_TIME`、`LOAD_START_TIME`、`LOAD_COMMIT_TIME` 和 `LOAD_FINISH_TIME` 支持毫秒精度。秒以下部分以六位小数渲染，其中最后三位始终为 `0`（例如 `2023-07-24 14:58:58.123000`）。针对这些字段的谓词（例如 `LOAD_FINISH_TIME <= '2023-07-24 14:58:58'`）也按毫秒精度进行求值。在更早的版本中，这些字段为秒级精度（格式为 `yyyy-MM-dd HH:mm:ss`）。
+
+:::
 
 ## RUNTIME_DETAILS
 


### PR DESCRIPTION
CREATE_TIME, LOAD_START_TIME, LOAD_COMMIT_TIME, and LOAD_FINISH_TIME now carry millisecond precision (commit 56c7be67fb). Update the format and example for these fields and add a note on the six-digit rendering and ms-precision predicate evaluation in the en/zh/ja pages.

Fixes #74133

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5