### PR TITLE
[Refactor] Extract ColumnMaterializer from GroupReader for column state management

### DIFF
--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -81,6 +81,7 @@ ADD_BE_LIB(Formats
         orc/memory_stream/MemoryOutputStream.cc
         parquet/arrow_memory_pool.cpp
         parquet/column_chunk_reader.cpp
+        parquet/column_materializer.cpp
         parquet/column_converter.cpp
         parquet/column_reader.cpp
         parquet/column_reader_factory.cpp

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -1,0 +1,372 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/column_materializer.h"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+
+#include "base/simd/simd.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk.h"
+#include "common/config_scan_io_fwd.h"
+#include "exprs/chunk_predicate_evaluator.h"
+#include "exprs/expr.h"
+#include "runtime/chunk_helper.h"
+#include "runtime/descriptors.h"
+
+namespace starrocks::parquet {
+
+void ColumnMaterializer::clear_classification() {
+    _active_column_indices.clear();
+    _lazy_column_indices.clear();
+    _active_slot_ids.clear();
+    _lazy_slot_ids.clear();
+    _dict_column_indices.clear();
+    _dict_column_sub_field_paths.clear();
+    _post_read_conjuncts_by_slot.clear();
+    _column_read_order_ctx.reset();
+}
+
+void ColumnMaterializer::add_active_column(int col_idx) {
+    _active_column_indices.push_back(col_idx);
+    _active_slot_ids.push_back(_param.read_cols[col_idx].slot_id());
+}
+
+void ColumnMaterializer::add_lazy_column(int col_idx) {
+    _lazy_column_indices.push_back(col_idx);
+    _lazy_slot_ids.push_back(_param.read_cols[col_idx].slot_id());
+}
+
+void ColumnMaterializer::promote_lazy_to_active() {
+    _active_column_indices.swap(_lazy_column_indices);
+    _active_slot_ids.swap(_lazy_slot_ids);
+}
+
+void ColumnMaterializer::rebuild_read_order_ctx() {
+    std::unordered_map<int, size_t> col_cost;
+    size_t all_cost = 0;
+    for (int col_idx : _active_column_indices) {
+        size_t flat_size = _param.read_cols[col_idx].slot_type().get_flat_size();
+        col_cost[col_idx] = flat_size;
+        all_cost += flat_size;
+    }
+    _column_read_order_ctx =
+            std::make_unique<ColumnReadOrderCtx>(_active_column_indices, all_cost, std::move(col_cost));
+}
+
+void ColumnMaterializer::add_dict_filter_column(int col_idx, std::vector<std::string>& sub_field_path) {
+    _dict_column_indices.emplace_back(col_idx);
+    if (_dict_column_sub_field_paths.find(col_idx) == _dict_column_sub_field_paths.end()) {
+        _dict_column_sub_field_paths.insert({col_idx, std::vector<std::vector<std::string>>({sub_field_path})});
+    } else {
+        _dict_column_sub_field_paths[col_idx].emplace_back(sub_field_path);
+    }
+}
+
+void ColumnMaterializer::add_post_read_conjunct(SlotId slot_id, ExprContext* ctx) {
+    _post_read_conjuncts_by_slot[slot_id].push_back(ctx);
+}
+
+Status ColumnMaterializer::init_read_chunk() {
+    std::vector<SlotDescriptor*> read_slots;
+    read_slots.reserve(_param.read_cols.size());
+    for (const auto& column : _param.read_cols) {
+        read_slots.emplace_back(column.slot_desc);
+    }
+    if (_param.reserved_field_slots != nullptr) {
+        for (auto* slot : *_param.reserved_field_slots) {
+            read_slots.push_back(slot);
+        }
+    }
+    ASSIGN_OR_RETURN(_read_chunk, RuntimeChunkHelper::new_chunk_checked(read_slots, _param.chunk_size));
+    return Status::OK();
+}
+
+ChunkPtr ColumnMaterializer::create_active_chunk() const {
+    return create_read_chunk(_active_slot_ids, true);
+}
+
+ChunkPtr ColumnMaterializer::create_lazy_chunk() const {
+    return create_read_chunk(_lazy_slot_ids, false);
+}
+
+ChunkPtr ColumnMaterializer::create_read_chunk(const std::vector<SlotId>& slot_ids,
+                                               bool include_reserved_fields) const {
+    auto chunk = std::make_shared<Chunk>();
+    chunk->columns().reserve(slot_ids.size());
+    for (SlotId slot_id : slot_ids) {
+        ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot_id);
+        chunk->append_column(column, slot_id);
+    }
+    if (include_reserved_fields && _param.reserved_field_slots != nullptr) {
+        for (const auto* slot : *_param.reserved_field_slots) {
+            ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot->id());
+            chunk->append_column(column, slot->id());
+        }
+    }
+    return chunk;
+}
+
+Status ColumnMaterializer::read_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter,
+                                     ChunkPtr* chunk) {
+    RETURN_IF_ERROR((*_column_readers)[slot_id]->read_range(range, filter, (*chunk)->get_column_by_slot_id(slot_id)));
+    _slot_cache[slot_id] = {(*chunk)->get_column_by_slot_id(slot_id)};
+    return Status::OK();
+}
+
+Status ColumnMaterializer::read_active_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk) {
+    return read_range(_active_column_indices, range, filter, chunk);
+}
+
+Status ColumnMaterializer::read_lazy_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk) {
+    return read_range(_lazy_column_indices, range, filter, chunk, true);
+}
+
+StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter,
+                                                                      ChunkPtr* chunk) {
+    DCHECK(_column_read_order_ctx != nullptr);
+    const std::vector<int>& read_order = _column_read_order_ctx->get_column_read_order();
+    size_t round_cost = 0;
+    double first_selectivity = -1;
+    DeferOp defer([&]() { _column_read_order_ctx->update_ctx(round_cost, first_selectivity); });
+    size_t hit_count = 0;
+
+    if (_param.reserved_field_slots != nullptr) {
+        for (const auto* slot : *_param.reserved_field_slots) {
+            SlotId slot_id = slot->id();
+            RETURN_IF_ERROR(read_slot(slot_id, range, filter, chunk));
+            if (_post_read_conjuncts_by_slot.find(slot_id) != _post_read_conjuncts_by_slot.end()) {
+                SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
+                std::vector<ExprContext*> ctxs = _post_read_conjuncts_by_slot.at(slot_id);
+                ASSIGN_OR_RETURN(hit_count, eval_slot_conjuncts(ctxs, slot_id, chunk, filter));
+                if (hit_count == 0) {
+                    break;
+                }
+            }
+        }
+    }
+    for (int col_idx : read_order) {
+        auto& column = _param.read_cols[col_idx];
+        round_cost += _column_read_order_ctx->get_column_cost(col_idx);
+        SlotId slot_id = column.slot_id();
+        RETURN_IF_ERROR(read_slot(slot_id, range, filter, chunk));
+
+        if (std::find(_dict_column_indices.begin(), _dict_column_indices.end(), col_idx) !=
+            _dict_column_indices.end()) {
+            SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
+            SCOPED_RAW_TIMER(&_param.stats->group_dict_filter_ns);
+            for (const auto& sub_field_path : _dict_column_sub_field_paths[col_idx]) {
+                RETURN_IF_ERROR(filter_dict_column(slot_id, (*chunk)->get_column_by_slot_id(slot_id), filter,
+                                                   sub_field_path, 0));
+                hit_count = SIMD::count_nonzero(*filter);
+                if (hit_count == 0) {
+                    return hit_count;
+                }
+            }
+        }
+
+        if (_post_read_conjuncts_by_slot.find(slot_id) != _post_read_conjuncts_by_slot.end()) {
+            SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
+            std::vector<ExprContext*> ctxs = _post_read_conjuncts_by_slot.at(slot_id);
+            ASSIGN_OR_RETURN(hit_count, eval_slot_conjuncts(ctxs, slot_id, chunk, filter));
+            if (hit_count == 0) {
+                break;
+            }
+        }
+        first_selectivity = first_selectivity < 0 ? hit_count * 1.0 / filter->size() : first_selectivity;
+    }
+
+    return hit_count;
+}
+
+Status ColumnMaterializer::rewrite_dict_conjuncts_to_predicate(bool* is_group_filtered) {
+    for (int col_idx : _dict_column_indices) {
+        const auto& column = _param.read_cols[col_idx];
+        SlotId slot_id = column.slot_id();
+        for (const auto& sub_field_path : _dict_column_sub_field_paths[col_idx]) {
+            if (*is_group_filtered) {
+                return Status::OK();
+            }
+            RETURN_IF_ERROR((*_column_readers)[slot_id]->rewrite_conjunct_ctxs_to_predicate(is_group_filtered,
+                                                                                            sub_field_path, 0));
+        }
+    }
+
+    return Status::OK();
+}
+
+Status ColumnMaterializer::filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
+                                              const std::vector<std::string>& sub_field_path, const size_t& layer) {
+    return (*_column_readers)[slot_id]->filter_dict_column(column, filter, sub_field_path, layer);
+}
+
+StatusOr<size_t> ColumnMaterializer::eval_slot_conjuncts(const std::vector<ExprContext*>& ctxs, SlotId slot_id,
+                                                         ChunkPtr* chunk, Filter* filter) {
+    auto temp_chunk = std::make_shared<Chunk>();
+    temp_chunk->columns().reserve(1);
+    ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
+    temp_chunk->append_column(column, slot_id);
+    return ChunkPredicateEvaluator::eval_conjuncts_into_filter(ctxs, temp_chunk.get(), filter);
+}
+
+Status ColumnMaterializer::read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range,
+                                      const Filter* filter, ChunkPtr* chunk, bool ignore_reserved_field) {
+    if (read_columns.empty() && _param.reserved_field_slots == nullptr) {
+        return Status::OK();
+    }
+    if (!ignore_reserved_field && _param.reserved_field_slots != nullptr) {
+        for (const auto& slot : *_param.reserved_field_slots) {
+            RETURN_IF_ERROR(read_slot(slot->id(), range, filter, chunk));
+        }
+    }
+
+    for (int col_idx : read_columns) {
+        const auto& column = _param.read_cols[col_idx];
+        RETURN_IF_ERROR(read_slot(column.slot_id(), range, filter, chunk));
+    }
+
+    return Status::OK();
+}
+
+Status ColumnMaterializer::fill_dst_column(SlotId slot_id, ColumnPtr& dst, ColumnPtr& src) {
+    return (*_column_readers)[slot_id]->fill_dst_column(dst, src);
+}
+
+void ColumnMaterializer::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end,
+                                           ColumnIOTypeFlags types) {
+    for (const auto& index : _active_column_indices) {
+        const auto& column = _param.read_cols[index];
+        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, true);
+    }
+
+    for (const auto& index : _lazy_column_indices) {
+        const auto& column = _param.read_cols[index];
+        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, false);
+    }
+}
+
+Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
+                                             const Range<uint64_t>& post_filter_range, const Filter& post_filter,
+                                             bool has_filter, ChunkPtr& active_chunk) {
+    ChunkPtr lazy_chunk = create_lazy_chunk();
+    if (has_filter) {
+        RETURN_IF_ERROR(read_lazy_range(post_filter_range, &post_filter, &lazy_chunk));
+        lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+    } else {
+        RETURN_IF_ERROR(read_lazy_range(full_range, nullptr, &lazy_chunk));
+    }
+    if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
+        return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
+                                                 active_chunk->num_rows(), lazy_chunk->num_rows()));
+    }
+    active_chunk->merge(std::move(*lazy_chunk));
+    _lazy_column_needed = true;
+    return Status::OK();
+}
+
+Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst,
+                                                 const std::unordered_set<SlotId>* skip_slots) {
+    for (const auto& column : _param.read_cols) {
+        SlotId slot_id = column.slot_id();
+        if (skip_slots && skip_slots->count(slot_id)) continue;
+        RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
+                                        active_chunk->get_column_by_slot_id(slot_id)));
+    }
+    if (_param.reserved_field_slots != nullptr) {
+        for (const auto* slot : *_param.reserved_field_slots) {
+            SlotId slot_id = slot->id();
+            RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
+                                            active_chunk->get_column_by_slot_id(slot_id)));
+        }
+    }
+    return Status::OK();
+}
+
+void ColumnMaterializer::classify_columns(const std::unordered_set<SlotId>& deferred_source_slots,
+                                          bool* out_has_reserved_field_filter) {
+    *out_has_reserved_field_filter = false;
+    const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
+    int read_col_idx = 0;
+    for (auto& column : _param.read_cols) {
+        if (column.is_extended_variant_virtual) {
+            ++read_col_idx;
+            continue;
+        }
+        SlotId slot_id = column.slot_id();
+        auto it = conjunct_ctxs_by_slot.find(slot_id);
+        if (it != conjunct_ctxs_by_slot.end()) {
+            for (ExprContext* ctx : it->second) {
+                std::vector<std::string> sub_field_path;
+                if (_try_use_dict_filter(read_col_idx, column, ctx, sub_field_path)) {
+                    add_dict_filter_column(read_col_idx, sub_field_path);
+                } else {
+                    add_post_read_conjunct(slot_id, ctx);
+                }
+            }
+            add_active_column(read_col_idx);
+        } else if (config::parquet_late_materialization_enable && deferred_source_slots.count(slot_id) == 0) {
+            add_lazy_column(read_col_idx);
+            (*_column_readers)[slot_id]->set_can_lazy_decode(true);
+        } else {
+            add_active_column(read_col_idx);
+        }
+        ++read_col_idx;
+    }
+
+    if (_param.reserved_field_slots != nullptr) {
+        for (auto* slot : *_param.reserved_field_slots) {
+            SlotId slot_id = slot->id();
+            auto it = conjunct_ctxs_by_slot.find(slot_id);
+            if (it != conjunct_ctxs_by_slot.end()) {
+                for (ExprContext* ctx : it->second) {
+                    add_post_read_conjunct(slot_id, ctx);
+                }
+                *out_has_reserved_field_filter = true;
+            }
+        }
+    }
+
+    rebuild_read_order_ctx();
+}
+
+bool ColumnMaterializer::_try_use_dict_filter(int col_idx, const GroupReaderParam::Column& column, ExprContext* ctx,
+                                              std::vector<std::string>& sub_field_path) {
+    const Expr* root_expr = ctx->root();
+    std::vector<std::vector<std::string>> subfields;
+    root_expr->get_subfields(&subfields);
+    for (int i = 1; i < subfields.size(); i++) {
+        if (subfields[i] != subfields[0]) {
+            return false;
+        }
+    }
+    if (subfields.size() != 0) {
+        sub_field_path = subfields[0];
+    }
+    return (*_column_readers)[column.slot_id()]->try_to_use_dict_filter(ctx, column.decode_needed, column.slot_id(),
+                                                                        sub_field_path, 0);
+}
+
+Status ColumnMaterializer::materialize_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter) {
+    if (_slot_cache.find(slot_id) != _slot_cache.end()) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(
+            (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
+    _slot_cache[slot_id] = {_read_chunk->get_column_by_slot_id(slot_id)};
+    return Status::OK();
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/column_materializer.h
+++ b/be/src/formats/parquet/column_materializer.h
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "common/global_types.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "exprs/expr_context.h"
+#include "formats/parquet/column_read_order_ctx.h"
+#include "formats/parquet/column_reader.h"
+#include "formats/parquet/group_reader.h"
+#include "storage/primitive/range.h"
+
+namespace starrocks::parquet {
+
+class ColumnMaterializer {
+public:
+    using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
+
+    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+            : _param(param), _column_readers(column_readers) {}
+
+    void clear_classification();
+    void add_active_column(int col_idx);
+    void add_lazy_column(int col_idx);
+    void add_active_slot(SlotId slot_id) { _active_slot_ids.push_back(slot_id); }
+    void promote_lazy_to_active();
+    void rebuild_read_order_ctx();
+
+    // Classify physical read_cols as active/lazy and populate dict-filter /
+    // post-read conjunct buckets.  _deferred_source_slots_ are variant-backed
+    // slots whose conjuncts are deferred until after projection.
+    void classify_columns(const std::unordered_set<SlotId>& deferred_source_slots, bool* out_has_reserved_field_filter);
+
+    const std::vector<int>& active_column_indices() const { return _active_column_indices; }
+    const std::vector<int>& lazy_column_indices() const { return _lazy_column_indices; }
+    std::vector<int>& mutable_active_column_indices() { return _active_column_indices; }
+    std::vector<int>& mutable_lazy_column_indices() { return _lazy_column_indices; }
+    std::vector<SlotId>& mutable_active_slot_ids() { return _active_slot_ids; }
+    const std::vector<SlotId>& active_slot_ids() const { return _active_slot_ids; }
+    const std::vector<SlotId>& lazy_slot_ids() const { return _lazy_slot_ids; }
+    ColumnReadOrderCtx* read_order_ctx() const { return _column_read_order_ctx.get(); }
+    size_t min_round_cost() const {
+        return _column_read_order_ctx == nullptr ? 0 : _column_read_order_ctx->get_min_round_cost();
+    }
+
+    void add_dict_filter_column(int col_idx, std::vector<std::string>& sub_field_path);
+    void add_post_read_conjunct(SlotId slot_id, ExprContext* ctx);
+    bool has_predicate_filter() const { return !_dict_column_indices.empty() || !_post_read_conjuncts_by_slot.empty(); }
+    size_t dict_filter_column_count() const { return _dict_column_indices.size(); }
+    const std::vector<int>& dict_column_indices() const { return _dict_column_indices; }
+    const std::unordered_map<int, std::vector<std::vector<std::string>>>& dict_column_sub_field_paths() const {
+        return _dict_column_sub_field_paths;
+    }
+    const std::unordered_map<SlotId, std::vector<ExprContext*>>& post_read_conjuncts_by_slot() const {
+        return _post_read_conjuncts_by_slot;
+    }
+
+    // Read chunk lifecycle (owned by this materializer)
+    Status init_read_chunk();
+    const ChunkPtr& read_chunk() const { return _read_chunk; }
+    // Mutable access for unit tests that bypass init_read_chunk().
+    ChunkPtr& mutable_read_chunk() { return _read_chunk; }
+    void reset_read_chunk() {
+        if (_read_chunk) _read_chunk->reset();
+        _slot_cache.clear();
+    }
+
+    ChunkPtr create_active_chunk() const;
+    ChunkPtr create_lazy_chunk() const;
+
+    Status read_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
+
+    Status read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range, const Filter* filter,
+                      ChunkPtr* chunk, bool ignore_reserved_field = false);
+    Status read_active_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
+    Status read_lazy_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
+    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
+
+    Status rewrite_dict_conjuncts_to_predicate(bool* is_group_filtered);
+    Status filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
+                              const std::vector<std::string>& sub_field_path, const size_t& layer);
+    StatusOr<size_t> eval_slot_conjuncts(const std::vector<ExprContext*>& ctxs, SlotId slot_id, ChunkPtr* chunk,
+                                         Filter* filter);
+
+    Status fill_dst_column(SlotId slot_id, ColumnPtr& dst, ColumnPtr& src);
+
+    // Per-slot cache scoped to the current get_next() range.  Populated by
+    // read_slot(); cleared by reset_read_chunk().  Avoids repeated Parquet
+    // I/O when the same slot is referenced by multiple expression branches.
+    struct SlotCacheEntry {
+        ColumnPtr values;
+    };
+    const SlotCacheEntry* get_slot_cache(SlotId slot_id) const {
+        auto it = _slot_cache.find(slot_id);
+        return it != _slot_cache.end() ? &it->second : nullptr;
+    }
+
+    // On-demand single-slot materialization.  Reads the slot through its
+    // ColumnReader into _read_chunk and populates _slot_cache.  Returns OK
+    // (no-op) if the slot is already cached for the current range.
+    Status materialize_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter);
+
+    // Post-filter lazy-column backfill.
+    Status read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
+                             const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk);
+    // Emit physical + reserved-field columns into dst. Skips slots listed in skip_slots.
+    Status emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst,
+                                 const std::unordered_set<SlotId>* skip_slots = nullptr);
+
+    bool lazy_column_needed() const { return _lazy_column_needed; }
+    void set_lazy_column_needed(bool v) { _lazy_column_needed = v; }
+
+    void collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end,
+                           ColumnIOTypeFlags types);
+
+private:
+    const GroupReaderParam& _param;
+    ColumnReaderMap* _column_readers = nullptr;
+
+    // Physical read column classification:
+    // - _active_column_indices and _lazy_column_indices partition physical
+    //   entries from GroupReaderParam::read_cols, excluding variant virtual
+    //   projection slots that do not have their own physical reader.
+    // - Active columns are read before predicate evaluation can finish; lazy
+    //   columns are read only after row filtering has produced the final row set.
+    // - *_slot_ids mirror those column-index sets for Chunk construction and
+    //   may additionally include hidden variant source slots. Therefore slot-id
+    //   lists are not a strict projection of read_cols.
+    std::vector<int> _active_column_indices;
+    std::vector<int> _lazy_column_indices;
+    std::vector<SlotId> _active_slot_ids;
+    std::vector<SlotId> _lazy_slot_ids;
+
+    // Predicate classification refines active columns:
+    // - _dict_column_indices is a subset of _active_column_indices. These
+    //   columns have one or more conjuncts that ColumnReader can evaluate on
+    //   dictionary values before full decode; subfield paths record which part
+    //   of a complex value the dict predicate targets.
+    // - _post_read_conjuncts_by_slot contains remaining conjuncts keyed by the
+    //   slot they need. A slot may be a physical read_col, a reserved field, or
+    //   a promoted variant virtual slot. These conjuncts run immediately after
+    //   their slot's column is read into the working chunk.
+    // - A conjunct belongs to exactly one of the dict-filter bucket or the
+    //   post-read bucket; slots without predicates appear in neither bucket.
+    std::vector<int> _dict_column_indices;
+    std::unordered_map<int, std::vector<std::vector<std::string>>> _dict_column_sub_field_paths;
+    std::unordered_map<SlotId, std::vector<ExprContext*>> _post_read_conjuncts_by_slot;
+
+    ChunkPtr create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields) const;
+
+    bool _try_use_dict_filter(int col_idx, const GroupReaderParam::Column& column, ExprContext* ctx,
+                              std::vector<std::string>& sub_field_path);
+
+    std::unique_ptr<ColumnReadOrderCtx> _column_read_order_ctx;
+
+    ChunkPtr _read_chunk;
+
+    // Per-range slot cache: populated by read_slot(), cleared by reset_read_chunk().
+    std::unordered_map<SlotId, SlotCacheEntry> _slot_cache;
+
+    bool _lazy_column_needed = false;
+};
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -23,16 +23,15 @@
 #include <utility>
 
 #include "base/simd/simd.h"
