### PR TITLE
[BugFix] Bound IVM adaptive refresh when the first delta exceeds mv_max_rows_per_refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.scheduler.mv.ivm;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -364,10 +365,24 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     private TvrTableDelta getBaseTableChangedDeltaAdaptive(BaseTableInfo baseTableInfo,
                                                            List<TvrTableDeltaTrait> tableDeltaTraits,
                                                            TvrTableDelta maxTvrDelta) {
+        AdaptiveDelta adaptive = computeAdaptiveDelta(baseTableInfo, tableDeltaTraits, maxTvrDelta,
+                Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh);
+        hasNextTaskRun |= adaptive.hasNext;
+        logger.info("Base table: {}, db: {}, max tvr delta: {}, adaptive tvr delta: {}, hasNextTaskRun: {}",
+                baseTableInfo.getTableName(), baseTableInfo.getDbName(), maxTvrDelta, adaptive.delta, hasNextTaskRun);
+        return adaptive.delta;
+    }
+
+    @VisibleForTesting
+    static AdaptiveDelta computeAdaptiveDelta(BaseTableInfo baseTableInfo,
+                                              List<TvrTableDeltaTrait> tableDeltaTraits,
+                                              TvrTableDelta maxTvrDelta, long maxRows, long maxBytes) {
         TvrTableSnapshot fromSnapshot = maxTvrDelta.fromSnapshot();
         TvrTableSnapshot toSnapshot = maxTvrDelta.toSnapshot();
         long addedRows = 0;
         long addedFileSize = 0;
+        boolean consumedAny = false;
+        boolean reachedCap = false;
         for (TvrTableDeltaTrait deltaTrait : tableDeltaTraits) {
             // TODO: We may need to handle the case where the deltaTrait is not append-only.
             if (!deltaTrait.isAppendOnly()) {
@@ -376,27 +391,34 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
             }
             addedRows += deltaTrait.getTvrDeltaStats().getAddedRows();
             addedFileSize += deltaTrait.getTvrDeltaStats().getAddedFileSize();
-
-            if (addedRows >= Config.mv_max_rows_per_refresh || addedFileSize >= Config.mv_max_bytes_per_refresh) {
-                logger.info("Base table: {}, db: {}, added rows: {}, added file size:{}, snapshot:{}" +
-                                "reached the max rows per refresh, stop processing further deltas",
-                        baseTableInfo.getTableName(), baseTableInfo.getDbName(), addedRows, addedFileSize, deltaTrait);
+            if (addedRows >= maxRows || addedFileSize >= maxBytes) {
+                reachedCap = true;
+                // A single delta that already meets the cap must still advance one step; otherwise
+                // toSnapshot stays at the range end and the whole backlog refreshes in one run.
+                if (!consumedAny) {
+                    toSnapshot = deltaTrait.getTvrDelta().toSnapshot();
+                }
                 break;
             }
-            logger.info("Base table: {}, db: {}, deltaTrait: {}, added rows: {}, fromSnapshot: {}, toSnapshot: {}",
-                    baseTableInfo.getTableName(), baseTableInfo.getDbName(), deltaTrait, addedRows,
-                    fromSnapshot, toSnapshot);
             toSnapshot = deltaTrait.getTvrDelta().toSnapshot();
+            consumedAny = true;
         }
         TvrTableDelta result = TvrTableDelta.of(fromSnapshot.to, toSnapshot.to);
-        // if the adaptive tvr delta is different from the max tvr delta, generate the next task run
-        hasNextTaskRun |= addedRows >= Config.mv_max_rows_per_refresh
+        boolean hasNext = reachedCap
                 && !toSnapshot.equals(maxTvrDelta.toSnapshot())
                 && !toSnapshot.to.isMax();
-        logger.info("Base table: {}, db: {}, max tvr delta: {}, adaptive tvr delta: {}, " +
-                        "toSnapshot:{}, hasNextTaskRun:{}", baseTableInfo.getTableName(), baseTableInfo.getDbName(),
-                maxTvrDelta, result, toSnapshot, hasNextTaskRun);
-        return result;
+        return new AdaptiveDelta(result, hasNext);
+    }
+
+    @VisibleForTesting
+    static final class AdaptiveDelta {
+        final TvrTableDelta delta;
+        final boolean hasNext;
+
+        AdaptiveDelta(TvrTableDelta delta, boolean hasNext) {
+            this.delta = delta;
+            this.hasNext = hasNext;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessorTest.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.ivm;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.common.tvr.TvrDeltaStats;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableDeltaTrait;
+import com.starrocks.sql.analyzer.SemanticException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MVIVMRefreshProcessorTest {
+
+    private static final long MAX_BYTES = Long.MAX_VALUE;
+    private static final long MAX_ROWS = Long.MAX_VALUE;
+    private static final BaseTableInfo TABLE = Mockito.mock(BaseTableInfo.class);
+
+    /**
+     * Build the trait list {@code IcebergMetadata.listTableDeltaTraits} emits for an all-append chain
+     * {@code base(excl) -> base+1 -> ... -> base+rows.length}: trait k carries delta
+     * {@code (base+k+1, base+k+2]} with snapshot {@code base+k+1}'s added rows, and the newest trait is
+     * the degenerate {@code (head, head]}. The per-trait stat is shifted one snapshot off its delta range,
+     * but the cumulative is exact, which is what the cap accounting relies on.
+     */
+    private static List<TvrTableDeltaTrait> appendChain(long base, long... rows) {
+        List<TvrTableDeltaTrait> traits = new ArrayList<>();
+        int n = rows.length;
+        for (int k = 0; k < n; k++) {
+            long from = base + k + 1;
+            long to = (k + 1 < n) ? base + k + 2 : base + n;
+            traits.add(TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(from, to), new TvrDeltaStats(rows[k], 0L)));
+        }
+        return traits;
+    }
+
+    @Test
+    public void fineGrainedCommitsBatchToCap() {
+        List<TvrTableDeltaTrait> traits = appendChain(10, 1, 1, 1, 1, 1, 1);
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 16L), 2, MAX_BYTES);
+        assertEquals(TvrTableDelta.of(10L, 12L), r.delta);
+        assertTrue(r.hasNext);
+    }
+
+    @Test
+    public void singleOversizedFirstCommitFormsItsOwnBatch() {
+        // Regression: the first commit alone exceeds the cap; it must become its own batch (10,12] with a
+        // follow-up, not swallow the whole (10,14] in one run.
+        List<TvrTableDeltaTrait> traits = appendChain(10, 5, 1, 1, 1);
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 14L), 2, MAX_BYTES);
+        assertEquals(TvrTableDelta.of(10L, 12L), r.delta);
+        assertTrue(r.hasNext);
+    }
+
+    @Test
+    public void singleCommitOverCapWithNothingElseRefreshesWholeRange() {
+        // A single snapshot cannot be subdivided; refresh it whole, no follow-up.
+        List<TvrTableDeltaTrait> traits = appendChain(10, 10);
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 11L), 2, MAX_BYTES);
+        assertEquals(TvrTableDelta.of(10L, 11L), r.delta);
+        assertFalse(r.hasNext);
+    }
+
+    @Test
+    public void wholeRangeUnderCapRefreshesAtOnce() {
+        List<TvrTableDeltaTrait> traits = appendChain(10, 1, 1, 1);
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 13L), 100, MAX_BYTES);
+        assertEquals(TvrTableDelta.of(10L, 13L), r.delta);
+        assertFalse(r.hasNext);
+    }
+
+    @Test
+    public void byteCapSchedulesFollowUp() {
+        // Regression: the byte cap must also schedule a follow-up (previously only the row cap did).
+        List<TvrTableDeltaTrait> traits = List.of(
+                TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(11L, 12L), new TvrDeltaStats(0L, 100L)),
+                TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(12L, 13L), new TvrDeltaStats(0L, 100L)),
+                TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(13L, 13L), new TvrDeltaStats(0L, 100L)));
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 13L), MAX_ROWS, 150L);
+        assertEquals(TvrTableDelta.of(10L, 12L), r.delta);
+        assertTrue(r.hasNext);
+    }
+
+    @Test
+    public void emptyStatsSingleTraitRefreshesWholeRange() {
+        // Mirrors today's cloud-native bookmark source (single trait, empty stats): the cap cannot bite,
+        // so the whole range refreshes in one run. The cloud-native source fix is a separate change.
+        List<TvrTableDeltaTrait> traits =
+                List.of(TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(10L, 16L), TvrDeltaStats.EMPTY));
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 16L), 2, MAX_BYTES);
+        assertEquals(TvrTableDelta.of(10L, 16L), r.delta);
+        assertFalse(r.hasNext);
+    }
+
+    @Test
+    public void nonAppendOnlyDeltaThrows() {
+        List<TvrTableDeltaTrait> traits = List.of(TvrTableDeltaTrait.ofRetractable(TvrTableDelta.of(11L, 12L)));
+        assertThrows(SemanticException.class,
+                () -> MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 12L), 2, MAX_BYTES));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When `mv_max_rows_per_refresh` (or `mv_max_bytes_per_refresh`) is set, an asynchronous IVM refresh is supposed to split a large base-table delta into multiple bounded task runs. In `MVIVMRefreshProcessor.getBaseTableChangedDeltaAdaptive` the loop accumulates each delta trait's added rows/bytes and stops once it reaches the cap — but the `break` fired **before** `toSnapshot` advanced, and `toSnapshot` was seeded to the **end** of the full delta. So when the first (oldest) delta trait alone already met the cap, `toSnapshot` stayed at the range end, the whole backlog was refreshed in a single run, and no follow-up run was scheduled — the cap had no effect on the per-refresh size.

Separately, the follow-up condition only checked the row cap, so reaching the **byte** cap also failed to schedule the next run.

Note: the defaults (`mv_max_rows_per_refresh = 100000000`, `mv_max_bytes_per_refresh = 20GB`) are large, so default refreshes are unaffected; only explicitly-lowered caps were impacted.

## What I'm doing:

- Always advance `toSnapshot` by at least one delta trait before breaking, so a single delta that already exceeds the cap becomes its own bounded batch and the remainder defers to a follow-up task run (forward progress preserved; a delta cannot be split below one snapshot).
- Make the follow-up condition honor the byte cap as well as the row cap, matching the break condition.
- Extract the decision into a pure `computeAdaptiveDelta` and add `MVIVMRefreshProcessorTest` covering fine-grained batching, the oversized-first-delta regression, the byte-cap follow-up, and the empty-stats single-trait (unchanged) case.

Fixes #issue: N/A — no public issue; found while reviewing IVM adaptive-refresh batching.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
