### PR TITLE
[Enhancement] Align local compaction MemTracker labels to Compaction-<tablet_id>

### DIFF
--- a/be/src/storage/compaction_task_factory.cpp
+++ b/be/src/storage/compaction_task_factory.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<CompactionTask> CompactionTaskFactory::create_compaction_task() 
     compaction_task->set_segment_iterator_num(segment_iterator_num);
     compaction_task->set_tablet_schema(tablet_schema);
     std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
-            MemTrackerType::COMPACTION_TASK, -1, "Compaction-" + std::to_string(compaction_task->task_id()),
+            MemTrackerType::COMPACTION_TASK, -1, "Compaction-" + std::to_string(_tablet->tablet_id()),
             GlobalEnv::GetInstance()->compaction_mem_tracker());
     compaction_task->set_mem_tracker(mem_tracker.release());
     return compaction_task;

--- a/be/src/storage/manual_compaction.cpp
+++ b/be/src/storage/manual_compaction.cpp
@@ -26,6 +26,7 @@
 #include "fmt/core.h"
 #include "gutil/strings/split.h"
 #include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "storage/base_compaction.h"
 #include "storage/compaction_manager.h"
 #include "storage/compaction_task.h"
@@ -44,14 +45,16 @@ Status run_manual_compaction(uint64_t tablet_id, const std::string& compaction_t
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     RETURN_IF(tablet == nullptr, Status::InvalidArgument(fmt::format("Not Found tablet:{}", tablet_id)));
 
-    auto* mem_tracker = GlobalEnv::GetInstance()->compaction_mem_tracker();
+    auto mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1,
+                                                    "Compaction-" + std::to_string(tablet->tablet_id()),
+                                                    GlobalEnv::GetInstance()->compaction_mem_tracker());
     if (tablet->updates() != nullptr) {
         StorageMetrics::instance()->update_compaction_request_total.increment(1);
         StorageMetrics::instance()->running_update_compaction_task_num.increment(1);
         DeferOp op([&] { StorageMetrics::instance()->running_update_compaction_task_num.increment(-1); });
         Status res;
         if (rowset_ids_string.empty()) {
-            res = tablet->updates()->compaction(mem_tracker);
+            res = tablet->updates()->compaction(mem_tracker.get());
         } else {
             std::vector<std::string> id_str_list = strings::Split(rowset_ids_string, ",", strings::SkipEmpty());
             std::vector<uint32_t> rowset_ids;
@@ -71,7 +74,7 @@ Status run_manual_compaction(uint64_t tablet_id, const std::string& compaction_t
             if (rowset_ids.empty()) {
                 return Status::InvalidArgument(fmt::format("empty argument. rowset_ids:{}", rowset_ids_string));
             }
-            res = tablet->updates()->compaction(mem_tracker, rowset_ids);
+            res = tablet->updates()->compaction(mem_tracker.get(), rowset_ids);
         }
         if (!res.ok()) {
             StorageMetrics::instance()->update_compaction_request_failed.increment(1);
@@ -104,7 +107,7 @@ Status run_manual_compaction(uint64_t tablet_id, const std::string& compaction_t
                 }
             }
         } else {
-            CumulativeCompaction cumulative_compaction(mem_tracker, tablet);
+            CumulativeCompaction cumulative_compaction(mem_tracker.get(), tablet);
 
             Status res = cumulative_compaction.compact();
             if (!res.ok()) {
@@ -139,7 +142,7 @@ Status run_manual_compaction(uint64_t tablet_id, const std::string& compaction_t
                         fmt::format("Failed to base compaction tablet={} no need to do", tablet->full_name()));
             }
         } else {
-            BaseCompaction base_compaction(mem_tracker, tablet);
+            BaseCompaction base_compaction(mem_tracker.get(), tablet);
 
             Status res = base_compaction.compact();
             if (!res.ok()) {

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -53,6 +53,7 @@
 #include "fs/fs_util.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "storage/compaction.h"
 #include "storage/compaction_manager.h"
 #include "storage/lake/local_pk_index_manager.h"
@@ -457,9 +458,12 @@ void* StorageEngine::_repair_compaction_thread_callback(void* arg) {
                 LOG(ERROR) << "repair compaction failed, tablet not primary key tablet found: " << task.first;
                 continue;
             }
+            auto mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1,
+                                                            "Compaction-" + std::to_string(tablet->tablet_id()),
+                                                            GlobalEnv::GetInstance()->compaction_mem_tracker());
             vector<pair<uint32_t, string>> rowset_results;
             for (auto rowsetid : task.second) {
-                auto st = tablet->updates()->compaction(GlobalEnv::GetInstance()->compaction_mem_tracker(), {rowsetid});
+                auto st = tablet->updates()->compaction(mem_tracker.get(), {rowsetid});
                 if (!st.ok()) {
                     LOG(WARNING) << "repair compaction failed tablet: " << task.first << " rowset: " << rowsetid << " "
                                  << st;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -837,14 +837,16 @@ static void do_manual_compaction(TabletManager* tablet_manager, ManualCompaction
         LOG(ERROR) << "manual compaction failed, tablet not primary key tablet found: " << t.tablet_id;
         return;
     }
-    auto* mem_tracker = GlobalEnv::GetInstance()->compaction_mem_tracker();
+    auto mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1,
+                                                    "Compaction-" + std::to_string(tablet->tablet_id()),
+                                                    GlobalEnv::GetInstance()->compaction_mem_tracker());
     auto st = tablet->updates()->get_rowsets_for_compaction(t.rowset_size_threshold, t.input_rowset_ids, t.total_bytes);
     if (!st.ok()) {
         t.status = st.to_string();
         LOG(WARNING) << "get_rowsets_for_compaction failed: " << st.message();
         return;
     }
-    st = tablet->updates()->compaction(mem_tracker, t.input_rowset_ids);
+    st = tablet->updates()->compaction(mem_tracker.get(), t.input_rowset_ids);
     t.status = st.to_string();
     if (!st.ok()) {
         LOG(WARNING) << "manual compaction failed: " << st.message() << " tablet:" << t.tablet_id;
@@ -913,8 +915,9 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
     }
     TRACE("found best tablet $0", best_tablet->get_tablet_info().tablet_id);
 
-    std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, "", _options.compaction_mem_tracker);
+    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
+            MemTrackerType::COMPACTION_TASK, -1, "Compaction-" + std::to_string(best_tablet->tablet_id()),
+            _options.compaction_mem_tracker);
     CumulativeCompaction cumulative_compaction(mem_tracker.get(), best_tablet);
 
     Status res = cumulative_compaction.compact();
@@ -954,8 +957,9 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int3
     }
     TRACE("found best tablet $0", best_tablet->get_tablet_info().tablet_id);
 