-#include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "common/config_scan_io_fwd.h"
 #include "common/statusor.h"
 #include "common/system/master_info.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
-#include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
@@ -44,7 +43,6 @@
 #include "formats/parquet/schema.h"
 #include "formats/parquet/variant_projection.h"
 #include "gen_cpp/Exprs_types.h"
-#include "runtime/chunk_helper.h"
 #include "types/type_descriptor.h"
 #include "utils.h"
 
@@ -92,6 +90,7 @@ GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, SkipRows
                          int64_t row_group_first_row)
         : _row_group_first_row(row_group_first_row), _skip_rows_ctx(std::move(skip_rows_ctx)), _param(param) {
     _row_group_metadata = &_param.file_metadata->t_metadata().row_groups[row_group_number];
+    _column_materializer = std::make_unique<ColumnMaterializer>(_param, &_column_readers);
     _variant = std::make_unique<VariantProjectionHandler>(this, _param, _row_group_metadata);
 }
 
@@ -102,6 +101,7 @@ GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, SkipRows
           _skip_rows_ctx(std::move(skip_rows_ctx)),
           _param(param) {
     _row_group_metadata = &_param.file_metadata->t_metadata().row_groups[row_group_number];
+    _column_materializer = std::make_unique<ColumnMaterializer>(_param, &_column_readers);
     _variant = std::make_unique<VariantProjectionHandler>(this, _param, _row_group_metadata);
 }
 
