### PR TITLE
[Enhancement] Improve Iceberg scan projection metrics reporting

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1139,7 +1139,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         List<FileScanTask> icebergScanTasks = Lists.newArrayList();
         try (CloseableIterator<FileScanTask> iterator =
                      buildFileScanTaskIterator((IcebergTable) table, icebergPredicate, tvrVersionRange,
-                             connectContext, enableCollectColumnStatistics)) {
+                             connectContext, enableCollectColumnStatistics, params.getFieldNames())) {
             while (iterator.hasNext()) {
                 FileScanTask scanTask = iterator.next();
 
@@ -1234,7 +1234,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                        GetRemoteFilesParams params) {
         CloseableIterator<FileScanTask> iterator =
                 buildFileScanTaskIterator(table, icebergPredicate, tvrVersionRange, ConnectContext.get(),
-                        params.isEnableColumnStats());
+                        params.isEnableColumnStats(), params.getFieldNames());
         return new RemoteFileInfoSource() {
             @Override
             public RemoteFileInfo getOutput() {
@@ -1279,7 +1279,8 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                                       Expression icebergPredicate,
                                                                       TvrVersionRange tvrVersionRange,
                                                                       ConnectContext connectContext,
-                                                                      boolean enableCollectColumnStats) {
+                                                                      boolean enableCollectColumnStats,
+                                                                      List<String> fieldNames) {
         if (tvrVersionRange.isEmpty()) {
             return new CloseableIterator<>() {
                 @Override
@@ -1342,6 +1343,10 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         if (icebergPredicate.op() != Expression.Operation.TRUE) {
             scan = (Scan) scan.filter(icebergPredicate);
+        }
+
+        if (fieldNames != null && !fieldNames.isEmpty()) {
+            scan = (Scan) scan.select(fieldNames);
         }
 
         Scan tableScan = scan;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1345,7 +1345,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             scan = (Scan) scan.filter(icebergPredicate);
         }
 
-        if (fieldNames != null && !fieldNames.isEmpty()) {
+        if (fieldNames != null) {
             scan = (Scan) scan.select(fieldNames);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -47,6 +47,7 @@ import com.starrocks.type.Type;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.metrics.ScanReportParser;
+import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -174,6 +175,15 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
 
+        Set<String> nativeColumnNames = icebergTable.getNativeTable().schema().columns().stream()
+                .map(Types.NestedField::name)
+                .collect(Collectors.toSet());
+        List<String> requiredColumnNames = desc.getSlots().stream()
+                .map(slot -> slot.getColumn().getName())
+                .filter(nativeColumnNames::contains)
+                .distinct()
+                .collect(Collectors.toList());
+
         GetRemoteFilesParams params =
                 IcebergGetRemoteFilesParams.newBuilder()
                         .setAllParams(tableFullMORParams)
@@ -182,6 +192,7 @@ public class IcebergScanNode extends ScanNode {
                         .setPredicate(icebergJobPlanningPredicate)
                         .setEnableColumnStats(scanOptimizeOption.getCanUseMinMaxOpt())
                         .setUsedForDelete(usedForDelete)
+                        .setFieldNames(requiredColumnNames)
                         .build();
 
         RemoteFileInfoSource remoteFileInfoSource;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -510,12 +510,12 @@ public class ExternalResourceCleanupTest {
         IcebergTable table = Mockito.mock(IcebergTable.class);
         Method m = IcebergMetadata.class.getDeclaredMethod(
                 "buildFileScanTaskIterator", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
-                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class);
+                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class, List.class);
         m.setAccessible(true);
         org.apache.iceberg.io.CloseableIterator<FileScanTask> iter =
                 (org.apache.iceberg.io.CloseableIterator<FileScanTask>) m.invoke(
                         metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
-                        TvrTableSnapshot.empty(), null, false);
+                        TvrTableSnapshot.empty(), null, false, null);
         Assertions.assertFalse(iter.hasNext());
         iter.close();
     }
@@ -540,11 +540,11 @@ public class ExternalResourceCleanupTest {
 
         Method m = IcebergMetadata.class.getDeclaredMethod(
                 "buildFileScanTaskIterator", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
-                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class);
+                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class, List.class);
         m.setAccessible(true);
         Assertions.assertThrows(java.lang.reflect.InvocationTargetException.class, () -> m.invoke(
                 metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
-                TvrTableSnapshot.of(Optional.of(1L)), null, false));
+                TvrTableSnapshot.of(Optional.of(1L)), null, false, null));
     }
 
     @Test
@@ -581,12 +581,12 @@ public class ExternalResourceCleanupTest {
 
         Method m = IcebergMetadata.class.getDeclaredMethod(
                 "buildFileScanTaskIterator", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
-                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class);
+                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class, List.class);
         m.setAccessible(true);
         org.apache.iceberg.io.CloseableIterator<FileScanTask> iter =
                 (org.apache.iceberg.io.CloseableIterator<FileScanTask>) m.invoke(
                         metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
-                        TvrTableDelta.of(Optional.of(1L), Optional.of(2L)), null, true);
+                        TvrTableDelta.of(Optional.of(1L), Optional.of(2L)), null, true, null);
         // iterator should be created and be consumable without exception
         iter.hasNext();
         iter.close();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1691,6 +1691,24 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testPredicateSearchKeyIgnoresFieldNames() {
+        GetRemoteFilesParams leftParams = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)))
+                .setFieldNames(Lists.newArrayList("c1"))
+                .build();
+        GetRemoteFilesParams rightParams = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)))
+                .setFieldNames(Lists.newArrayList("c2"))
+                .build();
+
+        PredicateSearchKey leftKey = PredicateSearchKey.of("db", "table", leftParams);
+        PredicateSearchKey rightKey = PredicateSearchKey.of("db", "table", rightParams);
+
+        Assertions.assertEquals(leftKey, rightKey);
+        Assertions.assertEquals(leftKey.hashCode(), rightKey.hashCode());
+    }
+
+    @Test
     public void testListPartitionNames() {
         mockedNativeTableB.newAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).appendFile(FILE_B_3).commit();
         new MockUp<IcebergHiveCatalog>() {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -10,6 +10,7 @@ import com.starrocks.connector.CatalogConnectorMetadata;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -1747,5 +1748,66 @@ public class IcebergScanNodeTest {
         AwsCloudCredential credential = awsConfig.getAwsCloudCredential();
         Assertions.assertEquals("AKIA_SINK_WRAPPED", credential.getAccessKey());
         Assertions.assertEquals("secret_sink_wrapped", credential.getSecretKey());
+    }
+
+    @Test
+    public void testSetupScanRangeLocationsPassesColumnNames(@Mocked GlobalStateMgr globalStateMgr,
+                                                               @Mocked MetadataMgr metadataMgr,
+                                                               @Mocked IcebergTable table,
+                                                               @Mocked Table nativeTable) throws Exception {
+        final GetRemoteFilesParams[] capturedParams = new GetRemoteFilesParams[1];
+        Schema nativeSchema = new Schema(
+                Types.NestedField.optional(1, "event_ts", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "src_ip4", Types.IntegerType.get()));
+
+        new Expectations() {{
+            table.getCatalogName(); result = "iceberg_catalog"; minTimes = 0;
+            table.getCatalogDBName(); result = "test_db"; minTimes = 0;
+            table.getCatalogTableName(); result = "test_tbl"; minTimes = 0;
+            table.getNativeTable(); result = nativeTable; minTimes = 0;
+            nativeTable.schema(); result = nativeSchema; minTimes = 0;
+            globalStateMgr.getMetadataMgr(); result = metadataMgr; minTimes = 0;
+            metadataMgr.getRemoteFiles((com.starrocks.catalog.Table) any, (GetRemoteFilesParams) any);
+            result = new mockit.Delegate() {
+                List<RemoteFileInfo> getRemoteFiles(com.starrocks.catalog.Table tbl,
+                                                     GetRemoteFilesParams params) {
+                    capturedParams[0] = params;
+                    return Collections.emptyList();
+                }
+            };
+            minTimes = 0;
+        }};
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+
+        SlotDescriptor slot1 = new SlotDescriptor(new SlotId(1), "event_ts", IntegerType.INT, true);
+        slot1.setColumn(new Column("event_ts", IntegerType.INT));
+        slot1.setIsMaterialized(true);
+        SlotDescriptor slot2 = new SlotDescriptor(new SlotId(2), "src_ip4", IntegerType.INT, true);
+        slot2.setColumn(new Column("src_ip4", IntegerType.INT));
+        slot2.setIsMaterialized(true);
+        SlotDescriptor hiddenSlot = new SlotDescriptor(new SlotId(3), IcebergTable.FILE_PATH, IntegerType.INT, true);
+        hiddenSlot.setColumn(new Column(IcebergTable.FILE_PATH, IntegerType.INT));
+        hiddenSlot.setIsMaterialized(true);
+        desc.addSlot(slot1);
+        desc.addSlot(slot2);
+        desc.addSlot(hiddenSlot);
+
+        IcebergScanNode scanNode = new IcebergScanNode(
+                new PlanNodeId(0), desc, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, null);
+
+        scanNode.setTvrVersionRange(TvrTableSnapshot.of(Optional.of(12345L)));
+        scanNode.setScanOptimizeOption(new ScanOptimizeOption());
+
+        scanNode.setupScanRangeLocations(false);
+
+        Assertions.assertNotNull(capturedParams[0], "params should have been captured");
+        List<String> fieldNames = capturedParams[0].getFieldNames();
+        Assertions.assertNotNull(fieldNames, "fieldNames should not be null");
+        Assertions.assertEquals(2, fieldNames.size());
+        Assertions.assertEquals("event_ts", fieldNames.get(0));
+        Assertions.assertEquals("src_ip4", fieldNames.get(1));
     }
 }

