### PR TITLE
[BugFix] Fix variant paths for struct casts with special chars

### DIFF
--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -261,13 +261,14 @@ public:
     CastVariantToStruct(const TExprNode& node, std::vector<Expr*> field_casts)
             : Expr(node), _field_casts(std::move(field_casts)) {
         _variant_paths.reserve(_type.field_names.size());
-        for (int i = 0; i < _type.field_names.size(); i++) {
-            std::string path_string = "$." + _type.field_names[i];
-            auto res = VariantPathParser::parse(Slice(path_string));
-            if (!res.ok()) {
-                throw std::runtime_error("Failed to parse variant path: " + path_string);
-            }
-            _variant_paths.emplace_back(res.value());
+        for (const auto& field_name : _type.field_names) {
+            // Each struct field maps directly to a top-level object key of the variant.
+            // Build the path segment straight from the field name instead of formatting it
+            // into a "$.<name>" string and re-parsing it. Re-parsing rejects field names
+            // that are not "simple keys" (anything outside [a-zA-Z0-9_], e.g. a leading
+            // '$' or an embedded '.'), even though such names are perfectly valid object
+            // keys, e.g. STRUCT<`$currency` STRING>.
+            _variant_paths.emplace_back(std::vector<VariantSegment>{VariantSegment::make_object(field_name)});
         }
     }
 

--- a/be/test/column/variant_path_parser_test.cpp
+++ b/be/test/column/variant_path_parser_test.cpp
@@ -435,9 +435,8 @@ TEST_F(VariantPathTest, ParseQuotedKeyWithSpecialChars) {
         std::vector<std::string> keys; // expected object-segment keys, in order
     };
     const std::vector<Case> cases = {
-            {"$['$currency']", {"$currency"}},      {R"($["$amount"])", {"$amount"}},
-            {"$['a.b']", {"a.b"}},                  {"$['a[0]b']", {"a[0]b"}},
-            {"$.outer['$inner']", {"outer", "$inner"}},
+            {"$['$currency']", {"$currency"}}, {R"($["$amount"])", {"$amount"}},           {"$['a.b']", {"a.b"}},
+            {"$['a[0]b']", {"a[0]b"}},         {"$.outer['$inner']", {"outer", "$inner"}},
     };
     for (const auto& c : cases) {
         auto result = VariantPathParser::parse(c.path);
@@ -459,10 +458,10 @@ TEST_F(VariantPathTest, ParseQuotedKeyEscapeSequences) {
         std::string key;
     };
     const std::vector<Case> cases = {
-            {R"($['a\'b'])", "a'b"},             // escaped single quote
-            {R"($['a\\b'])", "a\\b"},            // escaped backslash -> a<backslash>b
-            {R"($["a\"b"])", "a\"b"},            // escaped double quote
-            {R"($['tab\theld'])", "tab\theld"},  // \t -> tab character
+            {R"($['a\'b'])", "a'b"},            // escaped single quote
+            {R"($['a\\b'])", "a\\b"},           // escaped backslash -> a<backslash>b
+            {R"($["a\"b"])", "a\"b"},           // escaped double quote
+            {R"($['tab\theld'])", "tab\theld"}, // \t -> tab character
     };
     for (const auto& c : cases) {
         auto result = VariantPathParser::parse(c.path);

--- a/be/test/column/variant_path_parser_test.cpp
+++ b/be/test/column/variant_path_parser_test.cpp
@@ -426,4 +426,77 @@ TEST_F(VariantPathTest, IsAncestorOrSame) {
     EXPECT_FALSE(xy->is_ancestor_or_same(*ab));
 }
 
+// Bracket/quoted notation accepts keys that dot-notation cannot express ('$', '.', '[', ...).
+// This is the escape hatch a correct path builder must use for arbitrary object keys; it is
+// exactly what dot-notation ("$.<name>") fails to handle for names like "$currency".
+TEST_F(VariantPathTest, ParseQuotedKeyWithSpecialChars) {
+    struct Case {
+        std::string path;
+        std::vector<std::string> keys; // expected object-segment keys, in order
+    };
+    const std::vector<Case> cases = {
+            {"$['$currency']", {"$currency"}},      {R"($["$amount"])", {"$amount"}},
+            {"$['a.b']", {"a.b"}},                  {"$['a[0]b']", {"a[0]b"}},
+            {"$.outer['$inner']", {"outer", "$inner"}},
+    };
+    for (const auto& c : cases) {
+        auto result = VariantPathParser::parse(c.path);
+        ASSERT_TRUE(result.ok()) << "should parse: " << c.path;
+        const auto& segs = result.value().segments;
+        ASSERT_EQ(segs.size(), c.keys.size()) << "path: " << c.path;
+        for (size_t i = 0; i < segs.size(); ++i) {
+            EXPECT_TRUE(segs[i].is_object()) << "path: " << c.path << " seg " << i;
+            EXPECT_EQ(segs[i].get_key(), c.keys[i]) << "path: " << c.path << " seg " << i;
+        }
+    }
+}
+
+// Escape sequences inside quoted keys are unescaped by the parser (raw strings keep the
+// backslashes literal in the path under test).
+TEST_F(VariantPathTest, ParseQuotedKeyEscapeSequences) {
+    struct Case {
+        std::string path;
+        std::string key;
+    };
+    const std::vector<Case> cases = {
+            {R"($['a\'b'])", "a'b"},             // escaped single quote
+            {R"($['a\\b'])", "a\\b"},            // escaped backslash -> a<backslash>b
+            {R"($["a\"b"])", "a\"b"},            // escaped double quote
+            {R"($['tab\theld'])", "tab\theld"},  // \t -> tab character
+    };
+    for (const auto& c : cases) {
+        auto result = VariantPathParser::parse(c.path);
+        ASSERT_TRUE(result.ok()) << "should parse: " << c.path;
+        ASSERT_EQ(result.value().segments.size(), 1u) << "path: " << c.path;
+        EXPECT_TRUE(result.value().segments[0].is_object());
+        EXPECT_EQ(result.value().segments[0].get_key(), c.key) << "path: " << c.path;
+    }
+}
+
+// Multibyte (UTF-8) keys survive via quoted notation; dot-notation only allows ASCII [A-Za-z0-9_].
+TEST_F(VariantPathTest, ParseQuotedKeyUnicode) {
+    auto result = VariantPathParser::parse(std::string("$['naïve_名前']"));
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(result.value().segments.size(), 1u);
+    EXPECT_TRUE(result.value().segments[0].is_object());
+    EXPECT_EQ(result.value().segments[0].get_key(), "naïve_名前");
+}
+
+// Paths the grammar must reject. Documents the limits of dot-notation, the numeric-only
+// array-index rule, index overflow, and that '$[*]' wildcard is intentionally unsupported
+// (unlike the JSON path grammar).
+TEST_F(VariantPathTest, RejectsMalformedPaths) {
+    const std::vector<std::string> invalid = {
+            "$.a.$b",                  // '$' after '.' is not a simple key
+            "$[*]",                    // wildcard not supported
+            "$[-1]",                   // negative array index
+            "$..a",                    // empty key between dots
+            "$.a.",                    // trailing dot
+            "$[99999999999999999999]", // array index overflow
+    };
+    for (const auto& p : invalid) {
+        EXPECT_FALSE(VariantPathParser::parse(p).ok()) << "should reject: " << p;
+    }
+}
+
 } // namespace starrocks

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2935,8 +2935,7 @@ TEST_F(VectorizedCastExprTest, variant_cast_to_struct_with_special_char_field_na
     {
         // Field name starting with '$' (the exact case from the bug report).
         auto const_variant = make_const_variant_column_from_json(R"({"$currency":"USD"})", kInputSize);
-        auto result =
-                cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"$currency"}), const_variant);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"$currency"}), const_variant);
         assert_const_or_expanded_result(result, kInputSize, "{$currency:'USD'}");
     }
     {

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2923,6 +2923,100 @@ TEST_F(VectorizedCastExprTest, const_variant_cast_to_complex_types) {
     }
 }
 
