### PR TITLE
[BugFix] Fix deadlock between metrics daemon and alter resource group worker

### DIFF
--- a/be/src/compute_env/workgroup/work_group_manager.cpp
+++ b/be/src/compute_env/workgroup/work_group_manager.cpp
@@ -275,8 +275,10 @@ void WorkGroupManager::update_metrics_unlocked() {
 }
 
 void WorkGroupManager::update_metrics() {
-    std::unique_lock write_lock(_mutex);
-    update_metrics_unlocked();
+    std::unique_lock write_lock(_mutex, std::try_to_lock);
+    if (write_lock.owns_lock()) {
+        update_metrics_unlocked();
+    }
 }
 
 WorkGroupPtr WorkGroupManager::get_default_workgroup() {


### PR DESCRIPTION
## Why I'm doing:
We got an issue that some BEs blocked by deadlock after running alter resource group sql.

## What I'm doing:
After grab the stacktrace of blocked BE node:

The version we used: 3.5.7
But I found that the latest version also has this potential issue.

Query worker thread
64 tids: 333790:query_rpc, 333791:query_rpc, 333792:query_rpc, 333793:query_rpc, 333794:query_rpc, 333795:query_rpc, 333796:query_rpc, 333797:query_rpc, 333798:query_rpc, 333799:query_rpc, 333800:query_rpc, 333801:query_rpc, 333802:query_rpc, 333803:query_rpc, 333804:query_rpc, 333805:query_rpc, 333806:query_rpc, 333807:query_rpc, 333808:query_rpc, 333809:query_rpc, 333810:query_rpc, 333811:query_rpc, 333812:query_rpc, 333813:query_rpc, 333814:query_rpc, 333815:query_rpc, 333816:query_rpc, 333817:query_rpc, 333818:query_rpc, 333819:query_rpc, 333820:query_rpc, 333821:query_rpc, 333822:query_rpc, 333823:query_rpc, 333824:query_rpc, 333825:query_rpc, 333826:query_rpc, 333827:query_rpc, 333828:query_rpc, 333829:query_rpc, 333830:query_rpc, 333831:query_rpc, 333832:query_rpc, 333833:query_rpc, 333834:query_rpc, 333835:query_rpc, 333836:query_rpc, 333837:query_rpc, 333838:query_rpc, 333839:query_rpc, 333840:query_rpc, 333841:query_rpc, 333842:query_rpc, 333843:query_rpc, 333844:query_rpc, 333845:query_rpc, 333846:query_rpc, 333847:query_rpc, 333848:query_rpc, 333849:query_rpc, 333850:query_rpc, 333851:query_rpc, 333852:query_rpc, 333853:query_rpc
    0x7efd33462c35  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x98c35)
    0x7efd3346d33b  __pthread_rwlock_wrlock
         0x7e56cb9  starrocks::workgroup::WorkGroupManager::add_workgroup(std::shared_ptr<starrocks::workgroup::WorkGroup> const&)
         0xb9360a4  starrocks::pipeline::FragmentExecutor::_prepare_workgroup(starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
         0xb93c2e6  starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
         0xbaccd15  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
         0xbad038d  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
         0xbad778f  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
         0x7e37c7d  starrocks::PriorityThreadPool::work_thread(int)
         0xf93e49b  thread_proxy
    0x7efd33466aa4  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa4)
    0x7efd334f3c3c  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c3c)


Daemon metrics thread
tid: 333256:metrics_daemon
    0x7efd33462c35  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x98c35)
    0x7efd3346d33b  __pthread_rwlock_wrlock
         0x7e53251  std::_Function_handler<void (), starrocks::workgroup::WorkGroupManager::add_metrics_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&)::{lambda()#1}::operator()() const::{lambda()#1}>::_M_invoke(std::_An
         0xbae5c46  starrocks::calculate_metrics(void*)
        0x13624494  execute_native_thread_routine
    0x7efd33466aa4  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa4)
    0x7efd334f3c3c  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c3c)

Resource Group Altering Thread
tid: 334662:task_worker
    0x7efd33462c35  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x98c35)
    0x7efd3346d485  __pthread_rwlock_wrlock
         0xbc552a4  starrocks::MetricRegistry::register_hook(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&)
         0xb7ae018  starrocks::pipeline::ExecStateReporter::ExecStateReporter(std::vector<unsigned long, std::allocator<unsigned long> > const&)
         0xb7a2ad5  starrocks::pipeline::GlobalDriverExecutor::GlobalDriverExecutor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unique_ptr<starrocks::ThreadPool, std::default_delete<starrocks::ThreadPool> >, bool, std::vector<u
         0xb79ac89  starrocks::workgroup::PipelineExecutorSet::start()

          //// Before maybe_create_exclusive_executors_unlocked already hold the write lock of WorkGroupManager
         0xb795e5e  starrocks::workgroup::ExecutorsManager::maybe_create_exclusive_executors_unlocked(starrocks::workgroup::WorkGroup*, std::vector<unsigned long, std::allocator<unsigned long> > const&) const
         0x7e56981  starrocks::workgroup::WorkGroupManager::create_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&)
         0x7e56f86  starrocks::workgroup::WorkGroupManager::alter_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&)
         0x7e5759e  starrocks::workgroup::WorkGroupManager::apply(std::vector<starrocks::TWorkGroupOp, std::allocator<starrocks::TWorkGroupOp> > const&)
         0xb7ec060  starrocks::ReportWorkgroupTaskWorkerPool::_worker_thread_callback(void*)
        0x13624494  execute_native_thread_routine
    0x7efd33466aa4  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa4)
    0x7efd334f3c3c  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c3c)

Deadlock path:

metrics_daemon thread
  daemon.cpp:93
  calculate_metrics()
    → StarRocksMetrics::metrics()->trigger_hook()
        → shared_lock(_hooks_mutex) [lock!]
        → iterate hooks，invoke registered hook:
    
  work_group.cpp:312 (add_metrics_unlocked call_once registered lambda)
  [this] { update_metrics(); }
    
  work_group.cpp:490
  WorkGroupManager::update_metrics()
    → std::unique_lock write_lock(_mutex)
        ← BLOCKED，wait for WGM::_mutex write lock

 

task_worker thread
  apply() → create_workgroup_unlocked()
    → maybe_create_exclusive_executors_unlocked()  
      → PipelineExecutorSet::start()
        → ExecStateReporter ctor
          → MetricRegistry::register_hook()
              → unique_lock(_hooks_mutex)
                  ← BLOCKED，wait for metrics_daemon releasing shared_lock(_hooks_mutex)

Solution: use try lock in update_metrics. 
Consequence: the update_metrics may fail once. But will update the gauge in the next loop. So that it is acceptable.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
