### PR TITLE
[BugFix] Restore db-level UDFs to the renamed target db for FE followers

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1168,13 +1168,26 @@ public class RestoreJob extends AbstractJob {
 
     protected void addRestoredFunctions(Database db) {
         List<Function> functions = backupMeta.getFunctions();
-        for (Function fn : functions) {
-            try {
-                db.addFunction(fn, true, false);
-            } catch (StarRocksException e) {
-                status = new Status(ErrCode.COMMON_ERROR, "Add Function: " + fn.signatureString() +
-                        " failed when restore");
+        // Hold the db write lock across the name read and the journal writes so a concurrent
+        // ALTER DATABASE RENAME cannot slip between getFullName() and addFunction(); otherwise a
+        // follower could replay the rename before an OP_ADD_FUNCTION_V2 that still names the old db.
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            for (Function function : functions) {
+                try {
+                    // Rewrite the function's db to the restore target so a renamed restore (RESTORE ... AS
+                    // <new_db>) works on followers, which replay OP_ADD_FUNCTION_V2 and route the function
+                    // by Database.replayCreateFunctionLog -> getDb(functionName.getDb()).
+                    function.getFunctionName().setDb(db.getFullName());
+                    db.addFunction(function, true, false);
+                } catch (StarRocksException e) {
+                    status = new Status(ErrCode.COMMON_ERROR, "Add Function: " + function.signatureString() +
+                            " failed when restore");
+                }
             }
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -66,6 +66,7 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.WALApplier;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.KeysType;
@@ -1033,6 +1034,62 @@ public class RestoreJobTest {
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
 
         job.addRestoredFunctions(db);
+    }
+
+    @Test
+    public void testRestoreAddFunctionWritesTargetDbNameToEditLogForRenamedRestore() {
+        // Simulate "RESTORE ... AS <new_db>": the backed-up db-level function still carries
+        // its ORIGINAL source db name, but it is being restored into db `test_db`.
+        backupMeta = new BackupMeta(Lists.newArrayList());
+        Function backedUpFunction = new Function(new FunctionName("original_source_db", "test_function"),
+                new Type[] {IntegerType.INT}, new String[] {"argName"}, IntegerType.INT, false);
+        backupMeta.setFunctions(Lists.newArrayList(backedUpFunction));
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+
+        // Capture the db name carried by the function at the exact moment it is written to the
+        // OP_ADD_FUNCTION_V2 journal. This is what FE followers deserialize and route by via
+        // Database.replayCreateFunctionLog -> getDb(functionName.getDb()), so the assertion fails
+        // if the db rewrite happens after (or instead of) the journal write, which is precisely
+        // the case that leaves followers without the UDF.
+        List<String> dbNamesWrittenToEditLog = Lists.newArrayList();
+        new MockUp<EditLog>() {
+            @Mock
+            public void logAddFunction(Function function, WALApplier walApplier) {
+                dbNamesWrittenToEditLog.add(function.getFunctionName().getDb());
+                walApplier.apply(function);
+            }
+        };
+
+        job.addRestoredFunctions(db);
+
+        Assertions.assertEquals(Lists.newArrayList(db.getFullName()), dbNamesWrittenToEditLog);
+    }
+
+    @Test
+    public void testRestoreAddFunctionSetsErrorStatusWhenAddFunctionFails() {
+        backupMeta = new BackupMeta(Lists.newArrayList());
+        Function backedUpFunction = new Function(new FunctionName("original_source_db", "test_function"),
+                new Type[] {IntegerType.INT}, new String[] {"argName"}, IntegerType.INT, false);
+        backupMeta.setFunctions(Lists.newArrayList(backedUpFunction));
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+
+        // Force the function add to fail; the restore must surface it as an error status
+        // (and still release the db lock via the finally block).
+        new MockUp<Database>() {
+            @Mock
+            public void addFunction(Function function, boolean allowExists, boolean createIfNotExists)
+                    throws StarRocksException {
+                throw new StarRocksException("mocked add function failure");
+            }
+        };
+
+        job.addRestoredFunctions(db);
+
+        Assertions.assertFalse(job.getStatus().ok());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When backing up a database and restoring it under a new name (`RESTORE ... AS <new_db>`), db-level (non-global) UDFs are restored correctly on the FE **leader** but are **missing on FE followers**. Querying the restored UDF on a follower fails with `No matching function`.

Root cause: `RestoreJob.addRestoredFunctions` adds each backed-up function to the target database object directly, but leaves the function's `FunctionName.db` pointing at the *original source* database name.

- The leader works because it adds the function to the target `db` object and looks it up by function name (db name is irrelevant for in-db lookup).
- But the `OP_ADD_FUNCTION_V2` edit log carries the function as-is (old db name). Followers replay it via `Database.replayCreateFunctionLog -> getDb(functionName.getDb())`, which routes the function to the *old source* database (still present after a renamed restore) — or fails to resolve it. So the restored database ends up with no db-level UDFs on followers.

Global UDFs are unaffected because they carry `db = __global_udf_db__` and replay through a separate path.

## What I'm doing:

- In `addRestoredFunctions`, rewrite each function's `FunctionName.db` to the restore target db (`db.getFullName()`) **before** `db.addFunction(...)`, so the `OP_ADD_FUNCTION_V2` journal carries the target db name and followers route it to the restored database.
- Hold the database `WRITE` lock across the name read and all `addFunction` journal writes (mirroring the adjacent `addRestorePartitionsAndTables`), so a concurrent `ALTER DATABASE RENAME` cannot interleave between `getFullName()` and the journal write.
- Add an order-sensitive regression test that captures the db name carried by the function at the exact moment it is written to the journal.

Related test issue: StarRocks/StarRocksTest#11385

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)