### PR TITLE
[Enhancement] support meta scan for schema change (backport #72901)

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -237,6 +237,21 @@ StatusOr<std::unique_ptr<ColumnIterator>> SegmentMetaCollecter::_new_dcg_column_
     return nullptr;
 }
 
+StatusOr<const TabletColumn*> SegmentMetaCollecter::_get_tablet_column(ColumnId cid) const {
+    const auto& schema = _params->tablet_schema;
+    RETURN_IF(cid >= schema->num_columns(), Status::InvalidArgument("Invalid cid: " + std::to_string(cid)));
+    return &schema->column(cid);
+}
+
+StatusOr<ColumnReader*> SegmentMetaCollecter::_get_column_reader(ColumnId cid) const {
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    return const_cast<ColumnReader*>(_segment->column_with_uid(tablet_column->unique_id()));
+}
+
+bool SegmentMetaCollecter::_is_missing_default_column(const TabletColumn& column) const {
+    return !column.is_extended() && _segment->is_default_column(column);
+}
+
 Status SegmentMetaCollecter::_init_return_column_iterators() {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_segment->file_name()));
     RandomAccessFileOptions ropts;
@@ -247,16 +262,17 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
 
     auto max_cid = _params->cids.empty() ? 0 : *std::max_element(_params->cids.begin(), _params->cids.end());
     _column_iterators.resize(max_cid + 1);
