### PR TITLE
[Tool] Image rebuild on three-digit branches (branch-X.Y.Z)

### DIFF
--- a/.github/workflows/image-rebuild-three-digit.yml
+++ b/.github/workflows/image-rebuild-three-digit.yml
@@ -43,9 +43,7 @@ env:
 jobs:
   thirdparty-filter:
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.merged == true &&
-      github.repository == 'StarRocks/starrocks'
+    if: github.event.pull_request.merged == true
     outputs:
       thirdparty: ${{ steps.filter-info.outputs.thirdparty }}
     steps:
@@ -74,10 +72,7 @@ jobs:
     needs: thirdparty-filter
     runs-on: [self-hosted, normal]
     name: Thirdparty Update Image
-    if: >
-      github.event.pull_request.merged == true &&
-      github.repository == 'StarRocks/starrocks' &&
-      needs.thirdparty-filter.outputs.thirdparty == 'true'
+    if: github.event.pull_request.merged == true && needs.thirdparty-filter.outputs.thirdparty == 'true'
     env:
       PR_NUMBER: ${{ github.event.number }}
       BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/image-rebuild-three-digit.yml
+++ b/.github/workflows/image-rebuild-three-digit.yml
@@ -1,0 +1,104 @@
+name: IMAGE REBUILD (three-digit branches)
+
+# Mirrors only the `thirdparty-filter` + `thirdparty-update-image` jobs
+# from ci-merged.yml, scoped to three-digit patch branches
+# (branch-X.Y.Z) which ci-merged.yml's branch pattern `branch-[0-9].[0-9]`
+# does NOT match. Without this, a PR that touches thirdparty/** merged
+# into a three-digit branch leaves the official dev-env image stale,
+# causing:
+#   - silent CVE-scan blind spot (the scan reads the official image)
+#   - probabilistic BUILD failures on subsequent PRs that hit the
+#     thirdparty change
+#   - dockerhub public dev-env image stays stale (see
+#     elastic-update-image.sh:26-29, StarRocks-side rebuild also pings
+#     the Jenkins job that publishes to dockerhub)
+#
+# Why a separate workflow (not extending ci-merged.yml's `on:`):
+# ci-merged.yml's `update_backport_merged_msg` job calls
+# `get_next_release_tag.sh` which assumes `GITHUB_BASE_REF` is two-digit
+# (`branch-X.Y`). On a three-digit base it produces a four-digit
+# `version:4.1.1.X` label (cosmetic bug — visible to issue trackers).
+# By keeping this workflow independent we avoid that side effect; only
+# the image-rebuild path runs.
+#
+# Branch pattern uses `[0-9]+` per segment so multi-digit minors like
+# branch-4.10.0 are also covered. Pre-release suffixes (branch-4.1.1-rc01)
+# are NOT matched — same convention as ci-merged.yml's two-digit pattern.
+
+on:
+  pull_request_target:
+    branches:
+      - "branch-[0-9]+.[0-9]+.[0-9]+"
+    types:
+      - closed
+
+permissions:
+  pull-requests: write
+  issues: write
+  actions: write
+
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
+jobs:
+  thirdparty-filter:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged == true &&
+      github.repository == 'StarRocks/starrocks'
+    outputs:
+      thirdparty: ${{ steps.filter-info.outputs.thirdparty }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: linux-thirdparty-filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            thirdparty:
+              - 'thirdparty/**'
+              - '!thirdparty/build-thirdparty-darwin.sh'
+              - '!thirdparty/vars-darwin-aarch64.sh'
+            dev_env:
+              - 'docker/dockerfiles/dev-env/dev-env.Dockerfile'
+
+      - name: Prepare filter info
+        id: filter-info
+        run: |
+          thirdparty=false
+          if [[ "${{ steps.linux-thirdparty-filter.outputs.thirdparty }}" == 'true' || "${{ steps.linux-thirdparty-filter.outputs.dev_env }}" == 'true' ]]; then
+            thirdparty=true
+          fi
+          echo "thirdparty=${thirdparty}" >> $GITHUB_OUTPUT
+
+  thirdparty-update-image:
+    needs: thirdparty-filter
+    runs-on: [self-hosted, normal]
+    name: Thirdparty Update Image
+    if: >
+      github.event.pull_request.merged == true &&
+      github.repository == 'StarRocks/starrocks' &&
+      needs.thirdparty-filter.outputs.thirdparty == 'true'
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      BRANCH: ${{ github.base_ref }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: update image - ubuntu
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER ubuntu
+
+      - name: update image - centos7
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER centos7
+
+      - name: Clean ENV
+        if: always()
+        run: |
+          rm -rf ${{ github.workspace }}/*


### PR DESCRIPTION
## Why I'm doing:

`ci-merged.yml`'s `on: pull_request_target.branches` is `main` + `branch-[0-9].[0-9]` (two-digit only). When a PR that touches `thirdparty/**` is merged into a **three-digit patch branch** like `branch-4.1.1` / `branch-3.5.14`, the official dev-env image never gets rebuilt, leading to:

- **CVE-scan blind spot** — scans hit the now-stale official image
- **Probabilistic BUILD failures** on subsequent PRs that hit the thirdparty change
- **For StarRocks specifically, dockerhub's public dev-env images stay stale** — `ci-tool/bin/elastic-update-image.sh:26-29` pings `https://jenkins.starrocks.com/job/StarRocks-Dev-Env-Image/buildWithParameters` only on the ubuntu update step. Without this workflow firing on three-digit branches, dockerhub never gets a new tag for them.

Historically handled by manual rebuild (~2-3 incidents/year). This automates it.

## What I'm doing:

New workflow `image-rebuild-three-digit.yml` mirrors **only** the two image-rebuild jobs from `ci-merged.yml`:

1. `thirdparty-filter` — `dorny/paths-filter@v3` on `thirdparty/**` + `docker/dockerfiles/dev-env/dev-env.Dockerfile`
2. `thirdparty-update-image` — runs `ci-tool/bin/elastic-update-image.sh \$BRANCH \$PR_NUMBER {ubuntu,centos7}`

### Why a separate workflow, not extending ci-merged.yml's `on:`

ci-merged.yml has 9 jobs. Extending \`on: branches\` would also trigger:

- \`update_backport_merged_msg\` (\`base != 'main' && merged == true\`) — this calls \`ci-tool/scripts/get_next_release_tag.sh\` which assumes \`GITHUB_BASE_REF\` is two-digit. On a three-digit base it produces a four-digit \`version:4.1.1.X\` label — cosmetic bug visible to downstream issue trackers
- \`update_feature_issue\` (consumes the above label) — would write garbage to GitHub Issues for any \`[Feature]\` PR on a three-digit branch

Keeping this isolated avoids the cosmetic chain entirely; only image-rebuild runs.

### Branch pattern

\`branch-[0-9]+.[0-9]+.[0-9]+\` — each segment one-or-more digits, covering branch-4.1.1, branch-3.5.14, branch-4.10.0 etc. Pre-release suffixes (branch-4.1.1-rc01) NOT matched, same convention as ci-merged.yml.

### Script changes not needed

\`ci-tool/bin/elastic-update-image.sh\` already handles three-digit \`\$BRANCH\` (line 20 strips \`branch-\` prefix giving \`4.1.1-latest\` as an independent image tag, separate from \`4.1-latest\`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Verify after merge

1. Repo-sync auto-propagates this to the downstream fork (recent precedent: ci-merged.yml changes in #70234 / #70227 reached the downstream fork within minutes)
2. Any subsequent PR touching \`thirdparty/**\` merged into a three-digit branch (e.g. branch-4.1.1) triggers an \`IMAGE REBUILD (three-digit branches)\` workflow run
3. Job log shows \`elastic-update-image.sh\` succeeding for both ubuntu + centos7
4. Aliyun registry's \`<branch_suffix>-latest\` tag shows a fresh timestamp
5. For StarRocks namespace + ubuntu, the Jenkins job \`StarRocks-Dev-Env-Image\` is triggered and updates dockerhub
