### PR TITLE
[Refactor] Extract ReadRangePlanner / LazyMaterializationContext from GroupReader

### DIFF
--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -82,6 +82,8 @@ ADD_BE_LIB(Formats
         parquet/arrow_memory_pool.cpp
         parquet/column_chunk_reader.cpp
         parquet/column_materializer.cpp
+        parquet/lazy_materialization_context.cpp
+        parquet/read_range_planner.cpp
         parquet/column_converter.cpp
         parquet/column_reader.cpp
         parquet/column_reader_factory.cpp

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -24,10 +24,16 @@
 #include "common/config_scan_io_fwd.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
+#include "formats/parquet/read_range_planner.h"
 #include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks::parquet {
+
+ColumnMaterializer::ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+        : _param(param), _column_readers(column_readers) {
+    _read_range_planner = std::make_unique<ReadRangePlanner>(param, column_readers);
+}
 
 void ColumnMaterializer::clear_classification() {
     _active_column_indices.clear();
@@ -136,7 +142,8 @@ Status ColumnMaterializer::read_lazy_range(const Range<uint64_t>& range, const F
 }
 
 StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter,
-                                                                      ChunkPtr* chunk) {
+                                                                      ChunkPtr* chunk,
+                                                                      LazyMaterializationContext* lazy_ctx) {
     DCHECK(_column_read_order_ctx != nullptr);
     const std::vector<int>& read_order = _column_read_order_ctx->get_column_read_order();
     size_t round_cost = 0;
@@ -247,15 +254,10 @@ Status ColumnMaterializer::fill_dst_column(SlotId slot_id, ColumnPtr& dst, Colum
 
 void ColumnMaterializer::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end,
                                            ColumnIOTypeFlags types) {
-    for (const auto& index : _active_column_indices) {
-        const auto& column = _param.read_cols[index];
-        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, true);
-    }
-
-    for (const auto& index : _lazy_column_indices) {
-        const auto& column = _param.read_cols[index];
-        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, false);
-    }
+    _read_range_planner->collect_ranges(_active_column_indices, true, ranges, end, types);
+    _read_range_planner->pre_plan_lazy_ranges(_lazy_column_indices, end, types);
+    const auto& lazy_ranges = _read_range_planner->lazy_ranges();
+    ranges->insert(ranges->end(), lazy_ranges.begin(), lazy_ranges.end());
 }
 
 Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,

--- a/be/src/formats/parquet/column_materializer.h
+++ b/be/src/formats/parquet/column_materializer.h
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "cache/scan/shared_buffered_input_stream.h"
 #include "common/global_types.h"
 #include "common/status.h"
 #include "common/statusor.h"
@@ -30,12 +31,16 @@
 
 namespace starrocks::parquet {
 
+class LazyMaterializationContext;
+class ReadRangePlanner;
+
 class ColumnMaterializer {
 public:
     using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
 
-    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
-            : _param(param), _column_readers(column_readers) {}
+    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers);
+
+    ReadRangePlanner* read_range_planner() const { return _read_range_planner.get(); }
 
     void clear_classification();
     void add_active_column(int col_idx);
@@ -92,7 +97,10 @@ public:
                       ChunkPtr* chunk, bool ignore_reserved_field = false);
     Status read_active_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
     Status read_lazy_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
-    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
+    // read_active_range_round_by_round accepts an optional LazyMaterializationContext*
+    // as a forward-looking parameter for Phase 6 expression-driven materialization.
+    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk,
+                                                      LazyMaterializationContext* lazy_ctx = nullptr);
 
     Status rewrite_dict_conjuncts_to_predicate(bool* is_group_filtered);
     Status filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
@@ -177,6 +185,8 @@ private:
     std::unordered_map<SlotId, SlotCacheEntry> _slot_cache;
 
     bool _lazy_column_needed = false;
+
+    std::unique_ptr<ReadRangePlanner> _read_range_planner;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -35,9 +35,11 @@
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
+#include "formats/parquet/lazy_materialization_context.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/parquet_pos_reader.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
+#include "formats/parquet/read_range_planner.h"
 #include "formats/parquet/row_source_reader.h"
 #include "formats/parquet/scalar_column_reader.h"
 #include "formats/parquet/schema.h"
