### PR TITLE
[BugFix] Non-root compound predicates yield NotPushDown instead of EOF

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -191,6 +191,16 @@ Status prune_scan_ranges_by_partition_conjuncts(RuntimeState* state, const Tuple
 // Util methods.
 // ------------------------------------------------------------------------------------
 
+static constexpr std::string_view kNotPushDownPredicateStatus = "not push down predicate";
+
+static Status not_push_down_predicate_status() {
+    return Status::NotSupported(kNotPushDownPredicateStatus);
+}
+
+static bool is_not_push_down_predicate_status(const Status& status) {
+    return status.is_not_supported() && status.message() == kNotPushDownPredicateStatus;
+}
+
 static bool ignore_cast(const SlotDescriptor& slot, const Expr& expr) {
     if (slot.type().is_date_type() && expr.type().is_date_type()) {
         return true;
@@ -491,7 +501,14 @@ StatusOr<bool> ChunkPredicateBuilder<E, Type>::_normalize_compound_predicate(con
     auto process = [&]<CompoundNodeType ChildType>() -> StatusOr<bool> {
         ChunkPredicateBuilder<BoxedExpr, ChildType> child_builder(
                 _opts, build_raw_expr_containers(root_expr->children()), false);
-        ASSIGN_OR_RETURN(const bool normalized, child_builder.parse_conjuncts());
+        auto normalized_result = child_builder.parse_conjuncts();
+        if (!normalized_result.ok()) {
+            if (is_not_push_down_predicate_status(normalized_result.status())) {
+                return false;
+            }
+            return normalized_result.status();
+        }
+        const bool normalized = normalized_result.value();
         if (normalized) {
             _child_builders.emplace_back(std::move(child_builder));
         }
@@ -1278,6 +1295,9 @@ Status ChunkPredicateBuilder<E, Type>::build_olap_filters() {
             const bool empty_range = std::visit([](auto&& range) { return range.is_empty_value_range(); }, iter.second);
             if (empty_range) {
                 if constexpr (!Negative) {
+                    if (!_is_root_builder) {
+                        return not_push_down_predicate_status();
+                    }
                     return Status::EndOfFile("EOF, Filter by always false condition");
                 } else {
                     auto not_null_filter = std::visit(
@@ -1290,6 +1310,9 @@ Status ChunkPredicateBuilder<E, Type>::build_olap_filters() {
             const bool full_range = std::visit([](auto&& range) { return range.is_full_value_range(); }, iter.second);
             if (full_range) {
                 if constexpr (Negative) {
+                    if (!_is_root_builder) {
+                        return not_push_down_predicate_status();
+                    }
                     return Status::EndOfFile("EOF, Filter by always false condition");
                 } else {
                     auto not_null_filter = std::visit(

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -74,6 +74,35 @@ protected:
     std::vector<BoxedExprContext> _expr_containers;
 };
 
+static TExprNode create_compound_pred_node(TExprOpcode::type opcode) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::COMPOUND_PRED);
+    node.__set_num_children(2);
+    node.__set_opcode(opcode);
+    node.__set_child_type(TPrimitiveType::BOOLEAN);
+    node.__set_type(TypeDescriptor(TYPE_BOOLEAN).to_thrift());
+    node.__set_is_nullable(true);
+    return node;
+}
+
+static void append_int_eq_pred(std::vector<TExprNode>* nodes, SlotId slot_id, int32_t value) {
+    nodes->emplace_back(ExprsTestHelper::create_binary_pred_node(TPrimitiveType::INT, TExprOpcode::EQ));
+    nodes->emplace_back(ExprsTestHelper::create_slot_expr_node_t<TYPE_INT>(0, slot_id, true));
+    nodes->emplace_back(ExprsTestHelper::create_literal<TYPE_INT, int32_t>(value, false));
+}
+
+static TExpr create_or_pred_with_false_and_branch(SlotId slot_id) {
+    TExpr texpr;
+    texpr.nodes.emplace_back(create_compound_pred_node(TExprOpcode::COMPOUND_OR));
+    texpr.nodes.emplace_back(create_compound_pred_node(TExprOpcode::COMPOUND_OR));
+    append_int_eq_pred(&texpr.nodes, slot_id, 1);
+    append_int_eq_pred(&texpr.nodes, slot_id, 2);
+    texpr.nodes.emplace_back(create_compound_pred_node(TExprOpcode::COMPOUND_AND));
+    append_int_eq_pred(&texpr.nodes, slot_id, 1);
+    append_int_eq_pred(&texpr.nodes, slot_id, 2);
+    return texpr;
+}
+
 template <LogicalType Type>
 StatusOr<RuntimeFilterProbeDescriptor*> ChunkPredicateBuilderTest::_gen_runtime_filter_desc(SlotId slot_id) {
     TRuntimeFilterDescription tRuntimeFilterDescription;
@@ -366,6 +395,25 @@ TEST_F(ChunkPredicateBuilderTest, normalize_or_not_in_has_null_date) {
     ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::OR> builder(_opts, _expr_containers, false);
     ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
     ASSERT_FALSE(normalized);
+}
+
+TEST_F(ChunkPredicateBuilderTest, normalize_or_with_false_and_branch) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    _texprs.emplace_back(create_or_pred_with_false_and_branch(slot_id));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 1);
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, _expr_containers, true);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_TRUE(normalized);
+    ASSERT_FALSE(builder.is_pred_normalized(0));
+
+    ASSIGN_OR_ASSERT_FAIL(auto pred, builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool));
+    ASSERT_EQ(pred.debug_string(), "{\"and\":[]}");
 }
 
 TEST_F(ChunkPredicateBuilderTest, rt_has_no_null) {


### PR DESCRIPTION
## Why I'm doing:

Fixes a wrong-result issue in predicate pushdown for compound predicates under `UNION`.

 When a pushed-down predicate contains an impossible nested branch, for example:

```sql
  (measures = 'current' OR measures = 'cumulated')
  OR
  (measures = 'current' AND measures = 'cumulated')
```
The nested AND branch is always false, but the whole OR predicate is still valid. Previously, BE predicate normalization could convert the nested false branch into EndOfFile, then propagate that as scan-level EOF, causing OlapScanNode to emit no rows incorrectly.

**Root Cause**
ChunkPredicateBuilder::build_olap_filters() returned Status::EndOfFile for empty/full value ranges regardless of whether the builder represented the root scan predicate or a nested compound predicate.

For nested compound predicates, EOF should not mean “the whole scan is empty.” It should only mean this compound predicate cannot be safely pushed down.

## What I'm doing:

  For EOF-producing branches in build_olap_filters():

  - If _is_root_builder is true, keep returning Status::EndOfFile.
  - If _is_root_builder is false, return a local not-pushdown status instead.
  - In _normalize_compound_predicate(), handle the not-pushdown status by returning false, so the compound predicate is left for normal expression evaluation instead of being pushed to
    storage.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
