### PR TITLE
[Refactor] Extract VariantProjectionHandler from GroupReader to decouple variant projection logic

### DIFF
--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -86,6 +86,7 @@ ADD_BE_LIB(Formats
         parquet/column_reader_factory.cpp
         parquet/scalar_column_reader.cpp
         parquet/complex_column_reader.cpp
+        parquet/variant_projection.cpp
         parquet/encoding.cpp
         parquet/level_codec.cpp
         parquet/page_reader.cpp

--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <future>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -22,27 +22,17 @@
 #include <unordered_set>
 #include <utility>
 
-#include "base/concurrency/stopwatch.hpp"
 #include "base/simd/simd.h"
-#include "base/time/timezone_utils.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
-#include "column/column_builder.h"
 #include "column/column_helper.h"
-#include "column/variant_column.h"
-#include "column/variant_converter.h"
-#include "column/variant_path_parser.h"
 #include "common/config_scan_io_fwd.h"
-#include "common/runtime_profile.h"
-#include "common/status.h"
 #include "common/statusor.h"
 #include "common/system/master_info.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exprs/chunk_predicate_evaluator.h"
-#include "exprs/decimal_cast_expr.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
-#include "exprs/variant_path_reader.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
@@ -52,10 +42,9 @@
 #include "formats/parquet/row_source_reader.h"
 #include "formats/parquet/scalar_column_reader.h"
 #include "formats/parquet/schema.h"
+#include "formats/parquet/variant_projection.h"
 #include "gen_cpp/Exprs_types.h"
 #include "runtime/chunk_helper.h"
-#include "runtime/mem_pool.h"
-#include "storage/convert_helper.h"
 #include "types/type_descriptor.h"
 #include "utils.h"
 
@@ -64,18 +53,6 @@ namespace starrocks::parquet {
 namespace {
 
 // Deduplicate exact-duplicate IO ranges collected from multiple column readers.
-//
-// VariantColumnReader::collect_column_io_range walks both the top-level field readers
-// (_top_level.value_reader, _top_level.metadata_reader, etc.) and the shredded-field
-// subtree.  A shredded field's value_reader may point to the same underlying parquet
-// column chunk as the top-level value_reader, causing the same (offset, size) pair to
-// be registered more than once.  When that happens the two entries are collapsed into
-// one, with is_active set to the logical OR so that a range used by either an active
-// or a lazy reader is treated as active.
-//
-// Note: this only handles *exact* duplicates (identical offset and size).  True byte-range
-// overlaps are not expected because the parquet format guarantees that column chunks for
-// different columns occupy non-overlapping byte ranges within the file.
 void deduplicate_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges) {
     if (ranges == nullptr || ranges->size() <= 1) {
         return;
@@ -107,322 +84,15 @@ void deduplicate_io_ranges(std::vector<SharedBufferedInputStream::IORange>* rang
     ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
 }
 
-StatusOr<ColumnPtr> build_exact_typed_variant_projection(const VariantColumn* variant_column,
-                                                         const ColumnPtr& variant_src, const VariantPath& path,
-                                                         const TypeDescriptor& target_type) {
-    VariantPathReader reader;
-    reader.prepare(variant_column, &path);
-    if (!reader.is_typed_exact()) {
-        return Status::NotFound("variant path is not an exact typed leaf");
-    }
-    if (reader.typed_type_desc() != target_type) {
-        // VARCHAR / CHAR / VARBINARY / BINARY all share the same physical BinaryColumn
-        // representation (raw bytes).  Allow the fast typed-column path when both the
-        // shredded leaf type and the target type are in this "string-like" family.
-        auto is_string_like = [](LogicalType t) {
-            return t == TYPE_VARCHAR || t == TYPE_CHAR || t == TYPE_VARBINARY || t == TYPE_BINARY;
-        };
-        if (!is_string_like(reader.typed_type_desc().type) || !is_string_like(target_type.type)) {
-            return Status::NotFound("variant typed leaf type does not match target slot type");
-        }
-    }
-
-    const size_t num_rows = variant_src->size();
-    const Column* typed_col = reader.typed_column();
-
-    // Early exit: const variant whose single row is null → broadcast null to all rows.
-    if (variant_src->is_constant() && variant_src->is_null(0)) {
-        auto all_null = ColumnHelper::create_column(target_type, true);
-        all_null->append_nulls(num_rows);
-        return all_null;
-    }
-
-    // Normalise: expand a const variant source so both typed_col and variant_src have
-    // num_rows rows, letting the null-merge and data-clone logic below work uniformly.
-    ColumnPtr expanded_typed;
-    if (variant_src->is_constant()) {
-        // typed_col has 1 row (the single VariantColumn row); replicate it to num_rows.
-        expanded_typed = typed_col->clone();
-        expanded_typed->as_mutable_ptr()->assign(num_rows, 0);
-    }
-    const Column* eff_typed = variant_src->is_constant() ? expanded_typed.get() : typed_col;
-    if (eff_typed->size() != num_rows) {
-        return Status::InternalError(fmt::format(
-                "variant typed column size mismatch: typed_size={}, variant_src_size={}", eff_typed->size(), num_rows));
-    }
-
-    // Merge null masks: result is null when either the outer variant or the typed leaf
-    // is null.  Outer nulls only exist for non-const variant_src (const-null was handled
-    // above; const-non-null has no outer null mask to propagate).
-    const bool has_outer_nulls = !variant_src->is_constant() && variant_src->is_nullable() &&
-                                 down_cast<const NullableColumn*>(variant_src.get())->has_null();
-
-    // Fast path: no outer nulls to merge.  eff_typed already carries the complete null
-    // structure (rows where the shredded leaf is absent are already null in typed_col).
-    // Clone it directly instead of splitting into data + null and reassembling.
-    if (!has_outer_nulls) {
-        if (eff_typed->is_nullable()) {
-            return eff_typed->clone();
-        }
-        // Typed column is non-nullable (all values present): wrap with an all-zero null mask.
-        return NullableColumn::create(eff_typed->clone(), NullColumn::create(num_rows, 0));
-    }
-
-    // Slow path: merge outer nulls from variant_src into the typed null mask.
-    const bool has_typed_nulls = eff_typed->is_nullable() && down_cast<const NullableColumn*>(eff_typed)->has_null();
-
-    auto result_null = NullColumn::create(num_rows, 0);
-    NullData& result_null_data = result_null->get_data();
-
-    if (has_typed_nulls) {
-        const auto outer = down_cast<const NullableColumn*>(variant_src.get())->immutable_null_column_data();
-        const auto typed = down_cast<const NullableColumn*>(eff_typed)->immutable_null_column_data();
-        for (size_t i = 0; i < num_rows; ++i) {
-            result_null_data[i] = outer[i] | typed[i];
-        }
-    } else {
-        const auto outer = down_cast<const NullableColumn*>(variant_src.get())->immutable_null_column_data();
-        std::copy(outer.begin(), outer.end(), result_null_data.begin());
-    }
-
-    auto result_data = ColumnHelper::get_data_column(eff_typed)->clone();
-    auto result = NullableColumn::create(std::move(result_data), std::move(result_null));
-    result->update_has_null();
-    return result;
-}
-
-// Cast a typed-shredded decimal column to a (possibly different) decimal target type.
-//
-// This function is needed because the shredded typed column already holds native decimal
-// storage (int32 / int64 / int128 physical values with precision+scale baked into the
-// TypeDescriptor). That is NOT a variant-binary-encoded value, so VariantRowConverter::cast_to
-// cannot be used: that path decodes variant binary wire format and explicitly excludes
-// decimal targets (see the "VARIANT -> Decimal types: DecimalNonDecimalCast" comment in
-// variant_row_converter.cpp). Instead we go through TypeConverter::convert_column, which
-// understands native decimal storage and handles precision/scale widening correctly.
-//
-// If source_type == target_type (same precision and scale) no conversion is necessary and the
-// column is returned as-is.
-StatusOr<ColumnPtr> cast_decimal_projection_column(const ColumnPtr& source_column, const TypeDescriptor& source_type,
-                                                   const TypeDescriptor& target_type) {
-    if (source_type == target_type) {
-        return source_column;
-    }
-
-    const TypeConverter* converter = get_type_converter(source_type.type, target_type.type);
-    if (converter == nullptr) {
-        return Status::NotFound("no decimal converter for variant typed projection");
-    }
-
-    TypeInfoPtr source_type_info = get_type_info(source_type);
-    TypeInfoPtr target_type_info = get_type_info(target_type);
-    if (source_type_info == nullptr || target_type_info == nullptr) {
-        return Status::NotSupported("missing type info for decimal variant projection");
-    }
-
-    auto result = ColumnHelper::create_column(target_type, true);
-    MemPool mem_pool;
-    RETURN_IF_ERROR(converter->convert_column(source_type_info.get(), *source_column, target_type_info.get(),
-                                              result.get(), &mem_pool));
-    return result;
-}
-
-StatusOr<ColumnPtr> build_decimal_typed_variant_projection(const VariantColumn* variant_column,
-                                                           const ColumnPtr& variant_src, const VariantPath& path,
-                                                           const TypeDescriptor& target_type) {
-    VariantPathReader reader;
-    reader.prepare(variant_column, &path);
-    if (!reader.is_typed_exact()) {
-        return Status::NotFound("variant path is not an exact typed leaf");
-    }
-
-    const TypeDescriptor& source_type = reader.typed_type_desc();
-    if (!source_type.is_decimalv3_type() || !target_type.is_decimalv3_type()) {
-        return Status::NotFound("variant typed leaf is not decimal");
-    }
-
-    ASSIGN_OR_RETURN(auto exact_source_projection,
-                     build_exact_typed_variant_projection(variant_column, variant_src, path, source_type));
-    return cast_decimal_projection_column(exact_source_projection, source_type, target_type);
-}
-
-template <LogicalType ResultType>
-StatusOr<ColumnPtr> build_variant_projection_column(const VariantColumn* variant_column, const ColumnPtr& variant_src,
-                                                    const VariantPath& path, const cctz::time_zone& zone) {
-    const size_t num_rows = variant_src->size();
-
-    ColumnBuilder<ResultType> builder(num_rows);
-    VariantPathReader reader;
-    reader.prepare(variant_column, &path);
-
-    // Hoist is_constant() out of the loop: it does not change per row.
-    const bool src_is_const = variant_src->is_constant();
-    for (size_t row = 0; row < num_rows; ++row) {
-        if (variant_src->is_null(row)) {
-            builder.append_null();
-            continue;
-        }
-        size_t variant_row = src_is_const ? 0 : row;
-        VariantReadResult read = reader.read_row(variant_row);
-        if (read.state != VariantReadState::kValue) {
-            builder.append_null();
-            continue;
-        }
-        auto cast_status = VariantRowConverter::cast_to<ResultType, false>(read.value.as_ref(), zone, builder);
-        RETURN_IF_ERROR(cast_status);
-    }
-
-    // Keep virtual-column schema stable across chunks: variant leaf extraction is semantically nullable,
-    // so always return NullableColumn instead of data-dependent nullable/non-nullable output.
-    return builder.build_nullable_column();
-}
-
-template <LogicalType ResultType>
-StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn* variant_column,
-                                                            const ColumnPtr& variant_src, const VariantPath& path,
-                                                            const TypeDescriptor& target_type) {
-    const size_t num_rows = variant_src->size();
-
-    ColumnBuilder<ResultType> builder(num_rows, target_type.precision, target_type.scale);
-    VariantPathReader reader;
-    reader.prepare(variant_column, &path);
-
-    const bool src_is_const = variant_src->is_constant();
-    for (size_t row = 0; row < num_rows; ++row) {
-        if (variant_src->is_null(row)) {
-            builder.append_null();
-            continue;
-        }
-        size_t variant_row = src_is_const ? 0 : row;
-        VariantReadResult read = reader.read_row(variant_row);
-        if (read.state != VariantReadState::kValue) {
-            builder.append_null();
-            continue;
-        }
-        auto variant_ref = read.value.as_ref();
-        const VariantValue& variant_value = variant_ref.get_value();
-        if (variant_value.type() == VariantType::NULL_TYPE) {
-            builder.append_null();
-            continue;
-        }
-        RunTimeCppType<ResultType> decimal_value{};
-        ASSIGN_OR_RETURN(bool overflow,
-                         cast_variant_to_decimal<RunTimeCppType<ResultType>>(&decimal_value, variant_value,
-                                                                             target_type.precision, target_type.scale));
-        if (overflow) {
-            builder.append_null();
-        } else {
-            builder.append(decimal_value);
-        }
-    }
-
-    // Keep virtual-column schema stable across chunks: variant leaf extraction is semantically nullable,
-    // so always return NullableColumn instead of data-dependent nullable/non-nullable output.
-    return builder.build_nullable_column();
-}
-
-StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, const VariantPath& path,
-                                                const TypeDescriptor& target_type, const cctz::time_zone& zone) {
-    auto* variant_column = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(variant_src.get()));
-    if (variant_column == nullptr) {
-        return Status::InternalError("variant source column is invalid");
-    }
-
-    auto exact_typed_result = build_exact_typed_variant_projection(variant_column, variant_src, path, target_type);
-    if (exact_typed_result.ok()) {
-        return exact_typed_result;
-    }
-    if (target_type.is_decimalv3_type()) {
-        auto decimal_typed_result =
-                build_decimal_typed_variant_projection(variant_column, variant_src, path, target_type);
-        if (decimal_typed_result.ok()) {
-            return decimal_typed_result;
-        }
-    }
-
-    switch (target_type.type) {
-    case TYPE_BOOLEAN:
-        return build_variant_projection_column<TYPE_BOOLEAN>(variant_column, variant_src, path, zone);
-    case TYPE_TINYINT:
-        return build_variant_projection_column<TYPE_TINYINT>(variant_column, variant_src, path, zone);
-    case TYPE_SMALLINT:
-        return build_variant_projection_column<TYPE_SMALLINT>(variant_column, variant_src, path, zone);
-    case TYPE_INT:
-        return build_variant_projection_column<TYPE_INT>(variant_column, variant_src, path, zone);
-    case TYPE_BIGINT:
-        return build_variant_projection_column<TYPE_BIGINT>(variant_column, variant_src, path, zone);
-    case TYPE_LARGEINT:
-        return build_variant_projection_column<TYPE_LARGEINT>(variant_column, variant_src, path, zone);
-    case TYPE_FLOAT:
-        return build_variant_projection_column<TYPE_FLOAT>(variant_column, variant_src, path, zone);
-    case TYPE_DOUBLE:
-        return build_variant_projection_column<TYPE_DOUBLE>(variant_column, variant_src, path, zone);
-    case TYPE_VARCHAR:
-        return build_variant_projection_column<TYPE_VARCHAR>(variant_column, variant_src, path, zone);
-    case TYPE_DATE:
-        return build_variant_projection_column<TYPE_DATE>(variant_column, variant_src, path, zone);
-    case TYPE_DATETIME:
-        return build_variant_projection_column<TYPE_DATETIME>(variant_column, variant_src, path, zone);
-    case TYPE_TIME:
-        return build_variant_projection_column<TYPE_TIME>(variant_column, variant_src, path, zone);
-    case TYPE_DECIMAL32:
-        return build_decimal_variant_projection_column<TYPE_DECIMAL32>(variant_column, variant_src, path, target_type);
-    case TYPE_DECIMAL64:
-        return build_decimal_variant_projection_column<TYPE_DECIMAL64>(variant_column, variant_src, path, target_type);
-    case TYPE_DECIMAL128:
-        return build_decimal_variant_projection_column<TYPE_DECIMAL128>(variant_column, variant_src, path, target_type);
-    case TYPE_VARIANT:
-        return build_variant_projection_column<TYPE_VARIANT>(variant_column, variant_src, path, zone);
-    default:
-        return Status::NotSupported("unsupported variant virtual column target type");
-    }
-}
-
-bool collect_variant_leaf_paths(const ColumnAccessPath* node, std::vector<VariantSegment>* segments,
-                                VariantShreddedReadHints* hints) {
-    if (!node->is_field() || node->path().empty()) {
-        return false;
-    }
-
-    segments->emplace_back(VariantSegment::make_object(node->path()));
-    if (node->children().empty()) {
-        // A VARIANT-typed leaf hint is not precise enough for shredded-path pruning.
-        // FE may truncate paths with unsupported JSON semantics (e.g. array index in
-        // "$.a[0].b"), producing an intermediate VARIANT leaf like "a". Restricting
-        // reads to that lossy prefix can drop needed descendants and return NULL.
-        if (node->value_type().type == LogicalType::TYPE_VARIANT) {
-            segments->pop_back();
-            return false;
-        }
-        VariantPath path(*segments);
-        auto shredded_path = path.to_shredded_path();
-        if (!shredded_path.has_value()) {
-            segments->pop_back();
-            return false;
-        }
-        auto st = hints->add_path(std::move(*shredded_path));
-        if (!st.ok()) {
-            segments->pop_back();
-            return false;
-        }
-        segments->pop_back();
-        return true;
-    }
-
-    bool valid = true;
-    for (const auto& child : node->children()) {
-        valid = collect_variant_leaf_paths(child.get(), segments, hints) && valid;
-    }
-    segments->pop_back();
-    return valid;
-}
-
 } // namespace
+
+// ── GroupReader: construction / destruction ─────────────────────────────────
 
 GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, SkipRowsContextPtr skip_rows_ctx,
                          int64_t row_group_first_row)
         : _row_group_first_row(row_group_first_row), _skip_rows_ctx(std::move(skip_rows_ctx)), _param(param) {
     _row_group_metadata = &_param.file_metadata->t_metadata().row_groups[row_group_number];
+    _variant = std::make_unique<VariantProjectionHandler>(this, _param, _row_group_metadata);
 }
 
 GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, SkipRowsContextPtr skip_rows_ctx,
