### PR TITLE
[BugFix] Self-heal non-PK replica stuck with a permanent version hole

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -100,6 +100,13 @@ public class Replica implements Writable {
     // This version is only accessed by ReportHandler, so lock is unnecessary when updating.
     private volatile long lastReportVersion = 0;
 
+    // The continuous version of the previous tablet report that carried version_miss=true while the replica
+    // was behind the visible version, or -1 otherwise. Used by ReportHandler to require a permanent version
+    // hole to persist across two consecutive reports before triggering recovery, so a transient out-of-order
+    // publish that fills quickly is not mistaken for a stuck hole. Not serialized; leader-local, reset after a
+    // failover (which only delays detection by one report, never compromises safety).
+    private volatile long versionMissBaselineVersion = -1L;
+
     private int schemaHash = -1;
     @SerializedName(value = "dataSize")
     private volatile long dataSize = 0;
@@ -666,5 +673,13 @@ public class Replica implements Writable {
 
     public long getLastReportVersion() {
         return this.lastReportVersion;
+    }
+
+    public void setVersionMissBaselineVersion(long versionMissBaselineVersion) {
+        this.versionMissBaselineVersion = versionMissBaselineVersion;
+    }
+
+    public long getVersionMissBaselineVersion() {
+        return this.versionMissBaselineVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -675,6 +675,25 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                         continue;
                     }
 
+                    // A replica can end up with a permanent hole in its version chain that normal publish
+                    // can never fill (BE keeps reporting version_miss with a frozen continuous version).
+                    // Route it into the existing recovery path so it is marked bad and cloned. Skip restore
+                    // tables, like needRecover above (here olapTable is already resolved, so check it directly).
+                    if (olapTable.getState() != OlapTable.OlapTableState.RESTORE) {
+                        MaterializedIndex materializedIndex = physicalPartition.getIndex(tabletMeta.getIndexId());
+                        LocalTablet localTablet = materializedIndex == null
+                                ? null : (LocalTablet) materializedIndex.getTablet(tabletId);
+                        if (localTablet != null && needRecoverVersionMiss(olapTable, localTablet, replica,
+                                physicalPartition.getVisibleVersion(), backendTabletInfo)) {
+                            LOG.warn("replica {} of tablet {} on backend {} misses version persistently and "
+                                            + "cannot self-heal, mark it for recovery. replica in FE: {}, "
+                                            + "report version {}, partition visible version {}",
+                                    replica.getId(), tabletId, backendId, replica,
+                                    backendTabletInfo.getVersion(), physicalPartition.getVisibleVersion());
+                            tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
+                        }
+                    }
+
                     TStorageMedium storageMedium = storageMediumMap.get(physicalPartition.getParentId());
                     if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
                         if (storageMedium != backendTabletInfo.getStorage_medium()) {
@@ -839,6 +858,95 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
 
         // lastReportVersion should be increased monotonically.
         return backendTabletInfo.getVersion() < replicaInFe.getLastReportVersion();
+    }
+
+    /**
+     * Detect a replica that is stuck with a permanent hole in its version chain. This happens when a clone
+     * races with publish so a middle version is skipped while later versions keep landing: BE reports
+     * version_miss=true and its reported version (max_continuous_version) stays frozen below the partition's
+     * visible version. Such a replica can never catch up through normal publish, so it must be repaired by a
+     * clone. We route it through the same recovery path as a bad replica (handleRecoverTablet -> setBad), which
+     * removes it from query routing and write-target selection and lets TabletScheduler clone a fresh copy.
+     *
+     * <p>The detection is deliberately conservative: it only fires once the same below-visible continuous
+     * version has been reported with version_miss on two consecutive reports (so a transient out-of-order
+     * publish that fills quickly is not mistaken for a stuck hole), and only when another replica is
+     * genuinely caught up to act as query/clone source, so the tablet is never stranded (single-replica
+     * tablets are skipped). PK, colocate and restore tablets are excluded.
+     *
+     * <p>This method also maintains the replica's version-miss debounce baseline as a side effect, so it must
+     * be called for every (non-restore) report of a normal tablet, including healthy ones, to reset it.
+     */
+    private static boolean needRecoverVersionMiss(OlapTable olapTable, LocalTablet tablet, Replica replica,
+                                                  long visibleVersion, TTabletInfo backendTabletInfo) {
+        // Unconditional filters first: these replicas are never recovered by this path, so return before
+        // touching the debounce baseline below (no needless getter/setter).
+        if (replica.getState() != ReplicaState.NORMAL || replica.isBad()) {
+            return false;
+        }
+        // Replicas reported as unusable (used==false) are already handled by needRecover().
+        if (backendTabletInfo.isSetUsed() && !backendTabletInfo.isUsed()) {
+            return false;
+        }
+        // Primary-key tablets recover version errors through their own is_error_state path.
+        if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
+            return false;
+        }
+        // Colocate bad replicas take a different scheduler route (COLOCATE_REDUNDANT force-drop), out of
+        // scope for this fix. Checked last among the filters since it takes a global read lock.
+        if (GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(olapTable.getId())) {
+            return false;
+        }
+
+        // A version hole below the visible version that normal publish has not filled. Confirm it persists
+        // across two consecutive reports: the baseline holds the previous such report's continuous version,
+        // and is reset whenever the replica is not in this state, so a prior healthy report at the same
+        // version cannot be mistaken for a confirmation.
+        boolean versionMiss = backendTabletInfo.isSetVersion_miss() && backendTabletInfo.isVersion_miss();
+        long reportedContinuousVersion = backendTabletInfo.getVersion();
+        boolean holeBelowVisible = versionMiss && reportedContinuousVersion < visibleVersion;
+        boolean confirmedAcrossReports =
+                holeBelowVisible && replica.getVersionMissBaselineVersion() == reportedContinuousVersion;
+        replica.setVersionMissBaselineVersion(holeBelowVisible ? reportedContinuousVersion : -1L);
+        if (!confirmedAcrossReports) {
+            return false;
+        }
+        // Never strand the tablet: only recover when another replica is genuinely caught up and can serve as
+        // both query source and clone source.
+        return hasCaughtUpSourceReplicaOnAnotherBackend(tablet, replica, visibleVersion);
+    }
+
+    /**
+     * Whether the tablet has, on a backend other than the holed replica's, a healthy replica that is caught
+     * up to the visible version and can act as a query/clone source. Used by {@link #needRecoverVersionMiss}
+     * to avoid stranding a tablet that has no usable copy elsewhere.
+     *
+     * <p>The catch-up check uses {@link Replica#getLastReportVersion()}, which is set straight from the BE
+     * report, so (unlike the FE-side {@code Replica.version} that the version-miss bug inflates) it reflects
+     * the backend's true continuous version and proves the candidate genuinely holds the data.
+     */
+    private static boolean hasCaughtUpSourceReplicaOnAnotherBackend(LocalTablet tablet, Replica holedReplica,
+                                                                    long visibleVersion) {
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        for (Replica candidate : tablet.getAllReplicas()) {
+            if (candidate.getBackendId() == holedReplica.getBackendId()) {
+                continue;
+            }
+            if (candidate.isBad() || candidate.isErrorState() || candidate.getState() != ReplicaState.NORMAL
+                    || candidate.getLastFailedVersion() > 0) {
+                continue;
+            }
+            // lastReportVersion comes straight from the BE report, so (unlike the masked Replica.version) it
+            // reflects the candidate's true continuous version and proves it genuinely holds the data.
+            if (candidate.getLastReportVersion() < visibleVersion) {
+                continue;
+            }
+            Backend candidateBackend = systemInfoService.getBackend(candidate.getBackendId());
+            if (candidateBackend != null && candidateBackend.isAlive()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void taskReport(long backendId, Map<TTaskType, Set<Long>> runningTasks) {

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.SchemaChangeHandler;
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
@@ -25,6 +26,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -64,6 +66,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -553,5 +556,153 @@ public class ReportHandlerTest {
                 "exception message should mention stop reason, got: " + ex.getMessage());
         Assertions.assertEquals(0, reportHandler.getPendingTabletReportTaskCnt());
         Assertions.assertEquals(0, reportHandler.getReportQueueSize());
+    }
+
+    private static final long VERSION_MISS_VISIBLE = 100L;
+    private static final long HOLED_BACKEND_ID = 20001L;
+    private static final long ALIVE_SOURCE_BACKEND_ID = 20002L;
+    private static final long DEAD_SOURCE_BACKEND_ID = 20003L;
+
+    private static boolean invokeNeedRecoverVersionMiss(OlapTable table, LocalTablet tablet, Replica holed,
+                                                        TTabletInfo info) throws Exception {
+        Method method = ReportHandler.class.getDeclaredMethod("needRecoverVersionMiss",
+                OlapTable.class, LocalTablet.class, Replica.class, long.class, TTabletInfo.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, table, tablet, holed, VERSION_MISS_VISIBLE, info);
+    }
+
+    private static Replica versionMissReplica(long replicaId, long backendId, long lastReportVersion, boolean bad) {
+        // version is masked high (>= visible) to mimic the bug; lastReportVersion carries the BE truth.
+        Replica replica = new Replica(replicaId, backendId, 200L, 0, 0L, 0L, ReplicaState.NORMAL, -1L, 200L);
+        replica.setLastReportVersion(lastReportVersion);
+        if (bad) {
+            replica.setBad(true);
+        }
+        return replica;
+    }
+
+    private static TTabletInfo versionMissInfo(long reportedVersion) {
+        TTabletInfo info = new TTabletInfo();
+        info.setVersion(reportedVersion);
+        info.setVersion_miss(true);
+        return info;
+    }
+
+    private void mockVersionMissBackends() {
+        Backend alive1 = new Backend(HOLED_BACKEND_ID, "h1", 9050);
+        alive1.setAlive(true);
+        Backend alive2 = new Backend(ALIVE_SOURCE_BACKEND_ID, "h2", 9050);
+        alive2.setAlive(true);
+        Backend dead3 = new Backend(DEAD_SOURCE_BACKEND_ID, "h3", 9050);
+        dead3.setAlive(false);
+        Map<Long, Backend> backends = new HashMap<>();
+        backends.put(HOLED_BACKEND_ID, alive1);
+        backends.put(ALIVE_SOURCE_BACKEND_ID, alive2);
+        backends.put(DEAD_SOURCE_BACKEND_ID, dead3);
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackend(long id) {
+                return backends.get(id);
+            }
+        };
+    }
+
+    @Test
+    public void testNeedRecoverVersionMiss() throws Exception {
+        mockVersionMissBackends();
+        OlapTable dupTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb("test").getTable("binlog_report_handler_test");
+        OlapTable pkTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb("test").getTable("properties_change_test");
+
+        Replica holed = versionMissReplica(1L, HOLED_BACKEND_ID, 50L, false);
+        Replica caughtUpSource = versionMissReplica(2L, ALIVE_SOURCE_BACKEND_ID, VERSION_MISS_VISIBLE, false);
+        LocalTablet tablet = new LocalTablet(1000L, Lists.newArrayList(holed, caughtUpSource));
+
+        // Debounce: the first version_miss report only records the baseline (not flagged); the second
+        // consecutive report at the same frozen continuous version (50 < visible) is flagged, given a
+        // genuine caught-up source.
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, versionMissInfo(50L)));
+        Assertions.assertEquals(50L, holed.getVersionMissBaselineVersion());
+        Assertions.assertTrue(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, versionMissInfo(50L)));
+
+        // A prior healthy report at the same version must NOT count as a confirmation: a healthy report
+        // resets the baseline, so the first following version_miss report is not flagged on first sight.
+        TTabletInfo healthyAt50 = new TTabletInfo();
+        healthyAt50.setVersion(50L);
+        healthyAt50.setVersion_miss(false);
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, healthyAt50));
+        Assertions.assertEquals(-1L, holed.getVersionMissBaselineVersion());
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, versionMissInfo(50L)));
+
+        // An advancing continuous version is not a frozen hole: a baseline of 40 does not confirm 50.
+        holed.setVersionMissBaselineVersion(40L);
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, versionMissInfo(50L)));
+
+        // The remaining cases prime the baseline so the debounce passes and the specific guard is isolated.
+
+        // reportedVersion >= visible -> replica still usable, not flagged.
+        holed.setVersionMissBaselineVersion(100L);
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, versionMissInfo(100L)));
+
+        // used==false is handled by needRecover, not here.
+        holed.setVersionMissBaselineVersion(50L);
+        TTabletInfo usedFalse = versionMissInfo(50L);
+        usedFalse.setUsed(false);
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, usedFalse));
+
+        // Already bad -> not flagged.
+        Replica holedBad = versionMissReplica(3L, HOLED_BACKEND_ID, 50L, true);
+        holedBad.setVersionMissBaselineVersion(50L);
+        LocalTablet badTablet = new LocalTablet(1001L, Lists.newArrayList(holedBad, caughtUpSource));
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, badTablet, holedBad, versionMissInfo(50L)));
+
+        // Primary-key table -> not flagged.
+        holed.setVersionMissBaselineVersion(50L);
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(pkTable, tablet, holed, versionMissInfo(50L)));
+
+        // RF=1 (only the holed replica, no other source) -> not flagged.
+        holed.setVersionMissBaselineVersion(50L);
+        LocalTablet singleReplica = new LocalTablet(1002L, Lists.newArrayList(holed));
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, singleReplica, holed, versionMissInfo(50L)));
+
+        // All replicas holed but FE-masked: the sibling's version is masked high but its lastReportVersion
+        // (BE truth) is below visible -> no genuine source -> not flagged.
+        holed.setVersionMissBaselineVersion(50L);
+        Replica maskedSource = versionMissReplica(4L, ALIVE_SOURCE_BACKEND_ID, 50L, false);
+        LocalTablet allHoled = new LocalTablet(1003L, Lists.newArrayList(holed, maskedSource));
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, allHoled, holed, versionMissInfo(50L)));
+
+        // The only caught-up source is on a dead backend -> not flagged.
+        holed.setVersionMissBaselineVersion(50L);
+        Replica deadSource = versionMissReplica(5L, DEAD_SOURCE_BACKEND_ID, VERSION_MISS_VISIBLE, false);
+        LocalTablet deadSourceTablet = new LocalTablet(1004L, Lists.newArrayList(holed, deadSource));
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, deadSourceTablet, holed, versionMissInfo(50L)));
+
+        // An error-state sibling is not a usable source -> not flagged.
+        holed.setVersionMissBaselineVersion(50L);
+        Replica errorStateSource = versionMissReplica(6L, ALIVE_SOURCE_BACKEND_ID, VERSION_MISS_VISIBLE, false);
+        errorStateSource.setIsErrorState(true);
+        LocalTablet errorStateTablet = new LocalTablet(1006L, Lists.newArrayList(holed, errorStateSource));
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, errorStateTablet, holed, versionMissInfo(50L)));
+    }
+
+    @Test
+    public void testNeedRecoverVersionMissSkipsColocate() throws Exception {
+        new MockUp<ColocateTableIndex>() {
+            @Mock
+            public boolean isColocateTable(long tableId) {
+                return true;
+            }
+        };
+        mockVersionMissBackends();
+        OlapTable dupTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb("test").getTable("binlog_report_handler_test");
+        Replica holed = versionMissReplica(1L, HOLED_BACKEND_ID, 50L, false);
+        holed.setVersionMissBaselineVersion(50L);
+        Replica caughtUpSource = versionMissReplica(2L, ALIVE_SOURCE_BACKEND_ID, VERSION_MISS_VISIBLE, false);
+        LocalTablet tablet = new LocalTablet(1005L, Lists.newArrayList(holed, caughtUpSource));
+        // Colocate tables are excluded even when every other condition for recovery holds (baseline primed).
+        Assertions.assertFalse(invokeNeedRecoverVersionMiss(dupTable, tablet, holed, versionMissInfo(50L)));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

A clone racing with publish can skip a middle version on a non-primary-key replica while later versions keep landing, leaving a **permanent hole** in the replica's version chain. The BE honestly reports `version = max_continuous_version` with `version_miss = true`, but the FE finish path keeps advancing `Replica.version` past the hole (`lastFailedVersion` stays `-1`), so the FE believes the replica is healthy. As a result:

- queries keep routing to the holed replica and fail with `capture_consistent_versions error: version not found ... tablet_max_version:<frozen>`;
- the replica still counts toward write quorum;
- `TabletChecker` sees the tablet as HEALTHY and never schedules a repair, so the replica can **never self-heal**.

Related (chaos test that surfaced it): StarRocks/StarRocksTest#11386. Reproduced on `main`.

## What I'm doing:

Detect the stuck hole during tablet report and route the replica into the **existing** recovery path (`tabletRecoveryMap -> handleRecoverTablet -> setBad -> clone`). Marking it bad excludes it from query routing and write-target selection and lets `TabletScheduler` clone a fresh copy from a healthy sibling; the cloned replica then replaces the bad one. No new journal op, replay change, thrift/config change.

Detection (`ReportHandler.needRecoverVersionMiss`) is deliberately conservative:

- **Two-report debounce.** Acts only when the **same** below-visible continuous version is reported with `version_miss=true` on two consecutive reports, tracked by a new non-persisted, leader-local `Replica.versionMissBaselineVersion` that resets on any healthy/advancing report — so a transient out-of-order publish (or a prior healthy report at the same version) is not mistaken for a stuck hole.
- **Genuine source required.** Acts only when another replica on a different backend is `NORMAL`, non-bad, non-error, `lastFailedVersion <= 0`, alive, and `lastReportVersion >= visibleVersion`. `lastReportVersion` comes straight from the BE report, so (unlike the FE-masked `Replica.version`) it is not inflated by the masking that causes this bug — guaranteeing single-replica / all-holed tablets are never stranded and `recover_with_empty_tablet` is never engaged.
- **Excludes** primary-key, colocate, and restore tablets.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
