### PR TITLE
[Enhancement] Allow data skew detection when table row count may be inaccurate (backport #73998)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -444,6 +444,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SKEW_JOIN_OPTIMIZE_USE_MCV_COUNT = "skew_join_use_mcv_count";
     public static final String SKEW_JOIN_DATA_SKEW_THRESHOLD = "skew_join_data_skew_threshold";
     public static final String SKEW_JOIN_MAX_OTHER_SIDE_OVERLAP_ROW_COUNT = "skew_join_max_other_side_overlap_row_count";
+    public static final String ENABLE_SKEW_DETECT_WITH_INACCURATE_STATS = "enable_skew_detect_with_inaccurate_stats";
 
     public static final String CHOOSE_EXECUTE_INSTANCES_MODE = "choose_execute_instances_mode";
 
@@ -2690,6 +2691,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // With the default value of `skewJoinRandRange` = 1000, an overlap of 1M leads to 1Bn rows.
     @VarAttr(name = SKEW_JOIN_MAX_OTHER_SIDE_OVERLAP_ROW_COUNT, flag = VariableMgr.INVISIBLE)
     private long skewJoinMaxOtherSideOverlapRowCount = 1_000_000;
+
+    // When enabled, skew detection proceeds even when table row count is marked as potentially inaccurate (isTableRowCountMayInaccurate).
+    // This allows rules consuming skew info (joins, aggregations, window functions) to fire based on
+    // histogram/MCV data regardless of row count reliability.
+    @VarAttr(name = ENABLE_SKEW_DETECT_WITH_INACCURATE_STATS, flag = VariableMgr.INVISIBLE)
+    private boolean enableSkewDetectWithInaccurateStats = false;
 
     @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
     private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
@@ -5069,6 +5076,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableStatsToOptimizeSkewJoin(boolean enableStatsToOptimizeSkewJoin) {
         this.enableStatsToOptimizeSkewJoin = enableStatsToOptimizeSkewJoin;
+    }
+
+    public boolean isEnableSkewDetectWithInaccurateStats() {
+        return enableSkewDetectWithInaccurateStats;
+    }
+
+    public void setEnableSkewDetectWithInaccurateStats(boolean enableSkewDetectWithInaccurateStats) {
+        this.enableSkewDetectWithInaccurateStats = enableSkewDetectWithInaccurateStats;
     }
 
     public int getSkewJoinOptimizeUseMCVCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -15,6 +15,7 @@ package com.starrocks.sql.optimizer.skew;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
@@ -139,6 +140,20 @@ public class DataSkew {
     }
 
     /**
+     * In some cases the row count in statistics can be inaccurate,
+     * and enforcing skew detection in those cases can lead to false positives.
+     * This utility checks whether the inaccurate stats should be ignored for
+     * skew detection based on the session variable enableSkewDetectWithInaccurateStats
+     */
+    private static boolean shouldEnforceRowCountAccuracy() {
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null && ctx.getSessionVariable() != null) {
+            return !ctx.getSessionVariable().isEnableSkewDetectWithInaccurateStats();
+        }
+        return true;
+    }
+
+    /**
      * Utility method to get detailed information about if a column is skewed and how it is skewed.
      */
     public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic) {
@@ -151,7 +166,7 @@ public class DataSkew {
     public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
                                              Thresholds thresholds) {
         final var rowCount = statistics.getOutputRowCount();
-        if (statistics.isTableRowCountMayInaccurate() || rowCount < 1) {
+        if (rowCount < 1 || (statistics.isTableRowCountMayInaccurate() && shouldEnforceRowCountAccuracy())) {
             // Without sufficient information we can not make a decision.
             return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.INACCURATE_ROW_COUNT);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
@@ -17,11 +17,13 @@ package com.starrocks.sql.optimizer.skew;
 import com.google.crypto.tink.subtle.Random;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.statistics.Bucket;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Histogram;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -33,6 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataSkewTest {
+
+    @AfterEach
+    void tearDown() {
+        ConnectContext.remove();
+    }
 
     private static ColumnRefOperator createNewTestColumn() {
         return new ColumnRefOperator(Random.randInt(), Type.INT, UUID.randomUUID().toString(), true);
@@ -167,6 +174,60 @@ public class DataSkewTest {
         for (final var value : expectedMcvs) {
             assertTrue(nullAndMcvButMoreMcvSkewInfo.maybeMcvs().get().contains(value));
         }
+    }
+
+    @Test
+    void itShouldDetectSkewWhenInaccurateStatsAndSessionVariableEnabled() {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+        ctx.getSessionVariable().setEnableSkewDetectWithInaccurateStats(true);
+
+        final var skewedHistogram = getSkewedHistogram();
+        final var col = createNewTestColumn();
+        final var colStats = ColumnStatistic.builder()
+                .setNullsFraction(0.01)
+                .setHistogram(skewedHistogram)
+                .build();
+
+        final var stats = Statistics.buildFrom(
+                new Statistics.Builder()
+                        .setOutputRowCount(100_000)
+                        .addColumnStatistic(col, colStats)
+                        .build())
+                .setTableRowCountMayInaccurate(true)
+                .build();
+
+        assertTrue(DataSkew.isColumnSkewed(stats, colStats));
+
+        final var skewInfo = DataSkew.getColumnSkewInfo(stats, colStats);
+        assertEquals(DataSkew.SkewType.SKEWED_MCV, skewInfo.type());
+    }
+
+    @Test
+    void itShouldNotDetectSkewWhenInaccurateStatsAndSessionVariableDisabled() {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+
+        final var skewedHistogram = getSkewedHistogram();
+        final var col = createNewTestColumn();
+        final var colStats = ColumnStatistic.builder()
+                .setNullsFraction(0.01)
+                .setHistogram(skewedHistogram)
+                .build();
+
+        final var stats = Statistics.buildFrom(
+                new Statistics.Builder()
+                        .setOutputRowCount(100_000)
+                        .addColumnStatistic(col, colStats)
+                        .build())
+                .setTableRowCountMayInaccurate(true)
+                .build();
+
+        assertFalse(DataSkew.isColumnSkewed(stats, colStats));
+
+        final var skewInfo = DataSkew.getColumnSkewInfo(stats, colStats);
+        assertEquals(DataSkew.SkewType.NOT_SKEWED, skewInfo.type());
+        assertEquals(DataSkew.AdditionalInfo.INACCURATE_ROW_COUNT, skewInfo.additionalInfo());
     }
 
     private static Histogram getSkewedHistogram() {


### PR DESCRIPTION
## Why I'm doing:
We often see skew optimization rules not being applied because `DataSkew.getSkewCandidates` does not report skew. This is because statistics for the table sometimes report `isTableRowCountMayInaccurate()=true`, even though ColumnStatistics and MCVs are skewed and correct. 

There are multiple reasons why `isTableRowCountMayInaccurate()=true`, but one reason is due to cache eviction in tableStatsCache.
TableStatsCache is a fixed size cache in `CachedStatisticStorage`. Evicted entries trigger async reloads that may return empty results to the caller (mostly due to `enable_sync_statistics_load=false`). Due to this`getPartitionRows` may return a rowCount of 0 and we end up with a tableRowCount=0 in `computeOlapScanNode`, resulting in `isTableRowCountMayInaccurate = true`.

## What I'm doing:
Adds an session variable `enable_skew_detect_with_inaccurate_stats` that bypasses the `isTableRowCountMayInaccurate` guard in DataSkew. When enabled, skew detection proceeds based on available MCV/histogram data even when the row count is flagged as potentially inaccurate.

The check is implemented inside DataSkew itself, so all consumers (skew join elimination, aggregation skew handling, window function optimization) benefit without any call-site changes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