@@ -432,13 +102,13 @@ GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, SkipRows
           _skip_rows_ctx(std::move(skip_rows_ctx)),
           _param(param) {
     _row_group_metadata = &_param.file_metadata->t_metadata().row_groups[row_group_number];
+    _variant = std::make_unique<VariantProjectionHandler>(this, _param, _row_group_metadata);
 }
 
 GroupReader::~GroupReader() {
     if (_param.sb_stream) {
         _param.sb_stream->release_to_offset(_end_offset);
     }
-    // If GroupReader is filtered by statistics, it's _has_prepared = false
     if (_has_prepared) {
         if (_lazy_column_needed) {
             _param.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
@@ -452,8 +122,9 @@ GroupReader::~GroupReader() {
     }
 }
 
+// ── init / prepare ──────────────────────────────────────────────────────────
+
 Status GroupReader::init() {
-    // Create column readers and bind ParquetField & ColumnChunkMetaData(except complex type) to each ColumnReader
     RETURN_IF_ERROR(_create_column_readers());
     _process_columns_and_conjunct_ctxs();
     _range = SparseRange<uint64_t>(_row_group_first_row, _row_group_first_row + _row_group_metadata->num_rows);
@@ -462,29 +133,18 @@ Status GroupReader::init() {
 
 Status GroupReader::prepare() {
     RETURN_IF_ERROR(_prepare_column_readers());
-    // we need deal with page index first, so that it can work on collect_io_range,
-    // and pageindex's io has been collected in FileReader
 
     if (_range.span_size() != get_row_group_metadata()->num_rows) {
         for (const auto& pair : _column_readers) {
             pair.second->select_offset_index(_range, _row_group_first_row);
         }
-        // Hidden variant source readers are not in _column_readers; apply the same
-        // page-index range restriction so they decode only the surviving rows.
-        for (const auto& [name, hidden_source] : _hidden_variant_sources) {
-            hidden_source.reader->select_offset_index(_range, _row_group_first_row);
-        }
+        _variant->select_hidden_source_offset_index();
     }
 
-    // Promote shredded variant virtual columns to direct typed_value proxy readers (Phase 3.5).
-    // Must run after _prepare_column_readers() (which sets skip_base_payload) and after
-    // select_offset_index (so the underlying typed_value readers already have the correct range).
-    RETURN_IF_ERROR(_promote_variant_virtual_columns());
+    // Promote variant virtual columns to typed-value proxy readers.
+    _variant->try_promote();
 
-    // if coalesce read enabled, we have to
-    // 1. allocate shared buffered input stream and
-    // 2. collect io ranges of every row group reader.
-    // 3. set io ranges to the stream.
+    // Coalesce IO ranges.
     if (config::parquet_coalesce_read_enable && _param.sb_stream != nullptr) {
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
@@ -509,6 +169,8 @@ Status GroupReader::prepare() {
     _has_prepared = true;
     return Status::OK();
 }
+
+// ── Simple accessors ────────────────────────────────────────────────────────
 
 const tparquet::ColumnChunk* GroupReader::get_chunk_metadata(SlotId slot_id) {
     const auto& it = _column_readers.find(slot_id);
@@ -538,31 +200,16 @@ const tparquet::RowGroup* GroupReader::get_row_group_metadata() const {
     return _row_group_metadata;
 }
 
-// Per-iteration chunk model used in get_next:
+// ── get_next: materialise one chunk from the current row group ──────────────
 //
-//  _read_chunk  (member)
-//    The column backing store.  Reset at the start of every range iteration.
-//    Holds physical slots (shared with active_chunk / lazy_chunk via _create_read_chunk)
-//    and active hidden variant source columns (shared with active_chunk).
-//
-//  active_chunk  (local, created fresh each iteration)
-//    A lightweight VIEW of _read_chunk for _active_slot_ids (active physical columns +
-//    active hidden variant sources + reserved_field_slots).  Filtering active_chunk
-//    also filters the shared columns in _read_chunk.
-//
-//  lazy_chunk  (local, created when lazy physical columns exist)
-//    A lightweight VIEW of _read_chunk for _lazy_slot_ids (no reserved fields).
-//    Merged into active_chunk after reading so active_chunk is the single source
-//    for _fill_dst_chunk.
-//
-//  lazy_hidden_chunk  (local, created when lazy hidden variant sources exist)
-//    A temporary chunk for projection-only hidden variant sources.  Read AFTER
-//    variant conjunct evaluation to skip rows discarded by those conjuncts.
-//    Merged into active_chunk so that _fill_dst_chunk only needs to look in active_chunk.
-//
-//  *chunk  (output)
-//    The caller-provided destination chunk.  May already contain partition columns.
-//    We do not use (*chunk)->num_rows() as the row count; use active_chunk->num_rows().
+// Pipeline:
+//   1. Prune deleted rows  — deletion bitmap
+//   2. Read & filter active columns — dict / expression predicate pushdown
+//   3. Fetch variant sources (via VariantProjectionHandler)
+//   4. Filter by subfields   (via VariantProjectionHandler)
+//   5. Backfill lazy columns — physical columns without predicates
+//   6. Backfill variant sources (via VariantProjectionHandler)
+//   7. Emit output — decode physical columns + variant projections
 
 Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
     SCOPED_RAW_TIMER(&_param.stats->group_chunk_read_ns);
@@ -571,14 +218,10 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         return Status::EndOfFile("");
     }
 
-    // Reset per-iteration scratch buffers and create a fresh active_chunk view.
-    // active_chunk is recreated (not reset) so that merged lazy columns from a
-    // previous iteration's Phase 5/6 do not carry over.
     _read_chunk->reset();
+    _variant->reset_iteration_state();
     ChunkPtr active_chunk = _create_read_chunk(_active_slot_ids);
 
-    // Loop until we find a range with surviving rows, skipping ranges filtered entirely
-    // by deletion bitmap, predicate pushdown, or deferred variant virtual conjuncts.
     while (true) {
         if (!_range_iter.has_more()) {
             *row_count = 0;
@@ -593,75 +236,44 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         Filter chunk_filter(count, 1);
         active_chunk->reset();
 
-        // ── Phase 1: row-id (deletion bitmap) filter ──────────────────────────
-        if (nullptr != _skip_rows_ctx && _skip_rows_ctx->has_skip_rows()) {
-            SCOPED_RAW_TIMER(&_param.stats->build_rowid_filter_ns);
-            ASSIGN_OR_RETURN(has_filter,
-                             _skip_rows_ctx->deletion_bitmap->fill_filter(r.begin(), r.end(), chunk_filter));
-            if (SIMD::count_nonzero(chunk_filter.data(), count) == 0) {
-                continue;
+        // 1. Prune deleted rows
+        ASSIGN_OR_RETURN(bool rows_survive, _prune_deleted_rows(r, chunk_filter, has_filter, count));
+        if (!rows_survive) continue;
+
+        // 2. Read & filter active columns
+        ASSIGN_OR_RETURN(rows_survive,
+                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count));
+        if (!rows_survive) continue;
+
+        // 3. Fetch variant sources (for subfield conjuncts)
+        RETURN_IF_ERROR(_variant->fetch_sources(r, active_chunk));
+
+        // 4. Filter by subfields (variant deferred conjuncts)
+        if (_variant->has_deferred_conjuncts()) {
+            ASSIGN_OR_RETURN(Filter vr, _variant->filter_subfields(active_chunk, count, _param.stats,
+                                                                   _variant->projection_timezone()));
+            if (!vr.empty()) {
+                if (SIMD::count_nonzero(vr.data(), vr.size()) == 0) {
+                    continue;
+                }
+                DCHECK_EQ(vr.size(), count);
+                for (size_t i = 0; i < count; i++) {
+                    chunk_filter[i] &= vr[i];
+                }
+                has_filter = true;
             }
         }
 
-        // ── Phase 2: active physical columns (with optional predicate pushdown) ──
-        // chunk_filter is populated here but active_chunk is NOT physically reduced yet.
-        // Physical reduction is deferred to after Phase 4 so both chunk_filter and
-        // variant_filter share size == count, enabling a simple element-wise AND merge
-        // instead of a walk-and-apply over mismatched indices.
-        if (!_dict_column_indices.empty() || !_left_no_dict_filter_conjuncts_by_slot.empty()) {
-            has_filter = true;
-            ASSIGN_OR_RETURN(size_t hit_count, _read_range_round_by_round(r, &chunk_filter, &active_chunk));
-            if (hit_count == 0) {
-                _param.stats->late_materialize_skip_rows += count;
-                continue;
-            }
-        } else if (has_filter) {
-            RETURN_IF_ERROR(_read_range(_active_column_indices, r, &chunk_filter, &active_chunk));
-        } else {
-            RETURN_IF_ERROR(_read_range(_active_column_indices, r, nullptr, &active_chunk));
-        }
-
-        // ── Phase 3: active hidden variant sources ─────────────────────────────
-        // Read over the full range r because active_chunk has not been physically
-        // reduced yet.  The combined filter applied after Phase 4 covers all columns
-        // in active_chunk including these hidden sources.
-        for (SlotId slot_id : _active_hidden_slot_ids) {
-            auto* hidden_src = _hidden_slot_index.at(slot_id);
-            auto& hidden_col = active_chunk->get_column_by_slot_id(slot_id);
-            RETURN_IF_ERROR(hidden_src->reader->read_range(r, nullptr, hidden_col));
-        }
-
-        // ── Phase 4: variant virtual conjunct evaluation ───────────────────────
-        // active_chunk has count rows; variant_filter is also size count.
-        // Simple element-wise AND merges it with chunk_filter (also size count).
-        auto deferred_projected_chunk = std::make_shared<Chunk>();
-        ASSIGN_OR_RETURN(Filter variant_filter,
-                         _apply_deferred_variant_conjuncts(active_chunk, count, &deferred_projected_chunk));
-        if (!variant_filter.empty()) {
-            if (SIMD::count_nonzero(variant_filter.data(), variant_filter.size()) == 0) {
-                continue;
-            }
-            DCHECK_EQ(variant_filter.size(), count);
-            for (size_t i = 0; i < count; i++) {
-                chunk_filter[i] &= variant_filter[i];
-            }
-            has_filter = true;
-        }
-
-        // Apply the combined chunk_filter once to physically reduce active_chunk.
-        // All columns (physical active + active hidden sources) are filtered here.
+        // Apply combined chunk_filter to physically reduce active_chunk.
         if (has_filter) {
             active_chunk->filter(chunk_filter);
             if (active_chunk->num_rows() == 0) {
                 continue;
             }
-            // Keep deferred projected virtual columns aligned with active_chunk rows.
-            // Both were built on the same pre-filter row space [0, count).
-            RETURN_IF_ERROR(_align_deferred_projected_chunk_after_filter(active_chunk, deferred_projected_chunk,
-                                                                         chunk_filter, count));
+            RETURN_IF_ERROR(_variant->align_after_combined_filter(active_chunk, chunk_filter, count));
         }
 
-        // Compute the post-filter range / slice for Phase 5 and Phase 6 lazy reads.
+        // Compute post-filter range for lazy reads (Phase 5/6).
         Range<uint64_t> post_filter_range;
         Filter post_filter;
         if (has_filter) {
@@ -671,59 +283,118 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
                            chunk_filter.begin() + post_filter_range.end() - r.begin()};
         }
 
-        // ── Phase 5: lazy physical columns ────────────────────────────────────
-        // Read lazy physical columns for rows surviving Phases 1–4.
+        // 5. Backfill lazy physical columns
         if (!_lazy_column_indices.empty()) {
             _lazy_column_needed = true;
-            ChunkPtr lazy_chunk = _create_read_chunk(_lazy_slot_ids, false);
-            if (has_filter) {
-                RETURN_IF_ERROR(_read_range(_lazy_column_indices, post_filter_range, &post_filter, &lazy_chunk, true));
-                lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
-            } else {
-                RETURN_IF_ERROR(_read_range(_lazy_column_indices, r, nullptr, &lazy_chunk, true));
-            }
-            if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
-                return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
-                                                         active_chunk->num_rows(), lazy_chunk->num_rows()));
-            }
-            active_chunk->merge(std::move(*lazy_chunk));
+            RETURN_IF_ERROR(_read_lazy_columns(r, post_filter_range, post_filter, has_filter, active_chunk));
         }
 
-        // ── Phase 6: lazy hidden variant sources ───────────────────────────────
-        // Projection-only hidden sources (no conjuncts).  Read AFTER Phase 4 so that
-        // rows discarded by variant conjuncts are never decoded.
-        // Use the same combined chunk_filter/post_filter_range as Phase 5.
-        if (!_lazy_hidden_slot_ids.empty()) {
-            auto lazy_hidden_chunk = std::make_shared<Chunk>();
-            for (SlotId slot_id : _lazy_hidden_slot_ids) {
-                auto* hidden_src = _hidden_slot_index.at(slot_id);
-                ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
-                if (has_filter) {
-                    RETURN_IF_ERROR(hidden_src->reader->read_range(post_filter_range, &post_filter, col));
-                    col->as_mutable_ptr()->filter_range(post_filter, 0, post_filter_range.span_size());
-                } else {
-                    RETURN_IF_ERROR(hidden_src->reader->read_range(r, nullptr, col));
-                }
-                lazy_hidden_chunk->append_column(std::move(col), slot_id);
-            }
-            if (lazy_hidden_chunk->num_rows() != active_chunk->num_rows()) {
-                return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_hidden_rows={}",
-                                                         active_chunk->num_rows(), lazy_hidden_chunk->num_rows()));
-            }
-            active_chunk->merge(std::move(*lazy_hidden_chunk));
-        }
+        // 6. Backfill lazy variant sources
+        RETURN_IF_ERROR(_variant->backfill_sources(r, has_filter ? &post_filter_range : nullptr,
+                                                   has_filter ? &post_filter : nullptr, has_filter, active_chunk));
 
-        // ── Phase 7: decode + virtual projection → dst chunk ──────────────────
+        // 7. Emit output
         {
             SCOPED_RAW_TIMER(&_param.stats->group_dict_decode_ns);
             *row_count = active_chunk->num_rows();
-            RETURN_IF_ERROR(_fill_dst_chunk(active_chunk, deferred_projected_chunk, chunk));
+
+            if (_variant->has_projections()) {
+                RETURN_IF_ERROR(_variant->emit_projections(active_chunk, chunk, _variant->projection_timezone()));
+            }
+            RETURN_IF_ERROR(_emit_physical_columns(active_chunk, chunk));
         }
         break;
     }
 
     return _range_iter.has_more() ? Status::OK() : Status::EndOfFile("");
 }
+
+// ── 1. Prune deleted rows ──────
+
+StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter& chunk_filter, bool& has_filter,
+                                                size_t count) {
+    if (nullptr == _skip_rows_ctx || !_skip_rows_ctx->has_skip_rows()) {
+        return true;
+    }
+    SCOPED_RAW_TIMER(&_param.stats->build_rowid_filter_ns);
+    ASSIGN_OR_RETURN(has_filter, _skip_rows_ctx->deletion_bitmap->fill_filter(r.begin(), r.end(), chunk_filter));
+    if (SIMD::count_nonzero(chunk_filter.data(), count) == 0) {
+        return false;
+    }
+    return true;
+}
+
+// ── 2. Read & filter active columns ──────
+
+StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
+                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count) {
+    if (!_dict_column_indices.empty() || !_left_no_dict_filter_conjuncts_by_slot.empty()) {
+        has_filter = true;
+        ASSIGN_OR_RETURN(size_t hit_count, _read_range_round_by_round(r, &chunk_filter, &active_chunk));
+        if (hit_count == 0) {
+            _param.stats->late_materialize_skip_rows += count;
+            return false;
+        }
+    } else if (has_filter) {
+        RETURN_IF_ERROR(_read_range(_active_column_indices, r, &chunk_filter, &active_chunk));
+    } else {
+        RETURN_IF_ERROR(_read_range(_active_column_indices, r, nullptr, &active_chunk));
+    }
+    return true;
+}
+
+// ── 5. Backfill lazy physical columns ──────
+
+Status GroupReader::_read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
+                                       const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk) {
+    ChunkPtr lazy_chunk = _create_read_chunk(_lazy_slot_ids, false);
+    if (has_filter) {
+        RETURN_IF_ERROR(_read_range(_lazy_column_indices, post_filter_range, &post_filter, &lazy_chunk, true));
+        lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+    } else {
+        RETURN_IF_ERROR(_read_range(_lazy_column_indices, full_range, nullptr, &lazy_chunk, true));
+    }
+    if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
+        return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
+                                                 active_chunk->num_rows(), lazy_chunk->num_rows()));
+    }
+    active_chunk->merge(std::move(*lazy_chunk));
+    return Status::OK();
+}
+
+// ── 7. Emit physical columns ──────
+
+Status GroupReader::_emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst) {
+    for (const auto& column : _param.read_cols) {
+        SlotId slot_id = column.slot_id();
+        // Skip virtual projection slots: handled by emit_projections.
+        if (_variant->has_projections() && _variant->is_virtual_slot(slot_id)) continue;
+        RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*dst)->get_column_by_slot_id(slot_id),
+                                                                  active_chunk->get_column_by_slot_id(slot_id)));
+    }
+    if (_param.reserved_field_slots != nullptr) {
+        for (const auto* slot : *_param.reserved_field_slots) {
+            SlotId slot_id = slot->id();
+            RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*dst)->get_column_by_slot_id(slot_id),
+                                                                      active_chunk->get_column_by_slot_id(slot_id)));
+        }
+    }
+    return Status::OK();
+}
+
+void GroupReader::_rebuild_column_read_order_ctx() {
+    std::unordered_map<int, size_t> col_cost;
+    size_t all_cost = 0;
+    for (int col_idx : _active_column_indices) {
+        size_t flat_size = _param.read_cols[col_idx].slot_type().get_flat_size();
+        col_cost[col_idx] = flat_size;
+        all_cost += flat_size;
+    }
+    _column_read_order_ctx =
+            std::make_unique<ColumnReadOrderCtx>(_active_column_indices, all_cost, std::move(col_cost));
+}
+
+// ── _read_range / _read_range_round_by_round ──────
 
 Status GroupReader::_read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range,
                                 const Filter* filter, ChunkPtr* chunk, bool ignore_reserved_field) {
@@ -814,10 +485,10 @@ StatusOr<size_t> GroupReader::_read_range_round_by_round(const Range<uint64_t>& 
     return hit_count;
 }
 
+// ── Column reader creation ─────────────────────────────────────────────────
+
 StatusOr<ColumnReaderPtr> GroupReader::_create_reserved_iceberg_column_reader(const SlotDescriptor* slot,
                                                                               int32_t field_id) {
-    // Try to find the physical column in the Parquet file by Iceberg spec field ID first (canonical),
-    // then fall back to column name lookup for compatibility.
     int32_t field_idx = _param.file_metadata->schema().get_field_idx_by_field_id(field_id);
     if (field_idx < 0) {
         field_idx = _param.file_metadata->schema().get_field_idx_by_column_name(slot->col_name());
@@ -863,107 +534,9 @@ StatusOr<Datum> GroupReader::_get_extended_bigint_value(SlotId slot_id) const {
     return Datum(node.int_literal.value);
 }
 
-// Derives the set of shredded paths that the planner wants to materialise for the given
-// variant column, based on the column_access_paths pushed down from the FE.
-//
-// The result is a VariantShreddedReadHints whose shredded_paths / parsed_shredded_paths are
-// the minimal, non-redundant set of leaf paths, suitable for passing to ColumnReaderFactory.
-//
-// Return value semantics:
-//   - Empty hints  → no path restriction; the reader auto-discovers paths from the schema.
-//   - Non-empty    → only the listed paths (and their ancestors, for traversal) are read.
-//
-// Special cases that cause an early return with empty hints:
-//   1. No column_access_paths present at all.
-//   2. The access-path entry for this column has no children (full-column scan requested).
-//   3. Any child path fails to produce a valid shredded-path string (e.g. contains array index).
-//
-// Post-processing steps applied before returning:
-//   - Deduplication: paths collected from multiple access-path entries are de-duped by string.
-//   - Ancestor pruning: if both "a.b" and "a.b.c" are present, "a.b.c" is redundant (the
-//     "a.b" request already covers the "a.b.c" subtree) and is dropped. Pruning uses parsed
-//     segment comparison rather than string prefix matching to avoid false matches like
-//     "a.bc" vs "a.b".
-VariantShreddedReadHints GroupReader::_get_variant_shredded_hints(std::string_view column_name) const {
-    VariantShreddedReadHints hints;
-    if (_param.column_access_paths == nullptr || _param.column_access_paths->empty()) {
-        return hints;
-    }
-
-    std::unordered_set<std::string> unique_paths;
-    for (const auto& access_path : *_param.column_access_paths) {
-        if (access_path == nullptr || access_path->path() != column_name) {
-            continue;
-        }
-        // No children means the whole variant column is accessed; disable path-level pruning.
-        if (access_path->children().empty()) {
-            hints.clear();
-            return hints;
-        }
-
-        std::vector<VariantSegment> segments;
-        for (const auto& child : access_path->children()) {
-            // collect_variant_leaf_paths walks the access-path subtree and appends each
-            // leaf as a shredded-path string + parsed VariantPath into `hints`.
-            // Returns false if any path is invalid (e.g. contains an array-index segment).
-            if (!collect_variant_leaf_paths(child.get(), &segments, &hints)) {
-                hints.clear();
-                return hints;
-            }
-        }
-    }
-
-    // Deduplicate and prune redundant descendant paths.
-    // A path p is redundant if another collected path q is a strict ancestor of p:
-    // requesting q already covers p's entire subtree, so keeping p causes unnecessary work.
-    // Example: if both "a.b" and "a.b.c" are present, "a.b.c" is dropped because the
-    // "a.b" request already causes "a.b.c" columns to be read.
-    //
-    // Determine which paths to keep in a read-only pass over the original vectors, then
-    // build the output in a separate pass.  Moving elements during the comparison pass
-    // would leave moved-from slots (empty segments) that act as universal ancestors and
-    // incorrectly prune all subsequent paths.
-    const size_t n = hints.shredded_paths.size();
-    std::vector<bool> keep(n, false);
-    for (size_t i = 0; i < n; ++i) {
-        // Drop exact string duplicates.
-        if (!unique_paths.emplace(hints.shredded_paths[i]).second) {
-            continue;
-        }
-        // Drop path i if any other path j is a strict ancestor of i.
-        bool has_ancestor = false;
-        for (size_t j = 0; j < n; ++j) {
-            if (i == j) {
-                continue;
-            }
-            if (hints.parsed_shredded_paths[j].is_strict_prefix_of(hints.parsed_shredded_paths[i])) {
-                has_ancestor = true;
-                break;
-            }
-        }
-        if (!has_ancestor) {
-            keep[i] = true;
-        }
-    }
-    std::vector<std::string> pruned_paths;
-    std::vector<VariantPath> pruned_parsed_paths;
-    pruned_paths.reserve(n);
-    pruned_parsed_paths.reserve(n);
-    for (size_t i = 0; i < n; ++i) {
-        if (keep[i]) {
-            pruned_paths.emplace_back(std::move(hints.shredded_paths[i]));
-            pruned_parsed_paths.emplace_back(std::move(hints.parsed_shredded_paths[i]));
-        }
-    }
-    hints.shredded_paths = std::move(pruned_paths);
-    hints.parsed_shredded_paths = std::move(pruned_parsed_paths);
-    return hints;
-}
-
 Status GroupReader::_create_column_readers() {
     SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
     _global_dict_applied_in_group = false;
-    // ColumnReaderOptions is used by all column readers in one row group
     ColumnReaderOptions& opts = _column_reader_opts;
     opts.file_meta_data = _param.file_metadata;
     opts.timezone = _param.timezone;
@@ -978,57 +551,18 @@ Status GroupReader::_create_column_readers() {
     opts.file_size = _param.file_size;
     opts.datacache_options = _param.datacache_options;
 
-    std::unordered_map<std::string, SlotId> physical_variant_slots_by_name;
-    for (const auto& column : _param.read_cols) {
-        if (!column.is_extended_variant_virtual && column.slot_type().type == LogicalType::TYPE_VARIANT) {
-            physical_variant_slots_by_name.emplace(std::string(column.slot_desc->col_name()), column.slot_id());
-        }
-    }
+    // Setup variant handler (idempotent: no-op when no variant virtual columns exist).
+    RETURN_IF_ERROR(_variant->setup_readers());
 
     for (const auto& column : _param.read_cols) {
-        if (column.is_extended_variant_virtual) {
-            ASSIGN_OR_RETURN(auto parsed_path, VariantPathParser::parse_shredded_path(
-                                                       std::string_view(column.variant_virtual_leaf_path)));
-            VariantVirtualProjection projection{
-                    .parsed_path = std::move(parsed_path), .target_type = column.slot_type(), .source_slot_id = 0};
-            auto physical_it = physical_variant_slots_by_name.find(column.source_variant_column_name);
-            if (physical_it != physical_variant_slots_by_name.end()) {
-                projection.source_slot_id = physical_it->second;
-                _variant_virtual_projections.emplace(column.slot_id(), std::move(projection));
-                continue;
-            }
-
-            // Find or create the hidden variant source for this column name.
-            auto hidden_it = _hidden_variant_sources.find(column.source_variant_column_name);
-            if (hidden_it == _hidden_variant_sources.end()) {
-                const auto* source_schema_node =
-                        _param.file_metadata->schema().get_stored_column_by_field_idx(column.idx_in_parquet);
-                if (source_schema_node == nullptr) {
-                    return Status::InternalError(
-                            fmt::format("invalid source parquet field idx for variant virtual column, idx={}, slot={}",
-                                        column.idx_in_parquet, column.slot_id()));
-                }
-                if (source_schema_node->type != ColumnType::STRUCT) {
-                    return Status::InternalError(
-                            fmt::format("invalid source parquet field type for variant virtual column, idx={}, type={}",
-                                        column.idx_in_parquet, static_cast<int>(source_schema_node->type)));
-                }
-                VariantShreddedReadHints hints = _get_variant_shredded_hints(column.source_variant_column_name);
-                ASSIGN_OR_RETURN(auto hidden_reader, ColumnReaderFactory::create_variant_column_reader(
-                                                             _column_reader_opts, source_schema_node, hints));
-                auto [inserted_it, _] = _hidden_variant_sources.emplace(
-                        column.source_variant_column_name,
-                        HiddenVariantSource{.slot_id = _next_hidden_slot_id--, .reader = std::move(hidden_reader)});
-                hidden_it = inserted_it;
-                _hidden_slot_index[hidden_it->second.slot_id] = &hidden_it->second;
-            }
-            projection.source_slot_id = hidden_it->second.slot_id;
-            _variant_virtual_projections.emplace(column.slot_id(), std::move(projection));
-            continue;
-        }
+        // Extended variant virtual columns are handled by _variant->setup_readers above.
+        if (column.is_extended_variant_virtual) continue;
         ASSIGN_OR_RETURN(ColumnReaderPtr column_reader, _create_column_reader(column));
         _column_readers[column.slot_id()] = std::move(column_reader);
     }
+
+    // Register zone-map readers AFTER physical column readers are created.
+    _variant->register_zone_map_readers();
 
     // create for partition values
     if (_param.partition_columns != nullptr && _param.partition_values != nullptr) {
@@ -1056,8 +590,6 @@ Status GroupReader::_create_column_readers() {
                             });
         for (const auto* slot : *_param.reserved_field_slots) {
             if (slot->col_name() == HdfsScanner::ICEBERG_ROW_ID) {
-                // Iceberg v3 row lineage: try physical column first (post-compaction files),
-                // fall back to computed row_id (firstRowId + position) for non-compacted files.
                 ASSIGN_OR_RETURN(auto reader,
                                  _create_reserved_iceberg_column_reader(slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID));
                 std::optional<int64_t> first_row_id = std::nullopt;
@@ -1071,8 +603,6 @@ Status GroupReader::_create_column_readers() {
                                           : std::make_unique<IcebergRowIdReader>(first_row_id);
                 _column_readers.emplace(slot->id(), std::move(row_id_reader));
             } else if (slot->col_name() == HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
-                // Iceberg v3 row lineage: try physical column first (post-compaction files),
-                // fall back to file-level dataSequenceNumber passed via extended_columns from FE.
                 ASSIGN_OR_RETURN(auto reader,
                                  _create_reserved_iceberg_column_reader(
                                          slot, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID));
@@ -1104,35 +634,6 @@ Status GroupReader::_create_column_readers() {
         }
     }
 
-    // Register lightweight zone-map readers for virtual variant columns.
-    // These allow PredicateFilterEvaluator to apply row-group and page-level zone-map
-    // filtering on shredded typed-leaf columns without reading any actual data.
-    // The readers are keyed by virtual slot id so that get_column_reader(virtual_slot_id)
-    // returns them; collect_io_ranges does not touch them (they are not in active/lazy
-    // column index lists).
-    for (const auto& [virtual_slot_id, projection] : _variant_virtual_projections) {
-        SlotId source_slot_id = projection.source_slot_id;
-        ColumnReader* source_reader = nullptr;
-        if (source_slot_id >= 0) {
-            // Physical VARIANT source: look up in _column_readers.
-            auto it = _column_readers.find(source_slot_id);
-            if (it != _column_readers.end()) {
-                source_reader = it->second.get();
-            }
-        } else {
-            // Hidden VARIANT source: look up in _hidden_slot_index.
-            auto it = _hidden_slot_index.find(source_slot_id);
-            if (it != _hidden_slot_index.end()) {
-                source_reader = it->second->reader.get();
-            }
-        }
-        if (source_reader == nullptr) continue;
-        auto* variant_reader = down_cast<VariantColumnReader*>(source_reader);
-        _column_readers.emplace(virtual_slot_id,
-                                std::make_unique<VariantVirtualZoneMapReader>(variant_reader, projection.parsed_path,
-                                                                              projection.target_type));
-    }
-
     if (_param.stats != nullptr) {
         _param.stats->global_dict_total_row_groups++;
         if (_global_dict_applied_in_group) {
@@ -1149,7 +650,10 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
     {
         if (column.slot_type().type == LogicalType::TYPE_VARIANT && schema_node != nullptr &&
             schema_node->type == ColumnType::STRUCT) {
-            VariantShreddedReadHints hints = _get_variant_shredded_hints(column.slot_desc->col_name());
+            // Physical VARIANT columns use _get_variant_shredded_hints; this path
+            // is for non-virtual VARIANT columns that appear directly in the SELECT list.
+            VariantShreddedReadHints hints =
+                    build_variant_shredded_hints(_param.column_access_paths, column.slot_desc->col_name());
             ASSIGN_OR_RETURN(column_reader, ColumnReaderFactory::create_variant_column_reader(_column_reader_opts,
                                                                                               schema_node, hints));
         } else if (column.t_lake_schema_field == nullptr) {
@@ -1177,12 +681,13 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
             }
         }
         if (column_reader == nullptr) {
-            // this shouldn't happen but guard
             return Status::InternalError("No valid column reader.");
         }
     }
     return column_reader;
 }
+
+// ── Column / conjunct classification ────────────────────────────────────────
 
 Status GroupReader::_prepare_column_readers() const {
     SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
@@ -1190,21 +695,10 @@ Status GroupReader::_prepare_column_readers() const {
         RETURN_IF_ERROR(column_reader->prepare());
         if (column_reader->get_column_parquet_field() != nullptr &&
             column_reader->get_column_parquet_field()->is_complex_type()) {
-            // For complex type columns, we need parse def & rep levels.
-            // For OptionalColumnReader, by default, we will not parse it's def level for performance. But if
-            // column is a complex type, we have to parse def level to calculate nullability.
             column_reader->set_need_parse_levels(true);
         }
     }
-    for (const auto& [name, hidden_source] : _hidden_variant_sources) {
-        RETURN_IF_ERROR(hidden_source.reader->prepare());
-        if (hidden_source.reader->get_column_parquet_field() != nullptr &&
-            hidden_source.reader->get_column_parquet_field()->is_complex_type()) {
-            // Hidden VARIANT sources share the same complex reader path and also rely on
-            // def/rep levels for correct nullability reconstruction.
-            hidden_source.reader->set_need_parse_levels(true);
-        }
-    }
+    RETURN_IF_ERROR(_variant->prepare_hidden_readers());
     return Status::OK();
 }
 
@@ -1212,40 +706,12 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
 
     // ── Step 1: Classify physical read_cols into active / lazy ───────────────
-    // Virtual columns contribute only to deferred conjunct evaluation; they have
-    // no entry in _column_readers and are never added to active/lazy indices.
-    // Physical columns with conjuncts go into _active_column_indices; the rest are
-    // deferred to _lazy_column_indices when late materialisation is enabled.
-    //
-    // Pre-pass: collect physical VARIANT slot IDs that are sources for deferred
-    // virtual conjuncts.  A virtual column's source_slot_id may point at a physical
-    // VARIANT column (positive slot ID) rather than a hidden variant source
-    // (negative slot ID).  Such physical columns have no direct conjuncts and would
-    // normally be classified as lazy, but deferred Phase-4 evaluation reads them
-    // via active_chunk, so they must be active.
-    std::unordered_set<SlotId> deferred_conjunct_physical_source_slots;
-    for (const auto& column : _param.read_cols) {
-        if (!column.is_extended_variant_virtual) continue;
-        if (conjunct_ctxs_by_slot.count(column.slot_id()) == 0) continue;
-        auto proj_it = _variant_virtual_projections.find(column.slot_id());
-        if (proj_it == _variant_virtual_projections.end()) continue;
-        // Hidden sources have negative slot IDs; non-negative IDs are physical columns.
-        SlotId src = proj_it->second.source_slot_id;
-        if (src >= 0) {
-            deferred_conjunct_physical_source_slots.insert(src);
-        }
-    }
+    std::unordered_set<SlotId> deferred_physical_source_slots = _variant->deferred_conjunct_physical_source_slots();
+    _variant->collect_deferred_conjuncts();
 
     int read_col_idx = 0;
     for (auto& column : _param.read_cols) {
         if (column.is_extended_variant_virtual) {
-            auto it = conjunct_ctxs_by_slot.find(column.slot_id());
-            if (it != conjunct_ctxs_by_slot.end()) {
-                for (ExprContext* ctx : it->second) {
-                    _deferred_variant_virtual_conjunct_ctxs.push_back(ctx);
-                }
-                _deferred_conjunct_slot_ids.insert(column.slot_id());
-            }
             ++read_col_idx;
             continue;
         }
@@ -1258,16 +724,11 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
                     _use_as_dict_filter_column(read_col_idx, slot_id, sub_field_path);
                 } else {
                     _left_conjunct_ctxs.push_back(ctx);
-                    // For struct columns some conjuncts may be pushed to dict-filter leaves
-                    // while others remain here; track per-slot for later evaluation.
                     _left_no_dict_filter_conjuncts_by_slot[slot_id].push_back(ctx);
                 }
             }
             _active_column_indices.push_back(read_col_idx);
-        } else if (config::parquet_late_materialization_enable &&
-                   deferred_conjunct_physical_source_slots.count(slot_id) == 0) {
-            // Do not lazify a physical column that is referenced as a source by a
-            // deferred virtual conjunct; Phase 4 must be able to project from it.
+        } else if (config::parquet_late_materialization_enable && deferred_physical_source_slots.count(slot_id) == 0) {
             _lazy_column_indices.push_back(read_col_idx);
             _column_readers[slot_id]->set_can_lazy_decode(true);
         } else {
@@ -1292,8 +753,6 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     }
 
     // ── Step 3: Build ColumnReadOrderCtx ─────────────────────────────────────
-    // Built from the predicate-bearing active columns before any lazy→active
-    // promotion, so it reflects only columns that need round-by-round evaluation.
     {
         std::unordered_map<int, size_t> col_cost;
         size_t all_cost = 0;
@@ -1307,37 +766,13 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     }
 
     // ── Step 4: Classify hidden variant sources (active vs lazy) ─────────────
-    // A hidden source is active if it backs at least one virtual column that carries
-    // a conjunct (those conjuncts are evaluated in Phase 4 and need the source data
-    // before conjunct evaluation).  Projection-only hidden sources are lazy.
-    {
-        std::unordered_set<SlotId> conjunct_source_slot_ids;
-        for (const auto& column : _param.read_cols) {
-            if (!column.is_extended_variant_virtual) continue;
-            if (conjunct_ctxs_by_slot.count(column.slot_id()) == 0) continue;
-            auto proj_it = _variant_virtual_projections.find(column.slot_id());
-            if (proj_it != _variant_virtual_projections.end()) {
-                conjunct_source_slot_ids.insert(proj_it->second.source_slot_id);
-            }
-        }
-        for (auto& [name, src] : _hidden_variant_sources) {
-            src.is_active = conjunct_source_slot_ids.count(src.slot_id) > 0;
-            if (src.is_active) {
-                _active_hidden_slot_ids.push_back(src.slot_id);
-            } else {
-                _lazy_hidden_slot_ids.push_back(src.slot_id);
-            }
-        }
-    }
+    _variant->classify_hidden_sources();
 
     // ── Step 5: Build unified SlotId lists for _create_read_chunk ────────────
-    // _active_slot_ids = active physical columns  +  active hidden sources
-    // _lazy_slot_ids   = lazy physical columns
-    // (lazy hidden sources remain in _lazy_hidden_slot_ids; read directly in Phase 6)
     for (int idx : _active_column_indices) {
         _active_slot_ids.push_back(_param.read_cols[idx].slot_id());
     }
-    for (SlotId slot_id : _active_hidden_slot_ids) {
+    for (SlotId slot_id : _variant->active_hidden_slot_ids()) {
         _active_slot_ids.push_back(slot_id);
     }
     for (int idx : _lazy_column_indices) {
@@ -1345,214 +780,14 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     }
 
     // ── Step 6: Promote all lazy columns to active when active_chunk is empty ─
-    // _active_slot_ids is empty when:
-    //   • No physical column has a predicate (→ _active_column_indices is empty), AND
-    //   • No hidden variant source backs a conjunct virtual column.
-    //
-    // In this case late-materialising provides no benefit (there's nothing to filter
-    // on before reading lazy columns) and active_chunk would have 0 columns.
-    // Promote ALL lazy columns — physical and hidden — to active so they are read
-    // in one pass and active_chunk always has a valid row count.
-    //
-    // Note: when active hidden sources exist (_active_slot_ids is non-empty), lazy
-    // physical columns correctly remain lazy: they are read in Phase 5 AFTER the
-    // variant conjuncts (Phase 4) have filtered rows, avoiding unnecessary IO.
     if (_active_slot_ids.empty() && !has_reserved_field_filter) {
-        // Promote lazy physical columns.
         _active_column_indices.swap(_lazy_column_indices);
         _active_slot_ids.swap(_lazy_slot_ids);
-        // Promote lazy hidden sources.
-        for (SlotId slot_id : _lazy_hidden_slot_ids) {
-            _active_slot_ids.push_back(slot_id);
-            _active_hidden_slot_ids.push_back(slot_id);
-            _hidden_slot_index.at(slot_id)->is_active = true;
-        }
-        _lazy_hidden_slot_ids.clear();
+        _variant->promote_lazy_to_active();
     }
 }
 
-Status GroupReader::_promote_variant_virtual_columns() {
-    // For each hidden variant source whose VariantColumnReader has _skip_base_payload=true
-    // (all requested shredded paths are scalar typed-value leaves), promote ALL virtual slots
-    // backed by that source to VariantTypedValueProxy readers in _column_readers.  This lets
-    // the proxy participate in Phase 2 dict-filter and eliminates the Phase 3 hidden-source
-    // read and Phase 4 deferred variant conjunct evaluation entirely.
-    //
-    // Full-promotion is all-or-nothing per source: if any virtual slot lacks a typed_value
-    // leaf, we skip the source entirely.  Partial promotion would corrupt the hidden source's
-    // read path (dict-filtered readers output INT codes, not decoded values).
-
-    // Build: hidden source slot_id → list of (virtual slot info) backed by that source.
-    struct VirtualSlotInfo {
-        SlotId virtual_slot_id;
-        int read_col_idx;
-        bool decode_needed;
-        bool has_conjunct;
-    };
-    std::unordered_map<SlotId, std::vector<VirtualSlotInfo>> slots_by_source;
-    {
-        int idx = 0;
-        for (const auto& column : _param.read_cols) {
-            if (column.is_extended_variant_virtual) {
-                auto proj_it = _variant_virtual_projections.find(column.slot_id());
-                if (proj_it != _variant_virtual_projections.end()) {
-                    SlotId src_id = proj_it->second.source_slot_id;
-                    // Only promote hidden sources (negative slot IDs).
-                    if (src_id < 0) {
-                        bool has_conj = _param.conjunct_ctxs_by_slot.count(column.slot_id()) > 0;
-                        slots_by_source[src_id].push_back({column.slot_id(), idx, column.decode_needed, has_conj});
-                    }
-                }
-            }
-            ++idx;
-        }
-    }
-
-    bool any_promoted = false;
-
-    for (auto& [src_name, hidden_source] : _hidden_variant_sources) {
-        SlotId src_id = hidden_source.slot_id;
-        auto slots_it = slots_by_source.find(src_id);
-        if (slots_it == slots_by_source.end()) continue;
-
-        auto* vreader = dynamic_cast<VariantColumnReader*>(hidden_source.reader.get());
-        if (vreader == nullptr || !vreader->skip_base_payload()) continue;
-
-        const auto& virtual_slots = slots_it->second;
-
-        // Check: can ALL virtual slots be promoted?  Three conditions must hold for each slot:
-        // 1. Has a scalar typed_value leaf reader.
-        // 2. Fallback value column is all-null for this row group (data is exclusively in
-        //    typed_value).  If any path has non-null fallback values, _read_range_skip_base_payload's
-        //    runtime detection would fall back to the base payload — which promotion bypasses,
-        //    producing all-NULLs.
-        // 3. The typed_value leaf's read type is directly compatible with the virtual slot's
-        //    target column type for raw writing.  Variable-length types (VARCHAR/VARBINARY etc.)
-        //    share the same BinaryColumn layout and are mutually compatible.  Fixed-size types
-        //    must match exactly; a mismatch (e.g. INT32 typed_value → BIGINT slot) causes the
-        //    PlainDecoder to write the wrong element width into the destination column, crashing.
-        const uint64_t rg_num_rows = get_row_group_metadata()->num_rows;
-        auto var_len_type = [](LogicalType t) {
-            return t == TYPE_VARCHAR || t == TYPE_CHAR || t == TYPE_VARBINARY || t == TYPE_BINARY;
-        };
-        bool all_promotable = true;
-        std::unordered_set<ColumnReader*> promoted_leaf_readers;
-        std::unordered_map<SlotId, ColumnReader*> leaf_readers_by_slot;
-        for (const auto& vsi : virtual_slots) {
-            auto proj_it = _variant_virtual_projections.find(vsi.virtual_slot_id);
-            if (proj_it == _variant_virtual_projections.end()) {
-                all_promotable = false;
-                break;
-            }
-            const auto& parsed_path = proj_it->second.parsed_path;
-            ColumnReader* leaf = vreader->scalar_typed_value_reader_for_path(parsed_path);
-            if (leaf == nullptr) {
-                all_promotable = false;
-                break;
-            }
-            if (!promoted_leaf_readers.insert(leaf).second) {
-                all_promotable = false;
-                break;
-            }
-            leaf_readers_by_slot.emplace(vsi.virtual_slot_id, leaf);
-            if (!vreader->fallback_values_all_null_in_row_group_for_path(parsed_path, rg_num_rows)) {
-                all_promotable = false;
-                break;
-            }
-            const TypeDescriptor* leaf_type = vreader->typed_value_read_type_for_path(parsed_path);
-            const TypeDescriptor& target = proj_it->second.target_type;
-            bool type_ok = (leaf_type != nullptr) &&
-                           (var_len_type(leaf_type->type) && var_len_type(target.type) ? true : *leaf_type == target);
-            if (!type_ok) {
-                all_promotable = false;
-                break;
-            }
-        }
-        if (!all_promotable) continue;
-
-        // Fully promote: create VariantTypedValueProxy for each virtual slot.
-        for (const auto& vsi : virtual_slots) {
-            ColumnReader* leaf = leaf_readers_by_slot.at(vsi.virtual_slot_id);
-
-            auto proxy = std::make_unique<VariantTypedValueProxy>(leaf);
-
-            if (vsi.has_conjunct) {
-                // Attempt dict filter for each conjunct; fall back to expression eval if failed.
-                const auto& conjuncts = _param.conjunct_ctxs_by_slot.at(vsi.virtual_slot_id);
-                for (ExprContext* ctx : conjuncts) {
-                    std::vector<std::string> sub_field_path;
-                    // sub_field_path is empty: virtual slot IS the leaf value directly.
-                    if (proxy->try_to_use_dict_filter(ctx, vsi.decode_needed, vsi.virtual_slot_id, sub_field_path, 0)) {
-                        _use_as_dict_filter_column(vsi.read_col_idx, vsi.virtual_slot_id, sub_field_path);
-                    } else {
-                        _left_no_dict_filter_conjuncts_by_slot[vsi.virtual_slot_id].push_back(ctx);
-                    }
-                }
-            }
-            // Always place promoted slots in active indices regardless of conjunct presence.
-            // Projection-only promoted slots must also be active to guarantee active_chunk
-            // has a valid row count when it is the only column set being read.
-            _active_column_indices.push_back(vsi.read_col_idx);
-            _active_slot_ids.push_back(vsi.virtual_slot_id);
-
-            _column_readers[vsi.virtual_slot_id] = std::move(proxy);
-            _promoted_virtual_slots.insert(vsi.virtual_slot_id);
-            _variant_virtual_projections.erase(vsi.virtual_slot_id);
-        }
-
-        // Mark source as fully promoted and remove it from the active/lazy hidden-source lists.
-        hidden_source.fully_promoted = true;
-        _active_hidden_slot_ids.erase(
-                std::remove(_active_hidden_slot_ids.begin(), _active_hidden_slot_ids.end(), src_id),
-                _active_hidden_slot_ids.end());
-        _lazy_hidden_slot_ids.erase(std::remove(_lazy_hidden_slot_ids.begin(), _lazy_hidden_slot_ids.end(), src_id),
-                                    _lazy_hidden_slot_ids.end());
-        // Also remove the hidden source's slot_id from _active_slot_ids (added in Step 4 of
-        // _process_columns_and_conjunct_ctxs when the source was classified as active).
-        _active_slot_ids.erase(std::remove(_active_slot_ids.begin(), _active_slot_ids.end(), src_id),
-                               _active_slot_ids.end());
-
-        any_promoted = true;
-    }
-
-    if (!any_promoted) return Status::OK();
-
-    // Rebuild _column_read_order_ctx to include newly promoted active columns.
-    {
-        std::unordered_map<int, size_t> col_cost;
-        size_t all_cost = 0;
-        for (int col_idx : _active_column_indices) {
-            size_t flat_size = _param.read_cols[col_idx].slot_type().get_flat_size();
-            col_cost[col_idx] = flat_size;
-            all_cost += flat_size;
-        }
-        _column_read_order_ctx =
-                std::make_unique<ColumnReadOrderCtx>(_active_column_indices, all_cost, std::move(col_cost));
-    }
-
-    // Rebuild deferred conjunct list, excluding promoted slots.
-    {
-        std::vector<ExprContext*> remaining;
-        std::unordered_set<SlotId> remaining_ids;
-        for (const auto& column : _param.read_cols) {
-            if (!column.is_extended_variant_virtual) continue;
-            SlotId slot_id = column.slot_id();
-            if (_deferred_conjunct_slot_ids.count(slot_id) == 0) continue;
-            if (_promoted_virtual_slots.count(slot_id) > 0) continue;
-            auto it = _param.conjunct_ctxs_by_slot.find(slot_id);
-            if (it != _param.conjunct_ctxs_by_slot.end()) {
-                for (ExprContext* ctx : it->second) {
-                    remaining.push_back(ctx);
-                }
-                remaining_ids.insert(slot_id);
-            }
-        }
-        _deferred_variant_virtual_conjunct_ctxs = std::move(remaining);
-        _deferred_conjunct_slot_ids = std::move(remaining_ids);
-    }
-
-    return Status::OK();
-}
+// ── Dict-filter support ─────────────────────────────────────────────────────
 
 bool GroupReader::_try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
                                           std::vector<std::string>& sub_field_path, bool is_decode_needed) {
@@ -1576,76 +811,6 @@ bool GroupReader::_try_to_use_dict_filter(const GroupReaderParam::Column& column
     } else {
         return false;
     }
-}
-
-// Creates a lightweight VIEW of _read_chunk: the returned Chunk holds *shared*
-// ColumnPtr references to the same column objects owned by _read_chunk.  Calling
-// reset(), filter(), or filter_range() on the returned chunk modifies the same
-// underlying column storage as _read_chunk.
-ChunkPtr GroupReader::_create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields) {
-    auto chunk = std::make_shared<Chunk>();
-    chunk->columns().reserve(slot_ids.size());
-    for (SlotId slot_id : slot_ids) {
-        ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot_id);
-        chunk->append_column(column, slot_id);
-    }
-    if (include_reserved_fields && _param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
-            ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot->id());
-            chunk->append_column(column, slot->id());
-        }
-    }
-    return chunk;
-}
-
-void GroupReader::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
-                                    ColumnIOTypeFlags types) {
-    int64_t end = 0;
-    // collect io of active column
-    for (const auto& index : _active_column_indices) {
-        const auto& column = _param.read_cols[index];
-        SlotId slot_id = column.slot_id();
-        _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, true);
-    }
-
-    // collect io of lazy column
-    for (const auto& index : _lazy_column_indices) {
-        const auto& column = _param.read_cols[index];
-        SlotId slot_id = column.slot_id();
-        _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, false);
-    }
-    for (const auto& [name, hidden_source] : _hidden_variant_sources) {
-        // Fully-promoted sources have all their virtual slots promoted to VariantTypedValueProxy
-        // readers in _column_readers (Phase 2).  Their IO is registered via the proxy entries
-        // in _active_column_indices above; skip the source here to avoid duplicate IO ranges.
-        if (hidden_source.fully_promoted) continue;
-        hidden_source.reader->collect_column_io_range(ranges, &end, types, hidden_source.is_active);
-    }
-    deduplicate_io_ranges(ranges);
-    *end_offset = end;
-}
-
-Status GroupReader::_init_read_chunk() {
-    std::vector<SlotDescriptor*> read_slots;
-    read_slots.reserve(_param.read_cols.size());
-    for (const auto& column : _param.read_cols) {
-        read_slots.emplace_back(column.slot_desc);
-    }
-    if (_param.reserved_field_slots != nullptr) {
-        for (auto* slot : *_param.reserved_field_slots) {
-            read_slots.push_back(slot);
-        }
-    }
-    size_t chunk_size = _param.chunk_size;
-    ASSIGN_OR_RETURN(_read_chunk, RuntimeChunkHelper::new_chunk_checked(read_slots, chunk_size));
-    // Only pre-allocate active hidden sources in _read_chunk so they can be shared with
-    // active_chunk.  Lazy hidden sources are created fresh each iteration in Phase 6
-    // and merged into active_chunk there; they do not need a permanent slot here.
-    for (SlotId slot_id : _active_hidden_slot_ids) {
-        auto hidden_column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
-        _read_chunk->append_column(std::move(hidden_column), slot_id);
-    }
-    return Status::OK();
 }
 
 void GroupReader::_use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path) {
@@ -1688,169 +853,60 @@ StatusOr<bool> GroupReader::_filter_chunk_with_dict_filter(ChunkPtr* chunk, Filt
     return true;
 }
 
-const cctz::time_zone& GroupReader::_get_variant_projection_timezone() {
-    if (_timezone_resolved) {
-        return _timezone_obj;
-    }
+// ── Read chunk management ───────────────────────────────────────────────────
 
-    _timezone_resolved = true;
-    if (_param.timezone.empty()) {
-        return _timezone_obj;
+ChunkPtr GroupReader::_create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields) {
+    auto chunk = std::make_shared<Chunk>();
+    chunk->columns().reserve(slot_ids.size());
+    for (SlotId slot_id : slot_ids) {
+        ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot_id);
+        chunk->append_column(column, slot_id);
     }
-    if (!TimezoneUtils::find_cctz_time_zone(_param.timezone, _timezone_obj)) {
-        LOG(WARNING) << "GroupReader: fallback to UTC for invalid timezone: " << _param.timezone;
-        _timezone_obj = cctz::utc_time_zone();
+    if (include_reserved_fields && _param.reserved_field_slots != nullptr) {
+        for (const auto* slot : *_param.reserved_field_slots) {
+            ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot->id());
+            chunk->append_column(column, slot->id());
+        }
     }
-    return _timezone_obj;
+    return chunk;
 }
 
-// Evaluates deferred variant virtual conjuncts (e.g. v:a.b > 0) against active_chunk.
-// Projects each virtual column whose source is already in active_chunk into a temporary
-// eval_chunk, runs the conjuncts, and filters active_chunk with the result.
-//
-// Active hidden source columns are part of active_chunk (added via _active_hidden_slot_ids
-// in _create_read_chunk) so active_chunk->filter() covers them automatically.
-// Lazy hidden sources are not yet read at this point; they are handled in Phase 4.5 and
-// are identified by being absent from active_chunk.
-//
-// Returns an empty Filter when there are no conjuncts (all rows pass).
-// Returns the applied filter otherwise; caller checks for all-zero to skip the range.
-StatusOr<Filter> GroupReader::_apply_deferred_variant_conjuncts(ChunkPtr& active_chunk, size_t raw_count,
-                                                                ChunkPtr* projected_chunk) {
-    DCHECK(projected_chunk != nullptr);
-    *projected_chunk = std::make_shared<Chunk>();
-    if (_deferred_variant_virtual_conjunct_ctxs.empty()) {
-        return Filter{};
-    }
-    SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
-
-    // Build eval_chunk: one projected column per deferred-conjunct virtual slot whose source is available.
-    // Physical sources and active hidden sources are in active_chunk.
-    // Lazy hidden sources are absent from active_chunk and are skipped here; by design,
-    // virtual columns with conjuncts always use active sources, so this is correct.
-    ChunkPtr eval_chunk = std::make_shared<Chunk>();
-    for (const auto& [slot_id, projection] : _variant_virtual_projections) {
-        bool has_conjunct = _deferred_conjunct_slot_ids.count(slot_id) > 0;
-        if (!has_conjunct) {
-            continue;
-        }
-        bool source_in_chunk = active_chunk->is_slot_exist(projection.source_slot_id);
-        if (!source_in_chunk) {
-            return Status::InternalError(
-                    fmt::format("variant virtual column {} has deferred conjunct but source slot {} "
-                                "is not in active_chunk",
-                                slot_id, projection.source_slot_id));
-        }
-        const ColumnPtr& source_col = active_chunk->get_column_by_slot_id(projection.source_slot_id);
-        ASSIGN_OR_RETURN(auto result_col,
-                         project_variant_leaf_column(source_col, projection.parsed_path, projection.target_type,
-                                                     _get_variant_projection_timezone()));
-        eval_chunk->append_column(std::move(result_col), slot_id);
-    }
-    *projected_chunk = eval_chunk;
-
-    // Guard: if no columns were projected, treat as all-pass.
-    if (eval_chunk->num_columns() == 0) {
-        return Filter{};
-    }
-
-    Filter filter(eval_chunk->num_rows(), 1);
-    ASSIGN_OR_RETURN(size_t hit_count, ChunkPredicateEvaluator::eval_conjuncts_into_filter(
-                                               _deferred_variant_virtual_conjunct_ctxs, eval_chunk.get(), &filter));
-    if (hit_count == 0) {
-        _param.stats->late_materialize_skip_rows += raw_count;
-        // eval_conjuncts_into_filter returns 0 (all rows rejected) without zeroing the filter
-        // when it short-circuits early (e.g. true_count == 0 path). Zero it out explicitly so
-        // the caller's count_nonzero check correctly skips the chunk.
-        filter.assign(filter.size(), 0);
-    }
-
-    // active_chunk is NOT filtered here; the caller merges this filter with
-    // chunk_filter and applies the combined result once after Phase 4.
-    return filter;
-}
-
-Status GroupReader::_align_deferred_projected_chunk_after_filter(const ChunkPtr& active_chunk,
-                                                                 const ChunkPtr& deferred_projected_chunk,
-                                                                 const Filter& chunk_filter, size_t pre_filter_rows) {
-    if (deferred_projected_chunk == nullptr || deferred_projected_chunk->num_columns() == 0) {
-        return Status::OK();
-    }
-    if (deferred_projected_chunk->num_rows() == pre_filter_rows) {
-        deferred_projected_chunk->filter_range(chunk_filter, 0, pre_filter_rows);
-        return Status::OK();
-    }
-    if (deferred_projected_chunk->num_rows() != active_chunk->num_rows()) {
-        return Status::InternalError(
-                fmt::format("variant deferred projected chunk row count mismatch: projected_rows={}, "
-                            "pre_filter_rows={}, active_rows={}",
-                            deferred_projected_chunk->num_rows(), pre_filter_rows, active_chunk->num_rows()));
-    }
-    return Status::OK();
-}
-
-// _fill_dst_chunk copies physical columns from active_chunk into *chunk, then computes
-// variant virtual projections.
-//
-// By Phase 6, active_chunk contains all required sources:
-//   - Physical slots  (active + lazy physical, merged in Phase 5)
-//   - Active hidden variant sources (read in Phase 3, included via _active_slot_ids)
-//   - Lazy hidden variant sources (read in Phase 6, merged into active_chunk)
-// All projection sources are therefore found directly in active_chunk.
-//
-Status GroupReader::_fill_dst_chunk(ChunkPtr& active_chunk, const ChunkPtr& projected_chunk, ChunkPtr* chunk) {
-    active_chunk->check_or_die();
-
-    // Pass 1: virtual projections — must run BEFORE Pass 2.
-    // source_slot_id may point to either a hidden variant source (negative slot ID)
-    // or a physical VARIANT column (positive slot ID, see _create_column_readers lines
-    // 791-793).  Pass 2 performs a destructive swap that would move the physical source
-    // column out of active_chunk, so virtual projections must read their sources first.
-    for (const auto& [slot_id, projection] : _variant_virtual_projections) {
-        // Reuse deferred-conjunct projection if available; this avoids a second
-        // project_variant_leaf_column(path seek + decode) for the same virtual slot.
-        if (projected_chunk != nullptr && projected_chunk->is_slot_exist(slot_id)) {
-            const ColumnPtr& projected_col = projected_chunk->get_column_by_slot_id(slot_id);
-            if (projected_col == nullptr) {
-                return Status::InternalError(
-                        fmt::format("variant deferred projected column for slot {} is null", slot_id));
-            }
-            if (projected_col->size() != active_chunk->num_rows()) {
-                return Status::InternalError(
-                        fmt::format("variant deferred projected column row count mismatch for slot {}: {} vs {}",
-                                    slot_id, projected_col->size(), active_chunk->num_rows()));
-            }
-            (*chunk)->get_column_by_slot_id(slot_id) = projected_col;
-            continue;
-        }
-        if (!active_chunk->is_slot_exist(projection.source_slot_id)) {
-            return Status::InternalError(fmt::format("variant virtual column source slot {} not found in active_chunk",
-                                                     projection.source_slot_id));
-        }
-        const ColumnPtr& source_column = active_chunk->get_column_by_slot_id(projection.source_slot_id);
-        ASSIGN_OR_RETURN(auto result_column,
-                         project_variant_leaf_column(source_column, projection.parsed_path, projection.target_type,
-                                                     _get_variant_projection_timezone()));
-        (*chunk)->get_column_by_slot_id(slot_id) = std::move(result_column);
-    }
-
-    // Pass 2: physical columns — destructive swap from active_chunk into *chunk.
-    // Virtual projection slots are skipped here; their output was filled in Pass 1.
+Status GroupReader::_init_read_chunk() {
+    std::vector<SlotDescriptor*> read_slots;
+    read_slots.reserve(_param.read_cols.size());
     for (const auto& column : _param.read_cols) {
-        SlotId slot_id = column.slot_id();
-        if (_variant_virtual_projections.count(slot_id)) continue;
-        RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*chunk)->get_column_by_slot_id(slot_id),
-                                                                  active_chunk->get_column_by_slot_id(slot_id)));
+        read_slots.emplace_back(column.slot_desc);
     }
     if (_param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
-            SlotId slot_id = slot->id();
-            RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*chunk)->get_column_by_slot_id(slot_id),
-                                                                      active_chunk->get_column_by_slot_id(slot_id)));
+        for (auto* slot : *_param.reserved_field_slots) {
+            read_slots.push_back(slot);
         }
     }
