### PR TITLE
[Enhancement] Avoid group by skew optimization when high distinct NDV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctDataSkewEliminateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctDataSkewEliminateRule.java
@@ -69,6 +69,39 @@ public class GroupByCountDistinctDataSkewEliminateRule extends TransformationRul
         return INSTANCE;
     }
 
+    // Returns true when `SplitMultiPhaseAggRule` will pick the 4-stage shuffle-by-(g, d) shape
+    // as the sole alternative and the distinct column already has more distinct values than
+    // the number of buckets. In that case the (g, d) shuffle on its own distributes at least
+    // as well as the salt rewrite, so the rewrite is pure overhead.
+    //
+    // When the alternative may be the 3-stage shuffle-by-(g) shape, we keep the
+    // rewrite as a candidate because a hot value in g would otherwise cause severe runtime skew.
+    // The cost model's existing logic decides between them in that case.
+    private boolean shouldSkipRewriteSinceDistinctDistributedWell(OptExpression input, LogicalAggregationOperator aggOp,
+                                                                  ColumnRefOperator distinctColRef, int bucketNum,
+                                                                  OptimizerContext context) {
+        if (input.getGroupExpression() == null) {
+            return false;
+        }
+        final var inputStats = input.getGroupExpression().inputAt(0).getStatistics();
+        if (inputStats == null) {
+            return false;
+        }
+        final var distinctColStat = inputStats.getColumnStatistic(distinctColRef);
+        if (distinctColStat == null || distinctColStat.isUnknown()) {
+            return false;
+        }
+        if (distinctColStat.getDistinctValuesCount() <= bucketNum) {
+            return false;
+        }
+
+        final var groupKeys = Lists.newArrayList(aggOp.getGroupingKeys());
+        groupKeys.add(distinctColRef);
+        final var partitionBys = aggOp.getGroupingKeys();
+
+        return !SplitMultiPhaseAggRule.isThreeStageMoreEfficient(context.getConnectContext(), input, groupKeys, partitionBys);
+    }
+
     // compute the type of bucket column, since bucket column introduce extra cost, so we
     // choose just wide enough type to keep bucket number.
     private Type pickBucketType(int bucketNum) {
@@ -114,9 +147,13 @@ public class GroupByCountDistinctDataSkewEliminateRule extends TransformationRul
 
         // create auxiliary group-by column:
         // cast(murmur_hash3_32(cast(distinct_column as varchar))%bucketNum as NarrowInteger)
-        int bucketNum = context.getSessionVariable().getDistinctColumnBuckets();
-        // bucketNum ranges from [4, 65536]
-        bucketNum = Math.max(4, Math.min(65536, bucketNum));
+        final int bucketNum = Math.max(4, Math.min(65536, context.getSessionVariable().getDistinctColumnBuckets()));
+
+        if (!aggOp.checkGroupByCountDistinctWithSkewHint()
+                && shouldSkipRewriteSinceDistinctDistributedWell(input, aggOp, distinctColRef, bucketNum, context)) {
+            return Lists.newArrayList();
+        }
+
         ScalarOperator bucketCol = createBucketColumn(distinctColRef, bucketNum);
         ColumnRefOperator bucketColRef =
                 context.getColumnRefFactory().create(bucketCol, bucketCol.getType(), distinctColRef.isNullable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
@@ -392,9 +392,9 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
         return elseOperator;
     }
 
-    private boolean isThreeStageMoreEfficient(ConnectContext connectContext, OptExpression input,
-                                              List<ColumnRefOperator> groupKeys,
-                                              List<ColumnRefOperator> partitionByColumns) {
+    static boolean isThreeStageMoreEfficient(ConnectContext connectContext, OptExpression input,
+                                             List<ColumnRefOperator> groupKeys,
+                                             List<ColumnRefOperator> partitionByColumns) {
         final SessionVariable sv = connectContext.getSessionVariable();
         if (sv.getNewPlannerAggStage() == FOUR_STAGE.ordinal()) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggSkewTest.java
@@ -86,4 +86,91 @@ public class DistinctAggSkewTest extends PlanTestBase {
                 "  |  <slot 3> : 3: value\n" +
                 "  |  <slot 5> : CAST(murmur_hash3_32(CAST(3: value AS VARCHAR)) % 512 AS SMALLINT)");
     }
+
+    @Test
+    void testSkewRewriteNotAppliedWhenDistinctColNdvHighAndShufflesByDistinctCol() throws Exception {
+        // GIVEN
+        // When the distinct column has high NDV (> bucket count) and stage 1 groups by the distinct
+        // column, the standard plan already distributes well via (group, distinct_col) shuffle key.
+        // The bucket rewrite should be penalized so the CBO picks the standard plan.
+        final var sql = "select `group`, count(distinct value) as cnt from null_skew_table group by `group`";
+
+        // Group column is skewed (would normally trigger the rewrite with 0.2 reward)
+        final var skewedGroupStat = ColumnStatistic.builder() //
+                .setNullsFraction(0.8) //
+                .setDistinctValuesCount(2) //
+                .setAverageRowSize(8) //
+                .build();
+        // Distinct column has high NDV (> 1024 bucket count)
+        final var highNdvDistinctStat = ColumnStatistic.builder() //
+                .setNullsFraction(0.0) //
+                .setDistinctValuesCount(10_000_000) //
+                .setAverageRowSize(8) //
+                .build();
+
+        final var table = getOlapTable("null_skew_table");
+
+        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        statisticStorage.addColumnStatistic(table, "group", skewedGroupStat);
+        statisticStorage.addColumnStatistic(table, "value", highNdvDistinctStat);
+
+        try {
+            connectContext.getSessionVariable().setEnableDistinctColumnBucketization(true);
+            connectContext.getSessionVariable().setEnableForceGroupBySkewEliminateWhenSkewed(true);
+            setTableStatistics(table, 10_000_000);
+
+            // WHEN
+            final var plan = getFragmentPlan(sql);
+
+            // THEN
+            assertNotContains(plan, "murmur_hash3_32");
+            assertContains(plan, "HASH_PARTITIONED: 2: group, 3: value");
+        } finally {
+            connectContext.getSessionVariable().setEnableDistinctColumnBucketization(false);
+            connectContext.getSessionVariable().setEnableForceGroupBySkewEliminateWhenSkewed(false);
+        }
+    }
+
+    @Test
+    void testSkewRewriteAppliedWhenDistinctColNdvLow() throws Exception {
+        // GIVEN
+        // When the distinct column has low NDV (<= bucket count), the standard plan's shuffle by
+        // (group, distinct_col) doesn't provide good distribution. The bucket rewrite should still
+        // be applied when group-by columns are skewed.
+        final var sql = "select `group`, count(distinct value) as cnt from null_skew_table group by `group`";
+
+        // Group column is skewed
+        final var skewedGroupStat = ColumnStatistic.builder() //
+                .setNullsFraction(0.8) //
+                .setDistinctValuesCount(2) //
+                .setAverageRowSize(8) //
+                .build();
+        // Distinct column has low NDV (<= 1024 bucket count)
+        final var lowNdvDistinctStat = ColumnStatistic.builder() //
+                .setNullsFraction(0.0) //
+                .setDistinctValuesCount(500) //
+                .setAverageRowSize(8) //
+                .build();
+
+        final var table = getOlapTable("null_skew_table");
+
+        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        statisticStorage.addColumnStatistic(table, "group", skewedGroupStat);
+        statisticStorage.addColumnStatistic(table, "value", lowNdvDistinctStat);
+
+        try {
+            connectContext.getSessionVariable().setEnableDistinctColumnBucketization(true);
+            connectContext.getSessionVariable().setEnableForceGroupBySkewEliminateWhenSkewed(true);
+            setTableStatistics(table, 10_000_000);
+
+            // WHEN
+            final var plan = getFragmentPlan(sql);
+
+            // THEN
+            assertContains(plan, "murmur_hash3_32");
+        } finally {
+            connectContext.getSessionVariable().setEnableDistinctColumnBucketization(false);
+            connectContext.getSessionVariable().setEnableForceGroupBySkewEliminateWhenSkewed(false);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -534,12 +534,20 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
     }
 
     @Test
-    public void testGroupByDistinctColumnOptimization() throws Exception {
+    public void testGroupByDistinctColumnOptimizationNotTriggeredOnHighDistinctColNDV() throws Exception {
+        // Rationale for the negative assertion: in #17643 (Mar 2023) the salt rewrite was strictly
+        // better than the only available alternative (3-stage shuffle-by groups). After
+        // #39556 (Feb 2024) introduced the 4-stage shuffle-by (groups, distinct col) alternative, that alternative now
+        // covers the same distribution case with one fewer shuffle meaning in this case the rewrite should not be applied.
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/group_by_count_distinct_optimize"), null,
                         TExplainLevel.NORMAL);
-        Assertions.assertTrue(
+        Assertions.assertFalse(
                 replayPair.second.contains("CAST(murmur_hash3_32(CAST(42: case AS VARCHAR)) % 512 AS SMALLINT)"),
+                replayPair.second);
+        // Since we shuffle by (year, case) and case has a high NDV, we get uniformly distributed partitions
+        Assertions.assertTrue(
+                replayPair.second.contains("HASH_PARTITIONED: 39: year, 42: case"),
                 replayPair.second);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Currently, when `enableDistinctColumnBucketization` is true and all group by columns are skewed (or we have low cardinality), we rewrite the plan from
- (a) a 3-stage-agg: shuffle (groups), distinct global agg, global agg
- (b) a 4-stage-agg: shuffle (groups, distinct col), distinct global, local agg, shuffle (groups), local agg

to a 4-stage-agg: shuffle (groups, salting col), agg, agg, shuffle (groups)

In case (b), if `distinct col` already has a high NDV the original 4-stage-agg plan provides good distribution. Adding the salt rewrite here can even hurt the query performance because we have to compute the hash, it adds an extra agg and shuffle without making the distribution better (+ `multi_distinct_count` has to consider another dedup state due to the salting). We had a case where the rewrite caused 3x peak memory and almost 4x query runtime compared to the normal 4-stage-agg plan.

## What I'm doing:

Therefore, I am adding a guard in `GroupByCountDistinctDataSkewEliminateRule` that prevents the rewrite from application if we have a high NDV distinct column and the 3-stage-agg is _not_ an option (hence we have to decide between the 4-stage-agg and the 4-stage-agg with salting). In this case we rather want to apply the normal 4-stage-agg without salting.
 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
