### PR TITLE
[Enhancement] Add enable_stop_be_action config to control /api/_stop_be

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -782,6 +782,11 @@ CONF_mBool(enable_token_check, "true");
 // exempt. Default false for backward compatibility.
 CONF_mBool(enable_http_auth, "false");
 
+// Whether to enable the BE `/api/_stop_be` HTTP endpoint. When `false`, requests
+// to that endpoint are rejected with HTTP 403 and the BE process is not exited.
+// This config is static and requires a BE restart to take effect.
+CONF_Bool(enable_stop_be_action, "true");
+
 // to open/close system metrics
 CONF_Bool(enable_system_metrics, "true");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -465,7 +465,8 @@
         "download_low_speed_limit_kbps",
         "download_low_speed_time",
         "enable_token_check",
-        "enable_http_auth"
+        "enable_http_auth",
+        "enable_stop_be_action"
       ]
     },
     {

--- a/be/src/common/config_http_fwd.h
+++ b/be/src/common/config_http_fwd.h
@@ -37,4 +37,9 @@ CONF_mBool(enable_token_check, "true");
 // exempt. Default false for backward compatibility.
 CONF_mBool(enable_http_auth, "false");
 
+// Whether to enable the BE `/api/_stop_be` HTTP endpoint. When `false`, requests
+// to that endpoint are rejected with HTTP 403 and the BE process is not exited.
+// This config is static and requires a BE restart to take effect.
+CONF_Bool(enable_stop_be_action, "true");
+
 } // namespace starrocks::config

--- a/be/src/http/action/stop_be_action.cpp
+++ b/be/src/http/action/stop_be_action.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "base/utility/defer_op.h"
+#include "common/config_http_fwd.h"
 #include "common/process_exit.h"
 #include "http/http_channel.h"
 #include "http/http_request.h"
