### PR TITLE
Add Javadoc comment to NormalCdf class for improved documentation

### DIFF
--- a/contrib/java-udf/src/main/java/com/starrocks/udf/NormalCdf.java
+++ b/contrib/java-udf/src/main/java/com/starrocks/udf/NormalCdf.java
@@ -2,6 +2,10 @@ package com.starrocks.udf;
 
 import org.apache.commons.math3.special.Erf;
 
+/**
+ * Computes the cumulative distribution function (CDF) of a normal distribution.
+ * This UDF takes the mean, standard deviation, and a value as inputs and returns the corresponding CDF value.
+ */
 public class NormalCdf {
     public final Double evaluate(Double mean, Double standardDeviation, Double value) {
         if (mean == null || standardDeviation == null || value == null) {


### PR DESCRIPTION
## Problem Background
The `NormalCdf` class in `contrib/java-udf/src/main/java/com/starrocks/udf/NormalCdf.java` lacked proper Java documentation comments. This could reduce code readability and maintainability, as developers might not immediately understand the class's purpose or usage.

## Changes
- Added a Javadoc comment to the `NormalCdf` class to describe its functionality: computing the cumulative distribution function (CDF) of a normal distribution based on mean, standard deviation, and value inputs.

## Verification
- This change is purely documentation-related and does not alter the class's external behavior or API.
- Verified by reviewing the added comment for accuracy, consistency with the codebase's existing Javadoc style, and ensuring it does not introduce any functional changes.