### PR TITLE
[Enhancement] FeNameFormat: report ERR_TOO_LONG_IDENT for over-length identifier names

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -31,25 +31,32 @@ public class FeNameFormat {
     private FeNameFormat() {
     }
 
+    public static final int MAX_DB_NAME_LENGTH = 256;
+    public static final int MAX_TABLE_NAME_LENGTH = 1024;
+    public static final int MAX_COLUMN_NAME_LENGTH = 1024;
+    public static final int MAX_COMMON_NAME_LENGTH = 64;
+
     private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
 
     public static final char[] SPECIAL_CHARACTERS_IN_DB_NAME = new char[] {'-', '~', '!', '@', '#', '$',
             '%', '^', '&', '<', '>', '=', '+'};
     public static final char[] SPECIAL_CHARACTERS_IN_ICEBERG_NAMESPACE = new char[] {'-', '~', '!', '@', '#', '$',
             '%', '^', '&', '<', '>', '=', '+', '.'};
+    // Length stays encoded in this regex because checkRoleName matches against it directly without going through checkName.
     public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
 
-    // The length of db name is 256
+    // Length is enforced separately via the MAX_*_LENGTH constants (see checkName), so these regexes only describe
+    // character rules; over-length names report ERR_TOO_LONG_IDENT instead of the generic wrong-name error.
     public static String DB_NAME_REGEX = "";
-    public static final String TABLE_NAME_REGEX = "^[^\0]{1,1024}$";
+    public static final String TABLE_NAME_REGEX = "^[^\0]+$";
     public static String ICEBERG_NAMESPACE_REGEX = "";
 
     // Now we can not accept all characters because current design of delete save delete cond contains column name,
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
-    private static final String SHARED_NOTHING_COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,1024}$";
+    private static final String SHARED_NOTHING_COLUMN_NAME_REGEX = "^[^\0=<>!\\*]+$";
 
-    private static final String SHARED_DATE_COLUMN_NAME_REGEX = "^[^\0]{1,1024}$";
+    private static final String SHARED_DATE_COLUMN_NAME_REGEX = "^[^\0]+$";
 
     // The username by kerberos authentication may include the host name, so additional adaptation is required.
     private static final String MYSQL_USER_NAME_REGEX = "^\\w{1,64}/?[.\\w-]{0,63}$";
@@ -69,42 +76,48 @@ public class FeNameFormat {
             allowedSpecialCharacters += c;
         }
 
-        DB_NAME_REGEX = "^[a-zA-Z][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,255}$|" +
-                "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,254}$";
+        DB_NAME_REGEX = "^[a-zA-Z][\\w" + Pattern.quote(allowedSpecialCharacters) + "]*$|" +
+                "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]*$";
 
         allowedSpecialCharacters = "";
         for (Character c : SPECIAL_CHARACTERS_IN_ICEBERG_NAMESPACE) {
             allowedSpecialCharacters += c;
         }
-        ICEBERG_NAMESPACE_REGEX = "^[a-zA-Z][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,255}$|" +
-                "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,254}$";
+        ICEBERG_NAMESPACE_REGEX = "^[a-zA-Z][\\w" + Pattern.quote(allowedSpecialCharacters) + "]*$|" +
+                "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]*$";
     }
 
