### PR TITLE
[Enhancement] opt(lake pindex): origin-skip + parallel del-apply on cold rebuild

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -945,59 +945,68 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         return pkc;
     };
 
-    // Apply one decoded del column to the index. Order-dependent: replay_erase mutates state
-    // observed by later files' get(), so callers must invoke this sequentially in del_idx order.
-    auto apply_one = [&](int del_idx, MutableColumnPtr& pkc) -> Status {
-        const auto& del = rowset->metadata().del_files(del_idx);
-        // We can't insert delete operation to index directly, because some delete operation is
-        // older than current item, and we need to igore these delete operations.
-        std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));
-        std::vector<bool> filter(pkc->size(), false);
-        auto generate_filter_fn = [&]() {
-            if (rowset->id() != del.origin_rowset_id()) {
-                // del file in origin rowset doesn't need to skip.
-                for (int i = 0; i < pkc->size(); i++) {
-                    if (found_values[i] != IndexValue(NullIndexValue) &&
-                        found_values[i].get_rssid() > del.origin_rowset_id() + del.op_offset()) {
-                        // Use `rowset_id + op_offset` as delete file's rssid.
-                        // delete operation is too old for this key.
-                        filter[i] = true;
-                    }
-                }
-            }
-        };
-        // Rssid of delete files is equal to `rowset_id + op_offset`, and delete is always after upsert now,
-        // so we use max segment id as `op_offset`.
-        // TODO : support real order of mix upsert and delete in one transaction.
-        const uint32_t del_rebuild_rssid = rowset->id() + get_max_segment_idx(rowset->metadata());
-        // TODO: Refactor the code to remove tmp slice array.
-        Buffer<Slice> keys;
-        keys.reserve(pkc->size());
+    // A decoded del file ready to replay: key Slices (borrowing from the owned pk column) + per-key
+    // skip filter.
+    struct DecodedDel {
+        MutableColumnPtr pkc;     // owns the key bytes; keys/filter borrow from it
+        Buffer<Slice> keys;       // Slices into pkc
+        std::vector<bool> filter; // true = skip this delete (too old)
+    };
+
+    // Extract key Slices from a decoded pk column (binary: contiguous Slices; fixed: _key_size stride).
+    // The Slices borrow from pkc, so pkc must outlive them.
+    auto extract_keys = [&](const MutableColumnPtr& pkc, Buffer<Slice>* keys) -> Status {
+        keys->reserve(pkc->size());
         if (pkc->is_binary() || pkc->is_large_binary()) {
             // When PK table have multi pk columns or one pk column with varchar type,
             // we treat it as binary column.
-            ColumnHelper::build_slices(pkc, keys);
-            // 1. Get from pk index, to find out if this delete operation is too old.
-            RETURN_IF_ERROR(get(pkc->size(), keys.data(), found_values.data()));
-            generate_filter_fn();
-            // 2. insert delete operations to pk index.
-            RETURN_IF_ERROR(replay_erase(pkc->size(), keys.data(), filter, rowset_version, del_rebuild_rssid));
+            ColumnHelper::build_slices(pkc, *keys);
         } else {
             RawBytesVisitor visitor;
             RETURN_IF_ERROR(pkc->accept(&visitor));
             const auto* fkeys = visitor.result();
             for (size_t i = 0; i < pkc->size(); ++i) {
-                keys.emplace_back(fkeys, _key_size);
+                keys->emplace_back(fkeys, _key_size);
                 fkeys += _key_size;
             }
-            // 1. Get from pk index, to find out if this delete operation is too old.
-            RETURN_IF_ERROR(get(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), found_values.data()));
-            generate_filter_fn();
-            // 2. insert delete operations to pk index.
-            RETURN_IF_ERROR(replay_erase(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), filter,
-                                         rowset_version, del_rebuild_rssid));
         }
         return Status::OK();