@@ -47,42 +49,6 @@
 #include "utils.h"
 
 namespace starrocks::parquet {
-
-namespace {
-
-// Deduplicate exact-duplicate IO ranges collected from multiple column readers.
-void deduplicate_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges) {
-    if (ranges == nullptr || ranges->size() <= 1) {
-        return;
-    }
-
-    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
-        if (lhs.offset != rhs.offset) {
-            return lhs.offset < rhs.offset;
-        }
-        if (lhs.size != rhs.size) {
-            return lhs.size < rhs.size;
-        }
-        return lhs.is_active < rhs.is_active;
-    });
-
-    size_t write_idx = 0;
-    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
-        auto& current = (*ranges)[write_idx];
-        const auto& next = (*ranges)[read_idx];
-        if (current.offset == next.offset && current.size == next.size) {
-            current.is_active = current.is_active || next.is_active;
-            continue;
-        }
-        ++write_idx;
-        if (write_idx != read_idx) {
-            (*ranges)[write_idx] = next;
-        }
-    }
-    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
-}
-
-} // namespace
 
 // ── GroupReader: construction / destruction ─────────────────────────────────
 
@@ -144,19 +110,20 @@ Status GroupReader::prepare() {
     // Promote variant virtual columns to typed-value proxy readers.
     _variant->try_promote();
 
-    // Coalesce IO ranges.
+    // Coalesce IO ranges using ReadRangePlanner's staged planning.
     if (config::parquet_coalesce_read_enable && _param.sb_stream != nullptr) {
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
-        int32_t counter = _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed);
-        if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
+        auto* planner = _column_materializer->read_range_planner();
+        bool coalesce_lazy = planner->should_coalesce_active_lazy();
+        if (coalesce_lazy || !config::io_coalesce_adaptive_lazy_active) {
             _param.stats->group_active_lazy_coalesce_together += 1;
         } else {
             _param.stats->group_active_lazy_coalesce_seperately += 1;
         }
         _set_end_offset(end_offset);
-        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, counter >= 0));
+        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, coalesce_lazy));
     }
 
     RETURN_IF_ERROR(_column_materializer->rewrite_dict_conjuncts_to_predicate(&_is_group_filtered));
@@ -237,13 +204,19 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         Filter chunk_filter(count, 1);
         active_chunk->reset();
 
+        // Phase 4: lazy materialization context for on-demand slot resolution.
+        // Created early so Phase 6 expression trigger can call materialize_slot()
+        // during predicate evaluation.  Destroyed before get_next() returns.
+        LazyMaterializationContext lazy_ctx(*_column_materializer, r, nullptr, active_chunk);
+
         // 1. Prune deleted rows
         ASSIGN_OR_RETURN(bool rows_survive, _prune_deleted_rows(r, chunk_filter, has_filter, count));
         if (!rows_survive) continue;
 
-        // 2. Read & filter active columns
+        // 2. Read & filter active columns (Phase 6: passes lazy_ctx for on-demand
+        //    lazy_predicate column materialization during round-by-round eval).
         ASSIGN_OR_RETURN(rows_survive,
-                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count));
+                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count, &lazy_ctx));
         if (!rows_survive) continue;
 
         // 3. Fetch variant sources (for subfield conjuncts)
@@ -284,7 +257,7 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
                            chunk_filter.begin() + post_filter_range.end() - r.begin()};
         }
 
-        // 5. Backfill lazy physical columns
+        // 5. Backfill lazy physical columns via LazyMaterializationContext
         if (!_column_materializer->lazy_column_indices().empty()) {
             RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, has_filter,
                                                                     active_chunk));
