### PR TITLE
[Enhancement] Add FE config to print load profiles to fe profile log

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -248,6 +248,15 @@ This topic introduces the following types of FE configurations:
 - Description: When this item is set to `true`, the FE audit subsystem records the SQL text of statements into FE audit logs (`fe.audit.log`) processed by ConnectProcessor. The stored statement respects other controls: encrypted statements are redacted (`AuditEncryptionChecker`), sensitive credentials may be redacted or desensitized if `enable_sql_desensitize_in_log` is set, and digest recording is controlled by `enable_sql_digest`. When it is set to `false`, ConnectProcessor replaces the statement text with "?" in audit events — other audit fields (user, host, duration, status, slow-query detection via `qe_slow_log_ms`, and metrics) are still recorded. Enabling SQL audit increases forensic and troubleshooting visibility but may expose sensitive SQL content and increase log volume and I/O; disabling it improves privacy at the cost of losing full-statement visibility in audit logs.
 - Introduced in: -
 
+### `enable_print_load_profile_to_log`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When set to `true`, load profiles (such as Stream Load, Routine Load, Broker Load, and Merge Commit) are additionally written to the profile log (`fe.profile.log`) at INFO level when they are pushed to `ProfileManager`, as a single-line JSON record in the same format as the query profile log. This makes load profiles recoverable from the log even after they are evicted from `ProfileManager` due to the `profile_info_reserved_num` limit. The profile log is used (rather than `fe.log`) because its JSON layout caps strings at `sys_log_json_profile_max_string_length` instead of the much smaller `sys_log_json_max_string_length`, so large load profiles are not truncated; the file is rotated and retained by the `profile_log_*` parameters. Only profiles whose query type is `Load` are printed; query profiles are not affected. A load profile is printed only when it is actually collected (for example, when `enable_profile` is enabled or the load exceeds the big-load profile threshold).
+- Introduced in: -
+
 ### `enable_profile_log`
 
 - Default: true

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -238,6 +238,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：この項目が `true` に設定されている場合、FE 監査サブシステムは、ConnectProcessor によって処理されたステートメントの SQL テキストを FE 監査ログ (`fe.audit.log`) に記録します。格納されたステートメントは、他の制御に従います。暗号化されたステートメントは編集され (`AuditEncryptionChecker`)、`enable_sql_desensitize_in_log` が設定されている場合、機密性の高い資格情報は編集または非機密化される可能性があり、ダイジェストレコーディングは `enable_sql_digest` によって制御されます。`false` に設定されている場合、ConnectProcessor は監査イベントのステートメントテキストを "?" に置き換えます。他の監査フィールド (ユーザー、ホスト、期間、ステータス、`qe_slow_log_ms` を介した低速クエリ検出、およびメトリック) は引き続き記録されます。SQL 監査を有効にすると、フォレンジックとトラブルシューティングの可視性が向上しますが、機密性の高い SQL コンテンツが公開され、ログのボリュームと I/O が増加する可能性があります。無効にすると、監査ログでの完全なステートメントの可視性を失う代わりにプライバシーが向上します。
 - 導入時期：-
 
+### `enable_print_load_profile_to_log`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：`true` に設定すると、ロード profile（Stream Load、Routine Load、Broker Load、Merge Commit など）が `ProfileManager` にプッシュされる際に、INFO レベルで profile ログ (`fe.profile.log`) にも、query profile log と同じ単一行 JSON 形式で出力されます。これにより、`profile_info_reserved_num` の上限によってロード profile が `ProfileManager` から削除された後でも、ログから復元できます。`fe.log` ではなく profile ログを使うのは、その JSON レイアウトの文字列上限が `sys_log_json_max_string_length` よりもはるかに大きい `sys_log_json_profile_max_string_length` であり、大きなロード profile が切り詰められないためです。このファイルのローテーションと保持は `profile_log_*` パラメータで制御されます。クエリタイプが `Load` の profile のみが出力され、クエリ profile には影響しません。ロード profile は実際に収集された場合（例えば `enable_profile` が有効な場合、またはロードが大規模ロード profile のしきい値を超えた場合）にのみ出力されます。
+- 導入時期：-
+
 ### `enable_profile_log`
 
 - デフォルト：true

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -247,6 +247,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当此项设置为 `true` 时，FE 审计子系统会将 ConnectProcessor 处理的 SQL 语句文本记录到 FE 审计日志 (`fe.audit.log`) 中。存储的语句遵循其他控制：加密语句将被 redacted (`AuditEncryptionChecker`)，如果设置了 `enable_sql_desensitize_in_log`，敏感凭据可能会被 redacted 或脱敏，并且 digest 记录由 `enable_sql_digest` 控制。当设置为 `false` 时，ConnectProcessor 会在审计事件中将语句文本替换为 "?" — 其他审计字段（用户、主机、持续时间、状态、通过 `qe_slow_log_ms` 进行的慢查询检测以及指标）仍会记录。启用 SQL 审计会增加取证和故障排除的可见性，但可能会暴露敏感的 SQL 内容并增加日志量和 I/O；禁用它会提高隐私性，但代价是审计日志中会丢失完整的语句可见性。
 - 引入版本: -
 
