### PR TITLE
[BugFix]Fix web identity credential provider to use StsWebIdentityTokenFileCredentialsProvider

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.regions.Region;
@@ -48,7 +49,6 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
-import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.util.Map;
@@ -203,18 +203,7 @@ public class AwsCloudCredential implements CloudCredential {
         } else if (useInstanceProfile) {
             return InstanceProfileCredentialsProvider.builder().build();
         } else if (useWebIdentityProfile) {
-            // stsRegion takes precedence; fall back to region so STS client has a region when
-            // aws.s3.sts.region is not set but aws.s3.region is — avoids eager DefaultAwsRegionProviderChain
-            String effectiveStsRegion = !stsRegion.isEmpty() ? stsRegion : region;
-            StsClientBuilder stsClientBuilder = StsClient.builder();
-            if (!effectiveStsRegion.isEmpty()) {
-                stsClientBuilder.region(Region.of(effectiveStsRegion));
-            }
-            if (!stsEndpoint.isEmpty()) {
-                stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(stsEndpoint));
-            }
-            return StsWebIdentityTokenFileCredentialsProvider.builder()
-                    .stsClient(stsClientBuilder.build())
+            return WebIdentityTokenFileCredentialsProvider.builder()
                     .asyncCredentialUpdateEnabled(true)
                     .build();
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.util.Map;
@@ -202,9 +203,17 @@ public class AwsCloudCredential implements CloudCredential {
         } else if (useInstanceProfile) {
             return InstanceProfileCredentialsProvider.builder().build();
         } else if (useWebIdentityProfile) {
-            // Reads AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN from env vars via the default chain,
-            // mirroring BE's STSAssumeRoleWebIdentityCredentialsProvider behaviour.
-            return DefaultCredentialsProvider.builder().build();
+            StsClientBuilder stsClientBuilder = StsClient.builder();
+            if (!stsRegion.isEmpty()) {
+                stsClientBuilder.region(Region.of(stsRegion));
+            }
+            if (!stsEndpoint.isEmpty()) {
+                stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(stsEndpoint));
+            }
+            return StsWebIdentityTokenFileCredentialsProvider.builder()
+                    .stsClient(stsClientBuilder.build())
+                    .asyncCredentialUpdateEnabled(true)
+                    .build();
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             if (!sessionToken.isEmpty()) {
                 return StaticCredentialsProvider.create(

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -203,19 +203,20 @@ public class AwsCloudCredential implements CloudCredential {
         } else if (useInstanceProfile) {
             return InstanceProfileCredentialsProvider.builder().build();
         } else if (useWebIdentityProfile) {
-            StsWebIdentityTokenFileCredentialsProvider.Builder builder =
-                    StsWebIdentityTokenFileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true);
-            if (!stsRegion.isEmpty() || !stsEndpoint.isEmpty()) {
-                StsClientBuilder stsClientBuilder = StsClient.builder();
-                if (!stsRegion.isEmpty()) {
-                    stsClientBuilder.region(Region.of(stsRegion));
-                }
-                if (!stsEndpoint.isEmpty()) {
-                    stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(stsEndpoint));
-                }
-                builder.stsClient(stsClientBuilder.build());
+            // stsRegion takes precedence; fall back to region so STS client has a region when
+            // aws.s3.sts.region is not set but aws.s3.region is — avoids eager DefaultAwsRegionProviderChain
+            String effectiveStsRegion = !stsRegion.isEmpty() ? stsRegion : region;
+            StsClientBuilder stsClientBuilder = StsClient.builder();
+            if (!effectiveStsRegion.isEmpty()) {
+                stsClientBuilder.region(Region.of(effectiveStsRegion));
             }
-            return builder.build();
+            if (!stsEndpoint.isEmpty()) {
+                stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(stsEndpoint));
+            }
+            return StsWebIdentityTokenFileCredentialsProvider.builder()
+                    .stsClient(stsClientBuilder.build())
+                    .asyncCredentialUpdateEnabled(true)
+                    .build();
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             if (!sessionToken.isEmpty()) {
                 return StaticCredentialsProvider.create(

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -203,17 +203,19 @@ public class AwsCloudCredential implements CloudCredential {
         } else if (useInstanceProfile) {
             return InstanceProfileCredentialsProvider.builder().build();
         } else if (useWebIdentityProfile) {
-            StsClientBuilder stsClientBuilder = StsClient.builder();
-            if (!stsRegion.isEmpty()) {
-                stsClientBuilder.region(Region.of(stsRegion));
+            StsWebIdentityTokenFileCredentialsProvider.Builder builder =
+                    StsWebIdentityTokenFileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true);
+            if (!stsRegion.isEmpty() || !stsEndpoint.isEmpty()) {
+                StsClientBuilder stsClientBuilder = StsClient.builder();
+                if (!stsRegion.isEmpty()) {
+                    stsClientBuilder.region(Region.of(stsRegion));
+                }
+                if (!stsEndpoint.isEmpty()) {
+                    stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(stsEndpoint));
+                }
+                builder.stsClient(stsClientBuilder.build());
             }
-            if (!stsEndpoint.isEmpty()) {
-                stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(stsEndpoint));
-            }
-            return StsWebIdentityTokenFileCredentialsProvider.builder()
-                    .stsClient(stsClientBuilder.build())
-                    .asyncCredentialUpdateEnabled(true)
-                    .build();
+            return builder.build();
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             if (!sessionToken.isEmpty()) {
                 return StaticCredentialsProvider.create(

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -121,12 +121,11 @@ public class AwsCloudConfigurationTest {
     public void testWebIdentityGenerateCredentialsProvider() {
         Map<String, String> properties = new HashMap<>();
         properties.put("aws.s3.use_web_identity_token_file", "true");
-        properties.put("aws.s3.region", "us-east-1");
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         Assertions.assertNotNull(cloudConfiguration);
         AwsCredentialsProvider provider =
                 ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential().generateAWSCredentialsProvider();
-        Assertions.assertInstanceOf(StsWebIdentityTokenFileCredentialsProvider.class, provider);
+        Assertions.assertInstanceOf(WebIdentityTokenFileCredentialsProvider.class, provider);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -121,6 +121,7 @@ public class AwsCloudConfigurationTest {
     public void testWebIdentityGenerateCredentialsProvider() {
         Map<String, String> properties = new HashMap<>();
         properties.put("aws.s3.use_web_identity_token_file", "true");
+        properties.put("aws.s3.region", "us-east-1");
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         Assertions.assertNotNull(cloudConfiguration);
         AwsCredentialsProvider provider =

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -26,8 +26,10 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -113,6 +115,17 @@ public class AwsCloudConfigurationTest {
         Assertions.assertEquals("com.starrocks.credential.provider.AssumedRoleCredentialProvider",
                 configuration.get("fs.s3a.aws.credentials.provider"));
         Assertions.assertEquals("arn:aws:iam::123456789:role/MyRole", configuration.get("fs.s3a.assumed.role.arn"));
+    }
+
+    @Test
+    public void testWebIdentityGenerateCredentialsProvider() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.use_web_identity_token_file", "true");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assertions.assertNotNull(cloudConfiguration);
+        AwsCredentialsProvider provider =
+                ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential().generateAWSCredentialsProvider();
+        Assertions.assertInstanceOf(StsWebIdentityTokenFileCredentialsProvider.class, provider);
     }
 
     @Test


### PR DESCRIPTION
Replace DefaultCredentialsProvider with StsWebIdentityTokenFileCredentialsProvider in getBaseAWSCredentialsProvider for the useWebIdentityProfile path.

DefaultCredentialsProvider falls through the full credential chain and may pick up other credentials before reaching web identity. It also ignores stsRegion/stsEndpoint, which are honoured by all other credential types that make STS calls (instance profile + ARN, default behavior + ARN).

StsWebIdentityTokenFileCredentialsProvider directly calls AssumeRoleWithWebIdentity using AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN env vars, mirrors the BE STSAssumeRoleWebIdentityCredentialsProvider, and respects stsRegion/stsEndpoint consistently with existing assume-role flows.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