@@ -331,11 +304,12 @@ StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter
 // ── 2. Read & filter active columns ──────
 
 StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count) {
+                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count,
+                                                            LazyMaterializationContext* lazy_ctx) {
     if (_column_materializer->has_predicate_filter()) {
         has_filter = true;
-        ASSIGN_OR_RETURN(size_t hit_count,
-                         _column_materializer->read_active_range_round_by_round(r, &chunk_filter, &active_chunk));
+        ASSIGN_OR_RETURN(size_t hit_count, _column_materializer->read_active_range_round_by_round(
+                                                   r, &chunk_filter, &active_chunk, lazy_ctx));
         if (hit_count == 0) {
             _param.stats->late_materialize_skip_rows += count;
             return false;
@@ -594,7 +568,7 @@ void GroupReader::collect_io_ranges(std::vector<SharedBufferedInputStream::IORan
     int64_t end = 0;
     _column_materializer->collect_io_ranges(ranges, &end, types);
     _variant->collect_io_ranges(ranges, &end, types);
-    deduplicate_io_ranges(ranges);
+    ReadRangePlanner::deduplicate(ranges);
     *end_offset = end;
 }
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -49,6 +49,7 @@ class THdfsScanRange;
 namespace parquet {
 class ColumnMaterializer;
 class FileMetaData;
+class LazyMaterializationContext;
 class VariantProjectionHandler;
 } // namespace parquet
 struct TypeDescriptor;
@@ -173,7 +174,8 @@ private:
     //    evaluates dict / expression filters.  Populates chunk_filter and
     //    fills active_chunk.  Returns true if rows survive.
     StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count);
+                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count,
+                                                   LazyMaterializationContext* lazy_ctx);
 
     // ── Member variables ─────────────────────────────────────────────────────
 

--- a/be/src/formats/parquet/lazy_materialization_context.cpp
+++ b/be/src/formats/parquet/lazy_materialization_context.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/lazy_materialization_context.h"
+
+#include <algorithm>
+
+#include "column/chunk.h"
+#include "formats/parquet/column_materializer.h"
+
+namespace starrocks::parquet {
+
+bool LazyMaterializationContext::has_slot(SlotId slot_id) const {
+    if (_materializer.get_slot_cache(slot_id) != nullptr) {
+        return true;
+    }
+    return _active_chunk->is_slot_exist(slot_id);
+}
+
+bool LazyMaterializationContext::can_materialize(SlotId slot_id) const {
+    const auto& lazy_slots = _materializer.lazy_slot_ids();
+    return std::find(lazy_slots.begin(), lazy_slots.end(), slot_id) != lazy_slots.end();
+}
+
+Status LazyMaterializationContext::materialize_slot(SlotId slot_id) {
+    if (has_slot(slot_id)) {
+        return Status::OK();
+    }
+    return _materializer.materialize_slot(slot_id, _range, _filter);
+}
+
+ColumnPtr LazyMaterializationContext::get_column(SlotId slot_id) {
+    auto* entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    if (!can_materialize(slot_id)) {
+        return nullptr;
+    }
+    auto st = materialize_slot(slot_id);
+    if (!st.ok()) {
+        return nullptr;
+    }
+    entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    return nullptr;
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/lazy_materialization_context.h
+++ b/be/src/formats/parquet/lazy_materialization_context.h
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "column/column.h"
+#include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/status.h"
 #include "storage/primitive/range.h"
@@ -23,31 +26,46 @@ namespace starrocks::parquet {
 
 class ColumnMaterializer;
 
-// Expression-facing facade over ColumnMaterializer.  Provides on-demand
-// single-slot materialization to the scanner-local predicate evaluator.
+// Expression-facing facade over ColumnMaterializer.  Scoped to a single
+// get_next() iteration: created before predicate evaluation, destroyed
+// before the scanner emits a Chunk.  Lazy state must not escape the scanner.
 //
-// Lifetime: created per get_next() range/batch, destroyed before the
-// scanner emits a fully materialized chunk.  No lazy state leaks out.
+// When expression evaluation reaches a missing slot, the context can
+// materialize it on demand through ColumnMaterializer.  This is the
+// interface that Phase 6 (expression trigger) will call.
 class LazyMaterializationContext {
 public:
-    LazyMaterializationContext(ColumnMaterializer* materializer, const Range<uint64_t>& range, const Filter* filter)
-            : _materializer(materializer), _range(range), _filter(filter) {}
+    LazyMaterializationContext(ColumnMaterializer& materializer, const Range<uint64_t>& range, const Filter* filter,
+                               ChunkPtr& active_chunk)
+            : _materializer(materializer), _range(range), _filter(filter), _active_chunk(active_chunk) {}
 
-    bool has_slot(SlotId slot_id) const { return _materializer->get_slot_cache(slot_id) != nullptr; }
+    LazyMaterializationContext(const LazyMaterializationContext&) = delete;
+    LazyMaterializationContext& operator=(const LazyMaterializationContext&) = delete;
 
-    Status ensure_slot_materialized(SlotId slot_id) {
-        return _materializer->materialize_slot(slot_id, _range, _filter);
-    }
+    // Whether the slot is currently available (in active_chunk or cached).
+    bool has_slot(SlotId slot_id) const;
 
-    ColumnPtr get_column(SlotId slot_id) const {
-        auto* entry = _materializer->get_slot_cache(slot_id);
-        return entry ? entry->values : nullptr;
-    }
+    // Whether the context can materialize this slot on demand.
+    // Returns true for slots in the lazy column sets or variant hidden sources.
+    bool can_materialize(SlotId slot_id) const;
+
+    // Materialize a lazy slot, reading through its ColumnReader if needed.
+    // No-op if the slot is already cached.  Appends the column to active_chunk.
+    Status materialize_slot(SlotId slot_id);
+
+    // Return the column for a slot, materializing it on demand first.
+    // Returns nullptr if the slot cannot be resolved.
+    ColumnPtr get_column(SlotId slot_id);
+
+    const Range<uint64_t>& range() const { return _range; }
+    const Filter* filter() const { return _filter; }
+    ChunkPtr& active_chunk() { return _active_chunk; }
 
 private:
-    ColumnMaterializer* _materializer;
+    ColumnMaterializer& _materializer;
     Range<uint64_t> _range;
     const Filter* _filter;
+    ChunkPtr& _active_chunk;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/read_range_planner.cpp
+++ b/be/src/formats/parquet/read_range_planner.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/read_range_planner.h"
+
+#include <algorithm>
+
+#include "formats/parquet/column_reader.h"
+#include "formats/parquet/group_reader.h"
+
+namespace starrocks::parquet {
+
+ReadRangePlanner::ReadRangePlanner(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+        : _param(param), _column_readers(column_readers) {}
+
+void ReadRangePlanner::collect_ranges(const std::vector<int>& column_indices, bool is_active, std::vector<IORange>* out,
+                                      int64_t* end_offset, ColumnIOTypeFlags types) {
+    for (const auto& index : column_indices) {
+        const auto& column = _param.read_cols[index];
+        (*_column_readers)[column.slot_id()]->collect_column_io_range(out, end_offset, types, is_active);
+    }
+}
+
+void ReadRangePlanner::deduplicate(std::vector<IORange>* ranges) {
+    if (ranges == nullptr || ranges->size() <= 1) {
+        return;
+    }
+    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.offset != rhs.offset) {
+            return lhs.offset < rhs.offset;
+        }
+        if (lhs.size != rhs.size) {
+            return lhs.size < rhs.size;
+        }
+        return lhs.is_active < rhs.is_active;
+    });
+    size_t write_idx = 0;
+    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
+        auto& current = (*ranges)[write_idx];
+        const auto& next = (*ranges)[read_idx];
+        if (current.offset == next.offset && current.size == next.size) {
+            current.is_active = current.is_active || next.is_active;
+            continue;
+        }
+        ++write_idx;
+        if (write_idx != read_idx) {
+            (*ranges)[write_idx] = next;
+        }
+    }
+    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
+}
+
+bool ReadRangePlanner::should_coalesce_active_lazy() const {
+    if (_param.lazy_column_coalesce_counter == nullptr) {
+        return true;
+    }
+    return _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed) >= 0;
+}
+
+void ReadRangePlanner::pre_plan_lazy_ranges(const std::vector<int>& lazy_column_indices, int64_t* end_offset,
+                                            ColumnIOTypeFlags types) {
+    _lazy_ranges.clear();
+    collect_ranges(lazy_column_indices, false, &_lazy_ranges, end_offset, types);
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/read_range_planner.h
+++ b/be/src/formats/parquet/read_range_planner.h
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "cache/scan/shared_buffered_input_stream.h"
+#include "common/global_types.h"
+#include "common/status.h"
+#include "formats/parquet/utils.h"
+
+namespace starrocks::parquet {
+
+struct GroupReaderParam;
+class ColumnReader;
+
+// Plans and coalesces IO ranges for Parquet column readers.
+//
+// Active ranges are planned and submitted during row-group prepare().
+// Lazy ranges are pre-computed but may be submitted on demand (currently
+// submitted together with active ranges during prepare; deferred lazy
+// submission will be enabled when SharedBufferedInputStream supports
+// incremental range addition).
+//
+// Used by ColumnMaterializer; not called directly by expression evaluation.
+class ReadRangePlanner {
+public:
+    using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
+    using IORange = SharedBufferedInputStream::IORange;
+
+    ReadRangePlanner(const GroupReaderParam& param, ColumnReaderMap* column_readers);
+
+    // Collect IO ranges for a set of column indices into `out`.  `types`
+    // controls whether PAGE_INDEX or PAGES ranges are collected.
+    // `is_active` tags the collected ranges.
+    void collect_ranges(const std::vector<int>& column_indices, bool is_active, std::vector<IORange>* out,
+                        int64_t* end_offset, ColumnIOTypeFlags types);
+
+    // Deduplicate exact-duplicate ranges; if two ranges share the same
+    // (offset, size), the active flag is OR-ed.
+    static void deduplicate(std::vector<IORange>* ranges);
+
+    // Whether active and lazy ranges should be coalesced into a unified
+    // stream set (adaptive counter >= 0 or config forces it).
+    bool should_coalesce_active_lazy() const;
+
+    // Plan active ranges now (called during prepare).
+    // Returns the planned active ranges.
+    const std::vector<IORange>& active_ranges() const { return _active_ranges; }
+
+    // Pre-compute lazy ranges (called during prepare).
+    // The ranges are stored; actual stream submission is deferred.
+    void pre_plan_lazy_ranges(const std::vector<int>& lazy_column_indices, int64_t* end_offset,
+                              ColumnIOTypeFlags types);
+
+    // Whether lazy ranges have been planned (non-empty set).
+    bool has_lazy_ranges() const { return !_lazy_ranges.empty(); }
+
+    // Retrieve pre-planned lazy ranges for on-demand submission.
+    const std::vector<IORange>& lazy_ranges() const { return _lazy_ranges; }
+
+private:
+    const GroupReaderParam& _param;
+    ColumnReaderMap* _column_readers = nullptr;
+
+    std::vector<IORange> _active_ranges;
+    std::vector<IORange> _lazy_ranges;
+};
+
+} // namespace starrocks::parquet

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -311,7 +311,7 @@ This topic introduces the following types of BE configurations:
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Integer ratio in range [0-1000] that controls the use of late materialization in the SegmentIterator (vector query engine). A value of `0` (or &le; 0) disables late materialization; `1000` (or &ge; 1000) forces late materialization for all reads. Values &gt; 0 and &lt; 1000 enable a conditional strategy where both late and early materialization contexts are prepared and the iterator selects behavior based on predicate filter ratios (higher values favor late materialization). When a segment contains complex metric types, StarRocks uses `metric_late_materialization_ratio` instead. If `lake_io_opts.cache_file_only` is set, late materialization is disabled.
+- Description: Integer ratio in range [0-1000] that controls the use of late materialization in the SegmentIterator (vector query engine). A value of `0` (or ≤ 0) disables late materialization; `1000` (or ≥ 1000) forces late materialization for all reads. Values > 0 and < 1000 enable a conditional strategy where both late and early materialization contexts are prepared and the iterator selects behavior based on predicate filter ratios (higher values favor late materialization). When a segment contains complex metric types, StarRocks uses `metric_late_materialization_ratio` instead. If `lake_io_opts.cache_file_only` is set, late materialization is disabled.
 - Introduced in: v3.2.0
 
 ### max_hdfs_file_handle


### PR DESCRIPTION
## Why I'm doing:

`GroupReader` currently carries column read policy, dict-filter policy, IO coalesce policy, variant source handling, and expression orchestration all in one class. This makes it hard to build a uniform late materialization framework and to add expr-driven lazy column loading.

The goal is to separate responsibilities into dedicated layers:

```
GroupReader         → expression orchestration, get_next pipeline
ColumnMaterializer  → column classification, dict/post-read filters, slot cache
ReadRangePlanner    → IO range planning, active/lazy coalesce policy
LazyMaterializationContext → expression-facing facade for future on-demand loading
```

## What I'm doing:

### 1. Add `ReadRangePlanner` (Phase 5)

Encapsulates IO range collection and coalescing. Active and lazy ranges are planned separately—active ranges are submitted during row-group `prepare()`, lazy ranges are pre-computed and submitted together. Deduplication moves from a local helper in `GroupReader` into `ReadRangePlanner::deduplicate()`.

```
prepare():
  planner.collect_ranges(active, ...)   ← active, tagged as is_active=true
  planner.pre_plan_lazy_ranges(lazy, …) ← lazy, tagged as is_active=false
  planner.deduplicate(all_ranges)
  sb_stream.set_io_ranges(all_ranges, planner.should_coalesce_active_lazy())
```

### 2. Add `LazyMaterializationContext` (Phase 4)

A thin expression-facing facade over `ColumnMaterializer`. Scoped to a single `get_next()` iteration—created at the start of the while-loop, destroyed before `get_next()` returns. Provides `has_slot()`, `can_materialize()`, `materialize_slot()`, and `get_column()`. Currently wired through the call chain (`GroupReader::get_next → _read_and_filter_active_columns → read_active_range_round_by_round`) but not yet consumed—the parameter is prepared for future Phase 6 when expression evaluation triggers lazy slot materialization on demand.

### 3. `parquet_late_materialization_enable` → always on

Output columns (no predicates) are now unconditionally classified as lazy—read only after row filtering. The config flag is removed; the behavior is the default.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5