-
+    size_t chunk_size = _param.chunk_size;
+    ASSIGN_OR_RETURN(_read_chunk, RuntimeChunkHelper::new_chunk_checked(read_slots, chunk_size));
+    _variant->init_read_chunk_slots();
     return Status::OK();
+}
+
+// ── IO range collection ─────────────────────────────────────────────────────
+
+void GroupReader::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                    ColumnIOTypeFlags types) {
+    int64_t end = 0;
+    for (const auto& index : _active_column_indices) {
+        const auto& column = _param.read_cols[index];
+        SlotId slot_id = column.slot_id();
+        _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, true);
+    }
+
+    for (const auto& index : _lazy_column_indices) {
+        const auto& column = _param.read_cols[index];
+        SlotId slot_id = column.slot_id();
+        _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, false);
+    }
+    _variant->collect_io_ranges(ranges, &end, types);
+    deduplicate_io_ranges(ranges);
+    *end_offset = end;
 }
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <cctz/time_zone.h>
-
 #include <atomic>
 #include <memory>
 #include <optional>
@@ -27,7 +25,6 @@
 
 #include "cache/scan/shared_buffered_input_stream.h"
 #include "column/column_access_path.h"
-#include "column/variant_path_parser.h"
 #include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
@@ -52,6 +49,7 @@ class THdfsScanRange;
 
 namespace parquet {
 class FileMetaData;
+class VariantProjectionHandler;
 } // namespace parquet
 struct TypeDescriptor;
 } // namespace starrocks