@@ -110,15 +110,15 @@ GroupReader::~GroupReader() {
         _param.sb_stream->release_to_offset(_end_offset);
     }
     if (_has_prepared) {
-        if (_lazy_column_needed) {
+        if (_column_materializer->lazy_column_needed()) {
             _param.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
         } else {
             _param.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
         }
-        _param.stats->group_min_round_cost = _param.stats->group_min_round_cost == 0
-                                                     ? _column_read_order_ctx->get_min_round_cost()
-                                                     : std::min(_param.stats->group_min_round_cost,
-                                                                int64_t(_column_read_order_ctx->get_min_round_cost()));
+        _param.stats->group_min_round_cost =
+                _param.stats->group_min_round_cost == 0
+                        ? _column_materializer->min_round_cost()
+                        : std::min(_param.stats->group_min_round_cost, int64_t(_column_materializer->min_round_cost()));
     }
 }
 
@@ -159,8 +159,9 @@ Status GroupReader::prepare() {
         RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, counter >= 0));
     }
 
-    RETURN_IF_ERROR(_rewrite_conjunct_ctxs_to_predicates(&_is_group_filtered));
-    RETURN_IF_ERROR(_init_read_chunk());
+    RETURN_IF_ERROR(_column_materializer->rewrite_dict_conjuncts_to_predicate(&_is_group_filtered));
+    RETURN_IF_ERROR(_column_materializer->init_read_chunk());
+    _variant->init_read_chunk_slots();
 
     if (!_is_group_filtered) {
         _range_iter = _range.new_iterator();
@@ -218,9 +219,9 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         return Status::EndOfFile("");
     }
 
-    _read_chunk->reset();
+    _column_materializer->reset_read_chunk();
     _variant->reset_iteration_state();
-    ChunkPtr active_chunk = _create_read_chunk(_active_slot_ids);
+    ChunkPtr active_chunk = _column_materializer->create_active_chunk();
 
     while (true) {
         if (!_range_iter.has_more()) {
@@ -284,9 +285,9 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         }
 
         // 5. Backfill lazy physical columns
-        if (!_lazy_column_indices.empty()) {
-            _lazy_column_needed = true;
-            RETURN_IF_ERROR(_read_lazy_columns(r, post_filter_range, post_filter, has_filter, active_chunk));
+        if (!_column_materializer->lazy_column_indices().empty()) {
+            RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, has_filter,
+                                                                    active_chunk));
         }
 
         // 6. Backfill lazy variant sources
@@ -301,7 +302,10 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
             if (_variant->has_projections()) {
                 RETURN_IF_ERROR(_variant->emit_projections(active_chunk, chunk, _variant->projection_timezone()));
             }
-            RETURN_IF_ERROR(_emit_physical_columns(active_chunk, chunk));
+            {
+                auto skip_slots = _variant->projection_slot_ids();
+                RETURN_IF_ERROR(_column_materializer->emit_physical_columns(active_chunk, chunk, &skip_slots));
+            }
         }
         break;
     }
