### PR TITLE
[Tool] ai-sr-skills: drop rsync loop, runners now symlink skills

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -27,23 +27,6 @@ jobs:
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-')
     steps:
-      - name: Sync skills to latest
-        run: |
-          set -e
-          # Runners now symlink each skill from $HOME/starrocks-skills/<name>
-          # into $HOME/.claude/skills/<name>, so only the source checkout
-          # needs refreshing here. Drop the previous rsync loop — it was a
-          # no-op (or worse, ambiguous under symlinks) once the destination
-          # entries became symlinks pointing back at the source.
-          SKILL_REPO="$HOME/starrocks-skills"
-          if [ -d "$SKILL_REPO/.git" ]; then
-            cd "$SKILL_REPO" && git pull --ff-only --quiet \
-              || echo "WARN: git pull failed, using current checkout"
-          else
-            echo "WARN: $SKILL_REPO is not a git checkout, skip pull"
-          fi
-          ls -1 "$HOME/.claude/skills"
-
       - name: Recommend Reviewer (AI)
         run: |
           echo "=== DEBUG ==="

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -30,25 +30,19 @@ jobs:
       - name: Sync skills to latest
         run: |
           set -e
+          # Runners now symlink each skill from $HOME/starrocks-skills/<name>
+          # into $HOME/.claude/skills/<name>, so only the source checkout
+          # needs refreshing here. Drop the previous rsync loop — it was a
+          # no-op (or worse, ambiguous under symlinks) once the destination
+          # entries became symlinks pointing back at the source.
           SKILL_REPO="$HOME/starrocks-skills"
-          SKILL_DEST="$HOME/.claude/skills"
-
           if [ -d "$SKILL_REPO/.git" ]; then
             cd "$SKILL_REPO" && git pull --ff-only --quiet \
               || echo "WARN: git pull failed, using current checkout"
           else
             echo "WARN: $SKILL_REPO is not a git checkout, skip pull"
           fi
-
-          mkdir -p "$SKILL_DEST"
-          for skill_dir in "$SKILL_REPO"/*/; do
-            [ -d "$skill_dir" ] || continue
-            name=$(basename "$skill_dir")
-            rsync -a --delete "$skill_dir" "$SKILL_DEST/$name/"
-          done
-
-          echo "Skills synced to $SKILL_DEST:"
-          ls -1 "$SKILL_DEST"
+          ls -1 "$HOME/.claude/skills"
 
       - name: Recommend Reviewer (AI)
         run: |


### PR DESCRIPTION
## Why I'm doing:
Self-hosted runners now set up `$HOME/.claude/skills/<name>` as a symlink pointing to `$HOME/starrocks-skills/<name>`. On ci02 for example:

```
~/.claude/skills/starrocks-assign-pr-reviewer
    -> /root/starrocks-skills/starrocks-assign-pr-reviewer
```

With the symlink in place, the previous `rsync -a --delete` loop in the `Sync skills to latest` step is redundant — source and destination resolve to the same directory, so the rsync is a no-op at best, and under `--delete` semantics on symlinks the behavior is ambiguous.

## What I'm doing:
Drop the `mkdir -p` + per-skill `rsync` loop. Keep only the `git pull` that refreshes the source checkout (`$HOME/starrocks-skills`); the symlink picks up new content automatically.

This change will also propagate to the downstream fork via the existing repo-sync workflow, so no separate the downstream fork-side PR is needed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