+    };
+
+    // Phase-1 work (parallel-safe): read + decode the del file, extract keys, and build the skip
+    // filter. The index get() -- the ONLY SST-reading step here -- is needed *only* for del files that
+    // did NOT originate from this rowset; for origin del files the filter is a no-op (all false ->
+    // every key erased), so we skip the get() entirely and avoid its cold-start SST reads. This is the
+    // dominant cold-rebuild win. replay_erase (Phase 2) is a pure memtable write.
+    auto load_one = [&](int del_idx, DecodedDel* out) -> Status {
+        ASSIGN_OR_RETURN(out->pkc, read_one(del_idx));
+        RETURN_IF_ERROR(extract_keys(out->pkc, &out->keys));
+        out->filter.assign(out->keys.size(), false);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        if (rowset->id() != del.origin_rowset_id()) {
+            // Non-origin del file: drop deletes that are too old for the current index entry.
+            // We can't insert delete operation to index directly, because some delete operation is
+            // older than current item, and we need to igore these delete operations.
+            std::vector<IndexValue> found_values(out->keys.size(), IndexValue(NullIndexValue));
+            RETURN_IF_ERROR(get(out->keys.size(), out->keys.data(), found_values.data()));
+            // Use `rowset_id + op_offset` as delete file's rssid; deletes older than that are stale.
+            const uint32_t too_old = del.origin_rowset_id() + del.op_offset();
+            for (size_t i = 0; i < out->keys.size(); i++) {
+                if (found_values[i] != IndexValue(NullIndexValue) && found_values[i].get_rssid() > too_old) {
+                    out->filter[i] = true;
+                }
+            }
+        }
+        return Status::OK();
+    };
+
+    // Phase-2 work. Order-dependent memtable mutation; callers invoke sequentially in del_idx order.
+    // Rssid of delete files is equal to `rowset_id + op_offset`, and delete is always after upsert now,
+    // so we use max segment id as `op_offset`.
+    // TODO : support real order of mix upsert and delete in one transaction.
+    auto erase_one = [&](const DecodedDel& d) -> Status {
+        const uint32_t del_rebuild_rssid = rowset->id() + get_max_segment_idx(rowset->metadata());
+        return replay_erase(d.keys.size(), d.keys.data(), d.filter, rowset_version, del_rebuild_rssid);
     };
 
     // Gate the two-phase parallel path on update-memtracker pressure (see
@@ -1006,34 +1015,43 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     const bool use_two_phase = should_parallel_rebuild_prefetch(num_del_files);
 
     if (!use_two_phase) {
-        // Legacy single-pass loop: read+decode+apply per file, only one decoded column held at a time.
+        // Single-pass loop: load (read+decode+keys+maybe-get) then erase per file, in del_idx order.
+        // Only one decoded column held at a time.
         for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
             TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
-            ASSIGN_OR_RETURN(auto pkc, read_one(del_idx));
-            RETURN_IF_ERROR(apply_one(del_idx, pkc));
+            DecodedDel d;
+            RETURN_IF_ERROR(load_one(del_idx, &d));
+            RETURN_IF_ERROR(erase_one(d));
         }
         return Status::OK();
     }
 
-    // Phase 1 (parallel): read each delete file's bytes from object storage and deserialize
-    // them into a per-file pk column. Reads dominate cold-start cost (8 files × ~OSS_RTT each
-    // = seconds); parallelising them collapses that wall-clock without changing on-disk semantics.
-    // Memory tradeoff: this path holds all `num_del_files` decoded columns concurrently until
-    // Phase 2 consumes them — guarded above by the update-memtracker pressure check.
-    std::vector<MutableColumnPtr> pkcs(num_del_files);
+    // Phase 1 (parallel): load all del files — read+decode bytes, extract keys, and (for non-origin
+    // files only) run the index get() + build the skip filter. Both the OSS byte reads and the
+    // non-origin SST get()s — the cold-start cost — overlap here. Reuses pk_index_execution_thread_pool:
+    // get() runs its SST lookups synchronously without submitting back to this pool, so there is no
+    // pool-in-pool nesting. Memory tradeoff: holds all `num_del_files` decoded columns concurrently
+    // until Phase 2 consumes them — guarded above by the update-memtracker pressure check.
+    //
+    // Correct even when del files share keys: replay_erase writes (rowset_version, NULL) and every del
+    // file of a rowset uses the same rowset_version, so the erase is idempotent. For a shared key K in
+    // files A (earlier) < B (later): if A erases K it is NULL regardless of B; if A skips K it leaves
+    // K untouched so B sees the same value the serial path would. Either way the final index equals
+    // serial, so running every non-origin get() up-front against the same pre-erase snapshot is safe.
+    std::vector<DecodedDel> decoded(num_del_files);
     std::mutex shared_mutex;
     Status shared_status;
     auto record_err = [&](const Status& s) {
         std::lock_guard<std::mutex> l(shared_mutex);
         shared_status.update(s);
     };