+// Regression test: casting a VARIANT to a STRUCT whose field name is not a "simple key"
+// (anything outside [a-zA-Z0-9_]) must not abort the BE. CastVariantToStruct used to format
+// each field name into a "$.<name>" path string and re-parse it; the variant path parser
+// rejects such names, so the constructor threw "Failed to parse variant path: $.$currency"
+// and crashed the backend.
+// Repro SQL:
+//   SELECT CAST(CAST(PARSE_JSON('{"$currency": "USD"}') AS VARIANT) AS STRUCT<`$currency` STRING>);
+TEST_F(VectorizedCastExprTest, variant_cast_to_struct_with_special_char_field_name) {
+    constexpr size_t kInputSize = 3;
+    {
+        // Field name starting with '$' (the exact case from the bug report).
+        auto const_variant = make_const_variant_column_from_json(R"({"$currency":"USD"})", kInputSize);
+        auto result =
+                cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"$currency"}), const_variant);
+        assert_const_or_expanded_result(result, kInputSize, "{$currency:'USD'}");
+    }
+    {
+        // Field name containing '.' is likewise not a simple key; it must be treated as a
+        // single top-level object key rather than a nested "a -> b" path.
+        auto const_variant = make_const_variant_column_from_json(R"({"a.b":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a.b"}), const_variant);
+        assert_const_or_expanded_result(result, kInputSize, "{a.b:'v'}");
+    }
+}
+
+// Further non-simple struct field names: space, brackets, quote, multibyte. With the old
+// "$.<name>" + reparse approach, space/quote aborted the BE and brackets silently mis-resolved.
+TEST_F(VectorizedCastExprTest, variant_cast_to_struct_more_special_field_names) {
+    constexpr size_t kInputSize = 2;
+    {
+        auto cv = make_const_variant_column_from_json(R"({"a b":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a b"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{a b:'v'}");
+    }
+    {
+        auto cv = make_const_variant_column_from_json(R"({"a[0]":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a[0]"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{a[0]:'v'}");
+    }
+    {
+        auto cv = make_const_variant_column_from_json(R"({"a'b":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a'b"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{a'b:'v'}");
+    }
+    {
+        auto cv = make_const_variant_column_from_json(R"({"名前":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"名前"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{名前:'v'}");
+    }
+}
+
+// Parity with the JSON->struct edge cases: a field absent from the variant object, and a
+// field whose value is JSON null, both yield NULL (no error).
+TEST_F(VectorizedCastExprTest, variant_cast_to_struct_missing_and_null_fields) {
+    constexpr size_t kInputSize = 2;
+    {
+        // 'missing' is not present in the object.
+        auto cv = make_const_variant_column_from_json(R"({"x":1})", kInputSize);
+        auto result = cast_from_variant(
+                gen_struct_type_desc({TPrimitiveType::INT, TPrimitiveType::INT}, {"x", "missing"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{x:1,missing:NULL}");
+    }
+    {
+        // 'x' is present but its value is JSON null.
+        auto cv = make_const_variant_column_from_json(R"({"x":null})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::INT}, {"x"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{x:NULL}");
+    }
+}
+
+// A variant whose root is not an object (array or scalar) cast to a struct yields a NULL row.
+TEST_F(VectorizedCastExprTest, variant_cast_non_object_to_struct_returns_null) {
+    constexpr size_t kInputSize = 3;
+    for (const std::string& json : {std::string(R"([1,2])"), std::string("5")}) {
+        auto cv = make_const_variant_column_from_json(json, kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::INT}, {"x"}), cv);
+        ASSERT_TRUE(result->size() == 1 || result->size() == kInputSize);
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_TRUE(result->is_null(i)) << "json: " << json << " row " << i;
+        }
+    }
+}
+
+// Recursion: a nested struct field with a non-simple ('$') field name must work at every
+// level. Each nested CastVariantToStruct builds its own single-key path independently.
+TEST_F(VectorizedCastExprTest, variant_cast_to_nested_struct_with_special_field_name) {
+    constexpr size_t kInputSize = 2;
+    auto cv = make_const_variant_column_from_json(R"({"inner":{"$x":5}})", kInputSize);
+    TypeDescriptor inner = TypeDescriptor::create_struct_type({"$x"}, {TypeDescriptor(TYPE_INT)});
+    TypeDescriptor outer = TypeDescriptor::create_struct_type({"inner"}, {inner});
+    auto result = cast_from_variant(outer.to_thrift(), cv);
+    assert_const_or_expanded_result(result, kInputSize, "{inner:{$x:5}}");
+}
+
 // Verifies root typed-only scalar variant uses fast path for same-type cast and preserves null behavior.
 TEST_F(VectorizedCastExprTest, root_typed_only_scalar_cast_from_variant) {
     auto variant_col = make_root_typed_only_variant_bigint_column({7, 0, -3}, {0, 1, 0});

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2998,6 +2998,100 @@ TEST_F(VectorizedCastExprTest, const_variant_cast_to_complex_types) {
     }
 }
 
+// Regression test: casting a VARIANT to a STRUCT whose field name is not a "simple key"
+// (anything outside [a-zA-Z0-9_]) must not abort the BE. CastVariantToStruct used to format
+// each field name into a "$.<name>" path string and re-parse it; the variant path parser
+// rejects such names, so the constructor threw "Failed to parse variant path: $.$currency"
+// and crashed the backend.
+// Repro SQL:
+//   SELECT CAST(CAST(PARSE_JSON('{"$currency": "USD"}') AS VARIANT) AS STRUCT<`$currency` STRING>);
+TEST_F(VectorizedCastExprTest, variant_cast_to_struct_with_special_char_field_name) {
+    constexpr size_t kInputSize = 3;
+    {
+        // Field name starting with '$' (the exact case from the bug report).
+        auto const_variant = make_const_variant_column_from_json(R"({"$currency":"USD"})", kInputSize);
+        auto result =
+                cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"$currency"}), const_variant);
+        assert_const_or_expanded_result(result, kInputSize, "{$currency:'USD'}");
+    }
+    {
+        // Field name containing '.' is likewise not a simple key; it must be treated as a
+        // single top-level object key rather than a nested "a -> b" path.
+        auto const_variant = make_const_variant_column_from_json(R"({"a.b":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a.b"}), const_variant);
+        assert_const_or_expanded_result(result, kInputSize, "{a.b:'v'}");
+    }
+}
+
+// Further non-simple struct field names: space, brackets, quote, multibyte. With the old
+// "$.<name>" + reparse approach, space/quote aborted the BE and brackets silently mis-resolved.
+TEST_F(VectorizedCastExprTest, variant_cast_to_struct_more_special_field_names) {
+    constexpr size_t kInputSize = 2;
+    {
+        auto cv = make_const_variant_column_from_json(R"({"a b":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a b"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{a b:'v'}");
+    }
+    {
+        auto cv = make_const_variant_column_from_json(R"({"a[0]":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a[0]"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{a[0]:'v'}");
+    }
+    {
+        auto cv = make_const_variant_column_from_json(R"({"a'b":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"a'b"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{a'b:'v'}");
+    }
+    {
+        auto cv = make_const_variant_column_from_json(R"({"名前":"v"})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"名前"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{名前:'v'}");
+    }
+}
+
+// Parity with the JSON->struct edge cases: a field absent from the variant object, and a
+// field whose value is JSON null, both yield NULL (no error).
+TEST_F(VectorizedCastExprTest, variant_cast_to_struct_missing_and_null_fields) {
+    constexpr size_t kInputSize = 2;
+    {
+        // 'missing' is not present in the object.
+        auto cv = make_const_variant_column_from_json(R"({"x":1})", kInputSize);
+        auto result = cast_from_variant(
+                gen_struct_type_desc({TPrimitiveType::INT, TPrimitiveType::INT}, {"x", "missing"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{x:1,missing:NULL}");
+    }
+    {
+        // 'x' is present but its value is JSON null.
+        auto cv = make_const_variant_column_from_json(R"({"x":null})", kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::INT}, {"x"}), cv);
+        assert_const_or_expanded_result(result, kInputSize, "{x:NULL}");
+    }
+}
+
+// A variant whose root is not an object (array or scalar) cast to a struct yields a NULL row.
+TEST_F(VectorizedCastExprTest, variant_cast_non_object_to_struct_returns_null) {
+    constexpr size_t kInputSize = 3;
+    for (const std::string& json : {std::string(R"([1,2])"), std::string("5")}) {
+        auto cv = make_const_variant_column_from_json(json, kInputSize);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::INT}, {"x"}), cv);
+        ASSERT_TRUE(result->size() == 1 || result->size() == kInputSize);
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_TRUE(result->is_null(i)) << "json: " << json << " row " << i;
+        }
+    }
+}
+
+// Recursion: a nested struct field with a non-simple ('$') field name must work at every
+// level. Each nested CastVariantToStruct builds its own single-key path independently.
+TEST_F(VectorizedCastExprTest, variant_cast_to_nested_struct_with_special_field_name) {
+    constexpr size_t kInputSize = 2;
+    auto cv = make_const_variant_column_from_json(R"({"inner":{"$x":5}})", kInputSize);
+    TypeDescriptor inner = TypeDescriptor::create_struct_type({"$x"}, {TypeDescriptor(TYPE_INT)});
+    TypeDescriptor outer = TypeDescriptor::create_struct_type({"inner"}, {inner});
+    auto result = cast_from_variant(outer.to_thrift(), cv);
+    assert_const_or_expanded_result(result, kInputSize, "{inner:{$x:5}}");
+}
+
 // Verifies root typed-only scalar variant uses fast path for same-type cast and preserves null behavior.
 TEST_F(VectorizedCastExprTest, root_typed_only_scalar_cast_from_variant) {
     auto variant_col = make_root_typed_only_variant_bigint_column({7, 0, -3}, {0, 1, 0});

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -3010,8 +3010,7 @@ TEST_F(VectorizedCastExprTest, variant_cast_to_struct_with_special_char_field_na
     {
         // Field name starting with '$' (the exact case from the bug report).
         auto const_variant = make_const_variant_column_from_json(R"({"$currency":"USD"})", kInputSize);
-        auto result =
-                cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"$currency"}), const_variant);
+        auto result = cast_from_variant(gen_struct_type_desc({TPrimitiveType::VARCHAR}, {"$currency"}), const_variant);
         assert_const_or_expanded_result(result, kInputSize, "{$currency:'USD'}");
     }
     {


### PR DESCRIPTION
## Why I'm doing:
Variant to struct casting currently breaks if there are certain characters in the field name. 
## What I'm doing:

**Fix**: In the CastVariantToStruct constructor (cast_expr.h:264), instead of formatting each struct field name into a "$." + name string and re-parsing it through VariantPathParser, build the path segment directly:

```
_variant_paths.emplace_back(std::vector<VariantSegment>{VariantSegment::make_object(field_name)});
```
**Why it works**: The crash came from the re-parse step — the variant path parser only accepts "simple" unquoted keys ([a-zA-Z0-9_]), so a field name like $currency produced the unparseable $.$currency. Building the segment directly treats the entire field name as one literal object key, so there's no string to parse and nothing to reject — it's correct for $, ., quotes, unicode, any key.

I added test cases for this and also expanded the test coverage for variant parsing in general

Fixes #74122

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
