### PR TITLE
[BugFix] Fix count on iceberg tables for rewriting simple agg to hdfs…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -123,7 +123,7 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             // generate a placeholder column for scan node.
             // ___count___ must be the column name for backend code.
             String metaColumnName = "___" + aggCall.getFnName() + "___";
-            Column c = new Column(metaColumnName, NullType.NULL);
+            Column c = new Column(metaColumnName, IntegerType.BIGINT);
             c.setIsAllowNull(true);
             ColumnRefOperator placeholderColumn =
                     columnRefFactory.create(metaColumnName, aggCall.getType(), aggCall.isNullable());


### PR DESCRIPTION
We encountered a bug where counts on very large iceberg tables would fail. More details in the issue. 

## Why I'm doing:
Fixing the issue.

## What I'm doing:
Changing the slot type for the ___count___ value returned from the RewriteSimpleAggToHDFSScanRule from Null to BigINT so that it aligns with the actual type.

Fixes #74174

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
