### PR TITLE
[Enhancement] Support combined txn log / file bundling for multi-statement streaming loads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -368,6 +368,7 @@ public class LakeTableHelper {
         return sourceType == TransactionState.LoadJobSourceType.BACKEND_STREAMING ||
                 sourceType == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK ||
                 sourceType == TransactionState.LoadJobSourceType.INSERT_STREAMING ||
+                sourceType == TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING ||
                 sourceType == TransactionState.LoadJobSourceType.BATCH_LOAD_JOB;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -107,6 +107,8 @@ public class LakeTableHelperTest {
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
+        Assertions.assertTrue(
+                LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING));
         Assertions.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
         Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.LAKE_COMPACTION));
         Assertions.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
@@ -432,6 +434,8 @@ public class LakeTableHelperTest {
                     TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
         Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
                     TransactionState.LoadJobSourceType.INSERT_STREAMING));
+        Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
+                    TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING));
         Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(
                     TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
         Assertions.assertTrue(LakeTableHelper.isTransactionSupportCombinedTxnLog(


### PR DESCRIPTION
## Why I'm doing:

Multi-statement streaming loads begin their transaction with `LoadJobSourceType.MULTI_STATEMENT_STREAMING` (see `TransactionLoadAction` / `StreamLoadMultiStmtTask`), which is **not** included in `LakeTableHelper.isLoadingTransaction()`:

```java
private static boolean isLoadingTransaction(TransactionState.LoadJobSourceType sourceType) {
    return sourceType == BACKEND_STREAMING ||
            sourceType == ROUTINE_LOAD_TASK ||
            sourceType == INSERT_STREAMING ||
            sourceType == BATCH_LOAD_JOB;   // MULTI_STATEMENT_STREAMING missing
}
```

As a result, `supportCombinedTxnLog()` returns `false` for these loads, so `useCombinedTxnLog` is computed as `false`. The transaction then writes one txn log object **per tablet** to object storage (`kWriteTxnLog`) instead of a single combined txn log per transaction, multiplying the object-storage request rate on commit.

Note that a multi-statement streaming load goes through the exact same explicit-transaction commit path (`TransactionStmtExecutor.beginStmt` → `loadData` → `commitStmt`) as an explicit `BEGIN ... INSERT ... COMMIT` transaction, which uses `INSERT_STREAMING` and **already** supports combined txn log. The two differ only by source-type label, so this is the natural symmetric gap.

This is a follow-up to #74460, which added `FRONTEND_STREAMING` for the same reason.

## What I'm doing:

Add `MULTI_STATEMENT_STREAMING` to `isLoadingTransaction()` so multi-statement streaming loads also benefit from combined txn log, reducing object-storage request pressure on commit.

Updated `LakeTableHelperTest` accordingly (`testSupportCombinedTxnLog`, `testIsTransactionSupportCombinedTxnLog`).

File bundling read/write is unaffected and was already correct for these loads: `useAggregatePublish` at publish time is driven solely by `table.isFileBundling()`, and the read path is load-type agnostic. This change only reduces the number of txn log objects written before publish.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
