### PR TITLE
[Enhancement] Add FE metrics contract guard test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,13 @@
 /fe/fe-core/src/main/java/com/starrocks/metric/     @StarRocks/metadata-maintainer
 /fe/fe-core/src/main/java/com/starrocks/system/     @StarRocks/metadata-maintainer
 
+# FE metric-name contract (external contract).
+# FE metric names are scraped by downstream consumers (dashboards, alerting rules,
+# and external monitoring tooling), so changes to the metric names or to the golden
+# inventory must be reviewed deliberately. FeMetricsContractGuardTest fails on any drift.
+/fe/fe-core/src/test/resources/metric/fe_metrics_golden.txt                     @StarRocks/metadata-maintainer
+/fe/fe-core/src/test/java/com/starrocks/metric/FeMetricsContractGuardTest.java  @StarRocks/metadata-maintainer
+
 # connector
 /fe/fe-core/src/main/java/com/starrocks/connector/  @StarRocks/connector-maintainer
 /fe/fe-core/src/main/java/com/starrocks/credential/  @StarRocks/connector-maintainer

--- a/fe/fe-core/src/test/java/com/starrocks/metric/FeMetricsContractGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/FeMetricsContractGuardTest.java
@@ -1,0 +1,380 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Contract guard for FE (fe-core) metric {@code "name type unit"} entries.
+ *
+ * <p>FE metrics are an EXTERNAL contract: dashboards, alerting rules, and external monitoring
+ * tooling scrape them from the Prometheus endpoint (prefixed with {@code starrocks_fe_}).
+ * Adding, removing, or renaming a metric — or flipping its type (counter/gauge) or its unit —
+ * silently breaks those consumers: the type drives the Prometheus {@code # TYPE} line
+ * (PrometheusMetricVisitor) and the unit is exported on the JSON metrics endpoint
+ * (JsonMetricVisitor). This test scans the fe-core main sources and records, for each metric,
+ * a {@code "name type unit"} triple, then compares the result against a committed golden file
+ * ({@code fe-core/src/test/resources/metric/fe_metrics_golden.txt}). Any drift fails the
+ * build with an explicit added/removed report and a directive to notify downstream consumers.
+ *
+ * <p>The test is a pure source scan — it does NOT bootstrap the FE, so it runs fast and
+ * deterministically without any thrift/metadata wiring. The extraction rules below MUST
+ * stay identical to the spec documented in the golden file header.
+ *
+ * <p>To accept an intentional change, regenerate the golden file:
+ * <pre>
+ *   cd fe &amp;&amp; mvn -pl fe-core test \
+ *     -Dtest=FeMetricsContractGuardTest -Dmetrics.guard.regenerate=true
+ * </pre>
+ * then re-run without the flag to confirm it passes.
+ */
+public class FeMetricsContractGuardTest {
+
+    /** Source root to scan, rooted at {@code fe/}. */
+    private static final String SRC_ROOT_RELATIVE = "fe-core/src/main/java/com/starrocks";
+
+    /** Committed golden inventory, rooted at {@code fe/}. */
+    private static final String GOLDEN_RELATIVE = "fe-core/src/test/resources/metric/fe_metrics_golden.txt";
+
+    /** Set {@code -Dmetrics.guard.regenerate=true} to rewrite the golden file's data section. */
+    private static final String REGENERATE_PROPERTY = "metrics.guard.regenerate";
+
+    /**
+     * Metric ctor class -&gt; exported type label. The first ctor argument of each of these
+     * classes is the metric name, and the class itself fully determines the exported type:
+     * {@code counter}/{@code gauge} (PrometheusMetricVisitor emits
+     * {@code metric.getType().name().toLowerCase()}), while histogram families are exported as
+     * {@code summary}. Kept in sync with the offline generator and the golden file header.
+     */
+    private static final Map<String, String> CLASS_TYPE = new LinkedHashMap<>();
+
+    static {
+        CLASS_TYPE.put("LongCounterMetric", "counter");
+        CLASS_TYPE.put("DoubleCounterMetric", "counter");
+        CLASS_TYPE.put("LeaderAwareCounterMetricExternalLong", "counter");
+        CLASS_TYPE.put("LeaderAwareCounterMetricLong", "counter");
+        CLASS_TYPE.put("GaugeMetricImpl", "gauge");
+        CLASS_TYPE.put("GaugeMetric", "gauge");
+        CLASS_TYPE.put("LeaderAwareGaugeMetricLong", "gauge");
+        CLASS_TYPE.put("LeaderAwareGaugeMetricInteger", "gauge");
+        CLASS_TYPE.put("HistogramMetric", "summary");
+        CLASS_TYPE.put("LeaderAwareHistogramMetric", "summary");
+    }
+
+    /** Exported type label for the codahale and {@code HistogramMetric} families. */
+    private static final String SUMMARY = "summary";
+
+    /**
+     * Placeholder unit for entries whose ctor declares no {@code MetricUnit} (the histogram
+     * families) or whose name is a runtime-concatenated fragment (e.g. {@code brpc_pool_}), so
+     * the unit cannot be bound statically.
+     */
+    private static final String NO_UNIT = "-";
+
+    // A double-quoted string literal, capturing its inner content in group 1.
+    private static final String STRING = "\"((?:[^\"\\\\]|\\\\.)*)\"";
+
+    // `[static] final String IDENT = "literal";` -> group(1)=IDENT, group(2)=literal.
+    private static final Pattern CONST_RE = Pattern.compile(
+            "(?:static\\s+)?final\\s+String\\s+([A-Za-z_]\\w*)\\s*=\\s*" + STRING + "\\s*;");
+
+    // `new <AllowlistedClass>[<...>]( <firstArg> [, MetricUnit.X] ...` ->
+    // group(1)=class, group(2)=name literal, group(3)=name identifier, group(4)=unit enum.
+    private static final Pattern CTOR_RE = Pattern.compile(
+            "new\\s+(" + buildClassAlternation() + ")\\s*(?:<[^>]*>)?\\s*\\(\\s*(?:"
+                    + STRING + "|([A-Za-z_][\\w.]*))"
+                    + "(?:\\s*,\\s*(?:Metric\\.)?MetricUnit\\.([A-Za-z_]+))?");
+
+    // Codahale histogram name builder: `MetricRegistry.name(<args>)`.
+    private static final Pattern NAME_CALL_RE = Pattern.compile("MetricRegistry\\.name\\s*\\(([^)]*)\\)");
+
+    // A single argument that is exactly one string literal (group 1 = its content).
+    private static final Pattern ARG_STRING_RE = Pattern.compile("^\\s*" + STRING + "\\s*$");
+
+    // Identifier first-args are only resolved through the global constant map when they look
+    // like a constant (UPPER_SNAKE_CASE); camelCase params are treated as dynamic and skipped.
+    private static final Pattern UPPER_SNAKE_RE = Pattern.compile("^[A-Z][A-Z0-9_]*$");
+
+    @Test
+    public void feMetricNamesMatchGoldenContract() {
+        Path srcRoot = resolveUnderFe(SRC_ROOT_RELATIVE);
+        Path goldenFile = resolveUnderFe(GOLDEN_RELATIVE);
+
+        SortedSet<String> actual = scanMetricTriples(srcRoot);
+
+        if (Boolean.getBoolean(REGENERATE_PROPERTY)) {
+            writeGolden(goldenFile, actual);
+            System.out.println("[metrics-guard] Regenerated " + goldenFile + " with " + actual.size()
+                    + " metric (name, type, unit) entries. Re-run without -D" + REGENERATE_PROPERTY + " to verify.");
+            return;
+        }
+
+        SortedSet<String> golden = readGolden(goldenFile);
+        if (actual.equals(golden)) {
+            return;
+        }
+
+        SortedSet<String> added = new TreeSet<>(actual);
+        added.removeAll(golden);
+        SortedSet<String> removed = new TreeSet<>(golden);
+        removed.removeAll(actual);
+
+        throw new AssertionError(buildFailureMessage(added, removed, goldenFile));
+    }
+
+    /**
+     * Scan every {@code *.java} under {@code srcRoot} whose raw text contains "Metric" and
+     * return the sorted, de-duplicated set of {@code "name type unit"} entries. Mirrors the
+     * offline generator exactly.
+     */
+    private static SortedSet<String> scanMetricTriples(Path srcRoot) {
+        List<Path> javaFiles;
+        try (Stream<Path> stream = Files.walk(srcRoot)) {
+            javaFiles = stream.filter(p -> p.toString().endsWith(".java")).sorted().collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new AssertionError("Failed to walk source root " + srcRoot + ": " + e.getMessage(), e);
+        }
+
+        // Pass 1: build per-file and global constant maps. The global map resolves cross-file
+        // references (e.g. HttpMetricRegistry holds names used elsewhere). An identifier defined
+        // with conflicting values in more than one file is "ambiguous" and never resolved globally.
+        Map<Path, String> fileCodes = new LinkedHashMap<>();
+        Map<Path, Map<String, String>> localConsts = new HashMap<>();
+        Map<String, String> globalConst = new HashMap<>();
+        Set<String> ambiguous = new HashSet<>();
+
+        for (Path path : javaFiles) {
+            String raw = readFileChecked(path);
+            if (!raw.contains("Metric")) {
+                continue;
+            }
+            String code = stripComments(raw);
+            fileCodes.put(path, code);
+
+            Map<String, String> consts = new HashMap<>();
+            Matcher cm = CONST_RE.matcher(code);
+            while (cm.find()) {
+                consts.put(cm.group(1), cm.group(2));
+            }
+            localConsts.put(path, consts);
+
+            for (Map.Entry<String, String> e : consts.entrySet()) {
+                String key = e.getKey();
+                String value = e.getValue();
+                if (globalConst.containsKey(key) && !globalConst.get(key).equals(value)) {
+                    ambiguous.add(key);
+                }
+                globalConst.put(key, value);
+            }
+        }
+
+        // Pass 2: extract "name type unit" entries from metric constructors and codahale
+        // name() calls. The type comes from the ctor class; the unit from the optional second
+        // MetricUnit argument (none for histograms / codahale -> NO_UNIT).
+        SortedSet<String> entries = new TreeSet<>();
+        for (Map.Entry<Path, String> entry : fileCodes.entrySet()) {
+            Map<String, String> consts = localConsts.get(entry.getKey());
+            String code = entry.getValue();
+
+            Matcher ctor = CTOR_RE.matcher(code);
+            while (ctor.find()) {
+                String type = CLASS_TYPE.get(ctor.group(1));
+                String literal = ctor.group(2);
+                String ident = ctor.group(3);
+                String unitEnum = ctor.group(4);
+                String unit;
+                if (SUMMARY.equals(type) || unitEnum == null) {
+                    unit = NO_UNIT;
+                } else {
+                    unit = unitEnum.toLowerCase();
+                }
+                if (literal != null) {
+                    entries.add(literal + " " + type + " " + unit);
+                } else if (ident != null) {
+                    String resolved = resolve(ident, consts, globalConst, ambiguous);
+                    if (resolved != null) {
+                        entries.add(resolved + " " + type + " " + unit);
+                    }
+                }
+            }
+
+            Matcher nameCall = NAME_CALL_RE.matcher(code);
+            while (nameCall.find()) {
+                List<String> parts = new ArrayList<>();
+                for (String arg : nameCall.group(1).split(",")) {
+                    Matcher am = ARG_STRING_RE.matcher(arg);
+                    if (am.matches()) {
+                        parts.add(am.group(1));
+                    } else {
+                        break;
+                    }
+                }
+                if (!parts.isEmpty()) {
+                    entries.add(String.join(".", parts) + " " + SUMMARY + " " + NO_UNIT);
+                }
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Resolve an identifier first-arg to its literal value: per-file constant first, then the
+     * global UPPER_SNAKE constant map when unambiguous. Returns {@code null} for dynamic args.
+     */
+    private static String resolve(String ident, Map<String, String> consts,
+                                  Map<String, String> globalConst, Set<String> ambiguous) {
+        if (consts.containsKey(ident)) {
+            return consts.get(ident);
+        }
+        if (UPPER_SNAKE_RE.matcher(ident).matches()
+                && globalConst.containsKey(ident) && !ambiguous.contains(ident)) {
+            return globalConst.get(ident);
+        }
+        return null;
+    }
+
+    private static String stripComments(String source) {
+        String withoutBlockComments = source.replaceAll("(?s)/\\*.*?\\*/", "");
+        return withoutBlockComments.replaceAll("//[^\\n]*", "");
+    }
+
+    /** Longest-first (stable) alternation so {@code GaugeMetricImpl} is tried before {@code GaugeMetric}. */
+    private static String buildClassAlternation() {
+        List<String> classes = new ArrayList<>(CLASS_TYPE.keySet());
+        classes.sort((a, b) -> Integer.compare(b.length(), a.length()));
+        return String.join("|", classes);
+    }
+
+    private static SortedSet<String> readGolden(Path goldenFile) {
+        SortedSet<String> entries = new TreeSet<>();
+        for (String line : readFileChecked(goldenFile).split("\n", -1)) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            entries.add(trimmed);
+        }
+        return entries;
+    }
+
+    /**
+     * Rewrite only the data section of the golden file, preserving the human-maintained header
+     * (leading comment / blank lines) so regeneration never churns the documentation block.
+     */
+    private static void writeGolden(Path goldenFile, SortedSet<String> entries) {
+        List<String> headerLines = new ArrayList<>();
+        if (Files.exists(goldenFile)) {
+            for (String line : readFileChecked(goldenFile).split("\n", -1)) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    headerLines.add(line);
+                } else {
+                    break;
+                }
+            }
+        }
+        StringBuilder content = new StringBuilder();
+        for (String header : headerLines) {
+            content.append(header).append('\n');
+        }
+        for (String entry : entries) {
+            content.append(entry).append('\n');
+        }
+        try {
+            Files.write(goldenFile, content.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new AssertionError("Failed to write golden file " + goldenFile + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static String buildFailureMessage(SortedSet<String> added, SortedSet<String> removed, Path goldenFile) {
+        StringBuilder message = new StringBuilder();
+        message.append("\nFE metric-name contract changed — this is an EXTERNAL contract.\n");
+        message.append("Downstream consumers (dashboards, alerts, external monitoring tooling) depend on these.\n\n");
+        if (!removed.isEmpty()) {
+            message.append("REMOVED or RENAMED or RETYPED (").append(removed.size())
+                    .append(") — these BREAK consumers, notify downstream metric consumers:\n");
+            for (String entry : removed) {
+                message.append("  - ").append(entry).append("\n");
+            }
+            message.append("\n");
+        }
+        if (!added.isEmpty()) {
+            message.append("ADDED (").append(added.size()).append("):\n");
+            for (String entry : added) {
+                message.append("  + ").append(entry).append("\n");
+            }
+            message.append("\n");
+        }
+        message.append("If this change is intentional:\n");
+        message.append("  1. Regenerate the golden file:\n");
+        message.append("       cd fe && mvn -pl fe-core test -Dtest=FeMetricsContractGuardTest "
+                + "-Dmetrics.guard.regenerate=true\n");
+        message.append("  2. Re-run this test without the regenerate flag to confirm it passes.\n");
+        message.append("  3. For any REMOVED/RENAMED name, notify downstream metric consumers before\n");
+        message.append("     merging so dashboards, alerts, and external collectors can be updated.\n");
+        message.append("  4. Update user-facing docs under docs/{en,zh}/administration/management/monitoring/"
+                + " if applicable.\n");
+        message.append("Golden file: ").append(goldenFile).append("\n");
+        return message.toString();
+    }
+
+    /**
+     * Resolve {@code relativePath} (rooted at {@code fe/}) by walking ancestors of the test
+     * working directory. Surefire forks from {@code fe-core/}, Maven sometimes from {@code fe/},
+     * and IDE runners often from the repository root — all three are handled without hardcoding.
+     */
+    private static Path resolveUnderFe(String relativePath) {
+        Path workingDir = Paths.get("").toAbsolutePath();
+        for (Path candidate = workingDir; candidate != null; candidate = candidate.getParent()) {
+            Path direct = candidate.resolve(relativePath);
+            if (Files.exists(direct)) {
+                return direct;
+            }
+            Path underFe = candidate.resolve("fe").resolve(relativePath);
+            if (Files.exists(underFe)) {
+                return underFe;
+            }
+        }
+        throw new AssertionError("Failed to locate " + relativePath + " from working directory " + workingDir);
+    }
+
+    private static String readFileChecked(Path path) {
+        try {
+            return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+        } catch (IOException readFailure) {
+            throw new AssertionError("Failed to read " + path + ": " + readFailure.getMessage(), readFailure);
+        }
+    }
+}

--- a/fe/fe-core/src/test/resources/metric/fe_metrics_golden.txt
+++ b/fe/fe-core/src/test/resources/metric/fe_metrics_golden.txt
@@ -1,0 +1,286 @@
+# StarRocks FE metric-name contract (golden snapshot)
+# =====================================================
+# This file is the authoritative inventory of FE (fe-core) metric entries, one per
+# line as "<name> <type> <unit>". It is generated and verified by:
+#   com.starrocks.metric.FeMetricsContractGuardTest
+#
+# WHY THIS EXISTS
+# ---------------
+# FE metrics are part of an EXTERNAL contract. Downstream consumers (dashboards,
+# alerting rules, and external monitoring tooling) scrape them from the metrics
+# endpoint with the `starrocks_fe_` prefix. Renaming, removing, silently adding a
+# metric, or flipping its type/unit breaks those consumers:
+#   - name : the exported series name.
+#   - type : counter | gauge | summary. Drives the Prometheus `# TYPE` line
+#            (PrometheusMetricVisitor emits metric.getType().name().toLowerCase();
+#            histograms are emitted as `summary`).
+#   - unit : the MetricUnit (lowercased) exported on the JSON metrics endpoint
+#            (JsonMetricVisitor emits metric.getUnit().name().toLowerCase()).
+# This guard makes any such change show up as a failing test, so it is reviewed
+# deliberately instead of slipping through.
+#
+# WHEN THIS TEST FAILS
+# --------------------
+# The failure message lists the ADDED / REMOVED lines. Because the type and unit are
+# part of each line, a counter<->gauge flip or a unit change shows up as one removed +
+# one added line for the same name, exactly like a rename. For any REMOVED or RENAMED
+# or RETYPED line you MUST notify downstream metric consumers before merging. After
+# confirming the change is intended:
+#   1. Regenerate this file:
+#        cd fe && mvn -pl fe-core test \
+#          -Dtest=FeMetricsContractGuardTest \
+#          -Dmetrics.guard.regenerate=true
+#      (or set the system property in your IDE run config), then re-run normally.
+#   2. Update docs/en|zh/administration/management/monitoring/metrics(_details)
+#      if the change is user-facing.
+#   3. Notify downstream metric consumers for any removal/rename/retype so dashboards,
+#      alerts, and external collectors can be updated before the change ships.
+#
+# HOW ENTRIES ARE EXTRACTED (must stay identical to the Java scanner)
+# -------------------------------------------------------------------
+# Scope : every *.java under fe/fe-core/src/main/java/com/starrocks whose raw
+#         text contains the substring "Metric".
+# Per file:
+#   1. strip block comments /* ... */ then line comments // ...
+#   2. build a per-file constant map: [static] final String IDENT = "literal";
+#   3. metric ctors  new <ALLOWLISTED_CLASS>[<...>](<firstArg> [, MetricUnit.X] ...)
+#        name : literal first-arg, else identifier resolved via the per-file
+#               constant map, else the global UPPER_SNAKE constant map (when
+#               unambiguous), else SKIP (dynamic).
+#        type : derived from the ctor CLASS (see allowlist below).
+#        unit : the second MetricUnit.<X> argument lowercased; `-` when the ctor
+#               declares no unit (the histogram families) or when the name is a
+#               runtime-concatenated fragment so the unit cannot bind statically
+#               (e.g. brpc_pool_).
+#   4. codahale  MetricRegistry.name("a","b", dynArg) -> join leading string
+#      literals with "." (here: "a.b"), stop at the first non-literal arg;
+#      type=summary, unit=-.
+# Allowlisted metric classes and their exported type:
+#   counter : LongCounterMetric, DoubleCounterMetric,
+#             LeaderAwareCounterMetricExternalLong, LeaderAwareCounterMetricLong
+#   gauge   : GaugeMetricImpl, GaugeMetric, LeaderAwareGaugeMetricLong,
+#             LeaderAwareGaugeMetricInteger
+#   summary : HistogramMetric, LeaderAwareHistogramMetric (and codahale name(...))
+#
+# NOTES ON ENTRY SHAPES
+# ---------------------
+# - A few names are prefixes/fragments rather than complete exported names
+#   (e.g. `brpc_pool_`, `thread_pool`, `snmp`) because the source builds the
+#   full name by concatenation at runtime; the literal prefix is still the
+#   contract anchor and changing it is still a breaking change. A fragment whose
+#   surrounding expression is not a plain literal carries unit `-`.
+# - Dotted names (e.g. `query.latency.ms`, `journal.write.bytes`) are codahale
+#   histogram base names assembled by MetricRegistry.name(...); they are `summary -`.
+#
+# KNOWN DYNAMIC EXCLUSIONS (intentionally NOT in this golden; v1 scope)
+# ---------------------------------------------------------------------
+# These metric families build their names from runtime variables, so a static
+# literal scan cannot enumerate them. They are covered by a follow-up:
+#   - ResourceGroupMetricMgr  (metricName / metricsName params; literal prefixes
+#       query_resource_group, query_resource_group_err,
+#       query_resource_group_latency, resource_group_query_queue_total/
+#       pending/timeout)
+#   - ConnectorMetricsMgr     (connectorType param; e.g. iceberg, hive)
+#   - TransactionMetricRegistry (group-name param; e.g. txn_total_latency_ms)
+#
+# DO NOT hand-sort or hand-edit the entry list below — regenerate it with the
+# command above so it stays byte-identical to the scanner output.
+# -----------------------------------------------------------------------------
+brpc_backend_service counter requests
+brpc_exec_plan_fragment counter requests
+brpc_exec_plan_fragment_error counter requests
+brpc_lake_service counter requests
+brpc_pool_ gauge -
+brpc_total gauge requests
+cache_miss_ratio gauge nounit
+catalog_query.latency.ms summary -
+catalog_query_analysis_err counter requests
+catalog_query_analysis_err_rate gauge nounit
+catalog_query_err counter requests
+catalog_query_err_rate gauge nounit
+catalog_query_internal_err counter requests
+catalog_query_internal_err_rate gauge nounit
+catalog_query_latency_ms summary -
+catalog_query_success counter requests
+catalog_query_timeout counter requests
+catalog_query_timeout_rate gauge nounit
+catalog_query_total counter requests
+catalog_slow_query counter requests
+clone_task_copy_bytes counter bytes
+clone_task_copy_duration_ms counter milliseconds
+clone_task_success counter requests
+clone_task_total counter requests
+connection_total gauge connections
+database_num gauge operations
+db_size_bytes gauge bytes
+deploy_plan_fragments.latency.ms summary -
+edit_log_read counter operations
+edit_log_size_bytes counter bytes
+edit_log_write counter operations
+editlog.write.latency.ms summary -
+editlog_stacked_num gauge operations
+encryption_key_num gauge nounit
+failed_stats_collect_job counter requests
+http_connections_num counter nounit
+http_handling_requests_num counter nounit
+http_worker_pending_tasks_num gauge nounit
+http_workers_num gauge nounit
+iceberg_metadata_table_query_total counter requests
+iceberg_time_travel_query_total counter requests
+image_push counter operations
+image_write counter operations
+job gauge nounit
+journal.write.batch summary -
+journal.write.bytes summary -
+journal.write.latency.ms summary -
+last_finished_job_timestamp gauge microseconds
+load_add counter requests
+load_finished counter requests
+max_journal_id gauge nounit
+max_tablet_compaction_score gauge nounit
+memory_usage gauge bytes
+merge_commit_cn_num gauge nounit
+merge_commit_job_num gauge nounit
+merge_commit_load_bytes counter nounit
+merge_commit_load_rows counter nounit
+merge_commit_task_fail_num counter nounit
+merge_commit_task_running_num counter nounit
+merge_commit_task_success_num counter nounit
+merge_commit_total_actual_parallel gauge nounit
+merge_commit_total_expect_parallel gauge nounit
+merge_commit_txn_dispatch_fail_num counter nounit
+merge_commit_txn_dispatch_pending_num counter nounit
+merge_commit_txn_dispatch_retry_num counter nounit
+merge_commit_txn_dispatch_success_num counter nounit
+merge_commit_warehouse_num gauge nounit
+meta_log_count gauge nounit
+mv_inactive_state gauge nounit
+mv_partition_count gauge nounit
+mv_query_total_considered_count counter requests
+mv_query_total_count counter requests
+mv_query_total_hit_count counter requests
+mv_query_total_matched_count counter requests
+mv_query_total_text_based_matched_count counter requests
+mv_refresh_duration summary -
+mv_refresh_jobs counter requests
+mv_refresh_pending_jobs gauge nounit
+mv_refresh_running_jobs gauge nounit
+mv_refresh_total_empty_jobs counter requests
+mv_refresh_total_failed_jobs counter requests
+mv_refresh_total_retry_meta_count counter requests
+mv_refresh_total_success_jobs counter requests
+mv_row_count gauge nounit
+mv_storage_size gauge nounit
+object_count gauge nounit
+plan_advisor_guide_applied_total counter requests
+plan_advisor_guide_generated_total counter requests
+plan_advisor_optimization_duration_ms_total counter milliseconds
+publish_version_daemon_loop_total counter operations
+qps gauge nounit
+query.cache_miss_ratio.permille summary -
+query.latency.ms summary -
+query_analysis_err counter requests
+query_analysis_err_rate gauge nounit
+query_err counter requests
+query_err_rate gauge nounit
+query_internal_err counter requests
+query_internal_err_rate gauge nounit
+query_latency gauge milliseconds
+query_queue_pending counter requests
+query_queue_slot_pending counter requests
+query_queue_slot_running counter requests
+query_queue_timeout counter requests
+query_queue_total counter requests
+query_queue_v2_category_min_slots gauge requests
+query_queue_v2_category_pending_slots counter requests
+query_queue_v2_category_running_slots counter requests
+query_queue_v2_category_state counter requests
+query_queue_v2_category_total_allocated_slots counter requests
+query_queue_v2_category_weight gauge requests
+query_success counter requests
+query_timeout counter requests
+query_timeout_rate gauge nounit
+query_total counter requests
+report_queue_size gauge nounit
+request_total counter requests
+routine_load_error_rows counter rows
+routine_load_jobs gauge nounit
+routine_load_max_lag_of_partition gauge nounit
+routine_load_max_lag_time_of_partition gauge seconds
+routine_load_paused counter requests
+routine_load_receive_bytes counter bytes
+routine_load_rows counter rows
+rps gauge nounit
+running_stats_collect_job counter requests
+safe_mode gauge nounit
+scheduled_pending_tablet_num gauge nounit
+scheduled_running_tablet_num gauge nounit
+scheduled_tablet_num gauge nounit
+shortcircuit.latency.ms summary -
+shortcircuit_query counter requests
+shortcircuit_rpc counter requests
+slow_lock_held_time_ms summary -
+slow_lock_wait_time_ms summary -
+slow_query counter requests
+snmp gauge nounit
+spm_baseline_count gauge nounit
+spm_capture_candidate_total counter requests
+spm_rewrite_total counter requests
+sql_block_hit_count counter requests
+starmgr_meta_sync_process_time_total counter seconds
+starmgr_meta_sync_shard_deletion_total counter nounit
+starmgr_meta_sync_shard_group_deletion_total counter nounit
+table_load_aborted_tasks counter requests
+table_load_bytes counter bytes
+table_load_committed_tasks counter requests
+table_load_error_rows counter rows
+table_load_finished counter requests
+table_load_rows counter rows
+table_load_unselected_rows counter rows
+table_num gauge operations
+table_scan_bytes counter bytes
+table_scan_finished counter requests
+table_scan_rows counter rows
+table_size_bytes gauge bytes
+tablet_count gauge nounit
+tablet_max_compaction_score gauge nounit
+tablet_num gauge nounit
+tablet_pre_split.boundaries_planned summary -
+tablet_pre_split.post_submit_wait.ms summary -
+tablet_pre_split.pre_submit_wait.ms summary -
+tablet_pre_split_eligibility_skipped counter requests
+tablet_pre_split_load_abort counter requests
+tablet_pre_split_partitions_capped counter requests
+tablet_pre_split_partitions_total counter requests
+tablet_pre_split_post_submit_hard_cap counter requests
+tablet_pre_split_pre_create counter requests
+tablet_pre_split_sampler_failed counter requests
+tablet_pre_split_sampler_invocations counter requests
+tablet_pre_split_tier_used counter requests
+tablet_reshard_job.duration.ms summary -
+tablet_reshard_job_aborted counter requests
+tablet_reshard_job_finished counter requests
+tablet_reshard_job_total counter requests
+tablet_reshard_parallel_tablets gauge nounit
+thread_pool gauge nounit
+total_data_size_bytes gauge bytes
+total_stats_collect_job counter requests
+txn_begin counter requests
+txn_failed counter requests
+txn_reject counter requests
+txn_running gauge nounit
+txn_stream_load_begin_num counter nounit
+txn_stream_load_cache_eviction_num gauge nounit
+txn_stream_load_cache_hit_num gauge nounit
+txn_stream_load_cache_miss_num gauge nounit
+txn_stream_load_commit_num counter nounit
+txn_stream_load_load_num counter nounit
+txn_stream_load_prepare_num counter nounit
+txn_stream_load_rollback_num counter nounit
+txn_success counter requests
+unfinished_backup_job counter requests
+unfinished_query counter requests
+unfinished_restore_job counter requests
+vacuum_files_bytes counter bytes
+vacuum_files_count counter requests
+warehouse_query_queue gauge nounit


### PR DESCRIPTION
## Why I'm doing:

StarRocks FE metrics are an **external contract**. Downstream consumers — monitoring
dashboards, alerting rules, and external monitoring tooling — scrape them from the FE
monitoring endpoints (the Prometheus text endpoint, prefixed `starrocks_fe_`, plus the JSON
endpoint). A silent **rename / removal / type flip / unit change** of a metric breaks those
consumers with no compile-time or runtime signal.

## What I'm doing:

Add `FeMetricsContractGuardTest`, a pure source-scan guard that snapshots every FE metric as a
`<name> <type> <unit>` triple into a committed golden file
(`fe/fe-core/src/test/resources/metric/fe_metrics_golden.txt`) and fails the build whenever the
live set drifts from the golden.

- **name** — the metric name literal (scraped as `starrocks_fe_<name>`).
- **type** — derived from the ctor class: `counter` / `gauge` / `summary` (surfaces on the
  Prometheus `# TYPE` line).
- **unit** — the `MetricUnit` ctor arg, lowercased (surfaces in the JSON endpoint `unit`
  field); `-` when the ctor declares none (histogram families, runtime-concatenated names).

The test never bootstraps the FE — it scans `*.java` under
`fe/fe-core/src/main/java/com/starrocks` that contain `"Metric"`, so it runs fast in CI without
thrift/metadata wiring. Capturing **type + unit** (not just the name) means a Counter↔Gauge flip
or a unit change is caught even when the metric name is untouched.

To land an **intentional** change, regenerate the golden:

```bash
cd fe && mvn -pl fe-core test -Dtest=FeMetricsContractGuardTest -Dmetrics.guard.regenerate=true
```

The golden file and the test are gated by `CODEOWNERS` (`@StarRocks/metadata-maintainer`) so the
diff gets a deliberate human review. Pure additions are informational; removals / renames /
retypes / unit changes are the ones that should trigger a downstream-consumer notification.

**v1 scope:** 4 dynamic metric families that build names from runtime variables
(`ResourceGroupMetricMgr`, `ConnectorMetricsMgr`, `TransactionMetricRegistry`) are intentionally
excluded — a static literal scan cannot enumerate them. Coverage today: **198** metrics.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

