### PR TITLE
[Enhancement] Record eligibility_skipped on single-partition pre-split resolve failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitTargets.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitTargets.java
@@ -32,22 +32,27 @@ import java.util.List;
  * that contract in one place so every hook (and any future caller) checks the
  * same shape.
  *
- * <p>Each helper returns a sentinel ({@code null} or {@code -1}) for "no
- * match" so callers can chain early returns without intermediate booleans.
- * The eligibility gate inside {@link TabletPreSplitCoordinator#maybeAct}
+ * <p>The eligibility gate inside {@link TabletPreSplitCoordinator#maybeAct}
  * re-runs equivalent checks against the resolved {@code physicalPartitionId};
- * the helpers here only let the hook skip the pipeline construction.
+ * the helpers here only let the hook skip the pipeline construction. Because
+ * the single-partition hook flow short-circuits before {@code maybeAct}, the
+ * skip must still be attributed to a {@link SkipReason} so operators can see
+ * why pre-split did not run.
  *
  * <p><b>Two slices</b>:
  * <ul>
  *   <li>{@link #findEligibleTable} — table-only structural gate (range
  *       distribution, NORMAL state, no MV/rollup, supported sort key) used
- *       by the multi-partition coordinator's defensive re-check. The
- *       multi-partition coordinator does per-partition checks on its own
- *       under a short READ lock after pre-create.</li>
+ *       by the multi-partition coordinator's defensive re-check. Returns the
+ *       failing {@link SkipReason}, or {@code null} when the table is eligible;
+ *       the caller records it. The multi-partition coordinator does
+ *       per-partition checks on its own under a short READ lock after
+ *       pre-create.</li>
  *   <li>{@link #findEligibleTarget} — single-partition gate; performs the
  *       per-partition slice (single physical partition, single base tablet)
- *       and continues to gate the existing single-partition hooks unchanged.</li>
+ *       and gates the single-partition hooks. Returns the resolved
+ *       {@link EligibleTarget}, or {@code null} after recording the failing
+ *       {@link SkipReason} itself.</li>
  * </ul>
  */
 final class PreSplitTargets {
@@ -108,25 +113,43 @@ final class PreSplitTargets {
     }
 
     /**
-     * Chain {@link #findUniquePhysicalPartition} + {@link #findSingleBaseTabletId}
-     * into a single eligibility resolve. Used by every load-path hook so all
-     * callers produce the same {@link EligibleTarget} shape.
+     * Resolve the single-partition, single-tablet target for a load-path hook,
+     * recording the eligibility-skip counter when no eligible target is found.
      *
-     * @return the resolved {@link EligibleTarget}, or {@code null} when the
-     *         table has zero or multiple partitions, the base index lookup
-     *         fails (e.g. an alter raced the load), or the partition has
-     *         zero or multiple base-index tablets.
+     * <p>The recording is centralized here, rather than left to each caller,
+     * because the single-partition hook flows are the only callers and they all
+     * short-circuit before {@link TabletPreSplitCoordinator#maybeAct} — the gate
+     * that would otherwise record the skip. Folding it in means neither hook can
+     * forget it, and mirrors {@link TabletPreSplitCoordinator}'s own
+     * {@code skipEligibility}. (Contrast {@link #findEligibleTable}, which stays
+     * pure because its multi-partition caller needs the reason for its own
+     * {@code Skipped} outcome and records it itself.)
+     *
+     * @return the resolved {@link EligibleTarget}, or {@code null} when the table
+     *         does not have a single physical partition or its base index is
+     *         missing — records {@link SkipReason#METADATA_NOT_RESOLVED} (e.g. an
+     *         alter raced the load); or when the partition has zero or multiple
+     *         base-index tablets — records {@link SkipReason#MULTIPLE_BASE_INDEX_TABLETS}
+     *         (the common case on a re-load against an already-split partition).
      */
     static EligibleTarget findEligibleTarget(Database database, OlapTable olapTable) {
         PhysicalPartition uniquePartition = findUniquePhysicalPartition(olapTable);
         if (uniquePartition == null) {
+            PreSplitMetrics.recordEligibilitySkip(SkipReason.METADATA_NOT_RESOLVED);
             return null;
         }
-        long oldTabletId = findSingleBaseTabletId(olapTable, uniquePartition);
-        if (oldTabletId < 0) {
+        MaterializedIndex baseIndex = uniquePartition.getIndex(olapTable.getBaseIndexMetaId());
+        if (baseIndex == null) {
+            PreSplitMetrics.recordEligibilitySkip(SkipReason.METADATA_NOT_RESOLVED);
             return null;
         }
-        return new EligibleTarget(database, olapTable, uniquePartition.getId(), oldTabletId);
+        List<Tablet> baseTablets = baseIndex.getTablets();
+        if (baseTablets.size() != 1) {
+            PreSplitMetrics.recordEligibilitySkip(SkipReason.MULTIPLE_BASE_INDEX_TABLETS);
+            return null;
+        }
+        long baseTabletId = baseTablets.get(0).getId();
+        return new EligibleTarget(database, olapTable, uniquePartition.getId(), baseTabletId);
     }
 
     /**
@@ -141,21 +164,5 @@ final class PreSplitTargets {
             return null;
         }
         return partitions.iterator().next();
-    }
-
-    /**
-     * @return the single base-index tablet's id, or {@code -1} when the
-     *         partition has zero or multiple base-index tablets.
-     */
-    static long findSingleBaseTabletId(OlapTable table, PhysicalPartition partition) {
-        MaterializedIndex baseIndex = partition.getIndex(table.getBaseIndexMetaId());
-        if (baseIndex == null) {
-            return -1L;
-        }
-        List<Tablet> tablets = baseIndex.getTablets();
-        if (tablets.size() != 1) {
-            return -1L;
-        }
-        return tablets.get(0).getId();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
@@ -16,7 +16,9 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
@@ -24,11 +26,15 @@ import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.BrokerDesc;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -135,34 +141,33 @@ public class BrokerLoadPreSplitHookTest {
     }
 
     @Test
-    public void testSinglePartitionWithMultipleBaseTabletsShortCircuits() throws Exception {
+    public void testSinglePartitionWithMultipleBaseTabletsRecordsSkip() throws Exception {
+        // Table clears the table-level gate but its single base index already
+        // holds multiple tablets (the re-load-after-split case). The hook must
+        // record multiple_base_index_tablets and not delegate — the
+        // coordinator's maybeAct, which would otherwise record it, is never
+        // reached on the single-partition resolve-failure path.
+        OlapTable target = tablePassingTableLevelGate();
         MaterializedIndex baseIndex = mock(MaterializedIndex.class);
         when(baseIndex.getTablets()).thenReturn(List.of(mock(Tablet.class), mock(Tablet.class)));
-
         PhysicalPartition partition = mock(PhysicalPartition.class);
         when(partition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
-
-        OlapTable target = mock(OlapTable.class);
-        when(target.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(target.getPhysicalPartitions()).thenReturn(List.of(partition));
 
-        assertHookDoesNotDelegate(() ->
-                invokeHook(target, List.of(mock(BrokerFileGroup.class)), List.of()));
+        assertSinglePartitionResolveRecordsSkip(target, SkipReason.MULTIPLE_BASE_INDEX_TABLETS);
     }
 
     @Test
-    public void testMissingBaseIndexShortCircuits() throws Exception {
-        // Partition exists but the base-index lookup returns null — e.g. an
-        // alter changed the base-index id mid-load. Hook must skip.
+    public void testMissingBaseIndexRecordsSkip() throws Exception {
+        // Table clears the table-level gate but the base-index lookup returns
+        // null — e.g. an alter changed the base-index id mid-load. The hook
+        // must record metadata_not_resolved and not delegate.
+        OlapTable target = tablePassingTableLevelGate();
         PhysicalPartition partition = mock(PhysicalPartition.class);
         when(partition.getIndex(BASE_INDEX_META_ID)).thenReturn(null);
-
-        OlapTable target = mock(OlapTable.class);
-        when(target.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(target.getPhysicalPartitions()).thenReturn(List.of(partition));
 
-        assertHookDoesNotDelegate(() ->
-                invokeHook(target, List.of(mock(BrokerFileGroup.class)), List.of()));
+        assertSinglePartitionResolveRecordsSkip(target, SkipReason.METADATA_NOT_RESOLVED);
     }
 
     @Test
@@ -212,6 +217,58 @@ public class BrokerLoadPreSplitHookTest {
         when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(table.getPhysicalPartitions()).thenReturn(List.of(partition));
         return table;
+    }
+
+    /**
+     * Builds an unpartitioned {@link OlapTable} that clears the table-level
+     * eligibility gate ({@link PreSplitTargets#findEligibleTable}) so the hook
+     * proceeds into the single-partition flow. Per-partition shape (physical
+     * partitions, base index, tablets) is left to the caller to stub. The
+     * sort-key column is supplied by {@link #assertSinglePartitionResolveRecordsSkip}
+     * via a {@code MockedStatic<MetaUtils>}.
+     */
+    private static OlapTable tablePassingTableLevelGate() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        when(table.isRangeDistribution()).thenReturn(true);
+        when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(mock(MaterializedIndexMeta.class)));
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        PartitionInfo partitionInfo = mock(PartitionInfo.class);
+        when(partitionInfo.isPartitioned()).thenReturn(false);
+        when(table.getPartitionInfo()).thenReturn(partitionInfo);
+        return table;
+    }
+
+    /**
+     * Invokes the hook against a table that passes the table-level gate but
+     * fails single-partition target resolution, and asserts it (a) never
+     * delegates to the coordinator and (b) bumps the {@code eligibility_skipped}
+     * counter under {@code expectedReason} exactly once. A
+     * {@code MockedStatic<MetaUtils>} supplies a scalar sort key so the
+     * table-level gate's sort-key check passes.
+     */
+    private static void assertSinglePartitionResolveRecordsSkip(
+            OlapTable target, SkipReason expectedReason) throws Exception {
+        boolean savedHasInit = MetricRepo.hasInit;
+        MetricRepo.hasInit = true;
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(target))
+                    .thenReturn(List.of(PresplitTestSupport.bigintColumn("k")));
+            String label = expectedReason.name().toLowerCase();
+            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED
+                    .getMetric(label).getValue();
+
+            assertHookDoesNotDelegate(() ->
+                    invokeHook(target, List.of(mock(BrokerFileGroup.class)), List.of()));
+
+            Assertions.assertEquals(baseline + 1L,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED
+                            .getMetric(label).getValue().longValue(),
+                    "single-partition resolve failure must bump the " + label + " bucket");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitTargetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitTargetsTest.java
@@ -16,8 +16,12 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.IntegerType;
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
@@ -126,5 +131,95 @@ public class PreSplitTargetsTest {
             Assertions.assertNull(PreSplitTargets.findEligibleTable(mock(Database.class), table),
                     "fully eligible table must return null (no skip reason)");
         }
+    }
+
+    /**
+     * Stub an {@link OlapTable} whose single physical partition's base index
+     * holds {@code tabletCount} tablets. {@code tabletCount < 0} stubs a missing
+     * base index instead.
+     */
+    private static OlapTable tableWithSinglePartition(int tabletCount) {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(10L);
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        when(partition.getId()).thenReturn(100L);
+        when(table.getPhysicalPartitions()).thenReturn(List.of(partition));
+        if (tabletCount < 0) {
+            when(partition.getIndex(10L)).thenReturn(null);
+        } else {
+            MaterializedIndex baseIndex = mock(MaterializedIndex.class);
+            when(partition.getIndex(10L)).thenReturn(baseIndex);
+            List<Tablet> tablets = new ArrayList<>();
+            for (int i = 0; i < tabletCount; i++) {
+                Tablet tablet = mock(Tablet.class);
+                when(tablet.getId()).thenReturn(1000L + i);
+                tablets.add(tablet);
+            }
+            when(baseIndex.getTablets()).thenReturn(tablets);
+        }
+        return table;
+    }
+
+    @Test
+    public void resolvesSinglePartitionSingleTabletTarget() {
+        // Positive control: exactly one physical partition with one base tablet -> target.
+        OlapTable table = tableWithSinglePartition(1);
+        PreSplitTargets.EligibleTarget target =
+                PreSplitTargets.findEligibleTarget(mock(Database.class), table);
+        Assertions.assertNotNull(target);
+        Assertions.assertEquals(100L, target.partitionId());
+        Assertions.assertEquals(1000L, target.oldTabletId());
+    }
+
+    @Test
+    public void skipsWhenNoUniquePhysicalPartition() {
+        // Zero or multiple physical partitions cannot resolve a single target.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getPhysicalPartitions()).thenReturn(List.of(
+                mock(PhysicalPartition.class), mock(PhysicalPartition.class)));
+        assertResolveSkips(table, SkipReason.METADATA_NOT_RESOLVED);
+    }
+
+    @Test
+    public void skipsWhenBaseIndexMissing() {
+        // Base index gone (catalog raced an alter) -> metadata-not-resolved.
+        assertResolveSkips(tableWithSinglePartition(-1), SkipReason.METADATA_NOT_RESOLVED);
+    }
+
+    @Test
+    public void skipsWhenPartitionAlreadySplit() {
+        // The common re-load case: the partition was already split into multiple tablets.
+        assertResolveSkips(tableWithSinglePartition(4), SkipReason.MULTIPLE_BASE_INDEX_TABLETS);
+    }
+
+    @Test
+    public void skipsWhenPartitionHasNoTablet() {
+        // Zero base tablets also folds into the multi-tablet bucket (index present, count != 1).
+        assertResolveSkips(tableWithSinglePartition(0), SkipReason.MULTIPLE_BASE_INDEX_TABLETS);
+    }
+
+    /**
+     * Asserts {@code findEligibleTarget} returns {@code null} and bumps the
+     * {@code eligibility_skipped} counter under {@code expectedReason} exactly
+     * once — the recording is internal to the resolver, so callers (the
+     * single-partition hooks) need not remember it.
+     */
+    private static void assertResolveSkips(OlapTable table, SkipReason expectedReason) {
+        boolean savedHasInit = MetricRepo.hasInit;
+        MetricRepo.hasInit = true;
+        try {
+            long baseline = skipBucket(expectedReason);
+            Assertions.assertNull(PreSplitTargets.findEligibleTarget(mock(Database.class), table),
+                    "ineligible target must resolve to null");
+            Assertions.assertEquals(baseline + 1L, skipBucket(expectedReason),
+                    expectedReason.name().toLowerCase() + " bucket must increment by one");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+        }
+    }
+
+    private static long skipBucket(SkipReason reason) {
+        return MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED
+                .getMetric(reason.name().toLowerCase()).getValue().longValue();
     }
 }


### PR DESCRIPTION
## Why I'm doing:

The single-partition Sample-Based Tablet Pre-Split hook flow (INSERT-from-FILES and Broker Load) short-circuited **silently** when `PreSplitTargets.findEligibleTarget` could not resolve a single-physical-partition / single-base-tablet target. The `eligibility_skipped{reason}` counter is only emitted by `TabletPreSplitCoordinator.maybeAct`, which the single-partition flow never reaches on a resolve failure.

As a result, the most common operational case — a re-load against a partition that was already split (so it now has more than one base tablet) — produced **no metric at all**, so any operator dashboard built on `eligibility_skipped` under-counted on the multi-tablet branch. This was surfaced concretely by the post-merge regression run (a second load on an already-pre-split partition emitted no bvar despite correctly skipping pre-split).

## What I'm doing:

`PreSplitTargets.findEligibleTarget` now records the failing `SkipReason` into the **existing** `eligibility_skipped{reason}` counter before returning `null`:

- `metadata_not_resolved` — the table does not resolve to a single physical partition, or its base index is missing (e.g. an alter raced the load);
- `multiple_base_index_tablets` — the partition has zero or multiple base-index tablets (the already-split re-load case).

The recording is **centralized in the resolver, not the hooks**. Its only callers are the two single-partition hook flows, which all skip on a `null` target, so neither hook can forget the metric — and both hook bodies stay byte-identical to `main` (the whole change lives in `PreSplitTargets`). This mirrors `TabletPreSplitCoordinator.skipEligibility`, which also records internally. (The sibling table-level gate `findEligibleTable` stays pure because its multi-partition caller needs the reason for its own `Skipped` outcome and records it itself.)

- **No new counter and no new `SkipReason` values** — both labels are already valid and documented for `eligibility_skipped`; this just makes them reachable from the single-partition path. `target-non-empty` was already covered (a single non-empty tablet reaches `maybeAct` → `partition_not_empty`).
- The base-index/tablet resolution is inlined into `findEligibleTarget` (resolving the index once and naming each failure at its check), removing the now-unused `findSingleBaseTabletId` helper.

Tests: `PreSplitTargetsTest` covers every `findEligibleTarget` branch (no-unique-partition, missing base index, multiple tablets, zero tablets, and the eligible happy path), counter-asserting the recorded reason; `BrokerLoadPreSplitHookTest`'s single-partition resolve tests were strengthened to pass the table-level gate (so they genuinely reach `findEligibleTarget`) and assert the `eligibility_skipped` counter increments exactly once with no delegation. All pre-split FE suites green; checkstyle clean.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)