### PR TITLE
[BugFix] Use ParseUtil.backquote for identifiers in persisted routine load SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -58,6 +58,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
+import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock;
@@ -123,6 +124,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.starrocks.common.ErrorCode.ERR_LOAD_DATA_PARSE_ERROR;
 import static com.starrocks.common.ErrorCode.ERR_TOO_MANY_ERROR_ROWS;
@@ -1738,8 +1740,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     private String jobPropertiesToJsonString() {
         Map<String, String> jobProperties = Maps.newHashMap();
-        jobProperties.put("partitions",
-                partitions == null ? STAR_STRING : Joiner.on(",").join(partitions.getPartitionNames()));
+        jobProperties.put("partitions", partitions == null ? STAR_STRING
+                : partitions.getPartitionNames().stream().map(ParseUtil::backquote).collect(Collectors.joining(",")));
         jobProperties.put("columnToColumnExpr", columnDescs == null ? STAR_STRING : columnDescsToSql(columnDescs));
         jobProperties.put("whereExpr", whereExpr == null ? STAR_STRING : ExprToSql.toSql(whereExpr));
         if (getFormat().equalsIgnoreCase("json")) {
@@ -1768,7 +1770,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                 sb.append(",");
             }
             ImportColumnDesc desc = columnDescs.get(i);
-            sb.append("`").append(desc.getColumnName()).append("`");
+            sb.append(ParseUtil.backquote(desc.getColumnName()));
             if (desc.getExpr() != null) {
                 sb.append("=").append(ExprToSql.toSql(desc.getExpr()));
             }
@@ -1972,13 +1974,15 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         }
 
         // we use sql to persist the load properties, so we just put the load properties to sql.