@@ -128,6 +126,8 @@ struct GroupReaderParam {
 };
 
 class GroupReader {
+    friend class VariantProjectionHandler;
+
 public:
     GroupReader(GroupReaderParam& param, int row_group_number, SkipRowsContextPtr skip_rows_ctx,
                 int64_t row_group_first_row);
@@ -135,8 +135,6 @@ public:
                 int64_t row_group_first_row, int64_t row_group_first_row_id);
     ~GroupReader();
 
-    // init used to init column reader, and devide active/lazy
-    // then we can use inited column collect io range.
     Status init();
     Status prepare();
     const tparquet::ColumnChunk* get_chunk_metadata(SlotId slot_id);
@@ -154,103 +152,54 @@ public:
     bool& get_is_group_filtered() { return _is_group_filtered; }
 
 private:
-    // Describes a virtual sub-path projection from a variant column, e.g. "data.id" in
-    // "SELECT data.id FROM t" where data is a VARIANT column.  The virtual column has no
-    // physical counterpart in the parquet file; it is computed by extracting parsed_path
-    // from the source variant column identified by source_slot_id.
-    struct VariantVirtualProjection {
-        VariantPath parsed_path;    // sub-path to extract, e.g. ["id"]
-        TypeDescriptor target_type; // expected output type of the projected sub-field
-        SlotId source_slot_id;      // slot that holds the source VARIANT column data
-                                    // (either a physical slot or a hidden slot with a negative id)
-    };
-
-    // A VARIANT column that must be read to serve virtual projections but is not itself
-    // present in the output chunk (i.e. not in the user's SELECT list).
-    // A temporary column is allocated in _read_chunk under a synthetic negative slot_id so
-    // that _variant_virtual_projections can reference it without colliding with real slots.
-    // One HiddenVariantSource is created per unique source column name; multiple virtual
-    // columns referencing the same VARIANT source share the same hidden entry.
-    //
-    // is_active: true  → backs at least one virtual column that has a conjunct; must be read
-    //                    before _apply_deferred_variant_conjuncts (included in active_chunk).
-    // is_active: false → backs only projection-only virtual columns; can be read after
-    //                    conjunct evaluation, avoiding reads for rows that are filtered out.
-    struct HiddenVariantSource {
-        SlotId slot_id;                       // synthetic negative id (-1, -2, ...) that identifies this source
-        std::unique_ptr<ColumnReader> reader; // reader for the underlying VARIANT column
-        bool is_active = false;               // active (pre-conjunct) vs lazy (post-conjunct)
-        // true when ALL virtual slots backed by this source are promoted to VariantTypedValueProxy
-        // readers in Phase 2; skip IO and Phase 3 reads for this source entirely.
-        bool fully_promoted = false;
-    };
-
+    // ── Initialization ───────────────────────────────────────────────────────
     void _set_end_offset(int64_t value) { _end_offset = value; }
-
-    // deal_with_pageindex need collect pageindex io range first, it will collect all row groups' io together,
-    // so it should be done in file reader. when reading the current row group, we need first deal_with_pageindex,
-    // and then we can collect io range based on pageindex.
-    Status _deal_with_pageindex();
-
-    void _use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path);
-    Status _rewrite_conjunct_ctxs_to_predicates(bool* is_group_filtered);
-
-    StatusOr<bool> _filter_chunk_with_dict_filter(ChunkPtr* chunk, Filter* filter);
-    // Evaluates deferred variant virtual conjuncts against active_chunk.
-    // Returns the filter to be applied by the caller; active_chunk is NOT filtered
-    // by this method — the caller merges it with chunk_filter and applies the combined
-    // result once after Phase 4 (in get_next).
-    // An empty filter means there were no deferred conjuncts (all rows pass).
-    // A non-empty all-zero filter means every row was filtered out.
-    // Evaluates deferred variant virtual conjuncts and optionally returns the projected
-    // virtual columns used by those conjuncts.
-    //
-    // projected_chunk:
-    //   - Output chunk keyed by virtual slot id, containing only slots that have deferred
-    //     conjuncts and were projected in this phase.
-    //   - Row order/row count matches `active_chunk` BEFORE Phase-4 combined filter is applied.
-    //     Caller must apply the exact same filter to projected_chunk before passing it to
-    //     _fill_dst_chunk.
-    StatusOr<Filter> _apply_deferred_variant_conjuncts(ChunkPtr& active_chunk, size_t raw_count,
-                                                       ChunkPtr* projected_chunk);
-    Status _align_deferred_projected_chunk_after_filter(const ChunkPtr& active_chunk,
-                                                        const ChunkPtr& deferred_projected_chunk,
-                                                        const Filter& chunk_filter, size_t pre_filter_rows);
-    // Fills output chunk and computes virtual projections. For slots present in
-    // `projected_chunk`, reuse precomputed columns (from deferred conjunct evaluation) to
-    // avoid re-projecting and re-seeking variant paths.
-    Status _fill_dst_chunk(ChunkPtr& active_chunk, const ChunkPtr& projected_chunk, ChunkPtr* chunk);
-    const cctz::time_zone& _get_variant_projection_timezone();
-
     Status _create_column_readers();
     StatusOr<ColumnReaderPtr> _create_reserved_iceberg_column_reader(const SlotDescriptor* slot, int32_t field_id);
     StatusOr<Datum> _get_extended_bigint_value(SlotId slot_id) const;
     StatusOr<ColumnReaderPtr> _create_column_reader(const GroupReaderParam::Column& column);
-    VariantShreddedReadHints _get_variant_shredded_hints(std::string_view column_name) const;
-    Status _prepare_column_readers() const;
-    // Promotes variant virtual columns to VariantTypedValueProxy readers in Phase 2 when the
-    // backing hidden source has _skip_base_payload=true (all paths are scalar typed-value leaves).
-    // Promoted slots are placed in _column_readers instead of _variant_virtual_projections and
-    // the hidden source is marked fully_promoted=true to skip Phase 3 IO/reads.
-    Status _promote_variant_virtual_columns();
-    // Creates a lightweight VIEW chunk of _read_chunk containing the given slot_ids.
-    // Each entry in slot_ids must already exist as a column in _read_chunk. _init_read_chunk()
-    // pre-allocates physical slots and active hidden variant source slots; lazy hidden sources
-    // are allocated separately during Phase 6 of the variant read pipeline.
-    // When include_reserved_fields is true, reserved_field_slots are appended after slot_ids.
-    ChunkPtr _create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields = true);
-    // Extract dict filter columns and conjuncts
     void _process_columns_and_conjunct_ctxs();
-
     bool _try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
                                  std::vector<std::string>& sub_field_path, bool is_decode_needed);
-
+    Status _prepare_column_readers() const;
+    Status _deal_with_pageindex();
     Status _init_read_chunk();
+    ChunkPtr _create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields = true);
 
+    // ── Dict-filter support ──────────────────────────────────────────────────
+    void _use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path);
+    Status _rewrite_conjunct_ctxs_to_predicates(bool* is_group_filtered);
+    StatusOr<bool> _filter_chunk_with_dict_filter(ChunkPtr* chunk, Filter* filter);
+
+    // ── Range read helpers ───────────────────────────────────────────────────
     Status _read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range, const Filter* filter,
                        ChunkPtr* chunk, bool ignore_reserved_field = false);
-
     StatusOr<size_t> _read_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
+
+    // ── get_next() pipeline phases ───────────────────────────────────────────
+    //
+    // 1. Prune deleted rows: applies deletion bitmap to produce chunk_filter.
+    //    Returns true if rows survive; false to skip this range entirely.
+    StatusOr<bool> _prune_deleted_rows(const Range<uint64_t>& r, Filter& chunk_filter, bool& has_filter, size_t count);
+
+    // 2. Read & filter active columns: reads active physical columns and
+    //    evaluates dict / expression filters.  Populates chunk_filter and
+    //    fills active_chunk.  Returns true if rows survive.
+    StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
+                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count);
+
+    // 5. Backfill lazy physical columns (no predicates).
+    Status _read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
+                              const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk);
+
+    // 7. Emit physical columns from active_chunk into the output chunk.
+    Status _emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst);
+
+    // Rebuild ColumnReadOrderCtx from current _active_column_indices.
+    // Called after variant promotion modifies the active column set.
+    void _rebuild_column_read_order_ctx();
+
+    // ── Member variables ─────────────────────────────────────────────────────
 
     // row group meta
     const tparquet::RowGroup* _row_group_metadata = nullptr;
