### PR TITLE
[BugFix] Avoid holding coordinator lock during external resource cleanup (backport #72830)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -50,6 +50,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.ThriftServer;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -115,7 +116,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -126,6 +130,8 @@ public class DefaultCoordinator extends Coordinator {
     private static final Logger LOG = LogManager.getLogger(DefaultCoordinator.class);
 
     private static final int DEFAULT_PROFILE_TIMEOUT_SECOND = 2;
+    private static final ExecutorService EXTERNAL_RESOURCE_CLEANUP_EXECUTOR =
+            ThreadPoolManager.newDaemonCacheThreadPool(32, 1024, "external-resource-cleanup", false);
 
     private final JobSpec jobSpec;
     private final ExecutionDAG executionDAG;
@@ -166,6 +172,8 @@ public class DefaultCoordinator extends Coordinator {
     private ShortCircuitExecutor shortCircuitExecutor = null;
     private boolean isShortCircuit = false;
     private boolean isBinaryRow = false;
+    private final AtomicBoolean externalResourcesCleared = new AtomicBoolean(false);
+    private final AtomicBoolean externalResourcesCleanupScheduled = new AtomicBoolean(false);
 
     private long estimatedMemCost;
     private ExecutionSchedule scheduler;
@@ -1026,7 +1034,7 @@ public class DefaultCoordinator extends Coordinator {
 
     private void cancelInternal(PPlanFragmentCancelReason cancelReason) {
         jobSpec.getSlotProvider().cancelSlotRequirement(slot);
-        clearExternalResources();
+        clearExternalResourcesAsync();
 
         if (!isInternalCancel(cancelReason) && StringUtils.isEmpty(connectContext.getState().getErrorMessage())) {
             String errorMsg = String.format("[reason=%s] [msg=%s]", cancelReason, queryStatus.getErrorMsg());
@@ -1054,6 +1062,29 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public void clearExternalResources() {
+        if (!externalResourcesCleared.compareAndSet(false, true)) {
+            return;
+        }
+        doClearExternalResources();
+    }
+
+    private void clearExternalResourcesAsync() {
+        if (externalResourcesCleared.get() || !externalResourcesCleanupScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        // This is a containment for connector cleanup stalls, not a fix for the connector close itself.
+        // Some connectors may block while closing remote metadata/file iterators. Run cleanup outside the
+        // coordinator lock so KILL/query cancellation can still make progress if external cleanup stalls.
+        try {
+            EXTERNAL_RESOURCE_CLEANUP_EXECUTOR.execute(this::clearExternalResources);
+        } catch (RejectedExecutionException e) {
+            externalResourcesCleanupScheduled.set(false);
+            LOG.warn("submit external resource cleanup task failed, query id: {}",
+                    DebugUtil.printId(jobSpec.getQueryId()), e);
+        }
+    }
+
+    private void doClearExternalResources() {
         for (ScanNode scanNode : jobSpec.getScanNodes()) {
             try {
                 scanNode.clear();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -43,6 +43,8 @@ import com.starrocks.system.Backend;
 import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TPartitionType;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
@@ -59,6 +61,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class CoordinatorTest extends PlanTestBase {
@@ -235,5 +238,33 @@ public class CoordinatorTest extends PlanTestBase {
         Assertions.assertEquals(1, scanRangeAssignment.size());
         Assertions.assertEquals(1, instances.size());
 
+    }
+
+    @Test
+    public void testClearExternalResourcesOnlyOnce() {
+        AtomicInteger clearCount = new AtomicInteger();
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        ScanNode scanNode = new ScanNode(new PlanNodeId(0), desc, "counting-scan") {
+            @Override
+            public void clear() {
+                clearCount.incrementAndGet();
+            }
+
+            @Override
+            public java.util.List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected void toThrift(TPlanNode msg) {
+            }
+        };
+        DefaultCoordinator coordinatorWithScan = new DefaultCoordinator.Factory().createQueryScheduler(
+                ctx, Lists.newArrayList(), Collections.singletonList(scanNode), new TDescriptorTable(), null);
+
+        coordinatorWithScan.clearExternalResources();
+        coordinatorWithScan.clearExternalResources();
+
+        Assertions.assertEquals(1, clearCount.get());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

A customer query became unkillable on an FE follower. The saved jstack showed multiple KILL / timeout threads blocked in `DefaultCoordinator.cancel()` while waiting for the same coordinator lock:

```text
parking to wait for <0x0000eee53b179400>
  java.util.concurrent.locks.ReentrantLock.lock
  com.starrocks.qe.DefaultCoordinator.lock
  com.starrocks.qe.DefaultCoordinator.cancel
  com.starrocks.qe.StmtExecutor.cancel
  com.starrocks.qe.ConnectContext.kill
```

At the same time, another coordinator thread was already inside the cancellation / cleanup path and was stuck while closing Iceberg scan resources:

```text
query-deploy-16
  org.apache.iceberg.io.CloseableGroup.close
  org.apache.iceberg.io.CloseableIterable$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$4.close
  com.starrocks.connector.iceberg.IcebergMetadata.closeQuietly
  com.starrocks.connector.iceberg.IcebergMetadata$3.closePlannedTaskIterator
  com.starrocks.connector.iceberg.IcebergMetadata$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$1.close
  com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.close
  com.starrocks.planner.IcebergScanNode.clear
  com.starrocks.qe.DefaultCoordinator.clearExternalResources
  com.starrocks.qe.DefaultCoordinator.cancelInternal
  com.starrocks.qe.DefaultCoordinator.cancel
```

There was also a query execution thread stuck in a similar Iceberg cleanup path:

```text
starrocks-mysql-nio-pool-779
  org.apache.iceberg.io.CloseableGroup.close
  org.apache.iceberg.io.CloseableIterable$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$4.close
  com.starrocks.connector.iceberg.IcebergMetadata.closeQuietly
  com.starrocks.connector.iceberg.IcebergMetadata$3.closePlannedTaskIterator
  com.starrocks.connector.iceberg.IcebergMetadata$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$1.close
  com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.close
  com.starrocks.planner.IcebergScanNode.clear
  com.starrocks.qe.DefaultCoordinator.clearExternalResources
  com.starrocks.qe.DefaultCoordinator.cancelInternal
  com.starrocks.qe.DefaultCoordinator.getNext
```

This means external connector cleanup could run while the `DefaultCoordinator` lock was held. When Iceberg close stalled, the coordinator lock was not released, and all later KILL attempts blocked on the same lock. That is why the query appeared unkillable.

The current evidence suggests the stuck close is likely in the Iceberg planned-task iterator cleanup path, around `tableScan.planFiles()` / `plannedTaskIterable.close()`. However, the jstack stops at Iceberg `CloseableGroup.close()`, so it does not reveal which internal Iceberg closeable inside the group failed to finish. More diagnostics are needed from the next occurrence to identify the exact Iceberg-side root cause.

## What I'm doing:

This PR makes external scan resource cleanup no longer block the coordinator cancellation critical section.

Specifically:

- `cancelInternal()` now schedules external resource cleanup asynchronously instead of calling `clearExternalResources()` directly while the coordinator lock may be held.
- Cleanup runs on a dedicated `external-resource-cleanup` executor instead of the JVM-wide `ForkJoinPool.commonPool`, so a stalled connector close does not consume commonPool workers.
- External cleanup remains idempotent through `externalResourcesCleared`.
- Async scheduling is tracked separately through `externalResourcesCleanupScheduled`, so we do not mark resources as cleared before the cleanup task actually runs. If the async task is only queued, the normal synchronous `StmtExecutor` cleanup path can still take over.
- If cleanup task submission is rejected, the scheduled flag is reset and a WARN is logged.

This PR also adds slow-close diagnostics for Iceberg cleanup. These logs only fire if close is still running after 60 seconds, so normal queries do not emit extra logs.

The new diagnostics identify whether cleanup is stuck at:

```text
IcebergConnectorScanRangeSource.remoteFileInfoSource.close()
```

or at one of the Iceberg planned-task close layers:

```text
fileScanTaskIterator
fileScanTaskIterable
currentTaskIterator
currentTaskIterable
plannedTaskIterator
plannedTaskIterable
```

The log includes table name, snapshot id where available, closeable name, and closeable class.

With this change, if Iceberg or another connector stalls while closing metadata/file iterators, it may still delay the cleanup task, but it should no longer hold the `DefaultCoordinator` lock or block later KILL/query cancellation attempts. The slow-close logs should help determine the exact Iceberg close path if the issue happens again.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
<hr>This is an automatic backport of pull request #72830 done by [Mergify](https://mergify.com).


