### PR TITLE
[UT] Fix flaky BDBJEJournalTest caused by leaked BDB RepNode thread polluting JMockit expectations

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
@@ -28,6 +28,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.Util;
 import com.starrocks.journal.JournalException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.staros.StarMgrServer;
@@ -66,6 +67,18 @@ public class BDBJEJournalTest {
 
     @BeforeEach
     public void init() throws Exception {
+        // Tests in this class start real BDB replicated environments whose RepNode
+        // threads may fire BDBStateChangeListener asynchronously, even after close().
+        // That path (stateChange -> notifyNewFETypeTransfer -> Util.stdoutWithTime
+        // -> TimeUtils -> GlobalStateMgr.getCurrentState()) would hit the JMockit-mocked
+        // GlobalStateMgr of tests like testOpenFirstTime, and if it lands inside an
+        // Expectations recording phase it registers phantom expectations that later
+        // fail with "Missing invocations". Cut the path off here.
+        new MockUp<Util>() {
+            @Mock
+            public void stdoutWithTime(String msg) {
+            }
+        };
         BDBJEJournal.RETRY_TIME = 3;
         BDBJEJournal.SLEEP_INTERVAL_SEC = 0;
         // avoid checkpoint


### PR DESCRIPTION
## Why I'm doing:


  `BDBJEJournalTest.testOpenFirstTime` fails intermittently in CI with:

```
  Missing 1 invocation to:
  com.starrocks.qe.VariableMgr#getDefaultSessionVariable()
     on mock instance: com.starrocks.qe.VariableMgr@3beb3669
  Caused by: Missing invocations
      at com.starrocks.common.util.TimeUtils.getTimeZone(TimeUtils.java:160)
      at com.starrocks.common.util.TimeUtils.longToTimeString(TimeUtils.java:202)
      at com.starrocks.common.util.Util.stdoutWithTime(Util.java:435)
      at com.starrocks.ha.StateChangeExecutor.notifyNewFETypeTransfer(StateChangeExecutor.java:63)
      at com.starrocks.ha.BDBStateChangeListener.stateChange(BDBStateChangeListener.java:85)
      at com.sleepycat.je.rep.impl.node.NodeState.changeAndNotify(NodeState.java:79)
      at com.sleepycat.je.rep.impl.node.RepNode.run(RepNode.java:1859)
```

  Root cause:

  1. Other tests in this class (`testWrieNoMock`, `testAbort`, `testVerifyId`, ...) start
     **real** BDB-JE replicated environments via `initBDBEnv()`, which register a real
     `BDBStateChangeListener`. BDB-JE elections and state-change notifications run
     asynchronously on the `RepNode` thread and may still fire after `close()`, leaking
     into subsequent test methods.
  2. When the leaked thread wins an election it runs:
     `stateChange` → `notifyNewFETypeTransfer` → `Util.stdoutWithTime` →
     `TimeUtils.longToTimeString` → `TimeUtils.getTimeZone` →
     `GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultSessionVariable()`.
  3. `testOpenFirstTime` declares `@Mocked GlobalStateMgr`. JMockit mocking — and its
     record/replay phase switching — is JVM-global and not thread-aware. If the leaked
     thread executes the chain above while the main thread is inside one of the test's
     `new Expectations() {...}` blocks (recording phase), the background invocations are
     captured as **recorded expectations** on the cascaded `VariableMgr` mock, with the
     implicit `minTimes = 1`.
  4. Nothing ever satisfies these phantom expectations during replay, so the end-of-test
     verification fails with `Missing invocations`. That is also why the error's cause
     stack trace points at the `RepNode` thread: it is the recording site of the phantom
     expectation.

  ## What I'm doing:

  Install a `MockUp<Util>` in `@BeforeEach` that turns `Util.stdoutWithTime` into a no-op
  for every test in this class. This cuts off the only path by which the leaked BDB
  listener thread can reach the JMockit-mocked `GlobalStateMgr`, so a late state-change
  notification can no longer pollute the recording phase of mock-based tests.

  Test-only change; no production code is modified.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