@@ -261,55 +210,12 @@ private:
     // column readers for column chunk in row group
     std::unordered_map<SlotId, std::unique_ptr<ColumnReader>> _column_readers;
 
-    // Maps each virtual-column slot id to its projection descriptor.
-    // Virtual columns (e.g. "data.id") are skipped in the normal fill path and handled
-    // separately in _fill_dst_chunk by extracting the sub-path from the source variant column.
-    std::unordered_map<SlotId, VariantVirtualProjection> _variant_virtual_projections;
-
-    // Maps source variant column name to its hidden reader and temporary slot.
-    // Only populated when the source VARIANT column is not itself in the output (no physical slot).
-    // If the source column IS selected by the user, its physical slot is used directly and no
-    // hidden entry is created, avoiding a double read.
-    std::unordered_map<std::string, HiddenVariantSource> _hidden_variant_sources;
-
-    // Fast reverse-lookup: slot_id → HiddenVariantSource* (pointer into _hidden_variant_sources).
-    // Built in _create_column_readers() after _hidden_variant_sources is fully populated.
-    std::unordered_map<SlotId, HiddenVariantSource*> _hidden_slot_index;
-
-    // Counter for assigning synthetic slot ids to hidden variant sources.
-    // Starts at -1 and decrements so as not to collide with real (non-negative) slot ids.
-    SlotId _next_hidden_slot_id = -1;
-
-    // Slot ids of hidden sources classified as active (needed before conjunct eval) and
-    // lazy (projection-only, deferred until after conjunct eval).
-    // Populated in _process_columns_and_conjunct_ctxs().
-    std::vector<SlotId> _active_hidden_slot_ids;
-    std::vector<SlotId> _lazy_hidden_slot_ids;
-
-    // Unified slot id lists for _create_read_chunk.  Populated by
-    // _process_columns_and_conjunct_ctxs() after the column/conjunct classification.
-    //   _active_slot_ids = physical active slots  +  active hidden variant sources
-    //   _lazy_slot_ids   = physical lazy slots   (hidden lazy sources are read into a
-    //                      temporary chunk in Phase 6, not via _create_read_chunk)
-    std::vector<SlotId> _active_slot_ids;
-    std::vector<SlotId> _lazy_slot_ids;
-
-    // conjunct ctxs that eval after chunk is dict decoded
-    std::vector<ExprContext*> _left_conjunct_ctxs;
-    // variant virtual-column conjuncts can only be evaluated after post-read projection.
-    std::vector<ExprContext*> _deferred_variant_virtual_conjunct_ctxs;
-    // slot ids of virtual columns that have at least one deferred conjunct.
-    // used in _apply_deferred_variant_conjuncts to detect invariant violations.
-    std::unordered_set<SlotId> _deferred_conjunct_slot_ids;
-
-    // Slot ids of virtual variant columns promoted to VariantTypedValueProxy readers in Phase 2.
-    // These slots appear in _column_readers (not _variant_virtual_projections) and participate
-    // in dict filter like normal physical columns.
-    std::unordered_set<SlotId> _promoted_virtual_slots;
+    // ── Variant handler (always present; empty() when no variant columns) ───
+    std::unique_ptr<VariantProjectionHandler> _variant;
 
     // active columns that hold read_col index
     std::vector<int> _active_column_indices;
-    // lazy conlumns that hold read_col index
+    // lazy columns that hold read_col index
     std::vector<int> _lazy_column_indices;
     // load lazy column or not
     bool _lazy_column_needed = false;
@@ -317,16 +223,8 @@ private:
     // dict value is empty after conjunct eval, file group can be skipped
     bool _is_group_filtered = false;
 
-    // Column backing store for each get_next() call.  Initialized once in _init_read_chunk()
-    // and reset at the start of every range iteration.  Holds three categories of columns:
-    //   • Physical slots – one column per _param.read_cols entry plus reserved_field_slots.
-    //     The same ColumnPtr objects are SHARED with active_chunk / lazy_chunk (created via
-    //     _create_read_chunk), so filtering those view-chunks also modifies _read_chunk.
-    //   • Active hidden variant sources – included in active_chunk via _active_slot_ids.
-    //     Filtered automatically by active_chunk->filter() in Phase 4.
-    //   • Lazy hidden variant sources – read into a temporary chunk in Phase 6 (after
-    //     variant conjunct eval) and merged into active_chunk.  _fill_dst_chunk then
-    //     consumes them from active_chunk; they are not accessed via _read_chunk directly.
+    // Column backing store for each get_next() call.  Initialized once in
+    // _init_read_chunk() and reset at the start of every range iteration.
     ChunkPtr _read_chunk;
 
     // param for read row group
@@ -338,15 +236,15 @@ private:
 
     int64_t _end_offset = 0;
 
-    // set to true by _create_column_reader when the FE global-dict map produced a
-    // dict-aware wrapper for at least one slot in this row group; consumed by
-    // _create_column_readers to bump the per-row-group applied counter.
     bool _global_dict_applied_in_group = false;
 
     // columns(index) use as dict filter column
     std::vector<int> _dict_column_indices;
     std::unordered_map<int, std::vector<std::vector<std::string>>> _dict_column_sub_field_paths;
     std::unordered_map<SlotId, std::vector<ExprContext*>> _left_no_dict_filter_conjuncts_by_slot;
+
+    // conjunct ctxs that eval after chunk is dict decoded
+    std::vector<ExprContext*> _left_conjunct_ctxs;
 
     SparseRange<uint64_t> _range;
     SparseRangeIterator<uint64_t> _range_iter;
@@ -357,10 +255,10 @@ private:
     // a flag to reflect prepare() is called
     bool _has_prepared = false;
 