@@ -328,161 +332,20 @@ StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter
 
 StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
                                                             ChunkPtr& active_chunk, bool& has_filter, size_t count) {
-    if (!_dict_column_indices.empty() || !_left_no_dict_filter_conjuncts_by_slot.empty()) {
+    if (_column_materializer->has_predicate_filter()) {
         has_filter = true;
-        ASSIGN_OR_RETURN(size_t hit_count, _read_range_round_by_round(r, &chunk_filter, &active_chunk));
+        ASSIGN_OR_RETURN(size_t hit_count,
+                         _column_materializer->read_active_range_round_by_round(r, &chunk_filter, &active_chunk));
         if (hit_count == 0) {
             _param.stats->late_materialize_skip_rows += count;
             return false;
         }
     } else if (has_filter) {
-        RETURN_IF_ERROR(_read_range(_active_column_indices, r, &chunk_filter, &active_chunk));
+        RETURN_IF_ERROR(_column_materializer->read_active_range(r, &chunk_filter, &active_chunk));
     } else {
-        RETURN_IF_ERROR(_read_range(_active_column_indices, r, nullptr, &active_chunk));
+        RETURN_IF_ERROR(_column_materializer->read_active_range(r, nullptr, &active_chunk));
     }
     return true;
-}
-
-// ── 5. Backfill lazy physical columns ──────
-
-Status GroupReader::_read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
-                                       const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk) {
-    ChunkPtr lazy_chunk = _create_read_chunk(_lazy_slot_ids, false);
-    if (has_filter) {
-        RETURN_IF_ERROR(_read_range(_lazy_column_indices, post_filter_range, &post_filter, &lazy_chunk, true));
-        lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
-    } else {
-        RETURN_IF_ERROR(_read_range(_lazy_column_indices, full_range, nullptr, &lazy_chunk, true));
-    }
-    if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
-        return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
-                                                 active_chunk->num_rows(), lazy_chunk->num_rows()));
-    }
-    active_chunk->merge(std::move(*lazy_chunk));
-    return Status::OK();
-}
-
-// ── 7. Emit physical columns ──────
-
-Status GroupReader::_emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst) {
-    for (const auto& column : _param.read_cols) {
-        SlotId slot_id = column.slot_id();
-        // Skip virtual projection slots: handled by emit_projections.
-        if (_variant->has_projections() && _variant->is_virtual_slot(slot_id)) continue;
-        RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*dst)->get_column_by_slot_id(slot_id),
-                                                                  active_chunk->get_column_by_slot_id(slot_id)));
-    }
-    if (_param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
-            SlotId slot_id = slot->id();
-            RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*dst)->get_column_by_slot_id(slot_id),
-                                                                      active_chunk->get_column_by_slot_id(slot_id)));
-        }
-    }
-    return Status::OK();
-}
-
-void GroupReader::_rebuild_column_read_order_ctx() {
-    std::unordered_map<int, size_t> col_cost;
-    size_t all_cost = 0;
-    for (int col_idx : _active_column_indices) {
-        size_t flat_size = _param.read_cols[col_idx].slot_type().get_flat_size();
-        col_cost[col_idx] = flat_size;
-        all_cost += flat_size;
-    }
-    _column_read_order_ctx =
-            std::make_unique<ColumnReadOrderCtx>(_active_column_indices, all_cost, std::move(col_cost));
-}
-
-// ── _read_range / _read_range_round_by_round ──────
-
-Status GroupReader::_read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range,
-                                const Filter* filter, ChunkPtr* chunk, bool ignore_reserved_field) {
-    if (read_columns.empty() && _param.reserved_field_slots == nullptr) {
-        return Status::OK();
-    }
-    if (!ignore_reserved_field && _param.reserved_field_slots != nullptr) {
-        for (const auto& slot : *_param.reserved_field_slots) {
-            SlotId slot_id = slot->id();
-            RETURN_IF_ERROR(
-                    _column_readers[slot_id]->read_range(range, filter, (*chunk)->get_column_by_slot_id(slot_id)));
-        }
-    }
-
-    for (int col_idx : read_columns) {
-        auto& column = _param.read_cols[col_idx];
-        SlotId slot_id = column.slot_id();
-        RETURN_IF_ERROR(_column_readers[slot_id]->read_range(range, filter, (*chunk)->get_column_by_slot_id(slot_id)));
-    }
-
-    return Status::OK();
-}
-
-StatusOr<size_t> GroupReader::_read_range_round_by_round(const Range<uint64_t>& range, Filter* filter,
-                                                         ChunkPtr* chunk) {
-    const std::vector<int>& read_order = _column_read_order_ctx->get_column_read_order();
-    size_t round_cost = 0;
-    double first_selectivity = -1;
-    DeferOp defer([&]() { _column_read_order_ctx->update_ctx(round_cost, first_selectivity); });
-    size_t hit_count = 0;
-
-    if (_param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
-            SlotId slot_id = slot->id();
-            RETURN_IF_ERROR(
-                    _column_readers[slot_id]->read_range(range, filter, (*chunk)->get_column_by_slot_id(slot_id)));
-            if (_left_no_dict_filter_conjuncts_by_slot.find(slot_id) != _left_no_dict_filter_conjuncts_by_slot.end()) {
-                SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
-                std::vector<ExprContext*> ctxs = _left_no_dict_filter_conjuncts_by_slot.at(slot_id);
-                auto temp_chunk = std::make_shared<Chunk>();
-                temp_chunk->columns().reserve(1);
-                ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
-                temp_chunk->append_column(column, slot_id);
-                ASSIGN_OR_RETURN(hit_count,
-                                 ChunkPredicateEvaluator::eval_conjuncts_into_filter(ctxs, temp_chunk.get(), filter));
-                if (hit_count == 0) {
-                    break;
-                }
-            }
-        }
-    }
-    for (int col_idx : read_order) {
-        auto& column = _param.read_cols[col_idx];
-        round_cost += _column_read_order_ctx->get_column_cost(col_idx);
-        SlotId slot_id = column.slot_id();
-        RETURN_IF_ERROR(_column_readers[slot_id]->read_range(range, filter, (*chunk)->get_column_by_slot_id(slot_id)));
-
-        if (std::find(_dict_column_indices.begin(), _dict_column_indices.end(), col_idx) !=
-            _dict_column_indices.end()) {
-            SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
-            SCOPED_RAW_TIMER(&_param.stats->group_dict_filter_ns);
-            for (const auto& sub_field_path : _dict_column_sub_field_paths[col_idx]) {
-                RETURN_IF_ERROR(_column_readers[slot_id]->filter_dict_column((*chunk)->get_column_by_slot_id(slot_id),
-                                                                             filter, sub_field_path, 0));
-                hit_count = SIMD::count_nonzero(*filter);
-                if (hit_count == 0) {
-                    return hit_count;
-                }
-            }
-        }
-
-        if (_left_no_dict_filter_conjuncts_by_slot.find(slot_id) != _left_no_dict_filter_conjuncts_by_slot.end()) {
-            SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
-            std::vector<ExprContext*> ctxs = _left_no_dict_filter_conjuncts_by_slot.at(slot_id);
-            auto temp_chunk = std::make_shared<Chunk>();
-            temp_chunk->columns().reserve(1);
-            ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
-            temp_chunk->append_column(column, slot_id);
-            ASSIGN_OR_RETURN(hit_count,
-                             ChunkPredicateEvaluator::eval_conjuncts_into_filter(ctxs, temp_chunk.get(), filter));
-            if (hit_count == 0) {
-                break;
-            }
-        }
-        first_selectivity = first_selectivity < 0 ? hit_count * 1.0 / filter->size() : first_selectivity;
-    }
-
-    return hit_count;
 }
 
 // ── Column reader creation ─────────────────────────────────────────────────
