### PR TITLE
[BugFix] Do not throw exception in RewriteMultiDistinctRule when cbo_cte_reuse=false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -22,8 +22,6 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.ast.expression.ExprUtils;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -140,12 +138,7 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         boolean hasMultiColumns = distinctAggOperatorList.stream().anyMatch(f -> f.getColumnRefs().size() > 1);
         // exist multiple distinct columns should enable cte use
         if (hasMultiColumns) {
-            if (!context.getSessionVariable().isCboCteReuse()) {
-                throw new StarRocksPlannerException(ErrorType.USER_ERROR,
-                        "%s is unsupported when cbo_cte_reuse is disabled", distinctAggOperatorList);
-            } else {
-                return true;
-            }
+            return context.getSessionVariable().isCboCteReuse();
         }
 
         // respect prefer cte rewrite hint
@@ -185,8 +178,7 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         }
 
         if (!context.getSessionVariable().isCboCteReuse() && !canRewriteByMultiFunc) {
-            throw new StarRocksPlannerException(ErrorType.USER_ERROR,
-                    "%s is unsupported when cbo_cte_reuse is disabled", distinctAggOperatorList);
+            return false;
         }
 
         return !canRewriteByMultiFunc;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -22,6 +22,8 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -178,7 +180,8 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         }
 
         if (!context.getSessionVariable().isCboCteReuse() && !canRewriteByMultiFunc) {
-            return false;
+            throw new StarRocksPlannerException(ErrorType.USER_ERROR,
+                    "%s is unsupported when cbo_cte_reuse is disabled", distinctAggOperatorList);
         }
 
         return !canRewriteByMultiFunc;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -720,6 +720,16 @@ public class AggregateTest extends PlanTestBase {
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 16: k3 <=> 17: k3"), explainString);
+
+        boolean old = connectContext.getSessionVariable().isCboCteReuse();
+        try {
+            connectContext.getSessionVariable().setCboCteReuse(false);
+            explainString = getFragmentPlan(queryStr);
+            Assertions.assertTrue(explainString.contains("output: multi_distinct_count(1: k1, 2: k2), " +
+                    "multi_distinct_count(4: k4)"));
+        } finally {
+            connectContext.getSessionVariable().setCboCteReuse(old);
+        }
     }
 
     @Test


### PR DESCRIPTION

## Why I'm doing:

`java.sql.SQLSyntaxErrorException: [count(distinct 732: spu_id), count(distinct if(733: spu_status = 1, 732: spu_id, null))] is unsupported when cbo_cte_reuse is disabled`

## What I'm doing:

`return false` instead of throw exception.

Sql can actually run and get correct result, be/cn can handle like: multi_distinct(id1, id2)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