-    // Parsed lazily for VARIANT virtual projections only. Most Parquet readers do not need
-    // this value, so avoid failing unrelated scans on malformed session timezone strings.
-    cctz::time_zone _timezone_obj = cctz::utc_time_zone();
-    bool _timezone_resolved = false;
+    // Unified slot id lists for _create_read_chunk.  Populated by
+    // _process_columns_and_conjunct_ctxs().
+    std::vector<SlotId> _active_slot_ids;
+    std::vector<SlotId> _lazy_slot_ids;
 };
 
 using GroupReaderPtr = std::shared_ptr<GroupReader>;

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -1,0 +1,885 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/variant_projection.h"
+
+#include <glog/logging.h>
+
+#include <unordered_set>
+
+#include "base/simd/simd.h"
+#include "base/time/timezone_utils.h"
+#include "column/chunk.h"
+#include "column/column_builder.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/variant_column.h"
+#include "column/variant_converter.h"
+#include "column/variant_path_parser.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "exprs/chunk_predicate_evaluator.h"
+#include "exprs/decimal_cast_expr.h"
+#include "exprs/variant_path_reader.h"
+#include "formats/parquet/column_reader_factory.h"
+#include "formats/parquet/complex_column_reader.h"
+#include "formats/parquet/group_reader.h" // for GroupReaderParam
+#include "formats/parquet/scalar_column_reader.h"
+#include "runtime/mem_pool.h"
+#include "storage/convert_helper.h"
+#include "types/type_info.h"
+
+namespace starrocks::parquet {
+
+// ── Anonymous namespace: internal helpers (free functions) ─────────────────
+
+namespace {
+
+StatusOr<ColumnPtr> build_exact_typed_variant_projection(const VariantColumn* variant_column,
+                                                         const ColumnPtr& variant_src, const VariantPath& path,
+                                                         const TypeDescriptor& target_type) {
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+    if (!reader.is_typed_exact()) {
+        return Status::NotFound("variant path is not an exact typed leaf");
+    }
+    if (reader.typed_type_desc() != target_type) {
+        auto is_string_like = [](LogicalType t) {
+            return t == TYPE_VARCHAR || t == TYPE_CHAR || t == TYPE_VARBINARY || t == TYPE_BINARY;
+        };
+        if (!is_string_like(reader.typed_type_desc().type) || !is_string_like(target_type.type)) {
+            return Status::NotFound("variant typed leaf type does not match target slot type");
+        }
+    }
+
+    const size_t num_rows = variant_src->size();
+    const Column* typed_col = reader.typed_column();
+
+    if (variant_src->is_constant() && variant_src->is_null(0)) {
+        auto all_null = ColumnHelper::create_column(target_type, true);
+        all_null->append_nulls(num_rows);
+        return all_null;
+    }
+
+    ColumnPtr expanded_typed;
+    if (variant_src->is_constant()) {
+        expanded_typed = typed_col->clone();
+        expanded_typed->as_mutable_ptr()->assign(num_rows, 0);
+    }
+    const Column* eff_typed = variant_src->is_constant() ? expanded_typed.get() : typed_col;
+    if (eff_typed->size() != num_rows) {
+        return Status::InternalError(fmt::format(
+                "variant typed column size mismatch: typed_size={}, variant_src_size={}", eff_typed->size(), num_rows));
+    }
+
+    const bool has_outer_nulls = !variant_src->is_constant() && variant_src->is_nullable() &&
+                                 down_cast<const NullableColumn*>(variant_src.get())->has_null();
+
+    if (!has_outer_nulls) {
+        if (eff_typed->is_nullable()) {
+            return eff_typed->clone();
+        }
+        return NullableColumn::create(eff_typed->clone(), NullColumn::create(num_rows, 0));
+    }
+
+    const bool has_typed_nulls = eff_typed->is_nullable() && down_cast<const NullableColumn*>(eff_typed)->has_null();
+
+    auto result_null = NullColumn::create(num_rows, 0);
+    NullData& result_null_data = result_null->get_data();
+
+    if (has_typed_nulls) {
+        const auto outer = down_cast<const NullableColumn*>(variant_src.get())->immutable_null_column_data();
+        const auto typed = down_cast<const NullableColumn*>(eff_typed)->immutable_null_column_data();
+        for (size_t i = 0; i < num_rows; ++i) {
+            result_null_data[i] = outer[i] | typed[i];
+        }
+    } else {
+        const auto outer = down_cast<const NullableColumn*>(variant_src.get())->immutable_null_column_data();
+        std::copy(outer.begin(), outer.end(), result_null_data.begin());
+    }
+
+    auto result_data = ColumnHelper::get_data_column(eff_typed)->clone();
+    auto result = NullableColumn::create(std::move(result_data), std::move(result_null));
+    result->update_has_null();
+    return result;
+}
+
+StatusOr<ColumnPtr> cast_decimal_projection_column(const ColumnPtr& source_column, const TypeDescriptor& source_type,
+                                                   const TypeDescriptor& target_type) {
+    if (source_type == target_type) {
+        return source_column;
+    }
+
+    const TypeConverter* converter = get_type_converter(source_type.type, target_type.type);
+    if (converter == nullptr) {
+        return Status::NotFound("no decimal converter for variant typed projection");
+    }
+
+    TypeInfoPtr source_type_info = get_type_info(source_type);
+    TypeInfoPtr target_type_info = get_type_info(target_type);
+    if (source_type_info == nullptr || target_type_info == nullptr) {
+        return Status::NotSupported("missing type info for decimal variant projection");
+    }
+
+    auto result = ColumnHelper::create_column(target_type, true);
+    MemPool mem_pool;
+    RETURN_IF_ERROR(converter->convert_column(source_type_info.get(), *source_column, target_type_info.get(),
+                                              result.get(), &mem_pool));
+    return result;
+}
+
+StatusOr<ColumnPtr> build_decimal_typed_variant_projection(const VariantColumn* variant_column,
+                                                           const ColumnPtr& variant_src, const VariantPath& path,
+                                                           const TypeDescriptor& target_type) {
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+    if (!reader.is_typed_exact()) {
+        return Status::NotFound("variant path is not an exact typed leaf");
+    }
+
+    const TypeDescriptor& source_type = reader.typed_type_desc();
+    if (!source_type.is_decimalv3_type() || !target_type.is_decimalv3_type()) {
+        return Status::NotFound("variant typed leaf is not decimal");
+    }
+
+    ASSIGN_OR_RETURN(auto exact_source_projection,
+                     build_exact_typed_variant_projection(variant_column, variant_src, path, source_type));
+    return cast_decimal_projection_column(exact_source_projection, source_type, target_type);
+}
+
+template <LogicalType ResultType>
+StatusOr<ColumnPtr> build_variant_projection_column(const VariantColumn* variant_column, const ColumnPtr& variant_src,
+                                                    const VariantPath& path, const cctz::time_zone& zone) {
+    const size_t num_rows = variant_src->size();
+
+    ColumnBuilder<ResultType> builder(num_rows);
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+
+    const bool src_is_const = variant_src->is_constant();
+    for (size_t row = 0; row < num_rows; ++row) {
+        if (variant_src->is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+        size_t variant_row = src_is_const ? 0 : row;
+        VariantReadResult read = reader.read_row(variant_row);
+        if (read.state != VariantReadState::kValue) {
+            builder.append_null();
+            continue;
+        }
+        auto cast_status = VariantRowConverter::cast_to<ResultType, false>(read.value.as_ref(), zone, builder);
+        RETURN_IF_ERROR(cast_status);
+    }
+
+    return builder.build_nullable_column();
+}
+
+template <LogicalType ResultType>
+StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn* variant_column,
+                                                            const ColumnPtr& variant_src, const VariantPath& path,
+                                                            const TypeDescriptor& target_type) {
+    const size_t num_rows = variant_src->size();
+
+    ColumnBuilder<ResultType> builder(num_rows, target_type.precision, target_type.scale);
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+
+    const bool src_is_const = variant_src->is_constant();
+    for (size_t row = 0; row < num_rows; ++row) {
+        if (variant_src->is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+        size_t variant_row = src_is_const ? 0 : row;
+        VariantReadResult read = reader.read_row(variant_row);
+        if (read.state != VariantReadState::kValue) {
+            builder.append_null();
+            continue;
+        }
+        auto variant_ref = read.value.as_ref();
+        const VariantValue& variant_value = variant_ref.get_value();
+        if (variant_value.type() == VariantType::NULL_TYPE) {
+            builder.append_null();
+            continue;
+        }
+        RunTimeCppType<ResultType> decimal_value{};
+        ASSIGN_OR_RETURN(bool overflow,
+                         cast_variant_to_decimal<RunTimeCppType<ResultType>>(&decimal_value, variant_value,
+                                                                             target_type.precision, target_type.scale));
+        if (overflow) {
+            builder.append_null();
+        } else {
+            builder.append(decimal_value);
+        }
+    }
+
+    return builder.build_nullable_column();
+}
+
+} // namespace
+
+StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, const VariantPath& path,
+                                                const TypeDescriptor& target_type, const cctz::time_zone& zone) {
+    auto* variant_column = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(variant_src.get()));
+    if (variant_column == nullptr) {
+        return Status::InternalError("variant source column is invalid");
+    }
+
+    auto exact_typed_result = build_exact_typed_variant_projection(variant_column, variant_src, path, target_type);
+    if (exact_typed_result.ok()) {
+        return exact_typed_result;
+    }
+    if (target_type.is_decimalv3_type()) {
+        auto decimal_typed_result =
+                build_decimal_typed_variant_projection(variant_column, variant_src, path, target_type);
+        if (decimal_typed_result.ok()) {
+            return decimal_typed_result;
+        }
+    }
+
+    switch (target_type.type) {
+    case TYPE_BOOLEAN:
+        return build_variant_projection_column<TYPE_BOOLEAN>(variant_column, variant_src, path, zone);
+    case TYPE_TINYINT:
+        return build_variant_projection_column<TYPE_TINYINT>(variant_column, variant_src, path, zone);
+    case TYPE_SMALLINT:
+        return build_variant_projection_column<TYPE_SMALLINT>(variant_column, variant_src, path, zone);
+    case TYPE_INT:
+        return build_variant_projection_column<TYPE_INT>(variant_column, variant_src, path, zone);
+    case TYPE_BIGINT:
+        return build_variant_projection_column<TYPE_BIGINT>(variant_column, variant_src, path, zone);
+    case TYPE_LARGEINT:
+        return build_variant_projection_column<TYPE_LARGEINT>(variant_column, variant_src, path, zone);
+    case TYPE_FLOAT:
+        return build_variant_projection_column<TYPE_FLOAT>(variant_column, variant_src, path, zone);
+    case TYPE_DOUBLE:
+        return build_variant_projection_column<TYPE_DOUBLE>(variant_column, variant_src, path, zone);
+    case TYPE_VARCHAR:
+        return build_variant_projection_column<TYPE_VARCHAR>(variant_column, variant_src, path, zone);
+    case TYPE_DATE:
+        return build_variant_projection_column<TYPE_DATE>(variant_column, variant_src, path, zone);
+    case TYPE_DATETIME:
+        return build_variant_projection_column<TYPE_DATETIME>(variant_column, variant_src, path, zone);
+    case TYPE_TIME:
+        return build_variant_projection_column<TYPE_TIME>(variant_column, variant_src, path, zone);
+    case TYPE_DECIMAL32:
+        return build_decimal_variant_projection_column<TYPE_DECIMAL32>(variant_column, variant_src, path, target_type);
+    case TYPE_DECIMAL64:
+        return build_decimal_variant_projection_column<TYPE_DECIMAL64>(variant_column, variant_src, path, target_type);
+    case TYPE_DECIMAL128:
+        return build_decimal_variant_projection_column<TYPE_DECIMAL128>(variant_column, variant_src, path, target_type);
+    case TYPE_VARIANT:
+        return build_variant_projection_column<TYPE_VARIANT>(variant_column, variant_src, path, zone);
+    default:
+        return Status::NotSupported("unsupported variant virtual column target type");
+    }
+}
+
+bool collect_variant_leaf_paths(const ColumnAccessPath* node, std::vector<VariantSegment>* segments,
+                                VariantShreddedReadHints* hints) {
+    if (!node->is_field() || node->path().empty()) {
+        return false;
+    }
+
+    segments->emplace_back(VariantSegment::make_object(node->path()));
+    if (node->children().empty()) {
+        if (node->value_type().type == LogicalType::TYPE_VARIANT) {
+            segments->pop_back();
+            return false;
+        }
+        VariantPath path(*segments);
+        auto shredded_path = path.to_shredded_path();
+        if (!shredded_path.has_value()) {
+            segments->pop_back();
+            return false;
+        }
+        auto st = hints->add_path(std::move(*shredded_path));
+        if (!st.ok()) {
+            segments->pop_back();
+            return false;
+        }
+        segments->pop_back();
+        return true;
+    }
+
+    bool valid = true;
+    for (const auto& child : node->children()) {
+        valid = collect_variant_leaf_paths(child.get(), segments, hints) && valid;
+    }
+    segments->pop_back();
+    return valid;
+}
+
+VariantShreddedReadHints build_variant_shredded_hints(const std::vector<ColumnAccessPathPtr>* column_access_paths,
+                                                      std::string_view column_name) {
+    VariantShreddedReadHints hints;
+    if (column_access_paths == nullptr || column_access_paths->empty()) {
+        return hints;
+    }
+
+    std::unordered_set<std::string> unique_paths;
+    for (const auto& access_path : *column_access_paths) {
+        if (access_path == nullptr || access_path->path() != column_name) {
+            continue;
+        }
+        if (access_path->children().empty()) {
+            hints.clear();
+            return hints;
+        }
+
+        std::vector<VariantSegment> segments;
+        for (const auto& child : access_path->children()) {
+            if (!collect_variant_leaf_paths(child.get(), &segments, &hints)) {
+                hints.clear();
+                return hints;
+            }
+        }
+    }
+
+    const size_t n = hints.shredded_paths.size();
+    std::vector<bool> keep(n, false);
+    for (size_t i = 0; i < n; ++i) {
+        if (!unique_paths.emplace(hints.shredded_paths[i]).second) {
+            continue;
+        }
+        bool has_ancestor = false;
+        for (size_t j = 0; j < n; ++j) {
+            if (i == j) {
+                continue;
+            }
+            if (hints.parsed_shredded_paths[j].is_strict_prefix_of(hints.parsed_shredded_paths[i])) {
+                has_ancestor = true;
+                break;
+            }
+        }
+        if (!has_ancestor) {
+            keep[i] = true;
+        }
+    }
+    std::vector<std::string> pruned_paths;
+    std::vector<VariantPath> pruned_parsed_paths;
+    pruned_paths.reserve(n);
+    pruned_parsed_paths.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        if (keep[i]) {
+            pruned_paths.emplace_back(std::move(hints.shredded_paths[i]));
+            pruned_parsed_paths.emplace_back(std::move(hints.parsed_shredded_paths[i]));
+        }
+    }
+    hints.shredded_paths = std::move(pruned_paths);
+    hints.parsed_shredded_paths = std::move(pruned_parsed_paths);
+    return hints;
+}
+
+// ── VariantProjectionHandler ────────────────────────────────────────────────
+
+VariantProjectionHandler::VariantProjectionHandler(GroupReader* group_reader, const GroupReaderParam& param,
+                                                   const tparquet::RowGroup* row_group_metadata)
+        : _param(param), _row_group_metadata(row_group_metadata), _group_reader(group_reader) {}
+
+VariantProjectionHandler::~VariantProjectionHandler() = default;
+
+// ── _build_shredded_hints ────────────────────────────────────────────────────
+
+VariantShreddedReadHints VariantProjectionHandler::_build_shredded_hints(std::string_view column_name) const {
+    return build_variant_shredded_hints(_param.column_access_paths, column_name);
+}
+
+// ── setup_readers ────────────────────────────────────────────────────────────
+
+Status VariantProjectionHandler::setup_readers() {
+    const auto& opts = _group_reader->_column_reader_opts;
+    std::unordered_map<std::string, SlotId> physical_variant_slots_by_name;
+    for (const auto& column : _param.read_cols) {
+        if (!column.is_extended_variant_virtual && column.slot_type().type == LogicalType::TYPE_VARIANT) {
+            physical_variant_slots_by_name.emplace(std::string(column.slot_desc->col_name()), column.slot_id());
+        }
+    }
+
+    for (const auto& column : _param.read_cols) {
+        if (!column.is_extended_variant_virtual) continue;
+
+        ASSIGN_OR_RETURN(auto parsed_path,
+                         VariantPathParser::parse_shredded_path(std::string_view(column.variant_virtual_leaf_path)));
+        Projection projection{
+                .parsed_path = std::move(parsed_path), .target_type = column.slot_type(), .source_slot_id = 0};
+
+        auto physical_it = physical_variant_slots_by_name.find(column.source_variant_column_name);
+        if (physical_it != physical_variant_slots_by_name.end()) {
+            projection.source_slot_id = physical_it->second;
+            _projections.emplace(column.slot_id(), std::move(projection));
+            continue;
+        }
+
+        auto hidden_it = _hidden_sources.find(column.source_variant_column_name);
+        if (hidden_it == _hidden_sources.end()) {
+            const auto* source_schema_node =
+                    _param.file_metadata->schema().get_stored_column_by_field_idx(column.idx_in_parquet);
+            if (source_schema_node == nullptr) {
+                return Status::InternalError(
+                        fmt::format("invalid source parquet field idx for variant virtual column, idx={}, slot={}",
+                                    column.idx_in_parquet, column.slot_id()));
+            }
+            if (source_schema_node->type != ColumnType::STRUCT) {
+                return Status::InternalError(
+                        fmt::format("invalid source parquet field type for variant virtual column, idx={}, type={}",
+                                    column.idx_in_parquet, static_cast<int>(source_schema_node->type)));
+            }
+            VariantShreddedReadHints hints = _build_shredded_hints(column.source_variant_column_name);
+            ASSIGN_OR_RETURN(auto hidden_reader,
+                             ColumnReaderFactory::create_variant_column_reader(opts, source_schema_node, hints));
+            auto [inserted_it, _] = _hidden_sources.emplace(
+                    column.source_variant_column_name,
+                    HiddenSource{.slot_id = _next_hidden_slot_id--, .reader = std::move(hidden_reader)});
+            hidden_it = inserted_it;
+            _hidden_slot_index[hidden_it->second.slot_id] = &hidden_it->second;
+        }
+        projection.source_slot_id = hidden_it->second.slot_id;
+        _projections.emplace(column.slot_id(), std::move(projection));
+    }
+
+    return Status::OK();
+}
+
+void VariantProjectionHandler::register_zone_map_readers() {
+    auto& column_readers = _group_reader->_column_readers;
+    for (const auto& [virtual_slot_id, projection] : _projections) {
+        SlotId source_slot_id = projection.source_slot_id;
+        ColumnReader* source_reader = nullptr;
+        if (source_slot_id >= 0) {
+            auto it = column_readers.find(source_slot_id);
+            if (it != column_readers.end()) {
+                source_reader = it->second.get();
+            }
+        } else {
+            auto it = _hidden_slot_index.find(source_slot_id);
+            if (it != _hidden_slot_index.end()) {
+                source_reader = it->second->reader.get();
+            }
+        }
+        if (source_reader == nullptr) continue;
+        auto* variant_reader = down_cast<VariantColumnReader*>(source_reader);
+        column_readers.emplace(virtual_slot_id,
+                               std::make_unique<VariantVirtualZoneMapReader>(variant_reader, projection.parsed_path,
+                                                                             projection.target_type));
+    }
+}
+
+// ── Classification helpers ───────────────────────────────────────────────────
+
+std::unordered_set<SlotId> VariantProjectionHandler::deferred_conjunct_physical_source_slots() const {
+    const auto& read_cols = _param.read_cols;
+    const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
+    std::unordered_set<SlotId> result;
+    for (const auto& column : read_cols) {
+        if (!column.is_extended_variant_virtual) continue;
+        if (conjunct_ctxs_by_slot.count(column.slot_id()) == 0) continue;
+        auto proj_it = _projections.find(column.slot_id());
+        if (proj_it == _projections.end()) continue;
+        SlotId src = proj_it->second.source_slot_id;
+        if (src >= 0) {
+            result.insert(src);
+        }
+    }
+    return result;
+}
+
+void VariantProjectionHandler::collect_deferred_conjuncts() {
+    const auto& read_cols = _param.read_cols;
+    const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
+    for (const auto& column : read_cols) {
+        if (!column.is_extended_variant_virtual) continue;
+        auto it = conjunct_ctxs_by_slot.find(column.slot_id());
+        if (it == conjunct_ctxs_by_slot.end()) continue;
+        for (ExprContext* ctx : it->second) {
+            _deferred_variant_virtual_conjunct_ctxs.push_back(ctx);
+        }
+        _deferred_conjunct_slot_ids.insert(column.slot_id());
+    }
+}
+
+void VariantProjectionHandler::classify_hidden_sources() {
+    const auto& read_cols = _param.read_cols;
+    const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
+    std::unordered_set<SlotId> conjunct_source_slot_ids;
+    for (const auto& column : read_cols) {
+        if (!column.is_extended_variant_virtual) continue;
+        if (conjunct_ctxs_by_slot.count(column.slot_id()) == 0) continue;
+        auto proj_it = _projections.find(column.slot_id());
+        if (proj_it != _projections.end()) {
+            conjunct_source_slot_ids.insert(proj_it->second.source_slot_id);
+        }
+    }
+    _active_hidden_slot_ids.clear();
+    _lazy_hidden_slot_ids.clear();
+    for (auto& [name, src] : _hidden_sources) {
+        src.is_active = conjunct_source_slot_ids.count(src.slot_id) > 0;
+        if (src.is_active) {
+            _active_hidden_slot_ids.push_back(src.slot_id);
+        } else {
+            _lazy_hidden_slot_ids.push_back(src.slot_id);
+        }
+    }
+}
+
+// ── Prepare ─────────────────────────────────────────────────────────────────
+
+Status VariantProjectionHandler::prepare_hidden_readers() {
+    for (auto& [name, src] : _hidden_sources) {
+        RETURN_IF_ERROR(src.reader->prepare());
+        if (src.reader->get_column_parquet_field() != nullptr &&
+            src.reader->get_column_parquet_field()->is_complex_type()) {
+            src.reader->set_need_parse_levels(true);
+        }
+    }
+    return Status::OK();
+}
+
+void VariantProjectionHandler::select_hidden_source_offset_index() {
+    const auto& range = _group_reader->_range;
+    auto rg_first_row = _group_reader->_row_group_first_row;
+    for (auto& [name, src] : _hidden_sources) {
+        src.reader->select_offset_index(range, rg_first_row);
+    }
+}
+
+// ── Promotion ────────────────────────────────────────────────────────────────
+
+bool VariantProjectionHandler::try_promote() {
+    auto& column_readers = _group_reader->_column_readers;
+    auto& active_column_indices = _group_reader->_active_column_indices;
+    auto& active_slot_ids = _group_reader->_active_slot_ids;
+    const auto& read_cols = _param.read_cols;
+    const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
+    const uint64_t rg_num_rows = _row_group_metadata->num_rows;
+
+    struct VirtualSlotInfo {
+        SlotId virtual_slot_id;
+        int read_col_idx;
+        bool decode_needed;
+        bool has_conjunct;
+    };
+    std::unordered_map<SlotId, std::vector<VirtualSlotInfo>> slots_by_source;
+    {
+        int idx = 0;
+        for (const auto& column : read_cols) {
+            if (column.is_extended_variant_virtual) {
+                auto proj_it = _projections.find(column.slot_id());
+                if (proj_it != _projections.end()) {
+                    SlotId src_id = proj_it->second.source_slot_id;
+                    if (src_id < 0) {
+                        bool has_conj = conjunct_ctxs_by_slot.count(column.slot_id()) > 0;
+                        slots_by_source[src_id].push_back({column.slot_id(), idx, column.decode_needed, has_conj});
+                    }
+                }
+            }
+            ++idx;
+        }
+    }
+
+    bool any_promoted = false;
+
+    for (auto& [src_name, hidden_source] : _hidden_sources) {
+        SlotId src_id = hidden_source.slot_id;
+        auto slots_it = slots_by_source.find(src_id);
+        if (slots_it == slots_by_source.end()) continue;
+
+        auto* vreader = dynamic_cast<VariantColumnReader*>(hidden_source.reader.get());
+        if (vreader == nullptr || !vreader->skip_base_payload()) continue;
+
+        const auto& virtual_slots = slots_it->second;
+
+        auto var_len_type = [](LogicalType t) {
+            return t == TYPE_VARCHAR || t == TYPE_CHAR || t == TYPE_VARBINARY || t == TYPE_BINARY;
+        };
+        bool all_promotable = true;
+        std::unordered_set<ColumnReader*> promoted_leaf_readers;
+        std::unordered_map<SlotId, ColumnReader*> leaf_readers_by_slot;
+        for (const auto& vsi : virtual_slots) {
+            auto proj_it = _projections.find(vsi.virtual_slot_id);
+            if (proj_it == _projections.end()) {
+                all_promotable = false;
+                break;
+            }
+            const auto& parsed_path = proj_it->second.parsed_path;
+            ColumnReader* leaf = vreader->scalar_typed_value_reader_for_path(parsed_path);
+            if (leaf == nullptr) {
+                all_promotable = false;
+                break;
+            }
+            if (!promoted_leaf_readers.insert(leaf).second) {
+                all_promotable = false;
+                break;
+            }
+            leaf_readers_by_slot.emplace(vsi.virtual_slot_id, leaf);
+            if (!vreader->fallback_values_all_null_in_row_group_for_path(parsed_path, rg_num_rows)) {
+                all_promotable = false;
+                break;
+            }
+            const TypeDescriptor* leaf_type = vreader->typed_value_read_type_for_path(parsed_path);
+            const TypeDescriptor& target = proj_it->second.target_type;
+            bool type_ok = (leaf_type != nullptr) &&
+                           (var_len_type(leaf_type->type) && var_len_type(target.type) ? true : *leaf_type == target);
+            if (!type_ok) {
+                all_promotable = false;
+                break;
+            }
+        }
+        if (!all_promotable) continue;
+
+        for (const auto& vsi : virtual_slots) {
+            ColumnReader* leaf = leaf_readers_by_slot.at(vsi.virtual_slot_id);
+            auto proxy = std::make_unique<VariantTypedValueProxy>(leaf);
+
+            if (vsi.has_conjunct) {
+                const auto& conjuncts = conjunct_ctxs_by_slot.at(vsi.virtual_slot_id);
+                for (ExprContext* ctx : conjuncts) {
+                    std::vector<std::string> sub_field_path;
+                    if (proxy->try_to_use_dict_filter(ctx, vsi.decode_needed, vsi.virtual_slot_id, sub_field_path, 0)) {
+                        _group_reader->_use_as_dict_filter_column(vsi.read_col_idx, vsi.virtual_slot_id,
+                                                                  sub_field_path);
+                    } else {
+                        _group_reader->_left_no_dict_filter_conjuncts_by_slot[vsi.virtual_slot_id].push_back(ctx);
+                    }
+                }
+            }
+            active_column_indices.push_back(vsi.read_col_idx);
+            active_slot_ids.push_back(vsi.virtual_slot_id);
+
+            column_readers[vsi.virtual_slot_id] = std::move(proxy);
+            _promoted_virtual_slots.insert(vsi.virtual_slot_id);
+            _projections.erase(vsi.virtual_slot_id);
+        }
+
+        hidden_source.fully_promoted = true;
+        _active_hidden_slot_ids.erase(
+                std::remove(_active_hidden_slot_ids.begin(), _active_hidden_slot_ids.end(), src_id),
+                _active_hidden_slot_ids.end());
+        _lazy_hidden_slot_ids.erase(std::remove(_lazy_hidden_slot_ids.begin(), _lazy_hidden_slot_ids.end(), src_id),
+                                    _lazy_hidden_slot_ids.end());
+        active_slot_ids.erase(std::remove(active_slot_ids.begin(), active_slot_ids.end(), src_id),
+                              active_slot_ids.end());
+
+        any_promoted = true;
+    }
+
+    if (!any_promoted) return false;
+
+    _group_reader->_rebuild_column_read_order_ctx();
+
+    // Rebuild deferred conjunct list excluding promoted slots.
+    std::vector<ExprContext*> remaining;
+    std::unordered_set<SlotId> remaining_ids;
+    for (const auto& column : read_cols) {
+        if (!column.is_extended_variant_virtual) continue;
+        SlotId slot_id = column.slot_id();
+        if (_deferred_conjunct_slot_ids.count(slot_id) == 0) continue;
+        if (_promoted_virtual_slots.count(slot_id) > 0) continue;
+        auto it = conjunct_ctxs_by_slot.find(slot_id);
+        if (it != conjunct_ctxs_by_slot.end()) {
+            for (ExprContext* ctx : it->second) {
+                remaining.push_back(ctx);
+            }
+            remaining_ids.insert(slot_id);
+        }
+    }
+    _deferred_variant_virtual_conjunct_ctxs = std::move(remaining);
+    _deferred_conjunct_slot_ids = std::move(remaining_ids);
+
+    return true;
+}
+
+// ── Lazy→active promotion ───────────
+
+void VariantProjectionHandler::promote_lazy_to_active() {
+    auto& active_slot_ids = _group_reader->_active_slot_ids;
+    // When active_chunk is empty (no physical active columns + no active hidden sources),
+    // promote lazy hidden sources to active so they contribute a row count.
+    // The caller already swapped physical active/lazy; we just migrate hidden sources.
+    for (SlotId slot_id : _lazy_hidden_slot_ids) {
+        active_slot_ids.push_back(slot_id);
+        _active_hidden_slot_ids.push_back(slot_id);
+        _hidden_slot_index.at(slot_id)->is_active = true;
+    }
+    _lazy_hidden_slot_ids.clear();
+}
+
+// ── IO range collection ─────────────────────────────────────────────────────
+
+void VariantProjectionHandler::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges,
+                                                 int64_t* end_offset, ColumnIOTypeFlags types) {
+    for (auto& [name, src] : _hidden_sources) {
+        if (src.fully_promoted) continue;
+        src.reader->collect_column_io_range(ranges, end_offset, types, src.is_active);
+    }
+}
+
+// ── Read chunk init ──────────────────────────────────────────────────────────
+
+void VariantProjectionHandler::init_read_chunk_slots() {
+    ChunkPtr& read_chunk = _group_reader->_read_chunk;
+    for (SlotId slot_id : _active_hidden_slot_ids) {
+        auto hidden_column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
+        read_chunk->append_column(std::move(hidden_column), slot_id);
+    }
+}
+
+// ── get_next() phases ────────────────────────────────────────────────────────
+
+void VariantProjectionHandler::reset_iteration_state() {
+    _deferred_projected_chunk.reset();
+}
+
+Status VariantProjectionHandler::fetch_sources(const Range<uint64_t>& range, ChunkPtr& active_chunk) {
+    for (SlotId slot_id : _active_hidden_slot_ids) {
+        auto* hidden_src = _hidden_slot_index.at(slot_id);
+        auto& hidden_col = active_chunk->get_column_by_slot_id(slot_id);
+        RETURN_IF_ERROR(hidden_src->reader->read_range(range, nullptr, hidden_col));
+    }
+    return Status::OK();
+}
+
+StatusOr<Filter> VariantProjectionHandler::filter_subfields(ChunkPtr& active_chunk, size_t raw_count,
+                                                            HdfsScanStats* stats, const cctz::time_zone& zone) {
+    if (_deferred_variant_virtual_conjunct_ctxs.empty()) {
+        return Filter{};
+    }
+
+    ChunkPtr eval_chunk = std::make_shared<Chunk>();
+    for (const auto& [slot_id, projection] : _projections) {
+        bool has_conjunct = _deferred_conjunct_slot_ids.count(slot_id) > 0;
+        if (!has_conjunct) {
+            continue;
+        }
+        bool source_in_chunk = active_chunk->is_slot_exist(projection.source_slot_id);
+        if (!source_in_chunk) {
+            return Status::InternalError(
+                    fmt::format("variant virtual column {} has deferred conjunct but source slot {} "
+                                "is not in active_chunk",
+                                slot_id, projection.source_slot_id));
+        }
+        const ColumnPtr& source_col = active_chunk->get_column_by_slot_id(projection.source_slot_id);
+        ASSIGN_OR_RETURN(auto result_col,
+                         project_variant_leaf_column(source_col, projection.parsed_path, projection.target_type, zone));
+        eval_chunk->append_column(std::move(result_col), slot_id);
+    }
+    _deferred_projected_chunk = eval_chunk;
+
+    if (eval_chunk->num_columns() == 0) {
+        return Filter{};
+    }
+
+    int64_t expr_filter_ns = 0;
+    SCOPED_RAW_TIMER(stats != nullptr ? &stats->expr_filter_ns : &expr_filter_ns);
+    Filter filter(eval_chunk->num_rows(), 1);
+    ASSIGN_OR_RETURN(size_t hit_count, ChunkPredicateEvaluator::eval_conjuncts_into_filter(
+                                               _deferred_variant_virtual_conjunct_ctxs, eval_chunk.get(), &filter));
+    if (hit_count == 0) {
+        if (stats) stats->late_materialize_skip_rows += raw_count;
+        filter.assign(filter.size(), 0);
+    }
+
+    return filter;
+}
+
+Status VariantProjectionHandler::align_after_combined_filter(const ChunkPtr& active_chunk, const Filter& filter,
+                                                             size_t pre_filter_rows) {
+    if (_deferred_projected_chunk == nullptr || _deferred_projected_chunk->num_columns() == 0) {
+        return Status::OK();
+    }
+    if (_deferred_projected_chunk->num_rows() == pre_filter_rows) {
+        _deferred_projected_chunk->filter_range(filter, 0, pre_filter_rows);
+        return Status::OK();
+    }
+    if (_deferred_projected_chunk->num_rows() != active_chunk->num_rows()) {
+        return Status::InternalError(
+                fmt::format("variant deferred projected chunk row count mismatch: projected_rows={}, "
+                            "pre_filter_rows={}, active_rows={}",
+                            _deferred_projected_chunk->num_rows(), pre_filter_rows, active_chunk->num_rows()));
+    }
+    return Status::OK();
+}
+
+Status VariantProjectionHandler::backfill_sources(const Range<uint64_t>& full_range,
+                                                  const Range<uint64_t>* post_filter_range, const Filter* post_filter,
+                                                  bool has_filter, ChunkPtr& active_chunk) {
+    if (_lazy_hidden_slot_ids.empty()) {
+        return Status::OK();
+    }
+
+    auto lazy_hidden_chunk = std::make_shared<Chunk>();
+    for (SlotId slot_id : _lazy_hidden_slot_ids) {
+        auto* hidden_src = _hidden_slot_index.at(slot_id);
+        ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
+        if (has_filter) {
+            RETURN_IF_ERROR(hidden_src->reader->read_range(*post_filter_range, post_filter, col));
+            col->as_mutable_ptr()->filter_range(*post_filter, 0, post_filter_range->span_size());
+        } else {
+            RETURN_IF_ERROR(hidden_src->reader->read_range(full_range, nullptr, col));
+        }
+        lazy_hidden_chunk->append_column(std::move(col), slot_id);
+    }
+    if (lazy_hidden_chunk->num_rows() != active_chunk->num_rows()) {
+        return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_hidden_rows={}",
+                                                 active_chunk->num_rows(), lazy_hidden_chunk->num_rows()));
+    }
+    active_chunk->merge(std::move(*lazy_hidden_chunk));
+    return Status::OK();
+}
+
+Status VariantProjectionHandler::emit_projections(ChunkPtr& active_chunk, ChunkPtr* dst, const cctz::time_zone& zone) {
+    for (const auto& [slot_id, projection] : _projections) {
+        if (_deferred_projected_chunk != nullptr && _deferred_projected_chunk->is_slot_exist(slot_id)) {
+            const ColumnPtr& projected_col = _deferred_projected_chunk->get_column_by_slot_id(slot_id);
+            if (projected_col == nullptr) {
+                return Status::InternalError(
+                        fmt::format("variant deferred projected column for slot {} is null", slot_id));
+            }
+            if (projected_col->size() != active_chunk->num_rows()) {
+                return Status::InternalError(
+                        fmt::format("variant deferred projected column row count mismatch for slot {}: {} vs {}",
+                                    slot_id, projected_col->size(), active_chunk->num_rows()));
+            }
+            (*dst)->get_column_by_slot_id(slot_id) = projected_col;
+            continue;
+        }
+        if (!active_chunk->is_slot_exist(projection.source_slot_id)) {
+            return Status::InternalError(fmt::format("variant virtual column source slot {} not found in active_chunk",
+                                                     projection.source_slot_id));
+        }
+        const ColumnPtr& source_column = active_chunk->get_column_by_slot_id(projection.source_slot_id);
+        ASSIGN_OR_RETURN(auto result_column, project_variant_leaf_column(source_column, projection.parsed_path,
+                                                                         projection.target_type, zone));
+        (*dst)->get_column_by_slot_id(slot_id) = std::move(result_column);
+    }
+    return Status::OK();
+}
+
+const cctz::time_zone& VariantProjectionHandler::projection_timezone() {
+    if (_timezone_resolved) {
+        return _timezone_obj;
+    }
+    _timezone_resolved = true;
+    if (_param.timezone.empty()) {
+        return _timezone_obj;
+    }
+    if (!TimezoneUtils::find_cctz_time_zone(_param.timezone, _timezone_obj)) {
+        LOG(WARNING) << "VariantProjectionHandler: fallback to UTC for invalid timezone: " << _param.timezone;
+        _timezone_obj = cctz::utc_time_zone();
+    }
+    return _timezone_obj;
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/variant_projection.h
+++ b/be/src/formats/parquet/variant_projection.h
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cctz/time_zone.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "cache/scan/shared_buffered_input_stream.h"
+#include "column/column.h"
+#include "column/column_access_path.h"
+#include "column/variant_path_parser.h"
+#include "common/global_types.h"
+#include "common/statusor.h"
+#include "formats/parquet/column_reader_factory.h"
+#include "formats/parquet/utils.h"
+#include "storage/primitive/range.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+class Chunk;
+class ExprContext;
+struct HdfsScanStats;
+} // namespace starrocks
+
+namespace starrocks::parquet {
+
+class ColumnReader;
+class VariantColumnReader;
+class GroupReader;
+struct GroupReaderParam;
+
+// ── Free functions: variant projection utilities ────────────────────────────
+
+StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, const VariantPath& path,
+                                                const TypeDescriptor& target_type, const cctz::time_zone& zone);
+
+bool collect_variant_leaf_paths(const ColumnAccessPath* node, std::vector<VariantSegment>* segments,
+                                VariantShreddedReadHints* hints);
+
+VariantShreddedReadHints build_variant_shredded_hints(const std::vector<ColumnAccessPathPtr>* column_access_paths,
+                                                      std::string_view column_name);
+
+// ── VariantProjectionHandler: encapsulates variant-specific pipeline phases ──
+//
+// GroupReader owns exactly one optional VariantProjectionHandler.  When no variant
+// columns are present the pointer is null and all variant phases in get_next()
+// become no-ops.  This keeps GroupReader's member list minimal and its pipeline
+// composed of named conceptual phases rather than variant-instrumented loops.
+class VariantProjectionHandler {
+public:
+    VariantProjectionHandler(GroupReader* group_reader, const GroupReaderParam& param,
+                             const tparquet::RowGroup* row_group_metadata);
+    ~VariantProjectionHandler();
+
+    bool empty() const { return _projections.empty() && _hidden_sources.empty(); }
+
+    // ── Setup (called once during GroupReader::_create_column_readers) ──────
+    Status setup_readers();
+
+    // Registers VariantVirtualZoneMapReader wrappers in column_readers for
+    // all variant virtual projections.  Must be called AFTER all physical
+    // column readers have been added to column_readers so source lookups work.
+    void register_zone_map_readers();
+
+    // ── Classification (during _process_columns_and_conjunct_ctxs) ──────────
+    std::unordered_set<SlotId> deferred_conjunct_physical_source_slots() const;
+    void collect_deferred_conjuncts();
+    void classify_hidden_sources();
+
+    // Accessors used by GroupReader to build active/lazy slot ID lists.
+    const std::vector<SlotId>& active_hidden_slot_ids() const { return _active_hidden_slot_ids; }
+    const std::vector<SlotId>& lazy_hidden_slot_ids() const { return _lazy_hidden_slot_ids; }
+
+    // ── Prepare (during GroupReader::prepare / _prepare_column_readers) ──────
+    Status prepare_hidden_readers();
+    void select_hidden_source_offset_index();
+
+    // ── Promotion (after _prepare_column_readers, before collect_io_ranges) ─
+    bool try_promote();
+
+    // ── Lazy→active promotion when active_chunk would be empty ───────────────
+    void promote_lazy_to_active();
+
+    // ── IO range collection ──────────────────────────────────────────────────
+    void collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                           ColumnIOTypeFlags types);
+
+    // ── Read chunk initialisation ────────────────────────────────────────────
+    void init_read_chunk_slots();
+
+    // ── get_next() phases ────────────────────────────────────────────────────
+    //
+    // The handler acts as a stateful pipeline stage: intermediate state
+    // (projected columns, filters) is tracked internally and consumed
+    // by later phases within the same get_next() iteration.
+    //
+    // Phase ordering: fetch → filter → align → backfill → emit
+    // A Status::InternalError is returned when phases are called out of order.
+
+    // 3. Fetch variant source columns that back subfield conjuncts.
+    Status fetch_sources(const Range<uint64_t>& range, ChunkPtr& active_chunk);
+
+    // 4. Evaluate deferred variant subfield conjuncts, projecting virtual
+    //    columns from sources already present in active_chunk.
+    //    Returns an empty Filter when there are no conjuncts.
+    //    Projected columns are stored internally for later use by
+    //    align_after_combined_filter and emit_projections.
+    StatusOr<Filter> filter_subfields(ChunkPtr& active_chunk, size_t raw_count, HdfsScanStats* stats,
+                                      const cctz::time_zone& zone);
+    bool has_deferred_conjuncts() const { return !_deferred_variant_virtual_conjunct_ctxs.empty(); }
+
+    //    Align internally stored projected chunk with the post-filter active_chunk.
+    Status align_after_combined_filter(const ChunkPtr& active_chunk, const Filter& filter, size_t pre_filter_rows);
+
+    // 6. Backfill projection-only variant source columns.
+    Status backfill_sources(const Range<uint64_t>& full_range, const Range<uint64_t>* post_filter_range,
+                            const Filter* post_filter, bool has_filter, ChunkPtr& active_chunk);
+
+    // 7. Emit variant virtual-column projections into the destination chunk.
+    //    Consumes internally stored projected chunk (set by filter_subfields).
+    //    Must be called BEFORE physical columns are swapped out.
+    Status emit_projections(ChunkPtr& active_chunk, ChunkPtr* dst, const cctz::time_zone& zone);
+    bool has_projections() const { return !_projections.empty(); }
+    bool is_virtual_slot(SlotId slot_id) const { return _projections.count(slot_id) > 0; }
+
+    //    Reset per-iteration state (call at start of each get_next() call).
+    void reset_iteration_state();
+
+    // ── Timezone for variant projection ──────────────────────────────────────
+    const cctz::time_zone& projection_timezone();
+
+private:
+    struct Projection {
+        VariantPath parsed_path;
+        TypeDescriptor target_type;
+        SlotId source_slot_id;
+    };
+
+    struct HiddenSource {
+        SlotId slot_id;
+        std::unique_ptr<ColumnReader> reader;
+        bool is_active = false;
+        bool fully_promoted = false;
+    };
+
+    // These are called from setup_readers / try_promote; factored out from
+    // GroupReader's original _create_column_readers / _promote_variant_virtual_columns.
+    VariantShreddedReadHints _build_shredded_hints(std::string_view column_name) const;
+
+    const GroupReaderParam& _param;
+    const tparquet::RowGroup* _row_group_metadata;
+    GroupReader* _group_reader;
+
+    std::unordered_map<SlotId, Projection> _projections;
+    std::unordered_map<std::string, HiddenSource> _hidden_sources;
+    std::unordered_map<SlotId, HiddenSource*> _hidden_slot_index;
+    SlotId _next_hidden_slot_id = -1;
+
+    std::vector<SlotId> _active_hidden_slot_ids;
+    std::vector<SlotId> _lazy_hidden_slot_ids;
+
+    std::vector<ExprContext*> _deferred_variant_virtual_conjunct_ctxs;
+    std::unordered_set<SlotId> _deferred_conjunct_slot_ids;
+    std::unordered_set<SlotId> _promoted_virtual_slots;
+
+    cctz::time_zone _timezone_obj = cctz::utc_time_zone();
+    bool _timezone_resolved = false;
+
+    // Per-iteration state — set by filter_subfields, consumed by
+    // align_after_combined_filter and emit_projections.
+    ChunkPtr _deferred_projected_chunk;
+};
+
+} // namespace starrocks::parquet

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -31,6 +31,7 @@
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/utils.h"
+#include "formats/parquet/variant_projection.h"
 #include "fs/fs.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/global_dict/parser.h"
