### PR TITLE
[BugFix] Fix invalid JIT IR for CASE WHEN with mixed float/int when and result types

### DIFF
--- a/be/src/exprs/case_expr.cpp
+++ b/be/src/exprs/case_expr.cpp
@@ -162,7 +162,7 @@ public:
                         b.CreateBr(else_block);
                     } else { // if (whenExpr !=null & caseExpr = whenExpr), store the result
                         llvm::Value* cmp_eq = nullptr;
-                        if constexpr (lt_is_float<ResultType>) {
+                        if constexpr (lt_is_float<WhenType>) {
                             cmp_eq = b.CreateFCmpOEQ(datum_0.value, datum_i.value);
                         } else {
                             cmp_eq = b.CreateICmpEQ(datum_0.value, datum_i.value);

--- a/test/sql/test_jit/R/test_jit_case_when_mixed_types
+++ b/test/sql/test_jit/R/test_jit_case_when_mixed_types
@@ -1,0 +1,15 @@
+-- name: test_jit_case_when_mixed_types
+CREATE TABLE t (k INT, c DOUBLE) PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO t VALUES (1, 1.5), (2, 2.5);
+-- result:
+-- !result
+set jit_level = -1;
+-- result:
+-- !result
+SELECT CASE c WHEN 1.5 THEN 1 WHEN 2.5 THEN 2 ELSE 0 END FROM t ORDER BY 1;
+-- result:
+1
+2
+-- !result

--- a/test/sql/test_jit/T/test_jit_case_when_mixed_types
+++ b/test/sql/test_jit/T/test_jit_case_when_mixed_types
@@ -1,0 +1,5 @@
+-- name: test_jit_case_when_mixed_types
+CREATE TABLE t (k INT, c DOUBLE) PROPERTIES("replication_num"="1");
+INSERT INTO t VALUES (1, 1.5), (2, 2.5);
+set jit_level = -1;
+SELECT CASE c WHEN 1.5 THEN 1 WHEN 2.5 THEN 2 ELSE 0 END FROM t ORDER BY 1;


### PR DESCRIPTION
## Why I'm doing:

  For `CASE <expr> WHEN v1 THEN r1 ... END`, the JIT codegen in
  `VectorizedCaseExpr::generate_ir_impl` selects the equality compare instruction by
  `ResultType` (the type of the THEN/ELSE branches):

  ```cpp
  if constexpr (lt_is_float<ResultType>) {
      cmp_eq = b.CreateFCmpOEQ(datum_0.value, datum_i.value);
  } else {
      cmp_eq = b.CreateICmpEQ(datum_0.value, datum_i.value);
  }
  ```

  However, the two operands being compared (`datum_0` is the CASE expression,
  `datum_i` is a WHEN value) are both of `WhenType`. Whenever `WhenType` and
  `ResultType` differ in float-ness, the generated IR is invalid:

  - `WhenType=DOUBLE, ResultType=INT` → `icmp eq double ...` (icmp requires integer operands)
  - `WhenType=BIGINT, ResultType=DOUBLE` → `fcmp oeq i64 ...` (fcmp requires float operands)

  The invalid IR is rejected by `llvm::verifyModule` and the JIT compilation error is
  propagated to the client, so the query fails:

  ```
mysql> SELECT CASE c WHEN 1.5 THEN 1 WHEN 2.5 THEN 2 ELSE 0 END FROM t order by c;
ERROR 1064 (HY000): Failed to generate scalar function IR, errors: Invalid operand types for ICmp instruction
  %22 = icmp eq double %12, 1.500000e+00
Invalid operand types for ICmp instruction
  %23 = icmp eq double %12, 2.500000e+00
 backend [id=10001] [
  ```

  Reproduce (needs >= 2 WHEN branches, since a single-branch CASE is rewritten to `if()` by FE):

  ```sql
  CREATE TABLE t (k INT, c DOUBLE) PROPERTIES("replication_num"="1");
  INSERT INTO t VALUES (1, 1.5), (2, 2.5);
  SET jit_level = -1;
  SELECT CASE c WHEN 1.5 THEN 1 WHEN 2.5 THEN 2 ELSE 0 END FROM t;
  -- ERROR 1064: Invalid operand types for ICmp instruction
  ```

  The bug has existed since the case-when JIT was introduced in #40166. It went unnoticed
  because under the default adaptive mode (`jit_level=1`) the case-when is only JIT-compiled
  when its children are complex enough to pass the score check, and most real-world
  case-when expressions have consistent float-ness between the two types.

  ## What I'm doing:

  Select the compare instruction by `WhenType` (the actual type of both compare operands)
  instead of `ResultType`. Add a SQL test under `test/sql/test_jit/` covering the
  mixed-type combination with forced JIT (`jit_level=-1`).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
