### PR TITLE
[Enhancement] Raise lake_vacuum_min_batch_delete_size default from 100 to 200

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1819,7 +1819,7 @@ CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
-CONF_mInt64(lake_vacuum_min_batch_delete_size, "100");
+CONF_mInt64(lake_vacuum_min_batch_delete_size, "200");
 
 // TOPN RuntimeFilter parameters
 CONF_mInt32(desc_hint_split_range, "10");

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -104,7 +104,7 @@ CONF_mBool(experimental_enable_lake_capture_tablet_and_rowsets, "false");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
-CONF_mInt64(lake_vacuum_min_batch_delete_size, "100");
+CONF_mInt64(lake_vacuum_min_batch_delete_size, "200");
 
 // If the local pk index file is older than this threshold
 // it may be evicted if the disk is full

--- a/docs/en/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/BE_parameters/shared_lake_other.md
@@ -111,6 +111,14 @@ This topic introduces the following types of BE configurations:
 - Is mutable: Yes
 - Description: Sub-chunk granularity for `RowsMapperIterator` pipelined reads of `.lcrm` files during light Primary Key compaction publish in a shared-data cluster. Each output segment is split into `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` sub-chunks pipelined independently. Smaller values raise the achievable parallelism for few-but-large output segments at the cost of more range reads and an extra memcpy on consume. Defaults to 4 MiB to align with the starcache disk-tier block size.
 
+### lake_vacuum_min_batch_delete_size
+
+- Default: 200
+- Type: Int64
+- Unit: Number of files
+- Is mutable: Yes
+- Description: The number of stale files Vacuum batches into a single `DeleteObjects` request on a shared-data cluster. A larger batch amortizes per-call HTTP / auth / signing overhead and reduces the prefix-level request rate against the object store, at the cost of higher single-call latency and a larger replay cost when a transient error retries. Users running on AWS S3 are encouraged to raise this further (up to the protocol cap of 1000) where per-request server time is nearly batch-size insensitive.
+
 ### loop_count_wait_fragments_finish
 
 - Default: 2

--- a/docs/ja/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/BE_parameters/shared_lake_other.md
@@ -110,6 +110,14 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 変更可能: はい
 - 説明: 共有データクラスタでの主キーテーブル軽量コンパクション publish 時、`RowsMapperIterator` のパイプライン化された `.lcrm` 読み取りにおける sub-chunk の粒度。各出力 segment は `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` 個の sub-chunk に分割され、独立してパイプライン化されます。値を小さくするほど、少数の大きな出力 segment で達成可能な並列度が上がりますが、その代わりに範囲読み取りが増え、consume 時に追加の memcpy が発生します。デフォルトは 4 MiB で、starcache のディスク層 block サイズと一致させています。
 
+### lake_vacuum_min_batch_delete_size
+
+- デフォルト: 200
+- タイプ: Int64
+- 単位: ファイル数
+- 変更可能: はい
+- 説明: 共有データクラスタにおいて、Vacuum が単一の `DeleteObjects` リクエストにまとめる古いファイルの数。バッチを大きくすると、呼び出しごとの HTTP / 認証 / 署名オーバーヘッドが摊销され、オブジェクトストレージの prefix 単位リクエストレートへの圧力も軽減されますが、一回あたりの latency が上がり、瞬間的なエラーで retry した際の replay コストも増えます。AWS S3 では `DeleteObjects` のサーバー処理時間が batch size にほとんど依存しないため、AWS S3 ユーザーはこの値をプロトコル上限の `1000` までさらに引き上げることを推奨します。
+
 ### loop_count_wait_fragments_finish
 
 - デフォルト: 2

