### PR TITLE
[Feature] Support max_pt function in odps catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -440,4 +440,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     public void executeMetadataDelete(Table table, ScalarOperator predicate, ConnectContext context) {
         normal.executeMetadataDelete(table, predicate, context);
     }
+
+    @Override
+    public String getMaxPartitionValue(Table table, boolean nonEmptyPartition) {
+        return normal.getMaxPartitionValue(table, nonEmptyPartition);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -236,6 +236,10 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
+    default String getMaxPartitionValue(Table table, boolean nonEmptyPartition) {
+        return null;
+    }
+
     /**
      * Get partition info at a specific snapshot identified by the request context.
      * Default implementation ignores the context and falls back to the live-snapshot variant.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsCacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsCacheUpdateProcessor.java
@@ -22,11 +22,14 @@ import com.starrocks.catalog.OdpsTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.CacheUpdateProcessor;
 import com.starrocks.connector.DatabaseTableName;
+import org.apache.groovy.util.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
@@ -39,17 +42,20 @@ public class OdpsCacheUpdateProcessor implements CacheUpdateProcessor {
     private final LoadingCache<String, Set<String>> tableNameCache;
     private final LoadingCache<OdpsTableName, OdpsTable> tableCache;
     private final LoadingCache<OdpsTableName, List<Partition>> partitionCache;
+    private final LoadingCache<OdpsTableName, String> maxPartitionCache;
 
     public OdpsCacheUpdateProcessor(String catalogName,
                                     Odps odps,
                                     LoadingCache<String, Set<String>> tableNameCache,
                                     LoadingCache<OdpsTableName, OdpsTable> tableCache,
-                                    LoadingCache<OdpsTableName, List<Partition>> partitionCache) {
+                                    LoadingCache<OdpsTableName, List<Partition>> partitionCache,
+                                    LoadingCache<OdpsTableName, String> maxPtCache) {
         this.catalogName = catalogName;
         this.odps = odps;
         this.tableNameCache = tableNameCache;
         this.tableCache = tableCache;
         this.partitionCache = partitionCache;
+        this.maxPartitionCache = maxPtCache;
     }
 
     @Override
@@ -118,6 +124,27 @@ public class OdpsCacheUpdateProcessor implements CacheUpdateProcessor {
 
                 LOG.info("Background refreshed table {}.{} in catalog {}",
                         odpsTable.getCatalogDBName(), odpsTable.getCatalogTableName(), catalogName);
+
+                List<Partition> oPartitions = oTable.getPartitions();
+                partitionCache.invalidate(odpsTableName);
+                partitionCache.put(odpsTableName, oPartitions);
+                LOG.info("Background refreshed partitions of table {}.{} in catalog {}",
+                        odpsTable.getCatalogDBName(), odpsTable.getCatalogTableName(), catalogName);
+
+                Partition firstPartition = oPartitions.get(0);
+                String partitionKey = firstPartition
+                        .getPartitionSpec()
+                        .keys()
+                        .stream()
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException("Partition spec has no keys"));
+
+                Partition maxPartition = oPartitions.stream()
+                        .filter(p -> p.getPhysicalSize() > 0)
+                        .max(Comparator.comparing(p -> p.getPartitionSpec().get(partitionKey)))
+                        .orElseThrow(() -> new IllegalStateException("No valid partitions found"));
+                maxPartitionCache.invalidate(odpsTableName);
+                maxPartitionCache.put(odpsTableName, maxPartition.getPartitionSpec().get(partitionKey));
             } catch (Exception e) {
                 LOG.error("Failed to background refresh table {}.{} in catalog {}",
                         odpsTable.getCatalogDBName(), odpsTable.getCatalogTableName(), catalogName, e);
@@ -153,6 +180,26 @@ public class OdpsCacheUpdateProcessor implements CacheUpdateProcessor {
         partitionCache.put(odpsTableName, merged);
         LOG.debug("Refreshed {} partition(s) for table {}.{} in catalog {}",
                 refreshed.size(), odpsTable.getCatalogDBName(), odpsTable.getCatalogTableName(), catalogName);
+
+        Map<OdpsTableName, List<Partition>> latestPartitions =
+                Maps.of(odpsTableName, OdpsUtils.getOdpsTablePartitions(odps, odpsTable));
+        partitionCache.invalidate(odpsTableName);
+        partitionCache.putAll(latestPartitions);
+
+        Partition firstPartition = latestPartitions.get(odpsTableName).get(0);
+        String partitionKey = firstPartition
+                .getPartitionSpec()
+                .keys()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Partition spec has no keys"));
+
+        Partition maxPartition = latestPartitions.get(odpsTableName).stream()
+                .filter(p -> p.getPhysicalSize() > 0)
+                .max(Comparator.comparing(p -> p.getPartitionSpec().get(partitionKey)))
+                .orElseThrow(() -> new IllegalStateException("No valid partitions found"));
+        maxPartitionCache.invalidate(odpsTableName);
+        maxPartitionCache.put(odpsTableName, maxPartition.getPartitionSpec().get(partitionKey));
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
@@ -98,6 +98,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     private LoadingCache<String, Set<String>> tableNameCache;
     private LoadingCache<OdpsTableName, OdpsTable> tableCache;
     private LoadingCache<OdpsTableName, List<Partition>> partitionCache;
+    private LoadingCache<OdpsTableName, String> maxPartitionCache;
     private final Optional<OdpsCacheUpdateProcessor> cacheUpdateProcessor;
 
     public OdpsMetadata(Odps odps, String catalogName, AliyunCloudCredential aliyunCloudCredential,
@@ -118,7 +119,7 @@ public class OdpsMetadata implements ConnectorMetadata {
         settings = settingsBuilder.build();
         initMetaCache();
         this.cacheUpdateProcessor = Optional.of(new OdpsCacheUpdateProcessor(
-                catalogName, odps, tableNameCache, tableCache, partitionCache));
+                catalogName, odps, tableNameCache, tableCache, partitionCache, maxPartitionCache));
     }
 
     public Optional<OdpsCacheUpdateProcessor> getCacheUpdateProcessor() {
@@ -148,9 +149,14 @@ public class OdpsMetadata implements ConnectorMetadata {
             partitionCache = newCacheBuilder(Long.parseLong(properties.get(OdpsProperties.PARTITION_CACHE_EXPIRE_TIME)),
                     Long.parseLong(properties.get(OdpsProperties.PARTITION_CACHE_SIZE)))
                     .build(asyncReloading(CacheLoader.from(this::loadPartitions), executor));
+            maxPartitionCache = newCacheBuilder(Long.parseLong(properties.get(OdpsProperties.PARTITION_CACHE_EXPIRE_TIME)),
+                    Long.parseLong(properties.get(OdpsProperties.PARTITION_CACHE_SIZE)))
+                    .build(asyncReloading(CacheLoader.from(this::loadMaxPartition), executor));
         } else {
             partitionCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE)
                     .build(asyncReloading(CacheLoader.from(this::loadPartitions), executor));
+            maxPartitionCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE)
+                    .build(asyncReloading(CacheLoader.from(this::loadMaxPartition), executor));
         }
     }
 
@@ -293,6 +299,45 @@ public class OdpsMetadata implements ConnectorMetadata {
         return OdpsUtils.getOdpsTablePartitions(odps, odpsTableName);
     }
 
+    private String loadMaxPartition(OdpsTableName odpsTableName) {
+        com.aliyun.odps.Table odpsTable = OdpsUtils.getOdpsTable(odps, odpsTableName);
+
+        String maxPt = null;
+        List<Partition> odpsPartitions = get(partitionCache, odpsTableName);
+        if (odpsPartitions != null && !odpsPartitions.isEmpty()) {
+            String partitionKey = odpsPartitions.get(0)
+                    .getPartitionSpec()
+                    .keys()
+                    .stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Partition spec has no keys"));
+
+            // OdpsUtils.getOdpsTablePartitions returns partitions in ascending order.
+            // Scan from the end to find the latest non-empty partition in O(k) time
+            // instead of O(n) via stream().max(), mirroring the descending-iterator
+            // approach used in the else branch below.
+            for (int i = odpsPartitions.size() - 1; i >= 0; i--) {
+                Partition p = odpsPartitions.get(i);
+                if (p.getPhysicalSize() > 0) {
+                    maxPt = p.getPartitionSpec().get(partitionKey);
+                    break;
+                }
+            }
+        } else {
+            Iterator<Partition> iterator = odpsTable.getPartitionIterator(null, true, 10L, Long.MAX_VALUE);
+            while (iterator.hasNext()) {
+                Partition p = iterator.next();
+                PartitionSpec partitionSpec = p.getPartitionSpec();
+
+                if (p.getPhysicalSize() > 0) {
+                    maxPt = partitionSpec.get(partitionSpec.keys().stream().findFirst().orElse(null));
+                    break;
+                }
+            }
+        }
+        return maxPt;
+    }
+
     @Override
     public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames) {
         if (partitionNames == null || partitionNames.isEmpty()) {
@@ -308,6 +353,27 @@ public class OdpsMetadata implements ConnectorMetadata {
         return partitions.stream()
                 .filter(partition -> filter.contains(partition.getPartitionSpec().toString(false, true)))
                 .map(OdpsPartition::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getMaxPartitionValue(Table table, boolean nonEmptyPartition) {
+        if (nonEmptyPartition) {
+            return get(maxPartitionCache, OdpsTableName.of(table.getCatalogDBName(), table.getName()));
+        } else {
+            com.aliyun.odps.Table odpsTable = OdpsUtils.getOdpsTable(odps, table);
+            Iterator<Partition> iterator = odpsTable.getPartitionIterator(null, true, 10L, Long.MAX_VALUE);
+            String maxPt = null;
+            while (iterator.hasNext()) {
+                Partition p = iterator.next();
+                PartitionSpec partitionSpec = p.getPartitionSpec();
+
+                if (p.getPhysicalSize() > 0) {
+                    maxPt = partitionSpec.get(partitionSpec.keys().stream().findFirst().orElse(null));
+                    break;
+                }
+            }
+            return maxPt;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -704,6 +704,15 @@ public class MetadataMgr {
         return ImmutableList.copyOf(partitionNames.build());
     }
 
+    public String getMaxPartitionValue(Table table, boolean nonEmptyPartition) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
+        String maxPartition = null;
+        if (connectorMetadata.isPresent()) {
+            maxPartition = connectorMetadata.get().getMaxPartitionValue(table, nonEmptyPartition);
+        }
+        return maxPartition;
+    }
+
     public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator, Column> columns) {
         Statistics.Builder statistics = Statistics.builder();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -834,6 +835,25 @@ public class MetaFunctions {
             return ConstantOperator.createNull(VarcharType.VARCHAR);
         }
         return ConstantOperator.createVarchar(lastQueryId.toString());
+    }
+
+    @ConstantFunction(name = "max_pt", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator max_partition(ConstantOperator name) throws DdlException {
+        TableName tableName = TableName.fromString(name.getVarchar());
+
+        Table table =
+                GlobalStateMgr.getCurrentState()
+                        .getMetadataMgr()
+                        .getTable(new ConnectContext(), tableName)
+                        .orElseThrow(() -> new SemanticException("Table {} not found", tableName));
+
+        if (!table.isOdpsTable()) {
+            throw new SemanticException("`max_pt` function only support for [odps table].");
+        }
+
+        String partitionValue = GlobalStateMgr.getCurrentState().getMetadataMgr().getMaxPartitionValue(table, true);
+        return partitionValue == null ? ConstantOperator.createNull(VarcharType.VARCHAR)
+                : ConstantOperator.createVarchar(partitionValue);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsCacheUpdateProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsCacheUpdateProcessorTest.java
@@ -54,6 +54,7 @@ public class OdpsCacheUpdateProcessorTest {
     private LoadingCache<String, Set<String>> tableNameCache;
     private LoadingCache<OdpsTableName, OdpsTable> tableCache;
     private LoadingCache<OdpsTableName, List<Partition>> partitionCache;
+    private LoadingCache<OdpsTableName, String> maxPartitionCache;
 
     @BeforeEach
     public void setUp() {
@@ -77,11 +78,18 @@ public class OdpsCacheUpdateProcessorTest {
                         return ImmutableList.of();
                     }
                 });
+        maxPartitionCache = CacheBuilder.newBuilder()
+                .build(new CacheLoader<>() {
+                    @Override
+                    public String load(OdpsTableName key) {
+                        return mock(String.class);
+                    }
+                });
     }
 
     private OdpsCacheUpdateProcessor createProcessor() {
         return new OdpsCacheUpdateProcessor(
-                CATALOG_NAME, odps, tableNameCache, tableCache, partitionCache);
+                CATALOG_NAME, odps, tableNameCache, tableCache, partitionCache, maxPartitionCache);
     }
 
     // --- refreshTable ---

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsMetadataTest.java
@@ -14,8 +14,12 @@
 
 package com.starrocks.connector.odps;
 
+import com.aliyun.odps.Column;
 import com.aliyun.odps.OdpsException;
+import com.aliyun.odps.Partition;
+import com.aliyun.odps.PartitionSpec;
 import com.aliyun.odps.TableSchema;
+import com.aliyun.odps.type.TypeInfoFactory;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OdpsTable;
@@ -36,15 +40,25 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 public class OdpsMetadataTest extends MockedBase {
@@ -180,6 +194,248 @@ public class OdpsMetadataTest extends MockedBase {
         OdpsTable odpsTable = new OdpsTable("catalog", table);
         TTableDescriptor thrift = odpsTable.toThrift(null);
         Assertions.assertNotNull(thrift);
+    }
+
+    @Test
+    public void testGetMaxPartitionValueWithCache() {
+        // Use a unique table name to avoid affecting other tests
+        String testDbName = "test_project_cache";
+        String testTableName = "test_table_cache";
+        
+        // Create multiple partitions with different values
+        // We'll create partitions with values: 20230101, 20230102, 20230103, 20230105
+        // The max partition should be "20230105"
+        Partition partition1 = Mockito.mock(Partition.class);
+        Partition partition2 = Mockito.mock(Partition.class);
+        Partition partition3 = Mockito.mock(Partition.class);
+        Partition partition4 = Mockito.mock(Partition.class);
+
+        PartitionSpec spec1 = new PartitionSpec("p1=20230101");
+        PartitionSpec spec2 = new PartitionSpec("p1=20230102");
+        PartitionSpec spec3 = new PartitionSpec("p1=20230103");
+        PartitionSpec spec4 = new PartitionSpec("p1=20230105");
+
+        when(partition1.getPartitionSpec()).thenReturn(spec1);
+        when(partition1.getPhysicalSize()).thenReturn(1000L);
+        when(partition2.getPartitionSpec()).thenReturn(spec2);
+        when(partition2.getPhysicalSize()).thenReturn(2000L);
+        when(partition3.getPartitionSpec()).thenReturn(spec3);
+        when(partition3.getPhysicalSize()).thenReturn(3000L);
+        when(partition4.getPartitionSpec()).thenReturn(spec4);
+        when(partition4.getPhysicalSize()).thenReturn(4000L);
+
+        // Create a new independent mock Table to avoid affecting other tests
+        com.aliyun.odps.Table testOdpsTable = Mockito.mock(com.aliyun.odps.Table.class);
+        when(testOdpsTable.getPartitions()).thenReturn(ImmutableList.of(partition1, partition2, partition3, partition4));
+        when(testOdpsTable.getName()).thenReturn(testTableName);
+        when(testOdpsTable.getCreatedTime()).thenReturn(new java.util.Date());
+        when(testOdpsTable.getProject()).thenReturn(testDbName);
+        try {
+            doNothing().when(testOdpsTable).reload();
+        } catch (OdpsException e) {
+            // Ignore
+        }
+        
+        // Set up table schema similar to MockedBase
+        TableSchema tableSchema = new TableSchema();
+        tableSchema.addColumn(new Column("c1", TypeInfoFactory.STRING));
+        tableSchema.addColumn(new Column("c2", TypeInfoFactory.BIGINT));
+        tableSchema.addPartitionColumn(new Column("p1", TypeInfoFactory.STRING));
+        when(testOdpsTable.getSchema()).thenReturn(tableSchema);
+        
+        // Mock odps.tables().get() to return our test table for the specific table name
+        // This won't affect other tests since we use a unique table name
+        when(tables.get(testDbName, testTableName)).thenReturn(testOdpsTable);
+        
+        // Create a new OdpsMetadata instance with partition cache enabled
+        Map<String, String> properties = new HashMap<>();
+        properties.put(OdpsProperties.ACCESS_ID, "ak");
+        properties.put(OdpsProperties.ACCESS_KEY, "sk");
+        properties.put(OdpsProperties.ENDPOINT, "http://127.0.0.1");
+        properties.put(OdpsProperties.PROJECT, testDbName);
+        properties.put(OdpsProperties.TUNNEL_QUOTA, "pay-as-you-go");
+        properties.put(OdpsProperties.ENABLE_PARTITION_CACHE, "true");
+        properties.put(OdpsProperties.PARTITION_CACHE_EXPIRE_TIME, "1");
+        properties.put(OdpsProperties.PARTITION_CACHE_SIZE, "1000");
+        OdpsMetadata metadata = new OdpsMetadata(odps, "odps", aliyunCloudCredential, new OdpsProperties(properties));
+
+        // Get table to populate the cache
+        Table testTable = metadata.getTable(new ConnectContext(), testDbName, testTableName);
+        Assertions.assertNotNull(testTable);
+
+        // Test with nonEmptyPartition = false - should return max partition value from cache
+        // Expected max: "20230105" (the largest value among all partitions)
+        String maxPartition = metadata.getMaxPartitionValue(testTable, false);
+        Assertions.assertNotNull(maxPartition);
+        Assertions.assertEquals("20230105", maxPartition,
+                "Max partition should be 20230105, which is the largest value among all partitions in cache");
+
+        // Test with nonEmptyPartition = true - should also return max partition value from cache
+        // Since all partitions have physicalSize > 0, the result should be the same
+        String maxPartitionNonEmpty = metadata.getMaxPartitionValue(testTable, true);
+        Assertions.assertNotNull(maxPartitionNonEmpty);
+        Assertions.assertEquals("20230105", maxPartitionNonEmpty,
+                "Max partition should be 20230105, which is the largest value among non-empty partitions in cache");
+    }
+
+    @Test
+    public void testGetMaxPartitionValueWithNonEmptyPartition() {
+        // Use a unique table name to avoid affecting other tests
+        String testDbName = "test_project_nonempty";
+        String testTableName = "test_table_nonempty";
+        
+        // Create a metadata instance with partition cache enabled
+        Map<String, String> properties = new HashMap<>();
+        properties.put(OdpsProperties.ACCESS_ID, "ak");
+        properties.put(OdpsProperties.ACCESS_KEY, "sk");
+        properties.put(OdpsProperties.ENDPOINT, "http://127.0.0.1");
+        properties.put(OdpsProperties.PROJECT, testDbName);
+        properties.put(OdpsProperties.TUNNEL_QUOTA, "pay-as-you-go");
+        properties.put(OdpsProperties.ENABLE_PARTITION_CACHE, "true");
+        properties.put(OdpsProperties.PARTITION_CACHE_EXPIRE_TIME, "1");
+        properties.put(OdpsProperties.PARTITION_CACHE_SIZE, "1000");
+        OdpsMetadata metadata = new OdpsMetadata(odps, "odps", aliyunCloudCredential, new OdpsProperties(properties));
+
+        // Create partitions with different sizes and values
+        // We'll create partitions with values: 20230101 (empty), 20230102 (non-empty), 20230103 (empty), 20230104 (non-empty)
+        // The max non-empty partition should be "20230104"
+        Partition partition1 = Mockito.mock(Partition.class);
+        Partition partition2 = Mockito.mock(Partition.class);
+        Partition partition3 = Mockito.mock(Partition.class);
+        Partition partition4 = Mockito.mock(Partition.class);
+
+        PartitionSpec spec1 = new PartitionSpec("p1=20230101");
+        PartitionSpec spec2 = new PartitionSpec("p1=20230102");
+        PartitionSpec spec3 = new PartitionSpec("p1=20230103");
+        PartitionSpec spec4 = new PartitionSpec("p1=20230104");
+
+        when(partition1.getPartitionSpec()).thenReturn(spec1);
+        when(partition1.getPhysicalSize()).thenReturn(0L); // Empty partition
+        when(partition2.getPartitionSpec()).thenReturn(spec2);
+        when(partition2.getPhysicalSize()).thenReturn(2000L); // Non-empty partition
+        when(partition3.getPartitionSpec()).thenReturn(spec3);
+        when(partition3.getPhysicalSize()).thenReturn(0L); // Empty partition
+        when(partition4.getPartitionSpec()).thenReturn(spec4);
+        when(partition4.getPhysicalSize()).thenReturn(3000L); // Non-empty partition, this should be the max
+
+        // Create a new independent mock Table to avoid affecting other tests
+        com.aliyun.odps.Table testOdpsTable = Mockito.mock(com.aliyun.odps.Table.class);
+        when(testOdpsTable.getPartitions()).thenReturn(ImmutableList.of(partition1, partition2, partition3, partition4));
+        when(testOdpsTable.getName()).thenReturn(testTableName);
+        when(testOdpsTable.getCreatedTime()).thenReturn(new java.util.Date());
+        when(testOdpsTable.getProject()).thenReturn(testDbName);
+        try {
+            doNothing().when(testOdpsTable).reload();
+        } catch (OdpsException e) {
+            // Ignore
+        }
+        
+        // Set up table schema similar to MockedBase
+        TableSchema tableSchema = new TableSchema();
+        tableSchema.addColumn(new Column("c1", TypeInfoFactory.STRING));
+        tableSchema.addColumn(new Column("c2", TypeInfoFactory.BIGINT));
+        tableSchema.addPartitionColumn(new Column("p1", TypeInfoFactory.STRING));
+        when(testOdpsTable.getSchema()).thenReturn(tableSchema);
+        
+        // Mock odps.tables().get() to return our test table for the specific table name
+        // This won't affect other tests since we use a unique table name
+        when(tables.get(testDbName, testTableName)).thenReturn(testOdpsTable);
+
+        // Get table to populate the cache
+        Table testTable = metadata.getTable(new ConnectContext(), testDbName, testTableName);
+        Assertions.assertNotNull(testTable);
+
+        // Test with nonEmptyPartition = true - should return max partition value from non-empty partitions
+        // Expected max: "20230104" (the largest value among non-empty partitions: 20230102 and 20230104)
+        String maxPartition = metadata.getMaxPartitionValue(testTable, true);
+        Assertions.assertNotNull(maxPartition);
+        Assertions.assertEquals("20230104", maxPartition, 
+                "Max partition should be 20230104, which is the largest value among non-empty partitions");
+
+        // Test with nonEmptyPartition = false - should return max partition value from all partitions
+        // Expected max: "20230104" (the largest value among all partitions)
+        String maxPartitionAll = metadata.getMaxPartitionValue(testTable, false);
+        Assertions.assertNotNull(maxPartitionAll);
+        Assertions.assertEquals("20230104", maxPartitionAll,
+                "Max partition should be 20230104, which is the largest value among all partitions");
+    }
+
+    @Test
+    public void testGetMaxPartitionValueFromIterator() throws OdpsException {
+        // Use a unique table name to avoid affecting other tests
+        String testDbName = "test_project_iterator";
+        String testTableName = "test_table_iterator";
+        
+        // Create a metadata instance with partition cache disabled
+        Map<String, String> properties = new HashMap<>();
+        properties.put(OdpsProperties.ACCESS_ID, "ak");
+        properties.put(OdpsProperties.ACCESS_KEY, "sk");
+        properties.put(OdpsProperties.ENDPOINT, "http://127.0.0.1");
+        properties.put(OdpsProperties.PROJECT, testDbName);
+        properties.put(OdpsProperties.TUNNEL_QUOTA, "pay-as-you-go");
+        properties.put(OdpsProperties.ENABLE_PARTITION_CACHE, "false");
+        OdpsMetadata metadata = new OdpsMetadata(odps, "odps", aliyunCloudCredential, new OdpsProperties(properties));
+
+        // Create a unique mock table for this test
+        com.aliyun.odps.Table testOdpsTable = Mockito.mock(com.aliyun.odps.Table.class);
+        when(testOdpsTable.getName()).thenReturn(testTableName);
+        when(testOdpsTable.getProject()).thenReturn(testDbName);
+        when(testOdpsTable.getCreatedTime()).thenReturn(new Date()); // Required by OdpsTable constructor
+
+        // Set up table schema
+        TableSchema tableSchema = new TableSchema();
+        tableSchema.addColumn(new Column("c1", TypeInfoFactory.STRING));
+        tableSchema.addPartitionColumn(new Column("p1", TypeInfoFactory.STRING));
+        when(testOdpsTable.getSchema()).thenReturn(tableSchema);
+
+        try {
+            doNothing().when(testOdpsTable).reload();
+        } catch (OdpsException e) {
+            // Ignore
+        }
+
+        // Return empty list so partition cache stays empty and we always use the iterator branch
+        when(testOdpsTable.getPartitions()).thenReturn(Collections.emptyList());
+
+        // Mock odps.tables().get() to return our test table (doReturn so it overrides MockedBase's anyString stub)
+        doReturn(testOdpsTable).when(tables).get(testDbName, testTableName);
+
+        // Mock partition iterator with multiple partitions
+        Partition partition1 = Mockito.mock(Partition.class);
+        PartitionSpec spec1 = new PartitionSpec("p1=20230101");
+        when(partition1.getPartitionSpec()).thenReturn(spec1);
+        when(partition1.getPhysicalSize()).thenReturn(0L); // Empty partition
+
+        Partition partition2 = Mockito.mock(Partition.class);
+        PartitionSpec spec2 = new PartitionSpec("p1=20230102");
+        when(partition2.getPartitionSpec()).thenReturn(spec2);
+        when(partition2.getPhysicalSize()).thenReturn(1000L); // Non-empty partition
+
+        Partition partition3 = Mockito.mock(Partition.class);
+        PartitionSpec spec3 = new PartitionSpec("p1=20230103");
+        when(partition3.getPartitionSpec()).thenReturn(spec3);
+        when(partition3.getPhysicalSize()).thenReturn(2000L); // Non-empty partition
+
+        // Use a real iterator over partition list so each getPartitionIterator() call gets a fresh iteration
+        List<Partition> partitionList = Arrays.asList(partition1, partition2, partition3);
+        when(testOdpsTable.getPartitionIterator(any(), anyBoolean(), anyLong(), anyLong()))
+                .thenAnswer((Answer<Iterator<Partition>>) invocation -> partitionList.iterator());
+
+        Table testTable = metadata.getTable(new ConnectContext(), testDbName, testTableName);
+        Assertions.assertNotNull(testTable);
+
+        // Test getMaxPartitionValue when cache is empty, should use iterator
+        // With nonEmptyPartition = false, should return first partition value (20230101)
+        String maxPartition = metadata.getMaxPartitionValue(testTable, false);
+        Assertions.assertNotNull(maxPartition);
+        Assertions.assertEquals("20230101", maxPartition, 
+                "When nonEmptyPartition=false, should return first partition value from iterator");
+
+        // With nonEmptyPartition = true, should return first non-empty partition value (20230102)
+        String maxPartitionNonEmpty = metadata.getMaxPartitionValue(testTable, true);
+        Assertions.assertNotNull(maxPartitionNonEmpty);
+        Assertions.assertEquals("20230102", maxPartitionNonEmpty,
+                "When nonEmptyPartition=true, should return first non-empty partition value from iterator");
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.OdpsTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
@@ -507,5 +508,97 @@ public class MetadataMgrTest {
             AnalyzeTestUtil.getStarRocksAssert().dropCatalog(catalogName);
         } catch (Exception ignored) {
         }
+    }
+
+    @Test
+    public void testGetMaxPartitionValueWithOdpsCatalog() throws Exception {
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+
+        // Test with ODPS catalog
+        String createOdpsCatalogStmt = "CREATE EXTERNAL CATALOG odps_catalog PROPERTIES(\"type\"=\"odps\", " +
+                "\"odps.access.id\"=\"ak\", \"odps.access.key\"=\"sk\", \"odps.endpoint\"=\"http://127.0.0.1\", " +
+                "\"odps.project\"=\"odps_project\", \"odps.tunnel.quota\"=\"pay-as-you-go\")";
+        StarRocksAssert starRocksAssert = AnalyzeTestUtil.getStarRocksAssert();
+        try {
+            starRocksAssert.withCatalog(createOdpsCatalogStmt);
+
+            // Create MockedMetadataMgr and register mocked OdpsMetadata
+            ConnectContext connectContext = AnalyzeTestUtil.getConnectContext();
+            MockedMetadataMgr mockedMetadataMgr = new MockedMetadataMgr(
+                    connectContext.getGlobalStateMgr().getLocalMetastore(),
+                    connectContext.getGlobalStateMgr().getConnectorMgr());
+
+            // Create a simple mock ConnectorMetadata that implements getMaxPartitionValue
+            ConnectorMetadata mockedOdpsMetadata = new ConnectorMetadata() {
+                @Override
+                public String getMaxPartitionValue(com.starrocks.catalog.Table table, boolean nonEmptyPartition) {
+                    return "20230101";
+                }
+            };
+
+            mockedMetadataMgr.registerMockedMetadata("odps_catalog", mockedOdpsMetadata);
+            GlobalStateMgr.getCurrentState().setMetadataMgr(mockedMetadataMgr);
+
+            // Create a mock ODPS table
+            OdpsTable odpsTable = new OdpsTable() {
+                @Override
+                public String getCatalogName() {
+                    return "odps_catalog";
+                }
+
+                @Override
+                public String getCatalogDBName() {
+                    return "odps_project";
+                }
+
+                @Override
+                public String getName() {
+                    return "odps_table";
+                }
+            };
+
+            // Test getMaxPartitionValue with ODPS table
+            String maxPartition = mockedMetadataMgr.getMaxPartitionValue(odpsTable, false);
+            Assertions.assertEquals("20230101", maxPartition);
+
+            // Test with nonEmptyPartition = true
+            String maxPartitionNonEmpty = mockedMetadataMgr.getMaxPartitionValue(odpsTable, true);
+            Assertions.assertEquals("20230101", maxPartitionNonEmpty);
+
+            // Restore original metadataMgr
+            GlobalStateMgr.getCurrentState().setMetadataMgr(metadataMgr);
+        } finally {
+            try {
+                starRocksAssert.dropCatalog("odps_catalog");
+            } catch (Exception e) {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    @Test
+    public void testGetMaxPartitionValueWithNonExistentCatalog() {
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+
+        // Test with non-existent catalog
+        com.starrocks.catalog.Table nonExistentTable =
+                new com.starrocks.catalog.Table(com.starrocks.catalog.Table.TableType.ODPS) {
+                    @Override
+                    public String getCatalogName() {
+                        return "non_existent_catalog";
+                    }
+
+                    @Override
+                    public String getCatalogDBName() {
+                        return "db";
+                    }
+
+                    @Override
+                    public String getName() {
+                        return "table";
+                    }
+                };
+        String maxPartition = metadataMgr.getMaxPartitionValue(nonExistentTable, false);
+        Assertions.assertNull(maxPartition);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -17,19 +17,27 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.catalog.OdpsTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorReportException;
+import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.type.VarcharType;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +48,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -308,14 +317,14 @@ public class MetaFunctionsTest extends MVTestBase {
         starRocksAssert.withTable("create table base_table_single_mv(k1 int, v1 int) properties('replication_num'='1')");
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_single distributed by random " +
                 "as select k1, sum(v1) from test.base_table_single_mv group by k1");
-        
+
         ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_single_mv"));
         Assertions.assertNotNull(result);
         String json = result.getVarchar();
         Assertions.assertTrue(json.contains("\"name\":\"mv_single\""));
         Assertions.assertTrue(json.contains("\"level\":0"));
         Assertions.assertTrue(json.contains("\"related_mvs\":[]"));
-        
+
         starRocksAssert.dropMaterializedView("mv_single");
         starRocksAssert.dropTable("base_table_single_mv");
     }
@@ -324,27 +333,27 @@ public class MetaFunctionsTest extends MVTestBase {
     public void testInspectRelatedMvWithNestedMVs() throws Exception {
         // Create base table
         starRocksAssert.withTable("create table base_table_nested(k1 int, v1 int) properties('replication_num'='1')");
-        
+
         // Create first level MV
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_level_0 distributed by random " +
                 "as select k1, sum(v1) as sum_v1 from test.base_table_nested group by k1");
-        
+
         // Create second level MV (nested)
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_level_1 distributed by random " +
                 "as select k1, sum(sum_v1) as total from test.mv_level_0 group by k1");
-        
+
         ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_nested"));
         Assertions.assertNotNull(result);
         String json = result.getVarchar();
-        
+
         // Check level 0 MV
         Assertions.assertTrue(json.contains("\"name\":\"mv_level_0\""));
         Assertions.assertTrue(json.contains("\"level\":0"));
-        
+
         // Check nested level 1 MV
         Assertions.assertTrue(json.contains("\"name\":\"mv_level_1\""));
         Assertions.assertTrue(json.contains("\"level\":1"));
-        
+
         // Clean up in reverse order
         starRocksAssert.dropMaterializedView("mv_level_1");
         starRocksAssert.dropMaterializedView("mv_level_0");
@@ -354,21 +363,21 @@ public class MetaFunctionsTest extends MVTestBase {
     @Test
     public void testInspectRelatedMvWithMultipleMVsAtSameLevel() throws Exception {
         starRocksAssert.withTable("create table base_table_multi_mv(k1 int, v1 int, v2 int) properties('replication_num'='1')");
-        
+
         // Create multiple MVs at level 0
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_multi_1 distributed by random " +
                 "as select k1, sum(v1) from test.base_table_multi_mv group by k1");
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_multi_2 distributed by random " +
                 "as select k1, sum(v2) from test.base_table_multi_mv group by k1");
-        
+
         ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_multi_mv"));
         Assertions.assertNotNull(result);
         String json = result.getVarchar();
-        
+
         // Both MVs should be at level 0
         Assertions.assertTrue(json.contains("\"name\":\"mv_multi_1\"") || json.contains("\"name\":\"mv_multi_2\""));
         Assertions.assertTrue(json.contains("\"level\":0"));
-        
+
         starRocksAssert.dropMaterializedView("mv_multi_1");
         starRocksAssert.dropMaterializedView("mv_multi_2");
         starRocksAssert.dropTable("base_table_multi_mv");
@@ -378,23 +387,23 @@ public class MetaFunctionsTest extends MVTestBase {
     public void testInspectRelatedMvWithDeepNesting() throws Exception {
         // Create base table
         starRocksAssert.withTable("create table base_table_deep(k1 int, v1 int) properties('replication_num'='1')");
-        
+
         // Create level 0 MV
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_deep_0 distributed by random " +
                 "as select k1, sum(v1) as sum_v1 from test.base_table_deep group by k1");
-        
+
         // Create level 1 MV
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_deep_1 distributed by random " +
                 "as select k1, sum(sum_v1) as sum_v2 from test.mv_deep_0 group by k1");
-        
+
         // Create level 2 MV
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_deep_2 distributed by random " +
                 "as select k1, sum(sum_v2) as sum_v3 from test.mv_deep_1 group by k1");
-        
+
         ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_deep"));
         Assertions.assertNotNull(result);
         String json = result.getVarchar();
-        
+
         // Verify all levels exist
         Assertions.assertTrue(json.contains("\"name\":\"mv_deep_0\""));
         Assertions.assertTrue(json.contains("\"level\":0"));
@@ -402,7 +411,7 @@ public class MetaFunctionsTest extends MVTestBase {
         Assertions.assertTrue(json.contains("\"level\":1"));
         Assertions.assertTrue(json.contains("\"name\":\"mv_deep_2\""));
         Assertions.assertTrue(json.contains("\"level\":2"));
-        
+
         // Clean up in reverse order
         starRocksAssert.dropMaterializedView("mv_deep_2");
         starRocksAssert.dropMaterializedView("mv_deep_1");
@@ -421,17 +430,17 @@ public class MetaFunctionsTest extends MVTestBase {
         starRocksAssert.withTable("create table base_table_json(k1 int, v1 int) properties('replication_num'='1')");
         starRocksAssert.withRefreshedMaterializedView("create materialized view mv_json distributed by random " +
                 "as select k1, sum(v1) from test.base_table_json group by k1");
-        
+
         ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_json"));
         Assertions.assertNotNull(result);
         String json = result.getVarchar();
-        
+
         // Verify JSON structure contains required fields
         Assertions.assertTrue(json.contains("\"id\":"));
         Assertions.assertTrue(json.contains("\"name\":"));
         Assertions.assertTrue(json.contains("\"level\":"));
         Assertions.assertTrue(json.contains("\"related_mvs\":"));
-        
+
         starRocksAssert.dropMaterializedView("mv_json");
         starRocksAssert.dropTable("base_table_json");
     }
@@ -591,5 +600,183 @@ public class MetaFunctionsTest extends MVTestBase {
             connectContext.setCurrentRoleIds(UserIdentity.ROOT);
             connectContext.setThreadLocalInfo();
         }
+    }
+
+    @Test
+    public void testMaxPartitionWithOdpsTable() throws Exception {
+        // Use MockedMetadataMgr to avoid creating actual catalog
+        MockedMetadataMgr mockedMetadataMgr = new MockedMetadataMgr(
+                connectContext.getGlobalStateMgr().getLocalMetastore(),
+                connectContext.getGlobalStateMgr().getConnectorMgr());
+
+        // Create a mock ConnectorMetadata for ODPS that implements getMaxPartitionValue
+        ConnectorMetadata mockedOdpsMetadata = new ConnectorMetadata() {
+            @Override
+            public String getMaxPartitionValue(com.starrocks.catalog.Table table, boolean nonEmptyPartition) {
+                return "20230101";
+            }
+        };
+
+        mockedMetadataMgr.registerMockedMetadata("odps_catalog", mockedOdpsMetadata);
+        MetadataMgr originalMetadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        GlobalStateMgr.getCurrentState().setMetadataMgr(mockedMetadataMgr);
+
+        try {
+            // Mock the table and metadataMgr.getMaxPartitionValue
+            new Expectations(mockedMetadataMgr) {
+                {
+                    // Mock getTable(ConnectContext, TableName) which returns Optional<Table>
+                    mockedMetadataMgr.getTable((ConnectContext) any, (TableName) any);
+                    result = Optional.of(new OdpsTable() {
+                        @Override
+                        public String getCatalogName() {
+                            return "odps_catalog";
+                        }
+
+                        @Override
+                        public String getCatalogDBName() {
+                            return "project";
+                        }
+
+                        @Override
+                        public String getName() {
+                            return "test_table";
+                        }
+
+                        @Override
+                        public boolean isOdpsTable() {
+                            return true;
+                        }
+                    });
+                    minTimes = 0;
+
+                    mockedMetadataMgr.getMaxPartitionValue((Table) any, anyBoolean);
+                    result = "20230101";
+                    minTimes = 0;
+                }
+            };
+
+            // Test max_partition function with ODPS table
+            ConstantOperator result =
+                    MetaFunctions.max_partition(ConstantOperator.createVarchar("odps_catalog.project.test_table"));
+            Assertions.assertNotNull(result);
+            Assertions.assertFalse(result.isNull());
+            Assertions.assertEquals("20230101", result.getVarchar());
+        } finally {
+            // Restore original metadataMgr
+            GlobalStateMgr.getCurrentState().setMetadataMgr(originalMetadataMgr);
+        }
+    }
+
+    @Test
+    public void testMaxPartitionWithTableNotFound() {
+        assertThrows(SemanticException.class, () -> {
+            GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+            MetadataMgr metadataMgr = globalStateMgr.getMetadataMgr();
+
+            new Expectations(metadataMgr) {
+                {
+                    metadataMgr.getTable(connectContext, "odps_catalog", "project", "non_existent_table");
+                    result = null;
+                    minTimes = 0;
+                }
+            };
+
+            MetaFunctions.max_partition(ConstantOperator.createVarchar("odps_catalog.project.non_existent_table"));
+        });
+    }
+
+    @Test
+    public void testMaxPartitionWithUnsupportedTableType() {
+        assertThrows(SemanticException.class, () -> {
+            GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+            MetadataMgr metadataMgr = globalStateMgr.getMetadataMgr();
+
+            // Mock a table that is not ODPS or Hive
+            new Expectations(metadataMgr) {
+                {
+                    metadataMgr.getTable(connectContext, "mysql_catalog", "db", "test_table");
+                    result = new Table(Table.TableType.MYSQL) {
+                        @Override
+                        public String getCatalogName() {
+                            return "mysql_catalog";
+                        }
+
+                        @Override
+                        public String getCatalogDBName() {
+                            return "db";
+                        }
+
+                        @Override
+                        public String getName() {
+                            return "test_table";
+                        }
+
+                        @Override
+                        public boolean isOdpsTable() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean isHiveTable() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean isHMSExternalTable() {
+                            return true;
+                        }
+                    };
+                    minTimes = 0;
+                }
+            };
+
+            MetaFunctions.max_partition(ConstantOperator.createVarchar("mysql_catalog.db.test_table"));
+        });
+    }
+
+    @Test
+    public void testMaxPartitionWithNullPartitionValue() throws Exception {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MetadataMgr metadataMgr = globalStateMgr.getMetadataMgr();
+
+        // Mock the table and metadataMgr.getMaxPartitionValue returning null
+        new Expectations(metadataMgr) {
+            {
+                // Mock getTable(ConnectContext, TableName) which returns Optional<Table>
+                metadataMgr.getTable((ConnectContext) any, (TableName) any);
+                result = Optional.of(new OdpsTable() {
+                    @Override
+                    public String getCatalogName() {
+                        return "odps_catalog";
+                    }
+
+                    @Override
+                    public String getCatalogDBName() {
+                        return "project";
+                    }
+
+                    @Override
+                    public String getName() {
+                        return "test_table";
+                    }
+
+                    @Override
+                    public boolean isOdpsTable() {
+                        return true;
+                    }
+                });
+                minTimes = 0;
+
+                metadataMgr.getMaxPartitionValue((Table) any, anyBoolean);
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        // Test max_partition function when partition value is null
+        ConstantOperator result = MetaFunctions.max_partition(ConstantOperator.createVarchar("odps_catalog.project.test_table"));
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isNull());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
MaxCompute(ODPS) supports 'max_pt' function to get max non-empty partition of odps table in lexicographical order. Users migrated from ODPS get used to use 'max_pt' when querying ODPS table. It is necessary to be compatible SQL usage with ODPS.
Getting max partition is an expensive operation. Including get all partitions, sort partitions lexicographically by top-k. Considering most ODPS tables are t+1 updating, 'max_pt' value can be cached like `partitionCache`.

## What I'm doing:
Implement 'max_pt' meta function and max partition cache in `OdpsMetadata`. Partitions loaded from `partitionCache` will be sorted lexicographically. Empty partition is filtered. Values of max partitions are saved in `maxPartitionCache`, which is similar to `partitionCache`. `maxPartitionCache` is updated together with `partitionCache`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
