### PR TITLE
[Refactor] Make enable_http_auth immutable on FE and BE

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -779,8 +779,8 @@ CONF_mBool(enable_token_check, "true");
 
 // Whether to require Basic Auth for external BE HTTP endpoints. Internal endpoints
 // (BE-to-BE clone, internal load download, health probe, Prometheus metrics) are always
-// exempt. Default false for backward compatibility.
-CONF_mBool(enable_http_auth, "false");
+// exempt. Default false for backward compatibility. Immutable; requires a BE restart to change.
+CONF_Bool(enable_http_auth, "false");
 
 // to open/close system metrics
 CONF_Bool(enable_system_metrics, "true");

--- a/be/src/common/config_http_fwd.h
+++ b/be/src/common/config_http_fwd.h
@@ -34,7 +34,7 @@ CONF_mBool(enable_token_check, "true");
 
 // Whether to require Basic Auth for external BE HTTP endpoints. Internal endpoints
 // (BE-to-BE clone, internal load download, health probe, Prometheus metrics) are always
-// exempt. Default false for backward compatibility.
-CONF_mBool(enable_http_auth, "false");
+// exempt. Default false for backward compatibility. Immutable; requires a BE restart to change.
+CONF_Bool(enable_http_auth, "false");
 
 } // namespace starrocks::config

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -201,8 +201,8 @@ This topic introduces the following types of BE configurations:
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Introduced in: -
+- Is mutable: No
+- Introduced in: v4.2.0
 - Description: When true, most external BE HTTP endpoints require HTTP Basic Auth. Credentials are verified by RPC to the FE leader using the `checkAuth` Thrift method, so the user/password store on the FE side (including LDAP / security-integration) is the source of truth. The following are exempt:
   - Public probes / observability: `/api/health`, `/metrics`, `/metrics/memory`.
   - Token-gated internal transport (used by FE/BE for tablet clone and load-error file fetch): `/api/_tablet/_download`, `/api/_download_load`. These remain protected by their own token check; setting `enable_http_auth=true` does **not** compensate for `enable_token_check=false`.

--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -782,8 +782,8 @@ This topic introduces the following types of FE configurations:
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Introduced in: -
+- Is mutable: No
+- Introduced in: v4.2.0
 - Description: When true, most external FE HTTP endpoints require HTTP Basic Auth. Credentials are validated against the user store via `AuthenticationHandler.authenticate()`, so LDAP / security-integration login works on the HTTP path the same way it does for the MySQL protocol. The following are exempt:
   - Public probes / observability: `/api/health`, `/api/bootstrap`, `/api/idle_status`, `/api/v2/feature`, `/metrics`, `/api/oauth2`.
   - Peer-FE / control-plane paths that are IP-whitelisted or token-gated inside the handler: `/image`, `/check`, `/journal_id`, `/info`, `/role`, `/dump`, `/dump_starmgr`, `/service_id`, `/static`, `/api/_meta_replay_state`, `/api/get_small_file`.

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -173,8 +173,8 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - デフォルト: false
 - タイプ: Boolean
 - 単位: -
-- 変更可能: はい
-- 導入時期: -
+- 変更可能: いいえ
+- 導入時期: v4.2.0
 - 説明: true の場合、ほとんどの外部 BE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は Thrift `checkAuth` RPC で FE Leader に転送されて検証され、ユーザー名/パスワードは FE 側の認証システム（LDAP / security integration を含む）を正としています。次のエンドポイントは常に除外されます：
   - 公開プローブ / 可観測性: `/api/health`、`/metrics`、`/metrics/memory`。
   - トークン認証の内部転送（FE/BE 間の tablet clone と load エラーファイル取得に使用）: `/api/_tablet/_download`、`/api/_download_load`。これらは各自の token チェックで保護されており、`enable_http_auth=true` を有効にしても `enable_token_check=false` の影響を補うことはできません。

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -772,8 +772,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - デフォルト：false
 - タイプ：Boolean
 - 単位：-
-- 変更可能：Yes
-- 導入時期：-
+- 変更可能：No
+- 導入時期：v4.2.0
 - 説明：true の場合、ほとんどの外部 FE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は `AuthenticationHandler.authenticate()` を介してユーザーストアと照合されるため、LDAP / security integration による認証も MySQL プロトコルと同様に HTTP 経路で機能します。次のエンドポイントは常に除外されます：
   - 公開プローブ / 可観測性：`/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
   - ハンドラ内で IP ホワイトリストまたはトークンで認証する FE 間 / コントロールプレーン経路：`/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -188,8 +188,8 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 默认值：false
 - 类型：Boolean
 - 单位：-
-- 是否动态：是
-- 引入版本：-
+- 是否动态：否
+- 引入版本：v4.2.0
 - 描述：是否对大部分外部 BE HTTP 接口启用 Basic Auth。凭证通过 Thrift `checkAuth` RPC 转发到 FE Leader 校验，用户/密码以 FE 端的认证体系（含 LDAP / security integration）为准。以下接口始终豁免：
   - 公开探针 / 可观测性：`/api/health`、`/metrics`、`/metrics/memory`。
   - Token 鉴权的内部传输（FE/BE 用于 tablet clone 和 load 错误文件拉取）：`/api/_tablet/_download`、`/api/_download_load`。这些接口仍由各自的 token 检查保护；开启 `enable_http_auth=true` **不**能弥补 `enable_token_check=false` 带来的安全损失。

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -780,8 +780,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 引入版本: -
+- 是否可变: No
+- 引入版本: v4.2.0
 - 描述: 是否对大部分外部 FE HTTP 接口启用 Basic Auth。凭证通过 `AuthenticationHandler.authenticate()` 校验，因此 LDAP / security integration 在 HTTP 路径上的工作方式与 MySQL 协议一致。以下接口始终豁免:
   - 公开探针 / 可观测性: `/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
   - 由 handler 自行通过 IP 白名单或 token 鉴权的对等 FE / 控制面端点: `/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -852,9 +852,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_port = 8030;
 
-    @ConfField(mutable = true, comment = "Whether to require Basic Auth for external HTTP endpoints. " +
+    @ConfField(comment = "Whether to require Basic Auth for external HTTP endpoints. " +
             "Internal endpoints (FE meta sync, health/metrics probes, OAuth2 callback) are always exempt. " +
-            "Default false for backward compatibility.")
+            "Default false for backward compatibility. Immutable; requires an FE restart to change.")
     public static boolean enable_http_auth = false;
 
     /**


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

  Change `enable_http_auth` from a mutable config to an immutable one so it
  can only be set at startup and takes effect after a restart. The auth
  mode should not be flipped at runtime via ADMIN SET CONFIG.

  - FE: drop mutable = true from the @ConfField in Config.java
  - BE: change CONF_mBool to CONF_Bool in config.h
  - Docs: update FE/BE parameter pages (en/zh/ja) to mark it immutable
    and set the introduced version to v4.2.0

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
