### PR TITLE
[Enhancement] Surface real lock-wait and writer-wait time in lake load add_chunk stats

### DIFF
--- a/be/src/exec/data_sinks/tablet_sink_index_channel.cpp
+++ b/be/src/exec/data_sinks/tablet_sink_index_channel.cpp
@@ -905,6 +905,7 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
         _add_batch_counter.add_batch_execution_time_us += closure->result.execution_time_us();
         _add_batch_counter.add_batch_wait_lock_time_us += closure->result.wait_lock_time_us();
         _add_batch_counter.add_batch_wait_memtable_flush_time_us += closure->result.wait_memtable_flush_time_us();
+        _add_batch_counter.add_batch_wait_writer_time_us += closure->result.wait_writer_time_us();
         _add_batch_counter.add_batch_num++;
     }
 

--- a/be/src/exec/data_sinks/tablet_sink_index_channel.h
+++ b/be/src/exec/data_sinks/tablet_sink_index_channel.h
@@ -62,12 +62,15 @@ struct AddBatchCounter {
     int64_t client_prc_time_us = 0;
     // total time of wait memtable flush
     int64_t add_batch_wait_memtable_flush_time_us = 0;
+    // total time the server spent waiting for the async delta-writer write()/finish() callbacks
+    int64_t add_batch_wait_writer_time_us = 0;
 
     AddBatchCounter& operator+=(const AddBatchCounter& rhs) {
         add_batch_execution_time_us += rhs.add_batch_execution_time_us;
         add_batch_wait_lock_time_us += rhs.add_batch_wait_lock_time_us;
         add_batch_num += rhs.add_batch_num;
         add_batch_wait_memtable_flush_time_us += rhs.add_batch_wait_memtable_flush_time_us;
+        add_batch_wait_writer_time_us += rhs.add_batch_wait_writer_time_us;
         return *this;
     }
     friend AddBatchCounter operator+(const AddBatchCounter& lhs, const AddBatchCounter& rhs) {

--- a/be/src/exec/data_sinks/tablet_sink_sender.cpp
+++ b/be/src/exec/data_sinks/tablet_sink_sender.cpp
@@ -355,12 +355,23 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
     // print log of add batch time of all node, for tracing load performance easily
     std::stringstream ss;
     ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
-       << ", add chunk time(ms)/wait lock time(ms)/num: ";
+       << ", add chunk time(ms)/wait lock time(ms)/wait memtable flush time(ms)/wait writer time(ms)/other "
+          "time(ms)/num: ";
     for (auto const& pair : node_add_batch_counter_map) {
         total_server_rpc_time_us += pair.second.add_batch_execution_time_us;
         total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
+        // Residual of execution_time not covered by the lock/flush/writer buckets (e.g. write-context
+        // setup, delta-writer open, the immutable-partition scan and stale-memtable flush). Clamp to 0
+        // since the buckets are sampled independently.
+        int64_t other_time_us = pair.second.add_batch_execution_time_us - pair.second.add_batch_wait_lock_time_us -
+                                pair.second.add_batch_wait_memtable_flush_time_us -
+                                pair.second.add_batch_wait_writer_time_us;
+        other_time_us = other_time_us > 0 ? other_time_us : 0;
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
-           << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
+           << (pair.second.add_batch_wait_lock_time_us / 1000) << ")("
+           << (pair.second.add_batch_wait_memtable_flush_time_us / 1000) << ")("
+           << (pair.second.add_batch_wait_writer_time_us / 1000) << ")(" << (other_time_us / 1000) << ")("
+           << pair.second.add_batch_num << ")} ";
     }
     COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
     COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -462,6 +462,10 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     MonotonicStopWatch watch;
     watch.start();
     std::shared_lock<bthreads::BThreadSharedMutex> rolk(_rw_mtx);
+    // `watch` starts immediately before acquiring the shared lock, so the elapsed time at this
+    // point is the time spent waiting for `_rw_mtx` (e.g. blocked behind an open/incremental_open
+    // holding the exclusive lock). Report it back to the sender so lock contention is observable.
+    int64_t wait_lock_time_ns = watch.elapsed_time();
 
     if (UNLIKELY(!request.has_sender_id())) {
         response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
@@ -678,9 +682,27 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     // we need to proactively perform a flush when memory resources are insufficient.
     _flush_stale_memtables();
 
-    response->set_execution_time_us(watch.elapsed_time() / 1000);
-    response->set_wait_lock_time_us(0); // We didn't measure the lock wait time, just give the caller a fake time
-    response->set_wait_memtable_flush_time_us(wait_memtable_flush_time_ns / 1000);
+    // `add_chunks` (repeated-chunk RPC, enable_load_colocate_mv) reuses one response across all
+    // indexes, calling add_chunk() once per index. Accumulate every timing field so the reported
+    // value covers the whole RPC instead of only the last index. For the common single-chunk path
+    // the response starts empty, so this is equivalent to a plain set.
+    int64_t last_execution_time_us = 0;
+    int64_t last_wait_lock_time_us = 0;
+    int64_t last_wait_memtable_flush_time_us = 0;
+    int64_t last_wait_writer_time_us = 0;
+    if (response->has_execution_time_us()) {
+        last_execution_time_us = response->execution_time_us();
+        last_wait_lock_time_us = response->wait_lock_time_us();
+        last_wait_memtable_flush_time_us = response->wait_memtable_flush_time_us();
+        last_wait_writer_time_us = response->wait_writer_time_us();
+    }
+    response->set_execution_time_us(last_execution_time_us + watch.elapsed_time() / 1000);
+    response->set_wait_lock_time_us(last_wait_lock_time_us + wait_lock_time_ns / 1000);
+    response->set_wait_memtable_flush_time_us(last_wait_memtable_flush_time_us + wait_memtable_flush_time_ns / 1000);
+    // Time blocked in count_down_latch.wait() above, i.e. waiting for the async delta-writer
+    // write()/finish() callbacks. Lets the sender separate "waiting for the writer" from the
+    // lock wait and the memtable-flush back-pressure wait.
+    response->set_wait_writer_time_us(last_wait_writer_time_us + (finish_wait_writer_ts - start_wait_writer_ts) / 1000);
 
     if (!close_channel && request.wait_all_sender_close()) {
         _num_initial_senders.fetch_sub(1);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -542,11 +542,15 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     if (response->has_execution_time_us()) {
         last_execution_time_us = response->execution_time_us();
     }
+    int64_t last_wait_writer_time_us = response->has_wait_writer_time_us() ? response->wait_writer_time_us() : 0;
     response->set_execution_time_us(last_execution_time_us + watch.elapsed_time() / 1000);
     response->set_wait_lock_time_us(0); // We didn't measure the lock wait time, just give the caller a fake time
     response->set_wait_memtable_flush_time_us(wait_memtable_flush_time_us);
 
     auto wait_writer_ns = finish_wait_writer_ts - start_wait_writer_ts;
+    // Populate wait_writer_time_us for non-lake loads too, accumulating across repeated-chunk
+    // indexes like execution_time, so the sender's per-node breakdown surfaces writer stalls.
+    response->set_wait_writer_time_us(last_wait_writer_time_us + wait_writer_ns / 1000);
     auto wait_replica_ns = finish_wait_replica_ts - finish_wait_writer_ts;
     RuntimeMetrics::instance()->load_channel_add_chunks_wait_memtable_duration_us.increment(
             wait_memtable_flush_time_us);

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -389,6 +389,58 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
     ASSERT_FALSE(close_channel);
 }
 
+// Verify that timing fields in the response are accumulated, not overwritten, when one response
+// object is reused across multiple successful add_chunk() calls (the repeated-chunk RPC path that
+// LoadChannel::add_chunks drives for enable_load_colocate_mv).
+TEST_F(LakeTabletsChannelTest, test_add_chunk_accumulates_stats) {
+    auto open_request = _open_request;
+    open_request.set_num_senders(1);
+    ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
+
+    constexpr int kChunkSize = 128;
+    constexpr int kChunkSizePerTablet = kChunkSize / 4;
+    auto chunk = generate_data(kChunkSize);
+
+    PTabletWriterAddChunkRequest add_chunk_request;
+    add_chunk_request.set_index_id(kIndexId);
+    add_chunk_request.set_sender_id(0);
+    add_chunk_request.set_eos(false);
+    add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_timeout_ms(60000);
+    for (int i = 0; i < kChunkSize; i++) {
+        int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+        add_chunk_request.add_tablet_ids(tablet_id);
+        add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+    }
+    {
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+    }
+
+    // Reuse a single response across two successful add_chunk() calls.
+    PTabletWriterAddBatchResult response;
+    bool close_channel = false;
+
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &response, &close_channel);
+    ASSERT_EQ(TStatusCode::OK, response.status().status_code());
+    ASSERT_TRUE(response.has_execution_time_us());
+    ASSERT_TRUE(response.has_wait_writer_time_us());
+    int64_t exec_after_first = response.execution_time_us();
+    int64_t writer_after_first = response.wait_writer_time_us();
+
+    // Second in-order call reuses `response`, so it enters the has_execution_time_us() accumulate
+    // branch. The accumulated values must not drop below the first call's.
+    add_chunk_request.set_packet_seq(1);
+    {
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+    }
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &response, &close_channel);
+    ASSERT_EQ(TStatusCode::OK, response.status().status_code());
+    ASSERT_GE(response.execution_time_us(), exec_after_first);
+    ASSERT_GE(response.wait_writer_time_us(), writer_after_first);
+}
+
 TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -300,6 +300,9 @@ message PTabletWriterAddBatchResult {
     repeated int64 immutable_partition_ids = 8;
     optional bytes load_channel_profile = 9;
     optional LakeTabletData lake_tablet_data = 10;
+    // Time the server-side add_chunk handler spent blocked in count_down_latch.wait(),
+    // i.e. waiting for the async delta-writer write()/finish() callbacks to complete.
+    optional int64 wait_writer_time_us = 11;
 };
 
 message PTabletWriterAddSegmentRequest {


### PR DESCRIPTION
## Why I'm doing:

While diagnosing intermittent merge-commit (batch write) latency jitter (>10s) on a shared-data table, the FE-side load showed a single replica's server-side `add_chunk` `execution_time_us` spiking to ~16s while that BE had idle CPU/disk, no import thread-pool backlog, and normal object-store latency. The only remaining explanation is a non-IO wait inside the handler (lock contention or waiting on the async writer callbacks), but the current instrumentation cannot show it:

- `LakeTabletsChannel::add_chunk` hard-codes `wait_lock_time_us` to `0` (`// We didn't measure the lock wait time, just give the caller a fake time`), so time blocked acquiring the channel `_rw_mtx` shared lock — e.g. queued behind an `open`/`incremental_open` holding the exclusive lock — is invisible and folded into `execution_time_us`.
- The time spent in `count_down_latch.wait()` (waiting for the async delta-writer `write()`/`finish()` callbacks) is computed locally but never returned to the sender.

So the per-node `Olap table sink statistics` line (`(exec)(wait_lock)(num)`) can't tell whether the stall was lock wait, memtable-flush back-pressure, or waiting on the writer.

## What I'm doing:

Make the server-side `add_chunk` time breakdown observable per node:

- Measure the real `_rw_mtx` shared-lock acquisition time in `LakeTabletsChannel::add_chunk` and report it via `wait_lock_time_us` instead of a fake `0`.
- Add `wait_writer_time_us` to `PTabletWriterAddBatchResult` (new optional field `11`) and populate it from the `count_down_latch.wait()` span.
- Carry both through `AddBatchCounter` and print the full per-node breakdown — `(exec)(wait_lock)(wait_memtable_flush)(wait_writer)(num)` — in the `Olap table sink statistics` log line of `TabletSinkSender` and `TabletSinkColocateSender`.

This is observability-only: no change to the write path or data behavior. It lets a single-replica `add_chunk` stall be attributed to lock wait vs. flush back-pressure vs. writer wait directly from the load log.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
