### PR TITLE
[Enhancement] Detect and reassign range-colocate tablets misplaced across PACK shard groups

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -77,7 +77,7 @@ subprojects {
         set("protobuf-java.version", "3.25.5")
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.7")
-        set("staros.version", "4.1-rc4")
+        set("staros.version", "4.2-rc2")
         set("thrift.version", "0.23.0")
         set("tomcat.version", "8.5.70")
         set("lz4-java.version", "1.10.1")

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.alter.reshard;
 
+import com.staros.client.StarClientException;
+import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.ColocateGroupSchema;
 import com.starrocks.catalog.ColocateRange;
 import com.starrocks.catalog.ColocateRangeUtils;
@@ -28,10 +30,12 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.planner.RangeColocateScanDispatch;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -82,6 +86,11 @@ import java.util.stream.Collectors;
  */
 public class ColocateChecker {
     private static final Logger LOG = LogManager.getLogger(ColocateChecker.class);
+
+    // Cap on tablets per getShardInfo RPC during PACK reconcile. A local safety bound on this
+    // (potentially large) sweep — getShardInfo is not globally chunked, and other callers pass
+    // smaller, bounded lists.
+    private static final int GET_SHARD_INFO_BATCH_SIZE = 1000;
 
     /**
      * Invoked from {@link TabletReshardJobMgr#runAfterCatalogReady} on every scheduler tick.
@@ -151,10 +160,145 @@ public class ColocateChecker {
         }
 
         if (allAligned) {
-            colocateTableIndex.markAllGroupsWithSameColocateGroupIdStable(colocateGroupId, true);
-            LOG.info("marked colocate group id {} stable across {} peer GroupIds",
-                    colocateGroupId, peers.size());
+            // Ranges are settled, so each tablet's expected PACK shard group is now well-defined.
+            // Migrate any tablet still in the wrong PACK shard group (e.g. a split child left in the
+            // old group) into place, and flip the group stable ONLY once placement is repaired. The
+            // checker never revisits a stable group, so marking stable while a reassignment is still
+            // pending (or a StarOS query/RPC failed) would leak a permanently mis-placed tablet. This
+            // gate is on membership repair being issued and confirmed; gating on actual StarOS
+            // worker-placement convergence can be layered on top later.
+            if (reconcilePackPlacement(colocateTableIndex, peers, expectedRanges, colocateColumnCount)) {
+                colocateTableIndex.markAllGroupsWithSameColocateGroupIdStable(colocateGroupId, true);
+                LOG.info("marked colocate group id {} stable across {} peer GroupIds",
+                        colocateGroupId, peers.size());
+            }
         }
+    }
+
+    /**
+     * For every NORMAL-state table across all peer GroupIds, finds tablets whose actual StarOS
+     * PACK shard-group membership disagrees with the PACK group expected from their range and
+     * issues a {@link StarOSAgent#reassignShardGroups} to migrate each into place.
+     *
+     * @return {@code true} iff placement is fully settled — every table's membership was read
+     *         completely and no tablet needed repair. A read/RPC failure, an incomplete membership
+     *         response, a transient table-lookup failure, or any misplaced tablet (reassignment
+     *         issued but only confirmed by a re-read next cycle) makes the group NOT settled, so the
+     *         caller leaves it unstable and retries on the next tick.
+     */
+    private boolean reconcilePackPlacement(ColocateTableIndex colocateTableIndex,
+                                           List<ColocateTableIndex.GroupId> peers,
+                                           List<ColocateRange> expectedRanges, int colocateColumnCount) {
+        boolean settled = true;
+        for (ColocateTableIndex.GroupId peerGroupId : peers) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(peerGroupId.dbId);
+            if (db == null) {
+                continue;
+            }
+            for (long tableId : colocateTableIndex.getAllTableIds(peerGroupId)) {
+                Table fetchedTable;
+                try {
+                    fetchedTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+                } catch (Exception e) {
+                    LOG.debug("table {} lookup failed in db {} during PACK reconcile, retrying next cycle",
+                            tableId, db.getId(), e);
+                    settled = false;
+                    continue;
+                }
+                if (!(fetchedTable instanceof OlapTable olapTable)) {
+                    continue;
+                }
+                if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+                    settled = false;
+                    continue;
+                }
+                settled &= reconcileTablePackPlacement(db, olapTable, expectedRanges, colocateColumnCount);
+            }
+        }
+        return settled;
+    }
+
+    /**
+     * Snapshots every visible tablet's range under a table READ lock, queries the tablets' actual
+     * shard-group membership from StarOS in bounded batches, and reassigns each {@link MisplacedTablet}
+     * into its expected PACK shard group.
+     *
+     * @return {@code true} iff the table is fully settled: the membership read covered every tablet
+     *         and nothing needed repair. A StarOS query failure, an incomplete response (a requested
+     *         tablet missing from the result — treated as an unread membership, never as "no groups",
+     *         so it cannot turn into a bogus add-only reassignment), or any misplaced tablet
+     *         (reassignment issued, confirmed by the next cycle's re-read) ⇒ {@code false}.
+     */
+    private boolean reconcileTablePackPlacement(Database db, OlapTable table,
+                                                List<ColocateRange> expectedRanges, int colocateColumnCount) {
+        Map<Long, Range<Tuple>> tabletIdToRange = new HashMap<>();
+        try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
+            for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+                for (MaterializedIndex index :
+                        physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                    for (Tablet tablet : index.getTablets()) {
+                        if (tablet.getRange() != null) {
+                            tabletIdToRange.put(tablet.getId(), tablet.getRange().getRange());
+                        }
+                    }
+                }
+            }
+        }
+        if (tabletIdToRange.isEmpty()) {
+            return true;
+        }
+
+        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+        List<Long> tabletIds = new ArrayList<>(tabletIdToRange.keySet());
+        Map<Long, List<Long>> tabletIdToGroupIds = new HashMap<>();
+        // Query membership in bounded batches so one very large table cannot produce an oversized RPC.
+        for (int batchStart = 0; batchStart < tabletIds.size(); batchStart += GET_SHARD_INFO_BATCH_SIZE) {
+            List<Long> batch = tabletIds.subList(batchStart,
+                    Math.min(batchStart + GET_SHARD_INFO_BATCH_SIZE, tabletIds.size()));
+            try {
+                for (ShardInfo shardInfo : starOSAgent.getShardInfo(batch, StarOSAgent.DEFAULT_WORKER_GROUP_ID)) {
+                    tabletIdToGroupIds.put(shardInfo.getShardId(), shardInfo.getGroupIdsList());
+                }
+            } catch (StarClientException e) {
+                LOG.warn("failed to query shard membership for PACK reconcile of table {}.{}: {}",
+                        db.getFullName(), table.getName(), e.getMessage());
+                return false;
+            }
+        }
+        // An incomplete response is an unread membership, not "tablet has no groups": treat it as a
+        // failed read and retry next cycle, so a missing StarOS entry cannot become a bogus repair.
+        if (!tabletIdToGroupIds.keySet().containsAll(tabletIdToRange.keySet())) {
+            LOG.warn("incomplete shard membership response during PACK reconcile of table {}.{}; retrying",
+                    db.getFullName(), table.getName());
+            return false;
+        }
+
+        List<MisplacedTablet> misplacedTablets =
+                findMisplacedTablets(tabletIdToRange, tabletIdToGroupIds, expectedRanges, colocateColumnCount);
+        for (MisplacedTablet misplaced : misplacedTablets) {
+            // Send the minimal delta: only add the expected group if the tablet is not already in it
+            // (the double-membership case after a partial prior repair needs a remove-only update),
+            // and only remove a stale group if one is present.
+            List<Long> addGroupIds = tabletIdToGroupIds.get(misplaced.tabletId()).contains(misplaced.expectedPackGroupId())
+                    ? Collections.emptyList()
+                    : List.of(misplaced.expectedPackGroupId());
+            List<Long> removeGroupIds = misplaced.currentPackGroupId() == PhysicalPartition.INVALID_SHARD_GROUP_ID
+                    ? Collections.emptyList()
+                    : List.of(misplaced.currentPackGroupId());
+            try {
+                starOSAgent.reassignShardGroups(misplaced.tabletId(), addGroupIds, removeGroupIds);
+                LOG.info("reassigned tablet {} from PACK shard group {} to {} in table {}.{}",
+                        misplaced.tabletId(), misplaced.currentPackGroupId(), misplaced.expectedPackGroupId(),
+                        db.getFullName(), table.getName());
+            } catch (DdlException e) {
+                LOG.warn("failed to reassign tablet {} to PACK shard group {} in table {}.{}: {}",
+                        misplaced.tabletId(), misplaced.expectedPackGroupId(),
+                        db.getFullName(), table.getName(), e.getMessage());
+            }
+        }
+        // Settled only when nothing needed repair; if reassignments were issued, stay unstable so
+        // the next cycle re-reads and confirms membership before the group is flipped stable.
+        return misplacedTablets.isEmpty();
     }
 
     /**
@@ -256,19 +400,17 @@ public class ColocateChecker {
         return false;
     }
 
-    // ---- Misplaced-PACK-group detection (F5 backstop, detection half) ----
+    // ---- Misplaced-PACK-group detection ----
     //
-    // Range alignment (the loop above) is sufficient for query correctness but not for
-    // host-local execution: the originating user-driven Level-1 split leaves one child in the
-    // OLD PACK shard group, so after post-publish reclassification a tablet can be range-aligned
-    // yet sit in the wrong PACK shard group. The methods below identify those tablets by comparing
-    // each tablet's actual StarOS shard-group membership against the PACK shard group expected from
-    // its range per ColocateRangeMgr. The resulting (remove currentPackGroupId, add
-    // expectedPackGroupId) delta is exactly what a StarOSAgent.reassignShardGroups call will consume
-    // to migrate the tablet — that call is gated on a staros release exposing the UpdateShardInfo
-    // group-membership delta (see colocate.md "F5"), so this detection is currently the reusable,
-    // side-effect-free half. The range->PACK-group mapping itself lives in
-    // ColocateRangeUtils.lookupPackShardGroupId, shared with SplitTabletJob's post-publish classifier.
+    // Range alignment (the loop above) is sufficient for query correctness but not for host-local
+    // execution: a user-driven Level-1 split leaves one child in the OLD PACK shard group, so after
+    // post-publish reclassification a tablet can be range-aligned yet sit in the wrong PACK shard
+    // group. The methods below identify those tablets by comparing each tablet's actual StarOS
+    // shard-group membership against the PACK shard group expected from its range per
+    // ColocateRangeMgr. The resulting (remove currentPackGroupId, add expectedPackGroupId) delta is
+    // what StarOSAgent.reassignShardGroups consumes to migrate the tablet. The range->PACK-group
+    // mapping itself lives in ColocateRangeUtils.lookupPackShardGroupId, shared with SplitTabletJob's
+    // post-publish classifier.
 
     /**
      * A tablet whose actual PACK shard-group membership disagrees with the PACK shard group expected

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard;
 
 import com.starrocks.catalog.ColocateGroupSchema;
 import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeUtils;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -26,6 +27,8 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -36,11 +39,14 @@ import com.starrocks.sql.common.MetaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Colocate checker — drives every unstable range-colocate group toward range alignment
@@ -248,5 +254,87 @@ public class ColocateChecker {
         LOG.info("submitted SplitTabletJob {} for table {}.{} covering {} partitions",
                 job.getJobId(), db.getFullName(), table.getName(), alignmentMap.size());
         return false;
+    }
+
+    // ---- Misplaced-PACK-group detection (F5 backstop, detection half) ----
+    //
+    // Range alignment (the loop above) is sufficient for query correctness but not for
+    // host-local execution: the originating user-driven Level-1 split leaves one child in the
+    // OLD PACK shard group, so after post-publish reclassification a tablet can be range-aligned
+    // yet sit in the wrong PACK shard group. The methods below identify those tablets by comparing
+    // each tablet's actual StarOS shard-group membership against the PACK shard group expected from
+    // its range per ColocateRangeMgr. The resulting (remove currentPackGroupId, add
+    // expectedPackGroupId) delta is exactly what a StarOSAgent.reassignShardGroups call will consume
+    // to migrate the tablet — that call is gated on a staros release exposing the UpdateShardInfo
+    // group-membership delta (see colocate.md "F5"), so this detection is currently the reusable,
+    // side-effect-free half. The range->PACK-group mapping itself lives in
+    // ColocateRangeUtils.lookupPackShardGroupId, shared with SplitTabletJob's post-publish classifier.
+
+    /**
+     * A tablet whose actual PACK shard-group membership disagrees with the PACK shard group expected
+     * from its range. {@code currentPackGroupId} is a stale colocate PACK shard group the tablet is
+     * still a member of (or {@link PhysicalPartition#INVALID_SHARD_GROUP_ID} if it is in none), and
+     * {@code expectedPackGroupId} is where it belongs — together the move delta a future
+     * {@code reassignShardGroups} consumes.
+     */
+    public record MisplacedTablet(long tabletId, long currentPackGroupId, long expectedPackGroupId) {
+    }
+
+    /**
+     * Classifies one tablet's PACK-shard-group placement against expectation. Returns {@code null}
+     * when the tablet is correctly placed — a member of {@code expectedPackGroupId} and of no other
+     * PACK shard group in {@code packGroupIds}. Otherwise returns the {@link MisplacedTablet} move:
+     * {@code currentPackGroupId} is a stale colocate PACK shard group still present (or
+     * {@link PhysicalPartition#INVALID_SHARD_GROUP_ID} if none), and {@code expectedPackGroupId} is the
+     * target. SPREAD and unrelated shard groups are ignored because they are not in {@code packGroupIds}.
+     */
+    static MisplacedTablet classifyTabletPlacement(long tabletId, List<Long> actualGroupIds,
+                                                   long expectedPackGroupId, Set<Long> packGroupIds) {
+        boolean alreadyInExpectedGroup = actualGroupIds.contains(expectedPackGroupId);
+        long stalePackGroupId = PhysicalPartition.INVALID_SHARD_GROUP_ID;
+        for (long groupId : actualGroupIds) {
+            if (groupId != expectedPackGroupId && packGroupIds.contains(groupId)) {
+                stalePackGroupId = groupId;
+                break;
+            }
+        }
+        if (alreadyInExpectedGroup && stalePackGroupId == PhysicalPartition.INVALID_SHARD_GROUP_ID) {
+            return null;
+        }
+        return new MisplacedTablet(tabletId, stalePackGroupId, expectedPackGroupId);
+    }
+
+    /**
+     * Pure detection over a set of tablets: for each tablet whose colocate prefix maps to a known
+     * {@link ColocateRange} (via {@link ColocateRangeUtils#lookupPackShardGroupId}), compares its
+     * actual shard-group membership ({@code tabletIdToGroupIds}, as returned by
+     * {@code StarOSAgent.getShardInfo(...).getGroupIdsList()} — the StarOS shard id equals the tablet
+     * id in shared-data mode) against the expected PACK shard group and collects every
+     * {@link MisplacedTablet}. Tablets whose range is not covered by {@code expectedRanges} are
+     * skipped (defensive; cannot happen under the full-coverage invariant).
+     */
+    static List<MisplacedTablet> findMisplacedTablets(Map<Long, Range<Tuple>> tabletIdToRange,
+                                                      Map<Long, List<Long>> tabletIdToGroupIds,
+                                                      List<ColocateRange> expectedRanges,
+                                                      int colocateColumnCount) {
+        Set<Long> packGroupIds = expectedRanges.stream()
+                .map(ColocateRange::getShardGroupId)
+                .collect(Collectors.toSet());
+        List<MisplacedTablet> misplaced = new ArrayList<>();
+        for (Map.Entry<Long, Range<Tuple>> entry : tabletIdToRange.entrySet()) {
+            long tabletId = entry.getKey();
+            long expectedGroupId = ColocateRangeUtils.lookupPackShardGroupId(
+                    entry.getValue(), expectedRanges, colocateColumnCount);
+            if (expectedGroupId == PhysicalPartition.INVALID_SHARD_GROUP_ID) {
+                continue;
+            }
+            List<Long> actualGroupIds = tabletIdToGroupIds.getOrDefault(tabletId, Collections.emptyList());
+            MisplacedTablet misplacedTablet =
+                    classifyTabletPlacement(tabletId, actualGroupIds, expectedGroupId, packGroupIds);
+            if (misplacedTablet != null) {
+                misplaced.add(misplacedTablet);
+            }
+        }
+        return misplaced;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -948,10 +948,10 @@ public class SplitTabletJob extends TabletReshardJob {
 
     private static long lookupPackGroupId(List<ColocateRange> colocateRanges, int colocateColumnCount,
                                           Range<Tuple> range, long newTabletId) {
-        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(range, colocateColumnCount);
-        int colocateRangeIndex = ColocateRangeMgr.indexOf(colocateRanges, prefix);
-        Preconditions.checkState(colocateRangeIndex >= 0,
-                "Tablet %s has no covering ColocateRange for prefix %s", newTabletId, prefix);
-        return colocateRanges.get(colocateRangeIndex).getShardGroupId();
+        long packShardGroupId = ColocateRangeUtils.lookupPackShardGroupId(
+                range, colocateRanges, colocateColumnCount);
+        Preconditions.checkState(packShardGroupId != PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                "Tablet %s has no covering ColocateRange", newTabletId);
+        return packShardGroupId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
@@ -184,4 +184,24 @@ public class ColocateRangeUtils {
                 ranges.get(idx).getRange(), sortKeyColumns, colocateColumnCount);
         return expanded.contains(tabletRange);
     }
+
+    /**
+     * Returns the PACK shard-group id that owns {@code tabletRange}, by mapping the tablet's
+     * colocate prefix to the {@link ColocateRange} that contains it. Returns
+     * {@link PhysicalPartition#INVALID_SHARD_GROUP_ID} when no range covers the prefix.
+     *
+     * <p>Shared by the post-publish split classifier ({@code SplitTabletJob}) and the placement
+     * backstop ({@code ColocateChecker}): both must agree on which PACK group a tablet range maps
+     * to. Callers apply their own out-of-range policy — the classifier treats it as an invariant
+     * violation, the backstop skips the tablet.
+     */
+    public static long lookupPackShardGroupId(Range<Tuple> tabletRange, List<ColocateRange> ranges,
+                                              int colocateColumnCount) {
+        Tuple colocatePrefix = extractColocatePrefix(tabletRange, colocateColumnCount);
+        int rangeIndex = ColocateRangeMgr.indexOf(ranges, colocatePrefix);
+        if (rangeIndex < 0) {
+            return PhysicalPartition.INVALID_SHARD_GROUP_ID;
+        }
+        return ranges.get(rangeIndex).getShardGroupId();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -42,6 +42,7 @@ import com.staros.proto.ShardInfo;
 import com.staros.proto.StatusCode;
 import com.staros.proto.UpdateMetaGroupInfo;
 import com.staros.proto.UpdateShardGroupInfo;
+import com.staros.proto.UpdateShardInfo;
 import com.staros.proto.WarmupLevel;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerGroupSpec;
@@ -543,6 +544,35 @@ public class StarOSAgent {
             client.deleteShardGroup(serviceId, groupIds, true);
         } catch (StarClientException e) {
             LOG.warn("Failed to delete shard group. error: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Moves a shard between shard groups by applying an add/remove group-id delta through the
+     * StarOS UpdateShard RPC, leaving the shard's other group memberships (e.g. its SPREAD group)
+     * untouched. Used to migrate a range-colocate tablet into its expected PACK shard group after
+     * a split's post-publish range reclassification. A no-op (no RPC) when both deltas are empty.
+     */
+    public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds)
+            throws DdlException {
+        boolean noAdd = addGroupIds == null || addGroupIds.isEmpty();
+        boolean noRemove = removeGroupIds == null || removeGroupIds.isEmpty();
+        if (noAdd && noRemove) {
+            return;
+        }
+        prepare();
+        UpdateShardInfo.Builder builder = UpdateShardInfo.newBuilder().setShardId(shardId);
+        if (!noAdd) {
+            builder.addAllAddGroupIds(addGroupIds);
+        }
+        if (!noRemove) {
+            builder.addAllRemoveGroupIds(removeGroupIds);
+        }
+        try {
+            client.updateShard(serviceId, List.of(builder.build()));
+        } catch (StarClientException e) {
+            throw new DdlException("Failed to reassign shard " + shardId + " groups (add=" + addGroupIds
+                    + ", remove=" + removeGroupIds + "). error: " + e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -14,30 +14,46 @@
 
 package com.starrocks.alter.reshard;
 
+import com.staros.client.StarClientException;
 import com.staros.proto.PlacementPolicy;
+import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.ColocateRange;
 import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateRangeUtils;
 import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -112,6 +128,281 @@ public class ColocateCheckerTest {
 
         Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId),
                 "aligned + unstable group must be marked stable after one cycle");
+    }
+
+    private long firstVisibleTabletId() {
+        for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+            for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                for (Tablet tablet : index.getTablets()) {
+                    return tablet.getId();
+                }
+            }
+        }
+        return -1;
+    }
+
+    private long firstVisibleIndexSpreadGroup() {
+        for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+            for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                return index.getShardGroupId();
+            }
+        }
+        return -1;
+    }
+
+    @Test
+    public void testReconcileAddsMissingPackGroupAndStaysUnstable() throws Exception {
+        // The fresh single-range group is range-aligned. Stub getShardInfo so the lone tablet is
+        // missing its expected PACK group: the checker must issue an add-only reassign AND keep the
+        // group unstable (placement not yet confirmed) so a later cycle re-reads before stabilizing.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long expectedPackGroup = colocateTableIndex.getColocateRangeMgr()
+                .getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        long tabletId = firstVisibleTabletId();
+        final long stubSpreadGroup = firstVisibleIndexSpreadGroup();
+
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        Map<Long, List<Long>> reassignedRemove = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> result = new ArrayList<>();
+                for (long id : shardIds) {
+                    // group_ids deliberately omits the expected PACK group -> tablet looks misplaced.
+                    result.add(ShardInfo.newBuilder().setShardId(id).addGroupIds(stubSpreadGroup).build());
+                }
+                return result;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+                reassignedRemove.put(shardId, new ArrayList<>(removeGroupIds));
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertEquals(List.of(expectedPackGroup), reassignedAdd.get(tabletId),
+                "missing-PACK tablet must be reassigned to add its expected PACK group");
+        Assertions.assertEquals(List.of(), reassignedRemove.get(tabletId),
+                "no stale PACK group to remove in the add-only case");
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "group must stay unstable until a re-read confirms the repaired placement");
+    }
+
+    @Test
+    public void testReconcileBecomesStableAfterRepair() throws Exception {
+        // Simulate the real flow: the reassign applies the membership synchronously on StarMgr, so
+        // the next cycle's getShardInfo reflects it. The group must flip stable on that second cycle.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long expectedPackGroup = colocateTableIndex.getColocateRangeMgr()
+                .getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        final long stubSpreadGroup = firstVisibleIndexSpreadGroup();
+        boolean[] repaired = {false};
+        int[] reassignCount = {0};
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> result = new ArrayList<>();
+                for (long id : shardIds) {
+                    ShardInfo.Builder b = ShardInfo.newBuilder().setShardId(id).addGroupIds(stubSpreadGroup);
+                    if (repaired[0]) {
+                        b.addGroupIds(expectedPackGroup);
+                    }
+                    result.add(b.build());
+                }
+                return result;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignCount[0]++;
+                repaired[0] = true;
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        // The first cycle issues the reassign (which flips the stub to "repaired"); a later cycle
+        // re-reads the now-correct membership and flips the group stable. Run two cycles to drive
+        // convergence and assert the end state — the shared background scheduler may also tick, so
+        // the transient unstable state and exact reassign count are not asserted here (the
+        // stays-unstable-until-repaired behavior is covered by
+        // testReconcileAddsMissingPackGroupAndStaysUnstable).
+        new ColocateChecker().runOneCycle();
+        new ColocateChecker().runOneCycle();
+        Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId),
+                "group must become stable once the re-read shows the repaired placement");
+        Assertions.assertTrue(reassignCount[0] >= 1, "a reassign must have been issued to repair placement");
+    }
+
+    @Test
+    public void testReconcileStaysUnstableOnGetShardInfoFailure() throws Exception {
+        // A membership-read failure must NOT mark the group stable (else a mis-placement could leak);
+        // it stays unstable and is retried on the next tick.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) throws StarClientException {
+                throw new StarClientException(com.staros.proto.StatusCode.INVALID_ARGUMENT, "mocked read failure");
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "a getShardInfo failure must leave the group unstable for retry");
+    }
+
+    @Test
+    public void testReconcileStaysUnstableOnReassignFailure() throws Exception {
+        // A reassign RPC failure must keep the group unstable so the repair is retried.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        final long stubSpreadGroup = firstVisibleIndexSpreadGroup();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> result = new ArrayList<>();
+                for (long id : shardIds) {
+                    result.add(ShardInfo.newBuilder().setShardId(id).addGroupIds(stubSpreadGroup).build());
+                }
+                return result;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds)
+                    throws DdlException {
+                throw new DdlException("mocked reassign failure");
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "a reassign failure must leave the group unstable for retry");
+    }
+
+    @Test
+    public void testReconcileRemovesStalePackGroup() throws Exception {
+        // Build a 2-range aligned layout ([MIN,100)->P0, [100,MAX)->P1) with one tablet per range,
+        // then stub the first tablet as sitting in P1 (a sibling PACK group) instead of its expected
+        // P0. The reassign must both add P0 and remove the stale P1.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = colocateTableIndex.getColocateRangeMgr();
+        long packForLow = rangeMgr.getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        long packForHigh = GlobalStateMgr.getCurrentState().getStarOSAgent()
+                .createShardGroup(db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK);
+        Tuple boundary = intPrefix(100);
+        rangeMgr.setColocateRanges(groupId.grpId, Arrays.asList(
+                new ColocateRange(Range.lt(boundary), packForLow),
+                new ColocateRange(Range.ge(boundary), packForHigh)));
+
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
+        MaterializedIndex index = table.getPhysicalPartitions().iterator().next()
+                .getLatestMaterializedIndices(IndexExtState.VISIBLE).iterator().next();
+        Tablet lowTablet = index.getTablets().iterator().next();
+        lowTablet.setRange(new TabletRange(
+                ColocateRangeUtils.expandToFullSortKey(Range.lt(boundary), sortKeyColumns, 1)));
+        long highTabletId = 900000001L;
+        LakeTablet highTablet = new LakeTablet(highTabletId, new TabletRange(
+                ColocateRangeUtils.expandToFullSortKey(Range.ge(boundary), sortKeyColumns, 1)));
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        index.addTablet(highTablet, new TabletMeta(db.getId(), table.getId(), physicalPartitionId,
+                index.getId(), TStorageMedium.HDD, true));
+        long lowTabletId = lowTablet.getId();
+
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        Map<Long, List<Long>> reassignedRemove = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> result = new ArrayList<>();
+                for (long id : shardIds) {
+                    // Both tablets report membership in P1; only the low tablet (expected P0) is stale.
+                    result.add(ShardInfo.newBuilder().setShardId(id).addGroupIds(packForHigh).build());
+                }
+                return result;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+                reassignedRemove.put(shardId, new ArrayList<>(removeGroupIds));
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertEquals(List.of(packForLow), reassignedAdd.get(lowTabletId),
+                "stale tablet must be added to its expected PACK group P0");
+        Assertions.assertEquals(List.of(packForHigh), reassignedRemove.get(lowTabletId),
+                "stale tablet must be removed from the sibling PACK group P1");
+    }
+
+    @Test
+    public void testReconcileSendsRemoveOnlyWhenAlreadyInExpectedGroup() throws Exception {
+        // Double-membership (e.g. after a partial prior repair): the low tablet is already in its
+        // expected PACK group P0 but also still in the sibling P1. The reassign must be remove-only
+        // (empty add) so it does not redundantly re-add P0.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = colocateTableIndex.getColocateRangeMgr();
+        long packForLow = rangeMgr.getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        long packForHigh = GlobalStateMgr.getCurrentState().getStarOSAgent()
+                .createShardGroup(db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK);
+        Tuple boundary = intPrefix(100);
+        rangeMgr.setColocateRanges(groupId.grpId, Arrays.asList(
+                new ColocateRange(Range.lt(boundary), packForLow),
+                new ColocateRange(Range.ge(boundary), packForHigh)));
+
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
+        MaterializedIndex index = table.getPhysicalPartitions().iterator().next()
+                .getLatestMaterializedIndices(IndexExtState.VISIBLE).iterator().next();
+        Tablet lowTablet = index.getTablets().iterator().next();
+        lowTablet.setRange(new TabletRange(
+                ColocateRangeUtils.expandToFullSortKey(Range.lt(boundary), sortKeyColumns, 1)));
+        long highTabletId = 900000002L;
+        LakeTablet highTablet = new LakeTablet(highTabletId, new TabletRange(
+                ColocateRangeUtils.expandToFullSortKey(Range.ge(boundary), sortKeyColumns, 1)));
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        index.addTablet(highTablet, new TabletMeta(db.getId(), table.getId(), physicalPartitionId,
+                index.getId(), TStorageMedium.HDD, true));
+        long lowTabletId = lowTablet.getId();
+
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        Map<Long, List<Long>> reassignedRemove = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> result = new ArrayList<>();
+                for (long id : shardIds) {
+                    ShardInfo.Builder builder = ShardInfo.newBuilder().setShardId(id).addGroupIds(packForHigh);
+                    if (id == lowTabletId) {
+                        // already in its expected P0 AND still in the stale sibling P1
+                        builder.addGroupIds(packForLow);
+                    }
+                    result.add(builder.build());
+                }
+                return result;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+                reassignedRemove.put(shardId, new ArrayList<>(removeGroupIds));
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertEquals(List.of(), reassignedAdd.get(lowTabletId),
+                "must not re-add the already-present expected PACK group");
+        Assertions.assertEquals(List.of(packForHigh), reassignedRemove.get(lowTabletId),
+                "must remove the stale sibling PACK group");
     }
 
     @Test
