### PR TITLE
[BugFix] Record vector_index_ids on shared-data primary-key tablet writer

### DIFF
--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -299,6 +299,28 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
     return Status::OK();
 }
 
+void HorizontalGeneralTabletWriter::record_segment_vector_index_ids(SegmentFileInfo& segment_file_info,
+                                                                    SegmentWriter* seg_writer) const {
+    // Record which vector indexes need a .vi file for this segment. Shared by the duplicate-key
+    // flush path and the primary-key override (HorizontalPkTabletWriter) so the two cannot
+    // silently diverge: the PK override previously omitted this, dropping vector index builds
+    // for shared-data primary-key tables.
+    if (seg_writer->defer_vector_index_build()) {
+        // Async: skip bundle-file segments (.vi doesn't support the bundle format yet, so the
+        // index is rebuilt after compaction) and segments below the deferred-build threshold.
+        bool is_bundled = segment_file_info.bundle_file_offset.has_value();
+        if (is_bundled || segment_file_info.num_rows < seg_writer->vector_index_build_threshold()) {
+            return;
+        }
+    } else if (!seg_writer->has_vector_index_written()) {
+        // Sync: record only when .vi files were actually produced inline.
+        return;
+    }
+    for (const auto& [index_id, _] : seg_writer->vector_index_file_paths()) {
+        segment_file_info.vector_index_ids.push_back(index_id);
+    }
+}
+
 Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
     if (_seg_writer != nullptr) {
         uint64_t segment_size = 0;
@@ -316,34 +338,7 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         }
         _seg_writer->write_sort_key_fields_to(segment_file_info);
         segment_file_info.num_rows = _seg_writer->num_rows();
-        // Record which vector indexes need .vi files
-        // Skip bundled segments: .vi files don't support bundle format yet
-        bool is_bundled = segment_file_info.bundle_file_offset.has_value();
-        if (_seg_writer->defer_vector_index_build()) {
-            if (is_bundled) {
-                VLOG(3) << "Async vector index: tablet=" << _tablet_id << " segment=" << segment_file_info.path
-                        << " SKIPPED (bundled segment)";
-            } else if (segment_file_info.num_rows >= _seg_writer->vector_index_build_threshold()) {
-                for (const auto& [index_id, _] : _seg_writer->vector_index_file_paths()) {
-                    segment_file_info.vector_index_ids.push_back(index_id);
-                }
-                VLOG(3) << "Async vector index: tablet=" << _tablet_id << " segment=" << segment_file_info.path
-                        << " num_rows=" << segment_file_info.num_rows
-                        << " threshold=" << _seg_writer->vector_index_build_threshold() << " recorded "
-                        << segment_file_info.vector_index_ids.size() << " index_ids";
-            } else {
-                VLOG(3) << "Async vector index: tablet=" << _tablet_id << " segment=" << segment_file_info.path
-                        << " num_rows=" << segment_file_info.num_rows
-                        << " threshold=" << _seg_writer->vector_index_build_threshold() << " SKIPPED (below threshold)";
-            }
-        } else {
-            // Sync mode: record vector index IDs only when .vi files were actually produced.
-            if (_seg_writer->has_vector_index_written()) {
-                for (const auto& [index_id, _] : _seg_writer->vector_index_file_paths()) {
-                    segment_file_info.vector_index_ids.push_back(index_id);
-                }
-            }
-        }
+        record_segment_vector_index_ids(segment_file_info, _seg_writer.get());
         _data_size += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());
         _stats.segment_count++;

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -83,6 +83,13 @@ protected:
     virtual Status reset_segment_writer(bool eos);
     virtual Status flush_segment_writer(SegmentPB* segment = nullptr);
 
+    // Record into |segment_file_info| the vector indexes that need a .vi file, honoring the
+    // segment writer's sync/async build mode. Shared by this duplicate-key flush path and the
+    // primary-key override (HorizontalPkTabletWriter::flush_segment_writer) so the two cannot
+    // silently diverge: the PK override previously omitted this block, which dropped vector
+    // index builds for shared-data primary-key tables.
+    void record_segment_vector_index_ids(SegmentFileInfo& segment_file_info, SegmentWriter* seg_writer) const;
+
     std::unique_ptr<SegmentWriter> _seg_writer;
     BundleWritableFileContext* _bundle_file_context = nullptr;
     GlobalDictByNameMaps* _global_dicts = nullptr;

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -128,6 +128,10 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
         }
         _seg_writer->write_sort_key_fields_to(segment_file_info);
         segment_file_info.num_rows = _seg_writer->num_rows();
+        // Mirror the duplicate-key path: without this, shared-data primary-key tables never
+        // record vector_index_ids, so async builds are never scheduled and sync-built .vi
+        // files are never vacuumed.
+        record_segment_vector_index_ids(segment_file_info, _seg_writer.get());
         _data_size += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());
         _stats.segment_count++;

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -33,6 +33,7 @@
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/general_tablet_writer.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/pk_tablet_writer.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/test_util.h"
 #include "storage/rowset/segment_file_info.h"
@@ -311,6 +312,15 @@ protected:
         return schema_pb;
     }
 
