### PR TITLE
[BugFix] Skip null rows when merging a nullable immediate agg-state column

### DIFF
--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -431,11 +431,22 @@ public:
     void merge_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
                      AggDataPtr* states) const override {
         if (!this->support_nullable_immediate_input() && column->is_nullable()) {
-            NullableColumn* nullable_column = down_cast<NullableColumn*>(const_cast<Column*>(column));
-            DCHECK_EQ(false, nullable_column->has_null());
-            auto* data_column = nullable_column->data_column().get();
-            for (size_t i = 0; i < chunk_size; ++i) {
-                static_cast<const Derived*>(this)->merge(ctx, data_column, states[i] + state_offset, i);
+            const auto* nullable_column = down_cast<const NullableColumn*>(column);
+            const auto* data_column = nullable_column->data_column().get();
+            // The immediate-state column may carry real nulls, e.g. an agg_state column
+            // produced from NULL source rows. Skip null rows instead of feeding an
+            // invalid/empty state into the nested merge. See StarRocksTest issue #11379.
+            if (nullable_column->has_null()) {
+                const auto& null_data = nullable_column->immutable_null_column_data();
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    if (!null_data[i]) {
+                        static_cast<const Derived*>(this)->merge(ctx, data_column, states[i] + state_offset, i);
+                    }
+                }
+            } else {
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    static_cast<const Derived*>(this)->merge(ctx, data_column, states[i] + state_offset, i);
+                }
             }
         } else {
             for (size_t i = 0; i < chunk_size; ++i) {
@@ -455,10 +466,21 @@ public:
         };
 
         if (!this->support_nullable_immediate_input() && column->is_nullable()) {
-            NullableColumn* nullable_column = down_cast<NullableColumn*>(const_cast<Column*>(column));
-            DCHECK_EQ(false, nullable_column->has_null());
-            auto* data_column = nullable_column->data_column().get();
-            merge_selectively(data_column);
+            const auto* nullable_column = down_cast<const NullableColumn*>(column);
+            const auto* data_column = nullable_column->data_column().get();
+            // The immediate-state column may carry real nulls, e.g. an agg_state column
+            // produced from NULL source rows. Skip null rows instead of feeding an
+            // invalid/empty state into the nested merge. See StarRocksTest issue #11379.
+            if (nullable_column->has_null()) {
+                const auto& null_data = nullable_column->immutable_null_column_data();
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    if (filter[i] == 0 && !null_data[i]) {
+                        static_cast<const Derived*>(this)->merge(ctx, data_column, states[i] + state_offset, i);
+                    }
+                }
+            } else {
+                merge_selectively(data_column);
+            }
         } else {
             merge_selectively(column);
         }
