### PR TITLE
[UT] Fix flaky LakeReplicationTxnManagerTest caused by transient apply task reference

### DIFF
--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -18,7 +18,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <fstream>
+#include <thread>
 
 #include "base/path/filesystem_util.h"
 #include "base/testutil/assert.h"
@@ -94,7 +96,18 @@ public:
     void TearDown() override {
         auto status = StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
         EXPECT_TRUE(status.ok()) << status;
-        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+        // For primary key tablets, `rowset_commit` schedules an async ApplyCommitTask that holds a
+        // reference to the tablet. `drop_tablet` only waits until the apply logic finishes
+        // (_apply_running == false), not until the task object is destroyed, so there is a short
+        // window where the tablet's use_count is still > 1 and delete_shutdown_tablet() returns
+        // ResourceBusy. The extra reference is transient, so retry until the task is reclaimed.
+        for (int i = 0; i < 100; ++i) {
+            status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+            if (!status.is_resource_busy()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
         EXPECT_TRUE(status.ok()) << status;
         status = fs::remove_all(config::storage_root_path);
         EXPECT_TRUE(status.ok() || status.is_not_found()) << status;


### PR DESCRIPTION
## Why I'm doing:

 LakeReplicationTxnManagerTest is flaky under the PRIMARY_KEYS parameter. It intermittently fails in TearDown with:

```
  replication_txn_manager_test.cpp:91: Failure
  Value of: status.ok()
    Actual: false
  Expected: true
  Resource busy: used in somewhere, use count:2
```

  Root cause:

  For primary key tablets, rowset_commit schedules an asynchronous ApplyCommitTask on the apply thread pool, and that task object holds a shared_ptr to the tablet.

  In TearDown, drop_tablet calls TabletUpdates::stop_and_wait_apply_done(), which only waits until the apply logic finishes (_apply_running == false) — it does not wait until the ApplyCommitTask object is destroyed. There is a short
  window where:

  - the apply logic has signaled completion and woken up the waiter, but
  - the thread-pool worker has not yet released/destroyed the ApplyCommitTask, so it still holds a reference to the tablet.

  If delete_shutdown_tablet runs inside that window, info.tablet.use_count() is 2 (one from _shutdown_tablets, one from the lingering task) instead of 1, so it returns ResourceBusy and the test fails. This only affects PRIMARY_KEYS
  because only primary key tablets schedule the async apply task.

## What I'm doing:

  The extra reference is transient — it is released as soon as the apply task is reclaimed. This is a test-only timing issue, so the fix is scoped to the test: in TearDown, retry delete_shutdown_tablet with a bounded backoff (up to
  100 × 10ms = 1s) while it returns ResourceBusy, and only assert on the final status. Other error codes break out of the loop immediately so real failures are not masked.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
