### PR TITLE
[BugFix] Pad dict value buffer for expand_load one-past over-read

### DIFF
--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -282,7 +282,7 @@ public:
                 cnt += !is_nulls[i];
             }
         } else {
-            _temp_read_data.resize(read_count);
+            _temp_read_data.resize(read_count + 1);
             auto ret =
                     _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), _temp_read_data.data(), read_count);
             if (UNLIKELY(ret <= 0)) {


### PR DESCRIPTION
## Why I'm doing:

next_value_batch_with_nulls sized _temp_read_data to exactly read_count, but expand_load over-reads src by one element when a batch ends in trailing nulls (the branchless reference and the SIMD scalar tail read src[cnt] for every output position, and cnt == num_valid at a trailing null). This caused an ASan heap-buffer-overflow read of size 8 in the int64 dict VALUE path.

Resize to read_count + 1, matching the dict-code path which already pads.


```
==10640==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5210017df0a0 at pc 0x00002e25c3a5 bp 0x152219c51930 sp 0x152219c51928
READ of size 8 at 0x5210017df0a0 thread T340
    #0 0x2e25c3a4 in expand_load_selection_i64 be/src/base/simd/expand.cpp:123
    #1 0x2e25c4d4 in SIMD::Expand::expand_load_simd(long*, long const*, unsigned char const*, unsigned long) be/src/base/simd/expand.cpp:289
    #2 0x263f5fcd in void SIMD::Expand::expand_load<long>(long*, long const*, unsigned char const*, unsigned long) be/src/base/simd/expand.h:55
    #3 0x263f109b in void starrocks::parquet::CacheAwareDictDecoder::assign_data_with_nulls<long>(unsigned long, unsigned long, unsigned char const*, long const*, long*) be/src/formats/parquet/encoding_dict.h:143
    #4 0x263e3158 in starrocks::parquet::DictDecoder<long>::next_value_batch_with_nulls(unsigned long, unsigned long, starrocks::parquet::NullInfos const&, starrocks::Column*, unsigned char const*) be/src/formats/parquet/encoding_dict.h:292
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