@@ -41,6 +42,13 @@ std::string StopBeAction::construct_response_message(const std::string& msg) {
 
 void StopBeAction::handle(HttpRequest* req) {
     LOG(INFO) << "Accept one stop_be request " << req->debug_string();
+
+    if (!config::enable_stop_be_action) {
+        LOG(WARNING) << "Reject stop_be request because config::enable_stop_be_action is false";
+        HttpChannel::send_reply(req, HttpStatus::FORBIDDEN,
+                                construct_response_message("stop_be action is disabled by config"));
+        return;
+    }
 
     DeferOp defer([&]() {
 #ifdef USE_STAROS

--- a/be/src/http/action/stop_be_action.h
+++ b/be/src/http/action/stop_be_action.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <string>
 
 #include "http/http_handler.h"

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -174,6 +174,7 @@ Status HttpServiceBE::start() {
     // Register Stop Be action
     auto* stop_be_action = new StopBeAction(_env);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/_stop_be", stop_be_action);
+    _ev_http_server->register_handler(HttpMethod::POST, "/api/_stop_be", stop_be_action);
     _http_handlers.emplace_back(stop_be_action);
 
     // register pprof actions

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -251,6 +251,7 @@ set(EXEC_FILES
         ./http/http_client_test.cpp
         ./http/message_body_sink_test.cpp
         ./http/metrics_action_test.cpp
+        ./http/stop_be_action_test.cpp
         ./http/stream_load_test.cpp
         ./http/transaction_stream_load_test.cpp
         ./http/action/pprof_actions_test.cpp

--- a/be/test/http/stop_be_action_test.cpp
+++ b/be/test/http/stop_be_action_test.cpp
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/stop_be_action.h"
+
+#include <event2/http.h>
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+#include "common/config_http_fwd.h"
+#include "common/process_exit.h"
+#include "http/http_channel.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, std::string_view);
+
+namespace {
+HttpStatus k_response_status = HttpStatus::OK;
+std::string k_response_str;
+void inject_send_reply(HttpRequest* request, HttpStatus status, std::string_view content) {
+    k_response_status = status;
+    k_response_str = content;
+}
+} // namespace
+
+class StopBeActionTest : public testing::Test {
+public:
+    static void SetUpTestSuite() { s_injected_send_reply = inject_send_reply; }
+    static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
+
+    void SetUp() override {
+        _old_enable_stop_be_action = config::enable_stop_be_action;
+        k_response_status = HttpStatus::OK;
+        k_response_str = "";
+        _evhttp_req = evhttp_request_new(nullptr, nullptr);
+    }
+
+    void TearDown() override {
+        config::enable_stop_be_action = _old_enable_stop_be_action;
+        if (_evhttp_req != nullptr) {
+            evhttp_request_free(_evhttp_req);
+        }
+    }
+
+protected:
+    bool _old_enable_stop_be_action = true;
+    evhttp_request* _evhttp_req = nullptr;
+};
+
+// When the config is disabled, the request must be rejected with HTTP 403 and
+// the BE must not be put into the quick-exit path.
+TEST_F(StopBeActionTest, disabled_rejects_with_forbidden) {
+    config::enable_stop_be_action = false;
+
+    StopBeAction action(nullptr);
+    HttpRequest request(_evhttp_req);
+    request.set_method(HttpMethod::POST);
+    request.set_handler(&action);
+
+    // The disabled path must not change the process quick-exit state, regardless
+    // of any state left by other tests in this binary.
+    const bool quick_exit_before = process_quick_exit_in_progress();
+
+    action.handle(&request);
+
+    EXPECT_EQ(HttpStatus::FORBIDDEN, k_response_status);
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_TRUE(doc.HasMember("status"));
+    EXPECT_STREQ("stop_be action is disabled by config", doc["status"].GetString());
+
+    EXPECT_EQ(quick_exit_before, process_quick_exit_in_progress());
+}
+
+} // namespace starrocks

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -210,6 +210,15 @@ This topic introduces the following types of BE configurations:
 
   Privileged endpoints additionally require a SYSTEM-level RBAC privilege (`OPERATE` or `NODE`) that is **active** in the session — use `SET DEFAULT ROLE <roles> TO <user>;` or set `activate_all_roles_on_login=true` if the role is granted but not default. LDAP / security-integration group → role mappings activate automatically.
 
+### enable_stop_be_action
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Introduced in: -
+- Description: Whether to enable the BE `/api/_stop_be` HTTP endpoint, which shuts the BE process down. When `false`, requests to the endpoint are rejected with HTTP 403 and the BE process is not exited. This parameter requires a BE restart to take effect.
+
 ### be_port
 
 - Default: 9060

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -182,6 +182,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
   特権エンドポイントでは追加でセッション内に**有効化された** SYSTEM レベル RBAC 権限（`OPERATE` / `NODE`）が必要です。付与済みでデフォルトに設定されていない場合は `SET DEFAULT ROLE <roles> TO <user>;` または `activate_all_roles_on_login=true` を利用してください。LDAP / security integration のグループ → ロールマッピングは自動的に有効化されます。
 
+### enable_stop_be_action
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 導入時期: -
+- 説明: BE プロセスをシャットダウンする BE `/api/_stop_be` HTTP エンドポイントを有効にするかどうか。`false` の場合、このエンドポイントへのリクエストは HTTP 403 で拒否され、BE プロセスは終了しません。このパラメータを反映するには BE の再起動が必要です。
+
 ### be_port
 
 - デフォルト: 9060

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -197,6 +197,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
   特权接口还要求会话中**当前激活**了 SYSTEM 级 RBAC 权限（`OPERATE` 或 `NODE`）——若已 GRANT 但未设为默认角色，需 `SET DEFAULT ROLE <roles> TO <user>;` 或将 `activate_all_roles_on_login` 设为 `true`。LDAP / security integration 的组 → 角色映射会自动激活。
 
+### enable_stop_be_action
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：否
+- 引入版本：-
+- 描述：是否启用 BE `/api/_stop_be` HTTP 接口（用于关闭 BE 进程）。设置为 `false` 时，对该接口的请求将返回 HTTP 403，且不会退出 BE 进程。该参数需重启 BE 才能生效。
+
 ### be_port
 
 - 默认值：9060


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

  The BE `/api/_stop_be` HTTP endpoint shuts the BE process down. Add a
  boolean config `enable_stop_be_action` (default `true` to preserve
  existing behavior). When set to `false`, `StopBeAction::handle()` rejects
  the request with HTTP 403 and skips the quick-exit path, letting operators
  on untrusted networks turn the endpoint off. The config is static and
  requires a BE restart to take effect.

  Also register the endpoint for POST in addition to GET, and drop the
  now-unused `<atomic>` include from stop_be_action.h.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5