### PR TITLE
[Enhancement] Add refresh/placement observability columns to information_schema.materialized_views

### DIFF
--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -54,6 +54,11 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
         {"LAST_REFRESH_PROCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"LAST_REFRESH_JOB_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"LAST_REFRESH_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"WAREHOUSE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"REFRESH_MODE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"REFRESH_TRIGGER", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"REFRESH_POLICY", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"RESOURCE_GROUP", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -436,6 +441,61 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
                 } else {
                     fill_column_with_slot<TYPE_DATETIME>(column, (void*)&t);
                 }
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 29: {
+            // WAREHOUSE
+            if (info.__isset.warehouse) {
+                const std::string* str = &info.warehouse;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 30: {
+            // REFRESH_MODE
+            if (info.__isset.refresh_mode) {
+                const std::string* str = &info.refresh_mode;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 31: {
+            // REFRESH_TRIGGER
+            if (info.__isset.refresh_trigger) {
+                const std::string* str = &info.refresh_trigger;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 32: {
+            // REFRESH_POLICY
+            if (info.__isset.refresh_policy) {
+                const std::string* str = &info.refresh_policy;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 33: {
+            // RESOURCE_GROUP
+            if (info.__isset.resource_group) {
+                const std::string* str = &info.resource_group;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
             } else {
                 fill_data_column_with_null(column);
             }

--- a/be/test/exec/schema_materialized_views_scanner_test.cpp
+++ b/be/test/exec/schema_materialized_views_scanner_test.cpp
@@ -54,7 +54,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_scanner_initialization) {
 
     // Test that scanner has the correct number of columns
     auto slot_descs = scanner.get_slot_descs();
-    EXPECT_EQ(28, slot_descs.size());
+    EXPECT_EQ(33, slot_descs.size());
 
     // Test column names and types
     EXPECT_EQ("MATERIALIZED_VIEW_ID", slot_descs[0]->col_name());
@@ -85,6 +85,11 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_scanner_initialization) {
     EXPECT_EQ("LAST_REFRESH_PROCESS_TIME", slot_descs[25]->col_name());
     EXPECT_EQ("LAST_REFRESH_JOB_ID", slot_descs[26]->col_name());
     EXPECT_EQ("LAST_REFRESH_TIME", slot_descs[27]->col_name());
+    EXPECT_EQ("WAREHOUSE", slot_descs[28]->col_name());
+    EXPECT_EQ("REFRESH_MODE", slot_descs[29]->col_name());
+    EXPECT_EQ("REFRESH_TRIGGER", slot_descs[30]->col_name());
+    EXPECT_EQ("REFRESH_POLICY", slot_descs[31]->col_name());
+    EXPECT_EQ("RESOURCE_GROUP", slot_descs[32]->col_name());
 }
 
 TEST_F(SchemaMaterializedViewsScannerTest, test_uninitialized_scanner) {

--- a/docs/en/sql-reference/information_schema/materialized_views.md
+++ b/docs/en/sql-reference/information_schema/materialized_views.md
@@ -14,7 +14,7 @@ The following fields are provided in `materialized_views`:
 | MATERIALIZED_VIEW_ID                 | ID of the materialized view.                                 |
 | TABLE_SCHEMA                         | Database in which the materialized view resides.             |
 | TABLE_NAME                           | Name of the materialized view.                               |
-| REFRESH_TYPE                         | Refresh type of the materialized view. Valid values: `ROLLUP` (synchronous materialized view), `ASYNC` (asynchronous refresh materialized view), and `MANUAL` (manual refresh materialized view). When the value is `ROLLUP`, all fields related to activation status and refresh are empry.  |
+| REFRESH_TYPE                         | Refresh type of the materialized view. Valid values: `SYNC` (synchronous materialized view) and `ASYNC` (asynchronous materialized view, regardless of how the refresh is triggered). When the value is `SYNC`, all fields related to activation status and refresh are empty. See `REFRESH_TRIGGER` and `REFRESH_POLICY` for how an asynchronous materialized view is refreshed.  |
 | IS_ACTIVE                            | Indicates whether the materialized view is active. Inactive materialized views cannot be refreshed or queried. |
 | INACTIVE_REASON                      | The reason that the materialized view is inactive.           |
 | PARTITION_TYPE                       | Type of partitioning strategy for the materialized view.     |
@@ -39,3 +39,8 @@ The following fields are provided in `materialized_views`:
 | LAST_REFRESH_PROCESS_TIME            | Process time of the most recent refresh task.                |
 | LAST_REFRESH_JOB_ID                  | Job ID of the most recent refresh task.                      |
 | LAST_REFRESH_TIME                    | Time up to which base table updates are reflected in the materialized view. |
+| WAREHOUSE                            | Name of the warehouse that the asynchronous materialized view uses for its refresh tasks. Empty in shared-nothing mode, or for synchronous (rollup) materialized views. |
+| REFRESH_MODE                         | Configured refresh mode of the asynchronous materialized view. Valid values: `PCT` (partition change tracking, where only changed partitions are refreshed), `INCREMENTAL` (incremental view maintenance), and `AUTO`. Empty for synchronous materialized views. |
+| REFRESH_TRIGGER                      | How a refresh is triggered. Valid values: `NONE` (synchronous materialized view), `MANUAL` (only via REFRESH MATERIALIZED VIEW), `SCHEDULED` (periodic, via an EVERY interval), and `ON_BASE_TABLE_CHANGE` (automatically when a base table loads or changes). |
+| REFRESH_POLICY                       | Human-readable refresh policy. Valid values: `NONE`, `MANUAL`, `ON_BASE_TABLE_CHANGE`, or a schedule such as `START("yyyy-MM-dd HH:mm:ss") EVERY(INTERVAL n unit)` (the `START` clause is present only if a start time was defined). |
+| RESOURCE_GROUP                       | Resource group used for the materialized view's refresh tasks (from the materialized view's `resource_group` property). Defaults to `default_mv_wg` when not set. |

--- a/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -46,7 +46,7 @@ Since v3.3, `SHOW MATERIALIZED VIEWS` command will track the state of all task_r
 | id                         | The ID of the materialized view.                             |
 | database_name              | The name of the database in which the materialized view resides. |
 | name                       | The name of the materialized view.                           |
-| refresh_type               | The refresh type of the materialized view, including ROLLUP, MANUAL, ASYNC, and INCREMENTAL. |
+| refresh_type               | The refresh type of the materialized view. Valid values: `SYNC` (synchronous materialized view) and `ASYNC` (asynchronous materialized view, regardless of how the refresh is triggered). |
 | is_active                  | Whether the materialized view state is active. Valid Value: `true` and `false`. |
 | inactive_reason            | The reason why the materialized view is inactive.            |
 | partition_type             | The partition type of the materialized view, including RANGE and UNPARTITIONED.                |
@@ -71,6 +71,11 @@ Since v3.3, `SHOW MATERIALIZED VIEWS` command will track the state of all task_r
 | last_refresh_process_time  | The process start time of the latest refresh task.           |
 | last_refresh_job_id        | Job ID of the latest refresh task.                           |
 | last_refresh_time          | Time up to which base table updates are reflected in the materialized view. |
+| warehouse                  | Name of the warehouse that the asynchronous materialized view uses for its refresh tasks. Empty in shared-nothing mode, or for synchronous (rollup) materialized views. |
+| refresh_mode               | Configured refresh mode of the asynchronous materialized view. Valid values: `PCT` (partition change tracking, where only changed partitions are refreshed), `INCREMENTAL` (incremental view maintenance), and `AUTO`. Empty for synchronous materialized views. |
+| refresh_trigger            | How a refresh is triggered. Valid values: `NONE` (synchronous materialized view), `MANUAL` (only via REFRESH MATERIALIZED VIEW), `SCHEDULED` (periodic, via an EVERY interval), and `ON_BASE_TABLE_CHANGE` (automatically when a base table loads or changes). |
+| refresh_policy             | Human-readable refresh policy. Valid values: `NONE`, `MANUAL`, `ON_BASE_TABLE_CHANGE`, or a schedule such as `START("yyyy-MM-dd HH:mm:ss") EVERY(INTERVAL n unit)` (the `START` clause is present only if a start time was defined). |
+| resource_group             | Resource group used for the materialized view's refresh tasks (from the materialized view's `resource_group` property). Defaults to `default_mv_wg` when not set. |
 
 ## Examples
 
@@ -121,7 +126,7 @@ mysql> SHOW MATERIALIZED VIEWS WHERE NAME='customer_mv'\G
                         id: 10142
                       name: customer_mv
              database_name: test
-              refresh_type: MANUAL
+              refresh_type: ASYNC
                  is_active: true
    last_refresh_start_time: 2023-02-17 10:27:33
 last_refresh_finished_time: 2023-02-17 10:27:33
@@ -141,6 +146,11 @@ AS SELECT `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`, 
 FROM `test`.`customer`
 GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
                       rows: 0
+                 warehouse:
+              refresh_mode: PCT
+           refresh_trigger: MANUAL
+            refresh_policy: MANUAL
+            resource_group: default_mv_wg
 1 row in set (0.11 sec)
 ```
 
@@ -152,7 +162,7 @@ mysql> SHOW MATERIALIZED VIEWS WHERE NAME LIKE 'customer_mv'\G
                         id: 10142
                       name: customer_mv
              database_name: test
-              refresh_type: MANUAL
+              refresh_type: ASYNC
                  is_active: true
    last_refresh_start_time: 2023-02-17 10:27:33
 last_refresh_finished_time: 2023-02-17 10:27:33
@@ -172,5 +182,10 @@ AS SELECT `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`, 
 FROM `test`.`customer`
 GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
                       rows: 0
+                 warehouse:
+              refresh_mode: PCT
+           refresh_trigger: MANUAL
+            refresh_policy: MANUAL
+            resource_group: default_mv_wg
 1 row in set (0.12 sec)
 ```

--- a/docs/ja/sql-reference/information_schema/materialized_views.md
+++ b/docs/ja/sql-reference/information_schema/materialized_views.md
@@ -13,7 +13,7 @@ displayed_sidebar: docs
 | MATERIALIZED_VIEW_ID                 | マテリアライズドビューの ID。                                |
 | TABLE_SCHEMA                         | マテリアライズドビューが存在するデータベース。               |
 | TABLE_NAME                           | マテリアライズドビューの名前。                               |
-| REFRESH_TYPE                         | マテリアライズドビューのリフレッシュタイプ。 有効な値: `ROLLUP` (同期マテリアライズドビュー), `ASYNC` (非同期リフレッシュマテリアライズドビュー), および `MANUAL` (手動リフレッシュマテリアライズドビュー)。値が `ROLLUP` の場合、アクティベーションステータスとリフレッシュに関連するすべてのフィールドは空です。 |
+| REFRESH_TYPE                         | マテリアライズドビューのリフレッシュタイプ。有効な値: `SYNC` (同期マテリアライズドビュー) および `ASYNC` (非同期マテリアライズドビュー。リフレッシュのトリガー方法に関係なく)。値が `SYNC` の場合、アクティベーションステータスとリフレッシュに関連するすべてのフィールドは空です。非同期マテリアライズドビューのリフレッシュ方法については `REFRESH_TRIGGER` と `REFRESH_POLICY` を参照してください。 |
 | IS_ACTIVE                            | マテリアライズドビューがアクティブかどうかを示します。 非アクティブなマテリアライズドビューはリフレッシュまたはクエリできません。 |
 | INACTIVE_REASON                      | マテリアライズドビューが非アクティブである理由。             |
 | PARTITION_TYPE                       | マテリアライズドビューのパーティショニング戦略のタイプ。     |
@@ -32,3 +32,14 @@ displayed_sidebar: docs
 | LAST_REFRESH_ERROR_MESSAGE           | 最新のリフレッシュタスクのエラーメッセージ。                 |
 | TABLE_ROWS                           | マテリアライズドビュー内のデータ行数（おおよそのバックグラウンド統計に基づく）。 |
 | MATERIALIZED_VIEW_DEFINITION         | マテリアライズドビューの SQL 定義。                          |
+| EXTRA_MESSAGE                        | マテリアライズドビューの追加メッセージ。                     |
+| QUERY_REWRITE_STATUS                 | マテリアライズドビューのクエリリライトステータス。           |
+| CREATOR                              | マテリアライズドビューの作成者。                             |
+| LAST_REFRESH_PROCESS_TIME            | 最新のリフレッシュタスクの処理時間。                         |
+| LAST_REFRESH_JOB_ID                  | 最新のリフレッシュタスクのジョブ ID。                        |
+| LAST_REFRESH_TIME                    | ベーステーブルの更新がマテリアライズドビューに反映されている最新の時間。 |
+| WAREHOUSE                            | 非同期マテリアライズドビューがリフレッシュタスクに使用するウェアハウスの名前。ストレージ・コンピュート一体型モードの場合、または同期 (rollup) マテリアライズドビューの場合は空です。 |
+| REFRESH_MODE                         | 非同期マテリアライズドビューに設定されたリフレッシュモード。有効な値: `PCT` (パーティション変更追跡。変更されたパーティションのみをリフレッシュ)、`INCREMENTAL` (インクリメンタルビューメンテナンス)、`AUTO`。同期マテリアライズドビューの場合は空です。 |
+| REFRESH_TRIGGER                      | リフレッシュがトリガーされる方法。有効な値: `NONE` (同期マテリアライズドビュー)、`MANUAL` (REFRESH MATERIALIZED VIEW 経由のみ)、`SCHEDULED` (EVERY 間隔による定期実行)、`ON_BASE_TABLE_CHANGE` (ベーステーブルのロードまたは変更時に自動実行)。 |
+| REFRESH_POLICY                       | 人間が読めるリフレッシュポリシー。有効な値: `NONE`、`MANUAL`、`ON_BASE_TABLE_CHANGE`、または `START("yyyy-MM-dd HH:mm:ss") EVERY(INTERVAL n unit)` のようなスケジュール (`START` 句は開始時刻が定義されている場合にのみ含まれます)。 |
+| RESOURCE_GROUP                       | マテリアライズドビューのリフレッシュタスクに使用されるリソースグループ (マテリアライズドビューの `resource_group` プロパティから)。設定されていない場合は `default_mv_wg` がデフォルトです。 |

--- a/docs/ja/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/ja/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -47,7 +47,7 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | id                         | マテリアライズドビューのID。                             |
 | database_name              | マテリアライズドビューが存在するデータベースの名前。 |
 | name                       | マテリアライズドビューの名前。                           |
-| refresh_type               | マテリアライズドビューのリフレッシュタイプ。ROLLUP、MANUAL、ASYNC、INCREMENTAL などがあります。 |
+| refresh_type               | マテリアライズドビューのリフレッシュタイプ。有効な値: `SYNC` (同期マテリアライズドビュー) および `ASYNC` (非同期マテリアライズドビュー。リフレッシュのトリガー方法に関係なく)。 |
 | is_active                  | マテリアライズドビューの状態がアクティブかどうか。 有効な値: `true` と `false`。 |
 | partition_type             | マテリアライズドビューのパーティションタイプ。RANGE と UNPARTITIONED があります。                |
 | task_id                    | マテリアライズドビューのリフレッシュタスクのID。                  |
@@ -65,6 +65,17 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | last_refresh_error_message | マテリアライズドビューの最後のリフレッシュが失敗した理由（マテリアライズドビューの状態がアクティブでない場合）。 |
 | rows                       | マテリアライズドビューのデータ行数。            |
 | text                       | マテリアライズドビューを作成するために使用されたステートメント。          |
+| extra_message              | 最新のリフレッシュタスクに関する追加情報。                   |
+| query_rewrite_status       | マテリアライズドビューのクエリリライトステータス。           |
+| creator                    | マテリアライズドビューのリフレッシュタスクの作成者。         |
+| last_refresh_process_time  | 最新のリフレッシュタスクの処理開始時間。                     |
+| last_refresh_job_id        | 最新のリフレッシュタスクのジョブ ID。                        |
+| last_refresh_time          | ベーステーブルの更新がマテリアライズドビューに反映されている最新の時間。 |
+| warehouse                  | 非同期マテリアライズドビューがリフレッシュタスクに使用するウェアハウスの名前。ストレージ・コンピュート一体型モードの場合、または同期 (rollup) マテリアライズドビューの場合は空です。 |
+| refresh_mode               | 非同期マテリアライズドビューに設定されたリフレッシュモード。有効な値: `PCT` (パーティション変更追跡。変更されたパーティションのみをリフレッシュ)、`INCREMENTAL` (インクリメンタルビューメンテナンス)、`AUTO`。同期マテリアライズドビューの場合は空です。 |
+| refresh_trigger            | リフレッシュがトリガーされる方法。有効な値: `NONE` (同期マテリアライズドビュー)、`MANUAL` (REFRESH MATERIALIZED VIEW 経由のみ)、`SCHEDULED` (EVERY 間隔による定期実行)、`ON_BASE_TABLE_CHANGE` (ベーステーブルのロードまたは変更時に自動実行)。 |
+| refresh_policy             | 人間が読めるリフレッシュポリシー。有効な値: `NONE`、`MANUAL`、`ON_BASE_TABLE_CHANGE`、または `START("yyyy-MM-dd HH:mm:ss") EVERY(INTERVAL n unit)` のようなスケジュール (`START` 句は開始時刻が定義されている場合にのみ含まれます)。 |
+| resource_group             | マテリアライズドビューのリフレッシュタスクに使用されるリソースグループ (マテリアライズドビューの `resource_group` プロパティから)。設定されていない場合は `default_mv_wg` がデフォルトです。 |
 
 ## 例
 
@@ -115,7 +126,7 @@ mysql> SHOW MATERIALIZED VIEWS WHERE NAME='customer_mv'\G
                         id: 10142
                       name: customer_mv
              database_name: test
-              refresh_type: MANUAL
+              refresh_type: ASYNC
                  is_active: true
    last_refresh_start_time: 2023-02-17 10:27:33
 last_refresh_finished_time: 2023-02-17 10:27:33
@@ -135,6 +146,11 @@ AS SELECT `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`, 
 FROM `test`.`customer`
 GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
                       rows: 0
+                 warehouse:
+              refresh_mode: PCT
+           refresh_trigger: MANUAL
+            refresh_policy: MANUAL
+            resource_group: default_mv_wg
 1 row in set (0.11 sec)
 ```
 
@@ -146,7 +162,7 @@ mysql> SHOW MATERIALIZED VIEWS WHERE NAME LIKE 'customer_mv'\G
                         id: 10142
                       name: customer_mv
              database_name: test
-              refresh_type: MANUAL
+              refresh_type: ASYNC
                  is_active: true
    last_refresh_start_time: 2023-02-17 10:27:33
 last_refresh_finished_time: 2023-02-17 10:27:33
@@ -166,5 +182,10 @@ AS SELECT `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`, 
 FROM `test`.`customer`
 GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
                       rows: 0
+                 warehouse:
+              refresh_mode: PCT
+           refresh_trigger: MANUAL
+            refresh_policy: MANUAL
+            resource_group: default_mv_wg
 1 row in set (0.12 sec)
 ```

--- a/docs/zh/sql-reference/information_schema/materialized_views.md
+++ b/docs/zh/sql-reference/information_schema/materialized_views.md
@@ -13,7 +13,7 @@ displayed_sidebar: docs
 | MATERIALIZED_VIEW_ID                 | 物化视图 ID。                                    |
 | TABLE_SCHEMA                         | 物化视图所在的数据库名称。                       |
 | TABLE_NAME                           | 物化视图名称。                                   |
-| REFRESH_TYPE                         | 物化视图（刷新）类型，包括 `ROLLUP`（同步物化视图）、`ASYNC`（异步刷新物化视图）以及 `MANUAL`（手动刷新物化视图）。当此值为 `ROLLUP` 时，以下生效状态和刷新相关的字段为空。 |
+| REFRESH_TYPE                         | 物化视图（刷新）类型，有效值：`SYNC`（同步物化视图）和 `ASYNC`（异步物化视图，无论以何种方式触发刷新）。当此值为 `SYNC` 时，以下生效状态和刷新相关的字段为空。异步物化视图的刷新方式请参见 `REFRESH_TRIGGER` 和 `REFRESH_POLICY`。 |
 | IS_ACTIVE                            | 是否生效，失效的物化视图不会被刷新和查询改写。   |
 | INACTIVE_REASON                      | 失效的原因。                                     |
 | PARTITION_TYPE                       | 物化视图分区类型。                               |
@@ -38,3 +38,8 @@ displayed_sidebar: docs
 | LAST_REFRESH_PROCESS_TIME            | 最近一次刷新任务的处理时间。                     |
 | LAST_REFRESH_JOB_ID                  | 最近一次刷新任务的作业 ID。                      |
 | LAST_REFRESH_TIME                    | 物化视图已反映基表更新的最新时间。               |
+| WAREHOUSE                            | 异步物化视图执行刷新任务所使用的 warehouse 名称。在存算一体模式下，或对于同步（rollup）物化视图，该值为空。 |
+| REFRESH_MODE                         | 异步物化视图配置的刷新模式。有效值：`PCT`（分区变更跟踪，仅刷新发生变更的分区）、`INCREMENTAL`（增量视图维护）和 `AUTO`。对于同步物化视图为空。 |
+| REFRESH_TRIGGER                      | 刷新的触发方式。有效值：`NONE`（同步物化视图）、`MANUAL`（仅通过 REFRESH MATERIALIZED VIEW 触发）、`SCHEDULED`（周期性触发，通过 EVERY 间隔）和 `ON_BASE_TABLE_CHANGE`（基表导入或变更时自动触发）。 |
+| REFRESH_POLICY                       | 可读的刷新策略。有效值：`NONE`、`MANUAL`、`ON_BASE_TABLE_CHANGE`，或形如 `START("yyyy-MM-dd HH:mm:ss") EVERY(INTERVAL n unit)` 的调度（仅当定义了起始时间时才包含 `START` 子句）。 |
+| RESOURCE_GROUP                       | 物化视图刷新任务所使用的资源组（来自物化视图的 `resource_group` 属性）。未设置时默认为 `default_mv_wg`。 |

--- a/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -46,7 +46,7 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | id                         | 物化视图 ID。                                               |
 | database_name              | 物化视图所属的数据库名称。                                     |
 | name                       | 物化视图名称。                                               |
-| refresh_type               | 物化视图的更新方式，包括 ROLLUP、MANUAL、ASYNC、INCREMENTAL。   |
+| refresh_type               | 物化视图的更新方式，有效值：`SYNC`（同步物化视图）和 `ASYNC`（异步物化视图，无论以何种方式触发刷新）。   |
 | is_active                  | 物化视图状态是否为 active。有效值：`true` 和 `false`。          |
 | inactive_reason            | 物化视图失效的原因。                                          |
 | partition_type             | 物化视图的分区类型，包括 RANGE 和 UNPARTITIONED。|
@@ -71,6 +71,11 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | last_refresh_process_time  | 最近一次刷新任务的处理开始时间。                                |
 | last_refresh_job_id        | 最近一次刷新任务的作业 ID。                                     |
 | last_refresh_time          | 物化视图已反映基表更新的最新时间。                              |
+| warehouse                  | 异步物化视图执行刷新任务所使用的 warehouse 名称。在存算一体模式下，或对于同步（rollup）物化视图，该值为空。 |
+| refresh_mode               | 异步物化视图配置的刷新模式。有效值：`PCT`（分区变更跟踪，仅刷新发生变更的分区）、`INCREMENTAL`（增量视图维护）和 `AUTO`。对于同步物化视图为空。 |
+| refresh_trigger            | 刷新的触发方式。有效值：`NONE`（同步物化视图）、`MANUAL`（仅通过 REFRESH MATERIALIZED VIEW 触发）、`SCHEDULED`（周期性触发，通过 EVERY 间隔）和 `ON_BASE_TABLE_CHANGE`（基表导入或变更时自动触发）。 |
+| refresh_policy             | 可读的刷新策略。有效值：`NONE`、`MANUAL`、`ON_BASE_TABLE_CHANGE`，或形如 `START("yyyy-MM-dd HH:mm:ss") EVERY(INTERVAL n unit)` 的调度（仅当定义了起始时间时才包含 `START` 子句）。 |
+| resource_group             | 物化视图刷新任务所使用的资源组（来自物化视图的 `resource_group` 属性）。未设置时默认为 `default_mv_wg`。 |
 
 ## 示例
 
@@ -121,7 +126,7 @@ mysql> show materialized views  where name='customer_mv'\G
                         id: 10142
                       name: customer_mv
              database_name: test
-              refresh_type: MANUAL
+              refresh_type: ASYNC
                  is_active: true
    last_refresh_start_time: 2023-02-17 10:27:33
 last_refresh_finished_time: 2023-02-17 10:27:33
@@ -141,6 +146,11 @@ AS SELECT `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`, 
 FROM `test`.`customer`
 GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
                       rows: 0
+                 warehouse:
+              refresh_mode: PCT
+           refresh_trigger: MANUAL
+            refresh_policy: MANUAL
+            resource_group: default_mv_wg
 1 row in set (0.11 sec)
 ```
 
@@ -152,7 +162,7 @@ mysql> show materialized views  where name like 'customer_mv'\G
                         id: 10142
                       name: customer_mv
              database_name: test
-              refresh_type: MANUAL
+              refresh_type: ASYNC
                  is_active: true
    last_refresh_start_time: 2023-02-17 10:27:33
 last_refresh_finished_time: 2023-02-17 10:27:33
@@ -172,6 +182,11 @@ AS SELECT `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`, 
 FROM `test`.`customer`
 GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
                       rows: 0
+                 warehouse:
+              refresh_mode: PCT
+           refresh_trigger: MANUAL
+            refresh_policy: MANUAL
+            resource_group: default_mv_wg
 1 row in set (0.12 sec)
 
 ```

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1721,6 +1721,57 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 asyncRefreshContext.step == 0 && null == asyncRefreshContext.timeUnit;
     }
 
+    public String getRefreshTriggerString() {
+        if (refreshScheme == null) {
+            return "NONE";
+        }
+        MaterializedViewRefreshType type = refreshScheme.getType();
+        if (type == MaterializedViewRefreshType.SYNC) {
+            return "NONE";
+        }
+        if (type == MaterializedViewRefreshType.MANUAL) {
+            return "MANUAL";
+        }
+        return isLoadTriggeredRefresh() ? "ON_BASE_TABLE_CHANGE" : "SCHEDULED";
+    }
+
+    public String getRefreshPolicyString() {
+        if (refreshScheme == null) {
+            return "NONE";
+        }
+        MaterializedViewRefreshType type = refreshScheme.getType();
+        if (type == MaterializedViewRefreshType.SYNC) {
+            return "NONE";
+        }
+        if (type == MaterializedViewRefreshType.MANUAL) {
+            return "MANUAL";
+        }
+        if (isLoadTriggeredRefresh()) {
+            return "ON_BASE_TABLE_CHANGE";
+        }
+        StringBuilder sb = new StringBuilder();
+        appendAsyncRefreshSchedule(sb, refreshScheme.getAsyncRefreshContext());
+        return sb.toString().trim();
+    }
+
+    private void appendAsyncRefreshSchedule(StringBuilder sb, AsyncRefreshContext asyncRefreshContext) {
+        if (asyncRefreshContext.isDefineStartTime()) {
+            sb.append(" START(\"").append(Utils.getDatetimeFromLong(asyncRefreshContext.getStartTime())
+                            .format(DateUtils.DATE_TIME_FORMATTER))
+                    .append("\")");
+        }
+        if (asyncRefreshContext.getTimeUnit() != null) {
+            sb.append(" EVERY(INTERVAL ").append(asyncRefreshContext.getStep()).append(" ")
+                    .append(asyncRefreshContext.getTimeUnit()).append(")");
+        }
+    }
+
+    public String getResourceGroupString() {
+        TableProperty tableProperty = getTableProperty();
+        String resourceGroup = tableProperty == null ? null : tableProperty.getResourceGroup();
+        return Strings.isNullOrEmpty(resourceGroup) ? ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME : resourceGroup;
+    }
+
     /**
      * Return the partition refresh strategy of the materialized view.
      */
@@ -1911,16 +1962,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             }
         }
         if (refreshScheme != null && refreshScheme.getType() == MaterializedViewRefreshType.ASYNC) {
-            AsyncRefreshContext asyncRefreshContext = refreshScheme.getAsyncRefreshContext();
-            if (asyncRefreshContext.isDefineStartTime()) {
-                sb.append(" START(\"").append(Utils.getDatetimeFromLong(asyncRefreshContext.getStartTime())
-                                .format(DateUtils.DATE_TIME_FORMATTER))
-                        .append("\")");
-            }
-            if (asyncRefreshContext.getTimeUnit() != null) {
-                sb.append(" EVERY(INTERVAL ").append(asyncRefreshContext.getStep()).append(" ")
-                        .append(asyncRefreshContext.getTimeUnit()).append(")");
-            }
+            appendAsyncRefreshSchedule(sb, refreshScheme.getAsyncRefreshContext());
         }
 
         // properties

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -107,6 +107,11 @@ public class MaterializedViewsSystemTable extends SystemTable {
                         .column("LAST_REFRESH_PROCESS_TIME", DateType.DATETIME)
                         .column("LAST_REFRESH_JOB_ID", TypeFactory.createVarcharType(64))
                         .column("LAST_REFRESH_TIME", DateType.DATETIME)
+                        .column("WAREHOUSE", TypeFactory.createVarcharType(128))
+                        .column("REFRESH_MODE", TypeFactory.createVarcharType(16))
+                        .column("REFRESH_TRIGGER", TypeFactory.createVarcharType(24))
+                        .column("REFRESH_POLICY", TypeFactory.createVarcharType(256))
+                        .column("RESOURCE_GROUP", TypeFactory.createVarcharType(128))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -24,9 +24,11 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
@@ -39,6 +41,7 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.thrift.TMaterializedViewStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +78,11 @@ public class ShowMaterializedViewStatus {
     private long taskId;
     private String taskName;
     private long lastRefreshTime;
+    private String warehouse;
+    private String refreshMode;
+    private String refreshTrigger;
+    private String refreshPolicy;
+    private String resourceGroup;
     private List<TaskRunStatus> lastJobTaskRunStatus;
 
     /**
@@ -332,7 +340,8 @@ public class ShowMaterializedViewStatus {
         if (refreshScheme == null) {
             status.setRefreshType("UNKNOWN");
         } else {
-            status.setRefreshType(String.valueOf(mv.getRefreshScheme().getType()));
+            MaterializedViewRefreshType type = refreshScheme.getType();
+            status.setRefreshType(type == MaterializedViewRefreshType.SYNC ? "SYNC" : "ASYNC");
         }
         // is_active
         status.setActive(mv.isActive());
@@ -357,6 +366,13 @@ public class ShowMaterializedViewStatus {
         if (refreshScheme != null) {
             status.setLastRefreshTime(refreshScheme.getLastRefreshTime());
         }
+        boolean syncRefresh = refreshScheme != null
+                && refreshScheme.getType() == MaterializedViewRefreshType.SYNC;
+        status.setWarehouse(syncRefresh || !RunMode.isSharedDataMode() ? "" : mv.getWarehouseName());
+        status.setRefreshMode(syncRefresh || mv.getRefreshMode() == null ? null : mv.getRefreshMode().name());
+        status.setRefreshTrigger(mv.getRefreshTriggerString());
+        status.setRefreshPolicy(mv.getRefreshPolicyString());
+        status.setResourceGroup(mv.getResourceGroupString());
         status.setLastJobTaskRunStatus(taskTaskStatusJob);
         return status;
     }
@@ -365,7 +381,7 @@ public class ShowMaterializedViewStatus {
         ShowMaterializedViewStatus status = new ShowMaterializedViewStatus(indexMeta.getIndexMetaId(), dbName,
                 olapTable.getIndexNameByMetaId(indexMeta.getIndexMetaId()));
         // refresh_type
-        status.setRefreshType("ROLLUP");
+        status.setRefreshType("SYNC");
         // is_active
         status.setActive(true);
         // partition type
@@ -388,6 +404,11 @@ public class ShowMaterializedViewStatus {
         } else {
             status.setRows(0L);
         }
+        status.setWarehouse("");
+        status.setRefreshMode(null);
+        status.setRefreshTrigger("NONE");
+        status.setRefreshPolicy("NONE");
+        status.setResourceGroup(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME);
         return status;
     }
 
@@ -493,6 +514,46 @@ public class ShowMaterializedViewStatus {
 
     public void setLastRefreshTime(long lastRefreshTime) {
         this.lastRefreshTime = lastRefreshTime;
+    }
+
+    public String getWarehouse() {
+        return warehouse;
+    }
+
+    public void setWarehouse(String warehouse) {
+        this.warehouse = warehouse;
+    }
+
+    public String getRefreshMode() {
+        return refreshMode;
+    }
+
+    public void setRefreshMode(String refreshMode) {
+        this.refreshMode = refreshMode;
+    }
+
+    public String getRefreshTrigger() {
+        return refreshTrigger;
+    }
+
+    public void setRefreshTrigger(String refreshTrigger) {
+        this.refreshTrigger = refreshTrigger;
+    }
+
+    public String getRefreshPolicy() {
+        return refreshPolicy;
+    }
+
+    public void setRefreshPolicy(String refreshPolicy) {
+        this.refreshPolicy = refreshPolicy;
+    }
+
+    public String getResourceGroup() {
+        return resourceGroup;
+    }
+
+    public void setResourceGroup(String resourceGroup) {
+        this.resourceGroup = resourceGroup;
     }
 
     public void setLastJobTaskRunStatus(List<TaskRunStatus> lastJobTaskRunStatus) {
@@ -674,6 +735,11 @@ public class ShowMaterializedViewStatus {
         if (lastRefreshTime > 0) {
             status.setLast_refresh_time(TimeUtils.longToTimeString(lastRefreshTime));
         }
+        status.setWarehouse(Strings.nullToEmpty(this.warehouse));
+        status.setRefresh_mode(Strings.nullToEmpty(this.refreshMode));
+        status.setRefresh_trigger(Strings.nullToEmpty(this.refreshTrigger));
+        status.setRefresh_policy(Strings.nullToEmpty(this.refreshPolicy));
+        status.setResource_group(Strings.nullToEmpty(this.resourceGroup));
 
         return status;
     }
@@ -749,6 +815,11 @@ public class ShowMaterializedViewStatus {
         addField(resultRow, refreshJobStatus.getJobId());
         // last refresh time (data version timestamp used for staleness check)
         addField(resultRow, lastRefreshTime > 0 ? TimeUtils.longToTimeString(lastRefreshTime) : "");
+        addField(resultRow, Strings.nullToEmpty(warehouse));
+        addField(resultRow, Strings.nullToEmpty(refreshMode));
+        addField(resultRow, Strings.nullToEmpty(refreshTrigger));
+        addField(resultRow, Strings.nullToEmpty(refreshPolicy));
+        addField(resultRow, Strings.nullToEmpty(resourceGroup));
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -878,6 +878,11 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
                 .column("last_refresh_process_time", DATETIME)
                 .column("last_refresh_job_id", TypeFactory.createVarcharType(64))
                 .column("last_refresh_time", DATETIME)
+                .column("warehouse", TypeFactory.createVarcharType(128))
+                .column("refresh_mode", TypeFactory.createVarcharType(16))
+                .column("refresh_trigger", TypeFactory.createVarcharType(24))
+                .column("refresh_policy", TypeFactory.createVarcharType(256))
+                .column("resource_group", TypeFactory.createVarcharType(128))
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtToSelectStmtConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtToSelectStmtConverter.java
@@ -89,7 +89,12 @@ public final class ShowStmtToSelectStmtConverter {
             "creator",
             "last_refresh_process_time",
             "last_refresh_job_id",
-            "last_refresh_time"
+            "last_refresh_time",
+            "warehouse",
+            "refresh_mode",
+            "refresh_trigger",
+            "refresh_policy",
+            "resource_group"
     );
 
     private static final Map<String, String> MATERIALIZED_VIEW_ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -125,13 +125,49 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.creator AS creator, " +
                         "information_schema.materialized_views.last_refresh_process_time AS last_refresh_process_time, " +
                         "information_schema.materialized_views.last_refresh_job_id AS last_refresh_job_id, " +
-                        "information_schema.materialized_views.last_refresh_time AS last_refresh_time" +
+                        "information_schema.materialized_views.last_refresh_time AS last_refresh_time, " +
+                        "information_schema.materialized_views.warehouse AS warehouse, " +
+                        "information_schema.materialized_views.refresh_mode AS refresh_mode, " +
+                        "information_schema.materialized_views.refresh_trigger AS refresh_trigger, " +
+                        "information_schema.materialized_views.refresh_policy AS refresh_policy, " +
+                        "information_schema.materialized_views.resource_group AS resource_group" +
                         " FROM " +
                         "information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND " +
                         "(information_schema.materialized_views.TABLE_NAME = 'mv1')",
                 AstToStringBuilder.toString(queryStatement));
         checkShowMaterializedViewsStmt(stmt);
+    }
+
+    @Test
+    public void testWarehouseColumn() {
+        List<Column> schema = MaterializedViewsSystemTable.create().getBaseSchema();
+        Assertions.assertTrue(schema.stream().anyMatch(c -> c.getName().equalsIgnoreCase("WAREHOUSE")));
+    }
+
+    @Test
+    public void testRefreshModeColumn() {
+        List<Column> schema = MaterializedViewsSystemTable.create().getBaseSchema();
+        Assertions.assertTrue(schema.stream().anyMatch(c -> c.getName().equalsIgnoreCase("REFRESH_MODE")));
+    }
+
+    @Test
+    public void testRefreshTriggerColumn() {
+        List<Column> schema = MaterializedViewsSystemTable.create().getBaseSchema();
+        Assertions.assertTrue(schema.stream().anyMatch(c -> c.getName().equalsIgnoreCase("REFRESH_TRIGGER")));
+    }
+
+    @Test
+    public void testRefreshPolicyColumn() {
+        List<Column> schema = MaterializedViewsSystemTable.create().getBaseSchema();
+        Assertions.assertTrue(schema.stream().anyMatch(c -> c.getName().equalsIgnoreCase("REFRESH_POLICY")));
+    }
+
+    @Test
+    public void testResourceGroupColumn() {
+        List<Column> schema = MaterializedViewsSystemTable.create().getBaseSchema();
+        Assertions.assertTrue(schema.stream().anyMatch(c -> c.getName().equalsIgnoreCase("RESOURCE_GROUP")));
+        Assertions.assertEquals("RESOURCE_GROUP", schema.get(schema.size() - 1).getName());
     }
 
     private void checkShowMaterializedViewsStmt(ShowMaterializedViewsStmt stmt) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -1001,7 +1001,12 @@ public class ShowStmtMetaTest {
     public void testShowMaterializedViewsStmt() {
         ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("test_db", null);
         ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
-        Assertions.assertEquals(28, metaData.getColumnCount());
+        Assertions.assertEquals(33, metaData.getColumnCount());
+        Assertions.assertEquals("warehouse", metaData.getColumn(28).getName());
+        Assertions.assertEquals("refresh_mode", metaData.getColumn(29).getName());
+        Assertions.assertEquals("refresh_trigger", metaData.getColumn(30).getName());
+        Assertions.assertEquals("refresh_policy", metaData.getColumn(31).getName());
+        Assertions.assertEquals("resource_group", metaData.getColumn(32).getName());
         Assertions.assertEquals("id", metaData.getColumn(0).getName());
         Assertions.assertEquals("database_name", metaData.getColumn(1).getName());
         Assertions.assertEquals("name", metaData.getColumn(2).getName());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -56,7 +56,7 @@ public class ShowMaterializedViewStatusTest {
 
         List<String> resultSet = viewStatus.toResultSet();
 
-        Assertions.assertEquals(28, resultSet.size());
+        Assertions.assertEquals(33, resultSet.size());
         Assertions.assertEquals("", resultSet.get(3)); // refresh type
         Assertions.assertEquals("false", resultSet.get(4)); // is active
         Assertions.assertEquals("", resultSet.get(5)); // inactive reason
@@ -80,6 +80,11 @@ public class ShowMaterializedViewStatusTest {
         Assertions.assertEquals("", resultSet.get(23)); // process start time
         Assertions.assertEquals("", resultSet.get(24)); // last refresh job id
         Assertions.assertEquals("", resultSet.get(27)); // last refresh time
+        Assertions.assertEquals("", resultSet.get(28)); // warehouse
+        Assertions.assertEquals("", resultSet.get(29)); // refresh mode
+        Assertions.assertEquals("", resultSet.get(30)); // refresh trigger
+        Assertions.assertEquals("", resultSet.get(31)); // refresh policy
+        Assertions.assertEquals("", resultSet.get(32)); // resource group
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -593,18 +593,18 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
                 .explainContains("     constant exprs: ");
         starRocksAssert.query("select * from information_schema.materialized_views")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' ");
+                        "'d1' | 'test_mv1' | 'ASYNC' | 'true' | '' | 'UNPARTITIONED' ");
         starRocksAssert.query("select * from information_schema.materialized_views where table_name = 'test_mv1' ")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' ");
+                        "'d1' | 'test_mv1' | 'ASYNC' | 'true' | '' | 'UNPARTITIONED' ");
         starRocksAssert.query("select * from information_schema.materialized_views " +
                         "where TABLE_SCHEMA = 'd1' and TABLE_NAME = 'test_mv1'")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' ");
+                        "'d1' | 'test_mv1' | 'ASYNC' | 'true' | '' | 'UNPARTITIONED' ");
         starRocksAssert.query("select *, TASK_ID + 1 from information_schema.materialized_views " +
                         "where TABLE_SCHEMA = 'd1' and TABLE_NAME = 'test_mv1'")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' ");
+                        "'d1' | 'test_mv1' | 'ASYNC' | 'true' | '' | 'UNPARTITIONED' ");
 
         // not supported
         starRocksAssert.query("select * from information_schema.materialized_views where TABLE_NAME != 'test_mv1' ")

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -410,6 +410,11 @@ struct TMaterializedViewStatus {
     29: optional string last_refresh_process_time
     30: optional string last_refresh_job_id
     31: optional string last_refresh_time
+    32: optional string warehouse
+    33: optional string refresh_mode
+    34: optional string refresh_trigger
+    35: optional string refresh_policy
+    36: optional string resource_group
 }
 
 struct TListPipesParams {

--- a/test/sql/test_information_schema/R/test_materialized_views_columns
+++ b/test/sql/test_information_schema/R/test_materialized_views_columns
@@ -1,0 +1,60 @@
+-- name: test_materialized_views_columns @native
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table ss (event_day date, pv bigint) duplicate key(event_day)
+distributed by hash(event_day) buckets 2 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into ss values ('2020-01-14', 1), ('2020-01-15', 2);
+-- result:
+-- !result
+create materialized view mv_manual distributed by hash(event_day)
+refresh deferred manual
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+-- result:
+-- !result
+create materialized view mv_onchange distributed by hash(event_day)
+refresh deferred async
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+-- result:
+-- !result
+create materialized view mv_sched distributed by hash(event_day)
+refresh deferred async start('2024-01-01 00:00:00') every(interval 1 hour)
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+-- result:
+-- !result
+select TABLE_NAME, REFRESH_TYPE, REFRESH_MODE, REFRESH_TRIGGER, REFRESH_POLICY, RESOURCE_GROUP, WAREHOUSE
+from information_schema.materialized_views
+where TABLE_SCHEMA = 'db_${uuid0}' order by TABLE_NAME;
+-- result:
+mv_manual	ASYNC	PCT	MANUAL	MANUAL	default_mv_wg	
+mv_onchange	ASYNC	PCT	ON_BASE_TABLE_CHANGE	ON_BASE_TABLE_CHANGE	default_mv_wg	
+mv_sched	ASYNC	PCT	SCHEDULED	START("2024-01-01 00:00:00") EVERY(INTERVAL 1 HOUR)	default_mv_wg	
+-- !result
+create resource group rg_${uuid0} to (user = 'rguser_${uuid0}') with ('cpu_core_limit' = '1', 'mem_limit' = '10%');
+-- result:
+-- !result
+create materialized view mv_rg distributed by hash(event_day)
+refresh deferred manual properties('resource_group' = 'rg_${uuid0}')
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+-- result:
+-- !result
+select if(RESOURCE_GROUP = 'rg_${uuid0}', 'OK', concat('FAILED: ', RESOURCE_GROUP))
+from information_schema.materialized_views
+where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv_rg';
+-- result:
+OK
+-- !result
+drop materialized view mv_rg;
+-- result:
+-- !result
+drop resource group rg_${uuid0};
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_information_schema/T/test_materialized_views_columns
+++ b/test/sql/test_information_schema/T/test_materialized_views_columns
@@ -1,0 +1,41 @@
+-- name: test_materialized_views_columns @native
+create database db_${uuid0};
+use db_${uuid0};
+
+create table ss (event_day date, pv bigint) duplicate key(event_day)
+distributed by hash(event_day) buckets 2 properties("replication_num" = "1");
+insert into ss values ('2020-01-14', 1), ('2020-01-15', 2);
+
+-- Manual refresh: REFRESH_TRIGGER/REFRESH_POLICY = MANUAL
+create materialized view mv_manual distributed by hash(event_day)
+refresh deferred manual
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+
+-- Bare async refresh: load triggered, REFRESH_TRIGGER/REFRESH_POLICY = ON_BASE_TABLE_CHANGE
+create materialized view mv_onchange distributed by hash(event_day)
+refresh deferred async
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+
+-- Scheduled async refresh: REFRESH_TRIGGER = SCHEDULED, REFRESH_POLICY = START(...) EVERY(...)
+create materialized view mv_sched distributed by hash(event_day)
+refresh deferred async start('2024-01-01 00:00:00') every(interval 1 hour)
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+
+-- REFRESH_TYPE=ASYNC, REFRESH_MODE=PCT, RESOURCE_GROUP=default_mv_wg for all;
+-- WAREHOUSE is empty in shared-nothing mode.
+select TABLE_NAME, REFRESH_TYPE, REFRESH_MODE, REFRESH_TRIGGER, REFRESH_POLICY, RESOURCE_GROUP, WAREHOUSE
+from information_schema.materialized_views
+where TABLE_SCHEMA = 'db_${uuid0}' order by TABLE_NAME;
+
+-- RESOURCE_GROUP reflects the resource_group table property the refresh tasks use
+create resource group rg_${uuid0} to (user = 'rguser_${uuid0}') with ('cpu_core_limit' = '1', 'mem_limit' = '10%');
+create materialized view mv_rg distributed by hash(event_day)
+refresh deferred manual properties('resource_group' = 'rg_${uuid0}')
+as select event_day, sum(pv) as sum_pv from ss group by event_day;
+select if(RESOURCE_GROUP = 'rg_${uuid0}', 'OK', concat('FAILED: ', RESOURCE_GROUP))
+from information_schema.materialized_views
+where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv_rg';
+
+drop materialized view mv_rg;
+drop resource group rg_${uuid0};
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`information_schema.materialized_views` (and `SHOW MATERIALIZED VIEWS`) exposes a materialized view's last-refresh *state*, but not its *configuration*: which warehouse and resource group its refresh tasks run in, its refresh mode, and how/when it refreshes. Today users have to parse `SHOW CREATE MATERIALIZED VIEW` to learn any of this. In addition, `REFRESH_TYPE` reports the raw internal refresh-scheme enum (`MANUAL` / `ROLLUP` / `ASYNC` / `INCREMENTAL`), which conflates the synchronous/asynchronous distinction with the refresh trigger and is hard to consume.

## What I'm doing:

Add five columns to `information_schema.materialized_views` and the matching `SHOW MATERIALIZED VIEWS` output:

- `WAREHOUSE` — warehouse the asynchronous MV uses for its refresh tasks (empty for synchronous MVs)
- `REFRESH_MODE` — configured refresh mode: `PCT` / `INCREMENTAL` / `AUTO` (empty for synchronous MVs)
- `REFRESH_TRIGGER` — how a refresh is triggered: `NONE` / `MANUAL` / `SCHEDULED` / `ON_BASE_TABLE_CHANGE`
- `REFRESH_POLICY` — refresh policy: `NONE` / `MANUAL` / `ON_BASE_TABLE_CHANGE` / `START("...") EVERY(INTERVAL ...)`
- `RESOURCE_GROUP` — resource group used for the MV's refresh tasks (defaults to `default_mv_wg`)

It also changes `REFRESH_TYPE` to report only `SYNC` / `ASYNC` (it previously surfaced the raw refresh-scheme type such as `MANUAL` / `ROLLUP`). The new `REFRESH_TRIGGER` / `REFRESH_POLICY` columns now carry the detail that `REFRESH_TYPE` used to imply. This is a visible change to the `REFRESH_TYPE` value vocabulary; tooling that matched on the old strings needs to be updated.

Fixes #issue: N/A — observability enhancement, no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5