### PR TITLE
[Tool] ci: download Apache Thrift binary directly from CDN

### DIFF
--- a/.github/workflows/ci-merged-sonarcloud-fe.yml
+++ b/.github/workflows/ci-merged-sonarcloud-fe.yml
@@ -49,16 +49,12 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven
 
-      - name: Install Apache Thrift 0.13
+      - name: Install Apache Thrift
         run: |
-          mkdir -p ./.setup-thrift/oras
-          mkdir -p ./.setup-thrift/thrift
-          curl -sLO  https://github.com/deislabs/oras/releases/download/v0.7.0/oras_0.7.0_linux_amd64.tar.gz
-          tar -xvzf oras_0.7.0_linux_amd64.tar.gz
-          ln -sf $(pwd)/oras /usr/local/bin/oras
-          oras pull ghcr.io/dodopizza/setup-thrift/binaries:v0.13.0 --media-type application/vnd.unknown.layer.v1+tar.gz
-          tar zxf ./thrift.v0.13.0.tar.gz -C .
-          ln -sf $(pwd)/thrift /usr/local/bin/thrift
+          curl -fsSL --retry 3 --retry-delay 2 https://cdn-thirdparty.starrocks.com/thrift-binaries/latest/thrift.xz -o ./thrift.xz
+          xz -d ./thrift.xz
+          chmod +x ./thrift
+          mv -f ./thrift /usr/local/bin/thrift
 
       - name: Analyze FE
         env:

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -313,22 +313,18 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven
 
-      - name: Install Apache Thrift 0.13
-        id: install_thrift_0_13
+      - name: Install Apache Thrift
+        id: install_thrift
         if: steps.cache_maven_packages.outcome == 'success'
         run: |
-          mkdir -p ./.setup-thrift/oras
-          mkdir -p ./.setup-thrift/thrift
-          curl -sLO  https://github.com/deislabs/oras/releases/download/v0.7.0/oras_0.7.0_linux_amd64.tar.gz
-          tar -xvzf oras_0.7.0_linux_amd64.tar.gz
-          ln -sf $(pwd)/oras /usr/local/bin/oras
-          oras pull ghcr.io/dodopizza/setup-thrift/binaries:v0.13.0 --media-type application/vnd.unknown.layer.v1+tar.gz
-          tar zxf ./thrift.v0.13.0.tar.gz -C .
-          ln -sf $(pwd)/thrift /usr/local/bin/thrift
+          curl -fsSL --retry 3 --retry-delay 2 https://cdn-thirdparty.starrocks.com/thrift-binaries/latest/thrift.xz -o ./thrift.xz
+          xz -d ./thrift.xz
+          chmod +x ./thrift
+          mv -f ./thrift /usr/local/bin/thrift
 
       - name: Analyze FE
         id: analyze_fe
-        if: steps.install_thrift_0_13.outcome == 'success'
+        if: steps.install_thrift.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Replace the oras-based pull of thrift v0.13.0 with a direct download of the latest xz-compressed binary from cdn-thirdparty.starrocks.com. The binary is decompressed and moved into /usr/local/bin/thrift. Drop the version from the step name/id and update the dependent Analyze FE gate.

## Why I'm doing:

Fix sonarcube workflow failure. Example link: https://github.com/StarRocks/starrocks/actions/runs/26703570453/job/78700769367


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