@@ -703,189 +566,25 @@ Status GroupReader::_prepare_column_readers() const {
 }
 
 void GroupReader::_process_columns_and_conjunct_ctxs() {
-    const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
-
-    // ── Step 1: Classify physical read_cols into active / lazy ───────────────
-    std::unordered_set<SlotId> deferred_physical_source_slots = _variant->deferred_conjunct_physical_source_slots();
+    // ── Variant setup ─────────────────────────────────────────────────────────
+    auto deferred_slots = _variant->deferred_conjunct_physical_source_slots();
     _variant->collect_deferred_conjuncts();
 
-    int read_col_idx = 0;
-    for (auto& column : _param.read_cols) {
-        if (column.is_extended_variant_virtual) {
-            ++read_col_idx;
-            continue;
-        }
-        SlotId slot_id = column.slot_id();
-        auto it = conjunct_ctxs_by_slot.find(slot_id);
-        if (it != conjunct_ctxs_by_slot.end()) {
-            for (ExprContext* ctx : it->second) {
-                std::vector<std::string> sub_field_path;
-                if (_try_to_use_dict_filter(column, ctx, sub_field_path, column.decode_needed)) {
-                    _use_as_dict_filter_column(read_col_idx, slot_id, sub_field_path);
-                } else {
-                    _left_conjunct_ctxs.push_back(ctx);
-                    _left_no_dict_filter_conjuncts_by_slot[slot_id].push_back(ctx);
-                }
-            }
-            _active_column_indices.push_back(read_col_idx);
-        } else if (config::parquet_late_materialization_enable && deferred_physical_source_slots.count(slot_id) == 0) {
-            _lazy_column_indices.push_back(read_col_idx);
-            _column_readers[slot_id]->set_can_lazy_decode(true);
-        } else {
-            _active_column_indices.push_back(read_col_idx);
-        }
-        ++read_col_idx;
-    }
-
-    // ── Step 2: Reserved field conjuncts ─────────────────────────────────────
+    // ── Classify physical columns and conjuncts ───────────────────────────────
     bool has_reserved_field_filter = false;
-    if (_param.reserved_field_slots != nullptr) {
-        for (auto* slot : *_param.reserved_field_slots) {
-            SlotId slot_id = slot->id();
-            auto it = conjunct_ctxs_by_slot.find(slot_id);
-            if (it != conjunct_ctxs_by_slot.end()) {
-                for (ExprContext* ctx : it->second) {
-                    _left_no_dict_filter_conjuncts_by_slot[slot_id].push_back(ctx);
-                }
-                has_reserved_field_filter = true;
-            }
-        }
-    }
+    _column_materializer->classify_columns(deferred_slots, &has_reserved_field_filter);
 
-    // ── Step 3: Build ColumnReadOrderCtx ─────────────────────────────────────
-    {
-        std::unordered_map<int, size_t> col_cost;
-        size_t all_cost = 0;
-        for (int col_idx : _active_column_indices) {
-            size_t flat_size = _param.read_cols[col_idx].slot_type().get_flat_size();
-            col_cost[col_idx] = flat_size;
-            all_cost += flat_size;
-        }
-        _column_read_order_ctx =
-                std::make_unique<ColumnReadOrderCtx>(_active_column_indices, all_cost, std::move(col_cost));
-    }
-
-    // ── Step 4: Classify hidden variant sources (active vs lazy) ─────────────
+    // ── Variant hidden source classification ──────────────────────────────────
     _variant->classify_hidden_sources();
-
-    // ── Step 5: Build unified SlotId lists for _create_read_chunk ────────────
-    for (int idx : _active_column_indices) {
-        _active_slot_ids.push_back(_param.read_cols[idx].slot_id());
-    }
-    for (SlotId slot_id : _variant->active_hidden_slot_ids()) {
-        _active_slot_ids.push_back(slot_id);
-    }
-    for (int idx : _lazy_column_indices) {
-        _lazy_slot_ids.push_back(_param.read_cols[idx].slot_id());
+    for (SlotId sid : _variant->active_hidden_slot_ids()) {
+        _column_materializer->add_active_slot(sid);
     }
 
-    // ── Step 6: Promote all lazy columns to active when active_chunk is empty ─
-    if (_active_slot_ids.empty() && !has_reserved_field_filter) {
-        _active_column_indices.swap(_lazy_column_indices);
-        _active_slot_ids.swap(_lazy_slot_ids);
+    // ── Promote lazy to active when no active columns exist ───────────────────
+    if (_column_materializer->active_slot_ids().empty() && !has_reserved_field_filter) {
+        _column_materializer->promote_lazy_to_active();
         _variant->promote_lazy_to_active();
     }
-}
-
-// ── Dict-filter support ─────────────────────────────────────────────────────
-
-bool GroupReader::_try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
-                                          std::vector<std::string>& sub_field_path, bool is_decode_needed) {
-    const Expr* root_expr = ctx->root();
-    std::vector<std::vector<std::string>> subfields;
-    root_expr->get_subfields(&subfields);
-
-    for (int i = 1; i < subfields.size(); i++) {
-        if (subfields[i] != subfields[0]) {
-            return false;
-        }
-    }
-
-    if (subfields.size() != 0) {
-        sub_field_path = subfields[0];
-    }
-
-    if (_column_readers[column.slot_id()]->try_to_use_dict_filter(ctx, is_decode_needed, column.slot_id(),
-                                                                  sub_field_path, 0)) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-void GroupReader::_use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path) {
-    _dict_column_indices.emplace_back(col_idx);
-    if (_dict_column_sub_field_paths.find(col_idx) == _dict_column_sub_field_paths.end()) {
-        _dict_column_sub_field_paths.insert({col_idx, std::vector<std::vector<std::string>>({sub_field_path})});
-    } else {
-        _dict_column_sub_field_paths[col_idx].emplace_back(sub_field_path);
-    }
-}
-
-Status GroupReader::_rewrite_conjunct_ctxs_to_predicates(bool* is_group_filtered) {
-    for (int col_idx : _dict_column_indices) {
-        const auto& column = _param.read_cols[col_idx];
-        SlotId slot_id = column.slot_id();
-        for (const auto& sub_field_path : _dict_column_sub_field_paths[col_idx]) {
-            if (*is_group_filtered) {
-                return Status::OK();
-            }
-            RETURN_IF_ERROR(
-                    _column_readers[slot_id]->rewrite_conjunct_ctxs_to_predicate(is_group_filtered, sub_field_path, 0));
-        }
-    }
-
-    return Status::OK();
-}
-
-StatusOr<bool> GroupReader::_filter_chunk_with_dict_filter(ChunkPtr* chunk, Filter* filter) {
-    if (_dict_column_indices.size() == 0) {
-        return false;
-    }
-    for (int col_idx : _dict_column_indices) {
-        const auto& column = _param.read_cols[col_idx];
-        SlotId slot_id = column.slot_id();
-        for (const auto& sub_field_path : _dict_column_sub_field_paths[col_idx]) {
-            RETURN_IF_ERROR(_column_readers[slot_id]->filter_dict_column((*chunk)->get_column_by_slot_id(slot_id),
-                                                                         filter, sub_field_path, 0));
-        }
-    }
-    return true;
-}
-
-// ── Read chunk management ───────────────────────────────────────────────────
-
-ChunkPtr GroupReader::_create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields) {
-    auto chunk = std::make_shared<Chunk>();
-    chunk->columns().reserve(slot_ids.size());
-    for (SlotId slot_id : slot_ids) {
-        ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot_id);
-        chunk->append_column(column, slot_id);
-    }
-    if (include_reserved_fields && _param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
-            ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot->id());
-            chunk->append_column(column, slot->id());
-        }
-    }
-    return chunk;
-}
-
-Status GroupReader::_init_read_chunk() {
-    std::vector<SlotDescriptor*> read_slots;
-    read_slots.reserve(_param.read_cols.size());
-    for (const auto& column : _param.read_cols) {
-        read_slots.emplace_back(column.slot_desc);
-    }
-    if (_param.reserved_field_slots != nullptr) {
-        for (auto* slot : *_param.reserved_field_slots) {
-            read_slots.push_back(slot);
-        }
-    }
-    size_t chunk_size = _param.chunk_size;
-    ASSIGN_OR_RETURN(_read_chunk, RuntimeChunkHelper::new_chunk_checked(read_slots, chunk_size));
-    _variant->init_read_chunk_slots();
-    return Status::OK();
 }
 
 // ── IO range collection ─────────────────────────────────────────────────────
@@ -893,17 +592,7 @@ Status GroupReader::_init_read_chunk() {
 void GroupReader::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                     ColumnIOTypeFlags types) {
     int64_t end = 0;
-    for (const auto& index : _active_column_indices) {
-        const auto& column = _param.read_cols[index];
-        SlotId slot_id = column.slot_id();
-        _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, true);
-    }
-
-    for (const auto& index : _lazy_column_indices) {
-        const auto& column = _param.read_cols[index];
-        SlotId slot_id = column.slot_id();
-        _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, false);
-    }
+    _column_materializer->collect_io_ranges(ranges, &end, types);
     _variant->collect_io_ranges(ranges, &end, types);
     deduplicate_io_ranges(ranges);
     *end_offset = end;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -31,7 +31,6 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "exprs/expr_context.h"
-#include "formats/parquet/column_read_order_ctx.h"
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/metadata.h"
@@ -48,6 +47,7 @@ class TIcebergSchemaField;
 class THdfsScanRange;
 
 namespace parquet {
+class ColumnMaterializer;
 class FileMetaData;
 class VariantProjectionHandler;
 } // namespace parquet
@@ -162,19 +162,6 @@ private:
     bool _try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
                                  std::vector<std::string>& sub_field_path, bool is_decode_needed);
     Status _prepare_column_readers() const;
-    Status _deal_with_pageindex();
-    Status _init_read_chunk();
-    ChunkPtr _create_read_chunk(const std::vector<SlotId>& slot_ids, bool include_reserved_fields = true);
-
-    // ── Dict-filter support ──────────────────────────────────────────────────
-    void _use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path);
-    Status _rewrite_conjunct_ctxs_to_predicates(bool* is_group_filtered);
-    StatusOr<bool> _filter_chunk_with_dict_filter(ChunkPtr* chunk, Filter* filter);
-
-    // ── Range read helpers ───────────────────────────────────────────────────
-    Status _read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range, const Filter* filter,
-                       ChunkPtr* chunk, bool ignore_reserved_field = false);
-    StatusOr<size_t> _read_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
 
     // ── get_next() pipeline phases ───────────────────────────────────────────
     //
