### PR TITLE
[Refactor] Centralize L2/L3 cache-size fallbacks in CpuInfo and size agg two-level by L3

### DIFF
--- a/be/src/common/system/cpu_info.h
+++ b/be/src/common/system/cpu_info.h
@@ -89,13 +89,19 @@ public:
 
     static long get_l2_cache_size() {
         const auto& cache_sizes = CpuInfo::get_cache_sizes();
-        return cache_sizes[CpuInfo::L2_CACHE] ? cache_sizes[CpuInfo::L2_CACHE] : DEFAULT_L2_CACHE_SIZE;
+        return cache_sizes[CpuInfo::L2_CACHE] > 0 ? cache_sizes[CpuInfo::L2_CACHE] : DEFAULT_L2_CACHE_SIZE;
     }
 
+    // Returns the size of the last-level cache. A CPU with no shared L3 (e.g.
+    // ARM Cortex-A, some small x86) still reports a real L2, which is then the
+    // last-level cache, so fall back to it; fall back to a fixed default only
+    // when neither level is reported (cache info unreadable). Always positive,
+    // so callers can use the result directly without re-guarding it.
     static long get_l3_cache_size() {
-        auto& cache_sizes = get_cache_sizes();
-        return cache_sizes[CacheLevel::L3_CACHE] ? cache_sizes[CacheLevel::L3_CACHE]
-                                                 : cache_sizes[CacheLevel::L2_CACHE];
+        const auto& cache_sizes = CpuInfo::get_cache_sizes();
+        if (cache_sizes[CpuInfo::L3_CACHE] > 0) return cache_sizes[CpuInfo::L3_CACHE];
+        if (cache_sizes[CpuInfo::L2_CACHE] > 0) return cache_sizes[CpuInfo::L2_CACHE];
+        return DEFAULT_L3_CACHE_SIZE;
     }
 
     static std::vector<size_t> get_core_ids();
@@ -124,6 +130,7 @@ private:
     static int64_t _parse_cpu_flags(const std::string& values);
 
     static constexpr size_t DEFAULT_L2_CACHE_SIZE = 1 * 1024 * 1024;
