### PR TITLE
[Enhancement] Surface internal queries in current_queries with a type and make them killable

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
@@ -572,5 +572,6 @@ MySQL > show proc '/global_current_queries';
 | Warehouse    | The compute warehouse processing the query.                          |
 | CustomQueryId| Custom query identifier if specified.                               |
 | ResourceGroup| The resource group assigned to the query.                           |
+| QueryType    | The type of the query: `Query`, `Statistics` (such as ANALYZE), `Task`, `MV`, or `Internal`. |
 
 ```

--- a/docs/en/using_starrocks/running_queries.md
+++ b/docs/en/using_starrocks/running_queries.md
@@ -29,6 +29,7 @@ This article describes how to view running queries in StarRocks and analyze thei
 | Warehouse | Warehouse used by the query |
 | CustomQueryId | User-defined query ID |
 | ResourceGroup | Resource group used by the query |
+| QueryType | Type of the query: `Query` (user query), `Statistics` (statistics collection, such as ANALYZE), `Task` (task run), `MV` (materialized view refresh), or `Internal` (other internal query) |
 
 **Example**:
 ```sql
@@ -49,6 +50,7 @@ ExecTime      | 4.077 s
 Warehouse     | default_warehouse
 CustomQueryId |
 ResourceGroup | rg1
+QueryType     | Query
 ```
 
 ## global_current_queries
@@ -74,6 +76,7 @@ ExecTime      | 3.032 s
 Warehouse     | default_warehouse
 CustomQueryId |
 ResourceGroup | rg1
+QueryType     | Query
 ```
 
 ## running queries

--- a/docs/ja/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
@@ -573,5 +573,6 @@ MySQL > show proc '/global_current_queries';
 | Warehouse        | クエリを処理するコンピュートウェアハウス。                                   |
 | CustomQueryId    | カスタムクエリ識別子（指定された場合）。                                   |
 | ResourceGroup    | クエリに割り当てられたリソースグループ。                                   |
+| QueryType        | クエリのタイプ：`Query`、`Statistics`（ANALYZE など）、`Task`、`MV`、または `Internal`。 |
 
 ```

--- a/docs/ja/using_starrocks/running_queries.md
+++ b/docs/ja/using_starrocks/running_queries.md
@@ -29,6 +29,7 @@ sidebar_position: 9
 | Warehouse | クエリで使用されたウェアハウス |
 | CustomQueryId | ユーザー定義のクエリ ID |
 | ResourceGroup | クエリで使用されたリソースグループ |
+| QueryType | クエリのタイプ：`Query`（ユーザークエリ）、`Statistics`（ANALYZE などの統計情報収集）、`Task`（タスク実行）、`MV`（マテリアライズドビューのリフレッシュ）、または `Internal`（その他の内部クエリ） |
 
 **例**:
 ```sql
@@ -49,6 +50,7 @@ ExecTime      | 4.077 s
 Warehouse     | default_warehouse
 CustomQueryId |
 ResourceGroup | rg1
+QueryType     | Query
 ```
 
 ## global_current_queries
@@ -74,6 +76,7 @@ ExecTime      | 3.032 s
 Warehouse     | default_warehouse
 CustomQueryId |
 ResourceGroup | rg1
+QueryType     | Query
 ```
 
 ## 実行中のクエリ

--- a/docs/zh/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
@@ -572,5 +572,6 @@ MySQL > show proc '/global_current_queries';
 | Warehouse       | 处理查询的计算仓库。                                              |
 | CustomQueryId   | 自定义查询标识符（如果指定）。                                     |
 | ResourceGroup   | 分配给查询的资源组。                                              |
+| QueryType       | 查询类型：`Query`、`Statistics`（如 ANALYZE）、`Task`、`MV` 或 `Internal`。 |
 
 ```

--- a/docs/zh/using_starrocks/running_queries.md
+++ b/docs/zh/using_starrocks/running_queries.md
@@ -30,6 +30,7 @@ sidebar_position: 9
 | Warehouse | 查询使用的 Warehouse |
 | CustomQueryId | 用户自定义的查询 ID |
 | ResourceGroup | 查询使用的资源组 |
+| QueryType | 查询类型：`Query`（用户查询）、`Statistics`（统计信息采集，如 ANALYZE）、`Task`（任务执行）、`MV`（物化视图刷新）或 `Internal`（其他内部查询） |
 
 
 
@@ -53,6 +54,7 @@ ExecTime      | 4.077 s
 Warehouse     | default_warehouse
 CustomQueryId |
 ResourceGroup | rg1
+QueryType     | Query
 ```
 
 
