### PR TITLE
[UT] Tune LakePrimaryKeyConsistencyTest for parallel PK index path

### DIFF
--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -64,7 +64,7 @@ enum PICT_OP {
 
 static const std::string kTestGroupPath = "./test_lake_primary_key_consistency";
 static const int64_t MaxNumber = 1000000;
-static const int64_t MaxN = 10000;
+static const int64_t MaxN = 50000;
 static const size_t MaxUpsert = 4;
 static const size_t MaxBatchCnt = 5;
 static const int64_t io_failure_percent = 3;
@@ -277,6 +277,11 @@ public:
         config::enable_pk_strict_memcheck = false;
         _old_pk_index_eager_build_threshold_bytes = config::pk_index_eager_build_threshold_bytes;
         config::pk_index_eager_build_threshold_bytes = 1;
+        _old_pk_index_parallel_execution_min_rows = config::pk_index_parallel_execution_min_rows;
+        config::pk_index_parallel_execution_min_rows = 128;
+        _old_pk_index_parallel_compaction_task_split_threshold_bytes =
+                config::pk_index_parallel_compaction_task_split_threshold_bytes;
+        config::pk_index_parallel_compaction_task_split_threshold_bytes = 4 * 1024 * 1024;
     }
 
     void TearDown() override {
@@ -285,6 +290,9 @@ public:
         config::write_buffer_size = _old_memtable_size;
         config::enable_pk_strict_memcheck = _old_enable_pk_strict_memcheck;
         config::pk_index_eager_build_threshold_bytes = _old_pk_index_eager_build_threshold_bytes;
+        config::pk_index_parallel_execution_min_rows = _old_pk_index_parallel_execution_min_rows;
+        config::pk_index_parallel_compaction_task_split_threshold_bytes =
+                _old_pk_index_parallel_compaction_task_split_threshold_bytes;
     }
 
     std::shared_ptr<TabletMetadataPB> generate_tablet_metadata(KeysType keys_type) {
@@ -720,11 +728,13 @@ protected:
     int64_t _old_memtable_size = 0;
     bool _old_enable_pk_strict_memcheck = false;
     int64_t _old_pk_index_eager_build_threshold_bytes = 0;
+    int64_t _old_pk_index_parallel_execution_min_rows = 0;
+    int64_t _old_pk_index_parallel_compaction_task_split_threshold_bytes = 0;
 };
 
 TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {
     _seed = 1719499276; // seed
-    _run_second = 50;   // 50 second
+    _run_second = 100;  // 100 second
     LOG(INFO) << "LakePrimaryKeyConsistencyTest begin, seed : " << _seed;
     auto st = run_random_tests();
     if (!st.ok()) {
@@ -734,7 +744,7 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {
 
 TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
     _seed = time(nullptr); // use current ts as seed
-    _run_second = 50;      // 50 second
+    _run_second = 100;     // 100 second
     LOG(INFO) << "LakePrimaryKeyConsistencyTest begin, seed : " << _seed;
     auto st = run_random_tests();
     if (!st.ok()) {
@@ -743,8 +753,7 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
-                         ::testing::Values(PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::LOCAL},
-                                           PrimaryKeyParam{
-                                                   .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
+                         ::testing::Values(PrimaryKeyParam{
+                                 .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

The `LakePrimaryKeyConsistencyTest` random-stress test did not exercise the
parallel PK index execution and parallel compaction split code paths, and its
key space / run duration were small enough to give limited coverage. We also
no longer need to cover the local persistent index type in this lake test.

## What I'm doing:

Tune the test parameters to broaden coverage:

- Increase `MaxN` from 10000 to 50000 to enlarge the key space.
- Run each test for 100 seconds (was 50s).
- Set `pk_index_parallel_execution_min_rows=128` and
  `pk_index_parallel_compaction_task_split_threshold_bytes=4MB` (saved and
  restored around each test) so the parallel execution and parallel
  compaction-split paths are actually exercised.
- Limit the parameterized suite to `PersistentIndexTypePB::CLOUD_NATIVE`
  (drop `LOCAL`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
