### PR TITLE
[BugFix] Fix nullable analytic column append

### DIFF
--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -20,6 +20,7 @@
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/nullable_column.h"
 #include "common/config.h"
 #include "common/status.h"
 #include "exprs/agg/aggregate_state_allocator.h"
@@ -661,16 +662,25 @@ Status Analytor::_add_chunk(const ChunkPtr& chunk) {
 void Analytor::_append_column(size_t chunk_size, Column* dst_column, ColumnPtr& src_column) {
     DCHECK(!(src_column->is_constant() && dst_column->is_constant() && (!dst_column->empty()) &&
              (!src_column->empty()) && (src_column->compare_at(0, 0, *dst_column, 1) != 0)));
+    auto append_column = [dst_column](const Column& column, size_t offset, size_t count) {
+        if (column.is_nullable() && !dst_column->is_nullable()) {
+            const auto& nullable_column = down_cast<const NullableColumn&>(column);
+            DCHECK(!nullable_column.has_null());
+            dst_column->append(*nullable_column.data_column(), offset, count);
+        } else {
+            dst_column->append(column, offset, count);
+        }
+    };
     if (src_column->only_null()) {
         static_cast<void>(dst_column->append_nulls(chunk_size));
     } else if (src_column->is_constant() && !dst_column->is_constant()) {
         // Unpack const column, then append it to dst.
         auto* const_column = down_cast<ConstColumn*>(src_column.get());
         const_column->data_column()->assign(chunk_size, 0);
-        dst_column->append(*const_column->data_column(), 0, chunk_size);
+        append_column(*const_column->data_column(), 0, chunk_size);
     } else {
         // Most cases.
-        dst_column->append(*src_column, 0, chunk_size);
+        append_column(*src_column, 0, chunk_size);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

When `enable_push_down_pre_agg_with_rank` is enabled, a window count with rank can be split into local PARTITION-TOP-N pre-aggregation and global analytic merge.

On branch-3.5, the analytic merge path may append a `NullableColumn<Int64>` wrapper into a non-null `Int64Column` cache in `Analytor`. The 3.5 fixed-length column append implementation downcasts the source column to `FixedLengthColumnBase<T>`, so passing a nullable wrapper can make the merge count read wrapper memory as fixed-length data and return incorrect large values.

## What I'm doing:

Unwrap nullable source columns in `Analytor::_append_column` when the destination column is non-nullable and the nullable source has no nulls, then append the underlying data column. This avoids passing nullable wrappers to fixed-length destination append while keeping a debug invariant for true nulls.

The regression coverage is already present in `test/sql/test_window_function/R/test_window_pre_agg_with_rank` on branch-3.5.

Fixes #

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