--- a/docs/zh/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/BE_parameters/shared_lake_other.md
@@ -107,6 +107,14 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 是否动态：是
 - 描述：存算分离集群下，主键表轻量 Compaction 发布阶段，`RowsMapperIterator` 流水化读取 `.lcrm` 文件时使用的 sub-chunk 粒度。每个输出 segment 被切分为 `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` 个 sub-chunk，独立流水化。值越小，少而大的输出 segment 能获得越高的并发度，但代价是更多的范围读取和消费时一次额外的 memcpy。默认 4 MiB，与 starcache 磁盘层 block 大小对齐。
 
+### lake_vacuum_min_batch_delete_size
+
+- 默认值：200
+- 类型：Int64
+- 单位：文件数
+- 是否动态：是
+- 描述：存算分离集群下，Vacuum 单次 `DeleteObjects` 请求批量合并的过期文件数量。批量越大，单次调用摊销的 HTTP/认证/签名等固定开销越多，且对对象存储 prefix 级别的请求频次压力越小；代价是单次调用 latency 升高、出现瞬时错误需要 retry 时回放成本增大。AWS S3 用户可以进一步将该值调到协议上限 `1000`，因为 AWS S3 单 `DeleteObjects` 服务端耗时几乎与 batch size 无关。
+
 ### loop_count_wait_fragments_finish
 
 - 默认值：2


### PR DESCRIPTION
## Why I'm doing:

`lake_vacuum_min_batch_delete_size` controls how many stale files Vacuum batches into a single S3 `DeleteObjects` request. The protocol allows up to 1000 keys per request; the current default 100 leaves a lot of throughput on the table, especially on AWS S3 where per-request server processing time is nearly batch-size insensitive (~750–900 ms whether the batch holds 100 or 1000 keys).

Internal benchmark (starlet `S3FileSystemTest.test_delete_files_batch_perf`, single-thread `DeleteObjects` against a real bucket, 100,000 keys deleted per batch size):

| batch | AWS S3 (us-west-2) | Aliyun OSS (zhangjiakou) |
| ---: | --- | --- |
| 100  | 133 keys/s &nbsp;·&nbsp; avg 755 ms &nbsp;·&nbsp; p99 1126 ms | 1600 keys/s &nbsp;·&nbsp; avg 62.5 ms &nbsp;·&nbsp; p99 99 ms |
| 200  | 246 keys/s &nbsp;·&nbsp; avg 814 ms &nbsp;·&nbsp; p99 1740 ms | 1729 keys/s &nbsp;·&nbsp; avg 116 ms &nbsp;·&nbsp; p99 162 ms |
| 500  | 539 keys/s &nbsp;·&nbsp; avg 927 ms &nbsp;·&nbsp; p99 3606 ms | 1709 keys/s &nbsp;·&nbsp; avg 293 ms &nbsp;·&nbsp; p99 384 ms |
| 1000 | 1099 keys/s &nbsp;·&nbsp; avg 910 ms &nbsp;·&nbsp; p99 1740 ms | 1697 keys/s &nbsp;·&nbsp; avg 553 ms &nbsp;·&nbsp; p99 660 ms |

Key takeaways:
- **AWS S3 throughput is linear in batch size** — going 100 → 200 gains 85% throughput; OSS-like backends already saturate around batch=200 and gain ~8%.
- Per-call latency rises modestly (AWS 755 → 814 ms, OSS 62 → 115 ms) but remains well within typical Vacuum retry budgets.
- AWS users can push the value further (up to the 1000 protocol cap) for an extra ~4–5× throughput; this is documented as a tuning note.

Raising the default to 200 is the conservative middle ground that benefits every backend without regressing OSS latency materially. The flag stays `mutable`, so deployments can still pin a higher or lower value at runtime.

## What I'm doing:

- `be/src/common/config.h` and `be/src/common/config_lake_fwd.h`: change `CONF_mInt64(lake_vacuum_min_batch_delete_size, "100")` → `"200"`.
- `docs/{en,zh,ja}/administration/management/BE_parameters/shared_lake_other.md`: add the parameter entry with the AWS-tuning note (raise up to 1000). The full benchmark table is kept in this PR description rather than duplicated in the public docs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4