### PR TITLE
[BugFix] Fix potential OOB caused by partitioned join

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -143,6 +143,14 @@ public:
 
     bool not_empty() const { return !is_empty(); }
 
+    size_t accumulate_memory_usage() const {
+        size_t total_memory_usage = 0;
+        for (const auto& chunk : _chunks) {
+            total_memory_usage += chunk->memory_usage();
+        }
+        return total_memory_usage;
+    }
+
 private:
     MemTracker* _tracker;
     std::deque<ChunkPtr> _chunks;
@@ -266,22 +274,31 @@ Status PartitionedHashJoinProberImpl::push_probe_chunk(RuntimeState* state, Chun
             continue;
         }
 
-        if (_partition_input_channels[i].is_empty()) {
-            _partition_input_channels[i].push(chunk->clone_empty());
+        auto& partition_input_channel = _partition_input_channels[i];
+
+        if (partition_input_channel.is_empty()) {
+            partition_input_channel.push(chunk->clone_empty());
         }
 
-        if (_partition_input_channels[i].back()->num_rows() + size <= state->chunk_size()) {
-            _partition_input_channels[i].back()->append_selective(*chunk, selection.data(), from, size);
+        if (partition_input_channel.back()->num_rows() + size <= state->chunk_size()) {
+            partition_input_channel.append_selective_to_back(*chunk, selection.data(), from, size);
         } else {
-            _partition_input_channels[i].push(chunk->clone_empty());
-            _partition_input_channels[i].back()->append_selective(*chunk, selection.data(), from, size);
+            partition_input_channel.push(chunk->clone_empty());
+            partition_input_channel.append_selective_to_back(*chunk, selection.data(), from, size);
         }
 
-        if (_partition_input_channels[i].is_full()) {
-            _partition_input_channels[i].set_processing(true);
-            RETURN_IF_ERROR(probers[i]->push_probe_chunk(state, _partition_input_channels[i].pull()));
+        if (partition_input_channel.is_full()) {
+            partition_input_channel.set_processing(true);
+            RETURN_IF_ERROR(probers[i]->push_probe_chunk(state, partition_input_channel.pull()));
         }
     }
+#ifndef NDEBUG
+    size_t memory_usage = 0;
+    for (auto& channel : _partition_input_channels) {
+        memory_usage += channel.accumulate_memory_usage();
+    }
+    DCHECK_EQ(memory_usage, _mem_tracker.consumption());
+#endif
 
     return Status::OK();
 }
@@ -346,6 +363,7 @@ void PartitionedHashJoinProberImpl::reset(RuntimeState* runtime_state) {
         prober->reset(runtime_state);
     }
     _partition_input_channels.clear();
+    _mem_tracker.release(_mem_tracker.consumption());
     _all_input_finished = false;
     _remain_partition_idx = 0;
 }


### PR DESCRIPTION
## Why I'm doing:

Memory accounting in partition join probe input channel is inaccurate, causing pull channel to trigger out-of-bounds (OOB). This PR fixes inaccurate memory accounting in append_selective.

reproduce:
```
Build with ASAN and run test_partition_join
F20260604 15:27:24.875101 140723804915264 hash_join_components.cpp:151] Check failed: total_memory_usage == _tracker->consumption() (42437 vs. 655456) 
```

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/73791

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
