### PR TITLE
[BugFix] Reproduce nextVersion bump when replaying lake index fast-path alter jobs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -475,18 +475,35 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
             return;
         }
         if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN
-                || jobState == JobState.RUNNING || jobState == JobState.FINISHED_REWRITING) {
+                || jobState == JobState.RUNNING) {
             table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        } else if (jobState == JobState.FINISHED_REWRITING) {
+            table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+            // The live runRunningJob bumped each partition's nextVersion to
+            // commitVersion+1 at the FINISHED_REWRITING transition (see
+            // updateNextVersion). The edit log persists the job's state but
+            // NOT that in-memory catalog bump, so a cold-started or
+            // leader-switched FE must redo it here. Without this the
+            // partition's nextVersion stays one behind the version reserved
+            // here, and the next operation that asserts
+            // nextVersion == its own reserved commitVersion -- e.g. a
+            // following LakeTableSchemaChangeJob.replay() -> updateNextVersion
+            // -- fails its Preconditions.checkState and aborts journal replay,
+            // leaving the FE unable to start.
+            replayUpdateNextVersion(table);
         } else if (jobState == JobState.FINISHED) {
             // Reapply catalog mutation at replay so a cold-started FE sees
             // the post-alter table state. The mutation is idempotent by
             // design (add checks presence, drop is no-op on missing).
             //
-            // Also re-bump each partition's visibleVersion: the live FE
-            // captured this in memory only, and the next image may have been
-            // taken before the bump landed. Skip a partition whose live
-            // visibleVersion already covers the commitVersion (idempotent on
-            // replay-after-checkpoint).
+            // Also re-bump each partition's nextVersion and visibleVersion:
+            // the live FE captured both in memory only, and the next image may
+            // have been taken before the bump landed (or before the
+            // FINISHED_REWRITING journal that carries the nextVersion bump).
+            // Both bumps are idempotent: skip a partition that already
+            // advanced past the target (replay-after-checkpoint, or a later
+            // op that moved the version on).
+            replayUpdateNextVersion(table);
             for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
                 PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
                 if (pp != null && pp.getVisibleVersion() < e.getValue()) {
@@ -496,7 +513,29 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
             applyCatalogMutation(table);
             table.setState(OlapTable.OlapTableState.NORMAL);
         } else if (jobState == JobState.CANCELLED) {
+            // A job force-cancelled out of FINISHED_REWRITING has already
+            // reserved a commitVersion and bumped nextVersion on the live FE;
+            // reproduce that bump on replay too (no-op when the job was
+            // cancelled before reserving, since commitVersionMap is empty).
+            replayUpdateNextVersion(table);
             table.setState(OlapTable.OlapTableState.NORMAL);
+        }
+    }
+
+    // Reproduce, idempotently, the nextVersion bump that the live
+    // runRunningJob applied via updateNextVersion at the FINISHED_REWRITING
+    // transition. Never regress a partition whose nextVersion already covers
+    // commitVersion+1 (e.g. when the checkpoint image was taken after the bump
+    // landed, or after a later operation advanced the version).
+    private void replayUpdateNextVersion(OlapTable table) {
+        if (commitVersionMap == null) {
+            return;
+        }
+        for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
+            PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
+            if (pp != null && pp.getNextVersion() < e.getValue() + 1) {
+                pp.setNextVersion(e.getValue() + 1);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
@@ -385,6 +385,92 @@ public class LakeTableIndexFastPathJobBaseTest {
     }
 
     @Test
+    public void testReplay_FinishedRewritingBumpsNextVersion() throws Exception {
+        // Regression: the live runRunningJob bumps each partition's nextVersion
+        // to commitVersion+1 at FINISHED_REWRITING. Replay must reproduce it,
+        // otherwise the partition stays one version behind and a later job that
+        // asserts nextVersion == its reserved commitVersion (e.g.
+        // LakeTableSchemaChangeJob.updateNextVersion) aborts journal replay.
+        LakeTableAddIndexJob target = newJob();
+        LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commitMap = new HashMap<>();
+        commitMap.put(100L, 12L);
+        setField(other, "commitVersionMap", commitMap);
+
+        OlapTable table = mock(OlapTable.class);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        when(pp.getNextVersion()).thenReturn(12L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        runReplay(target, other, new Database(2L, "db"), table);
+        verify(table).setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        verify(pp).setNextVersion(13L);
+    }
+
+    @Test
+    public void testReplay_FinishedBumpsNextVersionWhenStale() throws Exception {
+        // FINISHED replay must reproduce BOTH the nextVersion bump (in case the
+        // image predates the FINISHED_REWRITING journal) and the visibleVersion
+        // bump.
+        LakeTableAddIndexJob target = newJob();
+        LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.FINISHED);
+        Map<Long, Long> commitMap = new HashMap<>();
+        commitMap.put(100L, 12L);
+        setField(other, "commitVersionMap", commitMap);
+        setField(other, "finishedTimeMs", 12345L);
+
+        OlapTable table = mock(OlapTable.class);
+        when(table.getIndexes()).thenReturn(new ArrayList<>());
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        when(pp.getNextVersion()).thenReturn(12L);
+        when(pp.getVisibleVersion()).thenReturn(11L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        runReplay(target, other, new Database(2L, "db"), table);
+        verify(pp).setNextVersion(13L);
+        verify(pp).setVisibleVersion(12L, 12345L);
+    }
+
+    @Test
+    public void testReplay_NextVersionBumpIsIdempotent() throws Exception {
+        // A later operation already advanced the partition past commitVersion+1
+        // (e.g. replay-after-checkpoint); replay must not regress nextVersion.
+        LakeTableAddIndexJob target = newJob();
+        LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commitMap = new HashMap<>();
+        commitMap.put(100L, 12L);
+        setField(other, "commitVersionMap", commitMap);
+
+        OlapTable table = mock(OlapTable.class);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        when(pp.getNextVersion()).thenReturn(20L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        runReplay(target, other, new Database(2L, "db"), table);
+        verify(pp, never()).setNextVersion(anyLong());
+    }
+
+    @Test
+    public void testReplay_CancelledBumpsNextVersionWhenReserved() throws Exception {
+        // Force-cancelled out of FINISHED_REWRITING: the version was reserved
+        // and nextVersion bumped on the live FE, so replay must reproduce it.
+        LakeTableAddIndexJob target = newJob();
+        LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.CANCELLED);
+        Map<Long, Long> commitMap = new HashMap<>();
+        commitMap.put(100L, 12L);
+        setField(other, "commitVersionMap", commitMap);
+
+        OlapTable table = mock(OlapTable.class);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        when(pp.getNextVersion()).thenReturn(12L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        runReplay(target, other, new Database(2L, "db"), table);
+        verify(table).setState(OlapTable.OlapTableState.NORMAL);
+        verify(pp).setNextVersion(13L);
+    }
+
+    @Test
     public void testReplay_CancelledFlipsToNormal() throws Exception {
         LakeTableAddIndexJob target = newJob();
         LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.CANCELLED);


### PR DESCRIPTION
## Why I'm doing:

A shared-data FE can fail to start / fail to switch to leader with:

```
failed to load journal type 121
java.lang.IllegalStateException: partitionNextVersion=13 commitVersion=14
    at com.starrocks.alter.LakeTableSchemaChangeJob.updateNextVersion(...)
    at com.starrocks.alter.LakeTableSchemaChangeJob.replay(...)
```

Root cause: `LakeTableIndexFastPathJob` (the fast path used for bloom-filter
and other lightweight index add/drop on cloud-native tables) bumps each
partition's `nextVersion` to `commitVersion + 1` in the **live**
`runRunningJob` at the `FINISHED_REWRITING` transition (via
`updateNextVersion`). The edit log persists the job's *state* transition but
not that in-memory catalog bump, and `LakeTableIndexFastPathJobBase.replay()`
never reproduced it — the `FINISHED_REWRITING` branch only set the table
state, and the `FINISHED` branch only re-bumped `visibleVersion`.

As a result, after an FE restart or leader switch the partition's
`nextVersion` stays exactly one version behind. The next operation that
asserts `nextVersion == its reserved commitVersion` — e.g. a subsequent
`LakeTableSchemaChangeJob.replay() -> updateNextVersion` — throws and aborts
journal replay, leaving the FE unable to start. The inconsistency is baked
into the journal, so every replay (checkpoint worker and leader transfer
alike) hits it.

Observed sequence on the affected table (`file_bundling` lake table):
inserts → v11, an index fast-path alter (`ALTER ... SET bloom_filter_columns`)
reserved v12 and bumped `nextVersion` (lost on replay), compaction → v13,
then a `LakeTableSchemaChangeJob` reserved `commitVersion=14`; on replay the
fast-path bump was missing so the partition only reached 13 and the schema
change's `checkState(nextVersion == 14)` failed.

## What I'm doing:

Reproduce the `nextVersion` bump on replay, idempotently, in the
`FINISHED_REWRITING`, `FINISHED` and `CANCELLED` branches of
`LakeTableIndexFastPathJobBase.replay()`, mirroring the `visibleVersion`
handling already present in the `FINISHED` branch. The bump never regresses a
partition that has already advanced past `commitVersion + 1` (safe for
replay-after-checkpoint and for a later op that moved the version on).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

> The `LakeTableIndexFastPathJob` fast path exists on `main` only (not in
> branch-4.1 / branch-4.0 / branch-3.5), so no backport is required.
