### PR TITLE
[BugFix] Fix __ROW_ID__ group keys for SELECT DISTINCT and positional GROUP BY in incremental MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -26,6 +26,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.GroupByClause;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryRelation;
@@ -47,6 +48,7 @@ import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.IsNullPredicate;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
 import com.starrocks.sql.ast.expression.SlotRef;
@@ -54,6 +56,7 @@ import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +136,24 @@ public class IVMAnalyzer {
 
     private static boolean isTemporal(Type t) {
         return t.isDate() || t.isDatetime();
+    }
+
+    // Mirror QueryTransformer.aggregate's grouping-key derivation: dedup, and drop constant keys
+    // unless every key is constant (then keep the first, like aggregate()'s groupAllConst). The
+    // synthesized DISTINCT GROUP BY and the encoded __ROW_ID__ must use the same keys the refresh
+    // aggregate groups by, or the merge join probes a different key set (no-match / duplicate rows).
+    private static List<Expr> normalizeGroupKeys(List<Expr> keys) {
+        boolean allConstant = keys.stream().allMatch(Expr::isConstant);
+        List<Expr> normalized = Lists.newArrayList();
+        for (Expr key : keys) {
+            if (key.isConstant() && !(allConstant && normalized.isEmpty())) {
+                continue;
+            }
+            if (!normalized.contains(key)) {
+                normalized.add(key);
+            }
+        }
+        return normalized;
     }
 
     private final ConnectContext connectContext;
@@ -271,6 +292,14 @@ public class IVMAnalyzer {
             throw new SemanticException("IVMAnalyzer does not support HAVING with aggregate functions, " +
                     "but got: %s", ExprToSql.toSql(selectRelation.getHaving()));
         }
+        // GROUPING SETS / ROLLUP / CUBE have no IVM delta rule (they lower to a Repeat operator), and
+        // GROUP BY ALL would fold the prepended __ROW_ID__ output into the grouping keys and double-encode
+        // the row id at refresh. Only plain GROUP BY keeps the encoded __ROW_ID__ aligned with the keys.
+        GroupByClause groupByClause = selectRelation.getGroupByClause();
+        if (groupByClause != null && groupByClause.getGroupingType() != GroupByClause.GroupingType.GROUP_BY) {
+            throw new SemanticException("IVMAnalyzer does not support %s for incremental view maintenance",
+                    groupByClause.getGroupingType());
+        }
         boolean isRetractable = checkAggregate(selectRelation);
         Relation innerRelation = selectRelation.getRelation();
         isRetractable |= checkRelation(innerRelation);
@@ -323,6 +352,23 @@ public class IVMAnalyzer {
         List<FunctionCallExpr> aggregateExprs = selectRelation.getAggregate();
         List<Expr> groupByExprs = selectRelation.getGroupBy();
 
+        // SELECT DISTINCT <outputs> is GROUP BY <outputs> with no aggregates, but the optimizer only
+        // lowers DISTINCT to a group-by at refresh. Rewrite it to a real GROUP BY so CREATE and refresh
+        // share the QUERY_COMPUTED path with a matching __ROW_ID__ join key. Re-analysis re-derives
+        // isDistinct from the SelectList and groupBy from the GroupByClause, so set both at the source.
+        if (selectRelation.isDistinct() && CollectionUtils.isEmpty(groupByExprs)) {
+            List<Expr> distinctKeys = normalizeGroupKeys(selectRelation.getOutputExpression());
+            // normalizeGroupKeys keeps a lone constant only when every output is constant
+            // (SELECT DISTINCT 1) -- that has no real grouping key, so leave it to the gate below
+            // (AUTO_INCREMENT) rather than synthesizing a constant GROUP BY (an ordinal on re-parse).
+            if (distinctKeys.stream().anyMatch(expr -> !expr.isConstant())) {
+                selectRelation.getSelectList().setIsDistinct(false);
+                selectRelation.setGroupByClause(new GroupByClause(
+                        ExprUtils.cloneAndResetList(distinctKeys), GroupByClause.GroupingType.GROUP_BY));
+                groupByExprs = distinctKeys;
+            }
+        }
+
         // Gate on GROUP BY, not aggregates: the refresh path (IvmDeltaAggregateRule) keys on
         // GROUP BY, so a GROUP BY-only query must also get QUERY_COMPUTED row ids here — else the
         // AUTO_INCREMENT MV it would otherwise build crashes refresh on a row-id type mismatch.
@@ -365,12 +411,13 @@ public class IVMAnalyzer {
                 .toList();
         selectRelation.setAggregate(newAggFuncs);
 
-        // Build the row ID function expression
-        int encodeRowIdVersion = IvmOpUtils.deduceEncodeRowIdVersion(groupByExprs);
+        // Build the row ID from the group keys, normalized like the refresh aggregate (see normalizeGroupKeys).
+        List<Expr> rowIdKeys = normalizeGroupKeys(groupByExprs);
+        int encodeRowIdVersion = IvmOpUtils.deduceEncodeRowIdVersion(rowIdKeys);
         if (statement != null) {
             statement.setEncodeRowIdVersion(encodeRowIdVersion);
         }
-        FunctionCallExpr rowIdFuncExpr = IvmOpUtils.buildRowIdFuncExpr(encodeRowIdVersion, groupByExprs);
+        FunctionCallExpr rowIdFuncExpr = IvmOpUtils.buildRowIdFuncExpr(encodeRowIdVersion, rowIdKeys);
         SelectList selectList = selectRelation.getSelectList();
         List<SelectListItem> newItems = Lists.newArrayList();
         // add row_id func expr
@@ -400,6 +447,20 @@ public class IVMAnalyzer {
         newAggFuncInfos.stream()
                 .forEach(aggFunctionInfo -> newOutputExpressions.add(aggFunctionInfo.newAggFunc));
         selectRelation.setOutputExpr(newOutputExpressions);
+
+        // __ROW_ID__ is now output column 1, so a positional GROUP BY ordinal would re-resolve to it
+        // on re-analysis -- the aggregate would group by the encoded row id and the merge join would
+        // re-encode it, splitting one group across rows. Shift ordinals past the prepended column.
+        GroupByClause groupByClause = selectRelation.getGroupByClause();
+        if (groupByClause != null && groupByClause.getGroupingType() == GroupByClause.GroupingType.GROUP_BY) {
+            ArrayList<Expr> shiftedKeys = Lists.newArrayList();
+            for (Expr key : groupByClause.getGroupingExprs()) {
+                shiftedKeys.add(key instanceof IntLiteral
+                        ? new IntLiteral(((IntLiteral) key).getLongValue() + 1)
+                        : key);
+            }
+            selectRelation.setGroupByClause(new GroupByClause(shiftedKeys, GroupByClause.GroupingType.GROUP_BY));
+        }
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -266,6 +266,10 @@ public class SelectRelation extends QueryRelation {
         return groupByClause;
     }
 
+    public void setGroupByClause(GroupByClause groupByClause) {
+        this.groupByClause = groupByClause;
+    }
+
     public boolean hasHavingClause() {
         return having != null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -94,6 +94,122 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
     }
 
     @Test
+    public void testIVMWithSelectDistinctNoAggregate() throws Exception {
+        // Statement-level SELECT DISTINCT used to pick AUTO_INCREMENT and crash refresh
+        // TypeChecker on the __ROW_ID__ merge join (BIGINT vs VARCHAR).
+        doTestWith3RunsNoCheckRewrite("SELECT DISTINCT id FROM `iceberg0`.`unpartitioned_db`.`t0` as a;",
+                plan -> {
+                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
+                            "TABLE: unpartitioned_db.t0\n" +
+                                    "     TABLE VERSION: Delta@[0,1]");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "__ROW_ID__ = ");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
+    public void testIVMWithSelectDistinctOverJoin() throws Exception {
+        // DISTINCT over a join normalizes to GROUP BY a.id, b.data and rides the same __ROW_ID__
+        // merge path — covers the join scope.
+        doTestWith3RunsNoCheckRewrite(
+                "SELECT DISTINCT a.id, b.data FROM `iceberg0`.`unpartitioned_db`.`t0` a " +
+                        "INNER JOIN `iceberg0`.`partitioned_db`.`t1` b ON a.id = b.id;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
+    public void testIVMWithSelectDistinctConstantOutput() throws Exception {
+        // Constant outputs are dropped from the group keys, so __ROW_ID__ encodes only id — the
+        // constant must not leak into the row-id encoding.
+        doTestWith3RunsNoCheckRewrite("SELECT DISTINCT 1, id FROM `iceberg0`.`unpartitioned_db`.`t0` as a;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
+    public void testIVMWithSelectDistinctDuplicateKeys() throws Exception {
+        // Duplicate DISTINCT keys are deduped to match the refresh aggregate's grouping; otherwise
+        // the encoded __ROW_ID__ would differ from the merge join key and probe the wrong rows.
+        doTestWith3RunsNoCheckRewrite(
+                "SELECT DISTINCT id AS a, id AS b FROM `iceberg0`.`unpartitioned_db`.`t0`;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
+    public void testIVMWithGroupByAllConstantKey() throws Exception {
+        // GROUP BY 1 is a positional ordinal; after __ROW_ID__ is prepended as output column 1 it must
+        // still resolve to the constant output column (one global group), not to __ROW_ID__ -- else the
+        // merge re-encodes the row id and splits the group across snapshots.
+        doTestWith3RunsNoCheckRewrite(
+                "SELECT 1, count(data) FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY 1;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
+    public void testIVMWithGroupByOrdinalColumn() throws Exception {
+        // A positional GROUP BY ordinal pointing at a real column must resolve to that column after
+        // __ROW_ID__ is prepended (ordinal shifted past it), so the aggregate groups by id -- not by
+        // __ROW_ID__, which would re-encode the row id and split each group across refreshes.
+        doTestWith3RunsNoCheckRewrite(
+                "SELECT id, count(data) FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY 1;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                }
+        );
+    }
+
+    @Test
     public void testIVMWithScanProjectFilter() throws Exception {
         doTestWith3Runs("SELECT id * 2 + 1, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` where id > 10;",
                 plan -> {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -119,6 +119,30 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * SELECT DISTINCT (no GROUP BY) must yield QUERY_COMPUTED like the equivalent GROUP BY,
+     * else the MV's AUTO_INCREMENT BIGINT __ROW_ID__ can't match refresh's VARCHAR key.
+     */
+    @Test
+    public void testSelectDistinctYieldsQueryComputedStrategy() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_select_distinct "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT DISTINCT id FROM `iceberg0`.`unpartitioned_db`.`t0`";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL);
+
+        assertTrue(result.isPresent(), "SELECT DISTINCT MV query must produce an IVM rewrite result");
+        assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy(),
+                "SELECT DISTINCT must yield QUERY_COMPUTED, not AUTO_INCREMENT");
+    }
+
+    /**
      * Distinct aggregates must be rejected at IVM analysis time; otherwise incremental
      * refresh would silently produce wrong data (the rewrite drops the DISTINCT flag).
      * MIN/MAX(DISTINCT) is not covered: the analyzer normalizes their DISTINCT away
@@ -175,6 +199,28 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                 "INCREMENTAL refresh must reject HAVING that references an aggregate");
         assertTrue(ex.getMessage().contains("does not support HAVING"),
                 "error message must mention HAVING rejection, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRejectGroupByAll() throws Exception {
+        // GROUP BY ALL re-derives its keys from the output list, which now leads with the prepended
+        // __ROW_ID__; grouping by it would double-encode the row id at refresh, so reject at CREATE.
+        String ddl = "CREATE MATERIALIZED VIEW mv_group_all "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY ALL";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        SemanticException ex = assertThrows(SemanticException.class,
+                () -> analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL),
+                "INCREMENTAL refresh must reject GROUP BY ALL");
+        assertTrue(ex.getMessage().contains("does not support")
+                        && ex.getMessage().contains("incremental view maintenance"),
+                "error must mention the unsupported grouping type, got: " + ex.getMessage());
     }
 
     /**

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_distinct
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_distinct
@@ -1,0 +1,167 @@
+-- name: test_ivm_with_iceberg_distinct
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table dist_base (
+  k int,
+  v bigint
+);
+-- result:
+-- !result
+insert into dist_base values (1, 10), (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT DISTINCT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k, v;
+-- result:
+1	10
+2	20
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base values (2, 20), (3, 30);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k, v;
+-- result:
+1	10
+2	20
+3	30
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_dup
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT DISTINCT k AS a, k AS b FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_dup WITH SYNC MODE;
+SELECT count(*) FROM test_mv_dup;
+-- result:
+3
+-- !result
+SELECT a, b FROM test_mv_dup ORDER BY a, b;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+DROP MATERIALIZED VIEW test_mv_dup;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_const
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT 1 AS c, count(v) AS cnt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base GROUP BY 1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_const WITH SYNC MODE;
+SELECT c, cnt FROM test_mv_const;
+-- result:
+1	5
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base values (4, 40);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_const WITH SYNC MODE;
+SELECT c, cnt FROM test_mv_const;
+-- result:
+1	6
+-- !result
+DROP MATERIALIZED VIEW test_mv_const;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_ord
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, count(v) AS cnt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base GROUP BY 1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_ord WITH SYNC MODE;
+SELECT k, cnt FROM test_mv_ord ORDER BY k;
+-- result:
+1	2
+2	2
+3	1
+4	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base values (2, 20);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_ord WITH SYNC MODE;
+SELECT k, cnt FROM test_mv_ord ORDER BY k;
+-- result:
+1	2
+2	3
+3	1
+4	1
+-- !result
+DROP MATERIALIZED VIEW test_mv_ord;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_distinct
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_distinct
@@ -1,0 +1,84 @@
+-- name: test_ivm_with_iceberg_distinct
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table dist_base (
+  k int,
+  v bigint
+);
+insert into dist_base values (1, 10), (1, 10), (2, 20);
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+set enable_materialized_view_rewrite = false;
+-- A SELECT DISTINCT MV is accepted at CREATE but used to crash on the first incremental
+-- refresh (__ROW_ID__ BIGINT vs from_binary VARCHAR). Refresh must dedup, never duplicate.
+CREATE MATERIALIZED VIEW test_mv1
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT DISTINCT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+SELECT k, v FROM test_mv1 ORDER BY k, v;
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base values (2, 20), (3, 30);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+SELECT k, v FROM test_mv1 ORDER BY k, v;
+DROP MATERIALIZED VIEW test_mv1;
+-- Duplicate DISTINCT keys (a and b are the same expr k) must collapse to one group key, matching
+-- the refresh aggregate; otherwise the encoded __ROW_ID__ keys differ from the merge join probe.
+CREATE MATERIALIZED VIEW test_mv_dup
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT DISTINCT k AS a, k AS b FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base;
+[UC]REFRESH MATERIALIZED VIEW test_mv_dup WITH SYNC MODE;
+SELECT count(*) FROM test_mv_dup;
+SELECT a, b FROM test_mv_dup ORDER BY a, b;
+DROP MATERIALIZED VIEW test_mv_dup;
+-- GROUP BY 1 is a positional ordinal; after __ROW_ID__ is prepended it must still resolve to the
+-- constant output column (one global group), not __ROW_ID__ -- else the count splits per snapshot.
+CREATE MATERIALIZED VIEW test_mv_const
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT 1 AS c, count(v) AS cnt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base GROUP BY 1;
+[UC]REFRESH MATERIALIZED VIEW test_mv_const WITH SYNC MODE;
+SELECT c, cnt FROM test_mv_const;
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base values (4, 40);
+[UC]REFRESH MATERIALIZED VIEW test_mv_const WITH SYNC MODE;
+SELECT c, cnt FROM test_mv_const;
+DROP MATERIALIZED VIEW test_mv_const;
+-- A positional GROUP BY ordinal pointing at a real column must resolve to that column after
+-- __ROW_ID__ is prepended; otherwise it groups by __ROW_ID__ and one key splits across refreshes.
+CREATE MATERIALIZED VIEW test_mv_ord
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, count(v) AS cnt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base GROUP BY 1;
+[UC]REFRESH MATERIALIZED VIEW test_mv_ord WITH SYNC MODE;
+SELECT k, cnt FROM test_mv_ord ORDER BY k;
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base values (2, 20);
+[UC]REFRESH MATERIALIZED VIEW test_mv_ord WITH SYNC MODE;
+SELECT k, cnt FROM test_mv_ord ORDER BY k;
+DROP MATERIALIZED VIEW test_mv_ord;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.dist_base force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

An incremental MV like `SELECT DISTINCT k FROM t` is accepted at CREATE but crashes on the
first incremental refresh: `Type check failed ... hash join equal predicate type mismatch:
left VARCHAR, right BIGINT, predicate: __ROW_ID__ = from_binary`.

IVMAnalyzer picks the `__ROW_ID__` strategy from whether there is a GROUP BY clause, but a
statement-level `DISTINCT` has no GROUP BY clause at analysis time (the optimizer only lowers
DISTINCT to a group-by at refresh). CREATE therefore builds an AUTO_INCREMENT BIGINT
`__ROW_ID__`, while refresh encodes the group keys to VARCHAR and joins the delta against the
MV on `__ROW_ID__`, failing type check. The earlier GROUP BY-only fix (#74030) did not cover
statement-level DISTINCT — the two are different representations.

While verifying edge cases a second, related defect surfaced: a positional `GROUP BY <ordinal>`
(e.g. `GROUP BY 1`) is silently broken for incremental MVs. IVMAnalyzer prepends `__ROW_ID__` as
output column 1, and on re-analysis the bare integer ordinal re-resolves against the new output
list to `__ROW_ID__` itself. The aggregate then groups by the already-encoded row id and the
refresh merge join re-encodes it, so a single logical group is stored under per-row row ids and
split across rows — an all-constant `GROUP BY 1` returned one row per source snapshot instead of
a single global row, and `GROUP BY 1` over a real column grouped by the row id rather than that
column.

## What I'm doing:

Two related fixes in IVMAnalyzer so the encoded `__ROW_ID__` always matches the group keys the
refresh aggregate uses:

1. **SELECT DISTINCT**: rewrite `SELECT DISTINCT <outputs>` into `GROUP BY <outputs>` so CREATE
   and refresh share the same QUERY_COMPUTED path with a matching `__ROW_ID__` join key.
   Re-analysis re-derives `isDistinct` from the SelectList and `groupBy` from the GroupByClause,
   so the rewrite clears the SelectList's distinct flag and sets a GroupByClause of explicit
   column refs at the source.

2. **Positional GROUP BY ordinal**: shift positional `GROUP BY <n>` ordinals past the prepended
   `__ROW_ID__` column so they keep pointing at the intended output column instead of re-resolving
   to `__ROW_ID__` (which made the aggregate group by the encoded row id and the merge join
   double-encode it, splitting one group across rows).

3. **Reject non-plain GROUP BY**: `GROUP BY ALL` / `GROUPING SETS` / `ROLLUP` / `CUBE` are now
   rejected at CREATE for incremental MVs. `GROUP BY ALL` re-derives its keys from the output list
   (now led by `__ROW_ID__`) and would fold the encoded row id into the grouping keys — the same
   double-encode hazard — while the multi-dimensional groupings have no IVM delta rule. Rejecting
   replaces silent wrong data (`GROUP BY ALL`) / an obscure plan-time error with a clear message.

Both the synthesized DISTINCT GROUP BY and the encoded `__ROW_ID__` are built from keys normalized
the same way `QueryTransformer.aggregate` derives grouping keys: dedup, and drop constant keys
unless every key is constant (then keep one) — so duplicate keys (`SELECT DISTINCT id, id`) or an
all-constant key do not encode a different key set than the refresh merge join.

Fixes #issue: N/A — no public tracking issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