+    Trace* trace = Trace::CurrentTrace();
     auto run_one = [&](int del_idx) {
-        auto res = read_one(del_idx);
-        if (!res.ok()) {
-            record_err(res.status());
-            return;
+        ADOPT_TRACE(trace);
+        auto st = load_one(del_idx, &decoded[del_idx]);
+        if (!st.ok()) {
+            record_err(st);
         }
-        pkcs[del_idx] = std::move(res).value();
     };
 
     auto token = GlobalEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
@@ -1051,9 +1069,9 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     token->wait();
     RETURN_IF_ERROR(shared_status);
 
-    // Phase 2 (sequential): order-dependent index mutations.
+    // Phase 2 (sequential): order-dependent memtable erases.
     for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
-        RETURN_IF_ERROR(apply_one(del_idx, pkcs[del_idx]));
+        RETURN_IF_ERROR(erase_one(decoded[del_idx]));
     }
     return Status::OK();
 }

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -24,7 +24,9 @@
 #include "column/raw_data_visitor.h"
 #include "column/runtime_type_traits.h"
 #include "common/config_primary_key_fwd.h"
+#include "fs/fs.h"
 #include "runtime/descriptors.h"
+#include "serde/column_array_serde.h"
 #include "storage/chunk_helper.h"
 #include "storage/del_vector.h"
 #include "storage/lake/meta_file.h"
@@ -199,6 +201,51 @@ protected:
         for (auto& k : keys) {
             out_keys->emplace_back(std::move(k));
         }
+    }
+
+    // --- Helpers for load_dels tests. ---
+    // A single-VARCHAR-key PK schema is used so the keys round-trip through a BinaryColumn and
+    // extract_keys() takes the binary branch (no _key_size init, which only load_from_lake_tablet does).
+
+    std::shared_ptr<TabletSchema> make_varchar_pk_schema() {
+        TabletSchemaPB pb;
+        pb.set_keys_type(PRIMARY_KEYS);
+        pb.set_num_short_key_columns(1);
+        pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+        auto* c0 = pb.add_column();
+        c0->set_unique_id(0);
+        c0->set_name("pk");
+        c0->set_type("VARCHAR");
+        c0->set_length(128);
+        c0->set_index_length(128);
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = pb.add_column();
+        c1->set_unique_id(1);
+        c1->set_name("v");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        return std::make_shared<TabletSchema>(pb);
+    }
+
+    // Serialize `keys` as a BinaryColumn and write it as a del file at del_location(tablet_id, name),
+    // matching what load_dels' read_one() expects to deserialize.
+    void write_binary_del_file(int64_t tablet_id, const std::string& name, const std::vector<std::string>& keys) {
+        auto col = BinaryColumn::create();
+        for (const auto& k : keys) {
+            col->append(Slice(k));
+        }
+        const int64_t max_size = serde::ColumnArraySerde::max_serialized_size(*col);
+        std::vector<uint8_t> buffer(max_size);
+        ASSIGN_OR_ABORT(auto* end, serde::ColumnArraySerde::serialize(*col, buffer.data()));
+        const size_t used = end - buffer.data();
+        auto path = _tablet_mgr->del_location(tablet_id, name);
+        WritableFileOptions opts;
+        opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE; // tests rewrite the same del path across runs
+        ASSIGN_OR_ABORT(auto wf, FileSystem::Default()->new_writable_file(opts, path));
+        ASSERT_OK(wf->append(Slice(reinterpret_cast<const char*>(buffer.data()), used)));
+        ASSERT_OK(wf->close());
     }
 };
 
