### PR TITLE
[Enhancement] Support SHOW CREATE ROUTINE LOAD for Pulsar datasource

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -292,7 +292,79 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
 
     @Override
     public String dataSourcePropertiesToSql() {
-        return "";
+        StringBuilder sb = new StringBuilder();
+        sb.append("(\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.PULSAR_SERVICE_URL_PROPERTY).append("\"=\"");
+        sb.append(serviceUrl).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.PULSAR_TOPIC_PROPERTY).append("\"=\"");
+        sb.append(topic).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.PULSAR_SUBSCRIPTION_PROPERTY).append("\"=\"");
+        sb.append(subscription).append("\",\n");
+
+        if (!customPulsarPartitions.isEmpty()) {
+            List<String> sortedPartitions = Lists.newArrayList(customPulsarPartitions);
+            Collections.sort(sortedPartitions);
+            sb.append("\"").append(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY).append("\"=\"");
+            sb.append(Joiner.on(",").join(sortedPartitions)).append("\",\n");
+
+            // Only emit pulsar_initial_positions when every partition still has
+            // an explicit initial position. After PulsarProgress.update() commits
+            // a partition it removes that partition's initial position, so
+            // getInitialPosition() returns -1. Fabricating a fallback value
+            // (e.g. POSITION_EARLIEST) would change replay semantics and could
+            // reload old data; omitting the property entirely is safer because
+            // the Pulsar subscription cursor governs the actual resume offset.
+            boolean allHavePosition = true;
+            List<String> initialPositionStrs = new ArrayList<>();
+            for (String partition : sortedPartitions) {
+                Long pos = ((PulsarProgress) progress).getInitialPosition(partition);
+                if (pos == -1L) {
+                    allHavePosition = false;
+                    break;
+                } else if (pos == POSITION_EARLIEST_VAL) {
+                    initialPositionStrs.add(POSITION_EARLIEST);
+                } else if (pos == POSITION_LATEST_VAL) {
+                    initialPositionStrs.add(POSITION_LATEST);
+                } else {
+                    initialPositionStrs.add(Long.toString(pos));
+                }
+            }
+            if (allHavePosition && !initialPositionStrs.isEmpty()) {
+                sb.append("\"").append(CreateRoutineLoadStmt.PULSAR_INITIAL_POSITIONS_PROPERTY).append("\"=\"");
+                sb.append(Joiner.on(",").join(initialPositionStrs)).append("\",\n");
+            }
+        }
+        // NOTE: When customPulsarPartitions is empty the job was created without
+        // explicit pulsar_partitions and auto-discovers partitions from the broker.
+        // We intentionally omit pulsar_partitions in the SHOW CREATE output so that
+        // a replayed CREATE ROUTINE LOAD statement keeps the auto-discovery behavior;
+        // emitting currentPulsarPartitions here would pin the recreated job to a
+        // fixed partition set and silently stop consuming newly added partitions.
+
+        // custom properties
+        for (Map.Entry<String, String> entry : customProperties.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            // mask sensitive properties
+            if (key.contains("password") || key.contains("secret") || key.contains("token")) {
+                value = "******";
+            }
+            // Escape embedded double-quotes so property values containing
+            // JSON (e.g. OAuth authParams) produce parsable DDL.
+            String escapedValue = value.replace("\\", "\\\\").replace("\"", "\\\"");
+            sb.append("\"").append("property.").append(key).append("\"=\"");
+            sb.append(escapedValue).append("\",\n");
+        }
+
+        if (sb.length() >= 2) {
+            sb.delete(sb.length() - 2, sb.length());
+            sb.append("\n");
+        }
+        sb.append(")");
+        return sb.toString();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1546,8 +1546,18 @@ public class ShowExecutor {
                 return new ShowResultSet(showResultMetaFactory.getMetadata(statement), rows);
             }
             RoutineLoadJob routineLoadJob = routineLoadJobList.get(0);
