### PR TITLE
[BugFix] Fix information_schema.loads stuck at PREPARING for multi-statement transaction stream load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -75,8 +75,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * </pre>
  *
  * Final states: CANCELLED, COMMITED, FINISHED.
- * COMMITING and ABORTING are intermediate; cancel is rejected in COMMITING.
+ * COMMITING and ABORTING are intermediate; cancel and new loads are rejected in COMMITING.
  * BEFORE_LOAD, LOADING, PREPARING, PREPARED are defined for compatibility but not used in this class.
+ *
+ * Sub-tasks in taskMaps are not registered as transaction state callbacks, so this task
+ * must propagate its final state to them: commit success and reconcile-found-committed call
+ * propagateCommitStateToSubTasks (COMMITED, or FINISHED when the txn is visible), and abort
+ * paths call cancelCoordinatorOnly (CANCELLED). Display outlets (information_schema.loads,
+ * SHOW STREAM LOAD) delegate to sub-tasks and rely on this propagation.
  */
 public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     private static final Logger LOG = LogManager.getLogger(StreamLoadMultiStmtTask.class);
@@ -290,6 +296,10 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
                         } finally {
                             writeUnlock();
                         }
+                        // Mark sub-tasks committed before tryRollbackNow invokes
+                        // cancelCoordinatorOnly on them; otherwise a committed
+                        // transaction would display CANCELLED sub-tasks.
+                        propagateCommitStateToSubTasks(status == TransactionStatus.VISIBLE);
                     }
                     return true;
                 }
@@ -450,6 +460,7 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
                 } finally {
                     writeUnlock();
                 }
+                propagateCommitStateToSubTasks();
             } else {
                 this.errorMsg = commitErrorMsg != null ? commitErrorMsg : "commit failed";
                 LOG.warn("Commit failed for transaction {}, label: {}, error: {}",
@@ -462,6 +473,42 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
                 }
                 tryRollbackNow();
             }
+        }
+    }
+
+    /**
+     * Propagate the committed transaction's final state to all sub-tasks, resolving the
+     * actual transaction status to decide between COMMITED and FINISHED.
+     * The explicit transaction created by TransactionStmtExecutor.beginStmt carries no
+     * callback id, so afterCommitted/afterVisible are never dispatched to this task.
+     * All display outlets (information_schema.loads, SHOW STREAM LOAD) delegate to the
+     * sub-tasks; without this propagation they would show PREPARING forever for
+     * committed transactions.
+     */
+    private void propagateCommitStateToSubTasks() {
+        if (taskMaps.isEmpty()) {
+            return;
+        }
+        boolean visible = false;
+        try {
+            TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                    .getTransactionState(dbId, txnId);
+            visible = txnState != null && txnState.getTransactionStatus() == TransactionStatus.VISIBLE;
+        } catch (Exception e) {
+            LOG.warn("Failed to get transaction status when propagating commit state, label: {}, " +
+                    "txnId: {}, treating as committed", label, txnId, e);
+        }
+        propagateCommitStateToSubTasks(visible);
+    }
+
+    /**
+     * Propagate the committed transaction's final state to all sub-tasks.
+     * Sub-tasks already in an unreversible state are left untouched.
+     */
+    private void propagateCommitStateToSubTasks(boolean visible) {
+        long finishTimeMs = this.endTimeMs != -1 ? this.endTimeMs : System.currentTimeMillis();
+        for (StreamLoadTask task : taskMaps.values()) {
+            task.markCommittedByParent(visible, finishTimeMs);
         }
     }
 
@@ -511,6 +558,14 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         if (isFinalState()) {
             if (endTimeMs == -1) {
                 endTimeMs = currentMs;
+            }
+            // Opportunistically converge sub-task display state: no transaction callback
+            // ever fires for multi-statement transactions, so a sub-task left COMMITED
+            // (commit returned before publish finished) or missed by a racing load is
+            // upgraded here once the transaction becomes visible.
+            if (this.state == State.COMMITED
+                    && taskMaps.values().stream().anyMatch(task -> !task.isFinalState())) {
+                propagateCommitStateToSubTasks();
             }
             return isForce || ((currentMs - endTimeMs) > Config.stream_load_task_keep_max_second * 1000L);
         }
