### PR TITLE
[BugFix] Resolve sort-key arity from materialized schema in colocate tablet split

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -662,10 +662,18 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
-    if (colocate_column_count < 0 || colocate_column_count > tablet_metadata->schema().sort_key_idxes_size()) {
+    // Resolve the sort-key arity from the materialized TabletSchema, not the raw TabletSchemaPB.
+    // A range-distributed table created without an explicit ORDER BY (e.g. a PRIMARY KEY table)
+    // leaves sort_key_idxes empty in the PB; the "empty sort_key_idxes => sort key is the key
+    // columns" convention (which the FE mirrors in MetaUtils.getRangeDistributionColumns) is only
+    // applied when the schema is materialized. Reading the raw PB here would see arity 0 and reject
+    // every colocate split, silently falling back to an identical tablet so the oversized tablet
+    // never splits. This mirrors the external-boundaries path's use of GlobalTabletSchemaMap.
+    auto tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_metadata->schema()).first;
+    const int32_t sort_key_arity = static_cast<int32_t>(tablet_schema->sort_key_idxes().size());
+    if (colocate_column_count < 0 || colocate_column_count > sort_key_arity) {
         return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}, sort key arity is {}",
-                                                   colocate_column_count,
-                                                   tablet_metadata->schema().sort_key_idxes_size()));
+                                                   colocate_column_count, sort_key_arity));
     }
 
     std::vector<SegmentSplitInfo> segments;

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -874,6 +874,30 @@ TEST(TabletSplitterTest, colocate_aware_split_keeps_stats_consistent_across_pref
     EXPECT_GT(left_it->second.second, 0);
 }
 
+// Regression for the DATA-DRIVEN colocate split rejecting tables whose sort key is implicit.
+// A PRIMARY KEY (or DUPLICATE KEY without an explicit ORDER BY) table leaves sort_key_idxes empty
+// in the raw TabletSchemaPB. get_tablet_split_ranges_impl must resolve the arity from the
+// materialized schema (empty sort_key_idxes => key columns) before validating colocate_column_count;
+// reading the raw PB saw arity 0 and rejected every colocate split, silently falling back to an
+// identical tablet so an oversized colocate tablet never split.
+TEST(TabletSplitterTest, data_driven_colocate_split_resolves_empty_sort_key_idxes) {
+    auto m = make_empty_metadata_bigint_key_no_sort_key_idxes(0, 100);
+    ASSERT_TRUE(m->schema().sort_key_idxes().empty());
+
+    // colocate_column_count == 1 (the single key column) must pass the arity gate now that it is
+    // resolved against the materialized schema. The empty tablet then fails later at segment
+    // loading -- proving the gate was passed (pre-fix it failed with "Invalid colocate_column_count").
+    std::vector<TabletRangeInfo> split_ranges;
+    auto s = get_tablet_split_ranges(/*tablet_manager=*/nullptr, m, /*split_count=*/2, &split_ranges,
+                                     /*colocate_column_count=*/1);
+    ASSERT_FALSE(s.ok());
+    const std::string msg = s.to_string();
+    EXPECT_EQ(std::string::npos, msg.find("Invalid colocate_column_count"))
+            << "arity gate must resolve empty sort_key_idxes to key columns; actual: " << msg;
+    EXPECT_NE(std::string::npos, msg.find("No segments"))
+            << "empty tablet must fail at segment loading, not the arity gate; actual: " << msg;
+}
+
 // -----------------------------------------------------------------------------
 // Happy path: empty tablet, K=2 well-formed ranges covering parent.
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Why I'm doing:

A range-distribution colocate table whose sort key is implicit — a PRIMARY KEY table, or a duplicate-key table created without an explicit `ORDER BY` — never splits its oversized tablets. Observed on a shared-data cluster: a ~48 GiB single-tablet PRIMARY KEY colocate table (`colocate_with` = the full primary key) auto-triggered a split 229 times in one day; every split job ran to `FINISHED`, yet the tablet's data size stayed byte-for-byte constant and it never shrank.

Root cause: the data-driven split path `get_tablet_split_ranges_impl` validated `colocate_column_count` against the **raw** `TabletSchemaPB.sort_key_idxes_size()`. For such tables `sort_key_idxes` is empty in the raw PB — the "empty `sort_key_idxes` ⇒ sort key is the key columns" convention is only applied when the schema is materialized. So the arity was read as 0, any `colocate_column_count > 0` was rejected with `InvalidArgument`, and `split_tablet` fell back to an identical-tablet publish — copying the tablet but never actually splitting it. Auto-split then re-fired every cycle with no progress. The external-boundaries split path already avoided this by materializing the schema via `GlobalTabletSchemaMap`.

## What I'm doing:

Resolve the sort-key arity from the materialized `TabletSchema` (via `GlobalTabletSchemaMap`, which applies the empty-`sort_key_idxes` ⇒ key-columns convention) and validate `colocate_column_count` against that, mirroring the external-boundaries path. The FE mirrors the same convention in `MetaUtils.getRangeDistributionColumns`.

Added a BE unit test (`tablet_splitter_test.cpp::data_driven_colocate_split_resolves_empty_sort_key_idxes`): a PRIMARY KEY metadata with empty `sort_key_idxes` and `colocate_column_count == key arity` now passes the arity gate (it fails later at segment loading rather than being wrongly rejected at the gate).

Audited the rest of the BE split/merge code: this is the only site reading raw `sort_key_idxes` where the convention matters; the range/sort-key helpers and the segment-metadata filter all operate on materialized schemas and are unaffected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
