### PR TITLE
[BugFix] Add catalog recycle bin size gauges

### DIFF
--- a/docs/en/administration/management/monitoring/metric_details/q-r.md
+++ b/docs/en/administration/management/monitoring/metric_details/q-r.md
@@ -99,6 +99,21 @@ description: "Alphabetical q - r"
 
 ## `readable_blocks_total (Deprecated)`
 
+## `recycle_bin_database_num`
+
+- Unit: Count
+- Description: Number of databases currently held in the FE catalog recycle bin.
+
+## `recycle_bin_partition_num`
+
+- Unit: Count
+- Description: Number of partitions currently held in the FE catalog recycle bin.
+
+## `recycle_bin_table_num`
+
+- Unit: Count
+- Description: Number of tables currently held in the FE catalog recycle bin.
+
 ## `resource_group_bigquery_count`
 
 - Unit: Count

--- a/docs/ja/administration/management/monitoring/metric_details/q-r.md
+++ b/docs/ja/administration/management/monitoring/metric_details/q-r.md
@@ -57,6 +57,21 @@ description: "Alphabetical q - r"
 
 ## `readable_blocks_total (Deprecated)`
 
+## `recycle_bin_database_num`
+
+- 単位: 個
+- 説明: FE カタログのリサイクルビンに現在保持されているデータベースの数。
+
+## `recycle_bin_partition_num`
+
+- 単位: 個
+- 説明: FE カタログのリサイクルビンに現在保持されているパーティションの数。
+
+## `recycle_bin_table_num`
+
+- 単位: 個
+- 説明: FE カタログのリサイクルビンに現在保持されているテーブルの数。
+
 ## `resource_group_bigquery_count`
 
 - 単位: カウント

--- a/docs/zh/administration/management/monitoring/metric_details/q-r.md
+++ b/docs/zh/administration/management/monitoring/metric_details/q-r.md
@@ -99,6 +99,21 @@ description: "Alphabetical q - r"
 
 ## `readable_blocks_total (Deprecated)`
 
+## `recycle_bin_database_num`
+
+- 单位：个
+- 描述：FE Catalog 回收站中当前保留的数据库数量。
+
+## `recycle_bin_partition_num`
+
+- 单位：个
+- 描述：FE Catalog 回收站中当前保留的分区数量。
+
+## `recycle_bin_table_num`
+
+- 单位：个
+- 描述：FE Catalog 回收站中当前保留的表数量。
+
 ## `resource_group_bigquery_count`
 
 - 单位：计数

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -1336,6 +1336,18 @@ public class CatalogRecycleBin extends LeaderDaemon implements Writable, MemoryT
         return idToPartition.get(id);
     }
 
+    public synchronized int getRecycleDatabaseNum() {
+        return idToDatabase.size();
+    }
+
+    public synchronized int getRecycleTableNum() {
+        return idToTableInfo.size();
+    }
+
+    public synchronized int getRecyclePartitionNum() {
+        return idToPartition.size();
+    }
+
     @VisibleForTesting
     synchronized RecycleTableInfo getRecycleTableInfo(long id) {
         for (Map<Long, RecycleTableInfo> tableEntry : idToTableInfo.rowMap().values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -605,6 +605,33 @@ public final class MetricRepo {
         };
         STARROCKS_METRIC_REGISTER.addMetric(snapshotConsecutiveFailures);
 
+        GaugeMetric<Long> recycleBinPartitionNum = new GaugeMetric<Long>(
+                "recycle_bin_partition_num", MetricUnit.NOUNIT, "number of partitions in the catalog recycle bin") {
+            @Override
+            public Long getValue() {
+                return (long) GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionNum();
+            }
+        };
+        STARROCKS_METRIC_REGISTER.addMetric(recycleBinPartitionNum);
+
+        GaugeMetric<Long> recycleBinTableNum = new GaugeMetric<Long>(
+                "recycle_bin_table_num", MetricUnit.NOUNIT, "number of tables in the catalog recycle bin") {
+            @Override
+            public Long getValue() {
+                return (long) GlobalStateMgr.getCurrentState().getRecycleBin().getRecycleTableNum();
+            }
+        };
+        STARROCKS_METRIC_REGISTER.addMetric(recycleBinTableNum);
+
+        GaugeMetric<Long> recycleBinDatabaseNum = new GaugeMetric<Long>(
+                "recycle_bin_database_num", MetricUnit.NOUNIT, "number of databases in the catalog recycle bin") {
+            @Override
+            public Long getValue() {
+                return (long) GlobalStateMgr.getCurrentState().getRecycleBin().getRecycleDatabaseNum();
+            }
+        };
+        STARROCKS_METRIC_REGISTER.addMetric(recycleBinDatabaseNum);
+
         // routine load jobs
         for (RoutineLoadJob.JobState state : RoutineLoadJob.JobState.values()) {
             Metric<Long> gauge = new LeaderAwareGaugeMetricLong("routine_load_jobs",

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -158,6 +158,30 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
+    public void testSizeAccessorsEmpty() {
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        Assertions.assertEquals(0, bin.getRecyclePartitionNum());
+        Assertions.assertEquals(0, bin.getRecycleTableNum());
+        Assertions.assertEquals(0, bin.getRecycleDatabaseNum());
+    }
+
+    @Test
+    public void testSizeAccessorsPopulated() throws Exception {
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));
+        Range<PartitionKey> range =
+                Range.range(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), columns),
+                        BoundType.CLOSED,
+                        PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("3")), columns),
+                        BoundType.CLOSED);
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+        Partition partition = new Partition(1L, 3L, "pt", new MaterializedIndex(), null);
+        bin.recyclePartition(new RecycleRangePartitionInfo(11L, 22L, partition, range, dataProperty, (short) 1, null));
+
+        Assertions.assertEquals(1, bin.getRecyclePartitionNum());
+    }
+
+    @Test
     public void testGetPartition() throws Exception {
         CatalogRecycleBin bin = new CatalogRecycleBin();
         List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));


### PR DESCRIPTION
## Why I'm doing:

Recycle-bin growth is a real contributor to FE memory usage (see the cluster-snapshot recycle-bin freeze fix #74379), but there is currently no metric exposing how much the `CatalogRecycleBin` holds. This makes it hard to spot a bin that is growing (heavy `INSERT OVERWRITE` / `DROP`, retention misconfiguration, or a stuck erase) before it pressures FE heap.

This is the observability companion to #74379. It is backported to the same release branches (3.5 / 4.0 / 4.1) so operators can see recycle-bin size on the versions where that fix lands. Split out from #74379 per review feedback, since the gauges are independent of the snapshot logic.

## What I'm doing:

Add three FE gauges for the current size of the catalog recycle bin:
- `recycle_bin_database_num`
- `recycle_bin_table_num`
- `recycle_bin_partition_num`

Backed by new `synchronized` size accessors on `CatalogRecycleBin`. Named with `_num` (not `_count`) since they are gauges, not counters.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5