+    static constexpr size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
 
     /// Initialize NUMA-related state - called from Init();
     static void _init_numa();

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -164,7 +164,7 @@ Status init_udaf_context(int64_t fid, const std::string& url, const std::string&
 
 int64_t Aggregator::get_two_level_threahold() {
     if (config::two_level_memory_threshold < 0) {
-        return agg::two_level_memory_threshold;
+        return agg::two_level_memory_threshold();
     }
     return config::two_level_memory_threshold;
 }

--- a/be/src/exec/aggregator_fwd.h
+++ b/be/src/exec/aggregator_fwd.h
@@ -3,13 +3,21 @@
 #include <cstddef>
 #include <memory>
 
+#include "common/system/cpu_info.h"
+
 namespace starrocks {
 namespace agg {
+// Threshold at which a single-level hash set/map is converted to two-level.
+// Sized to the detected L3 cache (falling back to L2, then a default) so the
+// conversion tracks the last-level cache instead of a fixed assumption. Debug
+// builds use a tiny value so tests exercise the two-level path cheaply.
+inline size_t two_level_memory_threshold() {
 #ifdef NDEBUG
-constexpr size_t two_level_memory_threshold = 33554432; // 32M, L3 Cache
+    return CpuInfo::get_l3_cache_size();
 #else
-constexpr size_t two_level_memory_threshold = 64;
+    return 64;
 #endif
+}
 } // namespace agg
 
 class Aggregator;

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -513,13 +513,8 @@ private:
 
 AdaptivePartitionHashJoinBuilder::AdaptivePartitionHashJoinBuilder(HashJoiner& hash_joiner)
         : HashJoinBuilder(hash_joiner), _cache_miss_factor(_calculate_cache_miss_factor(hash_joiner)) {
-    static constexpr size_t DEFAULT_L2_CACHE_SIZE = 1 * 1024 * 1024;
-    static constexpr size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
-    const auto& cache_sizes = CpuInfo::get_cache_sizes();
-    _L2_cache_size = cache_sizes[CpuInfo::L2_CACHE];
-    _L3_cache_size = cache_sizes[CpuInfo::L3_CACHE];
-    _L2_cache_size = _L2_cache_size ? _L2_cache_size : DEFAULT_L2_CACHE_SIZE;
-    _L3_cache_size = _L3_cache_size ? _L3_cache_size : DEFAULT_L3_CACHE_SIZE;
+    _L2_cache_size = CpuInfo::get_l2_cache_size();
+    _L3_cache_size = CpuInfo::get_l3_cache_size();
 }
 
 double AdaptivePartitionHashJoinBuilder::_calculate_cache_miss_factor(const HashJoiner& hash_joiner) {

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -286,12 +286,7 @@ std::pair<bool, JoinHashMapMethodUnaryType> JoinHashMapSelector::_try_use_range_
 
     const uint64_t row_count = table_items->row_count;
     const uint64_t bucket_size = JoinHashMapHelper::calc_bucket_size(table_items->row_count + 1);
-    static const size_t HALF_L3_CACHE_SIZE = [] {
-        static constexpr size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
-        const auto& cache_sizes = CpuInfo::get_cache_sizes();
-        const auto l3_cache = cache_sizes[CpuInfo::L3_CACHE] ? cache_sizes[CpuInfo::L3_CACHE] : DEFAULT_L3_CACHE_SIZE;
-        return l3_cache / 2;
-    }();
+    static const size_t HALF_L3_CACHE_SIZE = CpuInfo::get_l3_cache_size() / 2;
     static const size_t L2_CACHE_SIZE = CpuInfo::get_l2_cache_size();
 
     if ((table_items->join_type == TJoinOp::LEFT_ANTI_JOIN || table_items->join_type == TJoinOp::LEFT_SEMI_JOIN) &&

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -113,7 +113,7 @@ struct AdaptiveSliceHashSet {
     }
 
     void try_convert_to_two_level(MemPool* mem_pool) {
-        if (distinct_size % 65536 == 0 && mem_pool->total_allocated_bytes() >= agg::two_level_memory_threshold) {
+        if (distinct_size % 65536 == 0 && mem_pool->total_allocated_bytes() >= agg::two_level_memory_threshold()) {
             two_level_set = std::make_shared<SliceTwoLevelHashSetWithAggStateAllocator>();
             two_level_set->reserve(set->capacity());
             two_level_set->insert(set->begin(), set->end());

--- a/be/src/runtime/runtime_filter_factory.cpp
+++ b/be/src/runtime/runtime_filter_factory.cpp
@@ -136,17 +136,8 @@ static std::pair<CppType, CppType> calc_min_max_from_columns(const Columns& colu
 struct TryCreateRuntimeBitsetFilter {
     template <LogicalType LT>
     RuntimeFilter* operator()(const Columns& columns, size_t column_offset, size_t row_count) {
-        static auto cache_sizes = [] {
-            static constexpr size_t DEFAULT_L2_CACHE_SIZE = 1 * 1024 * 1024;
-            static constexpr size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
-
-            const auto& cache_sizes = CpuInfo::get_cache_sizes();
-            const auto cur_l2_cache_size = cache_sizes[CpuInfo::L2_CACHE];
-            const auto cur_l3_cache_size = cache_sizes[CpuInfo::L3_CACHE];
-            return std::pair{cur_l2_cache_size ? cur_l2_cache_size : DEFAULT_L2_CACHE_SIZE,
-                             cur_l3_cache_size ? cur_l3_cache_size : DEFAULT_L3_CACHE_SIZE};
-        }();
-        const auto& [l2_cache_size, l3_cache_size] = cache_sizes;
+        const size_t l2_cache_size = CpuInfo::get_l2_cache_size();
+        const size_t l3_cache_size = CpuInfo::get_l3_cache_size();
 
         const auto [min_value, max_value] = calc_min_max_from_columns<LT>(columns, column_offset);
         const size_t value_interval = static_cast<size_t>(RuntimeBitsetFilter<LT>::to_numeric(max_value)) -


### PR DESCRIPTION
## Why I'm doing

When the CPU does not report a cache size, BE falls back to a fixed default —
1 MiB for L2, 32 MiB for L3. That fallback is copy-pasted in four places, each
re-implementing the same guard:

- runtime filter — bitset vs bloom choice
- adaptive partition hash join — sizing
- join hash-map selector — range-direct mapping
- aggregation — `two_level_memory_threshold`, the point at which a single-level
  hash table is converted to two-level

These defaults should sit in one place, the `CpuInfo` getters. They could not,
because `get_l3_cache_size()` had no default and could return 0 or a negative
`sysconf` value, so each caller added its own copy.

The aggregation one is also the only change in behavior here: it was a plain
32 MiB constant (`33554432`) that never read the CPU. On a server with an L3
larger than 32 MiB it switched to two-level too early — while the table still
fit in L3. Sized to the real L3, it now waits.

## What I'm doing

1. Harden the getters: add the L3 default, reject a negative `sysconf` result,
   and have `get_l3_cache_size()` return L3, else L2, else the default — always
   positive, so callers stop re-guarding it. (A CPU with no shared L3 reports a
   real L2, which is its last-level cache.)
2. Point the three duplicated `DEFAULT_L2/L3_CACHE_SIZE` fallbacks at the getters.
3. Size the aggregation `two_level_memory_threshold` to the detected L3 instead
   of the fixed 32 MiB. Debug builds keep the tiny value so tests still hit the
   two-level path.

No new config. Aside from that threshold, behavior is unchanged on any host that
reports an L3.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
