### PR TITLE
[BugFix] fix data race on MaterializedIndexMeta updateSchemaBackendId

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -48,10 +48,10 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageType;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 // MaterializedIndexMeta is used to store metadata of a materialized index.
@@ -100,7 +100,12 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     private boolean isColocateMVIndex = false;
 
     private Expr whereClause;
-    private Set<Long> updateSchemaBackendId;
+
+    // Tracks backends that currently have an in-flight UPDATE_SCHEMA task. Accessed concurrently:
+    // the BE-report send path (add) runs under a shared READ lock at the same time as task-finish
+    // RPCs (remove), so this must be a thread-safe set. It carries no @SerializedName and is skipped
+    // by Gson (see HiddenAnnotationExclusionStrategy), so it is transient runtime state only.
+    private final Set<Long> updateSchemaBackendId = ConcurrentHashMap.newKeySet();
 
     public MaterializedIndexMeta() {
     }
@@ -251,21 +256,21 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return whereClause;
     }
 
-    public boolean hasUpdateSchemaTask(Long backendId) {
-        return updateSchemaBackendId != null && updateSchemaBackendId.contains(backendId);
-    }
-
-    public void addUpdateSchemaBackend(Long backendId) {
-        if (updateSchemaBackendId == null) {
-            updateSchemaBackendId = new HashSet<>();
-        }
-        updateSchemaBackendId.add(backendId);
+    /**
+     * Atomically reserves an UPDATE_SCHEMA slot for {@code backendId}. Returns {@code true} if the
+     * backend was newly reserved (the caller should send a task), or {@code false} if a task is
+     * already in flight for this backend (the caller should skip to avoid sending duplicate tasks).
+     *
+     * <p>This collapses the former check-then-act (a membership probe followed by a separate add)
+     * into a single atomic operation, so two senders running concurrently under the shared READ
+     * lock cannot both observe "no task" and both enqueue a duplicate task.
+     */
+    public boolean addUpdateSchemaBackendIfAbsent(Long backendId) {
+        return updateSchemaBackendId.add(backendId);
     }
 
     public void removeUpdateSchemaBackend(Long backendId) {
-        if (updateSchemaBackendId != null) {
-            updateSchemaBackendId.remove(backendId);
-        }
+        updateSchemaBackendId.remove(backendId);
     }
 
     // The column names of the materialized view are all lowercase, but the column names may be uppercase

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -480,8 +480,11 @@ public class LeaderImpl {
             long backendId = task.getBackendId();
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db != null) {
+                // Only this single known table's indexMeta is touched, so take a table-scoped
+                // intensive READ lock instead of a full DB lock. This matches the send path
+                // (ReportHandler) and lets DDL/ALTER on unrelated tables in the same DB proceed.
                 Locker locker = new Locker();
-                locker.lockDatabase(db.getId(), LockType.READ);
+                locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
                 try {
                     OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getTable(db.getId(), tableId);
@@ -492,7 +495,7 @@ public class LeaderImpl {
                         }
                     }
                 } finally {
-                    locker.unLockDatabase(db.getId(), LockType.READ);
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1953,31 +1953,42 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                     continue;
                 }
 
-                // already has one update scheam task, ignore to prevent send too many task
-                if (indexMeta.hasUpdateSchemaTask(backendId)) {
+                // Atomically reserve the slot for this backend to prevent sending too many tasks.
+                // The check-then-reserve is a single atomic operation, so two senders running
+                // concurrently under the shared READ lock cannot both observe "no task" and both
+                // enqueue a duplicate task. If a task is already in flight, skip this backend.
+                if (!indexMeta.addUpdateSchemaBackendIfAbsent(backendId)) {
                     continue;
                 }
 
-                List<TColumn> columnsDesc = Lists.newArrayList();
-                List<Integer> columnSortKeyUids = Lists.newArrayList();
+                try {
+                    List<TColumn> columnsDesc = Lists.newArrayList();
+                    List<Integer> columnSortKeyUids = Lists.newArrayList();
 
-                for (Column column : indexMeta.getSchema()) {
-                    TColumn tColumn = column.toThrift();
-                    tColumn.setColumn_name(column.getColumnId().getId());
-                    column.setIndexFlag(tColumn, olapTable.getIndexes(), olapTable.getBfColumnIds());
-                    columnsDesc.add(tColumn);
-                }
-                if (indexMeta.getSortKeyUniqueIds() != null) {
-                    columnSortKeyUids.addAll(indexMeta.getSortKeyUniqueIds());
-                }
-                TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids,
-                        indexMeta.getShortKeyColumnCount());
+                    for (Column column : indexMeta.getSchema()) {
+                        TColumn tColumn = column.toThrift();
+                        tColumn.setColumn_name(column.getColumnId().getId());
+                        column.setIndexFlag(tColumn, olapTable.getIndexes(), olapTable.getBfColumnIds());
+                        columnsDesc.add(tColumn);
+                    }
+                    if (indexMeta.getSortKeyUniqueIds() != null) {
+                        columnSortKeyUids.addAll(indexMeta.getSortKeyUniqueIds());
+                    }
+                    TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids,
+                            indexMeta.getShortKeyColumnCount());
 
-                UpdateSchemaTask task = new UpdateSchemaTask(backendId, db.getId(), olapTable.getId(),
-                        indexMetaId, tablets, indexMeta.getSchemaId(), indexMeta.getSchemaVersion(),
-                        columnParam);
-                updateSchemaBatchTask.addTask(task);
-                indexMeta.addUpdateSchemaBackend(backendId);
+                    UpdateSchemaTask task = new UpdateSchemaTask(backendId, db.getId(), olapTable.getId(),
+                            indexMetaId, tablets, indexMeta.getSchemaId(), indexMeta.getSchemaVersion(),
+                            columnParam);
+                    updateSchemaBatchTask.addTask(task);
+                } catch (RuntimeException e) {
+                    // Reservation happened before the task was built/enqueued, so release it on
+                    // failure. Otherwise this backend would stay marked forever (the finish RPC
+                    // only clears it after a task actually completes) and no future UPDATE_SCHEMA
+                    // task would ever be sent for it.
+                    indexMeta.removeUpdateSchemaBackend(backendId);
+                    throw e;
+                }
             } finally {
                 locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
@@ -48,6 +48,8 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class MaterializedIndexMetaTest {
 
@@ -71,5 +73,63 @@ public class MaterializedIndexMetaTest {
         columnNameToDefineExpr.put("upper", new StringLiteral());
         meta.setColumnsDefineExpr(columnNameToDefineExpr);
         Assertions.assertNotNull(column.getDefineExpr());
+    }
+
+    /**
+     * Regression test for the data race on updateSchemaBackendId. The send path (reserve) and the
+     * task-finish path (remove) both run under a shared READ lock, so they mutate the set
+     * concurrently. With a plain HashSet this races and can throw or corrupt the set during resize;
+     * with a concurrent set plus an atomic reserve-then-act it must be safe and consistent.
+     *
+     * <p>This is a probabilistic race test, not a deterministic one: it hammers the set hard enough
+     * that the old buggy implementation would very likely throw, but a passing run does not prove
+     * the absence of a race on every reintroduced bug.
+     */
+    @Test
+    public void testUpdateSchemaBackendConcurrency() throws InterruptedException {
+        List<Column> schema = Lists.newArrayList(new Column("c0", ArrayType.ARRAY_VARCHAR));
+        MaterializedIndexMeta meta = new MaterializedIndexMeta(0, schema, 0, 0,
+                (short) 0, TStorageType.COLUMN, KeysType.DUP_KEYS, null);
+
+        final int threadCount = 16;
+        final int iterations = 2000;
+        final int backendCount = 200;
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < iterations; i++) {
+                        Long backendId = (long) (i % backendCount);
+                        // Mirror the production check-then-act: only the sender that won the
+                        // reservation removes it, just like only a real task gets finished.
+                        if (meta.addUpdateSchemaBackendIfAbsent(backendId)) {
+                            meta.removeUpdateSchemaBackend(backendId);
+                        }
+                    }
+                } catch (Throwable e) {
+                    failure.compareAndSet(null, e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+            thread.start();
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+
+        Assertions.assertNull(failure.get(), "concurrent add/remove threw: " + failure.get());
+
+        // Every reservation was paired with a removal, so the set must be empty: a fresh reserve
+        // for any backend must succeed (return true), proving no entry leaked.
+        for (long backendId = 0; backendId < backendCount; backendId++) {
+            Assertions.assertTrue(meta.addUpdateSchemaBackendIfAbsent(backendId),
+                    "backend " + backendId + " was still reserved; an entry leaked");
+        }
     }
 }


### PR DESCRIPTION
updateSchemaBackendId was a plain HashSet mutated under the shared READ lock by both the BE-report send path (add) and task-finish RPCs (remove), which run concurrently. Concurrent add/add and add/remove on a non-thread- safe HashSet can lose entries or, during resize, corrupt the set.

Make the set a ConcurrentHashMap.newKeySet() and collapse the former check-then-act (hasUpdateSchemaTask + addUpdateSchemaBackend) into a single atomic addUpdateSchemaBackendIfAbsent so two senders cannot both observe "no task" and both enqueue a duplicate task. The send path now reserves before building the task and releases the reservation on failure so a backend is never left permanently marked. Table-scoped READ locks at the call sites are unchanged; thread-safety is encapsulated in the class.

Also narrow the finish path (LeaderImpl.finishUpdateSchemaTask) from a full DB READ lock to a table-scoped intensive READ lock. It only touches one known table's indexMeta, so the DB-wide lock was broader than needed; the intensive lock matches the send path and lets DDL/ALTER on unrelated tables in the same DB proceed concurrently.

Add a concurrency regression test that hammers reserve/remove from 16 threads and asserts no exception and an empty set afterward.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
