### PR TITLE
[Feature] SHOW CREATE FUNCTION (backport #73519)

### DIFF
--- a/docs/en/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION.md
+++ b/docs/en/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION.md
@@ -1,0 +1,44 @@
+---
+displayed_sidebar: docs
+---
+
+# SHOW CREATE FUNCTION
+
+SHOW CREATE FUNCTION returns the `CREATE FUNCTION` DDL for a user-defined function.
+
+## Syntax
+
+```SQL
+SHOW CREATE [GLOBAL] FUNCTION <function_name> ( <arg_type> [, ...] )
+```
+
+## Example
+
+```sql
+SHOW CREATE FUNCTION default_db.python_add(BIGINT);
+```
+
+```sql
+CREATE FUNCTION default_db.python_add(BIGINT)
+RETURNS BIGINT
+PROPERTIES (
+    "type" = "Python",
+    "file" = "inline",
+    "symbol" = "add",
+    "input" = "arrow"
+)
+AS $$
+
+import pyarrow.compute as pc
+
+def add(x):
+    return pc.add(x, 1)
+
+$$
+1 row in set (0.01 sec)
+```
+
+## Related SQL
+
+* [CREATE FUNCTION](CREATE_FUNCTION.md)
+* [SHOW FUNCTIONS](SHOW_FUNCTIONS.md)

--- a/docs/ja/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION.md
+++ b/docs/ja/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION.md
@@ -1,0 +1,44 @@
+---
+displayed_sidebar: docs
+---
+
+# SHOW CREATE FUNCTION
+
+SHOW CREATE FUNCTION は、ユーザー定義関数の `CREATE FUNCTION` DDL を返します。
+
+## 構文
+
+```SQL
+SHOW CREATE [GLOBAL] FUNCTION <function_name> ( <arg_type> [, ...] )
+```
+
+## 例
+
+```sql
+SHOW CREATE FUNCTION default_db.python_add(BIGINT);
+```
+
+```sql
+CREATE FUNCTION default_db.python_add(BIGINT)
+RETURNS BIGINT
+PROPERTIES (
+    "type" = "Python",
+    "file" = "inline",
+    "symbol" = "add",
+    "input" = "arrow"
+)
+AS $$
+
+import pyarrow.compute as pc
+
+def add(x):
+    return pc.add(x, 1)
+
+$$
+1 row in set (0.01 sec)
+```
+
+## 関連 SQL
+
+* [CREATE FUNCTION](CREATE_FUNCTION.md)
+* [SHOW FUNCTIONS](SHOW_FUNCTIONS.md)

--- a/docs/zh/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION.md
+++ b/docs/zh/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION.md
@@ -1,0 +1,44 @@
+---
+displayed_sidebar: docs
+---
+
+# SHOW CREATE FUNCTION
+
+SHOW CREATE FUNCTION 返回用户定义函数的 `CREATE FUNCTION` DDL。
+
+## 语法
+
+```SQL
+SHOW CREATE [GLOBAL] FUNCTION <function_name> ( <arg_type> [, ...] )
+```
+
+## 示例
+
+```sql
+SHOW CREATE FUNCTION default_db.python_add(BIGINT);
+```
+
+```sql
+CREATE FUNCTION default_db.python_add(BIGINT)
+RETURNS BIGINT
+PROPERTIES (
+    "type" = "Python",
+    "file" = "inline",
+    "symbol" = "add",
+    "input" = "arrow"
+)
+AS $$
+
+import pyarrow.compute as pc
+
+def add(x):
+    return pc.add(x, 1)
+
+$$
+1 row in set (0.01 sec)
+```
+
+## 相关 SQL
+
+* [CREATE FUNCTION](CREATE_FUNCTION.md)
+* [SHOW FUNCTIONS](SHOW_FUNCTIONS.md)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -48,6 +48,7 @@ import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 import org.apache.logging.log4j.util.Strings;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -366,19 +367,39 @@ public class AggregateFunction extends Function {
 
     @Override
     public String toSql(boolean ifNotExists) {
-        StringBuilder sb = new StringBuilder("CREATE AGGREGATE FUNCTION ");
-        if (ifNotExists) {
-            sb.append("IF NOT EXISTS ");
-        }
-        sb.append(dbName() + "." + signatureString() + "\n")
-                .append(" RETURNS " + getReturnType() + "\n")
-                .append(" LOCATION '" + getLocation() + "'\n")
-                .append(" SYMBOL='" + getSymbolName() + "'\n");
+        StringBuilder sb = new StringBuilder();
+        appendCreateHeader(sb, "AGGREGATE", ifNotExists);
+        sb.append(signatureString()).append("\n")
+                .append("RETURNS ").append(getReturnType()).append("\n");
 
-        if (getIntermediateType() != null) {
-            sb.append(" INTERMEDIATE " + getIntermediateType() + "\n");
-        }
+        Map<String, String> props = synthesizePropertiesFromFields();
+        appendPropertiesBlock(sb, props);
         return sb.toString();
+    }
+
+    private Map<String, String> synthesizePropertiesFromFields() {
+        Map<String, String> props = new LinkedHashMap<>();
+        String typeStr = binaryTypeToPropertyValue(getBinaryType());
+        if (typeStr != null) {
+            props.put(CreateFunctionStmt.TYPE_KEY, typeStr);
+        }
+        if (getLocation() != null) {
+            props.put(CreateFunctionStmt.FILE_KEY, getLocation().toString());
+        }
+        if (!Strings.isEmpty(getSymbolName())) {
+            props.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());
+        }
+        if (intermediateType != null) {
+            props.put(CreateFunctionStmt.INTERMEDIATE_KEY, intermediateType.toSql());
+        }
+        // Default isolation is isolated (true); only emit when explicitly shared.
+        if (!isolationType) {
+            props.put(CreateFunctionStmt.ISOLATION_KEY, "shared");
+        }
+        if (isAnalyticFn) {
+            props.put(CreateFunctionStmt.IS_ANALYTIC_NAME, "true");
+        }
+        return props;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -45,6 +45,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.PrintableMap;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.HdfsURI;
@@ -796,6 +797,47 @@ public class Function implements Writable {
     // Child classes must override this function.
     public String toSql(boolean ifNotExists) {
         return "";
+    }
+
+    protected void appendCreateHeader(StringBuilder sb, String functionTypeKeyword, boolean ifNotExists) {
+        boolean isGlobal = getFunctionName().isGlobalFunction();
+        sb.append("CREATE ");
+        if (isGlobal) {
+            sb.append("GLOBAL ");
+        }
+        if (functionTypeKeyword != null && !functionTypeKeyword.isEmpty()) {
+            sb.append(functionTypeKeyword).append(" ");
+        }
+        sb.append("FUNCTION ");
+        if (ifNotExists) {
+            sb.append("IF NOT EXISTS ");
+        }
+        if (!isGlobal) {
+            sb.append(dbName()).append(".");
+        }
+    }
+
+    protected static void appendPropertiesBlock(StringBuilder sb, Map<String, String> props) {
+        if (props == null || props.isEmpty()) {
+            return;
+        }
+        sb.append("PROPERTIES (\n")
+                .append(new PrintableMap<>(props, "=", true, true, true))
+                .append("\n)\n");
+    }
+
+    protected static String binaryTypeToPropertyValue(TFunctionBinaryType type) {
+        if (type == null) {
+            return null;
+        }
+        switch (type) {
+            case SRJAR:
+                return CreateFunctionStmt.TYPE_STARROCKS_JAR;
+            case PYTHON:
+                return CreateFunctionStmt.TYPE_STARROCKS_PYTHON;
+            default:
+                return null;
+        }
     }
 
     public static Function getFunction(List<Function> fns, Function desc, CompareMode mode) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -47,6 +47,7 @@ import com.starrocks.type.Type;
 import org.apache.logging.log4j.util.Strings;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -232,15 +233,42 @@ public class ScalarFunction extends Function {
 
     @Override
     public String toSql(boolean ifNotExists) {
-        StringBuilder sb = new StringBuilder("CREATE FUNCTION ");
-        if (ifNotExists) {
-            sb.append("IF NOT EXISTS ");
+        StringBuilder sb = new StringBuilder();
+        appendCreateHeader(sb, "", ifNotExists);
+        sb.append(signatureString()).append("\n")
+                .append("RETURNS ").append(getReturnType()).append("\n");
+
+        Map<String, String> props = synthesizePropertiesFromFields();
+        appendPropertiesBlock(sb, props);
+
+        if (content != null) {
+            // $$ ... $$ matches the inlineFunction grammar (ATTACHMENT token)
+            // so the emitted statement round-trips through CREATE FUNCTION.
+            sb.append("AS $$\n").append(content).append("\n$$\n");
         }
-        sb.append(dbName() + "." + signatureString() + "\n")
-                .append(" RETURNS " + getReturnType() + "\n")
-                .append(" LOCATION '" + getLocation() + "'\n")
-                .append(" SYMBOL='" + getSymbolName() + "'\n");
         return sb.toString();
+    }
+
+    private Map<String, String> synthesizePropertiesFromFields() {
+        Map<String, String> props = new LinkedHashMap<>();
+        String typeStr = binaryTypeToPropertyValue(getBinaryType());
+        if (typeStr != null) {
+            props.put(CreateFunctionStmt.TYPE_KEY, typeStr);
+        }
+        if (getLocation() != null) {
+            props.put(CreateFunctionStmt.FILE_KEY, getLocation().toString());
+        }
+        if (!Strings.isEmpty(getSymbolName())) {
+            props.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());
+        }
+        if (!Strings.isEmpty(inputType)) {
+            props.put(CreateFunctionStmt.INPUT_TYPE, inputType);
+        }
+        // Default isolation is isolated (true); only emit the property when explicitly shared.
+        if (!isolationType) {
+            props.put(CreateFunctionStmt.ISOLATION_KEY, "shared");
+        }
+        return props;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SqlFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SqlFunction.java
@@ -59,11 +59,9 @@ public class SqlFunction extends Function {
 
     @Override
     public String toSql(boolean ifNotExists) {
-        StringBuilder sb = new StringBuilder("CREATE FUNCTION ");
-        if (ifNotExists) {
-            sb.append("IF NOT EXISTS ");
-        }
-        sb.append(dbName()).append(".").append(getFunctionName().getFunction()).append("(");
+        StringBuilder sb = new StringBuilder();
+        appendCreateHeader(sb, "", ifNotExists);
+        sb.append(getFunctionName().getFunction()).append("(");
 
         for (int i = 0; i < getArgs().length; i++) {
             if (i != 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -38,6 +38,7 @@ import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 import com.starrocks.type.VarcharType;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
@@ -182,6 +183,34 @@ public class TableFunction extends Function {
         tableFn.setIs_left_join(isLeftJoin);
         fn.setTable_fn(tableFn);
         return fn;
+    }
+
+    @Override
+    public String toSql(boolean ifNotExists) {
+        StringBuilder sb = new StringBuilder();
+        appendCreateHeader(sb, "TABLE", ifNotExists);
+        // getReturnType() is always INVALID for TableFunction, use that only when tableFnReturnTypes is empty
+        Type returnType = tableFnReturnTypes.isEmpty() ? getReturnType() : tableFnReturnTypes.get(0);
+        sb.append(signatureString()).append("\n")
+                .append("RETURNS ").append(returnType.toSql()).append("\n");
+        Map<String, String> props = synthesizePropertiesFromFields();
+        appendPropertiesBlock(sb, props);
+        return sb.toString();
+    }
+
+    private Map<String, String> synthesizePropertiesFromFields() {
+        Map<String, String> props = new LinkedHashMap<>();
+        String typeStr = binaryTypeToPropertyValue(getBinaryType());
+        if (typeStr != null) {
+            props.put(CreateFunctionStmt.TYPE_KEY, typeStr);
+        }
+        if (getLocation() != null) {
+            props.put(CreateFunctionStmt.FILE_KEY, getLocation().toString());
+        }
+        if (symbolName != null && !symbolName.isEmpty()) {
+            props.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);
+        }
+        return props;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -61,6 +61,8 @@ import com.starrocks.catalog.ConnectorView;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSearchDesc;
+import com.starrocks.catalog.GlobalFunctionMgr;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.LocalTablet;
@@ -149,6 +151,7 @@ import com.starrocks.service.InformationSchemaDataSource;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.FunctionRefAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
@@ -158,6 +161,8 @@ import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.DescStorageVolumeStmt;
 import com.starrocks.sql.ast.DescribeStmt;
+import com.starrocks.sql.ast.FunctionArgsDef;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.HelpStmt;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.LakeTabletStatus;
@@ -182,6 +187,7 @@ import com.starrocks.sql.ast.ShowComputeNodeBlackListStmt;
 import com.starrocks.sql.ast.ShowComputeNodesStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateFunctionStmt;
 import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataCacheRulesStmt;
@@ -1268,6 +1274,60 @@ public class ShowExecutor {
             } catch (AccessDeniedException e) {
                 return false;
             }
+        }
+
+        @Override
+        public ShowResultSet visitShowCreateFunctionStatement(ShowCreateFunctionStmt statement, ConnectContext context) {
+            FunctionRef functionRef = statement.getFunctionRef();
+            FunctionArgsDef argsDef = statement.getArgsDef();
+            boolean isGlobal = statement.isGlobalFunction();
+            Database db = null;
+            String resolvedDbName = null;
+            try {
+                if (isGlobal) {
+                    Authorizer.checkSystemAction(context, PrivilegeType.CREATE_GLOBAL_FUNCTION);
+                } else {
+                    resolvedDbName = functionRef.getDbName();
+                    if (Strings.isNullOrEmpty(resolvedDbName)) {
+                        resolvedDbName = context.getDatabase();
+                        if (Strings.isNullOrEmpty(resolvedDbName)) {
+                            ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
+                        }
+                    }
+                    Authorizer.checkDbAction(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                            resolvedDbName, PrivilegeType.CREATE_FUNCTION);
+                    db = context.getGlobalStateMgr().getLocalMetastore().getDb(resolvedDbName);
+                    MetaUtils.checkDbNullAndReport(db, resolvedDbName);
+                }
+            } catch (AccessDeniedException e) {
+                AccessDeniedException.reportAccessDenied(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                        context.getCurrentUserIdentity(),
+                        context.getCurrentRoleIds(),
+                        isGlobal ? PrivilegeType.CREATE_GLOBAL_FUNCTION.name() : PrivilegeType.CREATE_FUNCTION.name(),
+                        isGlobal ? ObjectType.SYSTEM.name() : ObjectType.DATABASE.name(),
+                        isGlobal ? null : resolvedDbName);
+            }
+
+            Function fn;
+            if (isGlobal) {
+                GlobalFunctionMgr mgr = context.getGlobalStateMgr().getGlobalFunctionMgr();
+                FunctionSearchDesc desc = FunctionRefAnalyzer.buildFunctionSearchDesc(
+                        functionRef, argsDef, FunctionRefAnalyzer.GLOBAL_UDF_DB);
+                fn = mgr.getFunction(desc);
+            } else {
+                FunctionSearchDesc desc = FunctionRefAnalyzer.buildFunctionSearchDesc(
+                        functionRef, argsDef, db.getFullName());
+                fn = db.getFunction(desc);
+            }
+
+            if (fn == null) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Function " + functionRef.getFnName().toString() + " does not exist");
+            }
+
+            List<List<String>> rows = Lists.newArrayList();
+            rows.add(Lists.newArrayList(fn.toSql(false)));
+            return new ShowResultSet(showResultMetaFactory.getMetadata(statement), rows);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -63,6 +63,7 @@ import com.starrocks.sql.ast.ShowComputeNodeBlackListStmt;
 import com.starrocks.sql.ast.ShowComputeNodesStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateFunctionStmt;
 import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataCacheRulesStmt;
@@ -514,6 +515,13 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         return ShowResultSetMetaData.builder()
                 .addColumn(new Column("Table", TypeFactory.createVarcharType(20)))
                 .addColumn(new Column("Create Table", TypeFactory.createVarcharType(30)))
+                .build();
+    }
+
+    @Override
+    public ShowResultSetMetaData visitShowCreateFunctionStatement(ShowCreateFunctionStmt statement, Void context) {
+        return ShowResultSetMetaData.builder()
+                .addColumn(new Column("Create Function", TypeFactory.createVarcharType(30)))
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -51,6 +51,7 @@ import com.starrocks.sql.ast.ShowAnalyzeStatusStmt;
 import com.starrocks.sql.ast.ShowBasicStatsMetaStmt;
 import com.starrocks.sql.ast.ShowColumnStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateFunctionStmt;
 import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataDistributionStmt;
@@ -185,6 +186,16 @@ public class ShowStmtAnalyzer {
             if (node.getExpr() != null) {
                 ErrorReport.reportSemanticException(ERR_UNSUPPORTED_SQL_PATTERN);
             }
+            return null;
+        }
+
+        @Override
+        public Void visitShowCreateFunctionStatement(ShowCreateFunctionStmt node, ConnectContext context) {
+            String defaultDb = node.isGlobalFunction()
+                    ? FunctionRefAnalyzer.GLOBAL_UDF_DB
+                    : context.getDatabase();
+            FunctionRefAnalyzer.analyzeFunctionRef(node.getFunctionRef(), defaultDb);
+            FunctionRefAnalyzer.analyzeArgsDef(node.getArgsDef());
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -32,6 +32,7 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String MD5_CHECKSUM = "md5";
     public static final String TYPE_KEY = "type";
     public static final String ISOLATION_KEY = "isolation";
+    public static final String INTERMEDIATE_KEY = "intermediate";
     public static final String TYPE_STARROCKS_JAR = "StarrocksJar";
     public static final String TYPE_STARROCKS_PYTHON = "Python";
     public static final String EVAL_METHOD_NAME = "evaluate";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -341,6 +341,7 @@ import com.starrocks.sql.ast.ShowComputeNodeBlackListStmt;
 import com.starrocks.sql.ast.ShowComputeNodesStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateFunctionStmt;
 import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataCacheRulesStmt;
@@ -6845,6 +6846,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         return new DropFunctionStmt(functionRef, getFunctionArgsDef(context.typeList()),
                 createPos(context), dropIfExist);
+    }
+
+    @Override
+    public ParseNode visitShowCreateFunctionStatement(
+            com.starrocks.sql.parser.StarRocksParser.ShowCreateFunctionStatementContext context) {
+        QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
+        boolean isGlobal = context.GLOBAL() != null;
+        FunctionRef functionRef = new FunctionRef(qualifiedName, null, createPos(context), isGlobal);
+        if (isGlobal && !Strings.isNullOrEmpty(functionRef.getDbName())) {
+            throw new ParsingException(PARSER_ERROR_MSG.invalidUDFName(qualifiedName.toString()), qualifiedName.getPos());
+        }
+        FunctionArgsDef argsDef = getFunctionArgsDef(context.typeList());
+        return new ShowCreateFunctionStmt(functionRef, argsDef, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateFunctionStmtTest.java
@@ -1,0 +1,260 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultMetaFactory;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.ShowCreateFunctionStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ShowCreateFunctionStmtTest {
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase("test_udf_db").useDatabase("test_udf_db");
+        starRocksAssert.withFunction(
+                "CREATE FUNCTION test_udf_db.echo(string) RETURNS string PROPERTIES " +
+                        "(\"symbol\" = \"Echo\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+        starRocksAssert.withFunction(
+                "CREATE FUNCTION test_udf_db.echo(int) RETURNS int PROPERTIES " +
+                        "(\"symbol\" = \"Echo\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+        starRocksAssert.withFunction(
+                "CREATE GLOBAL FUNCTION echo_python(int) RETURNS int PROPERTIES " +
+                        "(\"symbol\" = \"Echo\", \"type\" = \"python\", \"file\" = \"xxx\", \"cust_prop\" = \"cust_val\");");
+        starRocksAssert.withFunction(
+                "CREATE FUNCTION test_udf_db.python_add(BIGINT) RETURNS BIGINT PROPERTIES (" +
+                        "\"type\" = \"Python\", \"file\" = \"inline\", " +
+                        "\"symbol\" = \"add\", \"input\" = \"arrow\") " +
+                        "AS $$\n" +
+                        "import pyarrow.compute as pc\n" +
+                        "def add(x):\n" +
+                        "    return pc.add(x, 1)\n" +
+                        "$$;");
+        starRocksAssert.withFunction(
+                "CREATE AGGREGATE FUNCTION test_udf_db.my_agg(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyAgg\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+        starRocksAssert.withFunction(
+                "CREATE AGGREGATE FUNCTION test_udf_db.my_agg_analytic(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyWindow\", \"type\" = \"StarrocksJar\", " +
+                        "\"file\" = \"xxx\", \"analytic\" = \"true\");");
+        starRocksAssert.withFunction(
+                "CREATE AGGREGATE FUNCTION test_udf_db.my_agg_shared(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyShared\", \"type\" = \"StarrocksJar\", " +
+                        "\"file\" = \"xxx\", \"isolation\" = \"shared\");");
+        starRocksAssert.withFunction(
+                "CREATE TABLE FUNCTION IF NOT EXISTS test_udf_db.my_table_fn(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyTableFn\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+        starRocksAssert.withFunction(
+                "CREATE GLOBAL FUNCTION my_global_udf(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyGlobalUdf\", \"type\" = \"StarrocksJar\", " +
+                        "\"file\" = \"file:///tmp/global.jar\");");
+        starRocksAssert.withFunction(
+                "CREATE FUNCTION test_udf_db.sql_add_one(x INT) RETURNS x + 1;");
+    }
+
+    @Test
+    public void testParseWithArgs() throws Exception {
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function test_udf_db.echo(string)", ctx);
+        Assertions.assertNotNull(stmt.getFunctionRef());
+        Assertions.assertNotNull(stmt.getArgsDef());
+        Assertions.assertEquals("echo", stmt.getFunctionRef().getFunctionName());
+        Assertions.assertFalse(stmt.isGlobalFunction());
+    }
+
+    @Test
+    public void testParseWithArgsCustProp() throws Exception {
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create global function echo_python(string)", ctx);
+        Assertions.assertNotNull(stmt.getFunctionRef());
+        Assertions.assertNotNull(stmt.getArgsDef());
+        Assertions.assertEquals("echo_python", stmt.getFunctionRef().getFunctionName());
+        Assertions.assertTrue(stmt.isGlobalFunction());
+    }
+
+    @Test
+    public void testParseGlobal() throws Exception {
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create global function my_global(int)", ctx);
+        Assertions.assertTrue(stmt.isGlobalFunction());
+    }
+
+    @Test
+    public void testParseGlobalRejectsDbQualifier() {
+        assertThrows(Exception.class, () -> UtFrameUtils.parseStmtWithNewParser(
+                "show create global function some_db.my_global(int)", ctx));
+    }
+
+    @Test
+    public void testMetaDataColumns() throws Exception {
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function echo(int)", ctx);
+        ShowResultMetaFactory factory = new ShowResultMetaFactory();
+        Assertions.assertEquals(1, factory.getMetadata(stmt).getColumnCount());
+        Assertions.assertEquals("Create Function", factory.getMetadata(stmt).getColumn(0).getName());
+    }
+
+    @Test
+    public void testAnalyzerRequiresDatabaseForNonGlobal() {
+        // No current database and no qualifier — analyzer should fail.
+        ConnectContext bareCtx = UtFrameUtils.createDefaultCtx();
+        bareCtx.setDatabase(null);
+        assertThrows(AnalysisException.class, () -> {
+            ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "show create function echo(int)", bareCtx);
+            com.starrocks.sql.analyzer.Analyzer.analyze(stmt, bareCtx);
+        });
+    }
+
+    @Test
+    public void testExecuteSpecificOverload() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function echo(string)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, rs.getResultRows().size());
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.contains("CREATE FUNCTION"), createSql);
+        Assertions.assertTrue(createSql.toUpperCase().contains("VARCHAR"), createSql);
+    }
+
+    @Test
+    public void testExecuteUnsizedVarcharMatchesStringOverload() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function echo(string)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, rs.getResultRows().size());
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.toUpperCase().contains("VARCHAR"), createSql);
+    }
+
+    @Test
+    public void testExecuteUnknownFunctionFails() {
+        ctx.setDatabase("test_udf_db");
+        assertThrows(SemanticException.class, () -> {
+            ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "show create function does_not_exist(int)", ctx);
+            ShowExecutor.execute(stmt, ctx);
+        });
+    }
+
+    @Test
+    public void testExecuteShowCreateAggregateFunction() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function my_agg(int)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.startsWith("CREATE AGGREGATE FUNCTION"), createSql);
+        Assertions.assertTrue(createSql.contains("\"type\" = \"StarrocksJar\""), createSql);
+        Assertions.assertTrue(createSql.contains("\"file\" = \"xxx\""), createSql);
+        Assertions.assertTrue(createSql.contains("\"intermediate\""), createSql);
+        Assertions.assertFalse(createSql.contains("\"isolation\""), createSql);
+        Assertions.assertFalse(createSql.contains("\"analytic\""), createSql);
+    }
+
+    @Test
+    public void testExecuteShowCreateAggregateFunctionAnalytic() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function my_agg_analytic(int)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.contains("\"analytic\" = \"true\""), createSql);
+    }
+
+    @Test
+    public void testExecuteShowCreateAggregateFunctionShared() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function my_agg_shared(int)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.contains("\"isolation\" = \"shared\""), createSql);
+    }
+
+    @Test
+    public void testExecuteShowCreateTableFunction() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function my_table_fn(int)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.startsWith("CREATE TABLE FUNCTION"), createSql);
+        Assertions.assertTrue(createSql.contains("\"type\" = \"StarrocksJar\""), createSql);
+        Assertions.assertTrue(createSql.contains("\"file\" = \"xxx\""), createSql);
+    }
+
+    @Test
+    public void testExecuteShowCreatePythonInlineFunction() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function python_add(bigint)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, rs.getResultRows().size());
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.startsWith("CREATE FUNCTION"), createSql);
+        Assertions.assertTrue(createSql.contains("\"type\" = \"Python\""), createSql);
+        Assertions.assertTrue(createSql.contains("\"file\" = \"inline\""), createSql);
+        Assertions.assertTrue(createSql.contains("\"symbol\" = \"add\""), createSql);
+        Assertions.assertTrue(createSql.contains("\"input\" = \"arrow\""), createSql);
+        Assertions.assertTrue(createSql.contains("AS $$"), createSql);
+        Assertions.assertTrue(createSql.contains("import pyarrow.compute"), createSql);
+        Assertions.assertTrue(createSql.contains("def add(x)"), createSql);
+    }
+
+    @Test
+    public void testExecuteShowCreateGlobalFunctionRoundTripsWithoutDbPrefix() throws Exception {
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create global function my_global_udf(int)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.startsWith("CREATE GLOBAL FUNCTION"), createSql);
+        Assertions.assertFalse(createSql.contains("__global_udf_db__"), createSql);
+        Assertions.assertTrue(createSql.contains("my_global_udf("), createSql);
+    }
+
+    @Test
+    public void testExecuteShowCreateSqlFunction() throws Exception {
+        ctx.setDatabase("test_udf_db");
+        ShowCreateFunctionStmt stmt = (ShowCreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(
+                "show create function sql_add_one(int)", ctx);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, rs.getResultRows().size());
+        String createSql = rs.getResultRows().get(0).get(0);
+        Assertions.assertTrue(createSql.startsWith("CREATE FUNCTION"), createSql);
+        Assertions.assertTrue(createSql.contains("sql_add_one("), createSql);
+        Assertions.assertTrue(createSql.contains("RETURNS"), createSql);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/AggStateDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/AggStateDescTest.java
@@ -16,6 +16,8 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.starrocks.sql.analyzer.ColumnDefAnalyzer;
+import com.starrocks.sql.ast.HdfsURI;
+import com.starrocks.thrift.TFunctionBinaryType;
 import com.starrocks.type.AggStateDesc;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
@@ -67,5 +69,73 @@ public class AggStateDescTest {
 
         AggStateDesc cloned3 = aggStateDesc3.clone();
         Assertions.assertEquals(aggStateDesc3, cloned3);
+    }
+
+    @Test
+    public void testToSqlEmitsCreateAggregateFunctionHeader() {
+        AggregateFunction fn = new AggregateFunction(
+                new FunctionName("test_db", "my_sum"),
+                Lists.<Type>newArrayList(IntegerType.INT),
+                IntegerType.BIGINT, null, false);
+        fn.setBinaryType(TFunctionBinaryType.SRJAR);
+        String sql = fn.toSql(false);
+        Assertions.assertTrue(sql.startsWith("CREATE AGGREGATE FUNCTION test_db.my_sum"), sql);
+        Assertions.assertTrue(sql.contains("RETURNS"), sql);
+        Assertions.assertFalse(sql.contains("IF NOT EXISTS"), sql);
+    }
+
+    @Test
+    public void testToSqlEmitsIfNotExistsWhenRequested() {
+        AggregateFunction fn = new AggregateFunction(
+                new FunctionName("test_db", "my_sum"),
+                Lists.<Type>newArrayList(IntegerType.INT),
+                IntegerType.BIGINT, null, false);
+        fn.setBinaryType(TFunctionBinaryType.SRJAR);
+        Assertions.assertTrue(fn.toSql(true).contains("CREATE AGGREGATE FUNCTION IF NOT EXISTS"));
+    }
+
+    @Test
+    public void testToSqlEmitsTypeFileSymbolProperties() {
+        AggregateFunction fn = new AggregateFunction(
+                new FunctionName("test_db", "my_sum"),
+                Lists.<Type>newArrayList(IntegerType.INT),
+                IntegerType.BIGINT, null, false);
+        fn.setBinaryType(TFunctionBinaryType.SRJAR);
+        fn.setLocation(new HdfsURI("file:///tmp/udf.jar"));
+        String sql = fn.toSql(false);
+        Assertions.assertTrue(sql.contains("\"type\" = \"StarrocksJar\""), sql);
+        Assertions.assertTrue(sql.contains("\"file\" = \"file:///tmp/udf.jar\""), sql);
+    }
+
+    @Test
+    public void testToSqlEmitsAnalyticPropertyForUDWF() {
+        // isAnalyticFn=true marks this as a window function — surfaced as "analytic" = "true".
+        AggregateFunction fn = new AggregateFunction(
+                new FunctionName("test_db", "my_window"),
+                Lists.<Type>newArrayList(IntegerType.INT),
+                IntegerType.BIGINT, null, false, true);
+        fn.setBinaryType(TFunctionBinaryType.SRJAR);
+        Assertions.assertTrue(fn.toSql(false).contains("\"analytic\" = \"true\""));
+    }
+
+    @Test
+    public void testToSqlIsolationOnlyEmittedWhenShared() {
+        // Default isolation is isolated; key omitted unless explicitly set to shared.
+        AggregateFunction isolated = new AggregateFunction(
+                new FunctionName("test_db", "my_sum"),
+                Lists.<Type>newArrayList(IntegerType.INT),
+                IntegerType.BIGINT, null, false);
+        isolated.setBinaryType(TFunctionBinaryType.SRJAR);
+        Assertions.assertFalse(isolated.toSql(false).contains("\"isolation\""),
+                "isolation key should be omitted when default (isolated)");
+
+        AggregateFunction shared = new AggregateFunction(
+                new FunctionName("test_db", "my_sum"),
+                Lists.<Type>newArrayList(IntegerType.INT),
+                IntegerType.BIGINT, null, false);
+        shared.setBinaryType(TFunctionBinaryType.SRJAR);
+        shared.setIsolationType(false);
+        Assertions.assertTrue(shared.toSql(false).contains("\"isolation\" = \"shared\""),
+                "isolation key should be emitted as 'shared' when isolationType is false");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -185,4 +185,27 @@ public class AnalyzeShowTest {
         Assertions.assertEquals(" LIMIT 10",
                 AstToStringBuilder.toString(showPartitionsStmt.getLimitElement()));
     }
+
+    @Test
+    public void testShowCreateFunctionResolvesDatabase() {
+        analyzeSuccess("show create function some_fn(int)");
+        analyzeSuccess("show create function test.some_fn(int, varchar(32))");
+    }
+
+    @Test
+    public void testShowCreateGlobalFunction() {
+        analyzeSuccess("show create global function my_global_fn(int)");
+        analyzeSuccess("show create global function my_global_fn(varchar(12), string)");
+    }
+
+    @Test
+    public void testShowCreateFunctionRejectsInvalidArgSize() {
+        analyzeFail("show create function test.some_fn(varchar(0))",
+                "Varchar size must be > 0: 0");
+    }
+
+    @Test
+    public void testShowCreateGlobalFunctionRejectsDbQualifier() {
+        analyzeFail("show create global function some_db.my_global_fn(int)");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
@@ -53,7 +54,9 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.SqlFunction;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AlreadyExistsException;
@@ -88,6 +91,8 @@ import com.starrocks.schema.MSchema;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.FunctionRefAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.TypeDefAnalyzer;
@@ -116,6 +121,7 @@ import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.DropTemporaryTableStmt;
 import com.starrocks.sql.ast.FunctionArgsDef;
 import com.starrocks.sql.ast.FunctionRef;
+import com.starrocks.sql.ast.HdfsURI;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
@@ -127,6 +133,7 @@ import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.ShowTabletStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
@@ -136,6 +143,8 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TFunctionBinaryType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang.StringUtils;
@@ -354,19 +363,105 @@ public class StarRocksAssert {
         String defaultDb = functionRef.isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB : ctx.getDatabase();
         FunctionRefAnalyzer.analyzeFunctionRef(functionRef, defaultDb);
         FunctionArgsDef argsDef = createFunctionStmt.getArgsDef();
-        TypeDef returnType = createFunctionStmt.getReturnType();
-        // check argument
         FunctionRefAnalyzer.analyzeArgsDef(argsDef);
-        TypeDefAnalyzer.analyze(returnType);
         FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(functionRef, defaultDb);
 
-        Function function = ScalarFunction.createUdf(
-                functionName, argsDef.getArgTypes(),
-                returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
-                "", "", "", "", !"shared".equalsIgnoreCase(""), null);
+        Function function;
+        if (createFunctionStmt.isBuildFunctionMode()) {
+            function = mockSqlFunction(createFunctionStmt, functionName, argsDef, ctx);
+        } else {
+            TypeDef returnType = createFunctionStmt.getReturnType();
+            TypeDefAnalyzer.analyze(returnType);
+            Map<String, String> props = createFunctionStmt.getProperties();
+            TFunctionBinaryType binaryType = detectBinaryType(props);
+            if (createFunctionStmt.isAggregate()) {
+                function = mockAggregateFunction(functionName, argsDef, returnType, props, binaryType);
+            } else if (createFunctionStmt.isTable()) {
+                function = mockTableFunction(functionName, argsDef, returnType, props, binaryType);
+            } else {
+                function = mockScalarFunction(createFunctionStmt, functionName, argsDef, returnType, props, binaryType);
+            }
+        }
 
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(ctx.getDatabase());
-        db.addFunction(function, true, false);
+        if (functionRef.isGlobalFunction()) {
+            GlobalStateMgr.getCurrentState().getGlobalFunctionMgr().replayAddFunction(function);
+        } else {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(ctx.getDatabase());
+            db.addFunction(function, true, false);
+        }
+    }
+
+    private static TFunctionBinaryType detectBinaryType(Map<String, String> props) {
+        return CreateFunctionStmt.TYPE_STARROCKS_PYTHON.equalsIgnoreCase(props.get(CreateFunctionStmt.TYPE_KEY))
+                ? TFunctionBinaryType.PYTHON
+                : TFunctionBinaryType.SRJAR;
+    }
+
+    private static SqlFunction mockSqlFunction(CreateFunctionStmt stmt, FunctionName functionName,
+                                               FunctionArgsDef argsDef, ConnectContext ctx) {
+        Expr expr = stmt.getExpr();
+        Map<String, Type> argsMap = new HashMap<>();
+        for (int i = 0; i < argsDef.getArgNames().size(); i++) {
+            argsMap.put(argsDef.getArgNames().get(i), argsDef.getArgTypes()[i]);
+        }
+        ExpressionAnalyzer.analyzeExpressionResolveSlot(expr, ctx, slotRef -> {
+            Type t = argsMap.get(slotRef.getColName());
+            if (t == null) {
+                throw new SemanticException("Cannot find argument " + slotRef.getColName() + " in function args");
+            }
+            slotRef.setType(t);
+        });
+        String sqlBody = AstToSQLBuilder.toSQLWithCredential(expr);
+        return new SqlFunction(functionName, argsDef.getArgTypes(), expr.getType(),
+                argsDef.getArgNames().toArray(new String[0]), sqlBody);
+    }
+
+    private static AggregateFunction mockAggregateFunction(FunctionName functionName, FunctionArgsDef argsDef,
+                                                           TypeDef returnType, Map<String, String> props,
+                                                           TFunctionBinaryType binaryType) {
+        AggregateFunction agg = new AggregateFunction(
+                functionName,
+                Arrays.asList(argsDef.getArgTypes()),
+                returnType.getType(),
+                TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength()),
+                argsDef.isVariadic(),
+                "true".equalsIgnoreCase(props.get(CreateFunctionStmt.IS_ANALYTIC_NAME)));
+        agg.setBinaryType(binaryType);
+        agg.setLocation(new HdfsURI(props.getOrDefault(CreateFunctionStmt.FILE_KEY, "")));
+        agg.setIsolationType(!"shared".equalsIgnoreCase(props.getOrDefault(CreateFunctionStmt.ISOLATION_KEY, "")));
+        return agg;
+    }
+
+    private static TableFunction mockTableFunction(FunctionName functionName, FunctionArgsDef argsDef,
+                                                   TypeDef returnType, Map<String, String> props,
+                                                   TFunctionBinaryType binaryType) {
+        TableFunction tbl = new TableFunction(
+                functionName,
+                Lists.newArrayList(functionName.getFunction()),
+                Arrays.asList(argsDef.getArgTypes()),
+                Lists.newArrayList(returnType.getType()),
+                argsDef.isVariadic());
+        tbl.setBinaryType(binaryType);
+        tbl.setLocation(new HdfsURI(props.getOrDefault(CreateFunctionStmt.FILE_KEY, "")));
+        tbl.setSymbolName(props.getOrDefault(CreateFunctionStmt.SYMBOL_KEY, ""));
+        return tbl;
+    }
+
+    private static ScalarFunction mockScalarFunction(CreateFunctionStmt stmt, FunctionName functionName,
+                                                     FunctionArgsDef argsDef, TypeDef returnType,
+                                                     Map<String, String> props, TFunctionBinaryType binaryType) {
+        boolean isolated = !"shared".equalsIgnoreCase(props.getOrDefault(CreateFunctionStmt.ISOLATION_KEY, ""));
+        ScalarFunction sfn = ScalarFunction.createUdf(
+                functionName, argsDef.getArgTypes(),
+                returnType.getType(), argsDef.isVariadic(), binaryType,
+                props.getOrDefault(CreateFunctionStmt.FILE_KEY, ""),
+                props.getOrDefault(CreateFunctionStmt.SYMBOL_KEY, ""),
+                "", "", isolated, null);
+        sfn.setInputType(props.get(CreateFunctionStmt.INPUT_TYPE));
+        if (stmt.getContent() != null) {
+            sfn.setContent(stmt.getContent());
+        }
+        return sfn;
     }
 
     public static void utCreateTableWithRetry(CreateTableStmt createTableStmt, ConnectContext ctx) throws Exception {

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -171,6 +171,7 @@ statement
 
     // UDF Statement
     | showFunctionsStatement
+    | showCreateFunctionStatement
     | dropFunctionStatement
     | createFunctionStatement
 
@@ -1580,6 +1581,10 @@ classifier
 
 showFunctionsStatement
     : SHOW FULL? (BUILTIN|GLOBAL)? FUNCTIONS ((FROM | IN) db=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
+    ;
+
+showCreateFunctionStatement
+    : SHOW CREATE GLOBAL? FUNCTION qualifiedName '(' typeList ')'
     ;
 
 dropFunctionStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -698,6 +698,10 @@ public interface AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
+    default R visitShowCreateFunctionStatement(ShowCreateFunctionStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
     default R visitSetDefaultStorageVolumeStatement(SetDefaultStorageVolumeStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowCreateFunctionStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowCreateFunctionStmt.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.parser.NodePosition;
+
+public class ShowCreateFunctionStmt extends ShowStmt {
+    private final FunctionRef functionRef;
+    private final FunctionArgsDef argsDef;
+
+    public ShowCreateFunctionStmt(FunctionRef functionRef, FunctionArgsDef argsDef) {
+        this(functionRef, argsDef, NodePosition.ZERO);
+    }
+
+    public ShowCreateFunctionStmt(FunctionRef functionRef, FunctionArgsDef argsDef, NodePosition pos) {
+        super(pos);
+        this.functionRef = functionRef;
+        this.argsDef = argsDef;
+    }
+
+    public FunctionRef getFunctionRef() {
+        return functionRef;
+    }
+
+    public FunctionArgsDef getArgsDef() {
+        return argsDef;
+    }
+
+    public boolean isGlobalFunction() {
+        return functionRef != null && functionRef.isGlobalFunction();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitShowCreateFunctionStatement(this, context);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Backport #73519 to branch-4.1 because it was requested for the 4.1 backport queue.

## What I'm doing:

- Backport `SHOW CREATE FUNCTION` syntax, analyzer/executor support, and function SQL serialization.
- Backport related FE tests and English/Japanese/Chinese documentation.

Backport #73519

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Verification:

- `git diff --check origin/branch-4.1...HEAD`
- `rg -n '<<<<<<<|>>>>>>>' ...` on touched docs/parser/FE files
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home mvn -pl fe-core -am -DskipTests -Dcheckstyle.skip compile` reached `fe-core` compilation; `fe-grammar`, `fe-parser`, and checkstyle validate completed, then the build failed on existing generated thrift generic type errors in `target/generated-sources/thrift`.