@@ -713,6 +768,13 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
             resp.setErrorMsg(String.format("stream load task %s has already been %s", label, state.name().toLowerCase()));
             return null;
         }
+        if (this.state == State.COMMITING) {
+            // Reject new loads while the commit is in progress: a sub-task created here
+            // would neither be included in the committing transaction nor be reached by
+            // propagateCommitStateToSubTasks, leaving it displayed as PREPARING forever.
+            resp.setErrorMsg(String.format("stream load task %s is committing, can not accept new loads", label));
+            return null;
+        }
 
         // For multi-statement tasks, delegate to specific table task if exists
         StreamLoadTask task = taskMaps.get(tableName);
@@ -748,6 +810,10 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         }
         if (this.state == State.COMMITED || this.state == State.FINISHED) {
             resp.setErrorMsg(String.format("stream load task %s has already been %s", label, state.name().toLowerCase()));
+            return null;
+        }
+        if (this.state == State.COMMITING) {
+            resp.setErrorMsg(String.format("stream load task %s is committing, can not accept new loads", label));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -506,7 +506,11 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
      * Sub-tasks already in an unreversible state are left untouched.
      */
     private void propagateCommitStateToSubTasks(boolean visible) {
-        long finishTimeMs = this.endTimeMs != -1 ? this.endTimeMs : System.currentTimeMillis();
+        // For FINISHED sub-tasks use the time visibility was observed: convergence via
+        // checkNeedRemove may happen long after the parent's commit endTimeMs, and the
+        // single-table afterVisible path also stamps the observation time. COMMITED
+        // sub-tasks keep the commit completion time.
+        long finishTimeMs = !visible && this.endTimeMs != -1 ? this.endTimeMs : System.currentTimeMillis();
         for (StreamLoadTask task : taskMaps.values()) {
             task.markCommittedByParent(visible, finishTimeMs);
         }
@@ -754,33 +758,46 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         loadIdLo = loadId.getLo();
     }
 
-    @Override
-    public TNetworkAddress tryLoad(int channelId, String tableName, TransactionResult resp) throws StarRocksException {
+    /**
+     * Check whether the task can accept load requests in its current state, filling
+     * resp with the rejection reason otherwise. Reads {@code state} without the lock
+     * when used as a fast-fail pre-check; the sub-task creation path in tryLoad
+     * re-runs it under the write lock to serialize against commitTxn's
+     * COMMITING/COMMITED transitions.
+     */
+    private boolean checkLoadAllowed(TransactionResult resp) {
         if (this.state == State.CANCELLED) {
             resp.setErrorMsg(String.format("stream load task %s has already been cancelled: %s", label, errorMsg));
-            return null;
+            return false;
         }
         if (this.state == State.ABORTING) {
             resp.setErrorMsg(String.format("stream load task %s is aborting: %s", label, abortReason));
-            return null;
+            return false;
         }
         if (this.state == State.COMMITED || this.state == State.FINISHED) {
             resp.setErrorMsg(String.format("stream load task %s has already been %s", label, state.name().toLowerCase()));
-            return null;
+            return false;
         }
         if (this.state == State.COMMITING) {
             // Reject new loads while the commit is in progress: a sub-task created here
             // would neither be included in the committing transaction nor be reached by
             // propagateCommitStateToSubTasks, leaving it displayed as PREPARING forever.
             resp.setErrorMsg(String.format("stream load task %s is committing, can not accept new loads", label));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public TNetworkAddress tryLoad(int channelId, String tableName, TransactionResult resp) throws StarRocksException {
+        if (!checkLoadAllowed(resp)) {
             return null;
         }
 
         // For multi-statement tasks, delegate to specific table task if exists
         StreamLoadTask task = taskMaps.get(tableName);
-        if (task != null) {
-            return task.tryLoad(0, tableName, resp);
-        } else {
+        if (task == null) {
+            // Resolve metadata outside the lock to keep the critical section small.
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 throw new MetaNotFoundException("Database " + dbId + "has been deleted");
@@ -790,30 +807,33 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
                 throw new MetaNotFoundException("Failed to find table " + tableName + " in db " + dbName);
             }
             long id = GlobalStateMgr.getCurrentState().getNextId();
-            task = new StreamLoadTask(id, db, table, label, user, clientIp, timeoutMs, 1, 0, createTimeMs, computeResource);
-            taskMaps.put(table.getName(), task);
-            LOG.info("Add stream load task {}", task.getShowInfo());
-            task.tryBegin(0, 1, txnId);
-            return task.tryLoad(0, tableName, resp);
+            StreamLoadTask newTask =
+                    new StreamLoadTask(id, db, table, label, user, clientIp, timeoutMs, 1, 0, createTimeMs, computeResource);
+            // Registering a new sub-task must be serialized with commitTxn's COMMITING
+            // transition (taken under the same write lock): otherwise a load racing with
+            // commit could add a sub-task that neither joins the committing transaction
+            // nor is reached by propagateCommitStateToSubTasks.
+            writeLock();
+            try {
+                if (!checkLoadAllowed(resp)) {
+                    return null;
+                }
+                task = taskMaps.putIfAbsent(table.getName(), newTask);
+                if (task == null) {
+                    task = newTask;
+                    LOG.info("Add stream load task {}", task.getShowInfo());
+                    task.tryBegin(0, 1, txnId);
+                }
+            } finally {
+                writeUnlock();
+            }
         }
+        return task.tryLoad(0, tableName, resp);
     }
 
     @Override
     public TNetworkAddress executeTask(int channelId, String tableName, HttpHeaders headers, TransactionResult resp) {
-        if (this.state == State.CANCELLED) {
-            resp.setErrorMsg(String.format("stream load task %s has already been cancelled: %s", label, errorMsg));
-            return null;
-        }
-        if (this.state == State.ABORTING) {
-            resp.setErrorMsg(String.format("stream load task %s is aborting: %s", label, abortReason));
-            return null;
-        }
-        if (this.state == State.COMMITED || this.state == State.FINISHED) {
-            resp.setErrorMsg(String.format("stream load task %s has already been %s", label, state.name().toLowerCase()));
-            return null;
-        }
-        if (this.state == State.COMMITING) {
-            resp.setErrorMsg(String.format("stream load task %s is committing, can not accept new loads", label));
+        if (!checkLoadAllowed(resp)) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1396,6 +1396,50 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
     }
 
     /**
+     * Mark this sub-task COMMITED (or FINISHED when the transaction is already visible)
+     * after the parent multi-statement transaction committed successfully.
+     * Sub-tasks of a multi-statement transaction are not registered as transaction state
+     * callbacks (the explicit transaction carries no callback id), so
+     * afterCommitted/afterVisible are never invoked on them; the parent task drives their
+     * terminal state instead. Without this, display outlets that delegate to sub-tasks
+     * (information_schema.loads, SHOW STREAM LOAD) would show PREPARING forever.
+     * A COMMITED sub-task may be upgraded to FINISHED by a later call with visible=true
+     * (the transaction became visible after the commit returned).
+     */
+    public void markCommittedByParent(boolean visible, long finishTimeMs) {
+        boolean becameVisible = false;
+        writeLock();
+        try {
+            if (state == State.CANCELLED || state == State.FINISHED) {
+                return;
+            }
+            State finalState = visible ? State.FINISHED : State.COMMITED;
+            if (state == finalState) {
+                return;
+            }
+            for (int i = 0; i < channelNum; i++) {
+                this.channels.set(i, finalState);
+            }
+            this.state = finalState;
+            if (this.commitTimeMs <= 0) {
+                this.commitTimeMs = finishTimeMs;
+            }
+            this.isCommitting = false;
+            if (visible) {
+                this.endTimeMs = finishTimeMs;
+                gcObject();
+                becameVisible = true;
+            }
+        } finally {
+            writeUnlock();
+            QeProcessorImpl.INSTANCE.unregisterQuery(loadId);
+        }
+        if (becameVisible) {
+            WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "StreamLoad: label[" + label + "]");
+        }
+    }
+
+    /**
      * Cancel the coordinator and set task state to CANCELLED without aborting the transaction.
      * This is used for sub-tasks in multi-statement transactions where the parent task
      * manages the transaction lifecycle.

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
@@ -561,4 +561,174 @@ public class StreamLoadMultiStmtTaskTest {
         Assertions.assertDoesNotThrow(deserialized::cancelAfterRestart);
         Assertions.assertEquals("CANCELLED", deserialized.getStateName());
     }
+
+    private StreamLoadTask addSubTask(String tableName, StreamLoadTask.State state) {
+        StreamLoadTask sub = new StreamLoadTask(2L, db, new OlapTable(), "label_multi", "u",
+                "127.0.0.1", 1000, 1, 0,
+                System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+        Deencapsulation.setField(sub, "tableName", tableName);
+        Deencapsulation.setField(sub, "state", state);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, StreamLoadTask> map =
+                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask,
+                        "taskMaps");
+        map.put(tableName, sub);
+        return sub;
+    }
+
+    private void mockCommitTxnDependencies(long txnId) {
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                ctx.setTxnId(txnId);
+            }
+
+            @Mock
+            public void loadData(long dbId, long tableId,
+                                 ExplicitTxnState.ExplicitTxnStateItem item,
+                                 com.starrocks.qe.ConnectContext context) {
+            }
+
+            @Mock
+            public void commitStmt(com.starrocks.qe.ConnectContext context,
+                                   com.starrocks.sql.ast.txn.CommitStmt stmt) {
+            }
+        };
+        new MockUp<StreamLoadTask>() {
+            @Mock
+            public OlapTable getTable() {
+                return new OlapTable();
+            }
+        };
+    }
+
+    // ---- Commit success must propagate final state to sub-tasks so that
+    // information_schema.loads / SHOW STREAM LOAD do not show PREPARING forever ----
+    @Test
+    public void testCommitTxnPropagatesFinishedToSubTasksWhenTxnVisible() throws Exception {
+        mockCommitTxnDependencies(777L);
+        TransactionState visibleTxn = new TransactionState();
+        visibleTxn.setTransactionStatus(TransactionStatus.VISIBLE);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return visibleTxn;
+            }
+        };
+
+        multiTask.beginTxn(new TransactionResult());
+        StreamLoadTask sub = addSubTask("tbl1", StreamLoadTask.State.PREPARED);
+
+        TransactionResult resp = new TransactionResult();
+        multiTask.commitTxn(new DefaultHttpHeaders(), resp);
+        Assertions.assertTrue(resp.stateOK());
+        Assertions.assertEquals("COMMITED", multiTask.getStateName());
+        Assertions.assertEquals("FINISHED", sub.getStateName());
+        Assertions.assertTrue(sub.endTimeMs() > 0);
+        Assertions.assertEquals("FINISHED", multiTask.toThrift().get(0).getState());
+    }
+
+    @Test
+    public void testCommitTxnPropagatesCommittedWhenTxnStatusUnknown() throws Exception {
+        mockCommitTxnDependencies(778L);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return null;
+            }
+        };
+
+        multiTask.beginTxn(new TransactionResult());
+        StreamLoadTask sub = addSubTask("tbl1", StreamLoadTask.State.PREPARED);
+
+        TransactionResult resp = new TransactionResult();
+        multiTask.commitTxn(new DefaultHttpHeaders(), resp);
+        Assertions.assertTrue(resp.stateOK());
+        Assertions.assertEquals("COMMITED", multiTask.getStateName());
+        Assertions.assertEquals("COMMITED", sub.getStateName());
+    }
+
+    // ---- Reconcile finding the txn committed must not leave sub-tasks CANCELLED ----
+    @Test
+    public void testReconcileCommittedPropagatesToSubTasksInsteadOfCancel() throws Exception {
+        ExplicitTxnState explicitState = new ExplicitTxnState();
+        TransactionState txnState = new TransactionState();
+        txnState.setTransactionStatus(TransactionStatus.VISIBLE);
+        explicitState.setTransactionState(txnState);
+        setupRollbackFailWithReconcileMock(300L, explicitState, false);
+
+        multiTask.beginTxn(new TransactionResult());
+        StreamLoadTask sub = addSubTask("tbl1", StreamLoadTask.State.PREPARING);
+
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertEquals("COMMITED", multiTask.getStateName());
+        Assertions.assertEquals("FINISHED", sub.getStateName());
+    }
+
+    // ---- New loads must be rejected while the commit is in progress ----
+    @Test
+    public void testTryLoadWhenCommiting() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITING);
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.tryLoad(0, "t", resp));
+        Assertions.assertFalse(resp.stateOK());
+        Assertions.assertTrue(resp.msg.contains("committing"));
+    }
+
+    @Test
+    public void testExecuteTaskWhenCommiting() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITING);
+        HttpHeaders headers = new DefaultHttpHeaders();
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.executeTask(0, "t", headers, resp));
+        Assertions.assertFalse(resp.stateOK());
+        Assertions.assertTrue(resp.msg.contains("committing"));
+    }
+
+    // ---- A COMMITED sub-task is upgraded to FINISHED once the txn becomes visible ----
+    @Test
+    public void testMarkCommittedByParentUpgradesCommittedToFinished() {
+        StreamLoadTask sub = addSubTask("tbl1", StreamLoadTask.State.PREPARING);
+        long now = System.currentTimeMillis();
+
+        sub.markCommittedByParent(false, now);
+        Assertions.assertEquals("COMMITED", sub.getStateName());
+
+        // repeated non-visible propagation is a no-op
+        sub.markCommittedByParent(false, now + 1);
+        Assertions.assertEquals("COMMITED", sub.getStateName());
+
+        sub.markCommittedByParent(true, now + 2);
+        Assertions.assertEquals("FINISHED", sub.getStateName());
+        Assertions.assertEquals(now + 2, sub.endTimeMs());
+        // commitTimeMs from the first propagation is preserved
+        Assertions.assertEquals(now, sub.commitTimeMs());
+
+        // CANCELLED/FINISHED are never overridden
+        sub.markCommittedByParent(false, now + 3);
+        Assertions.assertEquals("FINISHED", sub.getStateName());
+    }
+
+    // ---- The cleaner thread converges COMMITED sub-tasks once the txn is visible ----
+    @Test
+    public void testCheckNeedRemoveUpgradesCommittedSubTasksWhenVisible() {
+        TransactionState visibleTxn = new TransactionState();
+        visibleTxn.setTransactionStatus(TransactionStatus.VISIBLE);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return visibleTxn;
+            }
+        };
+        StreamLoadTask sub = addSubTask("tbl1", StreamLoadTask.State.COMMITED);
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITED);
+        Deencapsulation.setField(multiTask, "endTimeMs", System.currentTimeMillis());
+
+        Assertions.assertFalse(multiTask.checkNeedRemove(System.currentTimeMillis(), false));
+        Assertions.assertEquals("FINISHED", sub.getStateName());
+    }
 }

--- a/test/sql/test_information_schema/R/test_loads_predicate_pushdown
+++ b/test/sql/test_information_schema/R/test_loads_predicate_pushdown
@@ -162,7 +162,7 @@ select count(1) from information_schema.loads where db_name='db_${uuid0}' and us
 -- !result
 select count(1) from information_schema.loads where db_name='db_${uuid0}' and state='FINISHED';
 -- result:
-3
+4
 -- !result
 select count(1) from information_schema.loads where db_name='db_${uuid0}' and state='__NO_SUCH_STATE__';
 -- result:
@@ -206,7 +206,7 @@ select count(1) from information_schema.loads where db_name='db_${uuid0}' and lo
 -- !result
 select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_finish_time >= date_sub(now(), interval 1 hour) and load_finish_time <= date_add(now(), interval 1 hour);
 -- result:
-3
+4
 -- !result
 select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_finish_time > date_add(now(), interval 1 hour);
 -- result:

--- a/test/sql/test_stream_load/R/test_multi_statement_txn
+++ b/test/sql/test_stream_load/R/test_multi_statement_txn
@@ -309,3 +309,85 @@ select * from test3;
 3
 2
 -- !result
+-- name: test_multi_stream_load_loads_view_state
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test1` (
+  `id` int
+)
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `test2` (
+  `id` int
+)
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+  "Status": "OK",
+  "Message": ""
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:test1" -H "source_type:12" -H "format:json" -d '{"id":"1"}' -X PUT  ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "llal_00000000000000000000000000000000",
+    "TxnId": 0,
+    "LoadBytes": 10,
+    "StreamLoadPlanTimeMs": 0,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:test2" -H "source_type:12" -H "format:json" -d '{"id":"2"}' -X PUT  ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "llal_00000000000000000000000000000000",
+    "TxnId": 0,
+    "LoadBytes": 10,
+    "StreamLoadPlanTimeMs": 0,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/commit
+-- result:
+0
+{
+  "Label": "llal_00000000000000000000000000000000",
+  "Status": "OK",
+  "TxnId": 0,
+  "ChannelId": 0,
+  "Message": "",
+  "Prepared Channel Num": 1
+}
+-- !result
+select * from test1;
+-- result:
+1
+-- !result
+select * from test2;
+-- result:
+2
+-- !result
+select TABLE_NAME, STATE in ('FINISHED', 'COMMITED') from information_schema.loads where DB_NAME = 'db_${uuid0}' and LABEL = 'llal_${uuid0}' order by TABLE_NAME;
+-- result:
+test1	1
+test2	1
+-- !result

--- a/test/sql/test_stream_load/T/test_multi_statement_txn
+++ b/test/sql/test_stream_load/T/test_multi_statement_txn
@@ -70,3 +70,32 @@ CREATE TABLE `test3` (
 select * from test1;
 select * from test2;
 select * from test3;
+
+-- name: test_multi_stream_load_loads_view_state
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `test1` (
+  `id` int
+)
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+CREATE TABLE `test2` (
+  `id` int
+)
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/begin
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:test1" -H "source_type:12" -H "format:json" -d '{"id":"1"}' -X PUT  ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:test2" -H "source_type:12" -H "format:json" -d '{"id":"2"}' -X PUT  ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:llal_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/commit
+
+select * from test1;
+select * from test2;
+
+select TABLE_NAME, STATE in ('FINISHED', 'COMMITED') from information_schema.loads where DB_NAME = 'db_${uuid0}' and LABEL = 'llal_${uuid0}' order by TABLE_NAME;


### PR DESCRIPTION
## Why I'm doing:

Multi-table transactions written through the Flink connector (`/api/transaction/begin|load|commit` with `transaction_type: multi`, i.e. `LoadJobSourceType=MULTI_STATEMENT_STREAMING`) that have **successfully committed** are shown as `PREPARING` in `information_schema.loads` and `SHOW STREAM LOAD` forever. The transaction layer is correct (`SHOW PROC '/transactions/...'` shows all txns `VISIBLE`), only the display layer is wrong, so monitoring/alerting built on the loads view misreports long-running `PREPARING` loads.

Root cause: the explicit transaction created by `TransactionStmtExecutor.beginStmt` for multi-statement stream load carries no callback id, so `afterCommitted`/`afterVisible` are never dispatched to `StreamLoadMultiStmtTask`. Its `commitTxn` success path only advanced the parent task state, while every display outlet (`toThrift`, `getShowInfo`) delegates to the per-table sub-tasks in `taskMaps`, whose state never left `PREPARING`.

## What I'm doing:

Propagate the transaction's final state from the parent multi-statement task to its sub-tasks:

- `StreamLoadTask.markCommittedByParent(visible, finishTimeMs)`: marks a sub-task `COMMITED`, or `FINISHED` when the transaction is visible (sets `endTimeMs`, frees the coordinator, updates warehouse idle time). A `COMMITED` sub-task can later be upgraded to `FINISHED`; `CANCELLED`/`FINISHED` are never overridden.
- `StreamLoadMultiStmtTask.commitTxn` success path resolves the actual transaction status and propagates it to all sub-tasks.
- `reconcileWithTxnManager` propagates commit state before `tryRollbackNow` cancels sub-task coordinators, so a transaction that actually committed no longer displays `CANCELLED` sub-tasks.
- `tryLoad`/`executeTask` reject new loads while the task is `COMMITING`: a sub-task created mid-commit would neither join the committing transaction nor be reached by propagation, recreating the stuck-`PREPARING` symptom.
- `checkNeedRemove` (periodic cleaner) opportunistically upgrades remaining `COMMITED` sub-tasks once the transaction becomes visible, since no transaction callback ever fires for these transactions.

Tests:
- FE UT: 7 new cases in `StreamLoadMultiStmtTaskTest` covering commit propagation (visible and unknown txn status), reconcile-found-committed, `COMMITING` load rejection, `COMMITED`→`FINISHED` upgrade, and cleaner-driven convergence.
- SQL test: new case `test_multi_stream_load_loads_view_state` asserting `information_schema.loads` reaches a terminal state after a two-table multi-statement transaction commit.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)