### PR TITLE
[Tool] Add AI description enrichment to doc-needed issue workflow

### DIFF
--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -53,9 +53,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Python dependencies
-        run: pip install anthropic
-
       # Ensure the docs-maintainer label exists (idempotent)
       - name: Ensure labels exist
         run: |
@@ -102,34 +99,46 @@ jobs:
             --new-params-only \
             --diff-base HEAD^1 \
             --output json \
-            > /tmp/param_drift.json 2>&1
+            > /tmp/param_drift.json
           echo "exitcode=$?" >> $GITHUB_OUTPUT
 
       # When new undocumented params were found, re-run with AI descriptions so the
       # issue table includes a useful description draft rather than a blank cell.
-      # Skipped silently if ANTHROPIC_API_KEY is not configured in repo secrets.
+      # Skipped silently if DOCS_ANTHROPIC_API_KEY is not configured in repo secrets.
+      #
+      # Security: uses origin/main version of the script rather than the merged
+      # commit so a PR that also modifies extract_and_diff_params.py cannot
+      # exfiltrate the API key via pull_request_target.
       - name: Enrich parameters with AI descriptions
         if: steps.params.outputs.exitcode == '1'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.DOCS_ANTHROPIC_API_KEY }}
         run: |
           if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "ANTHROPIC_API_KEY not configured — skipping AI enrichment"
+            echo "DOCS_ANTHROPIC_API_KEY not configured — skipping AI enrichment"
             exit 0
           fi
+          # Install only when actually needed; failure here is non-fatal
+          pip install anthropic || { echo "pip install failed — skipping AI enrichment"; exit 0; }
+          # Extract the trusted base-branch copy of the script
+          git show origin/main:build-support/extract_and_diff_params.py > /tmp/param_extractor_base.py
           set +e
-          python3 build-support/extract_and_diff_params.py \
+          python3 /tmp/param_extractor_base.py \
             --new-params-only \
             --diff-base HEAD^1 \
             --output json \
             --with-ai-descriptions \
-            > /tmp/param_drift_ai.json 2>&1
+            > /tmp/param_drift_ai.json
           ec=$?
-          if [ "$ec" -le 1 ]; then
+          set -e
+          # Replace only if the output is non-empty valid JSON
+          if [ "$ec" -le 1 ] \
+              && [ -s /tmp/param_drift_ai.json ] \
+              && python3 -c "import json; json.load(open('/tmp/param_drift_ai.json'))" 2>/dev/null; then
             mv /tmp/param_drift_ai.json /tmp/param_drift.json
             echo "AI descriptions written to param_drift.json"
           else
-            echo "AI enrichment failed (exit $ec) — keeping original param_drift.json"
+            echo "AI enrichment did not produce valid JSON (exit $ec) — keeping original"
           fi
 
       # Build the issue body from the collected data

--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -118,10 +118,15 @@ jobs:
             echo "DOCS_ANTHROPIC_API_KEY not configured — skipping AI enrichment"
             exit 0
           fi
-          # Install only when actually needed; failure here is non-fatal
-          pip install anthropic || { echo "pip install failed — skipping AI enrichment"; exit 0; }
-          # Extract the trusted base-branch copy of the script
-          git show origin/main:build-support/extract_and_diff_params.py > /tmp/param_extractor_base.py
+          # Install only when actually needed; use python3 -m pip to target the
+          # same interpreter that will run the script; failure here is non-fatal
+          python3 -m pip install anthropic || { echo "pip install failed — skipping AI enrichment"; exit 0; }
+          # Extract the trusted base-branch copy of the script.
+          # origin/main should be present (fetch-depth: 0), but guard just in case.
+          if ! git show origin/main:build-support/extract_and_diff_params.py > /tmp/param_extractor_base.py 2>/dev/null; then
+            echo "Could not extract script from origin/main — skipping AI enrichment"
+            exit 0
+          fi
           set +e
           python3 /tmp/param_extractor_base.py \
             --new-params-only \

--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Python dependencies
+        run: pip install anthropic
+
       # Ensure the docs-maintainer label exists (idempotent)
       - name: Ensure labels exist
         run: |
@@ -101,6 +104,33 @@ jobs:
             --output json \
             > /tmp/param_drift.json 2>&1
           echo "exitcode=$?" >> $GITHUB_OUTPUT
+
+      # When new undocumented params were found, re-run with AI descriptions so the
+      # issue table includes a useful description draft rather than a blank cell.
+      # Skipped silently if ANTHROPIC_API_KEY is not configured in repo secrets.
+      - name: Enrich parameters with AI descriptions
+        if: steps.params.outputs.exitcode == '1'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.DOCS_ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY not configured — skipping AI enrichment"
+            exit 0
+          fi
+          set +e
+          python3 build-support/extract_and_diff_params.py \
+            --new-params-only \
+            --diff-base HEAD^1 \
+            --output json \
+            --with-ai-descriptions \
+            > /tmp/param_drift_ai.json 2>&1
+          ec=$?
+          if [ "$ec" -le 1 ]; then
+            mv /tmp/param_drift_ai.json /tmp/param_drift.json
+            echo "AI descriptions written to param_drift.json"
+          else
+            echo "AI enrichment failed (exit $ec) — keeping original param_drift.json"
+          fi
 
       # Build the issue body from the collected data
       - name: Build issue body


### PR DESCRIPTION
When extract_and_diff_params.py finds new undocumented parameters in a merged PR, re-run it with --with-ai-descriptions so the GitHub issue table includes an AI-drafted description rather than a blank cell.

The enrichment step is conditional: it only runs when parameters were detected (exitcode==1) and DOCS_ANTHROPIC_API_KEY is configured in repo secrets. If the API key is absent or the enrichment script fails, the original JSON is kept and the issue is still created without descriptions.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
