### PR TITLE
[Feature] Add Lance connector FE catalog and metadata discovery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LanceTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LanceTable.java
@@ -33,6 +33,11 @@ public class LanceTable extends Table {
     }
 
     @Override
+    public String getTableLocation() {
+        return uri;
+    }
+
+    @Override
     public boolean isSupported() {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LanceTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LanceTable.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class LanceTable extends Table {
+
+    @SerializedName(value = "uri")
+    private final String uri;
+
+    public LanceTable(long id, String name, List<Column> schema, String uri) {
+        super(id, name, TableType.LANCE, schema);
+        this.uri = uri;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public boolean isSupported() {
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -135,7 +135,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         @SerializedName("ICEBERG_VIEW")
         ICEBERG_VIEW,
         @SerializedName("PAIMON_VIEW")
-        PAIMON_VIEW;
+        PAIMON_VIEW,
+        @SerializedName("LANCE")
+        LANCE;
 
         public static String serialize(TableType type) {
             if (type == CLOUD_NATIVE) {
@@ -431,6 +433,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public boolean isBenchmarkTable() {
         return type == TableType.BENCHMARK;
+    }
+
+    public boolean isLanceTable() {
+        return type == TableType.LANCE;
     }
 
     public boolean isHMSTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorType.java
@@ -45,7 +45,8 @@ public enum ConnectorType {
     ODPS("odps", OdpsConnector.class, null),
     KUDU("kudu", KuduConnector.class, null),
     UNIFIED("unified", UnifiedConnector.class, null),
-    BENCHMARK("benchmark", BenchmarkConnector.class, BenchmarkConfig.class);
+    BENCHMARK("benchmark", BenchmarkConnector.class, BenchmarkConfig.class),
+    LANCE("lance", com.starrocks.connector.lance.LanceConnector.class, null);
 
     public static final Set<ConnectorType> SUPPORT_TYPE_SET = EnumSet.of(
             ES,
@@ -58,7 +59,8 @@ public enum ConnectorType {
             ODPS,
             KUDU,
             UNIFIED,
-            BENCHMARK
+            BENCHMARK,
+            LANCE
     );
 
     ConnectorType(String name, Class connectorClass, Class configClass) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
@@ -70,15 +70,17 @@ public class LanceApiConverter {
 
         if (lower.startsWith("list<") && lower.endsWith(">")) {
             String inner = clean.substring(5, clean.length() - 1);
-            return new ArrayType(parseType(inner));
+            return new ArrayType(parseType(stripTopLevelFieldLabel(inner)));
         }
 
-        if (lower.startsWith("fixed_size_list<") && lower.endsWith(">")) {
-            // "fixed_size_list<float32, 128>" -> mapped to Array of Float
-            int commaIdx = clean.lastIndexOf(",");
-            if (commaIdx > 16) {
-                String inner = clean.substring(16, commaIdx).trim();
-                return new ArrayType(parseType(inner));
+        if (lower.startsWith("fixed_size_list<")) {
+            // "fixed_size_list<float32, 128>" and "fixed_size_list<item: float>[128]" -> Array of item type
+            int closeIdx = clean.lastIndexOf(">");
+            if (closeIdx > 16) {
+                List<String> parts = splitTopLevel(clean.substring(16, closeIdx), ',');
+                if (!parts.isEmpty()) {
+                    return new ArrayType(parseType(stripTopLevelFieldLabel(parts.get(0))));
+                }
             }
         }
 
@@ -131,6 +133,31 @@ public class LanceApiConverter {
             parts.add(part);
         }
         partBuilder.setLength(0);
+    }
+
+    private static String stripTopLevelFieldLabel(String typeStr) {
+        int colonIdx = topLevelDelimiterIndex(typeStr, ':');
+        if (colonIdx > 0) {
+            return typeStr.substring(colonIdx + 1).trim();
+        }
+        return typeStr.trim();
+    }
+
+    private static int topLevelDelimiterIndex(String value, char delimiter) {
+        int bracketDepth = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '<') {
+                bracketDepth++;
+            }
+            if (ch == '>') {
+                bracketDepth--;
+            }
+            if (ch == delimiter && bracketDepth == 0) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private static void parseAndAddField(String fieldStr, ArrayList<StructField> fields) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.lance;
+
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
+
+import java.util.ArrayList;
+
+import static com.starrocks.type.BooleanType.BOOLEAN;
+import static com.starrocks.type.DateType.DATE;
+import static com.starrocks.type.DateType.DATETIME;
+import static com.starrocks.type.FloatType.DOUBLE;
+import static com.starrocks.type.FloatType.FLOAT;
+import static com.starrocks.type.IntegerType.BIGINT;
+import static com.starrocks.type.IntegerType.INT;
+import static com.starrocks.type.IntegerType.SMALLINT;
+import static com.starrocks.type.IntegerType.TINYINT;
+import static com.starrocks.type.VarbinaryType.VARBINARY;
+import static com.starrocks.type.VarcharType.VARCHAR;
+
+public class LanceApiConverter {
+
+    /**
+     * Maps safe string representations of Apache Arrow / Lance data types to StarRocks Types recursively.
+     * In Phase 1, we parse a structured string description of types (e.g., "list<float32>", "struct<a:int32,b:string>")
+     * into native StarRocks Type representation.
+     */
+    public static Type parseType(String typeStr) {
+        String clean = typeStr.trim();
+        String lower = clean.toLowerCase();
+        if (lower.equals("boolean") || lower.equals("bool")) {
+            return BOOLEAN;
+        } else if (lower.equals("int8") || lower.equals("tinyint")) {
+            return TINYINT;
+        } else if (lower.equals("int16") || lower.equals("smallint")) {
+            return SMALLINT;
+        } else if (lower.equals("int32") || lower.equals("int")) {
+            return INT;
+        } else if (lower.equals("int64") || lower.equals("bigint")) {
+            return BIGINT;
+        } else if (lower.equals("float16") || lower.equals("float32") || lower.equals("float")) {
+            return FLOAT;
+        } else if (lower.equals("float64") || lower.equals("double")) {
+            return DOUBLE;
+        } else if (lower.equals("string") || lower.equals("utf8") || lower.equals("varchar")) {
+            return VARCHAR;
+        } else if (lower.equals("binary") || lower.equals("varbinary")) {
+            return VARBINARY;
+        } else if (lower.equals("date") || lower.equals("date32")) {
+            return DATE;
+        } else if (lower.equals("timestamp") || lower.equals("datetime")) {
+            return DATETIME;
+        }
+
+        if (lower.startsWith("list<") && lower.endsWith(">")) {
+            String inner = clean.substring(5, clean.length() - 1);
+            return new ArrayType(parseType(inner));
+        }
+
+        if (lower.startsWith("fixed_size_list<") && lower.endsWith(">")) {
+            // "fixed_size_list<float32, 128>" -> mapped to Array of Float
+            int commaIdx = clean.lastIndexOf(",");
+            if (commaIdx > 16) {
+                String inner = clean.substring(16, commaIdx).trim();
+                return new ArrayType(parseType(inner));
+            }
+        }
+
+        if (lower.startsWith("struct<") && lower.endsWith(">")) {
+            String inner = clean.substring(7, clean.length() - 1);
+            ArrayList<StructField> fields = new ArrayList<>();
+            // Split fields by comma, being careful not to split nested structs
+            int bracketDepth = 0;
+            StringBuilder fieldBuilder = new StringBuilder();
+            for (int i = 0; i < inner.length(); i++) {
+                char ch = inner.charAt(i);
+                if (ch == '<') {
+                    bracketDepth++;
+                }
+                if (ch == '>') {
+                    bracketDepth--;
+                }
+                if (ch == ',' && bracketDepth == 0) {
+                    parseAndAddField(fieldBuilder.toString(), fields);
+                    fieldBuilder.setLength(0);
+                } else {
+                    fieldBuilder.append(ch);
+                }
+            }
+            if (fieldBuilder.length() > 0) {
+                parseAndAddField(fieldBuilder.toString(), fields);
+            }
+            return new StructType(fields);
+        }
+
+        return VARCHAR; // Fallback
+    }
+
+    private static void parseAndAddField(String fieldStr, ArrayList<StructField> fields) {
+        int colonIdx = fieldStr.indexOf(':');
+        if (colonIdx > 0) {
+            String name = fieldStr.substring(0, colonIdx).trim();
+            String typePart = fieldStr.substring(colonIdx + 1).trim();
+            fields.add(new StructField(name, parseType(typePart)));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
@@ -20,6 +20,7 @@ import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static com.starrocks.type.BooleanType.BOOLEAN;
 import static com.starrocks.type.DateType.DATE;
@@ -81,34 +82,55 @@ public class LanceApiConverter {
             }
         }
 
+        if (lower.startsWith("fixed_size_list:")) {
+            // "fixed_size_list:float:128" -> mapped to Array of Float
+            int sizeSeparatorIdx = clean.lastIndexOf(":");
+            if (sizeSeparatorIdx > 16) {
+                String inner = clean.substring(16, sizeSeparatorIdx).trim();
+                return new ArrayType(parseType(inner));
+            }
+        }
+
         if (lower.startsWith("struct<") && lower.endsWith(">")) {
             String inner = clean.substring(7, clean.length() - 1);
             ArrayList<StructField> fields = new ArrayList<>();
-            // Split fields by comma, being careful not to split nested structs
-            int bracketDepth = 0;
-            StringBuilder fieldBuilder = new StringBuilder();
-            for (int i = 0; i < inner.length(); i++) {
-                char ch = inner.charAt(i);
-                if (ch == '<') {
-                    bracketDepth++;
-                }
-                if (ch == '>') {
-                    bracketDepth--;
-                }
-                if (ch == ',' && bracketDepth == 0) {
-                    parseAndAddField(fieldBuilder.toString(), fields);
-                    fieldBuilder.setLength(0);
-                } else {
-                    fieldBuilder.append(ch);
-                }
-            }
-            if (fieldBuilder.length() > 0) {
-                parseAndAddField(fieldBuilder.toString(), fields);
+            for (String field : splitTopLevel(inner, ',')) {
+                parseAndAddField(field, fields);
             }
             return new StructType(fields);
         }
 
         return VARCHAR; // Fallback
+    }
+
+    static List<String> splitTopLevel(String value, char delimiter) {
+        ArrayList<String> parts = new ArrayList<>();
+        int bracketDepth = 0;
+        StringBuilder partBuilder = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '<') {
+                bracketDepth++;
+            }
+            if (ch == '>') {
+                bracketDepth--;
+            }
+            if (ch == delimiter && bracketDepth == 0) {
+                addPart(parts, partBuilder);
+            } else {
+                partBuilder.append(ch);
+            }
+        }
+        addPart(parts, partBuilder);
+        return parts;
+    }
+
+    private static void addPart(ArrayList<String> parts, StringBuilder partBuilder) {
+        String part = partBuilder.toString().trim();
+        if (!part.isEmpty()) {
+            parts.add(part);
+        }
+        partBuilder.setLength(0);
     }
 
     private static void parseAndAddField(String fieldStr, ArrayList<StructField> fields) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceApiConverter.java
@@ -64,7 +64,7 @@ public class LanceApiConverter {
             return VARBINARY;
         } else if (lower.equals("date") || lower.equals("date32")) {
             return DATE;
-        } else if (lower.equals("timestamp") || lower.equals("datetime")) {
+        } else if (lower.equals("timestamp") || lower.startsWith("timestamp[") || lower.equals("datetime")) {
             return DATETIME;
         }
 
@@ -107,17 +107,24 @@ public class LanceApiConverter {
 
     static List<String> splitTopLevel(String value, char delimiter) {
         ArrayList<String> parts = new ArrayList<>();
-        int bracketDepth = 0;
+        int angleBracketDepth = 0;
+        int squareBracketDepth = 0;
         StringBuilder partBuilder = new StringBuilder();
         for (int i = 0; i < value.length(); i++) {
             char ch = value.charAt(i);
             if (ch == '<') {
-                bracketDepth++;
+                angleBracketDepth++;
             }
             if (ch == '>') {
-                bracketDepth--;
+                angleBracketDepth--;
             }
-            if (ch == delimiter && bracketDepth == 0) {
+            if (ch == '[') {
+                squareBracketDepth++;
+            }
+            if (ch == ']') {
+                squareBracketDepth--;
+            }
+            if (ch == delimiter && angleBracketDepth == 0 && squareBracketDepth == 0) {
                 addPart(parts, partBuilder);
             } else {
                 partBuilder.append(ch);
@@ -144,16 +151,23 @@ public class LanceApiConverter {
     }
 
     private static int topLevelDelimiterIndex(String value, char delimiter) {
-        int bracketDepth = 0;
+        int angleBracketDepth = 0;
+        int squareBracketDepth = 0;
         for (int i = 0; i < value.length(); i++) {
             char ch = value.charAt(i);
             if (ch == '<') {
-                bracketDepth++;
+                angleBracketDepth++;
             }
             if (ch == '>') {
-                bracketDepth--;
+                angleBracketDepth--;
             }
-            if (ch == delimiter && bracketDepth == 0) {
+            if (ch == '[') {
+                squareBracketDepth++;
+            }
+            if (ch == ']') {
+                squareBracketDepth--;
+            }
+            if (ch == delimiter && angleBracketDepth == 0 && squareBracketDepth == 0) {
                 return i;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceConnector.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.lance;
+
+import com.starrocks.connector.Connector;
+import com.starrocks.connector.ConnectorContext;
+import com.starrocks.connector.ConnectorMetadata;
+
+import java.util.Map;
+
+public class LanceConnector implements Connector {
+    private final String catalogName;
+    private final Map<String, String> properties;
+    private final LanceMetadata metadata;
+
+    public LanceConnector(ConnectorContext context) {
+        this.catalogName = context.getCatalogName();
+        this.properties = context.getProperties();
+        this.metadata = new LanceMetadata(catalogName, properties);
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public void shutdown() {
+        // No-op for Phase 1
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceMetadata.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.lance;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LanceTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.qe.ConnectContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LanceMetadata implements ConnectorMetadata {
+    private final String catalogName;
+    private final Map<String, String> properties;
+    private final Map<String, Database> databases = new ConcurrentHashMap<>();
+    private final Map<String, List<Table>> tables = new ConcurrentHashMap<>();
+
+    public LanceMetadata(String catalogName, Map<String, String> properties) {
+        this.catalogName = catalogName;
+        this.properties = properties;
+        bootstrapMetadata();
+    }
+
+    private void bootstrapMetadata() {
+        // Bootstraps basic database and table definitions from the catalog configuration properties.
+        // This ensures SHOW DATABASES / SHOW TABLES can discover configured tables in production.
+        // e.g. properties can contain:
+        // "database" -> "default"
+        // "table.vectors.uri" -> "s3://bucket/vectors"
+        // "table.vectors.schema" -> "id:int64,embedding:fixed_size_list<float32, 128>"
+        String dbName = properties.getOrDefault("database", "default");
+        Database db = new Database(10001, dbName);
+        addDatabase(db);
+
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith("table.") && key.endsWith(".uri")) {
+                String tblName = key.substring(6, key.length() - 4);
+                String uri = entry.getValue();
+                String schemaStr = properties.get("table." + tblName + ".schema");
+                java.util.ArrayList<com.starrocks.catalog.Column> columns = new java.util.ArrayList<>();
+                if (schemaStr != null) {
+                    String[] fields = schemaStr.split(",");
+                    for (String field : fields) {
+                        int colonIdx = field.indexOf(':');
+                        if (colonIdx > 0) {
+                            String name = field.substring(0, colonIdx).trim();
+                            String typeStr = field.substring(colonIdx + 1).trim();
+                            columns.add(new com.starrocks.catalog.Column(name, LanceApiConverter.parseType(typeStr)));
+                        }
+                    }
+                }
+                LanceTable table = new LanceTable(20001, tblName, columns, uri);
+                addTable(dbName, table);
+            }
+        }
+    }
+
+    @Override
+    public Table.TableType getTableType() {
+        return Table.TableType.LANCE;
+    }
+
+    @Override
+    public List<String> listDbNames(ConnectContext context) {
+        return ImmutableList.copyOf(databases.keySet());
+    }
+
+    @Override
+    public List<String> listTableNames(ConnectContext context, String dbName) {
+        List<Table> tableList = tables.get(dbName);
+        if (tableList == null) {
+            return ImmutableList.of();
+        }
+        return tableList.stream().map(Table::getName).collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public Database getDb(ConnectContext context, String dbName) {
+        return databases.get(dbName);
+    }
+
+    @Override
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
+        List<Table> tableList = tables.get(dbName);
+        if (tableList == null) {
+            return null;
+        }
+        return tableList.stream()
+                .filter(t -> t.getName().equalsIgnoreCase(tblName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    // Helpers for unit tests to register metadata manually in Phase 1 (local catalogs)
+    public void addDatabase(Database db) {
+        databases.put(db.getFullName(), db);
+    }
+
+    public void addTable(String dbName, Table table) {
+        tables.computeIfAbsent(dbName, k -> Lists.newCopyOnWriteArrayList()).add(table);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceMetadata.java
@@ -16,12 +16,14 @@ package com.starrocks.connector.lance;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LanceTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.qe.ConnectContext;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,15 +57,14 @@ public class LanceMetadata implements ConnectorMetadata {
                 String tblName = key.substring(6, key.length() - 4);
                 String uri = entry.getValue();
                 String schemaStr = properties.get("table." + tblName + ".schema");
-                java.util.ArrayList<com.starrocks.catalog.Column> columns = new java.util.ArrayList<>();
+                ArrayList<Column> columns = new ArrayList<>();
                 if (schemaStr != null) {
-                    String[] fields = schemaStr.split(",");
-                    for (String field : fields) {
+                    for (String field : LanceApiConverter.splitTopLevel(schemaStr, ',')) {
                         int colonIdx = field.indexOf(':');
                         if (colonIdx > 0) {
                             String name = field.substring(0, colonIdx).trim();
                             String typeStr = field.substring(colonIdx + 1).trim();
-                            columns.add(new com.starrocks.catalog.Column(name, LanceApiConverter.parseType(typeStr)));
+                            columns.add(new Column(name, LanceApiConverter.parseType(typeStr)));
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/lance/LanceMetadata.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
+
 public class LanceMetadata implements ConnectorMetadata {
     private final String catalogName;
     private final Map<String, String> properties;
@@ -48,7 +50,7 @@ public class LanceMetadata implements ConnectorMetadata {
         // "table.vectors.uri" -> "s3://bucket/vectors"
         // "table.vectors.schema" -> "id:int64,embedding:fixed_size_list<float32, 128>"
         String dbName = properties.getOrDefault("database", "default");
-        Database db = new Database(10001, dbName);
+        Database db = new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName);
         addDatabase(db);
 
         for (Map.Entry<String, String> entry : properties.entrySet()) {
@@ -68,7 +70,7 @@ public class LanceMetadata implements ConnectorMetadata {
                         }
                     }
                 }
-                LanceTable table = new LanceTable(20001, tblName, columns, uri);
+                LanceTable table = new LanceTable(CONNECTOR_ID_GENERATOR.getNextId().asLong(), tblName, columns, uri);
                 addTable(dbName, table);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
@@ -56,6 +56,10 @@ public class LanceMetadataTest {
         Assertions.assertTrue(vectorType.isArrayType());
         Assertions.assertEquals(FLOAT, ((ArrayType) vectorType).getItemType());
 
+        Type lanceVectorType = LanceApiConverter.parseType("fixed_size_list:float:128");
+        Assertions.assertTrue(lanceVectorType.isArrayType());
+        Assertions.assertEquals(FLOAT, ((ArrayType) lanceVectorType).getItemType());
+
         // Struct types with case preservation
         Type structType = LanceApiConverter.parseType("struct<UserID:int64,embedding:fixed_size_list<float32,512>>");
         Assertions.assertTrue(structType.isStructType());
@@ -70,7 +74,8 @@ public class LanceMetadataTest {
         java.util.Map<String, String> properties = new java.util.HashMap<>();
         properties.put("database", "vectors_db");
         properties.put("table.users.uri", "s3://bucket/users");
-        properties.put("table.users.schema", "UserID:int64,embedding:fixed_size_list<float32,128>");
+        properties.put("table.users.schema",
+                "UserID:int64,embedding:fixed_size_list<float32, 128>,lance_embedding:fixed_size_list:float:128");
 
         LanceMetadata metadata = new LanceMetadata("lance_catalog", properties);
         Assertions.assertTrue(metadata.listDbNames(null).contains("vectors_db"));
@@ -86,6 +91,17 @@ public class LanceMetadataTest {
         com.starrocks.catalog.Column userIdCol = lanceDiscovered.getColumn("UserID");
         Assertions.assertNotNull(userIdCol);
         Assertions.assertEquals(BIGINT, userIdCol.getType());
+
+        Assertions.assertEquals(3, lanceDiscovered.getColumns().size());
+        Column embeddingCol = lanceDiscovered.getColumn("embedding");
+        Assertions.assertNotNull(embeddingCol);
+        Assertions.assertTrue(embeddingCol.getType().isArrayType());
+        Assertions.assertEquals(FLOAT, ((ArrayType) embeddingCol.getType()).getItemType());
+
+        Column lanceEmbeddingCol = lanceDiscovered.getColumn("lance_embedding");
+        Assertions.assertNotNull(lanceEmbeddingCol);
+        Assertions.assertTrue(lanceEmbeddingCol.getType().isArrayType());
+        Assertions.assertEquals(FLOAT, ((ArrayType) lanceEmbeddingCol.getType()).getItemType());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static com.starrocks.type.BooleanType.BOOLEAN;
+import static com.starrocks.type.DateType.DATETIME;
 import static com.starrocks.type.FloatType.DOUBLE;
 import static com.starrocks.type.FloatType.FLOAT;
 import static com.starrocks.type.IntegerType.BIGINT;
@@ -45,6 +46,8 @@ public class LanceMetadataTest {
         Assertions.assertEquals(FLOAT, LanceApiConverter.parseType("float32"));
         Assertions.assertEquals(DOUBLE, LanceApiConverter.parseType("float64"));
         Assertions.assertEquals(VARCHAR, LanceApiConverter.parseType("string"));
+        Assertions.assertEquals(DATETIME, LanceApiConverter.parseType("timestamp[us]"));
+        Assertions.assertEquals(DATETIME, LanceApiConverter.parseType("timestamp[us, tz=UTC]"));
 
         // Nested types
         Type arrayType = LanceApiConverter.parseType("list<float32>");
@@ -83,24 +86,38 @@ public class LanceMetadataTest {
         properties.put("database", "vectors_db");
         properties.put("table.users.uri", "s3://bucket/users");
         properties.put("table.users.schema",
-                "UserID:int64,embedding:fixed_size_list<float32, 128>,lance_embedding:fixed_size_list:float:128");
+                "UserID:int64,event_time:timestamp[us, tz=UTC],embedding:fixed_size_list<float32, 128>,"
+                        + "lance_embedding:fixed_size_list:float:128");
+        properties.put("table.events.uri", "s3://bucket/events");
+        properties.put("table.events.schema", "event_time:timestamp[us]");
 
         LanceMetadata metadata = new LanceMetadata("lance_catalog", properties);
         Assertions.assertTrue(metadata.listDbNames(null).contains("vectors_db"));
         Assertions.assertTrue(metadata.listTableNames(null, "vectors_db").contains("users"));
+        Assertions.assertTrue(metadata.listTableNames(null, "vectors_db").contains("events"));
 
         Table discovered = metadata.getTable(null, "vectors_db", "users");
         Assertions.assertNotNull(discovered);
         Assertions.assertTrue(discovered.isLanceTable());
         LanceTable lanceDiscovered = (LanceTable) discovered;
         Assertions.assertEquals("s3://bucket/users", lanceDiscovered.getUri());
+        Assertions.assertEquals("s3://bucket/users", lanceDiscovered.getTableLocation());
         Assertions.assertFalse(lanceDiscovered.isSupported()); // verified unsupported in planning
+
+        Table events = metadata.getTable(null, "vectors_db", "events");
+        Assertions.assertNotNull(events);
+        Assertions.assertNotEquals(lanceDiscovered.getId(), events.getId());
+        Assertions.assertEquals("s3://bucket/events", events.getTableLocation());
 
         com.starrocks.catalog.Column userIdCol = lanceDiscovered.getColumn("UserID");
         Assertions.assertNotNull(userIdCol);
         Assertions.assertEquals(BIGINT, userIdCol.getType());
 
-        Assertions.assertEquals(3, lanceDiscovered.getColumns().size());
+        Column eventTimeCol = lanceDiscovered.getColumn("event_time");
+        Assertions.assertNotNull(eventTimeCol);
+        Assertions.assertEquals(DATETIME, eventTimeCol.getType());
+
+        Assertions.assertEquals(4, lanceDiscovered.getColumns().size());
         Column embeddingCol = lanceDiscovered.getColumn("embedding");
         Assertions.assertNotNull(embeddingCol);
         Assertions.assertTrue(embeddingCol.getType().isArrayType());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
@@ -1,0 +1,121 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.lance;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LanceTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static com.starrocks.type.BooleanType.BOOLEAN;
+import static com.starrocks.type.FloatType.DOUBLE;
+import static com.starrocks.type.FloatType.FLOAT;
+import static com.starrocks.type.IntegerType.BIGINT;
+import static com.starrocks.type.IntegerType.INT;
+import static com.starrocks.type.VarcharType.VARCHAR;
+
+public class LanceMetadataTest {
+
+    @Test
+    public void testTypeParsing() {
+        // Scalar types
+        Assertions.assertEquals(BOOLEAN, LanceApiConverter.parseType("boolean"));
+        Assertions.assertEquals(INT, LanceApiConverter.parseType("int32"));
+        Assertions.assertEquals(BIGINT, LanceApiConverter.parseType("int64"));
+        Assertions.assertEquals(FLOAT, LanceApiConverter.parseType("float32"));
+        Assertions.assertEquals(DOUBLE, LanceApiConverter.parseType("float64"));
+        Assertions.assertEquals(VARCHAR, LanceApiConverter.parseType("string"));
+
+        // Nested types
+        Type arrayType = LanceApiConverter.parseType("list<float32>");
+        Assertions.assertTrue(arrayType.isArrayType());
+        Assertions.assertEquals(FLOAT, ((ArrayType) arrayType).getItemType());
+
+        // Vector embeddings as fixed_size_list
+        Type vectorType = LanceApiConverter.parseType("fixed_size_list<float32, 128>");
+        Assertions.assertTrue(vectorType.isArrayType());
+        Assertions.assertEquals(FLOAT, ((ArrayType) vectorType).getItemType());
+
+        // Struct types with case preservation
+        Type structType = LanceApiConverter.parseType("struct<UserID:int64,embedding:fixed_size_list<float32,512>>");
+        Assertions.assertTrue(structType.isStructType());
+        com.starrocks.type.StructType sType = (com.starrocks.type.StructType) structType;
+        Assertions.assertEquals(2, sType.getFields().size());
+        Assertions.assertEquals("UserID", sType.getFields().get(0).getName());
+        Assertions.assertEquals("embedding", sType.getFields().get(1).getName());
+    }
+
+    @Test
+    public void testMetadataDiscoveryBootstrap() {
+        java.util.Map<String, String> properties = new java.util.HashMap<>();
+        properties.put("database", "vectors_db");
+        properties.put("table.users.uri", "s3://bucket/users");
+        properties.put("table.users.schema", "UserID:int64,embedding:fixed_size_list<float32,128>");
+
+        LanceMetadata metadata = new LanceMetadata("lance_catalog", properties);
+        Assertions.assertTrue(metadata.listDbNames(null).contains("vectors_db"));
+        Assertions.assertTrue(metadata.listTableNames(null, "vectors_db").contains("users"));
+
+        Table discovered = metadata.getTable(null, "vectors_db", "users");
+        Assertions.assertNotNull(discovered);
+        Assertions.assertTrue(discovered.isLanceTable());
+        LanceTable lanceDiscovered = (LanceTable) discovered;
+        Assertions.assertEquals("s3://bucket/users", lanceDiscovered.getUri());
+        Assertions.assertFalse(lanceDiscovered.isSupported()); // verified unsupported in planning
+
+        com.starrocks.catalog.Column userIdCol = lanceDiscovered.getColumn("UserID");
+        Assertions.assertNotNull(userIdCol);
+        Assertions.assertEquals(BIGINT, userIdCol.getType());
+    }
+
+    @Test
+    public void testMetadataDiscovery() {
+        LanceMetadata metadata = new LanceMetadata("lance_catalog", new HashMap<>());
+        Assertions.assertEquals(Table.TableType.LANCE, metadata.getTableType());
+
+        Database db = new Database(10001, "db1");
+        metadata.addDatabase(db);
+
+        List<Column> columns = ImmutableList.of(
+                new Column("id", INT),
+                new Column("embedding", LanceApiConverter.parseType("fixed_size_list<float32, 128>"))
+        );
+        LanceTable table = new LanceTable(20001, "vectors_table", columns, "s3://bucket/vectors");
+        metadata.addTable("db1", table);
+
+        // Assert discovery API
+        Assertions.assertTrue(metadata.listDbNames(null).contains("db1"));
+        Assertions.assertTrue(metadata.listTableNames(null, "db1").contains("vectors_table"));
+        Assertions.assertEquals(db, metadata.getDb(null, "db1"));
+
+        Table discovered = metadata.getTable(null, "db1", "vectors_table");
+        Assertions.assertNotNull(discovered);
+        Assertions.assertTrue(discovered.isLanceTable());
+        LanceTable lanceDiscovered = (LanceTable) discovered;
+        Assertions.assertEquals("s3://bucket/vectors", lanceDiscovered.getUri());
+        Assertions.assertEquals(2, lanceDiscovered.getColumns().size());
+        Column embeddingCol = lanceDiscovered.getColumn("embedding");
+        Assertions.assertNotNull(embeddingCol);
+        Assertions.assertTrue(embeddingCol.getType().isArrayType());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/lance/LanceMetadataTest.java
@@ -51,10 +51,18 @@ public class LanceMetadataTest {
         Assertions.assertTrue(arrayType.isArrayType());
         Assertions.assertEquals(FLOAT, ((ArrayType) arrayType).getItemType());
 
+        Type arrowArrayType = LanceApiConverter.parseType("list<item: int32>");
+        Assertions.assertTrue(arrowArrayType.isArrayType());
+        Assertions.assertEquals(INT, ((ArrayType) arrowArrayType).getItemType());
+
         // Vector embeddings as fixed_size_list
         Type vectorType = LanceApiConverter.parseType("fixed_size_list<float32, 128>");
         Assertions.assertTrue(vectorType.isArrayType());
         Assertions.assertEquals(FLOAT, ((ArrayType) vectorType).getItemType());
+
+        Type arrowVectorType = LanceApiConverter.parseType("fixed_size_list<item: float>[128]");
+        Assertions.assertTrue(arrowVectorType.isArrayType());
+        Assertions.assertEquals(FLOAT, ((ArrayType) arrowVectorType).getItemType());
 
         Type lanceVectorType = LanceApiConverter.parseType("fixed_size_list:float:128");
         Assertions.assertTrue(lanceVectorType.isArrayType());

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -94,6 +94,7 @@ enum THdfsFileFormat {
   PARQUET = 5,
   ORC = 6,
   SEQUENCE_FILE = 7,
+  LANCE = 8,
 
   UNKNOWN = 100
 }


### PR DESCRIPTION

Refs #74520 

## Why I'm doing:

Introduce native Lance dataset support into StarRocks. Lance is a modern columnar format
optimized for ML/AI workloads with native vector embedding support. This PR establishes
the FE catalog and metadata discovery layer as the first step toward full integration.

## What I'm doing:

- Register `LANCE` as a native file format in `THdfsFileFormat` (thrift) and as a
  `ConnectorType` / `TableType` in the FE catalog.
- Add `LanceTable`, `LanceConnector`, `LanceMetadata`, and `LanceApiConverter` for
  catalog registration, metadata discovery, and recursive Arrow-to-StarRocks type
  conversion (including `fixed_size_list` for vector embeddings).
- Add `LanceMetadataTest` with unit tests for type parsing and metadata discovery.

This is Phase 1 of a multi-PR series. It covers FE catalog and metadata only — no
query planning, BE scanner, or native FFI integration yet.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)