### PR TITLE
[Doc] Document lake meta alter jobs in SHOW ALTER TABLE COLUMN

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
@@ -10,6 +10,7 @@ SHOW ALTER TABLE shows the execution of the ongoing ALTER TABLE operations, incl
 - Modify columns.
 - Optimize table schema (from v3.2), including modifying the bucketing method and the number of buckets.
 - Create and delete the rollup index.
+- Modify metadata-only properties of cloud-native (shared-data) tables, such as `file_bundling`, `enable_persistent_index`, `persistent_index_type`, and `compaction_strategy`. These changes run asynchronously and are shown under `COLUMN`.
 
 ## Syntax
 
@@ -29,7 +30,7 @@ SHOW ALTER TABLE shows the execution of the ongoing ALTER TABLE operations, incl
 
 - `{COLUMN ｜ OPTIMIZE | ROLLUP}`:
 
-  - If `COLUMN` is specified, this statement shows operations of modifying columns.
+  - If `COLUMN` is specified, this statement shows operations of modifying columns. For cloud-native (shared-data) tables, it also shows asynchronous metadata-only changes triggered by `ALTER TABLE ... SET (...)`, such as modifying `file_bundling`, `enable_persistent_index`, `persistent_index_type`, or `compaction_strategy`.
   - If `OPTIMIZE` is specified, this statement shows operations of optimizing table structure.
   - If `ROLLUP` is specified, this statement shows operations of adding or deleting the rollup index.
 

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
@@ -11,6 +11,7 @@ displayed_sidebar: docs
 - カラムの変更。
 - テーブルスキーマの最適化 (v3.2 から)、バケット方式やバケット数の変更を含む。
 - ロールアップインデックスの作成と削除。
+- クラウドネイティブ（ストレージ・コンピュート分離）テーブルのメタデータのみのプロパティ変更（`file_bundling`、`enable_persistent_index`、`persistent_index_type`、`compaction_strategy` など）。これらは非同期で実行され、`COLUMN` で表示されます。
 
 ## 構文
 
@@ -30,7 +31,7 @@ displayed_sidebar: docs
 
 - `{COLUMN ｜ OPTIMIZE | ROLLUP}`:
 
-  - `COLUMN` が指定された場合、このステートメントはカラムの変更操作を表示します。
+  - `COLUMN` が指定された場合、このステートメントはカラムの変更操作を表示します。クラウドネイティブ（ストレージ・コンピュート分離）テーブルでは、`ALTER TABLE ... SET (...)` によってトリガーされる非同期のメタデータのみの変更（`file_bundling`、`enable_persistent_index`、`persistent_index_type`、`compaction_strategy` の変更など）も表示します。
   - `OPTIMIZE` が指定された場合、このステートメントはテーブル構造の最適化操作を表示します。
   - `ROLLUP` が指定された場合、このステートメントはロールアップインデックスの追加または削除操作を表示します。
 

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
@@ -12,6 +12,7 @@ displayed_sidebar: docs
 - 修改列。
 - 优化表结构（自 3.2 版本起），包括修改分桶方式和分桶数量。
 - 创建和删除 rollup index。
+- 修改存算分离（cloud-native）表的元数据属性，例如 `file_bundling`、`enable_persistent_index`、`persistent_index_type` 和 `compaction_strategy`。此类操作以异步方式执行，并通过 `COLUMN` 查询。
 
 ## 语法
 
@@ -31,7 +32,7 @@ displayed_sidebar: docs
 ## 参数说明
 
 - `{COLUMN ｜ OPTIMIZE | ROLLUP}`：从 `COLUMN`、`OPTIMIZE` 和 `ROLLUP` 中必选其中一个。
-  - 如果指定了 `COLUMN`，该语句用于查询修改列的操作。
+  - 如果指定了 `COLUMN`，该语句用于查询修改列的操作。对于存算分离（cloud-native）表，该语句还会显示由 `ALTER TABLE ... SET (...)` 触发的异步元数据变更操作，例如修改 `file_bundling`、`enable_persistent_index`、`persistent_index_type` 或 `compaction_strategy`。
   - 如果指定了 `OPTIMIZE`，该语句用于查询优化表结构操作（修改分桶方式和分桶数量）。
   - 如果指定了 `ROLLUP`，该语句用于查询创建或删除 rollup index 的操作。
 - 当指定了 `COLUMN` 或者 `OPTIMIZE` 查询修改列或者优化表结构操作时，支持使用如下子句：


### PR DESCRIPTION
## Why I'm doing:

Follow-up to the merged PR #74198 ([Enhancement] Show lake meta alter jobs in SHOW ALTER TABLE COLUMN), which declared an Interface/UI display behavior change but did not ship documentation. Tracked by issue #74245 (auto-generated by `ci-doc-needs-update.yml`).

## What I'm doing:

Update the `SHOW ALTER TABLE` reference page in all three languages (`en`, `zh`, `ja`) to note that, for cloud-native (shared-data) tables, `SHOW ALTER TABLE COLUMN` now also displays the asynchronous metadata-only alter jobs triggered by `ALTER TABLE ... SET (...)` — for properties such as `file_bundling`, `enable_persistent_index`, `persistent_index_type`, and `compaction_strategy`. Previously these jobs were not shown by `SHOW ALTER TABLE COLUMN` at all.

Files changed:
- `docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md`
- `docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md`
- `docs/ja/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md`

Closes #74245

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5