### PR TITLE
[UT] Fix flaky InfoSchemaDbTest caused by JMockit ConcurrentModificationException

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -52,6 +52,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,10 @@ public class InfoSchemaDbTest {
 
     @BeforeEach
     public void beforeClass() throws Exception {
+        // Disable connector metadata background refresh to avoid background threads
+        // touching JMockit's shared (non-thread-safe) state while the test thread is
+        // recording Expectations, which leads to flaky ConcurrentModificationException.
+        Config.enable_background_refresh_connector_metadata = false;
         UtFrameUtils.createMinStarRocksCluster();
 
         ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
@@ -97,6 +102,11 @@ public class InfoSchemaDbTest {
         globalStateMgr.getAuthorizationMgr().createRole(createRoleStmt);
 
         authorizationManager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.enable_background_refresh_connector_metadata = true;
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

  `InfoSchemaDbTest#testShowExternalCatalogPrivilege` fails intermittently in CI with:

```
  java.util.ConcurrentModificationException
      at mockit.internal.expectations.state.ExecutingTest.isInjectableMock(ExecutingTest.java:142)
      at mockit.internal.expectations.state.ExecutingTest.addInjectableMock(ExecutingTest.java:137)
      at com.starrocks.catalog.InfoSchemaDbTest$4.(InfoSchemaDbTest.java:355)

  java.util.ConcurrentModificationException
      at mockit.internal.expectations.state.ExecutingTest.isInjectableMock(ExecutingTest.java:142)
      at mockit.internal.expectations.state.ExecutingTest.addInjectableMock(ExecutingTest.java:137)
      at com.starrocks.catalog.InfoSchemaDbTest$4.(InfoSchemaDbTest.java:355)
```

  Root cause: the test executes `CREATE EXTERNAL CATALOG` with a real connector, which starts the
  connector metadata background refresh threads (`enable_background_refresh_connector_metadata`
  defaults to true). These background threads touch the `@Mocked HiveMetaStoreClient`, and each mock
  instance registration goes through JMockit's `ExecutingTest.addInjectableMock`, which mutates a
  plain (non-thread-safe) `ArrayList` shared across all threads. Meanwhile the test thread is
  recording the `new Expectations(metadataMgr) {...}` block, which iterates the same list. When the
  two race, the iterator throws `ConcurrentModificationException`.

  The suppressed "Missing 1 invocation to MetadataMgr#getTable" is a side effect: the CME is thrown
  in the middle of recording, before `minTimes = 0` is applied, so the expectation keeps the default
  `minTimes = 1` and fails verification at teardown.

## What I'm doing:

  Disable connector metadata background refresh in `@BeforeEach` (before the cluster starts) and
  restore it in `@AfterEach`, so no background thread can touch JMockit's shared state while the
  test thread is recording expectations. The background refresh is irrelevant to this test anyway —
  all `MetadataMgr` metadata accesses are already mocked.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
