### PR TITLE
[Enhancement] Show lake meta alter jobs in SHOW ALTER TABLE COLUMN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -30,6 +30,8 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -46,6 +48,7 @@ import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.thrift.TTaskType;
+import com.starrocks.warehouse.Warehouse;
 import io.opentelemetry.api.trace.StatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -536,7 +539,32 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
 
     @Override
     protected void getInfo(List<List<Comparable>> infos) {
-        // LakeTableAlterMetaJob is not supported by show for now
+        // A meta-only change (file_bundling / persistent_index / compaction_strategy ...) has no
+        // shadow index or schema version, so the index/schema columns are filled with placeholders.
+        // Numeric columns must stay numeric (not NULL_STRING) so the cross-job sort in
+        // SchemaChangeHandler.getAlterJobInfosByDb does not mix String and Long comparables.
+        String progress = FeConstants.NULL_STRING;
+        if (jobState == JobState.RUNNING && getBatchTask() != null) {
+            progress = getBatchTask().getFinishedTaskNum() + "/" + getBatchTask().getTaskNum();
+        }
+
+        List<Comparable> info = Lists.newArrayList();
+        info.add(jobId);
+        info.add(tableName);
+        info.add(TimeUtils.longToTimeString(createTimeMs));
+        info.add(TimeUtils.longToTimeString(finishedTimeMs));
+        info.add(tableName); // IndexName: meta change applies to the whole table, use the table name
+        info.add(-1L); // IndexId: no shadow index
+        info.add(-1L); // OriginIndexId: no shadow index
+        info.add(FeConstants.NULL_STRING); // SchemaVersion: not a schema change
+        info.add(getWatershedTxnId());
+        info.add(jobState.name());
+        info.add(errMsg);
+        info.add(progress);
+        info.add(timeoutMs / 1000);
+        Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseId);
+        info.add(warehouse == null ? "null" : warehouse.getName());
+        infos.add(info);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -28,6 +28,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTable;
@@ -593,5 +594,48 @@ public class LakeTableAlterMetaJobTest {
             Thread.sleep(100);
         }
         Assertions.assertEquals(table2.getCompactionStrategy(), TCompactionStrategy.DEFAULT);
+    }
+
+    @Test
+    public void testGetInfo() {
+        // The meta job is in PENDING right after setUp().
+        List<List<Comparable>> infos = new ArrayList<>();
+        job.getInfo(infos);
+
+        // Exactly one row, matching the shared-data SHOW ALTER TABLE COLUMN schema (the 13 common
+        // columns plus the trailing Warehouse column present in shared-data mode).
+        Assertions.assertEquals(1, infos.size());
+        List<Comparable> row = infos.get(0);
+        Assertions.assertEquals(14, row.size());
+
+        // Key fields are populated (column order matches SchemaChangeProcDir.TITLE_NAMES).
+        Assertions.assertEquals(job.getJobId(), row.get(0));                        // JobId
+        Assertions.assertEquals(table.getName(), row.get(1));                       // TableName
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING.name(), row.get(9));    // State
+        Assertions.assertEquals(job.getTimeoutMs() / 1000, row.get(12));            // Timeout
+
+        // A meta-only change has no shadow index / schema version, so the numeric index columns
+        // use placeholders. They MUST stay numeric (Long), not NULL_STRING, otherwise the cross-job
+        // sort in SchemaChangeHandler.getAlterJobInfosByDb mixes String and Long comparables.
+        Assertions.assertTrue(row.get(0) instanceof Long);    // JobId
+        Assertions.assertTrue(row.get(5) instanceof Long);    // IndexId
+        Assertions.assertTrue(row.get(6) instanceof Long);    // OriginIndexId
+        Assertions.assertTrue(row.get(8) instanceof Long);    // TransactionId
+        Assertions.assertTrue(row.get(12) instanceof Long);   // Timeout
+        Assertions.assertEquals(-1L, row.get(5));
+        Assertions.assertEquals(-1L, row.get(6));
+
+        // Regression guard: the meta-job row must sort together with a regular schema-change row
+        // (which carries real Long IndexId / OriginIndexId and a String SchemaVersion) without
+        // throwing. Keep columns 0-4 equal so the comparator actually reaches the IndexId column.
+        List<Comparable> schemaChangeRow = new ArrayList<>(row);
+        schemaChangeRow.set(5, 10001L);   // real IndexId, like SchemaChangeJobV2
+        schemaChangeRow.set(6, 10001L);   // real OriginIndexId
+        schemaChangeRow.set(7, "1:0");    // real SchemaVersion
+        List<List<Comparable>> combined = new ArrayList<>();
+        combined.add(schemaChangeRow);
+        combined.add(row);
+        combined.sort(new ListComparator<>(0, 1, 2, 3, 4, 5));
+        Assertions.assertEquals(2, combined.size());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Meta-only alter jobs on cloud-native (lake) tables — `ALTER TABLE ... SET (...)` for `file_bundling`, `enable_persistent_index`, `persistent_index_type`, `compaction_strategy`, etc. — run asynchronously as a `LakeTableAlterMetaJob` (`JobType.SCHEMA_CHANGE`) and hold the table in `SCHEMA_CHANGE` state until they finish. While such a job runs, conflicting operations (e.g. automatic partition creation during load) fail with "A schema change operation is in progress on the table ...".

However, `SHOW ALTER TABLE COLUMN` does not display these jobs at all, because `LakeTableAlterMetaJobBase.getInfo()` was an empty no-op. Users had no SQL-visible way to see whether such a job exists, what state it is in (`RUNNING` / `FINISHED_REWRITING` / `FINISHED`), or its progress — they had to resort to FE logs.

## What I'm doing:

Implement `LakeTableAlterMetaJobBase.getInfo()` so these jobs emit a result row matching `SchemaChangeProcDir.TITLE_NAMES`, exactly like other alter jobs.

The job already lives in the same `alterJobsV2` map as regular schema changes and already carries `JobType.SCHEMA_CHANGE`, so `getAlterJobInfosByDb` already iterates it — it only lacked a row-producing `getInfo()`. A meta-only change has no shadow index or schema version, so those columns use placeholders; the useful columns (`State`, `TransactionId` (watershed txn), `Progress`, `CreateTime`/`FinishTime`, `Timeout`, `Warehouse`) are populated.

Note: numeric columns (`IndexId` / `OriginIndexId`) are filled with numeric placeholders (`-1`) rather than `NULL_STRING`, so they stay type-consistent with regular schema-change rows and do not break the cross-job sort (`ListComparator` over columns 0–5) in `SchemaChangeHandler.getAlterJobInfosByDb` when both job kinds coexist.

This mirrors the existing `LakeTableAsyncFastSchemaChangeJob.getInfo()` implementation.

Verified on a deployed shared-data cluster: after `ALTER TABLE ... SET ("file_bundling"="false")`, `SHOW ALTER TABLE COLUMN` now shows the meta job (it progressed `PENDING` → `FINISHED` with `FinishTime`/`TransactionId` populated), and a whole-DB query returning both the meta job and a regular `ADD COLUMN` job sorted without error. A unit test (`LakeTableAlterMetaJobTest.testGetInfo`) covers the row shape, the Long-typed numeric placeholders, and the cross-job sort.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
