### PR TITLE
[Enhancement] Add TASK_SOURCE column to information_schema.task_runs

### DIFF
--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -40,7 +40,8 @@ SchemaScanner::ColumnDesc SchemaTaskRunsScanner::_s_tbls_columns[] = {
         {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"PROPERTIES", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"JOB_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
-        {"PROCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true}};
+        {"PROCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"TASK_SOURCE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true}};
 
 SchemaTaskRunsScanner::SchemaTaskRunsScanner()
         : SchemaScanner(_s_tbls_columns, sizeof(_s_tbls_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
@@ -332,6 +333,20 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
                     }
                 } else {
                     nullable_column->append_nulls(1);
+                }
+            }
+            break;
+        }
+        case 18: {
+            // TASK_SOURCE
+            {
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(18);
+                if (task_run_info.__isset.task_source) {
+                    const std::string* str = &task_run_info.task_source;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+                } else {
+                    fill_data_column_with_null(column);
                 }
             }
             break;

--- a/be/test/exec/schema_task_runs_scanner_test.cpp
+++ b/be/test/exec/schema_task_runs_scanner_test.cpp
@@ -57,7 +57,7 @@ TEST_F(SchemaTaskRunsScannerTest, test_scanner_initialization) {
 
     // Test that scanner has the correct number of columns
     auto slot_descs = scanner.get_slot_descs();
-    EXPECT_EQ(17, slot_descs.size());
+    EXPECT_EQ(18, slot_descs.size());
 
     // Test column names and types
     EXPECT_EQ("QUERY_ID", slot_descs[0]->col_name());
@@ -77,6 +77,7 @@ TEST_F(SchemaTaskRunsScannerTest, test_scanner_initialization) {
     EXPECT_EQ("PROPERTIES", slot_descs[14]->col_name());
     EXPECT_EQ("JOB_ID", slot_descs[15]->col_name());
     EXPECT_EQ("PROCESS_TIME", slot_descs[16]->col_name());
+    EXPECT_EQ("TASK_SOURCE", slot_descs[17]->col_name());
 }
 
 TEST_F(SchemaTaskRunsScannerTest, test_uninitialized_scanner) {
@@ -140,6 +141,7 @@ TEST_F(SchemaTaskRunsScannerTest, test_single_task_run) {
     task_run.__set_properties("{\"priority\":\"high\"}");
     task_run.__set_job_id("job_001");
     task_run.__set_process_time(1640995400); // 2022-01-01 00:03:20
+    task_run.__set_task_source("INSERT");
 
     scanner._task_run_result.task_runs = {task_run};
     scanner._task_run_index = 0;
@@ -167,6 +169,7 @@ TEST_F(SchemaTaskRunsScannerTest, test_single_task_run) {
     EXPECT_TRUE(row.find("{\"priority\":\"high\"}") != std::string::npos);     // PROPERTIES
     EXPECT_TRUE(row.find("job_001") != std::string::npos);                     // JOB_ID
     EXPECT_TRUE(row.find("2022-01-01") != std::string::npos);                  // PROCESS_TIME
+    EXPECT_TRUE(row.find("INSERT") != std::string::npos);                      // TASK_SOURCE
 
     chunk->reset();
     EXPECT_OK(scanner.get_next(&chunk, &eos));

--- a/docs/en/sql-reference/information_schema/task_runs.md
+++ b/docs/en/sql-reference/information_schema/task_runs.md
@@ -27,6 +27,7 @@ The following fields are provided in `task_runs`:
 | PROPERTIES    | Properties of the task.                                      |
 | JOB_ID        | Job ID of the task.                                          |
 | PROCESS_TIME  | Process time of the task.                                    |
+| TASK_SOURCE   | Source that submitted the task. Valid values: `CTAS`, `MV`, `INSERT`, `PIPE`, and `DATACACHE_SELECT`. `UNKNOWN` is returned for legacy records whose source was not recorded. |
 
 A task run record is produced by either [SUBMIT TASK](../sql-statements/loading_unloading/ETL/SUBMIT_TASK.md) or [CREATE MATRIALIZED VIEW](../sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md).
 

--- a/docs/ja/sql-reference/information_schema/task_runs.md
+++ b/docs/ja/sql-reference/information_schema/task_runs.md
@@ -27,6 +27,7 @@ description: "task_runsは非同期タスクの実行に関する情報を提供
 | PROPERTIES    | タスクのプロパティ。                                         |
 | JOB_ID        | タスクのジョブ ID。                                          |
 | PROCESS_TIME  | タスクの処理時間。                                           |
+| TASK_SOURCE   | タスクを送信したソース。 有効な値は `CTAS`、`MV`、`INSERT`、`PIPE`、`DATACACHE_SELECT` です。ソースが記録されていないレガシーレコードの場合は `UNKNOWN` が返されます。 |
 
 タスク実行記録は、[SUBMIT TASK](../sql-statements/loading_unloading/ETL/SUBMIT_TASK.md) または [CREATE MATERIALIZED VIEW](../sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md) によって生成されます。
 

--- a/docs/zh/sql-reference/information_schema/task_runs.md
+++ b/docs/zh/sql-reference/information_schema/task_runs.md
@@ -27,6 +27,7 @@ description: "task_runs 提供异步任务执行的信息。"
 | PROPERTIES    | 任务的属性。                                                 |
 | JOB_ID        | 任务的作业 ID。                                              |
 | PROCESS_TIME  | 任务的处理时间。                                             |
+| TASK_SOURCE   | 提交任务的来源。有效值：`CTAS`、`MV`、`INSERT`、`PIPE` 和 `DATACACHE_SELECT`。对于未记录来源的历史记录，返回 `UNKNOWN`。 |
 
 Task Run 记录由 [SUBMIT TASK](../sql-statements/loading_unloading/ETL/SUBMIT_TASK.md) 或 [CREATE MATRIALIZED VIEW](../sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md) 生成。
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -93,6 +93,7 @@ public class TaskRunsSystemTable extends SystemTable {
                         .column("PROPERTIES", TypeFactory.createVarcharType(512))
                         .column("JOB_ID", TypeFactory.createVarcharType(64))
                         .column("PROCESS_TIME", DATETIME)
+                        .column("TASK_SOURCE", TypeFactory.createVarcharType(16))
                         .build(), TSchemaTableType.SCH_TASK_RUNS);
     }
 
@@ -235,6 +236,7 @@ public class TaskRunsSystemTable extends SystemTable {
             info.setProperties(status.getPropertiesJson());
             info.setProcess_time(status.getProcessStartTime() / 1000);
             info.setJob_id(status.getStartTaskRunId());
+            info.setTask_source(status.getSource().name());
             tasksResult.add(info);
         }
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -41,6 +41,8 @@ public class Constants {
 
     // TaskSource is used to distinguish special Processors for processing tasks from different sources.
     public enum TaskSource {
+        // Sentinel for task runs persisted before the source field existed; never set on new runs.
+        UNKNOWN,
         CTAS,
         MV,
         INSERT,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -103,8 +103,9 @@ public class TaskRunStatus implements Writable {
     @SerializedName("mergeRedundant")
     private boolean mergeRedundant = false;
 
+    // Runs persisted before this field existed have no recorded source and default to UNKNOWN (not a misleading CTAS).
     @SerializedName("source")
-    private Constants.TaskSource source = Constants.TaskSource.CTAS;
+    private Constants.TaskSource source = Constants.TaskSource.UNKNOWN;
 
     //////////// Variables should be volatile which can be visited by multi threads ///////////
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/TaskRunsSystemTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/TaskRunsSystemTableTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class TaskRunsSystemTableTest {
@@ -46,6 +48,54 @@ public class TaskRunsSystemTableTest {
                 .map(Column::getName)
                 .anyMatch("WAREHOUSE"::equalsIgnoreCase);
         Assertions.assertTrue(hasWarehouse, "task_runs system table should have a WAREHOUSE column");
+    }
+
+    @Test
+    public void testSchemaContainsTaskSourceColumnAsLast() {
+        List<Column> schema = TaskRunsSystemTable.getInstance().getBaseSchema();
+        boolean hasTaskSource = schema.stream()
+                .map(Column::getName)
+                .anyMatch("TASK_SOURCE"::equalsIgnoreCase);
+        Assertions.assertTrue(hasTaskSource, "task_runs system table should have a TASK_SOURCE column");
+        Assertions.assertEquals("TASK_SOURCE", schema.get(schema.size() - 1).getName());
+    }
+
+    @Test
+    public void testQuerySetsTaskSourceFromStatus(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked TaskManager taskManager) {
+        TaskRunStatus status = new TaskRunStatus();
+        status.setQueryId("q3");
+        status.setTaskName("task3");
+        status.setDbName("db1");
+        status.setSource(Constants.TaskSource.MV);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getTaskManager();
+                minTimes = 0;
+                result = taskManager;
+
+                taskManager.getMatchedTaskRunStatus((TGetTasksParams) any);
+                result = Lists.newArrayList(status);
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext context, String catalogName, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        TGetTaskRunInfoResult result = TaskRunsSystemTable.query(new TGetTasksParams());
+
+        Assertions.assertEquals(1, result.getTask_runs().size());
+        Assertions.assertEquals("MV", result.getTask_runs().get(0).getTask_source());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunStatusTest.java
@@ -16,6 +16,7 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.WarehouseManager;
@@ -87,5 +88,22 @@ public class TaskRunStatusTest {
         taskRunStatus.setMvTaskRunExtraMessage(new MVTaskRunExtraMessage());
         taskRunStatus.getMvTaskRunExtraMessage().setNextPartitionStart("2023-01-01");
         Assertions.assertEquals(Constants.TaskRunState.PENDING, taskRunStatus.getLastRefreshState());
+    }
+
+    @Test
+    public void testSourceIsUnknownWhenAbsentFromPersistedJson() {
+        // Runs persisted before the source field existed have no "source" key and must load as UNKNOWN,
+        // so task_runs surfaces them as UNKNOWN rather than a misleading CTAS.
+        String legacyJson = "{\"queryId\":\"q1\",\"taskName\":\"t1\",\"state\":\"SUCCESS\"}";
+        TaskRunStatus status = GsonUtils.GSON.fromJson(legacyJson, TaskRunStatus.class);
+        Assertions.assertEquals(Constants.TaskSource.UNKNOWN, status.getSource());
+    }
+
+    @Test
+    public void getLastRefreshStateTreatsUnknownSourceAsNonMv() {
+        // A legacy run carries an UNKNOWN source; getLastRefreshState must treat it as a non-MV run.
+        TaskRunStatus status = new TaskRunStatus();
+        status.setState(Constants.TaskRunState.SUCCESS);
+        Assertions.assertEquals(Constants.TaskRunState.SUCCESS, status.getLastRefreshState());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -387,7 +387,8 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
                 .explainContains("     constant exprs: ",
                         "NULL | 't_1024' | '2024-01-02 03:04:05' | '2024-01-02 03:04:05' | 'SUCCESS' | " +
                                 "NULL | 'default_warehouse' | 'd1' | 'insert into t1 select * from t1' | " +
-                                "'2024-01-02 03:04:05' | 0 | NULL | '0%' | '' | NULL | NULL | '1970-01-01 08:00:00'");
+                                "'2024-01-02 03:04:05' | 0 | NULL | '0%' | '' | NULL | NULL | " +
+                                "'1970-01-01 08:00:00' | 'UNKNOWN'");
         starRocksAssert.query("select state, error_message" +
                         " from information_schema.task_runs where task_name = 't_1024' ")
                 .explainContains("     constant exprs: ",

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -557,6 +557,8 @@ struct TTaskRunInfo {
 
     16: optional string job_id
     17: optional i64 process_time
+
+    18: optional string task_source
 }
 
 struct TGetTaskRunInfoResult {

--- a/test/sql/test_information_schema/R/test_task_run_status
+++ b/test/sql/test_information_schema/R/test_task_run_status
@@ -50,6 +50,36 @@ SELECT count(1) FROM information_schema.task_runs WHERE task_name = '${task_name
 -- result:
 1
 -- !result
+SELECT TASK_SOURCE FROM information_schema.task_runs WHERE task_name = '${task_name}';
+-- result:
+MV
+-- !result
+submit task task_src_insert_${uuid0} as insert into ss select * from ss;
+-- result:
+task_src_insert_${uuid0}	SUBMITTED
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for INSERT task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
+-- result:
+INSERT
+-- !result
+submit task task_src_ctas_${uuid0} as create table ss_ctas as select event_day, pv from ss;
+-- result:
+task_src_ctas_${uuid0}	SUBMITTED
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for CTAS task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
+-- result:
+CTAS
+-- !result
 admin set frontend config('enable_task_run_fe_evaluation'='false');
 -- result:
 -- !result

--- a/test/sql/test_information_schema/T/test_task_run_status
+++ b/test/sql/test_information_schema/T/test_task_run_status
@@ -20,6 +20,22 @@ SELECT count(1) FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='mv1';
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 SELECT count(1) FROM information_schema.task_runs WHERE task_name = '${task_name}';
+SELECT TASK_SOURCE FROM information_schema.task_runs WHERE task_name = '${task_name}';
+
+submit task task_src_insert_${uuid0} as insert into ss select * from ss;
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for INSERT task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
+submit task task_src_ctas_${uuid0} as create table ss_ctas as select event_day, pv from ss;
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for CTAS task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
 
 admin set frontend config('enable_task_run_fe_evaluation'='false');
 [UC]query_id=SELECT `QUERY_ID` FROM information_schema.task_runs WHERE task_name = '${task_name}' limit 1;


### PR DESCRIPTION
## Why I'm doing:

`information_schema.task_runs` exposes one row per task run but not which subsystem submitted it, so an MV refresh run can't be told apart from a CTAS / INSERT / PIPE / DATACACHE_SELECT run without cross-referencing other tables.

## What I'm doing:

Add a `TASK_SOURCE` column to `information_schema.task_runs`, sourced from the task's `Constants.TaskSource`: `MV` / `CTAS` / `INSERT` / `PIPE` / `DATACACHE_SELECT`, or `UNKNOWN` for legacy rows whose source was never recorded. Covers the FE system table, the `TTaskRunInfo` thrift struct, the BE schema scanner, plus FE UT and docs (en/zh/ja).

Fixes #issue: N/A — observability enhancement, no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5