### PR TITLE
[BugFix] Render columnToColumnExpr as SQL in SHOW ROUTINE LOAD

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1740,7 +1740,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         Map<String, String> jobProperties = Maps.newHashMap();
         jobProperties.put("partitions",
                 partitions == null ? STAR_STRING : Joiner.on(",").join(partitions.getPartitionNames()));
-        jobProperties.put("columnToColumnExpr", columnDescs == null ? STAR_STRING : Joiner.on(",").join(columnDescs));
+        jobProperties.put("columnToColumnExpr", columnDescs == null ? STAR_STRING : columnDescsToSql(columnDescs));
         jobProperties.put("whereExpr", whereExpr == null ? STAR_STRING : ExprToSql.toSql(whereExpr));
         if (getFormat().equalsIgnoreCase("json")) {
             jobProperties.put("dataFormat", "json");
@@ -1759,6 +1759,21 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         jobProperties.putAll(this.jobProperties);
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
         return gson.toJson(jobProperties);
+    }
+
+    private static String columnDescsToSql(List<ImportColumnDesc> columnDescs) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < columnDescs.size(); i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            ImportColumnDesc desc = columnDescs.get(i);
+            sb.append("`").append(desc.getColumnName()).append("`");
+            if (desc.getExpr() != null) {
+                sb.append("=").append(ExprToSql.toSql(desc.getExpr()));
+            }
+        }
+        return sb.toString();
     }
 
     public String jobPropertiesToSql() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -55,10 +55,12 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnSeparator;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.LabelName;
 import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.SqlParser;
@@ -850,6 +852,30 @@ public class KafkaRoutineLoadJobTest {
         
         // Verify: Should return empty map as fallback
         Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testJobPropertiesColumnToColumnExpr() {
+        KafkaRoutineLoadJob job = new KafkaRoutineLoadJob(1L, "test_job", 1L, 1L, "127.0.0.1:9020", "topic1");
+
+        List<ImportColumnDesc> columnDescs = Lists.newArrayList();
+        // plain column without expr
+        columnDescs.add(new ImportColumnDesc("col1"));
+        // mapping column with expr
+        Expr expr = SqlParser.parseSqlToExpr("col1 + 1", 0);
+        columnDescs.add(new ImportColumnDesc("col2", expr));
+        // column whose name needs quoting (contains the separator), must be backtick-wrapped
+        // so the rendered SQL stays unambiguous
+        columnDescs.add(new ImportColumnDesc("a,b"));
+        Deencapsulation.setField(job, "columnDescs", columnDescs);
+
+        String jobProperties = Deencapsulation.invoke(job, "jobPropertiesToJsonString");
+        // The expr must be rendered as readable SQL, not a Java object reference like
+        // com.starrocks.sql.ast.ImportColumnDesc@19e02a72
+        Assertions.assertFalse(jobProperties.contains("ImportColumnDesc@"), jobProperties);
+        // column names are backtick-wrapped, mapping column rendered as "`name`=<exprSql>"
+        Assertions.assertTrue(
+                jobProperties.contains("\"columnToColumnExpr\":\"`col1`,`col2`=col1 + 1,`a,b`\""), jobProperties);
     }
 
 


### PR DESCRIPTION
## Why I'm doing:

  `SHOW ROUTINE LOAD` joined the `ImportColumnDesc` list directly, but the
  class has no `toString()` override, so `JobProperties` showed default object
  references like `com.starrocks.sql.ast.ImportColumnDesc@19e02a72` instead
  of the column mapping.

## What I'm doing:

  Render each column desc explicitly: plain columns as the column name,
  mapping columns as "name=<exprSql>" via `ExprToSql`. `ImportColumnDesc` lives
  in fe-parser and cannot depend on `ExprToSql` (fe-core), so the rendering
  is done in RoutineLoadJob, mirroring the adjacent `whereExpr` handling.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