-    std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, "", _options.compaction_mem_tracker);
+    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
+            MemTrackerType::COMPACTION_TASK, -1, "Compaction-" + std::to_string(best_tablet->tablet_id()),
+            _options.compaction_mem_tracker);
     BaseCompaction base_compaction(mem_tracker.get(), best_tablet);
 
     Status res = base_compaction.compact();
@@ -1019,8 +1023,9 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
         StorageMetrics::instance()->running_update_compaction_task_num.increment(1);
         SCOPED_RAW_TIMER(&duration_ns);
 
-        std::unique_ptr<MemTracker> mem_tracker =
-                std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, "", _options.compaction_mem_tracker);
+        std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
+                MemTrackerType::COMPACTION_TASK, -1, "Compaction-" + std::to_string(best_tablet->tablet_id()),
+                _options.compaction_mem_tracker);
         res = best_tablet->updates()->compaction(mem_tracker.get());
     }
     StorageMetrics::instance()->update_compaction_duration_us.increment(duration_ns / 1000);

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -329,6 +329,10 @@ protected:
     int32_t _effective_cluster_id{-1};
 
 private:
+    // Friend class for testing
+    friend class StorageEngineCompactionTest;
+    friend class TabletUpdatesTest;
+
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.
     Status _open(const EngineOptions& options);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -568,6 +568,7 @@ SET(DW_TEST_FILES
     ./storage/snapshot_meta_test.cpp
     ./storage/sstable/concatenating_iterator_test.cpp
     ./storage/storage_metrics_test.cpp
+    ./storage/storage_engine_compaction_test.cpp
     ./storage/storage_engine_test.cpp
     ./storage/table_reader_remote_test.cpp
     ./storage/table_reader_test.cpp

--- a/be/test/storage/storage_engine_compaction_test.cpp
+++ b/be/test/storage/storage_engine_compaction_test.cpp
@@ -1,0 +1,250 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+
+#include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk_factory.h"
+#include "common/config_compaction_fwd.h"
+#include "common/config_storage_fwd.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/AgentService_types.h"
+#include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
+#include "storage/compaction.h"
+#include "storage/manual_compaction.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+
+namespace starrocks {
+
+// Exercises StorageEngine::_perform_cumulative_compaction / _perform_base_compaction, the legacy
+// (non event-based) compaction entry points. Unlike CumulativeCompactionTest / BaseCompactionTest,
+// which construct the Compaction objects directly, this drives the full path through
+// TabletManager::find_best_tablet_to_compaction so the engine-owned MemTracker creation is covered.
+class StorageEngineCompactionTest : public testing::Test {
+public:
+    ~StorageEngineCompactionTest() override {
+        if (_engine != nullptr) {
+            _engine->stop();
+            delete _engine;
+            _engine = nullptr;
+        }
+    }
+
+    TabletSharedPtr create_registered_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "k1";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn v1;
+        v1.column_name = "v1";
+        v1.__set_is_key(false);
+        v1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(v1);
+
+        Status st = StorageEngine::instance()->create_tablet(request);
+        if (!st.ok()) {
+            return nullptr;
+        }
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_visible_rowset(const TabletSharedPtr& tablet, int64_t version) {
+        RowsetWriterContext writer_context;
+        writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = VISIBLE;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version = Version(version, version);
+        writer_context.segments_overlap = NONOVERLAPPING;
+
+        std::unique_ptr<RowsetWriter> writer;
+        CHECK_OK(RowsetFactory::create_rowset_writer(writer_context, &writer));
+
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        auto chunk = ChunkFactory::new_chunk(schema, 128);
+        auto cols = chunk->columns();
+        for (int64_t i = 0; i < 128; ++i) {
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int64_t>(version * 1000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    void append_rowsets(const TabletSharedPtr& tablet, int num_rowsets) {
+        int64_t base_version = tablet->max_version().second;
+        for (int i = 1; i <= num_rowsets; ++i) {
+            RowsetSharedPtr rowset = create_visible_rowset(tablet, base_version + i);
+            ASSERT_TRUE(rowset != nullptr);
+            ASSERT_OK(tablet->add_rowset(rowset));
+        }
+    }
+
+    void SetUp() override {
+        config::min_cumulative_compaction_num_singleton_deltas = 2;
+        config::max_cumulative_compaction_num_singleton_deltas = 5;
+        config::max_compaction_concurrency = 1;
+        config::enable_event_based_compaction_framework = false;
+        Compaction::init(config::max_compaction_concurrency);
+
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+
+        _default_storage_root_path = config::storage_root_path;
+        config::storage_root_path = std::filesystem::current_path().string() + "/storage_engine_compaction_test";
+        fs::remove_all(config::storage_root_path);
+        ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
+
+        std::vector<StorePath> paths;
+        paths.emplace_back(config::storage_root_path);
+
+        EngineOptions options;
+        options.store_paths = paths;
+        options.compaction_mem_tracker = _compaction_mem_tracker.get();
+        if (_engine == nullptr) {
+            Status s = StorageEngine::open(options, &_engine);
+            ASSERT_TRUE(s.ok()) << s.to_string();
+        }
+    }
+
+    void TearDown() override {
+        if (_engine != nullptr) {
+            _engine->stop();
+            delete _engine;
+            _engine = nullptr;
+        }
+        if (fs::path_exist(config::storage_root_path)) {
+            ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
+        }
+        config::storage_root_path = _default_storage_root_path;
+    }
+
+protected:
+    // _perform_cumulative_compaction / _perform_base_compaction are private on StorageEngine and only this
+    // fixture is befriended. friendship is not inherited, so the TEST_F-generated subclasses cannot call them
+    // directly; route the calls through these helpers that live on the befriended fixture.
+    Status perform_cumulative_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range) {
+        return _engine->_perform_cumulative_compaction(data_dir, tablet_shards_range);
+    }
+    Status perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range) {
+        return _engine->_perform_base_compaction(data_dir, tablet_shards_range);
+    }
+
+    StorageEngine* _engine = nullptr;
+    std::unique_ptr<MemTracker> _compaction_mem_tracker;
+    std::string _default_storage_root_path;
+};
+
+TEST_F(StorageEngineCompactionTest, test_perform_cumulative_compaction) {
+    TabletSharedPtr tablet = create_registered_tablet(987001, 9001);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_NE(PRIMARY_KEYS, tablet->keys_type());
+
+    append_rowsets(tablet, 5);
+    tablet->calculate_cumulative_point();
+    ASSERT_GE(tablet->calc_cumulative_compaction_score(), 2);
+
+    int64_t versions_before = tablet->version_count();
+    Status st = perform_cumulative_compaction(_engine->get_stores()[0], {0, config::tablet_map_shard_size});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_LT(tablet->version_count(), versions_before);
+}
+
+TEST_F(StorageEngineCompactionTest, test_perform_base_compaction) {
+    TabletSharedPtr tablet = create_registered_tablet(987002, 9002);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_NE(PRIMARY_KEYS, tablet->keys_type());
+
+    append_rowsets(tablet, 5);
+    // Push the cumulative point above every rowset so they all become base-compaction inputs.
+    tablet->set_cumulative_layer_point(tablet->max_version().second + 1);
+    ASSERT_GE(tablet->calc_base_compaction_score(), 2);
+
+    int64_t versions_before = tablet->version_count();
+    Status st = perform_base_compaction(_engine->get_stores()[0], {0, config::tablet_map_shard_size});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_LT(tablet->version_count(), versions_before);
+}
+
+TEST_F(StorageEngineCompactionTest, test_perform_cumulative_compaction_no_suitable_tablet) {
+    // No registered tablet: find_best_tablet_to_compaction returns null and the engine reports NotFound.
+    Status st = perform_cumulative_compaction(_engine->get_stores()[0], {0, config::tablet_map_shard_size});
+    ASSERT_TRUE(st.is_not_found()) << st.to_string();
+}
+
+// run_manual_compaction on a non primary-key tablet with the size-tiered strategy disabled drives the
+// legacy CumulativeCompaction path, which now receives a Compaction-<tablet_id> labelled child tracker.
+TEST_F(StorageEngineCompactionTest, test_run_manual_cumulative_compaction) {
+    bool saved = config::enable_size_tiered_compaction_strategy;
+    config::enable_size_tiered_compaction_strategy = false;
+    DeferOp reset([&] { config::enable_size_tiered_compaction_strategy = saved; });
+
+    TabletSharedPtr tablet = create_registered_tablet(987003, 9003);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_NE(PRIMARY_KEYS, tablet->keys_type());
+
+    append_rowsets(tablet, 5);
+    tablet->calculate_cumulative_point();
+    ASSERT_GE(tablet->calc_cumulative_compaction_score(), 2);
+
+    int64_t versions_before = tablet->version_count();
+    ASSERT_OK(run_manual_compaction(tablet->tablet_id(), to_string(CompactionType::CUMULATIVE_COMPACTION), ""));
+    ASSERT_LT(tablet->version_count(), versions_before);
+}
+
+// Same as above for the legacy BaseCompaction path.
+TEST_F(StorageEngineCompactionTest, test_run_manual_base_compaction) {
+    bool saved = config::enable_size_tiered_compaction_strategy;
+    config::enable_size_tiered_compaction_strategy = false;
+    DeferOp reset([&] { config::enable_size_tiered_compaction_strategy = saved; });
+
+    TabletSharedPtr tablet = create_registered_tablet(987004, 9004);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_NE(PRIMARY_KEYS, tablet->keys_type());
+
+    append_rowsets(tablet, 5);
+    // Push the cumulative point above every rowset so they all become base-compaction inputs.
+    tablet->set_cumulative_layer_point(tablet->max_version().second + 1);
+    ASSERT_GE(tablet->calc_base_compaction_score(), 2);
+
+    int64_t versions_before = tablet->version_count();
+    ASSERT_OK(run_manual_compaction(tablet->tablet_id(), to_string(CompactionType::BASE_COMPACTION), ""));
+    ASSERT_LT(tablet->version_count(), versions_before);
+}
+
+} // namespace starrocks

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -28,6 +28,7 @@
 #include "script/script.h"
 #include "storage/chunk_helper.h"
 #include "storage/local_primary_key_recover.h"
+#include "storage/manual_compaction.h"
 #include "storage/primary_key_dump.h"
 #include "storage/rowset/rowset_meta_manager.h"
 #include "storage/task/engine_checksum_task.h"
@@ -4566,6 +4567,103 @@ TEST_F(TabletUpdatesTest, test_make_snapshot_on_tablet_meta_keep_rowsets) {
 
     ASSERT_TRUE(has_meta_file);
     ASSERT_TRUE(still_has_rowset_files);
+}
+
+// Manual compaction of a primary-key tablet goes through run_manual_compaction's updates() branch,
+// which now wraps the parent compaction tracker in a Compaction-<tablet_id> child before delegating to
+// TabletUpdates::compaction. Exercise that path end to end and assert the rowsets are merged.
+TEST_F(TabletUpdatesTest, test_run_manual_compaction) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(false);
+
+    const int N = 100;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
+    ASSERT_EQ(4, _tablet->updates()->max_version());
+    // Wait for all three commits to apply, otherwise compaction may snapshot a subset of the rowsets.
+    _tablet->updates()->wait_apply_done();
+    ASSERT_EQ(N, read_tablet(_tablet, 4));
+
+    // compaction_type is ignored for primary-key tablets; rowset_ids empty means compact the whole tablet.
+    ASSERT_OK(run_manual_compaction(_tablet->tablet_id(), "", ""));
+    // compaction() only commits the compaction edit; the rowset replacement applies asynchronously.
+    _tablet->updates()->wait_apply_done();
+
+    ASSERT_EQ(1, _tablet->updates()->num_rowsets());
+    ASSERT_EQ(N, read_tablet(_tablet, 4));
+    EXPECT_TRUE(_tablet->verify().ok());
+}
+
+// Same path but with an explicit rowset_ids list, exercising run_manual_compaction's
+// compaction(mem_tracker.get(), rowset_ids) branch (the one that also backs repair compaction).
+TEST_F(TabletUpdatesTest, test_run_manual_compaction_with_rowset_ids) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(false);
+
+    const int N = 100;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
+    ASSERT_EQ(4, _tablet->updates()->max_version());
+    // Wait for all three commits to apply before snapshotting the rowset ids to compact.
+    _tablet->updates()->wait_apply_done();
+
+    std::vector<uint32_t> rowset_ids;
+    size_t total_bytes = 0;
+    ASSERT_OK(_tablet->updates()->get_rowsets_for_compaction(INT64_MAX, rowset_ids, total_bytes));
+    ASSERT_FALSE(rowset_ids.empty());
+    std::string rowset_ids_string;
+    for (auto id : rowset_ids) {
+        if (!rowset_ids_string.empty()) {
+            rowset_ids_string += ",";
+        }
+        rowset_ids_string += std::to_string(id);
+    }
+
+    ASSERT_OK(run_manual_compaction(_tablet->tablet_id(), "", rowset_ids_string));
+    _tablet->updates()->wait_apply_done();
+    ASSERT_EQ(N, read_tablet(_tablet, 4));
+    EXPECT_TRUE(_tablet->verify().ok());
+}
+
+// Manual compaction submitted through the task queue runs StorageEngine::do_manual_compaction, which
+// also wraps the parent tracker in a Compaction-<tablet_id> child before delegating to TabletUpdates.
+TEST_F(TabletUpdatesTest, test_do_manual_compaction_via_task_queue) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(false);
+
+    const int N = 100;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
+    ASSERT_EQ(4, _tablet->updates()->max_version());
+    // Wait for all three commits to apply; do_manual_compaction snapshots the rowsets via
+    // get_rowsets_for_compaction, so an unapplied commit would be left out and num_rowsets would be > 1.
+    _tablet->updates()->wait_apply_done();
+
+    StorageEngine::instance()->submit_manual_compaction_task(_tablet->tablet_id(), INT64_MAX);
+    ASSERT_TRUE(run_pending_manual_compaction());
+    _tablet->updates()->wait_apply_done();
+
+    ASSERT_EQ(1, _tablet->updates()->num_rowsets());
+    ASSERT_EQ(N, read_tablet(_tablet, 4));
+    EXPECT_TRUE(_tablet->verify().ok());
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -691,9 +691,7 @@ public:
     // Drains one queued manual compaction task through StorageEngine::do_manual_compaction. The work
     // happens in StorageEngine's private _check_and_run_manual_compaction_task, which this fixture is
     // befriended to call; TEST_F bodies cannot reach it directly because friendship is not inherited.
