### PR TITLE
[BugFix] Add missing lake_schema_change thread pool metrics registration

### DIFF
--- a/be/src/agent/agent_metrics.cpp
+++ b/be/src/agent/agent_metrics.cpp
@@ -190,6 +190,7 @@ void AgentMetrics::_register_thread_pool_metrics(const std::string& name, Thread
     REGISTER_AGENT_THREAD_POOL_METRICS(drop);
     REGISTER_AGENT_THREAD_POOL_METRICS(create_tablet);
     REGISTER_AGENT_THREAD_POOL_METRICS(alter_tablet);
+    REGISTER_AGENT_THREAD_POOL_METRICS(lake_schema_change);
     REGISTER_AGENT_THREAD_POOL_METRICS(clear_transaction);
     REGISTER_AGENT_THREAD_POOL_METRICS(storage_medium_migrate);
     REGISTER_AGENT_THREAD_POOL_METRICS(check_consistency);


### PR DESCRIPTION
## Why I'm doing:
BE crashes at startup with `Check failed: false unknown agent thread pool metric group: lake_schema_change`. The `lake_schema_change` thread pool is created in `agent_server.cpp` and its metrics gauges are declared in `agent_metrics.h` via `METRICS_DEFINE_THREAD_POOL`, but the corresponding `REGISTER_AGENT_THREAD_POOL_METRICS` entry was missing from the dispatch table in `agent_metrics.cpp`.

the error message.

> Built on a system without sched_getcpu() support. Performance may be impacted.F20260605 14:17:14.575502 140398511453056 agent_metrics.cpp:213] Check failed: false unknown agent thread pool metric group: lake_schema_change

## What I'm doing:
Add `REGISTER_AGENT_THREAD_POOL_METRICS(lake_schema_change)` to `_register_thread_pool_metrics()`, aligning with the already-declared gauges and the thread pool creation site.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
