### PR TITLE
[Enhancement] Bump delta kernel version to 4.2

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -48,7 +48,7 @@ subprojects {
         set("bouncycastle.version", "1.84")
         set("byteman.version", "4.0.24")
         set("commons-beanutils.version", "1.11.0")
-        set("delta-kernel.version", "4.0.0rc1")
+        set("delta-kernel.version", "4.2.0")
         set("dlf-metastore-client.version", "0.2.14")
         set("dnsjava.version", "3.6.3")
         set("fastutil.version", "8.5.15")

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -135,6 +135,9 @@ dependencies {
     implementation("io.delta:delta-kernel-defaults") {
         exclude(group = "org.apache.hadoop", module = "hadoop-client-api")
         exclude(group = "org.apache.hadoop", module = "hadoop-client-runtime")
+        // FE uses slf4j 1.7.x with log4j-slf4j-impl; exclude delta's slf4j 2.x binding to avoid
+        // NoClassDefFoundError: org/slf4j/spi/LoggingEventBuilder at startup
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
     }
     implementation("io.grpc:grpc-api")
     implementation("io.grpc:grpc-core")

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -870,12 +870,12 @@ public class ColumnTypeConverter {
             }
             int fieldId = -1;
             String fieldPhysicalName = "";
-            if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_ID) &&
+            if (columnMappingMode.equalsIgnoreCase(ColumnMapping.ColumnMappingMode.ID.value) &&
                     field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_ID_KEY)) {
                 fieldId = ((Long) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_ID_KEY)).intValue();
             }
 