-    bool run_pending_manual_compaction() {
-        return StorageEngine::instance()->_check_and_run_manual_compaction_task();
-    }
+    bool run_pending_manual_compaction() { return StorageEngine::instance()->_check_and_run_manual_compaction_task(); }
 
     void SetUp() override {
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -688,6 +688,13 @@ public:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
+    // Drains one queued manual compaction task through StorageEngine::do_manual_compaction. The work
+    // happens in StorageEngine's private _check_and_run_manual_compaction_task, which this fixture is
+    // befriended to call; TEST_F bodies cannot reach it directly because friendship is not inherited.
+    bool run_pending_manual_compaction() {
+        return StorageEngine::instance()->_check_and_run_manual_compaction_task();
+    }
+
     void SetUp() override {
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
         config::enable_pk_size_tiered_compaction_strategy = false;


### PR DESCRIPTION
## Why I'm doing:

  Shared-data (lake) compaction tasks already label their MemTracker as
  "Compaction-<tablet_id>", but the shared-nothing (local) paths were
  inconsistent, making per-tablet compaction memory hard to attribute:

  - The event-based framework used "Compaction-<task_id>", where task_id is
    a global auto-increment counter unrelated to the tablet.
  - Legacy base/cumulative compaction and primary-key update compaction
    created the tracker with an empty label.

## What I'm doing:

  Unify all local paths to "Compaction-<tablet_id>" so the label identifies
  the tablet across both architectures, all table types, and both the
  event-based and legacy compaction frameworks.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
