### PR TITLE
[Refactor] Remove unused LocalLookUpRequestContext

### DIFF
--- a/be/src/exec/pipeline/fetch_processor.h
+++ b/be/src/exec/pipeline/fetch_processor.h
@@ -62,7 +62,6 @@ namespace starrocks::pipeline {
 //    drains the rebuilt chunks from the queue.
 class FetchProcessor : public std::enable_shared_from_this<FetchProcessor> {
 public:
-    friend class LocalLookUpRequestContext;
     friend class RemoteLookUpRequestContext;
     friend class FetchTask;
 

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -45,40 +45,6 @@ namespace starrocks::pipeline {
 
 DEFINE_FAIL_POINT(lookup_request_failed);
 
-// Copy the prepared request columns into the execution chunk so the local
-// lookup operator can execute without additional marshaling.
-Status LocalLookUpRequestContext::collect_input_columns(ChunkPtr chunk) {
-    // put all related columns into chunk, include source_id column and other related columns
-    size_t num_rows = fetch_ctx->request_chunk->num_rows();
-    for (const auto& [slot_id, idx] : fetch_ctx->request_chunk->get_slot_id_to_index_map()) {
-        auto src_col = fetch_ctx->request_chunk->get_column_by_index(idx);
-        auto dst_col = chunk->get_column_by_slot_id(slot_id)->as_mutable_raw_ptr();
-        dst_col->append(*src_col, 0, num_rows);
-    }
-    chunk->check_or_die();
-    return Status::OK();
-}
-StatusOr<size_t> LocalLookUpRequestContext::fill_response(const ChunkPtr& result_chunk,
-                                                          const std::vector<SlotDescriptor*>& slots,
-                                                          size_t start_offset) {
-    size_t num_rows = fetch_ctx->request_chunk->num_rows();
-    for (const auto& slot : slots) {
-        auto src_col = result_chunk->get_column_by_slot_id(slot->id());
-        auto dst_col = src_col->clone_empty();
-        dst_col->append(*src_col, start_offset, num_rows);
-        DCHECK(!fetch_ctx->response_columns.contains(slot->id()))
-                << "slot id: " << slot->id() << " already exists in response columns";
-        fetch_ctx->response_columns[slot->id()] = std::move(dst_col);
-    }
-    return num_rows;
-}
-
-void LocalLookUpRequestContext::callback(const Status& status) {
-    if (auto unit = fetch_ctx->unit.lock(); unit != nullptr) {
-        unit->finished_request_num++;
-    }
-}
-
 // Deserialize remote request payload into a reusable chunk for processing.
 Status RemoteLookUpRequestContext::collect_input_columns(ChunkPtr chunk) {
     request_chunk = std::make_shared<Chunk>();

--- a/be/src/exec/pipeline/lookup_request.h
+++ b/be/src/exec/pipeline/lookup_request.h
@@ -45,21 +45,6 @@ public:
 };
 using LookUpRequestContextPtr = std::shared_ptr<LookUpRequestContext>;
 
-class LocalLookUpRequestContext final : public LookUpRequestContext {
-public:
-    LocalLookUpRequestContext(FetchTaskContextPtr ctx) : fetch_ctx(std::move(ctx)) {}
-    ~LocalLookUpRequestContext() override = default;
-
-    TupleId request_tuple_id() const override { return fetch_ctx->request_tuple_id; }
-    Status collect_input_columns(ChunkPtr chunk) override;
-    StatusOr<size_t> fill_response(const ChunkPtr& result_chunk, const std::vector<SlotDescriptor*>& slots,
-                                   size_t start_offset) override;
-    void callback(const Status& status) override;
-
-    FetchTaskContextPtr fetch_ctx;
-};
-using LocalLookUpRequestContextPtr = std::shared_ptr<LocalLookUpRequestContext>;
-
 class RemoteLookUpRequestContext final : public LookUpRequestContext {
 public:
     RemoteLookUpRequestContext(::google::protobuf::RpcController* cntl, const PLookUpRequest* request,

--- a/be/test/exec/pipeline/fetch_task_test.cpp
+++ b/be/test/exec/pipeline/fetch_task_test.cpp
@@ -29,7 +29,6 @@
 #define private public
 #include "exec/pipeline/fetch_processor.h"
 #undef private
-#include "exec/pipeline/lookup_request.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gtest/gtest.h"
@@ -166,42 +165,6 @@ TEST(FetchTaskTest, shared_from_this_keeps_task_alive_after_batch_drops) {
     // After closure finishes and releases, FetchTask is destroyed.
     closure_hold.reset();
     EXPECT_TRUE(weak_task.expired());
-}
-
-// LocalLookUpRequestContext::callback should safely increment finished_request_num
-// when the BatchUnit is still alive.
-TEST(FetchTaskTest, local_callback_increments_counter_when_unit_alive) {
-    auto unit = std::make_shared<BatchUnit>();
-    unit->total_request_num = 2;
-    unit->finished_request_num = 0;
-
-    auto ctx = std::make_shared<FetchTaskContext>();
-    ctx->unit = unit;
-
-    LocalLookUpRequestContext local_ctx(ctx);
-    local_ctx.callback(Status::OK());
-
-    EXPECT_EQ(unit->finished_request_num.load(), 1);
-
-    local_ctx.callback(Status::OK());
-    EXPECT_EQ(unit->finished_request_num.load(), 2);
-}
-
-// LocalLookUpRequestContext::callback should not crash when the BatchUnit
-// has already been released (weak_ptr expired).
-TEST(FetchTaskTest, local_callback_safe_when_unit_expired) {
-    auto ctx = std::make_shared<FetchTaskContext>();
-
-    {
-        auto unit = std::make_shared<BatchUnit>();
-        unit->total_request_num = 1;
-        ctx->unit = unit;
-        // unit goes out of scope here, weak_ptr expires.
-    }
-
-    LocalLookUpRequestContext local_ctx(ctx);
-    // Should not crash or modify anything.
-    EXPECT_NO_FATAL_FAILURE(local_ctx.callback(Status::OK()));
 }
 
 TEST(FetchTaskTest, submit_remote_rpc_failure_marks_done_and_updates_status) {


### PR DESCRIPTION
## Why I'm doing:
LocalLookUpRequestContext was never instantiated in production code; only RemoteLookUpRequestContext is used by the lookup RPC path. Delete the dead class, its method definitions, the friend declaration in FetchProcessor, and the unit tests that exercised it directly.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
