### PR TITLE
[UT] Fix flaky RollupJobV2Test.testCancelPendingJobWithFlag

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -269,7 +269,11 @@ public class RollupJobV2Test extends DDLTestBase {
 
     @Test
     public void testCancelPendingJobWithFlag() throws Exception {
-        MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
+        // Use a standalone handler whose daemon thread is not started, so the job can never
+        // be picked up by the background alter scheduler. Using the global rollup handler is
+        // racy: its daemon may run the job to WAITING_TXN between process() and the explicit
+        // runPendingJob() call below, even if clearJobs() is called right after process().
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
 
         // add a rollup job
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
@@ -282,7 +286,6 @@ public class RollupJobV2Test extends DDLTestBase {
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         assertEquals(1, alterJobsV2.size());
         RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
-        materializedViewHandler.clearJobs(); // Disable the execution of job in background thread
 
         rollupJob.setIsCancelling(true);
         rollupJob.runPendingJob();


### PR DESCRIPTION
## Why I'm doing:

The test created the rollup job through the global rollup handler, whose background daemon runs alter jobs every alter_scheduler_interval_millisecond. The daemon could pick up the job and advance it from PENDING to WAITING_TXN between process() and the test's explicit runPendingJob() call, causing:

```
    java.lang.IllegalStateException: WAITING_TXN
        at com.starrocks.alter.RollupJobV2.runPendingJob(RollupJobV2.java)
```

clearJobs() cannot close this window because runAlterJobV2() iterates over a snapshot copy of the job map, so a job already picked up keeps running. It also means the background run executed with isCancelling=false, silently bypassing the cancel-flag path the test is meant to exercise.

Fix by using a standalone MaterializedViewHandler whose daemon thread is never started, so the job can only be driven by the test thread.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