-            if (routineLoadJob.getDataSourceTypeName().equals("PULSAR")) {
-                throw new SemanticException("not support pulsar datasource");
+            try {
+                String dbFullName = routineLoadJob.getDbFullName();
+                String tblName = routineLoadJob.getTableName();
+                try {
+                    Authorizer.checkAnyActionOnTable(context, new TableName(dbFullName, tblName));
+                } catch (AccessDeniedException e) {
+                    // No privilege → return empty result, same as SHOW ROUTINE LOAD.
+                    return new ShowResultSet(showResultMetaFactory.getMetadata(statement), rows);
+                }
+            } catch (MetaNotFoundException e) {
+                LOG.warn(e.getMessage(), e);
+                throw new SemanticException(e.getMessage());
             }
             StringBuilder createRoutineLoadSql = new StringBuilder();
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/PulsarRoutineLoadJobDataSourcePropertiesToSqlTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/PulsarRoutineLoadJobDataSourcePropertiesToSqlTest.java
@@ -1,0 +1,302 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.routineload;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.Pair;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.sql.ast.CreateRoutineLoadStmt;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link PulsarRoutineLoadJob#dataSourcePropertiesToSql()}.
+ *
+ * Covers the three review-comment fixes:
+ * 1. Custom partitions with partially committed positions must not produce
+ *    a shorter pulsar_initial_positions list — instead positions are omitted.
+ * 2. Auto-discovery jobs must not emit pulsar_partitions so replay preserves
+ *    partition auto-discovery.
+ * 3. Custom property values containing double-quotes must be escaped.
+ */
+public class PulsarRoutineLoadJobDataSourcePropertiesToSqlTest {
+
+    private static final String SERVICE_URL = "pulsar://localhost:6650";
+    private static final String TOPIC = "test-topic";
+    private static final String SUBSCRIPTION = "test-sub";
+
+    /**
+     * Helper to build a PulsarRoutineLoadJob with the given partitions and positions.
+     */
+    private PulsarRoutineLoadJob buildJob(List<String> customPartitions,
+                                          List<String> currentPartitions,
+                                          List<Pair<String, Long>> initialPositions,
+                                          Map<String, String> customProperties) {
+        PulsarRoutineLoadJob job = new PulsarRoutineLoadJob(
+                1L, "test_job", 1L, 1L, SERVICE_URL, TOPIC, SUBSCRIPTION);
+
+        if (customPartitions != null && !customPartitions.isEmpty()) {
+            Deencapsulation.setField(job, "customPulsarPartitions", customPartitions);
+        }
+        if (currentPartitions != null && !currentPartitions.isEmpty()) {
+            Deencapsulation.setField(job, "currentPulsarPartitions", currentPartitions);
+        }
+        if (initialPositions != null) {
+            PulsarProgress progress = (PulsarProgress) Deencapsulation.getField(job, "progress");
+            for (Pair<String, Long> pos : initialPositions) {
+                progress.addPartitionToInitialPosition(pos);
+            }
+        }
+        if (customProperties != null && !customProperties.isEmpty()) {
+            Deencapsulation.setField(job, "customProperties", customProperties);
+        }
+        return job;
+    }
+
+    // -------------------------------------------------------------------------
+    // Review comment 1: initial positions with partial commits
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCustomPartitions_allPositionsSet_emitsPositions() {
+        // All partitions have explicit initial positions → should emit pulsar_initial_positions
+        List<String> partitions = Lists.newArrayList("p0", "p1", "p2");
+        List<Pair<String, Long>> positions = Lists.newArrayList(
+                Pair.create("p0", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL),
+                Pair.create("p1", PulsarRoutineLoadJob.POSITION_LATEST_VAL),
+                Pair.create("p2", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL));
+        PulsarRoutineLoadJob job = buildJob(partitions, partitions, positions, null);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY),
+                "Should contain pulsar_partitions");
+        Assertions.assertTrue(sql.contains(CreateRoutineLoadStmt.PULSAR_INITIAL_POSITIONS_PROPERTY),
+                "Should contain pulsar_initial_positions when all partitions have positions");
+        // Verify positions are in sorted partition order (p0, p1, p2)
+        Assertions.assertTrue(sql.contains("POSITION_EARLIEST,POSITION_LATEST,POSITION_EARLIEST"),
+                "Positions should be listed in sorted partition order");
+    }
+
+    @Test
+    public void testCustomPartitions_somePositionsCommitted_omitsPositions() {
+        // Simulates partial commit: p0 and p1 have initial positions, but p2 was committed
+        // (PulsarProgress.update() removed p2's initial position, so getInitialPosition returns -1).
+        // SHOW CREATE must NOT emit pulsar_initial_positions at all (omit rather than mismatch).
+        List<String> partitions = Lists.newArrayList("p0", "p1", "p2");
+        List<Pair<String, Long>> positions = Lists.newArrayList(
+                Pair.create("p0", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL),
+                Pair.create("p1", PulsarRoutineLoadJob.POSITION_LATEST_VAL));
+        // Note: p2 has no initial position (simulates committed partition)
+        PulsarRoutineLoadJob job = buildJob(partitions, partitions, positions, null);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY),
+                "Should still contain pulsar_partitions");
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.PULSAR_INITIAL_POSITIONS_PROPERTY),
+                "Must NOT contain pulsar_initial_positions when some partitions have no position");
+    }
+
+    @Test
+    public void testCustomPartitions_noPositionsSet_omitsPositions() {
+        // Job created with pulsar_partitions but without pulsar_initial_positions.
+        // All partitions return -1 from getInitialPosition.
+        List<String> partitions = Lists.newArrayList("p0", "p1");
+        PulsarRoutineLoadJob job = buildJob(partitions, partitions, null, null);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY),
+                "Should contain pulsar_partitions");
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.PULSAR_INITIAL_POSITIONS_PROPERTY),
+                "Must NOT contain pulsar_initial_positions when no positions were set");
+    }
+
+    @Test
+    public void testCustomPartitions_allPositionsCommitted_omitsPositions() {
+        // All partitions were committed (all return -1).
+        List<String> partitions = Lists.newArrayList("p0", "p1");
+        // Set positions then simulate commit by updating progress
+        List<Pair<String, Long>> positions = Lists.newArrayList(
+                Pair.create("p0", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL),
+                Pair.create("p1", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL));
+        PulsarRoutineLoadJob job = buildJob(partitions, partitions, positions, null);
+
+        // Simulate PulsarProgress.update() which removes initial positions for committed partitions
+        PulsarProgress progress = (PulsarProgress) Deencapsulation.getField(job, "progress");
+        PulsarProgress commitProgress = new PulsarProgress();
+        Deencapsulation.setField(commitProgress, "partitionToBacklogNum",
+                Maps.newHashMap(Map.of("p0", 0L, "p1", 0L)));
+        progress.update(commitProgress);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY));
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.PULSAR_INITIAL_POSITIONS_PROPERTY),
+                "Must NOT contain pulsar_initial_positions after all partitions committed");
+    }
+
+    // -------------------------------------------------------------------------
+    // Review comment 2: auto-discovery jobs must not emit partitions
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testAutoDiscoveryJob_noCustomPartitions_omitsPartitions() {
+        // Job created without pulsar_partitions — auto-discovers from broker.
+        // currentPulsarPartitions may be populated from the broker, but SHOW CREATE
+        // must NOT emit them to preserve auto-discovery on replay.
+        List<String> currentPartitions = Lists.newArrayList("broker-p0", "broker-p1", "broker-p2");
+        PulsarRoutineLoadJob job = buildJob(null, currentPartitions, null, null);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY),
+                "Must NOT contain pulsar_partitions for auto-discovery jobs");
+        Assertions.assertFalse(sql.contains("broker-p0"),
+                "Must NOT emit current broker partitions");
+        // Verify basic properties are still present
+        Assertions.assertTrue(sql.contains(SERVICE_URL));
+        Assertions.assertTrue(sql.contains(TOPIC));
+        Assertions.assertTrue(sql.contains(SUBSCRIPTION));
+    }
+
+    @Test
+    public void testAutoDiscoveryJob_emptyEverything() {
+        // No custom partitions, no current partitions
+        PulsarRoutineLoadJob job = buildJob(null, null, null, null);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertFalse(sql.contains(CreateRoutineLoadStmt.PULSAR_PARTITIONS_PROPERTY),
+                "Must NOT contain pulsar_partitions");
+        Assertions.assertTrue(sql.contains(SERVICE_URL));
+        Assertions.assertTrue(sql.contains(TOPIC));
+        Assertions.assertTrue(sql.contains(SUBSCRIPTION));
+    }
+
+    // -------------------------------------------------------------------------
+    // Review comment 3: custom property value escaping
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCustomProperties_jsonValueWithDoubleQuotes_isEscaped() {
+        // OAuth authParams-like value with embedded double quotes
+        Map<String, String> props = Maps.newLinkedHashMap();
+        props.put("authParams", "{\"privateKey\":\"file:///path/key.json\",\"audience\":\"urn:sn:pulsar:test\"}");
+        PulsarRoutineLoadJob job = buildJob(null, null, null, props);
+
+        String sql = job.dataSourcePropertiesToSql();
+        // The value should have escaped double-quotes
+        Assertions.assertTrue(sql.contains("\\\"privateKey\\\""),
+                "Double quotes in property values must be escaped: " + sql);
+        Assertions.assertTrue(sql.contains("\\\"audience\\\""),
+                "Double quotes in property values must be escaped: " + sql);
+        // The property key itself should not be escaped
+        Assertions.assertTrue(sql.contains("\"property.authParams\"=\""),
+                "Property key format should be preserved: " + sql);
+    }
+
+    @Test
+    public void testCustomProperties_valueWithBackslashAndQuotes_isEscaped() {
+        Map<String, String> props = Maps.newLinkedHashMap();
+        props.put("testProp", "value with \\backslash and \"quotes\"");
+        PulsarRoutineLoadJob job = buildJob(null, null, null, props);
+
+        String sql = job.dataSourcePropertiesToSql();
+        // Backslash should be escaped first, then quotes
+        Assertions.assertTrue(sql.contains("\\\\backslash"),
+                "Backslashes in property values must be escaped: " + sql);
+        Assertions.assertTrue(sql.contains("\\\"quotes\\\""),
+                "Double quotes in property values must be escaped: " + sql);
+    }
+
+    @Test
+    public void testCustomProperties_sensitivePropertyIsMasked() {
+        Map<String, String> props = Maps.newLinkedHashMap();
+        props.put("auth.password", "my-secret-password");
+        props.put("auth.token", "my-secret-token");
+        props.put("client.secret", "my-client-secret");
+        props.put("normalProp", "normalValue");
+        PulsarRoutineLoadJob job = buildJob(null, null, null, props);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains("******"),
+                "Sensitive properties should be masked");
+        Assertions.assertFalse(sql.contains("my-secret-password"),
+                "Password value must not appear in output");
+        Assertions.assertFalse(sql.contains("my-secret-token"),
+                "Token value must not appear in output");
+        Assertions.assertFalse(sql.contains("my-client-secret"),
+                "Secret value must not appear in output");
+        Assertions.assertTrue(sql.contains("normalValue"),
+                "Non-sensitive properties should appear unmasked");
+    }
+
+    @Test
+    public void testCustomProperties_plainValue_noExtraEscaping() {
+        Map<String, String> props = Maps.newLinkedHashMap();
+        props.put("simpleProp", "simpleValue");
+        PulsarRoutineLoadJob job = buildJob(null, null, null, props);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains("\"property.simpleProp\"=\"simpleValue\""),
+                "Plain values should pass through without modification: " + sql);
+    }
+
+    // -------------------------------------------------------------------------
+    // Combined scenario tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCustomPartitionsWithPropertiesAndPositions() {
+        // Full scenario: custom partitions + initial positions + custom properties with JSON
+        List<String> partitions = Lists.newArrayList("p1", "p0");
+        List<Pair<String, Long>> positions = Lists.newArrayList(
+                Pair.create("p0", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL),
+                Pair.create("p1", PulsarRoutineLoadJob.POSITION_LATEST_VAL));
+        Map<String, String> props = Maps.newLinkedHashMap();
+        props.put("authPlugin", "org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2");
+        props.put("authParams", "{\"key\":\"val\"}");
+
+        PulsarRoutineLoadJob job = buildJob(partitions, partitions, positions, props);
+
+        String sql = job.dataSourcePropertiesToSql();
+        // Partitions should be sorted
+        Assertions.assertTrue(sql.contains("\"pulsar_partitions\"=\"p0,p1\""),
+                "Partitions should be sorted: " + sql);
+        // Positions should be emitted (all present)
+        Assertions.assertTrue(sql.contains(CreateRoutineLoadStmt.PULSAR_INITIAL_POSITIONS_PROPERTY));
+        // JSON property value should be escaped
+        Assertions.assertTrue(sql.contains("\\\"key\\\""),
+                "JSON in custom properties should be escaped: " + sql);
+    }
+
+    @Test
+    public void testPartitionsSortedCorrectly() {
+        // Verify partition sorting
+        List<String> partitions = Lists.newArrayList("partition-c", "partition-a", "partition-b");
+        List<Pair<String, Long>> positions = Lists.newArrayList(
+                Pair.create("partition-a", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL),
+                Pair.create("partition-b", PulsarRoutineLoadJob.POSITION_LATEST_VAL),
+                Pair.create("partition-c", PulsarRoutineLoadJob.POSITION_EARLIEST_VAL));
+        PulsarRoutineLoadJob job = buildJob(partitions, partitions, positions, null);
+
+        String sql = job.dataSourcePropertiesToSql();
+        Assertions.assertTrue(sql.contains("partition-a,partition-b,partition-c"),
+                "Partitions must be sorted alphabetically: " + sql);
+        Assertions.assertTrue(
+                sql.contains("POSITION_EARLIEST,POSITION_LATEST,POSITION_EARLIEST"),
+                "Positions must follow sorted partition order: " + sql);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support SHOW CREATE ROUTINE LOAD for Pulsar datasource

Fixes #74010

<img width="856" height="807" alt="image" src="https://github.com/user-attachments/assets/feef76e0-6b8c-44d8-bebe-6ff194473668" />

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