@@ -1391,6 +1438,142 @@ TEST_F(LakePersistentIndexTest, test_load_from_lake_tablet_parallel_matches_seri
                 << "key " << keys[i] << " missing after parallel rebuild";
         EXPECT_EQ(serial_values[i].get_value(), parallel_values[i].get_value())
                 << "parallel vs serial mismatch for key " << keys[i];
+    }
+}
+
+// A del file that did NOT originate from the rebuilt rowset must run get()+filter and drop deletes
+// that are too old for the current index entry. too_old = origin_rowset_id + op_offset: keys whose
+// current rssid (value >> 32) is <= too_old get erased; keys with a newer rssid keep their value.
+TEST_F(LakePersistentIndexTest, test_load_dels_non_origin_filters_stale_deletes) {
+    auto tablet_id = _tablet_metadata->id();
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+
+    std::vector<std::string> keys = {"k0", "k1", "k2", "k3"};
+    std::vector<uint32_t> rssids = {5, 5, 50, 50};
+    std::vector<Slice> key_slices;
+    std::vector<IndexValue> values;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        key_slices.emplace_back(keys[i]);
+        values.emplace_back(((uint64_t)rssids[i] << 32) | i);
+    }
+    ASSERT_OK(index->insert(keys.size(), key_slices.data(), values.data(), /*version=*/1));
+
+    write_binary_del_file(tablet_id, "del_nonorigin", keys);
+    RowsetMetadataPB rowset_meta;
+    rowset_meta.set_id(999);
+    auto* d = rowset_meta.add_del_files();
+    d->set_name("del_nonorigin");
+    d->set_origin_rowset_id(20); // != rowset id -> non-origin; too_old = 20 + 0
+    d->set_op_offset(0);
+
+    auto tablet_schema = make_varchar_pk_schema();
+    auto rowset = std::make_shared<Rowset>(_tablet_mgr.get(), tablet_id, &rowset_meta, /*index=*/0, tablet_schema);
+    std::vector<ColumnId> pk_columns = {0};
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+
+    ASSERT_OK(index->load_dels(rowset, pkey_schema, /*rowset_version=*/10));
+
+    std::vector<IndexValue> got(keys.size());
+    ASSERT_OK(index->get(keys.size(), key_slices.data(), got.data()));
+    EXPECT_EQ(IndexValue(NullIndexValue), got[0]); // rssid 5  <= 20 -> erased
+    EXPECT_EQ(IndexValue(NullIndexValue), got[1]); // rssid 5  <= 20 -> erased
+    EXPECT_EQ(values[2], got[2]);                  // rssid 50 >  20 -> stale delete skipped
+    EXPECT_EQ(values[3], got[3]);                  // rssid 50 >  20 -> stale delete skipped
+}
+
+// Origin-skip: a del file whose origin_rowset_id == the rebuilt rowset id skips get() entirely and
+// erases every key regardless of its current rssid. Same keys/rssids as the non-origin test above,
+// but here even the rssid-50 keys (which the non-origin path keeps) are erased.
+TEST_F(LakePersistentIndexTest, test_load_dels_origin_erases_all_keys) {
+    auto tablet_id = _tablet_metadata->id();
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+
+    std::vector<std::string> keys = {"k0", "k1", "k2", "k3"};
+    std::vector<uint32_t> rssids = {5, 5, 50, 50};
+    std::vector<Slice> key_slices;
+    std::vector<IndexValue> values;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        key_slices.emplace_back(keys[i]);
+        values.emplace_back(((uint64_t)rssids[i] << 32) | i);
+    }
+    ASSERT_OK(index->insert(keys.size(), key_slices.data(), values.data(), /*version=*/1));
+
+    write_binary_del_file(tablet_id, "del_origin", keys);
+    RowsetMetadataPB rowset_meta;
+    rowset_meta.set_id(777);
+    auto* d = rowset_meta.add_del_files();
+    d->set_name("del_origin");
+    d->set_origin_rowset_id(777); // == rowset id -> origin del file
+    d->set_op_offset(0);
+
+    auto tablet_schema = make_varchar_pk_schema();
+    auto rowset = std::make_shared<Rowset>(_tablet_mgr.get(), tablet_id, &rowset_meta, /*index=*/0, tablet_schema);
+    std::vector<ColumnId> pk_columns = {0};
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+
+    ASSERT_OK(index->load_dels(rowset, pkey_schema, /*rowset_version=*/10));
+
+    std::vector<IndexValue> got(keys.size());
+    ASSERT_OK(index->get(keys.size(), key_slices.data(), got.data()));
+    for (size_t i = 0; i < keys.size(); ++i) {
+        EXPECT_EQ(IndexValue(NullIndexValue), got[i]) << "key " << keys[i] << " should be erased by origin del";
+    }
+}
+
+// The two-phase parallel path (num_del_files > 1, parallel execution on) must produce the same index
+// as the single-pass path, including when del files share keys. Files are an origin + a non-origin del
+// that overlap on keys, exercising the idempotent-erase / shared-key reasoning in load_dels.
+TEST_F(LakePersistentIndexTest, test_load_dels_parallel_matches_single_pass) {
+    auto tablet_schema = make_varchar_pk_schema();
+    std::vector<ColumnId> pk_columns = {0};
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+
+    std::vector<std::string> keys = {"k0", "k1", "k2", "k3", "k4", "k5"};
+    std::vector<uint32_t> rssids = {5, 50, 5, 50, 5, 50};
+
+    auto run = [&](bool parallel) {
+        ConfigResetGuard<bool> g(&config::enable_pk_index_parallel_execution, parallel);
+        auto tablet_id = _tablet_metadata->id();
+        auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+        CHECK_OK(index->init(_tablet_metadata));
+
+        std::vector<Slice> key_slices;
+        std::vector<IndexValue> values;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            key_slices.emplace_back(keys[i]);
+            values.emplace_back(((uint64_t)rssids[i] << 32) | i);
+        }
+        CHECK_OK(index->insert(keys.size(), key_slices.data(), values.data(), /*version=*/1));
+
+        // Two del files that share keys: one non-origin (filters stale deletes), one origin (erase all).
+        write_binary_del_file(tablet_id, "del_a", {"k0", "k1", "k2"});
+        write_binary_del_file(tablet_id, "del_b", {"k2", "k3", "k4", "k5"});
+        RowsetMetadataPB rowset_meta;
+        rowset_meta.set_id(888);
+        auto* da = rowset_meta.add_del_files();
+        da->set_name("del_a");
+        da->set_origin_rowset_id(20); // non-origin, too_old = 20
+        da->set_op_offset(0);
+        auto* db = rowset_meta.add_del_files();
+        db->set_name("del_b");
+        db->set_origin_rowset_id(888); // origin -> erase all of k2..k5
+        db->set_op_offset(0);
+
+        auto rowset = std::make_shared<Rowset>(_tablet_mgr.get(), tablet_id, &rowset_meta, /*index=*/0, tablet_schema);
+        CHECK_OK(index->load_dels(rowset, pkey_schema, /*rowset_version=*/10));
+
+        std::vector<IndexValue> got(keys.size());
+        CHECK_OK(index->get(keys.size(), key_slices.data(), got.data()));
+        return got;
+    };
+
+    auto serial = run(false);
+    auto parallel = run(true);
+    ASSERT_EQ(serial.size(), parallel.size());
+    for (size_t i = 0; i < serial.size(); ++i) {
+        EXPECT_EQ(serial[i], parallel[i]) << "mismatch at key " << keys[i];
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

On shared-data cold-start, rebuilding the cloud-native PK index from a rowset's delete files (`LakePersistentIndex::load_dels`) was slow: each del file did an index `get()` whose SST reads are cold, and the files were applied serially. On cold 300-table runs `rebuild_index_del_cost` was the dominant cost (seconds).

Two observations make this avoidable:
1. A del file whose `origin_rowset_id` equals the rowset being rebuilt never needs the `get()`: the skip filter it would build is a no-op, so every key is erased anyway. The `get()` (and its cold SST reads) is pure waste for those files.
2. The only order-dependent step is the memtable `replay_erase`. Reading/decoding the del bytes, extracting keys, and running the non-origin `get()` are all parallel-safe against the same pre-erase snapshot.

## What I'm doing:

Rewrote `load_dels` into two phases:

- **`load_one` (parallel-safe):** read + decode the del file, extract keys, and — only for non-origin del files — run `get()` and build the skip filter. Origin del files skip `get()` entirely (origin-skip), avoiding the cold SST reads that dominated the cost.
- **`erase_one` (serial):** the order-dependent memtable `replay_erase`, replayed in `del_idx` order.

When the two-phase path is enabled (existing `should_parallel_rebuild_prefetch` gate: parallel execution on, `num_del_files > 1`, update mem-tracker below the rebuild ratio), Phase 1 runs every file's `load_one` concurrently so the non-origin `get()`s overlap, then Phase 2 erases serially. Otherwise it falls back to a single-pass `load_one`+`erase_one` loop holding one decoded column at a time.

This is correct even when del files share keys: `replay_erase` writes `(rowset_version, NULL)` and every del file of a rowset uses the same `rowset_version`, so the erase is idempotent and the parallel result equals the serial result.

Phase 1 reuses the existing `pk_index_execution_thread_pool` (registered as `cloud_native_pk_index_execution`). `get()` runs its SST lookups synchronously and never submits back to that pool, so there is no pool-in-pool nesting — no dedicated pool, config, or metric is added.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

This is a performance optimization of the PK-index cold rebuild path; the rebuilt index is identical to before.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Added BE unit tests in `lake_persistent_index_test.cpp`:
- `test_load_dels_non_origin_filters_stale_deletes` — non-origin del runs `get()`+filter; stale deletes (key rssid newer than `origin_rowset_id + op_offset`) are skipped, older ones erased.
- `test_load_dels_origin_erases_all_keys` — origin del erases every key regardless of rssid (origin-skip semantics), contrasting the non-origin case on identical input.
- `test_load_dels_parallel_matches_single_pass` — two key-sharing del files (one origin, one non-origin) produce an identical index via the parallel and single-pass paths.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
