### PR TITLE
[UT] Add end-to-end test for IVM adaptive refresh batching

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMAdaptiveBatchingIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMAdaptiveBatchingIcebergTest.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.ivm;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.Config;
+import com.starrocks.common.tvr.TvrVersionRange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class IVMAdaptiveBatchingIcebergTest extends MVIVMIcebergTestBase {
+
+    @Test
+    public void testFirstOversizedDeltaStillBatchesAndConverges() throws Exception {
+        starRocksAssert.withMaterializedView(
+                "CREATE MATERIALIZED VIEW `test`.`test_mv_batch` REFRESH DEFERRED MANUAL " +
+                        "PROPERTIES (\"refresh_mode\" = \"incremental\") " +
+                        "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`;");
+        MaterializedView mv = getMv("test_mv_batch");
+        seedTvrBaselineAtVersionZero(mv);          // committed = 0 -> routes to pure IVM, not first-refresh PCT
+        advanceTableVersionTo(4);
+        // Version 1 alone (5 rows) already exceeds the cap; versions 2-4 add 1 row each.
+        mockListTableDeltaTraitsPerVersion(5, 1, 1, 1);
+
+        long savedRows = Config.mv_max_rows_per_refresh;
+        Config.mv_max_rows_per_refresh = 2;
+        try {
+            ImmutableList.Builder<Long> committed = ImmutableList.builder();
+            int guard = 0;
+            while (getIVMRefreshedExecPlan(mv) != null) {
+                committed.add(committedToVersion(mv));
+                Assertions.assertTrue(++guard <= 10, "refresh did not converge");
+            }
+            // The oversized first delta becomes its own batch, then one version per run, converging
+            // to head 4. Before the shared-loop fix this collapsed to a single unbounded run ([4]).
+            Assertions.assertEquals(ImmutableList.of(1L, 2L, 3L, 4L), committed.build(),
+                    "an oversized first delta must still split into bounded batches");
+        } finally {
+            Config.mv_max_rows_per_refresh = savedRows;
+        }
+    }
+
+    private static long committedToVersion(MaterializedView mv) {
+        Map<BaseTableInfo, TvrVersionRange> committed = mv.getRefreshScheme().getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap();
+        return committed.values().iterator().next().to().getVersion();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMIcebergTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMIcebergTestBase.java
@@ -28,6 +28,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.BeforeAll;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -70,6 +71,28 @@ public class MVIVMIcebergTestBase extends MVIVMTestBase {
                         TvrDeltaStats.EMPTY)
         );
         mockListTableDeltaTraits(deltas);
+    }
+
+    /**
+     * Emit one append trait per version in {@code (from, to]}, where version {@code v} adds
+     * {@code rowsPerVersion[v-1]} rows, so the adaptive cap has a real multi-trait delta to split.
+     */
+    public void mockListTableDeltaTraitsPerVersion(long... rowsPerVersion) {
+        new MockUp<MockIcebergMetadata>() {
+            @Mock
+            public List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, com.starrocks.catalog.Table table,
+                                                                 TvrTableSnapshot fromSnapshotExclusive,
+                                                                 TvrTableSnapshot toSnapshotInclusive) {
+                long from = fromSnapshotExclusive.isEmpty() ? 0L : fromSnapshotExclusive.getSnapshotId();
+                long to = toSnapshotInclusive.getSnapshotId();
+                List<TvrTableDeltaTrait> traits = new ArrayList<>();
+                for (long v = from + 1; v <= to; v++) {
+                    traits.add(TvrTableDeltaTrait.ofMonotonic(
+                            TvrTableDelta.of(v - 1, v), new TvrDeltaStats(rowsPerVersion[(int) (v - 1)], 0L)));
+                }
+                return traits;
+            }
+        };
     }
 
     public void mockListTableDeltaTraitsThrows(String message) {

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_mv_max_rows_per_refresh
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_mv_max_rows_per_refresh
@@ -1,0 +1,103 @@
+-- name: test_ivm_with_iceberg_mv_max_rows_per_refresh
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t_batch (k int, v bigint);
+-- result:
+-- !result
+insert into t_batch values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_batch
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_batch WITH SYNC MODE;
+SELECT count(*) FROM test_mv_batch;
+-- result:
+2
+-- !result
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv_batch';
+admin set frontend config ("mv_max_rows_per_refresh" = "2");
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (3, 30);
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (4, 40);
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (5, 50);
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (6, 60);
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (7, 70);
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (8, 80);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_batch;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv_batch")
+-- result:
+None
+-- !result
+SELECT count(*) FROM test_mv_batch;
+-- result:
+8
+-- !result
+SELECT k, v FROM test_mv_batch ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+4	40
+5	50
+6	60
+7	70
+8	80
+-- !result
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND STATE = 'SUCCESS' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL';
+-- result:
+3
+-- !result
+admin set frontend config ("mv_max_rows_per_refresh" = "100000000");
+-- result:
+-- !result
+drop materialized view test_mv_batch;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_mv_max_rows_per_refresh
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_mv_max_rows_per_refresh
@@ -1,0 +1,61 @@
+-- name: test_ivm_with_iceberg_mv_max_rows_per_refresh
+-- mv_max_rows_per_refresh must split a large incremental delta into multiple bounded task runs
+-- on the asynchronous IVM path. Sync refresh always uses the whole delta, so this drives an
+-- async REFRESH and counts the resulting INCREMENTAL task runs.
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table t_batch (k int, v bigint);
+insert into t_batch values (1, 10), (2, 20);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Unpartitioned IVM MV -> pure-IVM refresh path.
+CREATE MATERIALIZED VIEW test_mv_batch
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch;
+
+-- Establish the TVR baseline (one run over the initial 2 rows).
+[UC]REFRESH MATERIALIZED VIEW test_mv_batch WITH SYNC MODE;
+SELECT count(*) FROM test_mv_batch;
+
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv_batch';
+
+-- Bound each refresh to 2 rows of delta.
+admin set frontend config ("mv_max_rows_per_refresh" = "2");
+
+-- Six single-row commits -> a 6-row delta spread over six snapshots.
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (3, 30);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (4, 40);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (5, 50);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (6, 60);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (7, 70);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_batch values (8, 80);
+
+-- Async refresh: the 6-row delta is split into multiple bounded INCREMENTAL runs.
+[UC]REFRESH MATERIALIZED VIEW test_mv_batch;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv_batch")
+
+-- Data is fully and correctly refreshed.
+SELECT count(*) FROM test_mv_batch;
+SELECT k, v FROM test_mv_batch ORDER BY k;
+
+-- The delta was processed as multiple INCREMENTAL runs, not one.
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND STATE = 'SUCCESS' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL';
+
+admin set frontend config ("mv_max_rows_per_refresh" = "100000000");
+drop materialized view test_mv_batch;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

StarRocks#74464 fixed the shared IVM adaptive-batching loop (`computeAdaptiveDelta`) but only unit-tested the pure function. There was no end-to-end coverage: the IVM-on-Iceberg integration harness (`MockIcebergMetadata`) stubs `listTableDeltaTraits` with a single empty-stats trait, so a low `mv_max_rows_per_refresh` never actually split a refresh into multiple task runs in any test.

## What I'm doing:

Adding two end-to-end tests for the adaptive batching path:

1. **Java integration test** — `IVMAdaptiveBatchingIcebergTest`. Adds a `(from, to]`-aware `mockListTableDeltaTraitsPerVersion(...)` helper to `MVIVMIcebergTestBase` that emits one append trait per version with real `TvrDeltaStats`, then drives an async incremental refresh whose oldest pending delta alone exceeds the cap (`[5,1,1,1]` rows, cap=2) and asserts the committed TVR advances in bounded batches converging to head (`[1,2,3,4]`) instead of collapsing into one unbounded run (`[4]`).

2. **SQL-tester test** — `test_ivm_with_iceberg_mv_max_rows_per_refresh`. On a real Iceberg-backed incremental MV: set `mv_max_rows_per_refresh=2`, append six single-row commits, then run an asynchronous `REFRESH`. Asserts the 6-row delta splits into **3 bounded INCREMENTAL task runs** (one unbounded run before the fix) and the data fully refreshes (8 rows). Recorded and validated 3/3 against a cluster carrying the #74464 fix.

Fixes #issue: N/A — test-only follow-up to StarRocks#74464.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