@@ -188,17 +175,6 @@ private:
     StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
                                                    ChunkPtr& active_chunk, bool& has_filter, size_t count);
 
-    // 5. Backfill lazy physical columns (no predicates).
-    Status _read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
-                              const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk);
-
-    // 7. Emit physical columns from active_chunk into the output chunk.
-    Status _emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst);
-
-    // Rebuild ColumnReadOrderCtx from current _active_column_indices.
-    // Called after variant promotion modifies the active column set.
-    void _rebuild_column_read_order_ctx();
-
     // ── Member variables ─────────────────────────────────────────────────────
 
     // row group meta
@@ -210,22 +186,15 @@ private:
     // column readers for column chunk in row group
     std::unordered_map<SlotId, std::unique_ptr<ColumnReader>> _column_readers;
 
+    // Column materialization layer over ColumnReaders. Predicate classification
+    // still lives in GroupReader until the next refactor steps.
+    std::unique_ptr<ColumnMaterializer> _column_materializer;
+
     // ── Variant handler (always present; empty() when no variant columns) ───
     std::unique_ptr<VariantProjectionHandler> _variant;
 
-    // active columns that hold read_col index
-    std::vector<int> _active_column_indices;
-    // lazy columns that hold read_col index
-    std::vector<int> _lazy_column_indices;
-    // load lazy column or not
-    bool _lazy_column_needed = false;
-
     // dict value is empty after conjunct eval, file group can be skipped
     bool _is_group_filtered = false;
-
-    // Column backing store for each get_next() call.  Initialized once in
-    // _init_read_chunk() and reset at the start of every range iteration.
-    ChunkPtr _read_chunk;
 
     // param for read row group
     const GroupReaderParam& _param;
@@ -238,27 +207,11 @@ private:
 
     bool _global_dict_applied_in_group = false;
 
-    // columns(index) use as dict filter column
-    std::vector<int> _dict_column_indices;
-    std::unordered_map<int, std::vector<std::vector<std::string>>> _dict_column_sub_field_paths;
-    std::unordered_map<SlotId, std::vector<ExprContext*>> _left_no_dict_filter_conjuncts_by_slot;
-
-    // conjunct ctxs that eval after chunk is dict decoded
-    std::vector<ExprContext*> _left_conjunct_ctxs;
-
     SparseRange<uint64_t> _range;
     SparseRangeIterator<uint64_t> _range_iter;
 
-    // round by round ctx
-    std::unique_ptr<ColumnReadOrderCtx> _column_read_order_ctx;
-
     // a flag to reflect prepare() is called
     bool _has_prepared = false;
-
-    // Unified slot id lists for _create_read_chunk.  Populated by
-    // _process_columns_and_conjunct_ctxs().
-    std::vector<SlotId> _active_slot_ids;
-    std::vector<SlotId> _lazy_slot_ids;
 };
 
 using GroupReaderPtr = std::shared_ptr<GroupReader>;