-            if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_NAME) &&
+            if (columnMappingMode.equalsIgnoreCase(ColumnMapping.ColumnMappingMode.NAME.value) &&
                     field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY)) {
                 fieldPhysicalName = (String) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
@@ -19,6 +19,7 @@ import com.google.common.cache.LoadingCache;
 import com.starrocks.common.Pair;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO;
 import io.delta.kernel.engine.JsonHandler;
 import io.delta.kernel.engine.ParquetHandler;
 import io.delta.kernel.types.StructType;
@@ -37,7 +38,7 @@ public class DeltaLakeEngine extends DefaultEngine {
     protected DeltaLakeEngine(Configuration hadoopConf, DeltaLakeCatalogProperties properties,
                               LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
                               LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
-        super(hadoopConf);
+        super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
         this.properties = properties;
         this.checkpointCache = checkpointCache;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStatus.java
@@ -33,6 +33,14 @@ public class DeltaLakeFileStatus {
         return path;
     }
 
+    public long getSize() {
+        return size;
+    }
+
+    public long getModificationTime() {
+        return modificationTime;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeJsonHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeJsonHandler.java
@@ -27,6 +27,7 @@ import com.starrocks.common.profile.Tracers;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultJsonHandler;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO;
 import io.delta.kernel.exceptions.KernelEngineException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
@@ -63,7 +64,7 @@ public class DeltaLakeJsonHandler extends DefaultJsonHandler {
     private final LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
 
     public DeltaLakeJsonHandler(Configuration hadoopConf, LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
-        super(hadoopConf);
+        super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
         this.maxBatchSize = hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);
         this.jsonCache = jsonCache;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -156,11 +156,10 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         String dbName = deltaLakeTable.getCatalogDBName();
         String tableName = deltaLakeTable.getCatalogTableName();
-        Engine engine = deltaLakeTable.getDeltaEngine();
         StructType schema = deltaLakeTable.getDeltaMetadata().getSchema();
 
         GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
-                .setTableVersionRange(TvrTableSnapshot.of(snapshot.getVersion(engine)))
+                .setTableVersionRange(TvrTableSnapshot.of(snapshot.getVersion()))
                 .setPredicate(predicate)
                 .setLimit(limit)
                 .build();
@@ -222,8 +221,8 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                 new ScalarOperationToDeltaLakeExpr.DeltaLakeContext(schema, partitionColumns);
         Predicate deltaLakePredicate = new ScalarOperationToDeltaLakeExpr().convert(scalarOperators, deltaLakeContext);
 
-        ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder(engine);
-        ScanImpl scan = (ScanImpl) scanBuilder.withFilter(engine, deltaLakePredicate).build();
+        ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder();
+        ScanImpl scan = (ScanImpl) scanBuilder.withFilter(deltaLakePredicate).build();
         long estimateRowSize = table.getColumns().stream().mapToInt(column -> column.getType().getTypeSize()).sum();
         return new CloseableIterator<>() {
             CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
@@ -89,7 +89,8 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
                     @NotNull
                     @Override
                     public List<ColumnarBatch> load(@NotNull Pair<DeltaLakeFileStatus, StructType> pair) {
-                        return DeltaLakeParquetHandler.readParquetFile(pair.first.getPath(), pair.second, hdfsConfiguration);
+                        return DeltaLakeParquetHandler.readParquetFile(pair.first.getPath(), pair.first.getSize(),
+                                pair.first.getModificationTime(), pair.second, hdfsConfiguration);
                     }
                 });
 
@@ -176,7 +177,7 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
         Engine deltaEngine = deltaLakeTable.getDeltaEngine();
         List<String> partitionColumnNames = deltaLakeTable.getPartitionColumnNames();
 
-        ScanBuilder scanBuilder = deltaLakeTable.getDeltaSnapshot().getScanBuilder(deltaEngine);
+        ScanBuilder scanBuilder = deltaLakeTable.getDeltaSnapshot().getScanBuilder();
         Scan scan = scanBuilder.build();
         try (CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches = scan.getScanFiles(deltaEngine)) {
             while (scanFilesAsBatches.hasNext()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
@@ -21,6 +21,8 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultParquetHandler;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO;
+import io.delta.kernel.engine.FileReadResult;
 import io.delta.kernel.exceptions.KernelEngineException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.replay.LogReplay;
@@ -43,17 +45,19 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
 
     public DeltaLakeParquetHandler(Configuration hadoopConf, LoadingCache<Pair<DeltaLakeFileStatus, StructType>,
             List<ColumnarBatch>> checkpointCache) {
-        super(hadoopConf);
+        super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
         this.checkpointCache = checkpointCache;
     }
 
-    public static List<ColumnarBatch> readParquetFile(String filePath, StructType physicalSchema, Configuration hadoopConf) {
+    public static List<ColumnarBatch> readParquetFile(String filePath, long fileSize, long modificationTime,
+                                                      StructType physicalSchema, Configuration hadoopConf) {
         try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL,
                 "DeltaLakeParquetHandler.readParquetFileAndGetColumnarBatch")) {
             io.delta.kernel.defaults.internal.parquet.ParquetFileReader batchReader =
-                    new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(hadoopConf);
-            CloseableIterator<ColumnarBatch> currentFileReader = batchReader.read(filePath, physicalSchema, Optional.empty());
+                    new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(new HadoopFileIO(hadoopConf));
+            CloseableIterator<ColumnarBatch> currentFileReader =
+                    batchReader.read(FileStatus.of(filePath, fileSize, modificationTime), physicalSchema, Optional.empty());
 
             List<ColumnarBatch> result = Lists.newArrayList();
             while (currentFileReader != null && currentFileReader.hasNext()) {
@@ -65,7 +69,7 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
     }
 
     @Override
-    public CloseableIterator<ColumnarBatch> readParquetFiles(
+    public CloseableIterator<FileReadResult> readParquetFiles(
             CloseableIterator<FileStatus> fileIter,
             StructType physicalSchema,
             Optional<Predicate> predicate) {
@@ -115,8 +119,8 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
             }
 
             @Override
-            public ColumnarBatch next() {
-                return currentColumnarBatchList.get(currentReadColumnarBatchIndex++);
+            public FileReadResult next() {
+                return new FileReadResult(currentColumnarBatchList.get(currentReadColumnarBatchIndex++), currentFile);
             }
 
             private void tryGetNextFileColumnarBatch() throws ExecutionException {
@@ -127,7 +131,8 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
                         Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaLakeFileStatus, physicalSchema);
                         currentColumnarBatchList = checkpointCache.get(key);
                     } else {
-                        currentColumnarBatchList = readParquetFile(currentFile, physicalSchema, hadoopConf);
+                        currentColumnarBatchList = readParquetFile(currentFile, deltaLakeFileStatus.getSize(),
+                                deltaLakeFileStatus.getModificationTime(), physicalSchema, hadoopConf);
                     }
                     currentReadColumnarBatchIndex = 0;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -62,13 +62,13 @@ public class DeltaUtils {
         SnapshotImpl snapshotImpl = snapshot.getSnapshot();
         String path = snapshot.getPath();
 
-        StructType deltaSchema = snapshotImpl.getSchema(deltaLakeEngine);
+        StructType deltaSchema = snapshotImpl.getSchema();
         if (deltaSchema == null) {
             throw new IllegalArgumentException(String.format("Unable to find Schema information in Delta log for " +
                     "%s.%s.%s", catalog, dbName, tblName));
         }
 
-        String columnMappingMode = ColumnMapping.getColumnMappingMode(snapshotImpl.getMetadata().getConfiguration());
+        String columnMappingMode = ColumnMapping.getColumnMappingMode(snapshotImpl.getMetadata().getConfiguration()).value;
         List<Column> fullSchema = Lists.newArrayList();
         for (StructField field : deltaSchema.fields()) {
             DataType dataType = field.getDataType();
@@ -107,11 +107,11 @@ public class DeltaUtils {
         int columnUniqueId = COLUMN_UNIQUE_ID_INIT_VALUE;
         String physicalName = "";
 
-        if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_ID) &&
+        if (columnMappingMode.equalsIgnoreCase(ColumnMapping.ColumnMappingMode.ID.value) &&
                 field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_ID_KEY)) {
             columnUniqueId = ((Long) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_ID_KEY)).intValue();
         }
-        if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_NAME) &&
+        if (columnMappingMode.equalsIgnoreCase(ColumnMapping.ColumnMappingMode.NAME.value) &&
                 field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY)) {
             physicalName = (String) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -25,8 +25,10 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.FileStatus;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.hadoop.fs.Path;
 
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,10 @@ import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_ORDINAL;
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_STATS_ORDINAL;
 
 public class ScanFileUtils {
+    private static final int TABLE_ROOT_ORDINAL = InternalScanFileUtils.SCAN_FILE_SCHEMA.indexOf("tableRoot");
+    private static final int ADD_FILE_PATH_ORDINAL =
+            ((StructType) InternalScanFileUtils.SCAN_FILE_SCHEMA.get("add").getDataType()).indexOf("path");
+
     public static class Records {
         @SerializedName(value = "numRecords")
         public long numRecords;
@@ -68,6 +74,21 @@ public class ScanFileUtils {
         return new DeltaLakeAddFileStatsSerDe(estimateRowCount, null, null, null);
     }
 
+    // delta-kernel 4.2 URI-decodes the path inside getAddFileStatus(), but BE opens the object key
+    // verbatim and the physical key keeps the URI-encoded add.path. Rebuild the absolute path from the
+    // raw add.path so the encoding is preserved (matching pre-4.2 behavior).
+    private static FileStatus getEncodedAddFileStatus(Row scanFileInfo) {
+        Row addFile = getAddFileEntry(scanFileInfo);
+        if (addFile.isNullAt(ADD_FILE_PATH_ORDINAL) || scanFileInfo.isNullAt(TABLE_ROOT_ORDINAL)) {
+            throw new IllegalArgumentException("There is no `add.path` or `tableRoot` entry in the scan file row");
+        }
+        FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileInfo);
+        String encodedPath = addFile.getString(ADD_FILE_PATH_ORDINAL);
+        String tableRoot = scanFileInfo.getString(TABLE_ROOT_ORDINAL);
+        String encodedAbsolutePath = new Path(tableRoot, encodedPath).toString();
+        return FileStatus.of(encodedAbsolutePath, fileStatus.getSize(), fileStatus.getModificationTime());
+    }
+
     private static Row getAddFileEntry(Row scanFileInfo) {
         if (scanFileInfo.isNullAt(ADD_FILE_ORDINAL)) {
             throw new IllegalArgumentException("There is no `add` entry in the scan file row");
@@ -88,7 +109,7 @@ public class ScanFileUtils {
         Set<String> partitionColumns = metadata.getPartitionColNames();
         Map<String, StructField> schema = buildCaseInsensitiveSchema(metadata.getSchema().fields());
 
-        FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(file);
+        FileStatus fileStatus = getEncodedAddFileStatus(file);
         Map<String, String> partitionValues = InternalScanFileUtils.getPartitionValues(file);
         Map<String, String> physicalNameToPartitionNameMap = Maps.newHashMap();
         // partition Values use column physical name(using in column mapping) as key, we need to convert it to logical name

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultJsonHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultJsonHandler.java
@@ -25,6 +25,7 @@ import com.starrocks.common.profile.Tracers;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultJsonHandler;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO;
 import io.delta.kernel.exceptions.KernelEngineException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
@@ -57,7 +58,7 @@ public class TraceDefaultJsonHandler extends DefaultJsonHandler {
     private final Configuration hadoopConf;
     private final int maxBatchSize;
     public TraceDefaultJsonHandler(Configuration hadoopConf) {
-        super(hadoopConf);
+        super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
         this.maxBatchSize =
                 hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultParquetHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultParquetHandler.java
@@ -18,6 +18,8 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultParquetHandler;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO;
+import io.delta.kernel.engine.FileReadResult;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.StructType;
@@ -33,20 +35,21 @@ import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 public class TraceDefaultParquetHandler extends DefaultParquetHandler {
     private final Configuration hadoopConf;
     public TraceDefaultParquetHandler(Configuration hadoopConf) {
-        super(hadoopConf);
+        super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
     }
 
     // This method copies the implementation from DefaultParquetHandler.java
     @Override
-    public CloseableIterator<ColumnarBatch> readParquetFiles(
+    public CloseableIterator<FileReadResult> readParquetFiles(
             CloseableIterator<FileStatus> fileIter,
             StructType physicalSchema,
             Optional<Predicate> predicate) throws IOException {
-        return new CloseableIterator<ColumnarBatch>() {
+        return new CloseableIterator<FileReadResult>() {
             private final io.delta.kernel.defaults.internal.parquet.ParquetFileReader batchReader =
-                    new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(hadoopConf);
+                    new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(new HadoopFileIO(hadoopConf));
             private CloseableIterator<ColumnarBatch> currentFileReader;
+            private String currentFilePath;
 
             @Override
             public void close() throws IOException {
@@ -66,7 +69,8 @@ public class TraceDefaultParquetHandler extends DefaultParquetHandler {
                     if (fileIter.hasNext()) {
                         try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL,
                                 "TraceDefaultParquetHandler.readParquetFile")) {
-                            String nextFile = fileIter.next().getPath();
+                            FileStatus nextFile = fileIter.next();
+                            currentFilePath = nextFile.getPath();
                             currentFileReader = batchReader.read(nextFile, physicalSchema, predicate);
                             return hasNext(); // recurse since it's possible the loaded file is empty
                         }
@@ -77,9 +81,9 @@ public class TraceDefaultParquetHandler extends DefaultParquetHandler {
             }
 
             @Override
-            public ColumnarBatch next() {
+            public FileReadResult next() {
                 try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "TraceDefaultParquetHandler.GetColumnarBatch")) {
-                    return currentFileReader.next();
+                    return new FileReadResult(currentFileReader.next(), currentFilePath);
                 }
             }
         };

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -37,7 +37,6 @@ import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.type.Type;
-import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -132,8 +131,7 @@ public class DeltaLakeScanNode extends ScanNode {
         this.enableIncrementalScanRanges = enableIncrementalScanRanges;
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         DeltaUtils.checkProtocolAndMetadata(snapshot.getProtocol(), snapshot.getMetadata());
-        Engine engine = deltaLakeTable.getDeltaEngine();
-        long snapshotId = snapshot.getVersion(engine);
+        long snapshotId = snapshot.getVersion();
 
         GetRemoteFilesParams params =
                 GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
@@ -174,7 +172,7 @@ public class DeltaLakeScanNode extends ScanNode {
                     explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
         output.append(prefix).append(String.format("TABLE VERSION: %s",
-                deltaLakeTable.getDeltaSnapshot().getVersion(deltaLakeTable.getDeltaEngine())));
+                deltaLakeTable.getDeltaSnapshot().getVersion()));
         output.append("\n");
 
         output.append(prefix).append(String.format("cardinality=%s", cardinality));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -394,13 +394,13 @@ public class ExternalResourceCleanupTest {
         Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
         Mockito.when(meta.getSchema()).thenReturn(schema);
         Mockito.when(meta.getPartitionColNames()).thenReturn(Set.of());
-        Mockito.when(snapshot.getVersion(engine)).thenReturn(1L);
+        Mockito.when(snapshot.getVersion()).thenReturn(1L);
 
         // Mock scan builder flow.
         ScanBuilderImpl scanBuilder = Mockito.mock(ScanBuilderImpl.class);
         ScanImpl scan = Mockito.mock(ScanImpl.class);
-        Mockito.when(snapshot.getScanBuilder(engine)).thenReturn(scanBuilder);
-        Mockito.when(scanBuilder.withFilter(Mockito.eq(engine), Mockito.any())).thenReturn(scanBuilder);
+        Mockito.when(snapshot.getScanBuilder()).thenReturn(scanBuilder);
+        Mockito.when(scanBuilder.withFilter(Mockito.any())).thenReturn(scanBuilder);
         Mockito.when(scanBuilder.build()).thenReturn(scan);
 
         // Mock row/batch iterators.
@@ -858,12 +858,12 @@ public class ExternalResourceCleanupTest {
         Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
         Mockito.when(meta.getSchema()).thenReturn(schema);
         Mockito.when(meta.getPartitionColNames()).thenReturn(Set.of());
-        Mockito.when(snapshot.getVersion(engine)).thenReturn(1L);
+        Mockito.when(snapshot.getVersion()).thenReturn(1L);
 
         ScanBuilderImpl scanBuilder = Mockito.mock(ScanBuilderImpl.class);
         ScanImpl scan = Mockito.mock(ScanImpl.class);
-        Mockito.when(snapshot.getScanBuilder(engine)).thenReturn(scanBuilder);
-        Mockito.when(scanBuilder.withFilter(Mockito.eq(engine), Mockito.any())).thenReturn(scanBuilder);
+        Mockito.when(snapshot.getScanBuilder()).thenReturn(scanBuilder);
+        Mockito.when(scanBuilder.withFilter(Mockito.any())).thenReturn(scanBuilder);
         Mockito.when(scanBuilder.build()).thenReturn(scan);
 
         CloseableIterator<FilteredColumnarBatch> emptyIter = new CloseableIterator<>() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
@@ -203,6 +203,10 @@ public class CachingDeltaLakeMetastoreTest {
                 public void checkpoint(Engine engine, long version)
                         throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
                 }
+
+                @Override
+                public void checksum(Engine engine, long version) throws TableNotFoundException, IOException {
+                }
             };
 
             new MockUp<TableImpl>() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeApiConverterTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.starrocks.connector.ColumnTypeConverter.fromDeltaLakeType;
-import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_NONE;
+import static io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode.NONE;
 
 public class DeltaLakeApiConverterTest {
     @Test
@@ -42,7 +42,7 @@ public class DeltaLakeApiConverterTest {
                 true
         );
 
-        Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
+        Type srType = fromDeltaLakeType(deltaType, NONE.value);
         Assertions.assertEquals(srType, new ArrayType(com.starrocks.type.IntegerType.INT));
     }
 
@@ -60,7 +60,7 @@ public class DeltaLakeApiConverterTest {
                 true
         );
 
-        Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
+        Type srType = fromDeltaLakeType(deltaType, NONE.value);
         Assertions.assertTrue(srType.isUnknown());
     }
 
@@ -72,7 +72,7 @@ public class DeltaLakeApiConverterTest {
                 true
         );
 
-        Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
+        Type srType = fromDeltaLakeType(deltaType, NONE.value);
         Assertions.assertEquals(srType,
                 new MapType(com.starrocks.type.IntegerType.INT, VarbinaryType.VARBINARY));
     }
@@ -85,7 +85,7 @@ public class DeltaLakeApiConverterTest {
         );
         DataType deltaType = new io.delta.kernel.types.StructType(fields);
 
-        Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
+        Type srType = fromDeltaLakeType(deltaType, NONE.value);
         Assertions.assertEquals(srType, new StructType(ImmutableList.of(
                 com.starrocks.type.IntegerType.INT,
                 TypeFactory.createDefaultCatalogString())));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -141,8 +141,8 @@ public class DeltaLakeMetadataTest {
         );
         // addFile schema, here we only care about the partitionValues, so not use all fields
         StructType addFileSchema = new StructType(Lists.newArrayList(
-                new StructField("path", BasePrimitiveType.createPrimitive("string"), true, null),
-                new StructField("partitionValues", mapType, true, null)));
+                new StructField("path", BasePrimitiveType.createPrimitive("string"), true),
+                new StructField("partitionValues", mapType, true)));
         DefaultStructVector addFile = new DefaultStructVector(3, addFileSchema, Optional.empty(), addFileCols);
         // construct a columnar batch which only contains addFile
         ColumnarBatch columnarBatch = new DefaultColumnarBatch(3,
@@ -171,7 +171,7 @@ public class DeltaLakeMetadataTest {
 
         new Expectations() {
             {
-                snapshot.getScanBuilder((Engine) any);
+                snapshot.getScanBuilder();
                 result = scanBuilder;
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeParquetHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeParquetHandlerTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.Pair;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.FileReadResult;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.util.Utils;
@@ -41,6 +42,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -69,7 +71,8 @@ public class DeltaLakeParquetHandlerTest {
                 @NotNull
                 @Override
                 public List<ColumnarBatch> load(@NotNull Pair<DeltaLakeFileStatus, StructType> pair) {
-                    return DeltaLakeParquetHandler.readParquetFile(pair.first.getPath(), pair.second, hdfsConfiguration);
+                    return DeltaLakeParquetHandler.readParquetFile(pair.first.getPath(), pair.first.getSize(),
+                            pair.first.getModificationTime(), pair.second, hdfsConfiguration);
                 }
             });
 
@@ -78,14 +81,15 @@ public class DeltaLakeParquetHandlerTest {
         String path = deltaLakePath + "/00000000000000000030.checkpoint.parquet";
         DeltaLakeParquetHandler deltaLakeParquetHandler = new DeltaLakeParquetHandler(hdfsConfiguration, checkpointCache);
         StructType readSchema = LogReplay.getAddRemoveReadSchema(true);
-        FileStatus fileStatus = FileStatus.of(path, 111, 111111);
+        File file = new File(path);
+        FileStatus fileStatus = FileStatus.of(path, file.length(), file.lastModified());
         DeltaLakeFileStatus deltaLakeFileStatus = DeltaLakeFileStatus.of(fileStatus);
 
         List<Row> addRows = Lists.newArrayList();
-        try (CloseableIterator<ColumnarBatch> parquetIter = deltaLakeParquetHandler.readParquetFiles(
+        try (CloseableIterator<FileReadResult> parquetIter = deltaLakeParquetHandler.readParquetFiles(
                 Utils.singletonCloseableIterator(fileStatus), readSchema, Optional.empty())) {
             while (parquetIter.hasNext()) {
-                ColumnarBatch columnarBatch = parquetIter.next();
+                ColumnarBatch columnarBatch = parquetIter.next().getData();
                 ColumnVector addsVector = columnarBatch.getColumnVector(ADD_FILE_ORDINAL);
 
                 for (int rowId = 0; rowId < addsVector.getSize(); rowId++) {
@@ -136,14 +140,14 @@ public class DeltaLakeParquetHandlerTest {
                     @NotNull
                     @Override
                     public List<ColumnarBatch> load(@NotNull Pair<String, StructType> pair) {
-                        return DeltaLakeParquetHandler.readParquetFile(pair.first, pair.second, hdfsConfiguration);
+                        return DeltaLakeParquetHandler.readParquetFile(pair.first, 0, 0, pair.second, hdfsConfiguration);
                     }
                 });
         List<ColumnarBatch> columnarBatches = Lists.newArrayList();
         new MockUp<DeltaLakeParquetHandler>() {
             @Mock
-            public List<ColumnarBatch> readParquetFile(@NotNull String path, @NotNull StructType schema,
-                                                       @NotNull Configuration hdfsConfiguration) {
+            public List<ColumnarBatch> readParquetFile(@NotNull String path, long fileSize, long modificationTime,
+                                                       @NotNull StructType schema, @NotNull Configuration hdfsConfiguration) {
                 return columnarBatches;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -21,7 +21,6 @@ import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.sql.optimizer.validate.ValidateException;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
-import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -34,15 +33,15 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_KEY;
-import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_NAME;
-import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_NONE;
+import static io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode.NAME;
+import static io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode.NONE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,20 +59,19 @@ public class DeltaUtilsTest {
         new Expectations(metadata) {
             {
                 metadata.getConfiguration();
-                result = ImmutableMap.of(COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_MODE_NAME);
+                result = ImmutableMap.of(COLUMN_MAPPING_MODE_KEY, NAME.value);
                 minTimes = 0;
             }
         };
 
-        DeltaUtils.checkProtocolAndMetadata(new Protocol(3, 7, Lists.newArrayList(),
-                Lists.newArrayList()), metadata);
+        DeltaUtils.checkProtocolAndMetadata(new Protocol(3, 7), metadata);
     }
 
     @Test
     public void testConvertDeltaSnapshotToSRTable(@Mocked SnapshotImpl snapshot) {
         new Expectations() {
             {
-                snapshot.getSchema((Engine) any);
+                snapshot.getSchema();
                 result = new StructType(Lists.newArrayList(new StructField("col1", IntegerType.INTEGER, true),
                         new StructField("col2", DateType.DATE, true)));
                 minTimes = 0;
@@ -82,8 +80,8 @@ public class DeltaUtilsTest {
 
         new MockUp<ColumnMapping>() {
             @Mock
-            public String getColumnMappingMode(Configuration configuration) {
-                return COLUMN_MAPPING_MODE_NONE;
+            public ColumnMapping.ColumnMappingMode getColumnMappingMode(Map<String, String> configuration) {
+                return NONE;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/ScanFileUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/ScanFileUtilsTest.java
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.starrocks.common.Pair;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.data.GenericRow;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.types.StructType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScanFileUtilsTest {
+    private static final StructType ADD_FILE_SCHEMA =
+            (StructType) InternalScanFileUtils.SCAN_FILE_SCHEMA_WITH_STATS.get("add").getDataType();
+    private static final int TABLE_ROOT_ORDINAL = InternalScanFileUtils.SCAN_FILE_SCHEMA.indexOf("tableRoot");
+
+    @Mocked
+    private Metadata metadata;
+
+    @BeforeEach
+    public void setUp() {
+        new Expectations() {
+            {
+                metadata.getPartitionColNames();
+                result = Collections.emptySet();
+                minTimes = 0;
+
+                metadata.getSchema();
+                result = new StructType();
+                minTimes = 0;
+            }
+        };
+    }
+
+    private static Row buildScanFileRow(String addPath, String tableRoot) {
+        Map<Integer, Object> addValues = new HashMap<>();
+        if (addPath != null) {
+            addValues.put(ADD_FILE_SCHEMA.indexOf("path"), addPath);
+        }
+        addValues.put(ADD_FILE_SCHEMA.indexOf("size"), 100L);
+        addValues.put(ADD_FILE_SCHEMA.indexOf("modificationTime"), 1L);
+        addValues.put(ADD_FILE_SCHEMA.indexOf("partitionValues"),
+                VectorUtils.stringStringMapValue(new HashMap<>()));
+        Row addRow = new GenericRow(ADD_FILE_SCHEMA, addValues);
+
+        Map<Integer, Object> scanValues = new HashMap<>();
+        scanValues.put(InternalScanFileUtils.ADD_FILE_ORDINAL, addRow);
+        scanValues.put(TABLE_ROOT_ORDINAL, tableRoot);
+        return new GenericRow(InternalScanFileUtils.SCAN_FILE_SCHEMA, scanValues);
+    }
+
+    @Test
+    public void testConvertPreservesEncodedPath() {
+        String encodedPath = "col_timestamp=2023-01-01%2001%3A01%3A01/part-00000.snappy.parquet";
+        Row scanFileRow = buildScanFileRow(encodedPath, "oss://bucket/db/t");
+
+        Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> result =
+                ScanFileUtils.convertFromRowToFileScanTask(false, scanFileRow, metadata, 1, null);
+
+        String path = result.first.getFileStatus().getPath();
+        Assertions.assertEquals(
+                "oss://bucket/db/t/col_timestamp=2023-01-01%2001%3A01%3A01/part-00000.snappy.parquet", path);
+        Assertions.assertNotEquals(InternalScanFileUtils.getAddFileStatus(scanFileRow).getPath(), path);
+    }
+
+    @Test
+    public void testConvertThrowsWhenPathMissing() {
+        Row scanFileRow = buildScanFileRow(null, "oss://bucket/db/t");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ScanFileUtils.convertFromRowToFileScanTask(false, scanFileRow, metadata, 1, null));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
@@ -128,7 +128,7 @@ public class DeltaLakeScanNodeTest {
                 result = engine;
                 minTimes = 0;
 
-                snapshot.getVersion(engine);
+                snapshot.getVersion();
                 result = 123L;
                 minTimes = 0;
             }};

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -78,7 +78,7 @@ under the License.
         <nimbusds.version>9.37.2</nimbusds.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <paimon.version>1.3.1</paimon.version>
-        <delta-kernel.version>4.0.0rc1</delta-kernel.version>
+        <delta-kernel.version>4.2.0</delta-kernel.version>
         <iceberg.version>1.10.0</iceberg.version>
         <staros.version>4.2-rc1</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
@@ -1425,6 +1425,12 @@ under the License.
                         <groupId>org.apache.hadoop</groupId>
                         <artifactId>hadoop-client-runtime</artifactId>
                     </exclusion>
+                  <!-- FE uses slf4j 1.7.x with log4j-slf4j-impl; exclude delta's slf4j 2.x binding to avoid
+                       NoClassDefFoundError: org/slf4j/spi/LoggingEventBuilder at startup -->
+                  <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                  </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
## Why I'm doing:

To support reading and writing to the unity catalog via catalog managed commits we need at least delta-kernel version 4.1

## What I'm doing:

Bump to 4.2 from rc1 and update references

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