@@ -81,6 +83,7 @@ ExecTime      | 3.032 s
 Warehouse     | default_warehouse
 CustomQueryId |
 ResourceGroup | rg1
+QueryType     | Query
 
 ```
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -70,6 +70,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             .add("Warehouse")
             .add("CustomQueryId")
             .add("ResourceGroup")
+            .add("QueryType")
             .build();
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -108,6 +108,26 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Find the ConnectContext of a running query by the query id string shown in
+     * "SHOW PROC '/current_queries'" (i.e. {@code DebugUtil.printId(executionId)}). This lets KILL QUERY
+     * target coordinator-backed queries that are not registered as client connections in ConnectScheduler,
+     * such as statistics collection (ANALYZE), task runs and materialized view refreshes. Queries without a
+     * ConnectContext are not visible in current_queries, so a context-based lookup mirrors that visibility.
+     */
+    public ConnectContext getConnectContextByQueryId(String queryId) {
+        if (queryId == null) {
+            return null;
+        }
+        for (QueryInfo info : coordinatorMap.values()) {
+            ConnectContext ctx = info.getConnectContext();
+            if (ctx != null && queryId.equals(DebugUtil.printId(ctx.getExecutionId()))) {
+                return ctx;
+            }
+        }
+        return null;
+    }
+
     @Override
     public void registerQuery(TUniqueId queryId, Coordinator coord) throws StarRocksException {
         registerQuery(queryId, new QueryInfo(coord));
@@ -176,14 +196,20 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                         DebugUtil.printId(entry.getKey()), context.getEndTime());
                 continue;
             }
-            if (!context.getState().isRunning()) {
+            // Determine liveness from the coordinator once the query is executing. Internal queries (e.g.
+            // statistics collection) reuse a single ConnectContext across many statements, so the context's
+            // last-command state may already be EOF/OK while a new coordinator-backed statement is actively
+            // running; context.getState().isRunning() must not be used to filter those out. Planning-phase
+            // entries have no coordinator yet and fall back to the context state.
+            if (info.coord != null) {
+                if (info.coord.isDone()) {
+                    LOG.warn("query {} is done, but doesn't clean from coordinator",
+                            DebugUtil.printId(entry.getKey()));
+                    continue;
+                }
+            } else if (!context.getState().isRunning()) {
                 LOG.warn("query {} is not running, context state: {}, but doesn't clean from coordinator",
                         DebugUtil.printId(entry.getKey()), context.getState());
-                continue;
-            }
-            if (info.coord != null && info.coord.isDone()) {
-                LOG.warn("query {} is done, but doesn't clean from coordinator",
-                        DebugUtil.printId(entry.getKey()));
                 continue;
             }
 
@@ -207,7 +233,8 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                     .user(context.getQualifiedUser())
                     .connId(String.valueOf(context.getConnectionId()))
                     .db(context.getDatabase())
-                    .execState(execState);
+                    .execState(execState)
+                    .queryType(getQueryType(context));
 
             if (info.getCoord() != null) {
                 itemBuilder
@@ -225,6 +252,31 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
             querySet.put(queryIdStr, itemBuilder.build());
         }
         return querySet;
+    }
+
+    /**
+     * Classify a running query by the origin of its ConnectContext, so that "SHOW PROC '/current_queries'"
+     * (and '/global_current_queries') can distinguish user queries from internal ones such as statistics
+     * collection (ANALYZE), task runs and materialized view refreshes.
+     */
+    private static String getQueryType(ConnectContext context) {
+        if (context.isStatisticsConnection()) {
+            return "Statistics";
+        }
+        if (context.getQuerySource() == null) {
+            return "Query";
+        }
+        switch (context.getQuerySource()) {
+            case TASK:
+                return "Task";
+            case MV:
+                return "MV";
+            case INTERNAL:
+                return "Internal";
+            case EXTERNAL:
+            default:
+                return "Query";
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -67,6 +67,7 @@ public class QueryStatisticsInfo {
     private String wareHouseName;
     private String customQueryId;
     private String resourceGroupName;
+    private String queryType = "";
 
     public QueryStatisticsInfo() {
     }
@@ -162,6 +163,10 @@ public class QueryStatisticsInfo {
         return customQueryId;
     }
 
+    public String getQueryType() {
+        return queryType;
+    }
+
     public QueryStatisticsInfo withQueryStartTime(long queryStartTime) {
         this.queryStartTime = queryStartTime;
         return this;
@@ -247,6 +252,11 @@ public class QueryStatisticsInfo {
         return this;
     }
 
+    public QueryStatisticsInfo withQueryType(String queryType) {
+        this.queryType = queryType;
+        return this;
+    }
+
     public TQueryStatisticsInfo toThrift() {
         return new TQueryStatisticsInfo()
                 .setQueryStartTime(queryStartTime)
@@ -265,7 +275,8 @@ public class QueryStatisticsInfo {
                 .setExecState(execState)
                 .setWareHouseName(wareHouseName)
                 .setCustomQueryId(customQueryId)
-                .setResourceGroupName(resourceGroupName);
+                .setResourceGroupName(resourceGroupName)
+                .setQueryType(queryType);
     }
 
     public static QueryStatisticsInfo fromThrift(TQueryStatisticsInfo tinfo) {
@@ -286,7 +297,9 @@ public class QueryStatisticsInfo {
                 .withExecState(tinfo.getExecState())
                 .withWareHouseName(tinfo.getWareHouseName())
                 .withCustomQueryId(tinfo.getCustomQueryId())
-                .withResourceGroupName(tinfo.getResourceGroupName());
+                .withResourceGroupName(tinfo.getResourceGroupName())
+                // queryType may be absent when the info comes from an older FE during a rolling upgrade.
+                .withQueryType(tinfo.isSetQueryType() ? tinfo.getQueryType() : "");
     }
 
     public List<String> formatToList() {
@@ -308,6 +321,7 @@ public class QueryStatisticsInfo {
         values.add(this.getWareHouseName());
         values.add(this.getCustomQueryId());
         values.add(this.getResourceGroupName());
+        values.add(this.getQueryType());
         return values;
     }
 
@@ -327,13 +341,14 @@ public class QueryStatisticsInfo {
                 spillBytes == that.spillBytes && execTime == that.execTime && execProgress == that.execProgress &&
                 execState == that.execState && Objects.equals(wareHouseName, that.wareHouseName) &&
                 Objects.equals(customQueryId, that.customQueryId) &&
-                Objects.equals(resourceGroupName, that.resourceGroupName);
+                Objects.equals(resourceGroupName, that.resourceGroupName) &&
+                Objects.equals(queryType, that.queryType);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(queryStartTime, feIp, queryId, connId, db, user, cpuCostNs, scanBytes, scanRows, memUsageBytes,
-                spillBytes, execTime, execProgress, execState, wareHouseName, customQueryId, resourceGroupName);
+                spillBytes, execTime, execProgress, execState, wareHouseName, customQueryId, resourceGroupName, queryType);
     }
 
     @Override
@@ -346,7 +361,8 @@ public class QueryStatisticsInfo {
                 ", db=" + db +
                 ", user=" + user +
                 ", cpuCostNs=" + cpuCostNs +
-                ", scanRows=" + scanBytes +
+                ", scanBytes=" + scanBytes +
+                ", scanRows=" + scanRows +
                 ", memUsageBytes=" + memUsageBytes +
                 ", spillBytes=" + spillBytes +
                 ", execTime=" + execTime +
@@ -355,6 +371,7 @@ public class QueryStatisticsInfo {
                 ", wareHouseName=" + wareHouseName +
                 ", customQueryId=" + customQueryId +
                 ", resourceGroupName=" + resourceGroupName +
+                ", queryType=" + queryType +
                 '}';
     }
 
@@ -385,7 +402,8 @@ public class QueryStatisticsInfo {
                     .withExecState(item.getExecState())
                     .withWareHouseName(item.getWarehouseName())
                     .withCustomQueryId(item.getCustomQueryId())
-                    .withResourceGroupName(item.getResourceGroupName());
+                    .withResourceGroupName(item.getResourceGroupName())
+                    .withQueryType(item.getQueryType());
             if (statistics != null) {
                 info.withScanBytes(statistics.getScanBytes())
                         .withScanRows(statistics.getScanRows())

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -41,6 +41,8 @@ public final class QueryStatisticsItem {
     private final String resourceGroupName;
     // PENDING/RUNNING/FINISHED
     private final String execState;
+    // Query/Internal/Statistics/Task/MV
+    private final String queryType;
 
     private QueryStatisticsItem(Builder builder) {
         this.customQueryId = builder.customQueryId;
@@ -56,6 +58,7 @@ public final class QueryStatisticsItem {
         this.warehouseName = builder.warehouseName;
         this.resourceGroupName = builder.resourceGroupName;
         this.execState = builder.execState;
+        this.queryType = builder.queryType;
     }
 
     public String getDb() {
@@ -115,6 +118,10 @@ public final class QueryStatisticsItem {
         return execState;
     }
 
+    public String getQueryType() {
+        return queryType;
+    }
+
     public static final class Builder {
         private String customQueryId;
         private String queryId;
@@ -129,6 +136,7 @@ public final class QueryStatisticsItem {
         private String warehouseName;
         private String resourceGroupName;
         private String execState;
+        private String queryType;
 
         public Builder() {
             fragmentInstanceInfos = Lists.newArrayList();
@@ -199,6 +207,11 @@ public final class QueryStatisticsItem {
             return this;
         }
 
+        public Builder queryType(String queryType) {
+            this.queryType = queryType;
+            return this;
+        }
+
         public QueryStatisticsItem build() {
             initDefaultValue(this);
             return new QueryStatisticsItem(this);
@@ -227,6 +240,10 @@ public final class QueryStatisticsItem {
 
             if (connId == null) {
                 builder.connId = "";
+            }
+
+            if (queryType == null) {
+                builder.queryType = "";
             }
 
             if (queryProfile == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1781,35 +1781,68 @@ public class StmtExecutor {
             context.getState().setOk();
             return;
         }
-        // > 0 means it is forwarded from other fe
-        if (context.getForwardTimes() == 0) {
-            String errorMsg = null;
-            // forward to all fe
-            for (Frontend fe : GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null /* all */)) {
-                LeaderOpExecutor leaderOpExecutor =
-                        new LeaderOpExecutor(Pair.create(fe.getHost(), fe.getRpcPort()), parsedStmt, originStmt,
-                                context, redirectStatus, false);
-                try {
-                    leaderOpExecutor.execute();
-                    // if query is successfully killed by this fe, it can return now
-                    if (context.getState().getStateType() == MysqlStateType.OK) {
-                        context.getState().setOk();
-                        return;
-                    }
-                    errorMsg = context.getState().getErrorMessage();
-                } catch (TTransportException e) {
-                    errorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort();
-                    LOG.warn(errorMsg, e);
-                } catch (Exception e) {
-                    errorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort() + " due to " +
-                            e.getMessage();
-                    LOG.warn(e.getMessage(), e);
-                }
-            }
-            // if the queryId is not found in any fe, print the error message
-            context.getState().setError(errorMsg == null ? ErrorCode.ERR_UNKNOWN_ERROR.formatErrorMsg() : errorMsg);
+
+        // Try to resolve and kill the query on the local FE first. Queries running here - including
+        // coordinator-backed internal queries (statistics collection, task runs, MV refreshes) that only
+        // live in this FE's coordinator map and never had a client connection - can be killed directly.
+        // This also avoids forwarding the kill to ourselves over thrift, which the receiving FE rejects
+        // when the self-connection's source address is not in its frontend host allowlist.
+        ConnectContext killCtx = findLocalKillTarget(queryId);
+        if (killCtx != null) {
+            handleKill(killCtx, false);
             return;
         }
+
+        // A request forwarded from another FE (forwardTimes > 0) must be resolvable locally; if it is not,
+        // the query no longer exists on this FE.
+        if (context.getForwardTimes() > 0) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_QUERY, queryId);
+            return;
+        }
+
+        // Not found locally: forward to the OTHER frontends so the FE that owns the query can kill it. Skip
+        // ourselves - the local FE was already searched above, and forwarding the kill back to this node over
+        // thrift can be rejected by the receiving FE's host allowlist in some network setups.
+        Frontend self = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf();
+        String selfNodeName = (self == null) ? null : self.getNodeName();
+        String forwardErrorMsg = null;
+        for (Frontend fe : GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null /* all */)) {
+            if (selfNodeName != null && selfNodeName.equals(fe.getNodeName())) {
+                continue;
+            }
+            LeaderOpExecutor leaderOpExecutor =
+                    new LeaderOpExecutor(Pair.create(fe.getHost(), fe.getRpcPort()), parsedStmt, originStmt,
+                            context, redirectStatus, false);
+            try {
+                leaderOpExecutor.execute();
+                // if query is successfully killed by that fe, it can return now
+                if (context.getState().getStateType() == MysqlStateType.OK) {
+                    context.getState().setOk();
+                    return;
+                }
+                // reached, but that fe does not own the query either; keep looking
+            } catch (TTransportException e) {
+                forwardErrorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort();
+                LOG.warn(forwardErrorMsg, e);
+            } catch (Exception e) {
+                forwardErrorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort() + " due to " +
+                        e.getMessage();
+                LOG.warn(e.getMessage(), e);
+            }
+        }
+        // Surface a frontend we could not reach as-is; otherwise the query was not found on any FE.
+        if (forwardErrorMsg != null) {
+            context.getState().setError(forwardErrorMsg);
+        } else {
+            ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_QUERY, queryId);
+        }
+    }
+
+    // Resolve a query running on the local FE by id, covering both client connections (in the
+    // ConnectScheduler / proxy manager) and coordinator-backed internal queries that are only present in
+    // the coordinator map (statistics collection, task runs, MV refreshes, etc.). The privilege check in
+    // handleKill() still applies via the resolved ConnectContext's user.
+    private ConnectContext findLocalKillTarget(String queryId) {
         ConnectContext killCtx = ExecuteEnv.getInstance().getScheduler().findContextByCustomQueryId(queryId);
         if (killCtx == null) {
             killCtx = ExecuteEnv.getInstance().getScheduler().findContextByQueryId(queryId);
@@ -1818,9 +1851,9 @@ public class StmtExecutor {
             killCtx = ProxyContextManager.getInstance().getContextByQueryId(queryId);
         }
         if (killCtx == null) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_QUERY, queryId);
+            killCtx = QeProcessorImpl.INSTANCE.getConnectContextByQueryId(queryId);
         }
-        handleKill(killCtx, false);
+        return killCtx;
     }
 
     // Process set statement.
@@ -3814,7 +3847,12 @@ public class StmtExecutor {
 
             coord = getCoordinatorFactory().createQueryScheduler(
                     context, plan.getFragments(), plan.getScanNodes(), plan.getDescTbl().toThrift(), plan);
-            QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), coord);
+            // Register with the ConnectContext and SQL so that these coordinator-backed internal queries
+            // (e.g. statistics dict/sample/table-stats collection, internal SimpleExecutor and user-variable
+            // sub-queries) are visible in "SHOW PROC '/current_queries'" and '/global_current_queries',
+            // instead of being filtered out by the sql/context null check in getQueryStatistics().
+            QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(),
+                    new QeProcessorImpl.QueryInfo(context, getRedactedOriginStmtInString(), coord));
 
             coord.exec();
             RowBatch batch;
@@ -3878,7 +3916,11 @@ public class StmtExecutor {
             context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
             coord = getCoordinatorFactory().createQueryScheduler(
                     context, plan.getFragments(), plan.getScanNodes(), plan.getDescTbl().toThrift(), plan);
-            QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), coord);
+            // Register with the ConnectContext and SQL so this coordinator-backed metadata collection query
+            // is visible in "SHOW PROC '/current_queries'" and '/global_current_queries', instead of being
+            // filtered out by the sql/context null check in getQueryStatistics().
+            QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(),
+                    new QeProcessorImpl.QueryInfo(context, getRedactedOriginStmtInString(), coord));
 
             coord.exec();
             RowBatch batch;

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
@@ -46,6 +46,7 @@ public class CurrentQueryStatisticsProcDirTest {
                 .queryId("queryId1")
                 .warehouseName("wh1")
                 .resourceGroupName("wg1")
+                .queryType("Statistics")
                 .build()
         );
         statistic.put("queryId2", new QueryStatisticsItem.Builder()
@@ -84,6 +85,8 @@ public class CurrentQueryStatisticsProcDirTest {
         Assertions.assertEquals("abc1", list1.get(15));
         // ResourceGroupName
         Assertions.assertEquals("wg1", list1.get(16));
+        // QueryType
+        Assertions.assertEquals("Statistics", list1.get(17));
 
         List<String> list2 = rows.get(1);
         Assertions.assertEquals(list2.size(), CurrentQueryStatisticsProcDir.TITLE_NAMES.size());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
@@ -20,8 +20,10 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.utframe.StarRocksAssert;
@@ -106,7 +108,7 @@ public class KillQueryHandleTest {
     @Test
     public void testKillStmtWhenQueryIdNotFound2(@Mocked StreamConnection connection, @Mocked TMasterOpResult result)
             throws Exception {
-        // test killing query is forwarded to fe and query not found
+        // test killing query is forwarded to another fe and the query is not found there either
         new MockUp<TMasterOpResult>() {
             @Mock
             public boolean isSetErrorMsg() {
@@ -128,11 +130,21 @@ public class KillQueryHandleTest {
                 return (T) result;
             }
         };
+        // Treat the sole test frontend as remote (not self), so the kill is actually forwarded to it.
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return null;
+            }
+        };
         ConnectContext ctx1 = prepareConnectContext(connection);
 
-        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        // The query is not present on this FE, so the kill is forwarded; the remote FE reaches but does not
+        // own the query, so the final result is a uniform "Unknown query id".
+        String missingId = UUIDUtil.genUUID().toString();
+        ConnectContext ctx = kill(missingId, true);
         Assertions.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
-        Assertions.assertEquals("query xxx not found", ctx.getState().getErrorMessage());
+        Assertions.assertEquals("Unknown query id: " + missingId, ctx.getState().getErrorMessage());
 
         ExecuteEnv.getInstance().getScheduler().unregisterConnection(ctx1);
     }
@@ -140,9 +152,17 @@ public class KillQueryHandleTest {
     @Test
     public void testKillStmtWhenConnectionFail(@Mocked StreamConnection connection) throws Exception {
         // test killing query is forwarded to fe but fe is down
+        // Treat the sole test frontend as remote (not self), so the kill is actually forwarded to it.
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return null;
+            }
+        };
         ConnectContext ctx1 = prepareConnectContext(connection);
 
-        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        // The query is not present on this FE, so the kill is forwarded; the remote FE is unreachable.
+        ConnectContext ctx = kill(UUIDUtil.genUUID().toString(), true);
         Assertions.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
         Assertions.assertTrue(ctx.getState().getErrorMessage().contains("ConnectException"));
 
@@ -161,9 +181,17 @@ public class KillQueryHandleTest {
                 throw new Exception("Unknown error x");
             }
         };
+        // Treat the sole test frontend as remote (not self), so the kill is actually forwarded to it.
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return null;
+            }
+        };
         ConnectContext ctx1 = prepareConnectContext(connection);
 
-        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        // The query is not present on this FE, so the kill is forwarded; the remote FE returns an unexpected error.
+        ConnectContext ctx = kill(UUIDUtil.genUUID().toString(), true);
         Assertions.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
         Assertions.assertEquals("Failed to connect to fe 127.0.0.1:9020 due to Unknown error x",
                 ctx.getState().getErrorMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QeProcessorImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QeProcessorImplTest.java
@@ -275,6 +275,146 @@ public class QeProcessorImplTest {
     }
 
     @Test
+    public void testCoordinatorOnlyQueryInfoSkipped() throws StarRocksException {
+        // Queries registered with the coordinator-only constructor (sql == null, context == null),
+        // e.g. the historical registration in executeStmtWithExecPlan, must be filtered out by
+        // getQueryStatistics() and therefore stay invisible in current_queries.
+        Coordinator mockCoord = Mockito.mock(Coordinator.class);
+        Mockito.when(mockCoord.isDone()).thenReturn(false);
+
+        QeProcessorImpl.QueryInfo info = new QeProcessorImpl.QueryInfo(mockCoord);
+        Assertions.assertNull(info.getSql());
+        Assertions.assertNull(info.getConnectContext());
+
+        QeProcessorImpl.INSTANCE.registerQuery(queryId, info);
+
+        Map<String, QueryStatisticsItem> stats = QeProcessorImpl.INSTANCE.getQueryStatistics();
+        Assertions.assertFalse(stats.containsKey(DebugUtil.printId(queryId)));
+
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+    }
+
+    @Test
+    public void testInternalQueryVisibleWhenRegisteredWithContextAndSql() throws StarRocksException {
+        // executeStmtWithExecPlan / executeStmtWithResultQueue now register coordinator-backed internal
+        // queries (statistics collection sub-queries, metadata collection, etc.) with the ConnectContext
+        // and SQL, so they become visible in current_queries / global_current_queries.
+        Mockito.when(mockContext.isPlanning()).thenReturn(false);
+        Mockito.when(mockContext.isPending()).thenReturn(false);
+
+        Coordinator mockCoord = Mockito.mock(Coordinator.class);
+        Mockito.when(mockCoord.getFragmentInstanceInfos()).thenReturn(Lists.newArrayList());
+        Mockito.when(mockCoord.getQueryProfile()).thenReturn(new RuntimeProfile("test"));
+        Mockito.when(mockCoord.getWarehouseName()).thenReturn("default_warehouse");
+        Mockito.when(mockCoord.getResourceGroupName()).thenReturn("");
+        Mockito.when(mockCoord.isDone()).thenReturn(false);
+
+        QeProcessorImpl.QueryInfo info = new QeProcessorImpl.QueryInfo(
+                mockContext, "INSERT INTO _statistics_.column_statistics SELECT ...", mockCoord);
+        QeProcessorImpl.INSTANCE.registerQuery(queryId, info);
+
+        Map<String, QueryStatisticsItem> stats = QeProcessorImpl.INSTANCE.getQueryStatistics();
+        String queryIdStr = DebugUtil.printId(queryId);
+        Assertions.assertTrue(stats.containsKey(queryIdStr));
+        Assertions.assertEquals("RUNNING", stats.get(queryIdStr).getExecState());
+        Assertions.assertEquals("INSERT INTO _statistics_.column_statistics SELECT ...",
+                stats.get(queryIdStr).getSql());
+
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+    }
+
+    @Test
+    public void testQueryTypeClassification() throws StarRocksException {
+        Coordinator mockCoord = Mockito.mock(Coordinator.class);
+        Mockito.when(mockCoord.getFragmentInstanceInfos()).thenReturn(Lists.newArrayList());
+        Mockito.when(mockCoord.getQueryProfile()).thenReturn(new RuntimeProfile("test"));
+        Mockito.when(mockCoord.getWarehouseName()).thenReturn("wh");
+        Mockito.when(mockCoord.getResourceGroupName()).thenReturn("");
+        Mockito.when(mockCoord.isDone()).thenReturn(false);
+
+        // Statistics connection wins over query source -> "Statistics" (covers ANALYZE collection).
+        Mockito.when(mockContext.isStatisticsConnection()).thenReturn(true);
+        Mockito.when(mockContext.getQuerySource()).thenReturn(QueryDetail.QuerySource.INTERNAL);
+        QeProcessorImpl.INSTANCE.registerQuery(queryId, new QeProcessorImpl.QueryInfo(mockContext, "sql", mockCoord));
+        Assertions.assertEquals("Statistics",
+                QeProcessorImpl.INSTANCE.getQueryStatistics().get(DebugUtil.printId(queryId)).getQueryType());
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+
+        // Task-submitted query -> "Task".
+        Mockito.when(mockContext.isStatisticsConnection()).thenReturn(false);
+        Mockito.when(mockContext.getQuerySource()).thenReturn(QueryDetail.QuerySource.TASK);
+        QeProcessorImpl.INSTANCE.registerQuery(queryId, new QeProcessorImpl.QueryInfo(mockContext, "sql", mockCoord));
+        Assertions.assertEquals("Task",
+                QeProcessorImpl.INSTANCE.getQueryStatistics().get(DebugUtil.printId(queryId)).getQueryType());
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+
+        // Regular user query -> "Query".
+        Mockito.when(mockContext.getQuerySource()).thenReturn(QueryDetail.QuerySource.EXTERNAL);
+        QeProcessorImpl.INSTANCE.registerQuery(queryId, new QeProcessorImpl.QueryInfo(mockContext, "sql", mockCoord));
+        Assertions.assertEquals("Query",
+                QeProcessorImpl.INSTANCE.getQueryStatistics().get(DebugUtil.printId(queryId)).getQueryType());
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+    }
+
+    @Test
+    public void testCoordinatorBackedQueryVisibleWhenContextStateFinished() throws StarRocksException {
+        // Internal queries (e.g. statistics collection) reuse a ConnectContext whose last-command state may
+        // already be EOF/OK while a new coordinator-backed statement is actively running. Liveness must be
+        // taken from the coordinator (isDone), not from context.getState().isRunning(), so such queries stay
+        // visible in current_queries.
+        QueryState finishedState = new QueryState();
+        finishedState.setEof(); // isRunning() == false
+        Mockito.when(mockContext.getState()).thenReturn(finishedState);
+        Mockito.when(mockContext.isPlanning()).thenReturn(false);
+        Mockito.when(mockContext.isPending()).thenReturn(false);
+
+        Coordinator mockCoord = Mockito.mock(Coordinator.class);
+        Mockito.when(mockCoord.getFragmentInstanceInfos()).thenReturn(Lists.newArrayList());
+        Mockito.when(mockCoord.getQueryProfile()).thenReturn(new RuntimeProfile("test"));
+        Mockito.when(mockCoord.getWarehouseName()).thenReturn("wh");
+        Mockito.when(mockCoord.getResourceGroupName()).thenReturn("");
+
+        // Coordinator still running -> visible despite the finished context state.
+        Mockito.when(mockCoord.isDone()).thenReturn(false);
+        QeProcessorImpl.INSTANCE.registerQuery(queryId,
+                new QeProcessorImpl.QueryInfo(mockContext, "SELECT ...", mockCoord));
+        Assertions.assertTrue(
+                QeProcessorImpl.INSTANCE.getQueryStatistics().containsKey(DebugUtil.printId(queryId)));
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+
+        // Coordinator done -> filtered out.
+        Mockito.when(mockCoord.isDone()).thenReturn(true);
+        QeProcessorImpl.INSTANCE.registerQuery(queryId,
+                new QeProcessorImpl.QueryInfo(mockContext, "SELECT ...", mockCoord));
+        Assertions.assertFalse(
+                QeProcessorImpl.INSTANCE.getQueryStatistics().containsKey(DebugUtil.printId(queryId)));
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+    }
+
+    @Test
+    public void testGetConnectContextByQueryId() throws StarRocksException {
+        Coordinator mockCoord = Mockito.mock(Coordinator.class);
+        Mockito.when(mockCoord.isDone()).thenReturn(false);
+
+        String queryIdStr = DebugUtil.printId(queryId);
+
+        // A coordinator-backed query registered with a ConnectContext is resolvable by its query id,
+        // so KILL QUERY can target it (e.g. statistics collection / task runs).
+        QeProcessorImpl.INSTANCE.registerQuery(queryId,
+                new QeProcessorImpl.QueryInfo(mockContext, "SELECT 1", mockCoord));
+        Assertions.assertSame(mockContext, QeProcessorImpl.INSTANCE.getConnectContextByQueryId(queryIdStr));
+        // Unknown query id resolves to null.
+        Assertions.assertNull(QeProcessorImpl.INSTANCE.getConnectContextByQueryId("does-not-exist"));
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+
+        // A coordinator-only registration (no ConnectContext) is not resolvable, matching its invisibility
+        // in current_queries.
+        QeProcessorImpl.INSTANCE.registerQuery(queryId, new QeProcessorImpl.QueryInfo(mockCoord));
+        Assertions.assertNull(QeProcessorImpl.INSTANCE.getConnectContextByQueryId(queryIdStr));
+        QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+    }
+
+    @Test
     public void testFromPlanningQueryStartExecTime() throws StarRocksException {
         long beforeCreate = System.currentTimeMillis();
         QeProcessorImpl.QueryInfo info =

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1743,6 +1743,7 @@ struct TQueryStatisticsInfo {
     15: optional string resourceGroupName
     16: optional string execProgress
     17: optional string execState
+    18: optional string queryType
 }
 
 struct TGetQueryStatisticsResponse {


### PR DESCRIPTION
## Why I'm doing:

Coordinator-backed internal queries (statistics collection for ANALYZE, task runs, materialized view refreshes, metadata collection, internal SimpleExecutor and user-variable sub-queries) were either invisible in "SHOW PROC '/current_queries'" or visible but not killable. This change:

- Registers queries run through executeStmtWithExecPlan and executeStmtWithResultQueue with their ConnectContext and SQL, so they are no longer filtered out by the sql/context null check in getQueryStatistics() and appear in current_queries and global_current_queries.
- Determines liveness of running queries from the coordinator (coord.isDone) rather than context.getState().isRunning(). Internal queries reuse one ConnectContext across many statements, so its last-command state may be EOF/OK while a new coordinator-backed statement is actively running; the old check wrongly filtered those out. Planning-phase entries (no coordinator yet) still fall back to the context state.
- Adds a QueryType column (Query / Statistics / Task / MV / Internal), derived from the query's ConnectContext (statistics connection flag and QuerySource), carried through QueryStatisticsItem / QueryStatisticsInfo and serialized via a new optional TQueryStatisticsInfo.queryType field for the cross-FE path.
- Lets KILL QUERY '<query_id>' target these queries. handleKillQuery now resolves the query on the local FE first (ConnectScheduler, proxy manager, and the coordinator map via QeProcessorImpl.getConnectContextByQueryId) and kills it directly, only forwarding to other frontends when it is not found locally. This avoids forwarding the kill to ourselves over thrift, which the receiving FE rejects when the self-connection's source address is not in its frontend host allowlist. The OPERATE privilege check in handleKill still applies via the resolved ConnectContext's user.

Update the running_queries and SHOW PROC docs (en/zh/ja).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5