-    // Shared validation for identifier names: rejects empty or characters not matching the format regex.
-    // The format regex also encodes the length bound, so callers do not pass a separate length.
-    // wrongNameArgs are the message args for wrongNameError.
-    private static void checkName(String name, String regex,
+    // Shared validation for identifier names: rejects empty, then over-length (ERR_TOO_LONG_IDENT),
+    // then characters not matching the format regex. wrongNameArgs are the message args for wrongNameError.
+    private static void checkName(String name, int maxLength, String regex,
                                   ErrorCode wrongNameError, Object... wrongNameArgs) {
-        if (Strings.isNullOrEmpty(name) || !name.matches(regex)) {
+        if (Strings.isNullOrEmpty(name)) {
+            ErrorReport.reportSemanticException(wrongNameError, wrongNameArgs);
+        }
+        if (name.length() > maxLength) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_TOO_LONG_IDENT, name, maxLength);
+        }
+        if (!name.matches(regex)) {
             ErrorReport.reportSemanticException(wrongNameError, wrongNameArgs);
         }
     }
 
     // The length of db name is 256.
     public static void checkDbName(String dbName) {
-        checkName(dbName, DB_NAME_REGEX, ErrorCode.ERR_WRONG_DB_NAME, dbName);
+        checkName(dbName, MAX_DB_NAME_LENGTH, DB_NAME_REGEX, ErrorCode.ERR_WRONG_DB_NAME, dbName);
     }
 
     public static void checkNamespace(String dbName) {
-        checkName(dbName, ICEBERG_NAMESPACE_REGEX, ErrorCode.ERR_WRONG_DB_NAME, dbName);
+        checkName(dbName, MAX_DB_NAME_LENGTH, ICEBERG_NAMESPACE_REGEX, ErrorCode.ERR_WRONG_DB_NAME, dbName);
     }
 
     public static void checkTableName(String tableName) {
-        checkName(tableName, TABLE_NAME_REGEX, ErrorCode.ERR_WRONG_TABLE_NAME, tableName);
+        checkName(tableName, MAX_TABLE_NAME_LENGTH, TABLE_NAME_REGEX, ErrorCode.ERR_WRONG_TABLE_NAME, tableName);
     }
 
     public static void checkPartitionName(String partitionName) throws AnalysisException {
-        checkName(partitionName, COMMON_NAME_REGEX, ErrorCode.ERR_WRONG_PARTITION_NAME, partitionName);
+        checkName(partitionName, MAX_COMMON_NAME_LENGTH, COMMON_NAME_REGEX,
+                ErrorCode.ERR_WRONG_PARTITION_NAME, partitionName);
 
         if (partitionName.startsWith(FORBIDDEN_PARTITION_NAME)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_PARTITION_NAME, partitionName);
@@ -118,7 +131,7 @@ public class FeNameFormat {
     public static void checkColumnName(String columnName, boolean isPartitionColumn) {
         String pattern = RunMode.isSharedNothingMode()
                 ? SHARED_NOTHING_COLUMN_NAME_REGEX : SHARED_DATE_COLUMN_NAME_REGEX;
-        checkName(columnName, pattern, ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
+        checkName(columnName, MAX_COLUMN_NAME_LENGTH, pattern, ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
 
         if (columnName.startsWith(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_COLUMN_NAME, columnName);
@@ -177,6 +190,6 @@ public class FeNameFormat {
     }
 
     public static void checkCommonName(String type, String name) {
-        checkName(name, COMMON_NAME_REGEX, ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
+        checkName(name, MAX_COMMON_NAME_LENGTH, COMMON_NAME_REGEX, ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -94,7 +94,11 @@ public class FeNameFormat {
         if (Strings.isNullOrEmpty(name)) {
             ErrorReport.reportSemanticException(wrongNameError, wrongNameArgs);
         }
-        if (name.length() > maxLength) {
+        // Count Unicode code points, not UTF-16 code units: MySQL measures identifier limits in characters
+        // (a supplementary character counts as one), and the previous format regexes did too (their {1,N}
+        // quantifiers match one code point per repetition). String.length() would count a surrogate pair as
+        // two and wrongly reject an otherwise-valid name near the limit.
+        if (name.codePointCount(0, name.length()) > maxLength) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_TOO_LONG_IDENT, name, maxLength);
         }
         if (!name.matches(regex)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -285,7 +285,7 @@ public class CreateTableAutoTabletTest {
             Assertions.fail(); // should raise Exception
         } catch (Exception e) {
             Assertions.assertEquals("Getting analyzing error. Detail message: Identifier name '"
-                    + longDbName + "' is too long, the maximum length is 256", e.getMessage());
+                    + longDbName + "' is too long, the maximum length is 256.", e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -284,8 +284,8 @@ public class CreateTableAutoTabletTest {
             UtFrameUtils.parseStmtWithNewParser(sql, UtFrameUtils.createDefaultCtx());
             Assertions.fail(); // should raise Exception
         } catch (Exception e) {
-            Assertions.assertEquals("Getting analyzing error. Detail message: Incorrect database name '"
-                    + longDbName + "'.", e.getMessage());
+            Assertions.assertEquals("Getting analyzing error. Detail message: Identifier name '"
+                    + longDbName + "' is too long, the maximum length is 256", e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
@@ -118,10 +118,53 @@ public class FeNameFormatTest {
     }
 
     @Test
+    public void testCheckNameTooLongMessage() {
+        // over-length names report ERR_TOO_LONG_IDENT ("is too long"), not the generic wrong-name error
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkTableName("a".repeat(1025)));
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkDbName("a".repeat(257)));
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkColumnName("a".repeat(1025)));
+    }
+
+    @Test
     public void testCheckNamespace() {
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("abc"));
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("ns1.ns2"));
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("ns1.ns2.ns3"));
+        // leading special character is rejected
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkNamespace("!ns"));
+        // over-length (> 256) reports ERR_TOO_LONG_IDENT
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkNamespace("a".repeat(257)));
+    }
+
+    @Test
+    public void testCheckPartitionName() {
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkPartitionName("p1"));
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkPartitionName("_p1"));
+        // invalid character / empty go through the generic wrong-name error
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkPartitionName("!p"));
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkPartitionName(""));
+        // over-length (> 64) reports ERR_TOO_LONG_IDENT
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkPartitionName("a".repeat(65)));
+        // forbidden placeholder prefix is rejected even when the format is otherwise valid
+        Assertions.assertThrows(SemanticException.class,
+                () -> FeNameFormat.checkPartitionName(FeNameFormat.FORBIDDEN_PARTITION_NAME + "x"));
+    }
+
+    @Test
+    public void testCheckCommonName() {
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkResourceName("res1"));
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkCatalogName("cat1"));
+        // invalid character / empty go through the generic wrong-name-format error
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkResourceName("!res"));
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkWarehouseName(""));
+        // over-length (> 64) reports ERR_TOO_LONG_IDENT
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkStorageVolumeName("a".repeat(65)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
@@ -129,6 +129,20 @@ public class FeNameFormatTest {
     }
 
     @Test
+    public void testCheckNameCountsCodePointsNotCodeUnits() {
+        // A supplementary character (surrogate pair) is one identifier character -- matching MySQL, which measures
+        // identifier limits in characters, and the old {1,N} regex quantifiers (one code point per repetition). It
+        // must count as one toward the limit, not two (its UTF-16 String.length()). TABLE_NAME_REGEX ("^[^\0]+$")
+        // allows arbitrary non-NUL characters, so this isolates the length-counting behaviour.
+        String emoji = new String(Character.toChars(0x1F600)); // U+1F600: String.length()==2, one code point
+        // 1024 code points (String.length()==2048) equals the table-name limit and must be accepted
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkTableName(emoji.repeat(1024)));
+        // 1025 code points exceeds the limit and reports ERR_TOO_LONG_IDENT rather than a format error
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "is too long",
+                () -> FeNameFormat.checkTableName(emoji.repeat(1025)));
+    }
+
+    @Test
     public void testCheckNamespace() {
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("abc"));
         Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("ns1.ns2"));

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode {
             "Illegal column/field reference '%s' of semi-/anti-join"),
     ERR_BAD_FUNC_ERROR(1055, new byte[] {'4', '2', '0', '0', '0'}, "Unknown function '%s'"),
     ERR_WRONG_VALUE_COUNT(1058, new byte[] {'2', '1', 'S', '0', '1'}, "Column count doesn't match value count"),
