### PR TITLE
[Enhancement] Support combined txn log / file bundling for FRONTEND_STREAMING loads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -361,20 +361,12 @@ public class LakeTableHelper {
     }
 
     public static boolean supportCombinedTxnLog(TransactionState.LoadJobSourceType sourceType) {
-        return RunMode.isSharedDataMode() && Config.lake_use_combined_txn_log && isLoadingTransaction(sourceType);
-    }
-
-    private static boolean isLoadingTransaction(TransactionState.LoadJobSourceType sourceType) {
-        return sourceType == TransactionState.LoadJobSourceType.BACKEND_STREAMING ||
-                sourceType == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK ||
-                sourceType == TransactionState.LoadJobSourceType.INSERT_STREAMING ||
-                sourceType == TransactionState.LoadJobSourceType.FRONTEND_STREAMING ||
-                sourceType == TransactionState.LoadJobSourceType.BATCH_LOAD_JOB;
+        return RunMode.isSharedDataMode() && Config.lake_use_combined_txn_log && sourceType.isLoadingTransaction();
     }
 
     // for now, only loading txn and compaction txn support combined txn log
     public static boolean isTransactionSupportCombinedTxnLog(TransactionState.LoadJobSourceType sourceType) {
-        return isLoadingTransaction(sourceType) || sourceType == TransactionState.LoadJobSourceType.LAKE_COMPACTION;
+        return sourceType.isLoadingTransaction() || sourceType == TransactionState.LoadJobSourceType.LAKE_COMPACTION;
     }
 
     // if one of the tables in tableIdList is LakeTable with file bundling, return true

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -368,6 +368,7 @@ public class LakeTableHelper {
         return sourceType == TransactionState.LoadJobSourceType.BACKEND_STREAMING ||
                 sourceType == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK ||
                 sourceType == TransactionState.LoadJobSourceType.INSERT_STREAMING ||
+                sourceType == TransactionState.LoadJobSourceType.FRONTEND_STREAMING ||
                 sourceType == TransactionState.LoadJobSourceType.BATCH_LOAD_JOB;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -100,23 +100,27 @@ public class TransactionState implements Writable, GsonPreProcessable {
     public static final TxnStateComparator TXN_ID_COMPARATOR = new TxnStateComparator();
 
     public enum LoadJobSourceType {
-        FRONTEND(1),                    // old dpp load, mini load, insert stmt(not streaming type) use this type
-        BACKEND_STREAMING(2),           // streaming load use this type
-        INSERT_STREAMING(3),            // insert stmt (streaming type) use this type
-        ROUTINE_LOAD_TASK(4),           // routine load task use this type
-        BATCH_LOAD_JOB(5),              // load job v2 for broker load
-        DELETE(6),                     // synchronization delete job use this type
-        LAKE_COMPACTION(7),            // compaction of LakeTable
-        FRONTEND_STREAMING(8),          // FE streaming load use this type
-        MV_REFRESH(9),                  // Refresh MV
-        REPLICATION(10),                // Replication
-        BYPASS_WRITE(11),               // Bypass BE, and write data file directly
-        MULTI_STATEMENT_STREAMING(12);  // multi statement streaming load
+        // The second argument marks whether the source type is a loading transaction, which is used to decide
+        // combined txn log support. When adding a new type, set it explicitly so the classification is not missed.
+        FRONTEND(1, false),                    // old dpp load, mini load, insert stmt(not streaming type) use this type
+        BACKEND_STREAMING(2, true),            // streaming load use this type
+        INSERT_STREAMING(3, true),             // insert stmt (streaming type) use this type
+        ROUTINE_LOAD_TASK(4, true),            // routine load task use this type
+        BATCH_LOAD_JOB(5, true),               // load job v2 for broker load
+        DELETE(6, false),                      // synchronization delete job use this type
+        LAKE_COMPACTION(7, false),             // compaction of LakeTable
+        FRONTEND_STREAMING(8, true),           // FE streaming load use this type
+        MV_REFRESH(9, false),                  // Refresh MV
+        REPLICATION(10, false),                // Replication
+        BYPASS_WRITE(11, false),               // Bypass BE, and write data file directly
+        MULTI_STATEMENT_STREAMING(12, false);  // multi statement streaming load
 
         private final int flag;
+        private final boolean loadingTransaction;
 
-        LoadJobSourceType(int flag) {
+        LoadJobSourceType(int flag, boolean loadingTransaction) {
             this.flag = flag;
+            this.loadingTransaction = loadingTransaction;
         }
 
         public int value() {
@@ -132,6 +136,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
 
         public int getFlag() {
             return flag;
+        }
+
+        public boolean isLoadingTransaction() {
+            return loadingTransaction;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -108,8 +108,8 @@ public class LakeTableHelperTest {
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
+        Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
         Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.LAKE_COMPACTION));
-        Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
         Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BYPASS_WRITE));
         Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.DELETE));
         Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.MV_REFRESH));
