### PR TITLE
[BugFix] Report real vacuum watermark when retain-boundary metadata is gone (backport #74429)

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -323,6 +323,11 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     auto min_version = std::max(1L, tablet_info.min_version());
     // grace_timestamp <= 0 means no grace timestamp
     auto skip_check_grace_timestamp = grace_timestamp <= 0;
+    // Whether the walk read at least one tablet metadata at or below |min_retain_version|. It stays
+    // false when the loop never runs (|min_version| has already advanced past |min_retain_version|)
+    // or when the very first read returns NotFound, i.e. the metadata at and below the retain
+    // boundary has already been vacuumed away by a previous run.
+    bool read_any_metadata = false;
     size_t extra_file_size = 0;
     int64_t prepare_vacuum_file_size = 0;
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_dir));
@@ -340,6 +345,7 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
             return res.status();
         } else {
             auto metadata = std::move(res).value();
+            read_any_metadata = true;
             extra_file_size += collect_extra_files_size(*metadata, min_retain_version);
             if (skip_check_grace_timestamp) {
                 DCHECK_LE(version, final_retain_version);
@@ -394,6 +400,18 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     auto t1 = butil::gettimeofday_ms();
     g_metadata_travel_latency << (t1 - t0);
     if (!skip_check_grace_timestamp) {
+        if (!read_any_metadata) {
+            // No tablet metadata exists at or below |final_retain_version| (== min_retain_version): the
+            // metadata down there has already been vacuumed away by a previous run. Reporting
+            // `final_retain_version - 1` here understates the real progress. When min_retain_version is
+            // pinned to a PhysicalPartition.metadataSwitchVersion whose metadata is already gone, that
+            // understatement permanently strands the switch version on the FE, because the FE only clears
+            // it once vacuumed_version >= switch_version. Report the true cleaned watermark instead: every
+            // version below |min_version| is gone, so cleanup has reached at least `min_version - 1`, and
+            // never below `final_retain_version` (which itself no longer exists).
+            *vacuumed_version = std::max<int64_t>(final_retain_version, min_version - 1);
+            return Status::OK();
+        }
         // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
         // The final_retain_version is set to min_retain_version or minmum exist version which has garbage files.
         // So we set vacuumed_version to `final_retain_version - 1` to avoid the garbage files of final_retain_version can

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -3365,4 +3365,40 @@ TEST_P(LakeVacuumTest, vacuum_load_spill_handles_invalid_hex_prefix) {
     EXPECT_EQ(0, deleted);
 }
 
+// Regression test: a PhysicalPartition.metadataSwitchVersion can be permanently stranded when the
+// switch version's tablet metadata (and everything at or below it) has already been vacuumed away
+// before the FE managed to clear the switch (e.g. an in-memory clear lost across an FE failover).
+// In that state collect_files_to_vacuum used to report `min_retain_version - 1`, which is below the
+// switch version, so the FE never clears it (it only clears once vacuumed_version >= switch_version).
+// The vacuum must instead report the real cleaned watermark so the switch can be cleared.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_min_retain_below_min_version) {
+    // The tablet's lowest existing version has already advanced past min_retain_version, so the
+    // metadata walk never runs. Only the visible version (5) metadata remains.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 5200,
+            "version": 5,
+            "commit_time": 1
+        }
+        )DEL")));
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(5200);
+    // Versions <= 4 are already gone; the lowest existing version is 5.
+    info->set_min_version(5);
+    // min_retain_version is pinned to a switch version (3) whose metadata no longer exists.
+    request.set_min_retain_version(3);
+    request.set_grace_timestamp(::time(nullptr) + 60);
+    request.set_min_active_txn_id(99999);
+    vacuum(_tablet_mgr.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // Before the fix: min_retain_version - 1 == 2 (< switch version 3 -> stranded forever).
+    // After the fix: max(min_retain_version, min_version - 1) == 4 (>= switch version 3).
+    EXPECT_EQ(4, response.vacuumed_version());
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

Backport of #74429 to branch-4.0.11 (customer hotfix).

For shared-data (lake) tables, a partition's `min_retain_version` is clamped to its
`PhysicalPartition.metadataSwitchVersion` (set by a `file_bundling` enable/disable `ALTER`) until
vacuum "crosses" that version. The FE clears the switch version only when a vacuum round reports
`vacuumed_version >= switch_version`.

If the tablet metadata at and below the retain boundary has already been vacuumed away by an earlier
run, `collect_files_to_vacuum` returns `min_retain_version - 1` -- either the walk never runs
(`min_version` advanced past `min_retain_version`) or the first `get_tablet_metadata` returns
`NotFound`. That watermark is below the switch version, so the FE never clears
`metadataSwitchVersion`. The switch is then stranded forever: old-format metadata can never be
reclaimed and `ALTER ... SET("file_bundling"=...)` is blocked by `allowUpdateFileBundling()`.

Observed in production: a vacuum round crossed the switch and cleared it in memory (the clear is not
journaled, only persisted at the next FE image checkpoint); during `switch == 0` later rounds
irreversibly deleted the switch version's metadata; then an FE failover before the next checkpoint
reverted `metadataSwitchVersion` from a stale image while the deletions were permanent.

## What I'm doing:

In `collect_files_to_vacuum`, when no tablet metadata exists at or below the retain boundary
(tracked by a new `read_any_metadata` flag), report the real cleaned watermark
`max(final_retain_version, min_version - 1)` instead of `final_retain_version - 1`, so the FE can
clear the stranded switch version on the next vacuum round. This also self-heals already-stranded
partitions. Normal paths are unaffected (the walk always reads at least one metadata).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

