### PR TITLE
[BugFix] Record exported row count in audit log for SELECT INTO OUTFILE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2078,7 +2078,8 @@ public class StmtExecutor {
     /**
      * The query result batch will piggyback query statistics in it
      */
-    private void processQueryStatisticsFromResult(RowBatch batch, ExecPlan execPlan, boolean isOutfileQuery) {
+    @VisibleForTesting
+    void processQueryStatisticsFromResult(RowBatch batch, ExecPlan execPlan, boolean isOutfileQuery) {
         if (batch != null && parsedStmt.getOrigStmt() != null && parsedStmt.getOrigStmt().getOrigStmt() != null) {
             statisticsForAuditLog = batch.getQueryStatistics();
             statisticsForAuditLogFromPlaceholder = false;
@@ -2093,8 +2094,16 @@ public class StmtExecutor {
             }
 
             analyzePlanWithExecStats(execPlan);
-            if (context.isArrowFlightSql()) {
-                context.updateReturnRows(statisticsForAuditLog.getReturnedRows());
+            // Arrow Flight SQL and OUTFILE queries do not deliver result rows to the client through
+            // the normal row batches (the responseRowBatch path in the result loop is skipped for
+            // both), so context.returnRows is never accumulated from batch sizes for them. Take the
+            // row count from the BE-reported statistics instead. Other queries already count rows
+            // per batch in the result loop, so they must NOT enter here to avoid double counting.
+            if (context.isArrowFlightSql() || isOutfileQuery) {
+                Long returnedRows = statisticsForAuditLog.getReturnedRows();
+                if (returnedRows != null) {
+                    context.updateReturnRows(returnedRows);
+                }
             }
 
             if (null == statisticsForAuditLog.statsItems || statisticsForAuditLog.statsItems.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.ShowFrontendsStmt;
 import com.starrocks.sql.ast.StatementBase;
@@ -243,6 +244,45 @@ public class StmtExecutorTest {
         Assertions.assertEquals("Delete", executor.getExecType());
         Assertions.assertTrue(executor.isExecLoadType());
         Assertions.assertEquals(ConnectContext.get().getSessionVariable().getInsertTimeoutS(), executor.getExecTimeout());
+    }
+
+    @Test
+    public void testProcessQueryStatisticsUpdatesReturnRowsForOutfileOnly() {
+        // OUTFILE (and Arrow Flight) queries do not deliver result rows through the normal row
+        // batches, so context.returnRows is never accumulated from batch row sizes and must be taken
+        // from the BE-reported statistics.returnedRows. Regular queries already count rows per batch,
+        // so they must NOT pull from statistics here, otherwise the count would be doubled.
+
+        // 1) OUTFILE query: returnRows should come from statistics.returnedRows (empty result batch).
+        ConnectContext outfileCtx = UtFrameUtils.createDefaultCtx();
+        StatementBase outfileStmt = SqlParser.parseSingleStatement("select 1", SqlModeHelper.MODE_DEFAULT);
+        outfileStmt.setOrigStmt(new OriginStatement("select 1", 0));
+        StmtExecutor outfileExecutor = new StmtExecutor(outfileCtx, outfileStmt);
+
+        RowBatch outfileBatch = new RowBatch();
+        PQueryStatistics outfileStats = new PQueryStatistics();
+        outfileStats.returnedRows = 42L;
+        outfileBatch.setQueryStatistics(outfileStats);
+
+        outfileCtx.resetReturnRows();
+        outfileExecutor.processQueryStatisticsFromResult(outfileBatch, null, true);
+        Assertions.assertEquals(42L, outfileCtx.getReturnRows());
+
+        // 2) Regular (non-OUTFILE, non-Arrow-Flight) query: returnRows must NOT be pulled from
+        //    statistics; it stays at whatever the per-batch loop accumulated (0 here).
+        ConnectContext plainCtx = UtFrameUtils.createDefaultCtx();
+        StatementBase plainStmt = SqlParser.parseSingleStatement("select 1", SqlModeHelper.MODE_DEFAULT);
+        plainStmt.setOrigStmt(new OriginStatement("select 1", 0));
+        StmtExecutor plainExecutor = new StmtExecutor(plainCtx, plainStmt);
+
+        RowBatch plainBatch = new RowBatch();
+        PQueryStatistics plainStats = new PQueryStatistics();
+        plainStats.returnedRows = 99L;
+        plainBatch.setQueryStatistics(plainStats);
+
+        plainCtx.resetReturnRows();
+        plainExecutor.processQueryStatisticsFromResult(plainBatch, null, false);
+        Assertions.assertEquals(0L, plainCtx.getReturnRows());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

For `SELECT ... INTO OUTFILE` over the MySQL protocol, the audit log recorded `ReturnRows=0` even when N rows were actually exported. OUTFILE does not deliver result rows to the client, so `ConnectContext.returnRows` (accumulated per result batch) stays 0; the BE-reported exported row count was fed into that counter only on the Arrow Flight SQL path, and `ConnectProcessor.auditAfterExec` then overwrote the audit `ReturnRows` field with the zero context counter. The client `Query OK, N rows affected` was correct, but the audit log under-reported.

## What I'm doing:

Widen the branch in `StmtExecutor.processQueryStatisticsFromResult` so OUTFILE queries (not only Arrow Flight SQL) take the row count from the BE-reported `QueryStatistics.returnedRows` — the number of rows actually written to file, summed across split files — guarded against null. Regular queries are unaffected: they already accumulate `returnRows` per result batch and do not enter this branch, so there is no double counting.

Verified end-to-end on a running cluster exporting to S3 (MinIO): same `SELECT ... INTO OUTFILE` went from audit `ReturnRows=0` (before) to `ReturnRows=7` (after). Also verified accurate across query shapes against a real table — `WHERE` filters, empty result (0), `LIMIT`, `ORDER BY`+`LIMIT`, `GROUP BY`, full scan, and a 1,000,000-row export split into 3 files — in every case `ReturnRows` equals the actual number of exported rows.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