@@ -436,7 +436,7 @@ public class LakeTableHelperTest {
                     TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
         Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
                     TransactionState.LoadJobSourceType.LAKE_COMPACTION));
-        Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
                     TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
         Assertions.assertFalse(LakeTableHelper.isTransactionSupportCombinedTxnLog(
                     TransactionState.LoadJobSourceType.BYPASS_WRITE));


### PR DESCRIPTION
## Why I'm doing:

Merge-commit (batch write) loads begin their transaction with `LoadJobSourceType.FRONTEND_STREAMING`, which is **not** included in `LakeTableHelper.isLoadingTransaction()`:

```java
private static boolean isLoadingTransaction(TransactionState.LoadJobSourceType sourceType) {
    return sourceType == BACKEND_STREAMING ||
            sourceType == ROUTINE_LOAD_TASK ||
            sourceType == INSERT_STREAMING ||
            sourceType == BATCH_LOAD_JOB;   // FRONTEND_STREAMING missing
}
```

Both `supportCombinedTxnLog()` and the `fileBundling` gate in `DatabaseTransactionMgr.beginTransaction()` depend on `isTransactionSupportCombinedTxnLog()` → `isLoadingTransaction()`. So for a merge-commit load, `useCombinedTxnLog` is computed as `false` **even when the target table has file bundling enabled**.

The transaction then falls back to per-tablet txn log writes (`kWriteTxnLog`) on the BE: every commit writes one txn log object per tablet to object storage. For a high-frequency merge-commit workload (e.g. `merge_commit_interval_ms=600`) spanning dozens of tablets, this multiplies the object-storage request rate and makes the `finish` phase highly sensitive to object-storage latency spikes — which can push the `add_chunk` RPC past its timeout and abort the load (`tablet writer add chunk timeout ... WaitWriteTime`).

## What I'm doing:

Classify `FRONTEND_STREAMING` (FE streaming load / merge-commit batch write) as a loading transaction so it also skips per-tablet txn log writes and benefits from combined txn log, reducing object-storage request pressure.

Per review feedback, the loading-transaction classification is moved off `LakeTableHelper.isLoadingTransaction()` onto the `LoadJobSourceType` enum itself (a per-constant flag + `isLoadingTransaction()` method), so adding a new source type forces setting the flag and the classification cannot be silently missed. No behavior change from the refactor.

File bundling read/write is unaffected and was already correct for these loads: `useAggregatePublish` at publish time is driven solely by `table.isFileBundling()`, and the read path is load-type agnostic. This change only reduces the number of txn log objects written before publish.

Verified on a shared-data cluster with `lake_metadata_cache_limit=0` (forcing bundled-metadata reads from object storage on every query). Both import types that produce `FRONTEND_STREAMING` were exercised against a `file_bundling` table and confirmed to commit as `FRONTEND_STREAMING`, publish to `VISIBLE`, and read back correctly:
- **Merge commit / batch write** (`enable_merge_commit`) — 3 loads, 30000 rows.
- **Parallel (channel) transaction stream load** (`/api/transaction/*` with `channel_id`/`channel_num`) — 10000 rows.

Note: `MULTI_STATEMENT_STREAMING` was evaluated and intentionally **not** included. Testing showed that enabling combined txn log for transaction stream load makes publish fail with a combined-txn-log 404 (the BE transaction-stream-load write path does not produce the combined log that publish expects), leaving the txn stuck in COMMITTED. Supporting it requires propagating the combined-txn-log strategy into that BE write path first, which is separate work.

Updated `LakeTableHelperTest` accordingly (`testSupportCombinedTxnLog`, `testIsTransactionSupportCombinedTxnLog`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1 
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4