+    _is_default_value_column_by_cid.assign(max_cid + 1, false);
     for (int i = 0; i < _params->fields.size(); i++) {
         if (_params->read_page[i]) {
             auto cid = _params->cids[i];
             if (_column_iterators[cid] == nullptr) {
+                ASSIGN_OR_RETURN(const TabletColumn* col, _get_tablet_column(cid));
                 ColumnIteratorOptions iter_opts;
-                const TabletColumn& col = _params->tablet_schema->column(cid);
                 std::string dcg_filename;
                 FileEncryptionInfo dcg_encryption_info;
                 ASSIGN_OR_RETURN(auto col_iter,
-                                 _new_dcg_column_iterator(col, &dcg_filename, &dcg_encryption_info, nullptr));
+                                 _new_dcg_column_iterator(*col, &dcg_filename, &dcg_encryption_info, nullptr));
                 if (col_iter != nullptr) {
                     // Find the column in delta column group
                     _column_iterators[cid] = std::move(col_iter);
@@ -267,7 +283,9 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
                     iter_opts.read_file = dcg_file.get();
                     _column_files[cid] = std::move(dcg_file);
                 } else {
-                    ASSIGN_OR_RETURN(_column_iterators[cid], _segment->new_column_iterator_or_default(col, nullptr));
+                    bool is_default_column = _is_missing_default_column(*col);
+                    ASSIGN_OR_RETURN(_column_iterators[cid], _segment->new_column_iterator_or_default(*col, nullptr));
+                    _is_default_value_column_by_cid[cid] = is_default_column;
                     iter_opts.read_file = _read_file.get();
                 }
                 iter_opts.check_dict_encoding = true;
@@ -345,13 +363,18 @@ std::string append_read_name(const ColumnReader* col_reader) {
 }
 
 Status SegmentMetaCollecter::_collect_flat_json(ColumnId cid, Column* column) {
-    const ColumnReader* col_reader = _segment->column(cid);
-    if (col_reader == nullptr) {
-        return Status::NotFound("don't found column");
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    if (!is_semi_type(tablet_column->type())) {
+        return Status::InternalError("column type mismatch");
     }
 
-    if (!is_semi_type(col_reader->column_type())) {
-        return Status::InternalError("column type mismatch");
+    ASSIGN_OR_RETURN(auto col_reader, _get_column_reader(cid));
+    if (col_reader == nullptr) {
+        if (_is_missing_default_column(*tablet_column)) {
+            column->append_datum(DatumArray());
+            return Status::OK();
+        }
+        return Status::NotFound("column not found");
     }
 
     if (col_reader->sub_readers() == nullptr || col_reader->sub_readers()->size() < 1) {
@@ -373,18 +396,16 @@ Status SegmentMetaCollecter::_collect_flat_json(ColumnId cid, Column* column) {
 
 // collect dict
 Status SegmentMetaCollecter::_collect_dict(ColumnId cid, Column* column, LogicalType type) {
-    if (!_column_iterators[cid]) {
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    if (cid >= _column_iterators.size() || !_column_iterators[cid]) {
         return Status::InvalidArgument("Invalid Collect Params.");
     }
-    auto& schema = _params->tablet_schema;
-    RETURN_IF(cid < 0 || cid >= schema->num_columns(), Status::InvalidArgument("Invalid cid: " + std::to_string(cid)));
-    auto& tablet_column = schema->column(cid);
-    if (tablet_column.type() == TYPE_VARCHAR || tablet_column.type() == TYPE_ARRAY) {
+    if (tablet_column->type() == TYPE_VARCHAR || tablet_column->type() == TYPE_ARRAY) {
         RETURN_IF_ERROR(_collect_dict_for_column(_column_iterators[cid].get(), cid, column));
-    } else if (tablet_column.type() == TYPE_JSON) {
+    } else if (tablet_column->type() == TYPE_JSON) {
         RETURN_IF_ERROR(_collect_dict_for_flatjson(cid, column));
     } else {
-        return Status::InvalidArgument("unsupported column type: " + type_to_string(tablet_column.type()));
+        return Status::InvalidArgument("unsupported column type: " + type_to_string(tablet_column->type()));
     }
     return {};
 }
@@ -392,10 +413,10 @@ Status SegmentMetaCollecter::_collect_dict(ColumnId cid, Column* column, Logical
 Status SegmentMetaCollecter::_collect_dict_for_column(ColumnIterator* column_iter, ColumnId cid, Column* column) {
     std::vector<Slice> words;
     if (!column_iter->all_page_dict_encoded()) {
-        auto& tablet_column = _params->tablet_schema->column(cid);
+        ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
         // For JSON data, the schema may be heterogeneous, meaning that some segments might not contain the dictionary column,
         // but a global dictionary could still be present and usable.
-        if (!tablet_column.is_extended() || !column_iter->only_nulls()) {
+        if (!tablet_column->is_extended() || !column_iter->only_nulls()) {
             return Status::GlobalDictError("no global dict");
         } else {
             return Status::OK();
@@ -442,12 +463,18 @@ Status SegmentMetaCollecter::_collect_dict_for_column(ColumnIterator* column_ite
 }
 
 Status SegmentMetaCollecter::_collect_dict_for_flatjson(ColumnId cid, Column* column) {
-    auto& tablet_column = _segment->tablet_schema().column(cid);
-    if (tablet_column.type() != TYPE_JSON) {
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    if (tablet_column->type() != TYPE_JSON) {
         return Status::InvalidArgument("not a flat json column");
     }
-    auto column_reader = _segment->column(cid);
-    RETURN_IF(column_reader == nullptr, Status::NotFound(fmt::format("column not found: {}", tablet_column.name())));
+    ASSIGN_OR_RETURN(auto column_reader, _get_column_reader(cid));
+    if (column_reader == nullptr) {
+        if (_is_missing_default_column(*tablet_column)) {
+            return Status::OK();
+        }
+        return Status::NotFound(fmt::format("column not found: {}", tablet_column->name()));
+    }
+    RETURN_IF(column_reader->sub_readers() == nullptr, Status::OK());
 
     auto& sub_readers = *column_reader->sub_readers();
     for (auto& sub_reader : sub_readers) {
@@ -480,14 +507,46 @@ Status SegmentMetaCollecter::_collect_min(ColumnId cid, Column* column, LogicalT
     return __collect_max_or_min<false>(cid, column, type);
 }
 
+Status SegmentMetaCollecter::_append_default_column_value(ColumnId cid, Column* column) {
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    if (_segment->num_rows() == 0) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+    if (!tablet_column->has_default_value()) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+
+    ASSIGN_OR_RETURN(auto column_iter, _segment->new_column_iterator_or_default(*tablet_column, nullptr));
+    ColumnIteratorOptions iter_opts;
+    RETURN_IF_ERROR(column_iter->init(iter_opts));
+
+    size_t n = 1;
+    return column_iter->next_batch(&n, column);
+}
+
+Status SegmentMetaCollecter::_collect_count_for_default_column(ColumnId cid, Column* column) {
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    if (!tablet_column->has_default_value() && !tablet_column->is_nullable()) {
+        return Status::InternalError(
+                fmt::format("invalid nonexistent column({}) without default value.", tablet_column->name()));
+    }
+
+    bool is_null_default = !tablet_column->has_default_value();
+    column->append_datum(int64_t(is_null_default ? 0 : _segment->num_rows()));
+    return Status::OK();
+}
+
 template <bool is_max>
 Status SegmentMetaCollecter::__collect_max_or_min(ColumnId cid, Column* column, LogicalType type) {
-    if (cid >= _segment->num_columns()) {
-        return Status::NotFound("");
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    ASSIGN_OR_RETURN(auto col_reader, _get_column_reader(cid));
+    if (col_reader == nullptr && _is_missing_default_column(*tablet_column)) {
+        return _append_default_column_value(cid, column);
     }
-    ColumnReader* col_reader = const_cast<ColumnReader*>(_segment->column(cid));
     if (col_reader == nullptr || col_reader->segment_zone_map() == nullptr) {
-        return Status::NotFound("");
+        return Status::NotFound("segment zone map not found");
     }
     if (col_reader->column_type() != type) {
         return Status::InternalError("column type mismatch");
@@ -521,8 +580,12 @@ Status SegmentMetaCollecter::_collect_rows(Column* column, LogicalType type) {
 }
 
 Status SegmentMetaCollecter::_collect_count(ColumnId cid, Column* column, LogicalType type) {
-    if (!_column_iterators[cid]) {
-        return Status::InvalidArgument("Invalid Collect Params.");
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    if (cid < _is_default_value_column_by_cid.size() && _is_default_value_column_by_cid[cid]) {
+        return _collect_count_for_default_column(cid, column);
+    }
+    if (cid >= _column_iterators.size() || !_column_iterators[cid]) {
+        return Status::InvalidArgument(fmt::format("Invalid Collect Params. column: {}", tablet_column->name()));
     }
 
     uint32_t num_rows = _segment->num_rows();
@@ -535,8 +598,15 @@ Status SegmentMetaCollecter::_collect_count(ColumnId cid, Column* column, Logica
 }
 
 Status SegmentMetaCollecter::_collect_column_size(ColumnId cid, Column* column, LogicalType type) {
-    ColumnReader* col_reader = const_cast<ColumnReader*>(_segment->column(cid));
-    RETURN_IF(col_reader == nullptr, Status::NotFound("column not found: " + std::to_string(cid)));
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    ASSIGN_OR_RETURN(auto col_reader, _get_column_reader(cid));
+    if (col_reader == nullptr) {
+        if (_is_missing_default_column(*tablet_column)) {
+            column->append_datum(int64_t(0));
+            return Status::OK();
+        }
+        return Status::NotFound("column not found: " + std::to_string(cid));
+    }
 
     size_t total_mem_footprint = _collect_column_size_recursive(col_reader);
     column->append_datum(int64_t(total_mem_footprint));
@@ -545,8 +615,15 @@ Status SegmentMetaCollecter::_collect_column_size(ColumnId cid, Column* column, 
 
 Status SegmentMetaCollecter::_collect_column_compressed_size(ColumnId cid, Column* column, LogicalType type) {
     // Compressed size estimation: sum of data page sizes via ordinal index ranges
-    ColumnReader* col_reader = const_cast<ColumnReader*>(_segment->column(cid));
-    RETURN_IF(col_reader == nullptr, Status::NotFound("column not found: " + std::to_string(cid)));
+    ASSIGN_OR_RETURN(const TabletColumn* tablet_column, _get_tablet_column(cid));
+    ASSIGN_OR_RETURN(auto col_reader, _get_column_reader(cid));
+    if (col_reader == nullptr) {
+        if (_is_missing_default_column(*tablet_column)) {
+            column->append_datum(int64_t(0));
+            return Status::OK();
+        }
+        return Status::NotFound("column not found: " + std::to_string(cid));
+    }
 
     int64_t total = _collect_column_compressed_size_recursive(col_reader);
     column->append_datum(total);

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -145,6 +145,9 @@ public:
 private:
     Status _init_return_column_iterators();
     Status _collect(const std::string& name, ColumnId cid, Column* column, LogicalType type);
+    StatusOr<const TabletColumn*> _get_tablet_column(ColumnId cid) const;
+    StatusOr<ColumnReader*> _get_column_reader(ColumnId cid) const;
+    bool _is_missing_default_column(const TabletColumn& column) const;
     Status _collect_dict(ColumnId cid, Column* column, LogicalType type);
     Status _collect_dict_for_flatjson(ColumnId cid, Column* column);
     Status _collect_dict_for_column(ColumnIterator* column_iter, ColumnId cid, Column* column);
@@ -155,6 +158,8 @@ private:
     Status _collect_flat_json(ColumnId cid, Column* column);
     Status _collect_column_size(ColumnId cid, Column* column, LogicalType type);
     Status _collect_column_compressed_size(ColumnId cid, Column* column, LogicalType type);
+    Status _append_default_column_value(ColumnId cid, Column* column);
+    Status _collect_count_for_default_column(ColumnId cid, Column* column);
     template <bool is_max>
     Status __collect_max_or_min(ColumnId cid, Column* column, LogicalType type);
     StatusOr<SegmentSharedPtr> _get_dcg_segment(uint32_t ucid);
@@ -168,6 +173,7 @@ private:
     int64_t _collect_column_compressed_size_recursive(ColumnReader* col_reader);
     SegmentSharedPtr _segment;
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;
+    std::vector<bool> _is_default_value_column_by_cid;
     const SegmentMetaCollecterParams* _params = nullptr;
     std::unique_ptr<RandomAccessFile> _read_file;
     OlapReaderStatistics _stats;

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -448,4 +448,193 @@ TEST_F(SegmentMetaCollecterTest, test_collect_with_dcg_loader_non_pk) {
 // For now, the mock loader tests above verify that the DCG code path is correctly integrated
 // into SegmentMetaCollecter's initialization and collection logic.
 
+TEST_F(SegmentMetaCollecterTest, test_collect_drop_rename_reorder_column_by_uid) {
+    TabletSchemaPB schema_pb;
+    auto col0 = schema_pb.add_column();
+    col0->set_name("c0");
+    col0->set_type("INT");
+    col0->set_is_key(true);
+    col0->set_is_nullable(false);
+    col0->set_unique_id(10);
+
+    auto col1 = schema_pb.add_column();
+    col1->set_name("c1");
+    col1->set_type("INT");
+    col1->set_is_key(false);
+    col1->set_is_nullable(false);
+    col1->set_unique_id(11);
+
+    auto col2 = schema_pb.add_column();
+    col2->set_name("c2");
+    col2->set_type("INT");
+    col2->set_is_key(false);
+    col2->set_is_nullable(false);
+    col2->set_unique_id(12);
+
+    auto segment_schema = TabletSchema::create(schema_pb);
+
+    std::string segment_name = "test_schema_change_uid_meta.dat";
+    DeferOp defer_op([&] { delete_file(segment_name); });
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(segment_name));
+    auto encryption_pair = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
+    WritableFileOptions file_options{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE,
+                                     .encryption_info = encryption_pair.info};
+    ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(file_options, segment_name));
+
+    SegmentWriter writer(std::move(wf), 0, segment_schema, SegmentWriterOptions());
+    EXPECT_OK(writer.init());
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    for (int v : {1, 2, 3}) {
+        c0->append(v);
+    }
+    for (int v : {100, 200, 300}) {
+        c1->append(v);
+    }
+    for (int v : {7, 9, 11}) {
+        c2->append(v);
+    }
+    auto chunk = std::make_shared<Chunk>(Columns{c0, c1, c2}, std::make_shared<Schema>(segment_schema->schema()));
+    ASSERT_OK(writer.append_chunk(*chunk));
+
+    uint64_t file_size, index_size, footer_pos;
+    EXPECT_OK(writer.finalize(&file_size, &index_size, &footer_pos));
+
+    FileInfo file_info{.path = segment_name, .encryption_meta = encryption_pair.encryption_meta};
+    ASSIGN_OR_ABORT(auto segment, Segment::open(fs, file_info, 0, segment_schema));
+
+    TabletSchemaPB current_schema_pb;
+    auto renamed_c2 = current_schema_pb.add_column();
+    renamed_c2->set_name("renamed_c2");
+    renamed_c2->set_type("INT");
+    renamed_c2->set_is_key(false);
+    renamed_c2->set_is_nullable(false);
+    renamed_c2->set_unique_id(12);
+
+    auto current_c0 = current_schema_pb.add_column();
+    current_c0->set_name("c0");
+    current_c0->set_type("INT");
+    current_c0->set_is_key(true);
+    current_c0->set_is_nullable(false);
+    current_c0->set_unique_id(10);
+
+    auto current_schema = TabletSchema::create(current_schema_pb);
+
+    SegmentMetaCollecter collecter(segment);
+    SegmentMetaCollecterParams params;
+    params.fields = {META_MIN, META_MAX, META_COUNT_COL, META_COLUMN_SIZE};
+    params.field_type = {TYPE_INT, TYPE_INT, TYPE_BIGINT, TYPE_BIGINT};
+    params.cids = {0, 0, 0, 0};
+    params.read_page = {false, false, true, false};
+    params.tablet_schema = current_schema;
+
+    SegmentMetaCollectOptions options;
+    EXPECT_OK(collecter.init(&params, options));
+    EXPECT_OK(collecter.open());
+
+    auto min_col = Int32Column::create();
+    auto max_col = Int32Column::create();
+    auto count_col = Int64Column::create();
+    auto size_col = Int64Column::create();
+    std::vector<Column*> columns = {min_col.get(), max_col.get(), count_col.get(), size_col.get()};
+
+    EXPECT_OK(collecter.collect(&columns));
+    EXPECT_EQ(7, min_col->get(0).get_int32());
+    EXPECT_EQ(11, max_col->get(0).get_int32());
+    EXPECT_EQ(3, count_col->get(0).get_int64());
+    EXPECT_GT(size_col->get(0).get_int64(), 0);
+}
+
+TEST_F(SegmentMetaCollecterTest, test_collect_added_column_default_values) {
+    TabletSchemaPB schema_pb;
+    auto col0 = schema_pb.add_column();
+    col0->set_name("c0");
+    col0->set_type("INT");
+    col0->set_is_key(true);
+    col0->set_is_nullable(false);
+    col0->set_unique_id(20);
+
+    auto segment_schema = TabletSchema::create(schema_pb);
+
+    std::string segment_name = "test_add_column_default_meta.dat";
+    DeferOp defer_op([&] { delete_file(segment_name); });
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(segment_name));
+    auto encryption_pair = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
+    WritableFileOptions file_options{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE,
+                                     .encryption_info = encryption_pair.info};
+    ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(file_options, segment_name));
+
+    SegmentWriter writer(std::move(wf), 0, segment_schema, SegmentWriterOptions());
+    EXPECT_OK(writer.init());
+
+    auto c0 = Int32Column::create();
+    for (int v : {1, 2, 3}) {
+        c0->append(v);
+    }
+    auto chunk = std::make_shared<Chunk>(Columns{c0}, std::make_shared<Schema>(segment_schema->schema()));
+    ASSERT_OK(writer.append_chunk(*chunk));
+
+    uint64_t file_size, index_size, footer_pos;
+    EXPECT_OK(writer.finalize(&file_size, &index_size, &footer_pos));
+
+    FileInfo file_info{.path = segment_name, .encryption_meta = encryption_pair.encryption_meta};
+    ASSIGN_OR_ABORT(auto segment, Segment::open(fs, file_info, 0, segment_schema));
+
+    TabletSchemaPB current_schema_pb;
+    auto current_c0 = current_schema_pb.add_column();
+    current_c0->set_name("c0");
+    current_c0->set_type("INT");
+    current_c0->set_is_key(true);
+    current_c0->set_is_nullable(false);
+    current_c0->set_unique_id(20);
+
+    auto added_null = current_schema_pb.add_column();
+    added_null->set_name("added_null");
+    added_null->set_type("INT");
+    added_null->set_is_key(false);
+    added_null->set_is_nullable(true);
+    added_null->set_unique_id(21);
+
+    auto added_default = current_schema_pb.add_column();
+    added_default->set_name("added_default");
+    added_default->set_type("INT");
+    added_default->set_is_key(false);
+    added_default->set_is_nullable(false);
+    added_default->set_default_value("7");
+    added_default->set_unique_id(22);
+
+    auto current_schema = TabletSchema::create(current_schema_pb);
+
+    SegmentMetaCollecter collecter(segment);
+    SegmentMetaCollecterParams params;
+    params.fields = {META_MIN, META_COUNT_COL, META_COLUMN_SIZE, META_MIN, META_COUNT_COL, META_COLUMN_SIZE};
+    params.field_type = {TYPE_INT, TYPE_BIGINT, TYPE_BIGINT, TYPE_INT, TYPE_BIGINT, TYPE_BIGINT};
+    params.cids = {1, 1, 1, 2, 2, 2};
+    params.read_page = {false, true, false, false, true, false};
+    params.tablet_schema = current_schema;
+
+    SegmentMetaCollectOptions options;
+    EXPECT_OK(collecter.init(&params, options));
+    EXPECT_OK(collecter.open());
+
+    auto nullable_min = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto nullable_count = Int64Column::create();
+    auto nullable_size = Int64Column::create();
+    auto default_min = Int32Column::create();
+    auto default_count = Int64Column::create();
+    auto default_size = Int64Column::create();
+    std::vector<Column*> columns = {nullable_min.get(), nullable_count.get(), nullable_size.get(),
+                                    default_min.get(),  default_count.get(),  default_size.get()};
+
+    EXPECT_OK(collecter.collect(&columns));
+    EXPECT_TRUE(nullable_min->is_null(0));
+    EXPECT_EQ(0, nullable_count->get(0).get_int64());
+    EXPECT_EQ(0, nullable_size->get(0).get_int64());
+    EXPECT_EQ(7, default_min->get(0).get_int32());
+    EXPECT_EQ(3, default_count->get(0).get_int64());
+    EXPECT_EQ(0, default_size->get(0).get_int64());
+}
+
 } // namespace starrocks

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -475,7 +475,7 @@ TEST_F(SegmentMetaCollecterTest, test_collect_drop_rename_reorder_column_by_uid)
 
     std::string segment_name = "test_schema_change_uid_meta.dat";
     DeferOp defer_op([&] { delete_file(segment_name); });
-    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(segment_name));
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(segment_name));
     auto encryption_pair = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
     WritableFileOptions file_options{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE,
                                      .encryption_info = encryption_pair.info};
@@ -560,7 +560,7 @@ TEST_F(SegmentMetaCollecterTest, test_collect_added_column_default_values) {
 
     std::string segment_name = "test_add_column_default_meta.dat";
     DeferOp defer_op([&] { delete_file(segment_name); });
-    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(segment_name));
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(segment_name));
     auto encryption_pair = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
     WritableFileOptions file_options{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE,
                                      .encryption_info = encryption_pair.info};

--- a/test/sql/test_meta_scan/R/test_meta_scan_schema_change
+++ b/test/sql/test_meta_scan/R/test_meta_scan_schema_change
@@ -1,0 +1,106 @@
+-- name: test_meta_scan_fast_schema_change_uncompacted_segment @native
+CREATE DATABASE test_meta_scan_schema_change_${uuid0};
+-- result:
+-- !result
+USE test_meta_scan_schema_change_${uuid0};
+-- result:
+-- !result
+CREATE TABLE meta_schema_change (
+    k1 INT,
+    c0 INT,
+    c_drop INT,
+    c_move INT,
+    v1 VARCHAR(20)
+)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true",
+    "base_compaction_forbidden_time_ranges" = "* * * * *"
+);
+-- result:
+-- !result
+INSERT INTO meta_schema_change VALUES
+(1, 10, 100, 1000, 'alpha'),
+(2, 20, 200, 2000, 'beta'),
+(3, 30, NULL, 3000, 'gamma');
+-- result:
+-- !result
+[UC]rowset_before=SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+-- result:
+2
+-- !result
+[UC]segment_before=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+-- result:
+1
+-- !result
+SELECT ${rowset_before} >= 1 AS has_rowset_before, ${segment_before} >= 1 AS has_segment_before;
+-- result:
+1	1
+-- !result
+ALTER TABLE meta_schema_change RENAME COLUMN c_move TO c_renamed;
+-- result:
+-- !result
+ALTER TABLE meta_schema_change DROP COLUMN c_drop;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+ALTER TABLE meta_schema_change ADD COLUMN added_null INT NULL AFTER c0;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+ALTER TABLE meta_schema_change ADD COLUMN added_default INT DEFAULT '7' AFTER added_null;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+ALTER TABLE meta_schema_change MODIFY COLUMN c_renamed INT AFTER added_default;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+[UC]rowset_after=SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+-- result:
+2
+-- !result
+[UC]segment_after=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+-- result:
+1
+-- !result
+SELECT ${rowset_after} = ${rowset_before} AND ${segment_after} = ${segment_before} AND ${segment_after} > 0 AS old_segment_uncompacted;
+-- result:
+1
+-- !result
+SELECT min(c_renamed), max(c_renamed), count(c_renamed),
+       min(added_null) IS NULL, max(added_null) IS NULL, count(added_null),
+       min(added_default), max(added_default), count(added_default)
+FROM meta_schema_change [_META_];
+-- result:
+1000	3000	3	1	1	0	7	7	3
+-- !result
+SELECT column_size(added_null), column_compressed_size(added_null),
+       column_size(added_default), column_compressed_size(added_default)
+FROM meta_schema_change [_META_];
+-- result:
+0	0	0	0
+-- !result
+SELECT k1, c0, added_null, added_default, c_renamed, v1 FROM meta_schema_change ORDER BY k1;
+-- result:
+1	10	None	7	1000	alpha
+2	20	None	7	2000	beta
+3	30	None	7	3000	gamma
+-- !result
+DROP DATABASE test_meta_scan_schema_change_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_meta_scan/T/test_meta_scan_schema_change
+++ b/test/sql/test_meta_scan/T/test_meta_scan_schema_change
@@ -1,0 +1,58 @@
+-- name: test_meta_scan_fast_schema_change_uncompacted_segment @native
+CREATE DATABASE test_meta_scan_schema_change_${uuid0};
+USE test_meta_scan_schema_change_${uuid0};
+
+CREATE TABLE meta_schema_change (
+    k1 INT,
+    c0 INT,
+    c_drop INT,
+    c_move INT,
+    v1 VARCHAR(20)
+)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true",
+    "base_compaction_forbidden_time_ranges" = "* * * * *"
+);
+
+INSERT INTO meta_schema_change VALUES
+(1, 10, 100, 1000, 'alpha'),
+(2, 20, 200, 2000, 'beta'),
+(3, 30, NULL, 3000, 'gamma');
+
+[UC]rowset_before=SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+[UC]segment_before=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+SELECT ${rowset_before} >= 1 AS has_rowset_before, ${segment_before} >= 1 AS has_segment_before;
+
+ALTER TABLE meta_schema_change RENAME COLUMN c_move TO c_renamed;
+
+ALTER TABLE meta_schema_change DROP COLUMN c_drop;
+function: wait_alter_table_finish()
+
+ALTER TABLE meta_schema_change ADD COLUMN added_null INT NULL AFTER c0;
+function: wait_alter_table_finish()
+
+ALTER TABLE meta_schema_change ADD COLUMN added_default INT DEFAULT '7' AFTER added_null;
+function: wait_alter_table_finish()
+
+ALTER TABLE meta_schema_change MODIFY COLUMN c_renamed INT AFTER added_default;
+function: wait_alter_table_finish()
+
+[UC]rowset_after=SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+[UC]segment_after=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'meta_schema_change' AND c.TABLE_SCHEMA = 'test_meta_scan_schema_change_${uuid0}';
+SELECT ${rowset_after} = ${rowset_before} AND ${segment_after} = ${segment_before} AND ${segment_after} > 0 AS old_segment_uncompacted;
+
+SELECT min(c_renamed), max(c_renamed), count(c_renamed),
+       min(added_null) IS NULL, max(added_null) IS NULL, count(added_null),
+       min(added_default), max(added_default), count(added_default)
+FROM meta_schema_change [_META_];
+
+SELECT column_size(added_null), column_compressed_size(added_null),
+       column_size(added_default), column_compressed_size(added_default)
+FROM meta_schema_change [_META_];
+
+SELECT k1, c0, added_null, added_default, c_renamed, v1 FROM meta_schema_change ORDER BY k1;
+
+DROP DATABASE test_meta_scan_schema_change_${uuid0} FORCE;


### PR DESCRIPTION
## Why I'm doing:

Backport https://github.com/StarRocks/starrocks/pull/72901 to branch-4.1.

After some schema change like add column, the new added column could not be found in the old segment files, so the meta scan will throw a not found error now. This may cause background statistics analyze failed.

## What I'm doing:

The first four schema changes are relatively straightforward:

- DROP COLUMN: the new schema no longer reads this column, so the old physical column in existing segments can be ignored.
- RENAME COLUMN: only the name changes; the column uid stays the same, so the reader should be located by uid.
- REORDER COLUMN: the ordinal/cid changes, but the column uid stays the same, so locating the reader by uid is sufficient.
- ADD COLUMN: old segments do not have the new physical column, so the meta reader can synthesize the default value or NULL.

The remaining cases are harder:

1. ALTER COLUMN TYPE min/max values come from the segment zone map, and those values are encoded using the old physical type. We would need explicit type conversion logic.
2. Complex/derived/access-path changes, such as flat JSON paths, extended columns, or nested type layout changes.

These 2 types enhancement could be processed in independent prs in future.

Backport notes:

- Cherry-picked from https://github.com/StarRocks/starrocks/commit/149e174b5ae1bd7e9f1d34517cc02b8f6ef8e8ce.
- Resolved conflicts in `be/src/storage/meta_reader.cpp` and `be/src/storage/meta_reader.h`.
- Kept the branch-4.1 collect path and did not backport the main-only virtual-column collect path.
- Preserved the branch-4.1 `only_nulls()` handling in dict collection.

Validation:

- `git diff --check HEAD~1..HEAD`
- `cmake --build be/ut_build_Debug --target Storage -j 8` on branch-4.1

Fixes https://github.com/StarRocks/starrocks/pull/72901

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

