### PR TITLE
[BugFix] Backquote table name when persisting routine load origStmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1957,7 +1957,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         }
 
         // we use sql to persist the load properties, so we just put the load properties to sql.
-        String sql = String.format("CREATE ROUTINE LOAD %s ON %s %s" +
+        // Backquote the table name so that reserved-keyword table names (e.g. `order`) can be
+        // re-parsed when the statement is deserialized on FE restart; otherwise getLoadDesc()
+        // fails to parse and routineLoadDesc is lost.
+        String sql = String.format("CREATE ROUTINE LOAD %s ON `%s` %s" +
                         " PROPERTIES (\"desired_concurrent_number\"=\"1\")" +
                         " FROM KAFKA (\"kafka_topic\" = \"my_topic\")",
                 name, tableName, originLoadDesc.toSql());

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -1047,7 +1047,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS TERMINATED BY ';'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY ';' " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
@@ -1057,7 +1057,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "ROWS TERMINATED BY '\n'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n' " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
@@ -1068,7 +1068,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS(`a`, `b`, `c`=1)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1) " +
@@ -1080,7 +1080,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "TEMPORARY PARTITION(`p1`, `p2`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1093,7 +1093,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 1", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1107,7 +1107,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS TERMINATED BY '\t'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1121,7 +1121,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "ROWS TERMINATED BY 'a'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1135,7 +1135,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS(`a`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1148,7 +1148,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         " PARTITION(`p1`, `p2`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1162,7 +1162,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 5", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1176,7 +1176,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 5 and b like 'c1%' and c between 1 and 100 and substring(d,1,5) = 'cefd' ", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON unknown " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1187,6 +1187,38 @@ public class RoutineLoadJobTest {
                 "AND (substring(`d`, 1, 5) = 'cefd') " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
+    }
+
+    @Test
+    public void testMergeLoadDescToOriginStatementWithReservedKeywordTable() throws Exception {
+        // The table name "order" is a reserved keyword. getTableName() returns it without
+        // backquotes, so the regenerated statement must add backquotes itself; otherwise the
+        // persisted SQL fails to be re-parsed on FE restart and routineLoadDesc becomes null.
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                2L, 3L, "192.168.1.2:10000", "topic") {
+            @Override
+            public String getTableName() {
+                return "order";
+            }
+        };
+        String originStmt = "CREATE ROUTINE LOAD job ON `order` " +
+                "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
+                "FROM KAFKA (\"kafka_topic\" = \"my_topic\")";
+        routineLoadJob.setOrigStmt(new OriginStatementInfo(originStmt, 0));
+
+        RoutineLoadDesc loadDesc = CreateRoutineLoadStmt.getLoadDesc(new OriginStatementInfo(
+                "ALTER ROUTINE LOAD FOR job COLUMNS(`a`, `b`, `c` = 1)", 0), null);
+        routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
+
+        // The regenerated statement must keep the reserved-keyword table name backquoted.
+        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `order` " +
+                "COLUMNS(`a`, `b`, `c` = 1) " +
+                "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
+                "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
+
+        // Re-parsing the persisted statement must succeed (this is what happens on FE restart).
+        RoutineLoadDesc reparsed = CreateRoutineLoadStmt.getLoadDesc(routineLoadJob.getOrigStmt(), null);
+        Assertions.assertNotNull(reparsed);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

  `ALTER ROUTINE LOAD` with a load clause (COLUMNS/WHERE/PARTITION) rebuilds
  the persisted statement via `mergeLoadDescToOriginStatement()` using
  String.format("... ON %s ...", tableName). The table name is rendered
  without backquotes, so a reserved-keyword table name (e.g. `order`)
  produces an invalid statement such as "ON ORDER".

  On FE restart this broken statement is re-parsed in
  `CreateRoutineLoadStmt.getLoadDesc();` parsing fails on the reserved word,
  the exception is swallowed, and routineLoadDesc becomes null. FE still
  starts and the job is still listed, but its column mapping / WHERE /
  partition info is lost, so ingestion misbehaves or the job pauses.

## What I'm doing:

  Backquote the table name (ON `%s`) so reserved-keyword table names can be
  re-parsed after deserialization. No escaping of backquotes is needed since
  table names cannot contain them.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