-        // Backquote the table name so that reserved-keyword table names (e.g. `order`) can be
-        // re-parsed when the statement is deserialized on FE restart; otherwise getLoadDesc()
-        // fails to parse and routineLoadDesc is lost.
-        String sql = String.format("CREATE ROUTINE LOAD %s ON `%s` %s" +
+        // Backquote the job name and table name so that reserved-keyword or special-character
+        // identifiers (e.g. `order`) can be re-parsed when the statement is deserialized on FE
+        // restart; otherwise getLoadDesc() fails to parse and routineLoadDesc is lost. ParseUtil
+        // .backquote also escapes embedded backticks (a -> `a`, a`b -> `a``b`), which naive
+        // string concatenation does not.
+        String sql = String.format("CREATE ROUTINE LOAD %s ON %s %s" +
                         " PROPERTIES (\"desired_concurrent_number\"=\"1\")" +
                         " FROM KAFKA (\"kafka_topic\" = \"my_topic\")",
-                name, tableName, originLoadDesc.toSql());
+                ParseUtil.backquote(name), ParseUtil.backquote(tableName), originLoadDesc.toSql());
         LOG.debug("merge result: {}", sql);
         origStmt = new OriginStatementInfo(sql, 0);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -867,15 +867,20 @@ public class KafkaRoutineLoadJobTest {
         // column whose name needs quoting (contains the separator), must be backtick-wrapped
         // so the rendered SQL stays unambiguous
         columnDescs.add(new ImportColumnDesc("a,b"));
+        // column whose name itself contains a backtick: the embedded backtick must be doubled
+        // (a`b -> `a``b`), otherwise the rendered SQL is malformed.
+        columnDescs.add(new ImportColumnDesc("a`b"));
         Deencapsulation.setField(job, "columnDescs", columnDescs);
 
         String jobProperties = Deencapsulation.invoke(job, "jobPropertiesToJsonString");
         // The expr must be rendered as readable SQL, not a Java object reference like
         // com.starrocks.sql.ast.ImportColumnDesc@19e02a72
         Assertions.assertFalse(jobProperties.contains("ImportColumnDesc@"), jobProperties);
-        // column names are backtick-wrapped, mapping column rendered as "`name`=<exprSql>"
+        // column names are backtick-wrapped (embedded backticks doubled), mapping column rendered
+        // as "`name`=<exprSql>"
         Assertions.assertTrue(
-                jobProperties.contains("\"columnToColumnExpr\":\"`col1`,`col2`=col1 + 1,`a,b`\""), jobProperties);
+                jobProperties.contains("\"columnToColumnExpr\":\"`col1`,`col2`=col1 + 1,`a,b`,`a``b`\""),
+                jobProperties);
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -1047,7 +1047,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS TERMINATED BY ';'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY ';' " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
@@ -1057,7 +1057,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "ROWS TERMINATED BY '\n'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n' " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
@@ -1068,7 +1068,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS(`a`, `b`, `c`=1)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1) " +
@@ -1080,7 +1080,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "TEMPORARY PARTITION(`p1`, `p2`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1093,7 +1093,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 1", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY ';', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1107,7 +1107,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS TERMINATED BY '\t'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY '\n', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1121,7 +1121,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "ROWS TERMINATED BY 'a'", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`, `b`, `c` = 1), " +
@@ -1135,7 +1135,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "COLUMNS(`a`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1148,7 +1148,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         " PARTITION(`p1`, `p2`)", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1162,7 +1162,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 5", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1176,7 +1176,7 @@ public class RoutineLoadJobTest {
                 "ALTER ROUTINE LOAD FOR job " +
                         "WHERE a = 5 and b like 'c1%' and c between 1 and 100 and substring(d,1,5) = 'cefd' ", 0), null);
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `unknown` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `unknown` " +
                 "COLUMNS TERMINATED BY '\t', " +
                 "ROWS TERMINATED BY 'a', " +
                 "COLUMNS(`a`), " +
@@ -1211,12 +1211,47 @@ public class RoutineLoadJobTest {
         routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
 
         // The regenerated statement must keep the reserved-keyword table name backquoted.
-        Assertions.assertEquals("CREATE ROUTINE LOAD job ON `order` " +
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `order` " +
                 "COLUMNS(`a`, `b`, `c` = 1) " +
                 "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
                 "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
 
         // Re-parsing the persisted statement must succeed (this is what happens on FE restart).
+        RoutineLoadDesc reparsed = CreateRoutineLoadStmt.getLoadDesc(routineLoadJob.getOrigStmt(), null);
+        Assertions.assertNotNull(reparsed);
+    }
+
+    @Test
+    public void testMergeLoadDescToOriginStatementWithBackquoteInTableName() throws Exception {
+        // A table name that itself contains a backquote must have the embedded backquote doubled
+        // (ta`ble -> `ta``ble`), otherwise the regenerated statement is malformed and cannot be
+        // re-parsed on FE restart. Naive string concatenation (`%s`) would produce `ta`ble`, which
+        // is unparseable.
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                2L, 3L, "192.168.1.2:10000", "topic") {
+            @Override
+            public String getTableName() {
+                return "ta`ble";
+            }
+        };
+        String originStmt = "CREATE ROUTINE LOAD `job` ON `ta``ble` " +
+                "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
+                "FROM KAFKA (\"kafka_topic\" = \"my_topic\")";
+        routineLoadJob.setOrigStmt(new OriginStatementInfo(originStmt, 0));
+
+        RoutineLoadDesc loadDesc = CreateRoutineLoadStmt.getLoadDesc(new OriginStatementInfo(
+                "ALTER ROUTINE LOAD FOR job COLUMNS(`a`, `b`, `c` = 1)", 0), null);
+        routineLoadJob.mergeLoadDescToOriginStatement(loadDesc);
+
+        // The embedded backquote must be escaped (doubled) in the regenerated statement.
+        Assertions.assertEquals("CREATE ROUTINE LOAD `job` ON `ta``ble` " +
+                "COLUMNS(`a`, `b`, `c` = 1) " +
+                "PROPERTIES (\"desired_concurrent_number\"=\"1\") " +
+                "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", routineLoadJob.getOrigStmt().originStmt);
+
+        // Re-parsing the persisted statement must succeed: `ta``ble` is a single valid
+        // BACKQUOTED_IDENTIFIER token, so getLoadDesc() parses it and routineLoadDesc is preserved.
+        // Naive concatenation (`ta`ble`) would instead be a parse error, dropping routineLoadDesc.
         RoutineLoadDesc reparsed = CreateRoutineLoadStmt.getLoadDesc(routineLoadJob.getOrigStmt(), null);
         Assertions.assertNotNull(reparsed);
     }


### PR DESCRIPTION
## Why I'm doing:

The routine load origStmt regeneration and the SHOW ROUTINE LOAD job properties hand-rolled backtick wrapping (or none at all) for identifiers. This had two problems:

1. Embedded backticks were not escaped, so a name containing a backtick produced malformed, unparseable SQL.
2. The job name and partition names were not quoted at all, so a reserved-keyword job/partition name produced SQL that fails to re-parse on FE restart (routineLoadDesc is lost), the same class of bug that the table-name and columnToColumnExpr fixes addressed.

Route every identifier (job name, table name, column names, partition names) through ParseUtil.backquote, which both wraps in backticks and doubles embedded backticks (a`b -> `a``b`). This consolidates the quoting into one utility instead of piecemeal string concatenation.

Add regression coverage for backquoted job names, an embedded-backtick table name, and an embedded-backtick column name.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