+### `enable_print_load_profile_to_log`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 当设置为 `true` 时，导入 profile（如 Stream Load、Routine Load、Broker Load、Merge Commit 等）在被推送到 `ProfileManager` 时，会额外以 INFO 级别写入 profile 日志 (`fe.profile.log`)，格式为单行 JSON，与 query profile log 一致。这样即使导入 profile 因 `profile_info_reserved_num` 限制而从 `ProfileManager` 中被淘汰，仍可从日志中找回。之所以写入 profile 日志而非 `fe.log`，是因为其 JSON layout 的字符串上限是 `sys_log_json_profile_max_string_length`，而非小得多的 `sys_log_json_max_string_length`，因此较大的导入 profile 不会被截断；该文件的轮转与保留由 `profile_log_*` 系列参数控制。仅打印查询类型为 `Load` 的 profile，查询 profile 不受影响。只有在导入 profile 实际被收集时（例如启用了 `enable_profile`，或导入耗时超过大导入 profile 阈值）才会打印。
+- 引入版本: -
+
 ### `enable_profile_log`
 
 - 默认值: true

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3627,6 +3627,20 @@ public class Config extends ConfigBase {
     public static String profile_info_format = "default";
 
     /**
+     * When enabled, load profiles (stream load, routine load, broker load, merge commit, etc.) are
+     * additionally written to the profile log (fe.profile.log) when pushed to `ProfileManager`, as a
+     * single-line JSON record in the same format as the query profile log. This makes load profiles
+     * recoverable from the log even after they are evicted from `ProfileManager`
+     * due to `profile_info_reserved_num`. The profile log is used rather than fe.log because its JSON
+     * layout caps strings at `sys_log_json_profile_max_string_length` instead of the much smaller
+     * `sys_log_json_max_string_length`, so large profiles are not truncated. Only profiles with
+     * QUERY_TYPE = "Load" are printed; query profiles are not affected.
+     * Default value: false
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_print_load_profile_to_log = false;
+
+    /**
      * When the session variable `enable_profile` is set to `false` and `big_query_profile_threshold` is set to 0,
      * the amount of time taken by a load exceeds the default_big_load_profile_threshold_second,
      * a profile is generated for that load.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -38,11 +38,13 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.Gson;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -72,6 +74,12 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
  */
 public class ProfileManager implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(ProfileManager.class);
+    // Dedicated profile logger writing to fe.profile.log, whose JSON layout uses the much larger
+    // sys_log_json_profile_max_string_length cap, so large profiles are not truncated (unlike fe.log,
+    // which caps the JSON message field at sys_log_json_max_string_length).
+    private static final Logger PROFILE_LOG = LogManager.getLogger("profile");
+    // Single-line JSON, matching the query profile log written by StmtExecutor.
+    private static final Gson GSON = new Gson();
     private static ProfileManager INSTANCE = null;
     public static final String QUERY_ID             = ProfileKeyDictionary.QUERY_ID;
     public static final String START_TIME           = ProfileKeyDictionary.START_TIME;
@@ -229,7 +237,56 @@ public class ProfileManager implements MemoryTrackable {
 
         LOG.debug("push profile for query: {}, remove profile for query: {}", queryId, removedQueryId);
 
+        if (Config.enable_print_load_profile_to_log
+                && "Load".equals(element.infoStrings.get(QUERY_TYPE))) {
+            PROFILE_LOG.info(GSON.toJson(buildLoadQueryDetail(element, profileString)));
+        }
+
         return profileString;
+    }
+
+    // Build a QueryDetail for a load profile so it is logged in the same single-line JSON shape as
+    // the query profile log (StmtExecutor). Numeric execution stats that loads do not expose are left
+    // at their defaults, matching how query profiles serialize unavailable values.
+    private static QueryDetail buildLoadQueryDetail(ProfileElement element, String profileString) {
+        Map<String, String> info = element.infoStrings;
+        QueryDetail detail = new QueryDetail();
+        detail.setQueryId(info.get(QUERY_ID));
+        detail.setQuery(false);
+        detail.setStartTime(element.startTimeMs);
+        detail.setEndTime(element.endTimeMs);
+        if (element.startTimeMs > 0 && element.endTimeMs >= element.startTimeMs) {
+            detail.setLatency(element.endTimeMs - element.startTimeMs);
+        }
+        detail.setDatabase(info.get(DEFAULT_DB));
+        detail.setSql(info.get(SQL_STATEMENT));
+        detail.setUser(info.get(USER));
+        if (info.get(WAREHOUSE_CNGROUP) != null) {
+            detail.setWarehouse(info.get(WAREHOUSE_CNGROUP));
+        }
+        detail.setState(toLoadState(info.get(QUERY_STATE)));
+        detail.setProfile(profileString);
+        return detail;
+    }
+
+    // Map the QUERY_STATE string recorded by the various load paths to a QueryMemState. The state field is
+    // kept so downstream consumers of the profile log (e.g. BYOC / manager) that expect it stay compatible.
+    // Spellings differ: stream/routine load use "Finished"/"Aborted", broker load "Finished"/"Running", and
+    // merge commit the upper-case TaskState name ("FINISHED"/"ABORTED"/"CANCELLED"/...); anything not
+    // recognized as terminal success/cancel/abort maps to RUNNING. This mirrors the profile's own QUERY_STATE
+    // (the same value shown by SHOW PROFILELIST). Caveat: LoadLoadingTask records "Finished" from its finally
+    // block even when a broker load failed, so such a load is reported FINISHED here too; fixing that
+    // precisely belongs in the load task that builds the profile, not in this serializer.
+    private static QueryDetail.QueryMemState toLoadState(String state) {
+        if ("Finished".equalsIgnoreCase(state)) {
+            return QueryDetail.QueryMemState.FINISHED;
+        } else if ("Cancelled".equalsIgnoreCase(state)) {
+            return QueryDetail.QueryMemState.CANCELLED;
+        } else if ("Aborted".equalsIgnoreCase(state)) {
+            return QueryDetail.QueryMemState.FAILED;
+        } else {
+            return QueryDetail.QueryMemState.RUNNING;
+        }
     }
 
     public boolean hasProfile(String queryId) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileManagerTest.java
@@ -90,6 +90,49 @@ public class ProfileManagerTest {
         manager.clearProfiles();
     }
 
+    private RuntimeProfile buildLoadProfile(String queryId, String state) {
+        RuntimeProfile profile = new RuntimeProfile("");
+        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        summaryProfile.addInfoString(ProfileManager.QUERY_ID, queryId);
+        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
+        summaryProfile.addInfoString(ProfileManager.QUERY_STATE, state);
+        summaryProfile.addInfoString(ProfileManager.START_TIME, "2024-01-01 10:00:00");
+        summaryProfile.addInfoString(ProfileManager.END_TIME, "2024-01-01 10:00:05");
+        summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, "test_db");
+        summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, "stream load label");
+        summaryProfile.addInfoString(ProfileManager.USER, "root");
+        summaryProfile.addInfoString(ProfileManager.WAREHOUSE_CNGROUP, "default_warehouse");
+        profile.addChild(summaryProfile);
+        return profile;
+    }
+
+    @Test
+    public void testPrintLoadProfileToLog() {
+        ProfileManager manager = ProfileManager.getInstance();
+        boolean original = Config.enable_print_load_profile_to_log;
+        Config.enable_print_load_profile_to_log = true;
+        try {
+            // Each state exercises buildLoadQueryDetail plus one branch of toLoadState:
+            // Finished -> FINISHED, Aborted -> FAILED, CANCELLED -> CANCELLED, Running -> RUNNING (default).
+            String[][] loads = {
+                    {"load-finished", "Finished"},
+                    {"load-aborted", "Aborted"},
+                    {"load-cancelled", "CANCELLED"},
+                    {"load-running", "Running"}};
+            for (String[] load : loads) {
+                manager.pushProfile(null, buildLoadProfile(load[0], load[1]));
+                assertTrue(manager.hasProfile(load[0]), "Load profile should be stored");
+            }
+
+            // A query profile must not take the load-profile log path but is still stored normally.
+            manager.pushProfile(null, buildRuntimeProfile("a-query", "Query"));
+            assertTrue(manager.hasProfile("a-query"), "Query profile should be stored");
+        } finally {
+            Config.enable_print_load_profile_to_log = original;
+            manager.clearProfiles();
+        }
+    }
+
     @Test
     public void testPushExceed() {
         ProfileManager manager = ProfileManager.getInstance();


### PR DESCRIPTION
## Why I'm doing:

Load profiles (stream load, routine load, broker load, merge-commit load) share the **same** in-memory `ProfileManager` store as query profiles. That store is a single `LinkedHashMap` capped by `profile_info_reserved_num` (default 500) and evicted **FIFO across all profile types**. A burst of one type silently evicts the other, and once a profile is evicted it is **unrecoverable** — there is no durable store. This makes it hard to retrieve a useful load profile after the fact.

## What I'm doing:

Add a mutable FE config `enable_print_load_profile_to_log` (default `false`). When enabled, load profiles are additionally printed to `fe.log` at INFO level when they are pushed to `ProfileManager`, so they remain recoverable from the log even after eviction.

- The hook is the single central `ProfileManager.pushProfile`, which already eagerly formats the profile string — so logging reuses that string at no extra cost.
- Only profiles with `QUERY_TYPE = "Load"` (stream/routine/broker/merge load) are printed; query profiles are not affected.
- The default path adds only one config comparison.
- A load profile is printed only when it is actually collected (i.e. `enable_profile = true` or the load crosses the big-load profile threshold), matching the subset `ProfileManager` would otherwise have held.

Docs updated for `FE_parameters` in en/zh/ja.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

> New config `enable_print_load_profile_to_log`, default `false` — behavior is unchanged unless explicitly enabled.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5