### PR TITLE
[BugFix] Fix use-after-free of LLVMContext when JIT compilation fails

### DIFF
--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -55,6 +55,7 @@
 #include <mutex>
 #include <utility>
 
+#include "base/failpoint/fail_point.h"
 #include "base/utility/defer_op.h"
 #include "common/compiler_util.h"
 #include "common/config_expr_fwd.h"
@@ -406,11 +407,15 @@ private:
     ShardedLRUCache _cache;
 };
 
+DEFINE_FAIL_POINT(jit_compile_failed);
+
 // Optimise and compile the module.
-static inline StatusOr<JITCallablePtr> optimize_and_finalize_module(const std::string& expr_name,
-                                                                    std::unique_ptr<llvm::LLVMContext> context,
-                                                                    std::unique_ptr<llvm::Module>&& module,
-                                                                    JITObjectCache& object_cache) {
+static StatusOr<JITCallablePtr> optimize_and_finalize_module(const std::string& expr_name,
+                                                             std::unique_ptr<llvm::LLVMContext>&& context,
+                                                             std::unique_ptr<llvm::Module>&& module,
+                                                             JITObjectCache& object_cache) {
+    // Simulates a JIT compilation failure to exercise the early-return error path.
+    FAIL_POINT_TRIGGER_RETURN(jit_compile_failed, Status::JitCompileError("injected jit compile error"));
     ASSIGN_OR_RETURN(auto jtmb, make_target_machine_builder());
     auto mem_mgr = CustomizedInProcessMemoryManager::create();
     ASSIGN_OR_RETURN(auto lljit, build_JIT(jtmb, object_cache, *mem_mgr));

--- a/test/sql/test_jit/R/test_jit_compile_failure_no_crash
+++ b/test/sql/test_jit/R/test_jit_compile_failure_no_crash
@@ -1,0 +1,23 @@
+-- name: test_jit_compile_failure_no_crash @sequential
+CREATE TABLE t (k INT, c DOUBLE) PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO t VALUES (1, 1.5), (2, 2.5);
+-- result:
+-- !result
+set jit_level = -1;
+-- result:
+-- !result
+admin enable failpoint 'jit_compile_failed';
+-- result:
+-- !result
+function: assert_query_error_contains("SELECT cast(k as largeint) * 3 + k FROM t ORDER BY 1", "injected jit compile error")
+-- result:
+None
+-- !result
+admin disable failpoint 'jit_compile_failed';
+-- result:
+-- !result
+CLEANUP {
+  admin disable failpoint 'jit_compile_failed';
+} END CLEANUP

--- a/test/sql/test_jit/T/test_jit_compile_failure_no_crash
+++ b/test/sql/test_jit/T/test_jit_compile_failure_no_crash
@@ -1,0 +1,10 @@
+-- name: test_jit_compile_failure_no_crash @sequential
+CREATE TABLE t (k INT, c DOUBLE) PROPERTIES("replication_num"="1");
+INSERT INTO t VALUES (1, 1.5), (2, 2.5);
+set jit_level = -1;
+admin enable failpoint 'jit_compile_failed';
+function: assert_query_error_contains("SELECT cast(k as largeint) * 3 + k FROM t ORDER BY 1", "injected jit compile error")
+admin disable failpoint 'jit_compile_failed';
+CLEANUP {
+  admin disable failpoint 'jit_compile_failed';
+} END CLEANUP


### PR DESCRIPTION
 ## Why I'm doing:

  When JIT compilation fails, BE may crash with SIGSEGV. Crash stack:

  ```
  PC: llvm::LLVMContext::removeModule(llvm::Module*)
  *** SIGSEGV (@0x0) received ***
      @ llvm::LLVMContext::removeModule(llvm::Module*)
      @ llvm::Module::~Module()
      @ starrocks::JITEngine::_compile(...)
      @ starrocks::JITEngine::_get_jit_callable_or_create(...)
      @ starrocks::JITEngine::get_jit_callable(...)
      @ starrocks::JITExpr::prepare_impl(...)
      @ starrocks::JITExpr::prepare(...)
      @ starrocks::ExprContext::prepare(...)
      @ starrocks::pipeline::ProjectOperatorFactory::prepare(...)
      @ starrocks::pipeline::FragmentContext::prepare_all_pipelines()
  ```

  The root cause is a split-ownership bug in `optimize_and_finalize_module`:

  ```cpp
  StatusOr<JITCallablePtr> JITEngine::_compile(...) {
      auto llvm_context = std::make_unique<llvm::LLVMContext>();
      auto module = std::make_unique<llvm::Module>(module_id, *llvm_context);
      ...
      return optimize_and_finalize_module(expr_name, std::move(llvm_context), std::move(module), ...);
  }

  static StatusOr<JITCallablePtr> optimize_and_finalize_module(
          ...,
          std::unique_ptr<llvm::LLVMContext> context,   // by value: ownership moves into the callee
          std::unique_ptr<llvm::Module>&& module,       // rvalue ref: ownership stays in _compile
          ...)
  ```

  `context` is taken by value, so its ownership transfers into the callee, while `module` is taken
  by rvalue reference, so its ownership stays in `_compile`. On the success path both are moved
  into a `ThreadSafeModule` together and everything is fine. But on **any early error return**
  (e.g. `llvm::verifyModule` rejecting the IR):

  1. the callee's `context` parameter is destroyed, deleting the `LLVMContext`;
  2. back in `_compile`, the local `module` is destroyed later;
  3. `llvm::Module::~Module()` calls `Context.removeModule(this)` to unregister itself from its
     context, which is already freed → **use-after-free**.

  Depending on heap state this either crashes the BE (SIGSEGV above) or silently reads/writes
  freed memory. Any JIT compilation failure takes this path; in production it was triggered by
  the invalid IR from the case-when codegen bug fixed in #<bug1-PR>.

  ## What I'm doing:

  - Take `context` by rvalue reference as well, so that on every early return the ownership of
    both objects stays in `_compile`, whose locals are destroyed in reverse declaration order
    (`module` first, then `llvm_context`) — the order `Module::~Module` requires. On success both
    are still moved into the `ThreadSafeModule` together, unchanged. A comment documents the
    destruction-order requirement to prevent this from regressing.
  - Add a failpoint `jit_compile_failed` at the entry of `optimize_and_finalize_module` and a SQL
    test that injects a compile failure and asserts the error is cleanly propagated to the client
    while the BE stays alive.

  Verified with `BUILD_TYPE=ASAN ENABLE_FAULT_INJECTION=ON`:
  - before the fix: the injected failure reports heap-use-after-free in `llvm::Module::~Module`;
  - after the fix: the query fails with the injected `JitCompileError` and the BE keeps serving.

  Test notes: the test forces JIT with `jit_level = -1`, is tagged `@sequential` because the
  failpoint is process-global on the BE, and uses an expression shape that is never successfully
  compiled within the test, because successfully compiled shapes are cached process-wide by
  expression structure (not by table/column), and a cache hit would bypass the failpoint.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