+    // Primary-key variant of create_vi_schema_pb_async: identical async vector index, but
+    // keys_type=PRIMARY_KEYS so the write is driven through HorizontalPkTabletWriter, whose
+    // flush_segment_writer override historically dropped vector_index_ids.
+    TabletSchemaPB create_vi_pk_schema_pb_async(uint32_t threshold) {
+        auto schema_pb = create_vi_schema_pb_async(threshold);
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        return schema_pb;
+    }
+
     ChunkUniquePtr build_chunk(const TabletSchemaCSPtr& tablet_schema, int num_rows) {
         auto schema = ChunkHelper::convert_schema(tablet_schema);
         auto chunk = ChunkFactory::new_chunk(schema, num_rows);
@@ -388,6 +398,40 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_location_prov
     std::string vi_path = _lp->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
 
+    writer->close();
+}
+
+// Sync mode (default, no index_build_mode=async): HorizontalPkTabletWriter must record
+// vector_index_ids for a segment that produced a .vi inline, mirroring the duplicate-key
+// path (test_horizontal_writer_vi_via_tablet_mgr). Before the fix the PK override recorded
+// nothing, so the inline-built .vi could never be reclaimed by vacuum (which keys off
+// segment_metas.vector_index_ids). Both build flavors above the threshold record the id and
+// write a .vi next to the segment: a TenANN build writes a real index, a non-TenANN build
+// writes the empty-mark placeholder (IndexDescriptor::mark_word via EmptyVectorIndexBuilder).
+// So the recording and the .vi artifact are asserted unconditionally here, matching the
+// duplicate-key test above.
+TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_sync_records_index_ids) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    auto schema_pb = create_vi_schema_pb();
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 4103;
+    auto writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                             /*flush_pool=*/nullptr, /*is_compaction=*/false);
+    ASSERT_OK(writer->open());
+    auto chunk = build_chunk(tablet_schema, 5);
+    ASSERT_OK(writer->write(*chunk));
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(1u, writer->segments().size());
+    const auto& seg = writer->segments().front();
+    EXPECT_EQ(5, seg.num_rows);
+    ASSERT_EQ(1u, seg.vector_index_ids.size());
+    EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
+    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    EXPECT_TRUE(fs::path_exist(vi_path));
     writer->close();
 }
 
@@ -743,6 +787,57 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_async_below_threshol
     const auto& seg = writer->segments().front();
     EXPECT_EQ(5, seg.num_rows);
     EXPECT_TRUE(seg.vector_index_ids.empty()) << "below-threshold async segment should not record vi ids";
+    writer->close();
+}
+
+// Regression for shared-data primary-key vector index loss: HorizontalPkTabletWriter
+// overrides flush_segment_writer and historically forgot to record vector_index_ids, so
+// async builds were never scheduled (and sync-built .vi files never vacuumed) for PK
+// tables. With the shared record_segment_vector_index_ids helper the PK path now matches
+// the duplicate-key path. Async + above-threshold => exactly one recorded index id.
+// (Before the fix this segment recorded zero index ids and the assert below fails.)
+TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_async_above_threshold_records_index_ids) {
+    auto schema_pb = create_vi_pk_schema_pb_async(/*threshold=*/3);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 4101;
+    auto writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                             /*flush_pool=*/nullptr, /*is_compaction=*/false);
+    ASSERT_OK(writer->open());
+    auto chunk = build_chunk(tablet_schema, 5); // >= threshold
+    ASSERT_OK(writer->write(*chunk));
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(1u, writer->segments().size());
+    const auto& seg = writer->segments().front();
+    EXPECT_EQ(5, seg.num_rows);
+    ASSERT_EQ(1u, seg.vector_index_ids.size());
+    EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
+
+    // Async: no .vi inline; the deferred build task produces it later.
+    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    EXPECT_FALSE(fs::path_exist(vi_path));
+    writer->close();
+}
+
+// Boundary: PK writer, async + below-threshold => no vector_index_ids recorded. Confirms
+// the shared helper's threshold gate is applied on the PK path too (not just duplicate-key).
+TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_async_below_threshold_skips_record) {
+    auto schema_pb = create_vi_pk_schema_pb_async(/*threshold=*/100);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 4102;
+    auto writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                             /*flush_pool=*/nullptr, /*is_compaction=*/false);
+    ASSERT_OK(writer->open());
+    auto chunk = build_chunk(tablet_schema, 5); // < threshold
+    ASSERT_OK(writer->write(*chunk));
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(1u, writer->segments().size());
+    const auto& seg = writer->segments().front();
+    EXPECT_EQ(5, seg.num_rows);
+    EXPECT_TRUE(seg.vector_index_ids.empty()) << "below-threshold async PK segment should not record vi ids";
     writer->close();
 }
 


### PR DESCRIPTION
## Why I'm doing:

On shared-data primary-key tables, a vector index is silently lost. `HorizontalPkTabletWriter::flush_segment_writer` overrides the duplicate-key flush path but never sets `SegmentFileInfo::vector_index_ids`, while `HorizontalGeneralTabletWriter` (and both vertical writers) do. Since the normal PK load path always uses `HorizontalPkTabletWriter`, PK segments are committed with empty `vector_index_ids` in their metadata.

The downstream effects: async builds are never scheduled — `lake_service` only reports a tablet for VI build, and `VectorIndexBuildTask` only selects a segment, when `segment_metas.vector_index_ids` is non-empty — so every vector query on an async-mode PK table silently falls back to brute force. In sync mode the `.vi` is still built inline, but it is never reclaimed by vacuum, which deletes `.vi` files by walking `segment_metas.vector_index_ids`, leaking files in object storage.

## What I'm doing:

Extract the `vector_index_ids` recording out of `HorizontalGeneralTabletWriter::flush_segment_writer` into a shared protected helper `record_segment_vector_index_ids(...)`, and call it from both the duplicate-key and the primary-key horizontal flush paths so the two cannot silently diverge again (the divergence is what caused this bug). No behavior change for duplicate-key tables; the helper body is byte-for-byte the previous logic.

Added regression tests in `shared_data_vector_index_test.cpp` driving `HorizontalPkTabletWriter` end to end: async above-threshold (records the id), async below-threshold (records nothing), and sync mode (records the id and produces the inline `.vi` under WITH_TENANN).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5