@@ -196,11 +487,11 @@ public class ColocateCheckerTest {
         colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
     }
 
-    // ---- F5 detection half: misplaced-PACK-group detection (pure, no cluster) ----
+    // ---- Misplaced-PACK-group detection (pure, no cluster) ----
     //
-    // These exercise the read-only detection logic that the (currently staros-release-blocked)
-    // reassignShardGroups call will consume. They build ColocateRange lists and per-tablet
-    // group-id lists directly, so they do not depend on the cluster spun up in beforeClass.
+    // These exercise the read-only detection logic that reassignShardGroups consumes. They build
+    // ColocateRange lists and per-tablet group-id lists directly, so they do not depend on the
+    // cluster spun up in beforeClass.
 
     private static final long SPREAD = 900L;
     private static final long PACK_G1 = 1001L;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.ColocateRangeMgr;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
@@ -38,6 +39,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -189,6 +194,79 @@ public class ColocateCheckerTest {
                 new ColocateRange(Range.lt(boundaryPrefix), firstShardGroupId),
                 new ColocateRange(Range.ge(boundaryPrefix), secondShardGroupId)));
         colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+    }
+
+    // ---- F5 detection half: misplaced-PACK-group detection (pure, no cluster) ----
+    //
+    // These exercise the read-only detection logic that the (currently staros-release-blocked)
+    // reassignShardGroups call will consume. They build ColocateRange lists and per-tablet
+    // group-id lists directly, so they do not depend on the cluster spun up in beforeClass.
+
+    private static final long SPREAD = 900L;
+    private static final long PACK_G1 = 1001L;
+    private static final long PACK_G2 = 1002L;
+
+    private static Tuple intPrefix(int v) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(v))));
+    }
+
+    /** Two colocate ranges split at prefix 100: [MIN, 100) -> G1, [100, MAX) -> G2. */
+    private static List<ColocateRange> twoRangesAt100() {
+        Tuple boundary = intPrefix(100);
+        return Arrays.asList(
+                new ColocateRange(Range.lt(boundary), PACK_G1),
+                new ColocateRange(Range.ge(boundary), PACK_G2));
+    }
+
+    @Test
+    public void testClassifyCorrectPlacementReturnsNull() {
+        Set<Long> packGroupIds = Set.of(PACK_G1, PACK_G2);
+        // Tablet sits in its SPREAD group and the expected PACK group G2, nothing stale.
+        Assertions.assertNull(ColocateChecker.classifyTabletPlacement(
+                77L, List.of(SPREAD, PACK_G2), PACK_G2, packGroupIds));
+    }
+
+    @Test
+    public void testClassifyStalePackGroupIsMisplaced() {
+        Set<Long> packGroupIds = Set.of(PACK_G1, PACK_G2);
+        // Originating-partition case: tablet stayed in old PACK group G1 but belongs in G2.
+        Assertions.assertEquals(new ColocateChecker.MisplacedTablet(77L, PACK_G1, PACK_G2),
+                ColocateChecker.classifyTabletPlacement(77L, List.of(SPREAD, PACK_G1), PACK_G2, packGroupIds));
+    }
+
+    @Test
+    public void testClassifyMissingPackGroupHasNoCurrent() {
+        Set<Long> packGroupIds = Set.of(PACK_G1, PACK_G2);
+        // Tablet is in no PACK group at all -> needs an add, no remove.
+        Assertions.assertEquals(
+                new ColocateChecker.MisplacedTablet(77L, PhysicalPartition.INVALID_SHARD_GROUP_ID, PACK_G2),
+                ColocateChecker.classifyTabletPlacement(77L, List.of(SPREAD), PACK_G2, packGroupIds));
+    }
+
+    @Test
+    public void testClassifyDoubleMembershipIsMisplaced() {
+        Set<Long> packGroupIds = Set.of(PACK_G1, PACK_G2);
+        // Transient double membership: in expected G2 but also still in stale G1 -> must shed G1.
+        Assertions.assertEquals(new ColocateChecker.MisplacedTablet(77L, PACK_G1, PACK_G2),
+                ColocateChecker.classifyTabletPlacement(
+                        77L, List.of(SPREAD, PACK_G1, PACK_G2), PACK_G2, packGroupIds));
+    }
+
+    @Test
+    public void testFindMisplacedTabletsComposesRangeAndMembership() {
+        List<ColocateRange> ranges = twoRangesAt100();
+        Map<Long, Range<Tuple>> tabletIdToRange = new HashMap<>();
+        tabletIdToRange.put(10L, Range.ge(intPrefix(50)));    // expected G1
+        tabletIdToRange.put(20L, Range.ge(intPrefix(150)));   // expected G2
+        Map<Long, List<Long>> tabletIdToGroupIds = new HashMap<>();
+        tabletIdToGroupIds.put(10L, List.of(SPREAD, PACK_G1)); // correctly placed
+        tabletIdToGroupIds.put(20L, List.of(SPREAD, PACK_G1)); // stuck in G1, belongs in G2
+
+        List<ColocateChecker.MisplacedTablet> result = ColocateChecker.findMisplacedTablets(
+                tabletIdToRange, tabletIdToGroupIds, ranges, 1);
+
+        Assertions.assertEquals(
+                List.of(new ColocateChecker.MisplacedTablet(20L, PACK_G1, PACK_G2)), result);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeUtilsTest.java
@@ -216,4 +216,30 @@ public class ColocateRangeUtilsTest {
                 () -> ColocateRangeUtils.extractColocatePrefix(tabletRange, 2));
     }
 