--- a/be/src/formats/parquet/lazy_materialization_context.h
+++ b/be/src/formats/parquet/lazy_materialization_context.h
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/column.h"
+#include "common/global_types.h"
+#include "common/status.h"
+#include "storage/primitive/range.h"
+
+namespace starrocks::parquet {
+
+class ColumnMaterializer;
+
+// Expression-facing facade over ColumnMaterializer.  Provides on-demand
+// single-slot materialization to the scanner-local predicate evaluator.
+//
+// Lifetime: created per get_next() range/batch, destroyed before the
+// scanner emits a fully materialized chunk.  No lazy state leaks out.
+class LazyMaterializationContext {
+public:
+    LazyMaterializationContext(ColumnMaterializer* materializer, const Range<uint64_t>& range, const Filter* filter)
+            : _materializer(materializer), _range(range), _filter(filter) {}
+
+    bool has_slot(SlotId slot_id) const { return _materializer->get_slot_cache(slot_id) != nullptr; }
+
+    Status ensure_slot_materialized(SlotId slot_id) {
+        return _materializer->materialize_slot(slot_id, _range, _filter);
+    }
+
+    ColumnPtr get_column(SlotId slot_id) const {
+        auto* entry = _materializer->get_slot_cache(slot_id);
+        return entry ? entry->values : nullptr;
+    }
+
+private:
+    ColumnMaterializer* _materializer;
+    Range<uint64_t> _range;
+    const Filter* _filter;
+};
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -32,6 +32,7 @@
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/decimal_cast_expr.h"
 #include "exprs/variant_path_reader.h"
+#include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/group_reader.h" // for GroupReaderParam
@@ -559,8 +560,8 @@ void VariantProjectionHandler::select_hidden_source_offset_index() {
 
 bool VariantProjectionHandler::try_promote() {
     auto& column_readers = _group_reader->_column_readers;
-    auto& active_column_indices = _group_reader->_active_column_indices;
-    auto& active_slot_ids = _group_reader->_active_slot_ids;
+    auto& active_column_indices = _group_reader->_column_materializer->mutable_active_column_indices();
+    auto& active_slot_ids = _group_reader->_column_materializer->mutable_active_slot_ids();
     const auto& read_cols = _param.read_cols;
     const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
     const uint64_t rg_num_rows = _row_group_metadata->num_rows;
@@ -648,10 +649,9 @@ bool VariantProjectionHandler::try_promote() {
                 for (ExprContext* ctx : conjuncts) {
                     std::vector<std::string> sub_field_path;
                     if (proxy->try_to_use_dict_filter(ctx, vsi.decode_needed, vsi.virtual_slot_id, sub_field_path, 0)) {
-                        _group_reader->_use_as_dict_filter_column(vsi.read_col_idx, vsi.virtual_slot_id,
-                                                                  sub_field_path);
+                        _group_reader->_column_materializer->add_dict_filter_column(vsi.read_col_idx, sub_field_path);
                     } else {
-                        _group_reader->_left_no_dict_filter_conjuncts_by_slot[vsi.virtual_slot_id].push_back(ctx);
+                        _group_reader->_column_materializer->add_post_read_conjunct(vsi.virtual_slot_id, ctx);
                     }
                 }
             }
@@ -677,7 +677,7 @@ bool VariantProjectionHandler::try_promote() {
 
     if (!any_promoted) return false;
 
-    _group_reader->_rebuild_column_read_order_ctx();
+    _group_reader->_column_materializer->rebuild_read_order_ctx();
 
     // Rebuild deferred conjunct list excluding promoted slots.
     std::vector<ExprContext*> remaining;
@@ -704,7 +704,7 @@ bool VariantProjectionHandler::try_promote() {
 // ── Lazy→active promotion ───────────
 
 void VariantProjectionHandler::promote_lazy_to_active() {
-    auto& active_slot_ids = _group_reader->_active_slot_ids;
+    auto& active_slot_ids = _group_reader->_column_materializer->mutable_active_slot_ids();
     // When active_chunk is empty (no physical active columns + no active hidden sources),
     // promote lazy hidden sources to active so they contribute a row count.
     // The caller already swapped physical active/lazy; we just migrate hidden sources.
@@ -729,7 +729,7 @@ void VariantProjectionHandler::collect_io_ranges(std::vector<SharedBufferedInput
 // ── Read chunk init ──────────────────────────────────────────────────────────
 
 void VariantProjectionHandler::init_read_chunk_slots() {
-    ChunkPtr& read_chunk = _group_reader->_read_chunk;
+    ChunkPtr& read_chunk = _group_reader->_column_materializer->mutable_read_chunk();
     for (SlotId slot_id : _active_hidden_slot_ids) {
         auto hidden_column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
         read_chunk->append_column(std::move(hidden_column), slot_id);
@@ -880,6 +880,13 @@ const cctz::time_zone& VariantProjectionHandler::projection_timezone() {
         _timezone_obj = cctz::utc_time_zone();
     }
     return _timezone_obj;
+}
+
+std::unordered_set<SlotId> VariantProjectionHandler::projection_slot_ids() const {
+    std::unordered_set<SlotId> ids;
+    ids.reserve(_projections.size());
+    for (const auto& [id, _] : _projections) ids.insert(id);
+    return ids;
 }
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/variant_projection.h
+++ b/be/src/formats/parquet/variant_projection.h
@@ -140,6 +140,7 @@ public:
     Status emit_projections(ChunkPtr& active_chunk, ChunkPtr* dst, const cctz::time_zone& zone);
     bool has_projections() const { return !_projections.empty(); }
     bool is_virtual_slot(SlotId slot_id) const { return _projections.count(slot_id) > 0; }
+    std::unordered_set<SlotId> projection_slot_ids() const;
 
     //    Reset per-iteration state (call at start of each get_next() call).
     void reset_iteration_state();

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -42,6 +42,7 @@
 #include "exprs/expr_factory.h"
 #include "exprs/in_const_predicate.hpp"
 #include "formats/parquet/column_chunk_reader.h"
+#include "formats/parquet/column_materializer.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/page_reader.h"
 #include "formats/parquet/parquet_block_split_bloom_filter.h"
@@ -1281,8 +1282,10 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
 
     // c3 is dict filter column
     {
-        ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_indices.size());
-        int col_idx = file_reader->_row_group_readers[0]->_dict_column_indices[0];
+        const auto& dict_column_indices =
+                file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
+        ASSERT_EQ(1, dict_column_indices.size());
+        int col_idx = dict_column_indices[0];
         ASSERT_EQ(2, file_reader->_row_group_readers[0]->_param.read_cols[col_idx].slot_id());
     }
 
@@ -1309,7 +1312,7 @@ TEST_F(FileReaderTest, TestGetNextOtherFilter) {
     ASSERT_TRUE(status.ok());
 
     // c1 is other conjunct filter column
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_left_conjunct_ctxs.size());
+    ASSERT_EQ(1u, file_reader->_row_group_readers[0]->_column_materializer->post_read_conjuncts_by_slot().count(0));
     const auto& conjunct_ctxs_by_slot = file_reader->_row_group_readers[0]->_param.conjunct_ctxs_by_slot;
     ASSERT_NE(conjunct_ctxs_by_slot.find(0), conjunct_ctxs_by_slot.end());
 
@@ -1349,13 +1352,15 @@ TEST_F(FileReaderTest, TestMultiFilterWithMultiPage) {
 
     // c3 is dict filter column
     {
-        ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_indices.size());
-        int col_idx = file_reader->_row_group_readers[0]->_dict_column_indices[0];
+        const auto& dict_column_indices =
+                file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
+        ASSERT_EQ(1, dict_column_indices.size());
+        int col_idx = dict_column_indices[0];
         ASSERT_EQ(2, file_reader->_row_group_readers[0]->_param.read_cols[col_idx].slot_id());
     }
 
     // c0 is conjunct filter column
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_left_conjunct_ctxs.size());
+    ASSERT_EQ(1u, file_reader->_row_group_readers[0]->_column_materializer->post_read_conjuncts_by_slot().count(0));
     const auto& conjunct_ctxs_by_slot = file_reader->_row_group_readers[0]->_param.conjunct_ctxs_by_slot;
     ASSERT_NE(conjunct_ctxs_by_slot.find(0), conjunct_ctxs_by_slot.end());
 
@@ -1382,7 +1387,7 @@ TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
     ASSERT_TRUE(status.ok());
 
     // c0 is conjunct filter column
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_left_conjunct_ctxs.size());
+    ASSERT_EQ(1u, file_reader->_row_group_readers[0]->_column_materializer->post_read_conjuncts_by_slot().count(0));
     const auto& conjunct_ctxs_by_slot = file_reader->_row_group_readers[0]->_param.conjunct_ctxs_by_slot;
     ASSERT_NE(conjunct_ctxs_by_slot.find(0), conjunct_ctxs_by_slot.end());
 
@@ -1407,8 +1412,10 @@ TEST_F(FileReaderTest, TestReadStructUpperColumns) {
 
     // c3 is dict filter column
     {
-        ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_indices.size());
-        int col_idx = file_reader->_row_group_readers[0]->_dict_column_indices[0];
+        const auto& dict_column_indices =
+                file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
+        ASSERT_EQ(1, dict_column_indices.size());
+        int col_idx = dict_column_indices[0];
         ASSERT_EQ(1, file_reader->_row_group_readers[0]->_param.read_cols[col_idx].slot_id());
     }
 
@@ -2294,7 +2301,7 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutRequiredComplexType) {
     chunk->append_column(ColumnHelper::create_column(type_b, true), chunk->num_columns());
     chunk->append_column(ColumnHelper::create_column(TYPE_INT_INT_MAP_DESC, true), chunk->num_columns());
 
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_left_conjunct_ctxs.size());
+    ASSERT_EQ(1u, file_reader->_row_group_readers[0]->_column_materializer->post_read_conjuncts_by_slot().count(0));
     const auto& conjunct_ctxs_by_slot = file_reader->_row_group_readers[0]->_param.conjunct_ctxs_by_slot;
     ASSERT_NE(conjunct_ctxs_by_slot.find(0), conjunct_ctxs_by_slot.end());
 
@@ -2358,7 +2365,7 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutOptionalComplexType) {
     chunk->append_column(ColumnHelper::create_column(type_b, true), chunk->num_columns());
     chunk->append_column(ColumnHelper::create_column(TYPE_INT_INT_MAP_DESC, true), chunk->num_columns());
 
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_left_conjunct_ctxs.size());
+    ASSERT_EQ(1u, file_reader->_row_group_readers[0]->_column_materializer->post_read_conjuncts_by_slot().count(0));
     const auto& conjunct_ctxs_by_slot = file_reader->_row_group_readers[0]->_param.conjunct_ctxs_by_slot;
     ASSERT_NE(conjunct_ctxs_by_slot.find(0), conjunct_ctxs_by_slot.end());
 
@@ -2762,11 +2769,14 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_indices.size());
-    ASSERT_EQ(3, file_reader->_row_group_readers[0]->_dict_column_indices[0]);
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_sub_field_paths.size());
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_sub_field_paths[3].size());
-    ASSERT_EQ(subfield_path, file_reader->_row_group_readers[0]->_dict_column_sub_field_paths[3][0]);
+    const auto& dict_column_indices = file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
+    const auto& dict_column_sub_field_paths =
+            file_reader->_row_group_readers[0]->_column_materializer->dict_column_sub_field_paths();
+    ASSERT_EQ(1, dict_column_indices.size());
+    ASSERT_EQ(3, dict_column_indices[0]);
+    ASSERT_EQ(1, dict_column_sub_field_paths.size());
+    ASSERT_EQ(1, dict_column_sub_field_paths.at(3).size());
+    ASSERT_EQ(subfield_path, dict_column_sub_field_paths.at(3)[0]);
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
         chunk->reset();