+    ERR_TOO_LONG_IDENT(1059, new byte[] {'4', '2', '0', '0', '0'},
+            "Identifier name '%s' is too long, the maximum length is %s"),
     ERR_DUP_FIELDNAME(1060, new byte[] {'4', '2', 'S', '2', '1'}, "Duplicate column name '%s'"),
     ERR_NONUNIQ_TABLE(1066, new byte[] {'4', '2', '0', '0', '0'}, "Not unique table/alias: '%s'"),
     ERR_NO_SUCH_THREAD(1094, new byte[] {'H', 'Y', '0', '0', '0'}, "Unknown thread id: %d"),


### PR DESCRIPTION
## Why I'm doing:

When a database / table / column / namespace / partition / common identifier name exceeds its maximum length, StarRocks reports the generic `Incorrect ... name '...'` error. That message does not tell the user *why* the name is wrong (it looks like a character-format violation), and it diverges from MySQL, which returns a dedicated `ER_TOO_LONG_IDENT` (1059) error for over-length identifiers.

The length bound used to be baked into each format regex (e.g. `{1,1024}`), so an over-length name failed the regex and surfaced as a character-format error rather than a length error.

## What I'm doing:

- Add `ERR_TOO_LONG_IDENT` (MySQL 1059, SQLSTATE `42000`): `Identifier name '%s' is too long, the maximum length is %s`.
- Move length validation into the shared `FeNameFormat.checkName` helper so it runs **before** the character regex. Order is now: empty → over-length (`ERR_TOO_LONG_IDENT`) → character regex (generic wrong-name error).
- De-length the format regexes (`{1,1024}`/`{0,255}` → `+`/`*`) so over-length names reach the length check instead of failing the regex first. `COMMON_NAME_REGEX` keeps its bound because `checkRoleName` matches it directly without going through `checkName`.
- Introduce `MAX_DB_NAME_LENGTH` / `MAX_TABLE_NAME_LENGTH` / `MAX_COLUMN_NAME_LENGTH` / `MAX_COMMON_NAME_LENGTH` constants threaded into the call sites.

This covers `checkDbName`, `checkNamespace`, `checkTableName`, `checkColumnName`, `checkPartitionName`, and `checkCommonName`. Public method signatures are unchanged, so no callers need edits.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