--- a/test/sql/test_iceberg/R/test_iceberg_column_projection
+++ b/test/sql/test_iceberg/R/test_iceberg_column_projection
@@ -1,0 +1,109 @@
+-- name: test_iceberg_column_projection
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set enable_profile = true;
+-- result:
+-- !result
+set enable_async_profile = false;
+-- result:
+-- !result
+create external table t_col_proj (c1 int, c2 string, c3 bigint, c4 string);
+-- result:
+-- !result
+INSERT INTO t_col_proj VALUES (1, 'a', 100, 'b'), (2, 'c', 200, 'd'), (3, 'e', 300, 'f');
+-- result:
+-- !result
+select c1 from t_col_proj order by c1;
+-- result:
+1
+2
+3
+-- !result
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+-- result:
+projectedFieldNames=[c1]
+-- !result
+select c1, c3 from t_col_proj order by c1;
+-- result:
+1	100
+2	200
+3	300
+-- !result
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+-- result:
+projectedFieldNames=[c1, c3]
+-- !result
+select c1, c2, c3, c4 from t_col_proj order by c1;
+-- result:
+1	a	100	b
+2	c	200	d
+3	e	300	f
+-- !result
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+-- result:
+projectedFieldNames=[c1, c2, c3, c4]
+-- !result
+select c4 from t_col_proj order by c4;
+-- result:
+b
+d
+f
+-- !result
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+-- result:
+projectedFieldNames=[c4]
+-- !result
+select c2, c4 from t_col_proj order by c2;
+-- result:
+a	b
+c	d
+e	f
+-- !result
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+-- result:
+projectedFieldNames=[c2, c4]
+-- !result
+select c1 from t_col_proj where c3 > 0 order by c1;
+-- result:
+1
+2
+3
+-- !result
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+-- result:
+projectedFieldNames=[c1, c3]
+-- !result
+drop table t_col_proj force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_column_projection
+++ b/test/sql/test_iceberg/T/test_iceberg_column_projection
@@ -1,0 +1,67 @@
+-- name: test_iceberg_column_projection
+-- description: Verify Iceberg TableScan .select() produces accurate projectedFieldNames per query
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+set catalog iceberg_sql_test_${uuid0};
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+set enable_profile = true;
+set enable_async_profile = false;
+
+create external table t_col_proj (c1 int, c2 string, c3 bigint, c4 string);
+INSERT INTO t_col_proj VALUES (1, 'a', 100, 'b'), (2, 'c', 200, 'd'), (3, 'e', 300, 'f');
+
+-- ============================================================
+-- Case 1: SELECT c1 only
+-- ============================================================
+select c1 from t_col_proj order by c1;
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+
+-- ============================================================
+-- Case 2: SELECT c1, c3
+-- ============================================================
+select c1, c3 from t_col_proj order by c1;
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+
+-- ============================================================
+-- Case 3: SELECT c1, c2, c3, c4 (all columns)
+-- ============================================================
+select c1, c2, c3, c4 from t_col_proj order by c1;
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+
+-- ============================================================
+-- Case 4: SELECT c4 only
+-- ============================================================
+select c4 from t_col_proj order by c4;
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+
+-- ============================================================
+-- Case 5: SELECT c2, c4
+-- ============================================================
+select c2, c4 from t_col_proj order by c2;
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+
+-- ============================================================
+-- Case 6: predicate column included
+-- ============================================================
+select c1 from t_col_proj where c3 > 0 order by c1;
+select distinct regexp_extract(line, '(projectedFieldNames=\\[[^]]+\\])', 1)
+from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v
+where v.line like '%projectedFieldNames=%';
+
+drop table t_col_proj force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
Iceberg scan metrics currently report all table columns as projected, even when the query only needs a subset of columns. This is misleading in EXPLAIN/profile output and can cause users to suspect unnecessary full-column reads, although BE column pruning already works correctly.

## What I'm doing:
Pass the required Iceberg native column names into `TableScan.select()` so Iceberg scan metrics report the actual projected columns.

The Iceberg change is mainly an observability fix:

```text
StarRocks pruned slots
        |
        v
Iceberg native column names only
        |
        v
TableScan.select(...)
        |
        v
Accurate projected columns in scan metrics
```

This does not change BE Parquet column pruning behavior.

## Cache and correctness concerns:
This change does not affect the cached data file list or column statistics.

Iceberg file planning is still driven by the table snapshot and predicate. The projected columns passed to `TableScan.select()` only affect the scan projection metadata reported by Iceberg, not which data files match the predicate.

Column stats are also safe: manifest stats are stored in `DataFile` metadata and are not reduced by this projection. BE column reads continue to be controlled by StarRocks tuple/slot descriptors.

So the practical impact of this change is limited to more accurate Iceberg scan report metrics, especially `projectedFieldIds/projectedFieldNames`. It does not change BE data reads or introduce a correctness dependency on projection-specific split cache entries.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