@@ -3341,12 +3351,14 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_indices.size());
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_indices[0]);
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_sub_field_paths.size());
-    ASSERT_EQ(1, file_reader->_row_group_readers[0]->_dict_column_sub_field_paths[1].size());
-    ASSERT_EQ(std::vector<std::string>({"c_struct", "c0"}),
-              file_reader->_row_group_readers[0]->_dict_column_sub_field_paths[1][0]);
+    const auto& dict_column_indices = file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
+    const auto& dict_column_sub_field_paths =
+            file_reader->_row_group_readers[0]->_column_materializer->dict_column_sub_field_paths();
+    ASSERT_EQ(1, dict_column_indices.size());
+    ASSERT_EQ(1, dict_column_indices[0]);
+    ASSERT_EQ(1, dict_column_sub_field_paths.size());
+    ASSERT_EQ(1, dict_column_sub_field_paths.at(1).size());
+    ASSERT_EQ(std::vector<std::string>({"c_struct", "c0"}), dict_column_sub_field_paths.at(1)[0]);
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
         chunk->reset();

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -28,6 +28,7 @@
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
+#include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/utils.h"
@@ -333,7 +334,8 @@ static StatusOr<std::string> variant_json_at(const ColumnPtr& column, size_t row
 static Status fill_dst_chunk_without_projected(GroupReader* group_reader, ChunkPtr& active_chunk, ChunkPtr* dst_chunk) {
     RETURN_IF_ERROR(group_reader->_variant->emit_projections(active_chunk, dst_chunk,
                                                              group_reader->_variant->projection_timezone()));
-    return group_reader->_emit_physical_columns(active_chunk, dst_chunk);
+    auto skip_slots = group_reader->_variant->projection_slot_ids();
+    return group_reader->_column_materializer->emit_physical_columns(active_chunk, dst_chunk, &skip_slots);
 }
 
 static ColumnPtr make_typed_only_variant_column_for_virtual_column_test() {
@@ -794,11 +796,11 @@ TEST_F(GroupReaderTest, TestInit) {
 
 static void replace_column_readers(GroupReader* group_reader, GroupReaderParam* param) {
     group_reader->_column_readers.clear();
-    group_reader->_active_column_indices.clear();
+    group_reader->_column_materializer->clear_classification();
     for (size_t i = 0; i < param->read_cols.size(); i++) {
         auto r = std::make_unique<MockColumnReader>(param->read_cols[i].type_in_parquet);
         group_reader->_column_readers[i] = std::move(r);
-        group_reader->_active_column_indices.push_back(i);
+        group_reader->_column_materializer->add_active_column(i);
     }
 }
 
@@ -835,7 +837,7 @@ TEST_F(GroupReaderTest, TestGetNext) {
     // replace column readers
     replace_column_readers(group_reader, param);
     // create chunk
-    group_reader->_read_chunk = _create_chunk(param);
+    group_reader->_column_materializer->mutable_read_chunk() = _create_chunk(param);
 
     auto chunk = _create_chunk(param);
 
@@ -3073,8 +3075,9 @@ TEST_F(GroupReaderTest, CollectIORangesDeduplicatesIdenticalRangesAcrossReaders)
     ASSERT_OK(group_reader->init());
 
     group_reader->_column_readers.clear();
-    group_reader->_active_column_indices = {0};
-    group_reader->_lazy_column_indices = {1};
+    group_reader->_column_materializer->clear_classification();
+    group_reader->_column_materializer->add_active_column(0);
+    group_reader->_column_materializer->add_lazy_column(1);
     group_reader->_column_readers.emplace(
             0, std::make_unique<MockIORangeColumnReader>(std::vector<SharedBufferedInputStream::IORange>{{100, 20}}));
     group_reader->_column_readers.emplace(
@@ -3135,7 +3138,7 @@ TEST_F(GroupReaderTest, ProcessColumnsDefersVirtualColumnConjunctsUntilAfterProj
 
     group_reader->_process_columns_and_conjunct_ctxs();
     ASSERT_EQ(1, group_reader->_variant->_deferred_variant_virtual_conjunct_ctxs.size());
-    ASSERT_TRUE(group_reader->_left_conjunct_ctxs.empty());
+    ASSERT_TRUE(group_reader->_column_materializer->post_read_conjuncts_by_slot().empty());
 
     auto read_chunk = std::make_shared<Chunk>();
     read_chunk->append_column(variant_source, source_slot->id());
@@ -3321,8 +3324,8 @@ TEST_F(GroupReaderTest, ProcessColumnsClassifiesHiddenSourcesAsActiveOrLazy) {
                           group_reader->_variant->_lazy_hidden_slot_ids.end(),
                           lazy_src_id) != group_reader->_variant->_lazy_hidden_slot_ids.end());
     // active_src_id should also appear in unified _active_slot_ids
-    EXPECT_TRUE(std::find(group_reader->_active_slot_ids.begin(), group_reader->_active_slot_ids.end(),
-                          active_src_id) != group_reader->_active_slot_ids.end());
+    const auto& active_slot_ids = group_reader->_column_materializer->active_slot_ids();
+    EXPECT_TRUE(std::find(active_slot_ids.begin(), active_slot_ids.end(), active_src_id) != active_slot_ids.end());
     // _deferred_conjunct_slot_ids must contain vslot_active
     EXPECT_EQ(1u, group_reader->_variant->_deferred_conjunct_slot_ids.count(vslot_active->id()));
 }
@@ -3434,12 +3437,15 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionClassifiesDictFilterConjuncts) {
     group_reader->_variant->try_promote();
 
     EXPECT_EQ(2, group_reader->_variant->_promoted_virtual_slots.size());
-    ASSERT_EQ(1, group_reader->_dict_column_indices.size());
-    EXPECT_EQ(0, group_reader->_dict_column_indices[0]);
-    EXPECT_EQ(1u, group_reader->_dict_column_sub_field_paths.count(0));
-    ASSERT_EQ(1u, group_reader->_left_no_dict_filter_conjuncts_by_slot.count(expr_slot->id()));
-    EXPECT_EQ(1, group_reader->_left_no_dict_filter_conjuncts_by_slot.at(expr_slot->id()).size());
-    EXPECT_EQ(0u, group_reader->_left_no_dict_filter_conjuncts_by_slot.count(dict_slot->id()));
+    const auto& dict_column_indices = group_reader->_column_materializer->dict_column_indices();
+    const auto& dict_column_sub_field_paths = group_reader->_column_materializer->dict_column_sub_field_paths();
+    const auto& post_read_conjuncts = group_reader->_column_materializer->post_read_conjuncts_by_slot();
+    ASSERT_EQ(1, dict_column_indices.size());
+    EXPECT_EQ(0, dict_column_indices[0]);
+    EXPECT_EQ(1u, dict_column_sub_field_paths.count(0));
+    ASSERT_EQ(1u, post_read_conjuncts.count(expr_slot->id()));
+    EXPECT_EQ(1, post_read_conjuncts.at(expr_slot->id()).size());
+    EXPECT_EQ(0u, post_read_conjuncts.count(dict_slot->id()));
 }
 
 TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsNonAllNullFallback) {
@@ -3547,7 +3553,7 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionKeepsUnpromotedMixedSourceActiveA
 
     group_reader->_variant->try_promote();
 
-    group_reader->_rebuild_column_read_order_ctx();
+    group_reader->_column_materializer->rebuild_read_order_ctx();
 
     EXPECT_EQ(1u, group_reader->_variant->_promoted_virtual_slots.count(promoted_slot->id()));
     EXPECT_EQ(0u, group_reader->_variant->_promoted_virtual_slots.count(unpromoted_slot->id()));
@@ -3561,8 +3567,10 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionKeepsUnpromotedMixedSourceActiveA
     EXPECT_EQ(group_reader->_variant->_active_hidden_slot_ids.end(),
               std::find(group_reader->_variant->_active_hidden_slot_ids.begin(),
                         group_reader->_variant->_active_hidden_slot_ids.end(), promoted_source_slot_id));
-    EXPECT_EQ(1u, group_reader->_column_read_order_ctx->get_column_read_order().size());
-    EXPECT_EQ(0, group_reader->_column_read_order_ctx->get_column_read_order()[0]);
+    auto* read_order_ctx = group_reader->_column_materializer->read_order_ctx();
+    ASSERT_NE(nullptr, read_order_ctx);
+    EXPECT_EQ(1u, read_order_ctx->get_column_read_order().size());
+    EXPECT_EQ(0, read_order_ctx->get_column_read_order()[0]);
 }
 
 TEST_F(GroupReaderTest, CreateColumnReadersRegistersVirtualZoneMapReaderForHiddenSource) {
@@ -3637,10 +3645,10 @@ TEST_F(GroupReaderTest, ProcessColumnsPopulatesLazySlotIdsForPhysicalColumnsWith
     // column is expected to land in _lazy_column_indices / _lazy_slot_ids.
     group_reader->_process_columns_and_conjunct_ctxs();
 
-    EXPECT_TRUE(std::find(group_reader->_active_slot_ids.begin(), group_reader->_active_slot_ids.end(),
-                          active_slot->id()) != group_reader->_active_slot_ids.end());
-    EXPECT_TRUE(std::find(group_reader->_lazy_slot_ids.begin(), group_reader->_lazy_slot_ids.end(), lazy_slot->id()) !=
-                group_reader->_lazy_slot_ids.end());
+    const auto& active_slot_ids = group_reader->_column_materializer->active_slot_ids();
+    const auto& lazy_slot_ids = group_reader->_column_materializer->lazy_slot_ids();
+    EXPECT_TRUE(std::find(active_slot_ids.begin(), active_slot_ids.end(), active_slot->id()) != active_slot_ids.end());
+    EXPECT_TRUE(std::find(lazy_slot_ids.begin(), lazy_slot_ids.end(), lazy_slot->id()) != lazy_slot_ids.end());
 }
 
 // Covers: physical VARIANT column with no direct conjuncts must be promoted to
@@ -3689,10 +3697,10 @@ TEST_F(GroupReaderTest, ProcessColumnsPromotesPhysicalVariantSourceForDeferredCo
     group_reader->_process_columns_and_conjunct_ctxs();
 
     // Physical slot must be active (not lazy) because a deferred conjunct needs it.
-    EXPECT_TRUE(std::find(group_reader->_active_slot_ids.begin(), group_reader->_active_slot_ids.end(),
-                          phys_slot->id()) != group_reader->_active_slot_ids.end());
-    EXPECT_TRUE(std::find(group_reader->_lazy_slot_ids.begin(), group_reader->_lazy_slot_ids.end(), phys_slot->id()) ==
-                group_reader->_lazy_slot_ids.end());
+    const auto& active_slot_ids = group_reader->_column_materializer->active_slot_ids();
+    const auto& lazy_slot_ids = group_reader->_column_materializer->lazy_slot_ids();
+    EXPECT_TRUE(std::find(active_slot_ids.begin(), active_slot_ids.end(), phys_slot->id()) != active_slot_ids.end());
+    EXPECT_TRUE(std::find(lazy_slot_ids.begin(), lazy_slot_ids.end(), phys_slot->id()) == lazy_slot_ids.end());
     // The virtual conjunct slot must be registered.
     EXPECT_EQ(1u, group_reader->_variant->_deferred_conjunct_slot_ids.count(virt_slot->id()));
 }


### PR DESCRIPTION
## Why I'm doing:

`GroupReader` accumulated all column-level state and machinery (classification, dict-filter, conjuncts, read scheduling, chunk management, IO coalesce) into a single class. This blocks expr-driven late materialization, where columns should be read on demand rather than unioned upfront.

## What I'm doing:

Introduce `ColumnMaterializer` — a new middle layer between `GroupReader` and `ColumnReader`:

```
GroupReader                     GroupReader
 (orchestration)               ├─ _column_materializer  ← owns column state, reads, filters, cache
                               ├─ _variant
                               └─ _column_readers
```

Moved in: column classification, dict/post-read conjuncts, chunk lifecycle, read/filter/emit pipeline, IO coalesce, per-range slot cache, and `LazyMaterializationContext` (expression-facing facade for future on-demand reads).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