@@ -467,11 +489,22 @@ public:
     void merge_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column* input, size_t start,
                                   size_t size) const override {
         if (!this->support_nullable_immediate_input() && input->is_nullable()) {
-            NullableColumn* nullable_column = down_cast<NullableColumn*>(const_cast<Column*>(input));
-            DCHECK_EQ(false, nullable_column->has_null());
-            auto* data_column = nullable_column->data_column().get();
-            for (size_t i = start; i < start + size; ++i) {
-                static_cast<const Derived*>(this)->merge(ctx, data_column, state, i);
+            const auto* nullable_column = down_cast<const NullableColumn*>(input);
+            const auto* data_column = nullable_column->data_column().get();
+            // The immediate-state column may carry real nulls, e.g. an agg_state column
+            // produced from NULL source rows. Skip null rows instead of feeding an
+            // invalid/empty state into the nested merge. See StarRocksTest issue #11379.
+            if (nullable_column->has_null()) {
+                const auto& null_data = nullable_column->immutable_null_column_data();
+                for (size_t i = start; i < start + size; ++i) {
+                    if (!null_data[i]) {
+                        static_cast<const Derived*>(this)->merge(ctx, data_column, state, i);
+                    }
+                }
+            } else {
+                for (size_t i = start; i < start + size; ++i) {
+                    static_cast<const Derived*>(this)->merge(ctx, data_column, state, i);
+                }
             }
         } else {
             for (size_t i = start; i < start + size; ++i) {

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -2911,4 +2911,92 @@ TEST_F(AggregateTest, test_ds_theta_count_distinct) {
     ASSERT_EQ(5, result_column->get_data()[0]);
 }
 
+// ============================================================================
+// Regression tests for StarRocksTest issue #11379:
+// BE crash during memtable-flush aggregation of an agg_state column whose
+// aggregate function has support_nullable_immediate_input() == false (e.g. a
+// not-null ds_hll_count_distinct agg_state column), when the intermediate-state
+// column actually carries nulls.
+//
+// In that case the merge_batch* paths in AggregateFunctionBatchHelper take the
+// "non-nullable function + nullable immediate input" branch. That branch used to
+// assume the column has no nulls (DCHECK_EQ(false, has_null())), strip the null
+// wrapper and merge every row. When the immediate-state column actually contains
+// nulls this aborts under ASAN/Debug ("Check failed: false == has_null()"), or
+// feeds a null/empty slice into the nested merge under Release (SIGSEGV). After
+// the fix, null rows in the immediate-state column must be skipped.
+//
+// `sum` is used because it has support_nullable_immediate_input() == false. The
+// null row carries a non-zero value (999) so that merging it by mistake corrupts
+// the result (10 + 999 + 20 instead of 10 + 20).
+// ============================================================================
+static ColumnPtr make_nullable_state_column_with_null() {
+    auto data_column = Int64Column::create();
+    data_column->append(10);
+    data_column->append(999); // value on the null row; must NOT be merged
+    data_column->append(20);
+    auto null_column = NullColumn::create();
+    null_column->append(0);
+    null_column->append(1); // row 1 is null
+    null_column->append(0);
+    auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    nullable_column->set_has_null(true);
+    return nullable_column;
+}
+
+TEST_F(AggregateTest, test_merge_batch_single_state_skips_null_immediate_state) {
+    const AggregateFunction* func = get_aggregate_function("sum", TYPE_BIGINT, TYPE_BIGINT, false);
+    ASSERT_FALSE(func->support_nullable_immediate_input());
+
+    auto nullable_column = make_nullable_state_column_with_null();
+    auto state = ManagedAggrState::create(ctx, func);
+    func->merge_batch_single_state(ctx, state->state(), nullable_column.get(), 0, nullable_column->size());
+
+    auto result = Int64Column::create();
+    func->finalize_to_column(ctx, state->state(), result.get());
+    ASSERT_EQ(30, result->get_data()[0]); // 10 + 20, not 10 + 999 + 20
+}
+
+TEST_F(AggregateTest, test_merge_batch_skips_null_immediate_state) {
+    const AggregateFunction* func = get_aggregate_function("sum", TYPE_BIGINT, TYPE_BIGINT, false);
+
+    auto nullable_column = make_nullable_state_column_with_null();
+    auto s0 = ManagedAggrState::create(ctx, func);
+    auto s1 = ManagedAggrState::create(ctx, func);
+    auto s2 = ManagedAggrState::create(ctx, func);
+    std::vector<AggDataPtr> states{s0->state(), s1->state(), s2->state()};
+
+    func->merge_batch(ctx, nullable_column->size(), 0, nullable_column.get(), states.data());
+
+    auto result = Int64Column::create();
+    func->finalize_to_column(ctx, s0->state(), result.get());
+    func->finalize_to_column(ctx, s1->state(), result.get());
+    func->finalize_to_column(ctx, s2->state(), result.get());
+    ASSERT_EQ(10, result->get_data()[0]);
+    ASSERT_EQ(0, result->get_data()[1]); // null row skipped, state untouched
+    ASSERT_EQ(20, result->get_data()[2]);
+}
+
+TEST_F(AggregateTest, test_merge_batch_selectively_skips_null_immediate_state) {
+    const AggregateFunction* func = get_aggregate_function("sum", TYPE_BIGINT, TYPE_BIGINT, false);
+
+    auto nullable_column = make_nullable_state_column_with_null();
+    auto s0 = ManagedAggrState::create(ctx, func);
+    auto s1 = ManagedAggrState::create(ctx, func);
+    auto s2 = ManagedAggrState::create(ctx, func);
+    std::vector<AggDataPtr> states{s0->state(), s1->state(), s2->state()};
+    Filter filter;
+    filter.resize(3, 0); // all selected; the null row must still be skipped
+
+    func->merge_batch_selectively(ctx, nullable_column->size(), 0, nullable_column.get(), states.data(), filter);
+
+    auto result = Int64Column::create();
+    func->finalize_to_column(ctx, s0->state(), result.get());
+    func->finalize_to_column(ctx, s1->state(), result.get());
+    func->finalize_to_column(ctx, s2->state(), result.get());
+    ASSERT_EQ(10, result->get_data()[0]);
+    ASSERT_EQ(0, result->get_data()[1]);
+    ASSERT_EQ(20, result->get_data()[2]);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
BE crashes during memtable-flush aggregation of an `agg_state` column. Two crash signatures were observed:
- **ASAN/Debug**: `Check failed: false == nullable_column->has_null()` inside `AggStateUnion::merge_batch_single_state`, reproduced by a `ds_hll_count_distinct` agg_state table.
- **Release**: SIGSEGV in the nested sketch / percentile `merge`.

Both come from the storage-side aggregation path (`MemTable::_aggregate` → `ChunkAggregator` → `AggFuncBasedValueAggregator` → agg-state combinator merge) on the async `AsyncDeltaWriter` flush thread, which is why it was hard to reproduce by hand.

## What I'm doing:
`AggregateFunctionBatchHelper::merge_batch` / `merge_batch_selectively` / `merge_batch_single_state` have a branch for `!support_nullable_immediate_input() && column->is_nullable()`. It assumed the (nullable-typed) intermediate-state column never actually contains nulls (`DCHECK_EQ(false, has_null())`), stripped the null wrapper and merged every row. When an agg_state column genuinely carries nulls (produced from NULL source rows), this aborts under ASAN/Debug and feeds a null/empty slice into the nested merge under Release, crashing the BE.

This PR makes those three paths **skip null rows** in the immediate-state column (matching the single-row `NullableAggregateFunctionBase::merge` semantics) instead of asserting/merging them.

Scope: fixes the crash on the `support_nullable_immediate_input() == false` branch (e.g. not-null `ds_hll` / `ds_theta` agg_state columns). A separate crash on the nullable (`else`) branch for `percentile_approx_weighted` is tracked separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