+    @Test
+    public void testLookupPackShardGroupIdMapsPrefixToOwningRange() {
+        // Two colocate ranges split at prefix 100: [MIN, 100) -> 1001, [100, MAX) -> 1002.
+        Tuple boundary = makeTuple(100);
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(boundary), 1001L),
+                new ColocateRange(Range.ge(boundary), 1002L));
+        // prefix 50 lands in the first range, prefix 150 in the second.
+        Assertions.assertEquals(1001L,
+                ColocateRangeUtils.lookupPackShardGroupId(Range.ge(makeTuple(50)), ranges, 1));
+        Assertions.assertEquals(1002L,
+                ColocateRangeUtils.lookupPackShardGroupId(Range.ge(makeTuple(150)), ranges, 1));
+        // A boundary-aligned tablet at exactly 100 belongs to the second range ([100, MAX)).
+        Assertions.assertEquals(1002L,
+                ColocateRangeUtils.lookupPackShardGroupId(Range.ge(boundary), ranges, 1));
+        // An unbounded-below tablet (-inf) maps to the first range.
+        Assertions.assertEquals(1001L,
+                ColocateRangeUtils.lookupPackShardGroupId(Range.all(), ranges, 1));
+    }
+
+    @Test
+    public void testLookupPackShardGroupIdReturnsSentinelWhenUncovered() {
+        Assertions.assertEquals(PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                ColocateRangeUtils.lookupPackShardGroupId(Range.all(), List.of(), 1));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -35,6 +35,7 @@ import com.staros.proto.ShardInfo;
 import com.staros.proto.StarStatus;
 import com.staros.proto.StatusCode;
 import com.staros.proto.UpdateShardGroupInfo;
+import com.staros.proto.UpdateShardInfo;
 import com.staros.proto.WarmupLevel;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerGroupSpec;
@@ -453,6 +454,50 @@ public class StarOSAgentTest {
         Deencapsulation.setField(starosAgent, "serviceId", "1");
         // test delete shard group
         ExceptionChecker.expectThrowsNoException(() -> starosAgent.deleteShardGroup(Lists.newArrayList(1L, 2L)));
+    }
+
+    @Test
+    public void testReassignShardGroups() throws StarClientException {
+        UpdateShardInfo expected = UpdateShardInfo.newBuilder()
+                .setShardId(100L)
+                .addAllAddGroupIds(Lists.newArrayList(2L))
+                .addAllRemoveGroupIds(Lists.newArrayList(1L))
+                .build();
+        new Expectations(client) {
+            {
+                client.updateShard("1", Lists.newArrayList(expected));
+                result = null;
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        ExceptionChecker.expectThrowsNoException(() ->
+                starosAgent.reassignShardGroups(100L, Lists.newArrayList(2L), Lists.newArrayList(1L)));
+    }
+
+    @Test
+    public void testReassignShardGroupsNoOpWhenDeltaEmpty() throws StarClientException {
+        new Expectations(client) {
+            {
+                client.updateShard(anyString, (List<UpdateShardInfo>) any);
+                times = 0;
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        ExceptionChecker.expectThrowsNoException(() ->
+                starosAgent.reassignShardGroups(100L, Lists.newArrayList(), Lists.newArrayList()));
+    }
+
+    @Test
+    public void testReassignShardGroupsWrapsClientException() throws StarClientException {
+        new Expectations(client) {
+            {
+                client.updateShard(anyString, (List<UpdateShardInfo>) any);
+                result = new StarClientException(StatusCode.INVALID_ARGUMENT, "mocked failure");
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        Assertions.assertThrows(DdlException.class, () ->
+                starosAgent.reassignShardGroups(100L, Lists.newArrayList(2L), Lists.newArrayList(1L)));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Range-distribution colocate tablets in shared-data mode each belong to a SPREAD shard group (per partition) and one PACK shard group (per colocate range). The originating user-driven Level-1 split leaves one child in the **old** PACK shard group, so after post-publish range reclassification a tablet can be range-aligned yet still sit in the wrong PACK shard group — query correctness is preserved, but compute-side host co-residency for the colocate join is lost on that bucket.

The StarOS shard-group reassignment RPC needed to fix this shipped in `4.2-rc2`. This PR detects the misplaced tablets and migrates them into their expected PACK shard group.

## What I'm doing:

- **Backstop**: once a colocate group is range-aligned, `ColocateChecker` queries each NORMAL-state table's tablets' actual membership and reassigns any misplaced tablet into its expected PACK shard group. The stable flip is **gated on placement repair**: the group is marked stable only after a membership re-read confirms nothing needs repair; a StarOS query/RPC failure, an incomplete response, or a just-issued reassignment keeps it unstable and retried next tick (the checker never revisits a stable group, so marking it stable while mis-placed would leak permanently). `getShardInfo` is chunked, and an incomplete response is treated as an unread membership (never "no groups") to avoid bogus add-only reassignments.
- **Build fix**: bump `staros.version` `4.1-rc4` → `4.2-rc2` in `fe/build.gradle.kts`. The upstream bump (#74873) updated only `fe/pom.xml`, leaving the Gradle build (and Gradle-based CI) on the pre-delta client.

Deferred follow-ups: immediate reassignment inside `SplitTabletJob.applyColocateRangeSplitResult` (latency optimization — the backstop already converges within one checker cycle); gating group stability on actual StarOS placement convergence via `queryShardGroupStable` (F7).

Unit/integration tests in `ColocateCheckerTest`, `ColocateRangeUtilsTest`, `StarOSAgentTest`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)