### PR TITLE
[UT] Add cross-publish multi-statement batch integration test for tablet split

### DIFF
--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3027,6 +3027,152 @@ TEST_F(LakeTabletReshardTest, test_split_cross_publish_sets_rowset_range_in_txn_
     EXPECT_EQ(added_rowset.range().SerializeAsString(), published_meta->range().SerializeAsString());
 }
 
+// Cross-publish a multi-statement (non-PK batch) transaction onto split children
+// end-to-end via publish_version, exercising the #10 invariant through the REAL
+// pipeline rather than a hand-built combine input:
+//   convert_txn_log_for_splitting scales EACH statement's stats by /split_count
+//   independently (split_index < n % split_count gets +1, so the remainder of an odd
+//   count lands on the lowest indexes), then NonPrimaryKeyTxnLogApplier's batch combine
+//   merges the per-statement op_writes into one composite rowset on each child.
+// The combine must
+//   (1) retain a statement's segment even when ITS num_rows scaled to 0 on this child
+//       (gated on segment_metas_size, not the scaled num_rows) -- else data is lost,
+//   (2) adopt the FIRST log's uid, CopyFrom-preserved IDENTICALLY across sibling
+//       children -- a stable MERGE dedup identity, and
+//   (3) scale per statement, not once over the aggregate.
+// The TxnLogApplierBatchTest unit tests cover the combine with pre-scaled inputs; this
+// drives publish_version so the scaling and the combine are proven to compose.
+//
+// Inputs are chosen so the per-statement path is distinguishable from a (buggy)
+// sum-then-scale-once path, and so the scaled-to-0 statement is ALSO the uid source:
+//   stmt_a (load0, FIRST log, uid 7777): num_rows=1,  data_size=11
+//   stmt_b (load1,             uid 9999): num_rows=9,  data_size=99
+// Per-statement scaling with split_count=2 (scaled = n/2 + (idx < n%2 ? 1 : 0)):
+//                       child0 (idx 0)     child1 (idx 1)
+//   stmt_a rows      ->     1                  0   <- scales to 0, segment must survive
+//   stmt_b rows      ->     5                  4
+//   merged num_rows  ->     6                  4   (sum 10; sum-then-scale would give 5/5)
+//   stmt_a data      ->     6                  5
+//   stmt_b data      ->    50                 49
+//   merged data_size ->    56                 54   (sum 110; sum-then-scale would give 55/55)
+// Both children adopt stmt_a's uid 7777 (the first log) -- NOT stmt_b's 9999, and NOT
+// "first positive-row contributor" (stmt_a scaled to 0 on child1 yet still defines the uid).
+TEST_F(LakeTabletReshardTest, test_split_cross_publish_multi_stmt_batch_keeps_scaled_zero_segment) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id = next_id();
+    const int64_t child0_id = next_id();
+    const int64_t child1_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id);
+    prepare_tablet_dirs(child0_id);
+    prepare_tablet_dirs(child1_id);
+
+    // A child's base metadata: non-PK (DUP) so NonPrimaryKeyTxnLogApplier's batch combine
+    // is selected, carrying the post-split sub-range so convert_txn_log_for_splitting can
+    // clip the cross-published rowset ranges.
+    auto make_child_meta = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(1);
+        meta->mutable_schema()->set_keys_type(DUP_KEYS);
+        meta->mutable_schema()->set_id(1);
+        auto* range = meta->mutable_range();
+        range->mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+        range->set_lower_bound_included(true);
+        range->mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+        range->set_upper_bound_included(false);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child_meta(child0_id)));
+    EXPECT_OK(put_tablet_metadata(make_child_meta(child1_id)));
+
+    const int64_t txn_id = next_id();
+    PUniqueId load0;
+    load0.set_hi(1);
+    load0.set_lo(1);
+    PUniqueId load1;
+    load1.set_hi(1);
+    load1.set_lo(2);
+
+    // One multi-statement transaction with two per-load_id txn logs on the OLD tablet.
+    // |uid_lo| is the rowset's producer uid (hi=1, lo=uid_lo); distinct per statement so
+    // the merged uid can be attributed to a specific source log.
+    auto write_stmt_log = [&](const PUniqueId& load_id, const std::string& segment_name, int64_t num_rows,
+                              int64_t data_size, int64_t uid_lo) {
+        auto log = std::make_shared<TxnLogPB>();
+        log->set_tablet_id(old_tablet_id);
+        log->set_txn_id(txn_id);
+        auto* rowset = log->mutable_op_write()->mutable_rowset();
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(num_rows);
+        rowset->set_data_size(data_size);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(segment_name);
+        sm->set_size(data_size);
+        rowset->mutable_uid()->set_hi(1);
+        rowset->mutable_uid()->set_lo(uid_lo);
+        EXPECT_OK(_tablet_manager->put_txn_log(log, _tablet_manager->txn_log_location(old_tablet_id, txn_id, load_id)));
+    };
+    write_stmt_log(load0, "stmt_a.dat", /*num_rows=*/1, /*data_size=*/11, /*uid_lo=*/7777);
+    write_stmt_log(load1, "stmt_b.dat", /*num_rows=*/9, /*data_size=*/99, /*uid_lo=*/9999);
+
+    auto make_txn_info = [&]() {
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+        txn_info.set_txn_type(TXN_NORMAL);
+        txn_info.set_combined_txn_log(false);
+        txn_info.set_commit_time(1);
+        txn_info.set_force_publish(false);
+        txn_info.add_load_ids()->CopyFrom(load0);
+        txn_info.add_load_ids()->CopyFrom(load1);
+        return txn_info;
+    };
+
+    auto publish_child = [&](int64_t child_id, int32_t split_index) -> RowsetMetadataPB {
+        lake::PublishTabletInfo tablet_info(lake::PublishTabletInfo::SPLITTING_TABLET, old_tablet_id, child_id,
+                                            /*split_count=*/2, split_index);
+        auto txn_info = make_txn_info();
+        auto published_or = lake::publish_version(_tablet_manager.get(), tablet_info, base_version, new_version,
+                                                  std::span<const TxnInfoPB>(&txn_info, 1), false);
+        EXPECT_OK(published_or.status());
+        ASSIGN_OR_ABORT(auto meta, _tablet_manager->get_tablet_metadata(child_id, new_version));
+        EXPECT_EQ(1, meta->rowsets_size());
+        return meta->rowsets(0);
+    };
+
+    // split_index=1: stmt_a (the FIRST log) scales to num_rows=0, but its segment survives.
+    auto child1_rowset = publish_child(child1_id, /*split_index=*/1);
+    EXPECT_EQ(2, child1_rowset.segment_metas_size())
+            << "the cross-published statement whose num_rows scaled to 0 must keep its segment";
+    EXPECT_EQ(4, child1_rowset.num_rows());   // stmt_a 0 + stmt_b 4
+    EXPECT_EQ(54, child1_rowset.data_size()); // stmt_a 5 + stmt_b 49
+    for (const auto& segment_meta : child1_rowset.segment_metas()) {
+        EXPECT_TRUE(segment_meta.shared());
+    }
+
+    // split_index=0: the odd-count remainders both land here.
+    auto child0_rowset = publish_child(child0_id, /*split_index=*/0);
+    EXPECT_EQ(2, child0_rowset.segment_metas_size());
+    EXPECT_EQ(6, child0_rowset.num_rows());   // stmt_a 1 + stmt_b 5
+    EXPECT_EQ(56, child0_rowset.data_size()); // stmt_a 6 + stmt_b 50
+
+    // Per-statement scaling, not sum-then-scale: aggregate scaling would yield 5/5 rows and
+    // 55/55 data on both children; the asymmetric 6/4 and 56/54 prove each statement scaled
+    // on its own. Conservation: the per-child shares add back to the originals (10 and 110).
+    EXPECT_EQ(10, child0_rowset.num_rows() + child1_rowset.num_rows());
+    EXPECT_EQ(110, child0_rowset.data_size() + child1_rowset.data_size());
+
+    // Cross-sibling MERGE identity: both children adopt the FIRST log's (stmt_a) producer uid
+    // 7777 verbatim -- not stmt_b's 9999, and not a "first positive-row" pick (stmt_a scaled
+    // to 0 on child1 yet still defines the uid).
+    EXPECT_TRUE(child0_rowset.has_uid());
+    EXPECT_EQ(child1_rowset.uid().SerializeAsString(), child0_rowset.uid().SerializeAsString());
+    EXPECT_EQ(1, child0_rowset.uid().hi());
+    EXPECT_EQ(7777, child0_rowset.uid().lo());
+}
+
 TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for_splitting) {
     auto base_metadata = std::make_shared<TabletMetadataPB>();
     base_metadata->set_id(next_id());


### PR DESCRIPTION
## Why I'm doing:

The lake (shared-data) tablet SPLIT cross-publish path — where a transaction committed on a parent tablet is published after the tablet is split — is currently covered only by `TxnLogApplierBatchTest.*`, which feed `NonPrimaryKeyTxnLogApplier`'s batch combine **pre-scaled** inputs. Nothing proved that the real `convert_txn_log_for_splitting` per-statement stat scaling composes correctly with the segment-gated batch combine through the full `publish_version` path.

This is the path of the prior data-loss class: a multi-statement non-PK batch where a statement's `num_rows < split_count` scales to 0 on some children; the combine must still keep that statement's segment (gated on `segment_metas_size`, not the scaled `num_rows`) and adopt a stable cross-sibling uid. This gap could only be reproduced via a code-level interleave — at the SQL level a shared-data split's reshard window is sub-second, so a concurrent commit-publish cannot reliably land inside it.

## What I'm doing:

Add one deterministic BE integration test, `LakeTabletReshardTest.test_split_cross_publish_multi_stmt_batch_keeps_scaled_zero_segment`, that drives `publish_version` with a `SPLITTING_TABLET` `PublishTabletInfo` and a two-statement non-PK batch transaction (two per-`load_id` txn logs on the old tablet), publishing to two sibling children (`split_index` 0 and 1). It asserts the cross-publish invariants end-to-end:

1. A statement whose `num_rows` scales to 0 on a child keeps its segment (no dropped data).
2. Scaling is **per statement**, not over the aggregate — inputs `(rows=1,data=11)` + `(rows=9,data=99)` yield `child0=6/56`, `child1=4/54`, whereas a sum-then-scale-once bug would give `5/5` and `55/55`.
3. The merged-rowset uid is taken from the **first** log and is identical across siblings — the scaled-to-0 statement is the first log and the uid source, proving the uid is not a "first positive-row contributor" pick.

No production code changes — the cross-publish path is already deterministically drivable through `publish_version` (see the adjacent `test_split_cross_publish_sets_rowset_range_in_txn_log`), so no fault-injection hook is needed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