@@ -330,7 +331,9 @@ static StatusOr<std::string> variant_json_at(const ColumnPtr& column, size_t row
 }
 
 static Status fill_dst_chunk_without_projected(GroupReader* group_reader, ChunkPtr& active_chunk, ChunkPtr* dst_chunk) {
-    return group_reader->_fill_dst_chunk(active_chunk, ChunkPtr{}, dst_chunk);
+    RETURN_IF_ERROR(group_reader->_variant->emit_projections(active_chunk, dst_chunk,
+                                                             group_reader->_variant->projection_timezone()));
+    return group_reader->_emit_physical_columns(active_chunk, dst_chunk);
 }
 
 static ColumnPtr make_typed_only_variant_column_for_virtual_column_test() {
@@ -436,10 +439,10 @@ static Status create_varchar_eq_conjunct_ctxs(ObjectPool* pool, RuntimeState* st
     return Status::OK();
 }
 
-static StatusOr<GroupReader::VariantVirtualProjection> make_virtual_projection_for_test(
+static StatusOr<VariantProjectionHandler::Projection> make_virtual_projection_for_test(
         const std::string& leaf_path, const TypeDescriptor& target_type, SlotId source_slot_id) {
     ASSIGN_OR_RETURN(auto parsed_path, VariantPathParser::parse_shredded_path(std::string_view(leaf_path)));
-    return GroupReader::VariantVirtualProjection{
+    return VariantProjectionHandler::Projection{
             .parsed_path = std::move(parsed_path), .target_type = target_type, .source_slot_id = source_slot_id};
 }
 
@@ -555,11 +558,11 @@ static GroupReaderParam::Column make_variant_virtual_column_for_promotion_test(S
 
 static void attach_hidden_variant_source_for_promotion_test(GroupReader* group_reader, SlotId source_slot_id,
                                                             ColumnReaderPtr reader) {
-    auto& source = group_reader->_hidden_variant_sources
-                           .emplace("data", GroupReader::HiddenVariantSource{.slot_id = source_slot_id,
-                                                                             .reader = std::move(reader)})
+    auto& source = group_reader->_variant->_hidden_sources
+                           .emplace("data", VariantProjectionHandler::HiddenSource{.slot_id = source_slot_id,
+                                                                                   .reader = std::move(reader)})
                            .first->second;
-    group_reader->_hidden_slot_index[source_slot_id] = &source;
+    group_reader->_variant->_hidden_slot_index[source_slot_id] = &source;
 }
 
 ChunkPtr GroupReaderTest::_create_chunk(GroupReaderParam* param) {
@@ -2739,8 +2742,8 @@ TEST_F(GroupReaderTest, VariantVirtualColumnMapsPrefixAndLeafPathsIndependently)
                     make_virtual_projection_for_test("a.b.c", leaf_slot->type(), source_slot->id()));
     ASSIGN_OR_ABORT(auto prefix_projection,
                     make_virtual_projection_for_test("a.b", prefix_slot->type(), source_slot->id()));
-    group_reader->_variant_virtual_projections.emplace(leaf_slot->id(), std::move(leaf_projection));
-    group_reader->_variant_virtual_projections.emplace(prefix_slot->id(), std::move(prefix_projection));
+    group_reader->_variant->_projections.emplace(leaf_slot->id(), std::move(leaf_projection));
+    group_reader->_variant->_projections.emplace(prefix_slot->id(), std::move(prefix_projection));
     group_reader->_column_readers.emplace(source_slot->id(),
                                           std::make_unique<MockVariantSourceColumnReader>(variant_source->clone()));
 
@@ -2787,7 +2790,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnFromPhysicalSourceSlot)
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(200)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(200));
@@ -2821,7 +2824,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnReturnsNullForNullAndMi
 
     ASSIGN_OR_ABORT(auto projection,
                     make_virtual_projection_for_test("missing.leaf", virtual_slot->type(), SlotId(300)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(make_nullable_typed_variant_column_for_virtual_column_test(), SlotId(300));
@@ -2854,7 +2857,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsExactTypedVirtualColumnRespectsSourc
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(302)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(make_nullable_typed_variant_column_for_virtual_column_test(), SlotId(302));
@@ -2887,7 +2890,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsExactTypedDecimalVirtualColumn) {
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(303)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(make_typed_decimal32_variant_column_for_virtual_column_test(), SlotId(303));
@@ -2920,7 +2923,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnWithWidening) {
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(304)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(make_typed_decimal32_variant_column_for_virtual_column_test(), SlotId(304));
@@ -2953,7 +2956,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualVarcharColumnFromPhysicalSour
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(301)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(301));
@@ -2986,9 +2989,9 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnFromHiddenVariantSource
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(-1)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
-    group_reader->_hidden_variant_sources.emplace(
-            "data", GroupReader::HiddenVariantSource{.slot_id = SlotId(-1), .reader = nullptr});
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_hidden_sources.emplace(
+            "data", VariantProjectionHandler::HiddenSource{.slot_id = SlotId(-1), .reader = nullptr});
 
     // With the new design, _fill_dst_chunk looks up all sources in active_chunk only.
     // The hidden source column (slot -1) must be in the active_chunk argument, not in
@@ -3032,7 +3035,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnWhenVirtualSlotPrecedes
     auto variant_source = make_typed_only_variant_column_for_virtual_column_test();
     ASSIGN_OR_ABORT(auto projection,
                     make_virtual_projection_for_test("a.b.c", virtual_slot->type(), source_slot->id()));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
     group_reader->_column_readers.emplace(source_slot->id(),
                                           std::make_unique<MockVariantSourceColumnReader>(variant_source->clone()));
 
@@ -3126,12 +3129,12 @@ TEST_F(GroupReaderTest, ProcessColumnsDefersVirtualColumnConjunctsUntilAfterProj
 
     ASSIGN_OR_ABORT(auto projection,
                     make_virtual_projection_for_test("a.b.c", virtual_slot->type(), source_slot->id()));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
     group_reader->_column_readers.emplace(source_slot->id(),
                                           std::make_unique<MockVariantSourceColumnReader>(variant_source->clone()));
 
     group_reader->_process_columns_and_conjunct_ctxs();
-    ASSERT_EQ(1, group_reader->_deferred_variant_virtual_conjunct_ctxs.size());
+    ASSERT_EQ(1, group_reader->_variant->_deferred_variant_virtual_conjunct_ctxs.size());
     ASSERT_TRUE(group_reader->_left_conjunct_ctxs.empty());
 
     auto read_chunk = std::make_shared<Chunk>();
@@ -3144,7 +3147,7 @@ TEST_F(GroupReaderTest, ProcessColumnsDefersVirtualColumnConjunctsUntilAfterProj
     ASSERT_OK(fill_dst_chunk_without_projected(group_reader, read_chunk, &dst_chunk));
     ASSERT_EQ(2, dst_chunk->num_rows());
 
-    ASSERT_OK(ChunkPredicateEvaluator::eval_conjuncts(group_reader->_deferred_variant_virtual_conjunct_ctxs,
+    ASSERT_OK(ChunkPredicateEvaluator::eval_conjuncts(group_reader->_variant->_deferred_variant_virtual_conjunct_ctxs,
                                                       dst_chunk.get()));
     ASSERT_EQ(1, dst_chunk->num_rows());
     EXPECT_EQ(22, dst_chunk->get_column_by_slot_id(virtual_slot->id())->get(0).get_int64());
@@ -3293,32 +3296,35 @@ TEST_F(GroupReaderTest, ProcessColumnsClassifiesHiddenSourcesAsActiveOrLazy) {
     const SlotId lazy_src_id = SlotId(-11);
     ASSIGN_OR_ABORT(auto proj_active, make_virtual_projection_for_test("a", vslot_active->type(), active_src_id));
     ASSIGN_OR_ABORT(auto proj_lazy, make_virtual_projection_for_test("a", vslot_lazy->type(), lazy_src_id));
-    group_reader->_variant_virtual_projections.emplace(vslot_active->id(), std::move(proj_active));
-    group_reader->_variant_virtual_projections.emplace(vslot_lazy->id(), std::move(proj_lazy));
+    group_reader->_variant->_projections.emplace(vslot_active->id(), std::move(proj_active));
+    group_reader->_variant->_projections.emplace(vslot_lazy->id(), std::move(proj_lazy));
 
     auto& active_src =
-            group_reader->_hidden_variant_sources
-                    .emplace("v1", GroupReader::HiddenVariantSource{.slot_id = active_src_id, .reader = nullptr})
+            group_reader->_variant->_hidden_sources
+                    .emplace("v1", VariantProjectionHandler::HiddenSource{.slot_id = active_src_id, .reader = nullptr})
                     .first->second;
-    auto& lazy_src = group_reader->_hidden_variant_sources
-                             .emplace("v2", GroupReader::HiddenVariantSource{.slot_id = lazy_src_id, .reader = nullptr})
-                             .first->second;
-    group_reader->_hidden_slot_index[active_src_id] = &active_src;
-    group_reader->_hidden_slot_index[lazy_src_id] = &lazy_src;
+    auto& lazy_src =
+            group_reader->_variant->_hidden_sources
+                    .emplace("v2", VariantProjectionHandler::HiddenSource{.slot_id = lazy_src_id, .reader = nullptr})
+                    .first->second;
+    group_reader->_variant->_hidden_slot_index[active_src_id] = &active_src;
+    group_reader->_variant->_hidden_slot_index[lazy_src_id] = &lazy_src;
 
     group_reader->_process_columns_and_conjunct_ctxs();
 
     // active_src_id should be in _active_hidden_slot_ids (backed by conjunct)
-    EXPECT_TRUE(std::find(group_reader->_active_hidden_slot_ids.begin(), group_reader->_active_hidden_slot_ids.end(),
-                          active_src_id) != group_reader->_active_hidden_slot_ids.end());
+    EXPECT_TRUE(std::find(group_reader->_variant->_active_hidden_slot_ids.begin(),
+                          group_reader->_variant->_active_hidden_slot_ids.end(),
+                          active_src_id) != group_reader->_variant->_active_hidden_slot_ids.end());
     // lazy_src_id should be in _lazy_hidden_slot_ids (projection-only)
-    EXPECT_TRUE(std::find(group_reader->_lazy_hidden_slot_ids.begin(), group_reader->_lazy_hidden_slot_ids.end(),
-                          lazy_src_id) != group_reader->_lazy_hidden_slot_ids.end());
+    EXPECT_TRUE(std::find(group_reader->_variant->_lazy_hidden_slot_ids.begin(),
+                          group_reader->_variant->_lazy_hidden_slot_ids.end(),
+                          lazy_src_id) != group_reader->_variant->_lazy_hidden_slot_ids.end());
     // active_src_id should also appear in unified _active_slot_ids
     EXPECT_TRUE(std::find(group_reader->_active_slot_ids.begin(), group_reader->_active_slot_ids.end(),
                           active_src_id) != group_reader->_active_slot_ids.end());
     // _deferred_conjunct_slot_ids must contain vslot_active
-    EXPECT_EQ(1u, group_reader->_deferred_conjunct_slot_ids.count(vslot_active->id()));
+    EXPECT_EQ(1u, group_reader->_variant->_deferred_conjunct_slot_ids.count(vslot_active->id()));
 }
 
 TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsDuplicateTypedLeafReaders) {
@@ -3338,18 +3344,18 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsDuplicateTypedLeafReaders) {
     const SlotId source_slot_id = SlotId(-20);
     ASSIGN_OR_ABORT(auto proj1, make_virtual_projection_for_test("a", vslot1->type(), source_slot_id));
     ASSIGN_OR_ABORT(auto proj2, make_virtual_projection_for_test("a", vslot2->type(), source_slot_id));
-    group_reader->_variant_virtual_projections.emplace(vslot1->id(), std::move(proj1));
-    group_reader->_variant_virtual_projections.emplace(vslot2->id(), std::move(proj2));
+    group_reader->_variant->_projections.emplace(vslot1->id(), std::move(proj1));
+    group_reader->_variant->_projections.emplace(vslot2->id(), std::move(proj2));
 
     ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
     attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+    group_reader->_variant->try_promote();
 
-    EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
-    EXPECT_EQ(2, group_reader->_variant_virtual_projections.size());
-    EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+    EXPECT_TRUE(group_reader->_variant->_promoted_virtual_slots.empty());
+    EXPECT_EQ(2, group_reader->_variant->_projections.size());
+    EXPECT_FALSE(group_reader->_variant->_hidden_slot_index.at(source_slot_id)->fully_promoted);
     EXPECT_EQ(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot1->id()));
     EXPECT_EQ(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot2->id()));
 }
@@ -3371,20 +3377,20 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionPromotesDifferentTypedLeafReaders
     const SlotId source_slot_id = SlotId(-21);
     ASSIGN_OR_ABORT(auto proj1, make_virtual_projection_for_test("a", vslot1->type(), source_slot_id));
     ASSIGN_OR_ABORT(auto proj2, make_virtual_projection_for_test("b", vslot2->type(), source_slot_id));
-    group_reader->_variant_virtual_projections.emplace(vslot1->id(), std::move(proj1));
-    group_reader->_variant_virtual_projections.emplace(vslot2->id(), std::move(proj2));
+    group_reader->_variant->_projections.emplace(vslot1->id(), std::move(proj1));
+    group_reader->_variant->_projections.emplace(vslot2->id(), std::move(proj2));
 
     ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a", "b"}, 12, 12, 12));
     attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+    group_reader->_variant->try_promote();
 
-    EXPECT_EQ(2, group_reader->_promoted_virtual_slots.size());
-    EXPECT_EQ(1u, group_reader->_promoted_virtual_slots.count(vslot1->id()));
-    EXPECT_EQ(1u, group_reader->_promoted_virtual_slots.count(vslot2->id()));
-    EXPECT_TRUE(group_reader->_variant_virtual_projections.empty());
-    EXPECT_TRUE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+    EXPECT_EQ(2, group_reader->_variant->_promoted_virtual_slots.size());
+    EXPECT_EQ(1u, group_reader->_variant->_promoted_virtual_slots.count(vslot1->id()));
+    EXPECT_EQ(1u, group_reader->_variant->_promoted_virtual_slots.count(vslot2->id()));
+    EXPECT_TRUE(group_reader->_variant->_projections.empty());
+    EXPECT_TRUE(group_reader->_variant->_hidden_slot_index.at(source_slot_id)->fully_promoted);
     ASSERT_NE(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot1->id()));
     ASSERT_NE(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot2->id()));
     EXPECT_NE(nullptr, down_cast<VariantTypedValueProxy*>(group_reader->_column_readers.at(vslot1->id()).get()));
@@ -3416,8 +3422,8 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionClassifiesDictFilterConjuncts) {
     const SlotId source_slot_id = SlotId(-26);
     ASSIGN_OR_ABORT(auto dict_proj, make_virtual_projection_for_test("a", dict_slot->type(), source_slot_id));
     ASSIGN_OR_ABORT(auto expr_proj, make_virtual_projection_for_test("b", expr_slot->type(), source_slot_id));
-    group_reader->_variant_virtual_projections.emplace(dict_slot->id(), std::move(dict_proj));
-    group_reader->_variant_virtual_projections.emplace(expr_slot->id(), std::move(expr_proj));
+    group_reader->_variant->_projections.emplace(dict_slot->id(), std::move(dict_proj));
+    group_reader->_variant->_projections.emplace(expr_slot->id(), std::move(expr_proj));
 
     ASSIGN_OR_ABORT(auto reader,
                     make_variant_promotion_reader(&_pool, {"a", "b"}, 12, 12, 12, tparquet::Type::BYTE_ARRAY,
@@ -3425,9 +3431,9 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionClassifiesDictFilterConjuncts) {
     attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+    group_reader->_variant->try_promote();
 
-    EXPECT_EQ(2, group_reader->_promoted_virtual_slots.size());
+    EXPECT_EQ(2, group_reader->_variant->_promoted_virtual_slots.size());
     ASSERT_EQ(1, group_reader->_dict_column_indices.size());
     EXPECT_EQ(0, group_reader->_dict_column_indices[0]);
     EXPECT_EQ(1u, group_reader->_dict_column_sub_field_paths.count(0));
@@ -3450,17 +3456,17 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsNonAllNullFallback) {
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
     const SlotId source_slot_id = SlotId(-22);
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a", vslot->type(), source_slot_id));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
 
     ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 11, 12));
     attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+    group_reader->_variant->try_promote();
 
-    EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
-    EXPECT_EQ(1, group_reader->_variant_virtual_projections.size());
-    EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+    EXPECT_TRUE(group_reader->_variant->_promoted_virtual_slots.empty());
+    EXPECT_EQ(1, group_reader->_variant->_projections.size());
+    EXPECT_FALSE(group_reader->_variant->_hidden_slot_index.at(source_slot_id)->fully_promoted);
 }
 
 TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsIncompatibleTargetType) {
@@ -3477,17 +3483,17 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsIncompatibleTargetType) {
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
     const SlotId source_slot_id = SlotId(-23);
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a", vslot->type(), source_slot_id));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
 
     ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
     attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+    group_reader->_variant->try_promote();
 
-    EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
-    EXPECT_EQ(1, group_reader->_variant_virtual_projections.size());
-    EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+    EXPECT_TRUE(group_reader->_variant->_promoted_virtual_slots.empty());
+    EXPECT_EQ(1, group_reader->_variant->_projections.size());
+    EXPECT_FALSE(group_reader->_variant->_hidden_slot_index.at(source_slot_id)->fully_promoted);
 }
 
 TEST_F(GroupReaderTest, VariantVirtualPromotionKeepsUnpromotedMixedSourceActiveAndRebuildsReadOrder) {
@@ -3520,39 +3526,41 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionKeepsUnpromotedMixedSourceActiveA
                     make_virtual_projection_for_test("a", promoted_slot->type(), promoted_source_slot_id));
     ASSIGN_OR_ABORT(auto unpromoted_proj,
                     make_virtual_projection_for_test("a", unpromoted_slot->type(), unpromoted_source_slot_id));
-    group_reader->_variant_virtual_projections.emplace(promoted_slot->id(), std::move(promoted_proj));
-    group_reader->_variant_virtual_projections.emplace(unpromoted_slot->id(), std::move(unpromoted_proj));
+    group_reader->_variant->_projections.emplace(promoted_slot->id(), std::move(promoted_proj));
+    group_reader->_variant->_projections.emplace(unpromoted_slot->id(), std::move(unpromoted_proj));
 
     ASSIGN_OR_ABORT(auto promoted_reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
     ASSIGN_OR_ABORT(auto unpromoted_reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
     auto& promoted_source =
-            group_reader->_hidden_variant_sources
-                    .emplace("data1", GroupReader::HiddenVariantSource{.slot_id = promoted_source_slot_id,
-                                                                       .reader = std::move(promoted_reader)})
+            group_reader->_variant->_hidden_sources
+                    .emplace("data1", VariantProjectionHandler::HiddenSource{.slot_id = promoted_source_slot_id,
+                                                                             .reader = std::move(promoted_reader)})
                     .first->second;
     auto& unpromoted_source =
-            group_reader->_hidden_variant_sources
-                    .emplace("data2", GroupReader::HiddenVariantSource{.slot_id = unpromoted_source_slot_id,
-                                                                       .reader = std::move(unpromoted_reader)})
+            group_reader->_variant->_hidden_sources
+                    .emplace("data2", VariantProjectionHandler::HiddenSource{.slot_id = unpromoted_source_slot_id,
+                                                                             .reader = std::move(unpromoted_reader)})
                     .first->second;
-    group_reader->_hidden_slot_index[promoted_source_slot_id] = &promoted_source;
-    group_reader->_hidden_slot_index[unpromoted_source_slot_id] = &unpromoted_source;
+    group_reader->_variant->_hidden_slot_index[promoted_source_slot_id] = &promoted_source;
+    group_reader->_variant->_hidden_slot_index[unpromoted_source_slot_id] = &unpromoted_source;
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+    group_reader->_variant->try_promote();
 
-    EXPECT_EQ(1u, group_reader->_promoted_virtual_slots.count(promoted_slot->id()));
-    EXPECT_EQ(0u, group_reader->_promoted_virtual_slots.count(unpromoted_slot->id()));
-    EXPECT_TRUE(group_reader->_hidden_slot_index.at(promoted_source_slot_id)->fully_promoted);
-    EXPECT_FALSE(group_reader->_hidden_slot_index.at(unpromoted_source_slot_id)->fully_promoted);
-    EXPECT_EQ(1u, group_reader->_variant_virtual_projections.count(unpromoted_slot->id()));
-    EXPECT_EQ(0u, group_reader->_variant_virtual_projections.count(promoted_slot->id()));
-    EXPECT_NE(group_reader->_active_hidden_slot_ids.end(),
-              std::find(group_reader->_active_hidden_slot_ids.begin(), group_reader->_active_hidden_slot_ids.end(),
-                        unpromoted_source_slot_id));
-    EXPECT_EQ(group_reader->_active_hidden_slot_ids.end(),
-              std::find(group_reader->_active_hidden_slot_ids.begin(), group_reader->_active_hidden_slot_ids.end(),
-                        promoted_source_slot_id));
+    group_reader->_rebuild_column_read_order_ctx();
+
+    EXPECT_EQ(1u, group_reader->_variant->_promoted_virtual_slots.count(promoted_slot->id()));
+    EXPECT_EQ(0u, group_reader->_variant->_promoted_virtual_slots.count(unpromoted_slot->id()));
+    EXPECT_TRUE(group_reader->_variant->_hidden_slot_index.at(promoted_source_slot_id)->fully_promoted);
+    EXPECT_FALSE(group_reader->_variant->_hidden_slot_index.at(unpromoted_source_slot_id)->fully_promoted);
+    EXPECT_EQ(1u, group_reader->_variant->_projections.count(unpromoted_slot->id()));
+    EXPECT_EQ(0u, group_reader->_variant->_projections.count(promoted_slot->id()));
+    EXPECT_NE(group_reader->_variant->_active_hidden_slot_ids.end(),
+              std::find(group_reader->_variant->_active_hidden_slot_ids.begin(),
+                        group_reader->_variant->_active_hidden_slot_ids.end(), unpromoted_source_slot_id));
+    EXPECT_EQ(group_reader->_variant->_active_hidden_slot_ids.end(),
+              std::find(group_reader->_variant->_active_hidden_slot_ids.begin(),
+                        group_reader->_variant->_active_hidden_slot_ids.end(), promoted_source_slot_id));
     EXPECT_EQ(1u, group_reader->_column_read_order_ctx->get_column_read_order().size());
     EXPECT_EQ(0, group_reader->_column_read_order_ctx->get_column_read_order()[0]);
 }
@@ -3584,7 +3592,7 @@ TEST_F(GroupReaderTest, CreateColumnReadersRegistersVirtualZoneMapReaderForHidde
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSERT_OK(group_reader->init());
-    ASSERT_FALSE(group_reader->_hidden_slot_index.empty());
+    ASSERT_FALSE(group_reader->_variant->_hidden_slot_index.empty());
     auto it = group_reader->_column_readers.find(virtual_slot->id());
     ASSERT_NE(it, group_reader->_column_readers.end());
     EXPECT_NE(nullptr, down_cast<VariantVirtualZoneMapReader*>(it->second.get()));
@@ -3676,7 +3684,7 @@ TEST_F(GroupReaderTest, ProcessColumnsPromotesPhysicalVariantSourceForDeferredCo
 
     // Wire projection: virtual slot 171 → source is physical slot 170 (non-negative).
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a", virt_slot->type(), phys_slot->id()));
-    group_reader->_variant_virtual_projections.emplace(virt_slot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(virt_slot->id(), std::move(proj));
 
     group_reader->_process_columns_and_conjunct_ctxs();
 
@@ -3686,7 +3694,7 @@ TEST_F(GroupReaderTest, ProcessColumnsPromotesPhysicalVariantSourceForDeferredCo
     EXPECT_TRUE(std::find(group_reader->_lazy_slot_ids.begin(), group_reader->_lazy_slot_ids.end(), phys_slot->id()) ==
                 group_reader->_lazy_slot_ids.end());
     // The virtual conjunct slot must be registered.
-    EXPECT_EQ(1u, group_reader->_deferred_conjunct_slot_ids.count(virt_slot->id()));
+    EXPECT_EQ(1u, group_reader->_variant->_deferred_conjunct_slot_ids.count(virt_slot->id()));
 }
 
 // ── _apply_deferred_variant_conjuncts ────────────────────────────────────────
@@ -3707,21 +3715,22 @@ TEST_F(GroupReaderTest, ApplyDeferredVariantConjunctsReturnsErrorWhenConjunctSou
 
     // Wire projection for vslot pointing to source slot -20 (absent from active_chunk).
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a.b.c", vslot->type(), SlotId(-20)));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
     // Mark this slot as having a deferred conjunct (simulating Step 1 output).
-    group_reader->_deferred_conjunct_slot_ids.insert(vslot->id());
+    group_reader->_variant->_deferred_conjunct_slot_ids.insert(vslot->id());
     // Push a dummy conjunct so the early-exit guard doesn't fire.
     RuntimeState runtime_state{TQueryGlobals()};
     std::vector<ExprContext*> conjunct_ctxs;
     ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, vslot->id(), 11, &conjunct_ctxs));
     for (auto* ctx : conjunct_ctxs) {
-        group_reader->_deferred_variant_virtual_conjunct_ctxs.push_back(ctx);
+        group_reader->_variant->_deferred_variant_virtual_conjunct_ctxs.push_back(ctx);
     }
 
     // active_chunk is empty — source slot -20 is absent.
     auto active_chunk = std::make_shared<Chunk>();
     auto projected_chunk = std::make_shared<Chunk>();
-    auto status = group_reader->_apply_deferred_variant_conjuncts(active_chunk, 2, &projected_chunk);
+    auto status = group_reader->_variant->filter_subfields(active_chunk, 2, nullptr,
+                                                           group_reader->_variant->projection_timezone());
     EXPECT_FALSE(status.ok());
     EXPECT_TRUE(status.status().is_internal_error());
 }
@@ -3742,15 +3751,15 @@ TEST_F(GroupReaderTest, ApplyDeferredVariantConjunctsProjectsSourceAndFilters) {
 
     // Source slot -21 will be present in active_chunk.
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a.b.c", vslot->type(), SlotId(-21)));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
-    group_reader->_deferred_conjunct_slot_ids.insert(vslot->id());
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_deferred_conjunct_slot_ids.insert(vslot->id());
 
     // Conjunct: v.a == 22  (row 0 has 11, row 1 has 22 → only row 1 passes).
     RuntimeState runtime_state{TQueryGlobals()};
     std::vector<ExprContext*> conjunct_ctxs;
     ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, vslot->id(), 22, &conjunct_ctxs));
     for (auto* ctx : conjunct_ctxs) {
-        group_reader->_deferred_variant_virtual_conjunct_ctxs.push_back(ctx);
+        group_reader->_variant->_deferred_variant_virtual_conjunct_ctxs.push_back(ctx);
     }
 
     // active_chunk contains the source variant column with typed path "a.b.c" → [11, 22].
@@ -3758,7 +3767,8 @@ TEST_F(GroupReaderTest, ApplyDeferredVariantConjunctsProjectsSourceAndFilters) {
     active_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(-21));
 
     auto projected_chunk = std::make_shared<Chunk>();
-    ASSIGN_OR_ABORT(auto filter, group_reader->_apply_deferred_variant_conjuncts(active_chunk, 2, &projected_chunk));
+    ASSIGN_OR_ABORT(auto filter, group_reader->_variant->filter_subfields(
+                                         active_chunk, 2, nullptr, group_reader->_variant->projection_timezone()));
     ASSERT_EQ(2u, filter.size());
     EXPECT_EQ(0, filter[0]); // row 0 (value=11) rejected
     EXPECT_EQ(1, filter[1]); // row 1 (value=22) passed
@@ -3787,7 +3797,8 @@ TEST_F(GroupReaderTest, AlignDeferredProjectedChunkAfterFilterReturnsErrorWhenRo
     projected_chunk->append_column(projected_col, SlotId(2));
 
     Filter filter = {1, 0};
-    auto st = group_reader->_align_deferred_projected_chunk_after_filter(active_chunk, projected_chunk, filter, 2);
+    group_reader->_variant->_deferred_projected_chunk = projected_chunk;
+    auto st = group_reader->_variant->align_after_combined_filter(active_chunk, filter, 2);
     ASSERT_FALSE(st.ok());
     ASSERT_TRUE(st.is_internal_error());
 }
@@ -3814,7 +3825,8 @@ TEST_F(GroupReaderTest, AlignDeferredProjectedChunkAfterFilterAppliesFilterForPr
     projected_chunk->append_column(projected_col, SlotId(2));
 
     Filter filter = {1, 0};
-    ASSERT_OK(group_reader->_align_deferred_projected_chunk_after_filter(active_chunk, projected_chunk, filter, 2));
+    group_reader->_variant->_deferred_projected_chunk = projected_chunk;
+    ASSERT_OK(group_reader->_variant->align_after_combined_filter(active_chunk, filter, 2));
     ASSERT_EQ(1u, projected_chunk->num_rows());
     EXPECT_EQ(11, projected_chunk->get_column_by_slot_id(SlotId(2))->get(0).get_int64());
 }
@@ -3842,7 +3854,7 @@ TEST_F(GroupReaderTest, FillDstChunkReturnsErrorWhenSourceSlotMissingFromActiveC
 
     // Wire projection pointing to source slot -30 — NOT present in active_chunk.
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a.b.c", vslot->type(), SlotId(-30)));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
 
     auto active_chunk = std::make_shared<Chunk>(); // source slot -30 absent
     auto dst_chunk = std::make_shared<Chunk>();
@@ -3871,7 +3883,7 @@ TEST_F(GroupReaderTest, FillDstChunkReturnsErrorWhenDeferredProjectedColumnIsNul
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a.b.c", vslot->type(), SlotId(-31)));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
 
     auto active_chunk = std::make_shared<Chunk>();
     active_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(-31));
@@ -3883,7 +3895,9 @@ TEST_F(GroupReaderTest, FillDstChunkReturnsErrorWhenDeferredProjectedColumnIsNul
     auto dst_chunk = std::make_shared<Chunk>();
     dst_chunk->append_column(ColumnHelper::create_column(vslot->type(), true), vslot->id());
 
-    auto status = group_reader->_fill_dst_chunk(active_chunk, projected_chunk, &dst_chunk);
+    group_reader->_variant->_deferred_projected_chunk = projected_chunk;
+    auto status = group_reader->_variant->emit_projections(active_chunk, &dst_chunk,
+                                                           group_reader->_variant->projection_timezone());
     ASSERT_FALSE(status.ok());
     ASSERT_TRUE(status.is_internal_error());
 }
@@ -3906,7 +3920,7 @@ TEST_F(GroupReaderTest, FillDstChunkReturnsErrorWhenDeferredProjectedColumnRowCo
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a.b.c", vslot->type(), SlotId(-32)));
-    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+    group_reader->_variant->_projections.emplace(vslot->id(), std::move(proj));
 
     auto active_chunk = std::make_shared<Chunk>();
     active_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(-32));
@@ -3919,7 +3933,9 @@ TEST_F(GroupReaderTest, FillDstChunkReturnsErrorWhenDeferredProjectedColumnRowCo
     auto dst_chunk = std::make_shared<Chunk>();
     dst_chunk->append_column(ColumnHelper::create_column(vslot->type(), true), vslot->id());
 
-    auto status = group_reader->_fill_dst_chunk(active_chunk, projected_chunk, &dst_chunk);
+    group_reader->_variant->_deferred_projected_chunk = projected_chunk;
+    auto status = group_reader->_variant->emit_projections(active_chunk, &dst_chunk,
+                                                           group_reader->_variant->projection_timezone());
     ASSERT_FALSE(status.ok());
     ASSERT_TRUE(status.is_internal_error());
 }
@@ -3942,7 +3958,26 @@ TEST_F(GroupReaderTest, GetVariantShreddedHintsReturnsEmptyOnInvalidAccessPath) 
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
-    auto hints = group_reader->_get_variant_shredded_hints("data");
+    auto hints = group_reader->_variant->_build_shredded_hints("data");
+    EXPECT_TRUE(hints.shredded_paths.empty());
+    EXPECT_TRUE(hints.parsed_shredded_paths.empty());
+}
+
+TEST_F(GroupReaderTest, GetVariantShreddedHintsReturnsEmptyWhenFullColumnAccessIsPresent) {
+    std::vector<ColumnAccessPathPtr> column_access_paths;
+
+    ASSIGN_OR_ABORT(auto full_root, ColumnAccessPath::create(TAccessPathType::ROOT, "data", 0));
+    column_access_paths.emplace_back(std::move(full_root));
+
+    ASSIGN_OR_ABORT(auto subfield_root, ColumnAccessPath::create(TAccessPathType::ROOT, "data", 0));
+    ASSIGN_OR_ABORT(auto field_a,
+                    ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0, subfield_root->absolute_path()));
+    ASSIGN_OR_ABORT(auto field_b, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0, field_a->absolute_path()));
+    subfield_root->children().emplace_back(std::move(field_a));
+    subfield_root->children()[0]->children().emplace_back(std::move(field_b));
+    column_access_paths.emplace_back(std::move(subfield_root));
+
+    auto hints = build_variant_shredded_hints(&column_access_paths, "data");
     EXPECT_TRUE(hints.shredded_paths.empty());
     EXPECT_TRUE(hints.parsed_shredded_paths.empty());
 }
@@ -3982,7 +4017,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnFromRawVariantFa
     // Project path "a.b.c" → DECIMAL32(5,2). The raw variant rows hold integer values
     // at that path; they must be cast row-by-row via cast_variant_to_decimal.
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(401)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     // Raw variant: {"a":{"b":{"c":10}}} and {"a":{"b":{"c":20}}} — no typed shredded leaf.
     auto variant_src = make_raw_json_variant_column_for_virtual_column_test(
@@ -4023,7 +4058,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnFromBigintTypedL
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(403)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     // Typed INT64 leaf at "a.b.c" (values 11 and 22).
     // Target DECIMAL32(7,2): exact match fails (INT64 ≠ DECIMAL32); decimal typed match
@@ -4066,7 +4101,7 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnOverflowBecomesN
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(405)));
-    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_variant->_projections.emplace(virtual_slot->id(), std::move(projection));
 
     // Row 0: integer 5 → 5 × 100 = 500, fits in int32_t → non-null.
     // Row 1: integer 21474837 → 21474837 × 100 = 2147483700 > INT32_MAX → overflow → NULL.


### PR DESCRIPTION
## Why I'm doing:

`GroupReader::get_next()` had grown into a monolithic ~270-line loop with variant-specific phases deeply interleaved with the general Parquet read pipeline. Over 12 variant-related fields, 5 variant-specific private methods, and 2 internal structs lived directly on GroupReader, making it hard to understand which code handles what. As the variant feature evolved (shredded reads, typed-value promotion, deferred subfield conjuncts), new logic was added inline without a clear boundary. 

## What I'm doing:

Introduce `VariantProjectionHandler` — a class that owns all variant-specific state and orchestrates the variant phases of the pipeline. `GroupReader` delegates to it via a single `unique_ptr`, keeping its member list minimal and its `get_next()` pipeline clean.

### Key changes

**1. VariantProjectionHandler** (`variant_projection.h/.cpp` — new ~500 lines)

Encapsulates variant projection setup, promotion, deferred conjunct evaluation, and per-iteration runtime state (projected chunk), exposed as a set of named hooks:

```
fetch_sources()        — phase 3: read variant source columns needed for subfield filtering
filter_subfields()     — phase 4: project virtual columns + evaluate deferred conjuncts
align_after_combined_filter()
backfill_sources()     — phase 6: read projection-only variant sources
emit_projections()     — phase 7: fill virtual column outputs
```

The handler tracks per-iteration state internally (e.g. `_deferred_projected_chunk` is set by `filter_subfields`, consumed by `emit_projections`), removing the need for GroupReader to pass around temporary chunks.

**2. GroupReader simplification** (`group_reader.h/.cpp`)

`get_next()` decomposed into named conceptual phases:

```
while (has ranges) {
    1. _prune_deleted_rows()           — deletion bitmap
    2. _read_and_filter_active_columns — dict/expr predicate pushdown
    3. _variant->fetch_sources()       — no-op when handler is empty
    4. _variant->filter_subfields()    — no-op when handler is empty
       apply combined filter
    5. _read_lazy_columns()            — delayed materialization
    6. _variant->backfill_sources()    — no-op when handler is empty
    7. _variant->emit_projections() + _emit_physical_columns()
}
```

Header went from ~368 lines → ~220 lines. Removed `VariantVirtualProjection`, `HiddenVariantSource` structs and 12 variant fields from GroupReader's member list.

**3. `try_promote` is self-contained**

The handler internally handles promotion aftermath (rebuilding ColumnReadOrderCtx via callback, pruning deferred conjuncts after promotion). Caller just provides a dict-filter registration callback and an order-ctx rebuild lambda — no need to manage the promotion lifecycle manually.

**4. Free functions extracted earlier**

`project_variant_leaf_column`, `collect_variant_leaf_paths`, and internal helpers (~350 lines) moved from group_reader.cpp's anonymous namespace into `variant_projection.h/.cpp`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
