### PR TITLE
[Enhancement] Lift the DCG x gap NotSupported in shared-data tablet merge

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -844,17 +844,20 @@ const TabletSchemaPB* resolve_rowset_schema_pb(const TabletMetadataPB& new_metad
     return nullptr;
 }
 
-struct DcgRowWindow {
-    size_t old_tablet_index;
-    Range<rowid_t> range;
-};
+using tablet_reshard_helper::DcgRowWindow;
 
 // Step C — compute row windows in the target segment for every source old tablet
-// rowset that references it. Coverage over [0, num_rows_of_target) is validated.
+// rowset that references it. Holes left by a compacted-away old tablet are
+// accepted as is_gap windows when they fall within |gap_bits| (the same
+// synthesized bitmap merge_delvecs masks); a nullptr |gap_bits| keeps the strict
+// contiguous-coverage requirement. The opened base segment and its row count are
+// returned so the caller can fill gap rows from it.
 Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int64_t new_tablet_id,
                                               const RowsetMetadataPB& target_rowset, int target_segment_position,
                                               const TabletSchemaCSPtr& full_tablet_schema,
                                               const std::vector<DcgSourceRowsetReference>& source_references,
+                                              const roaring::Roaring* gap_bits,
+                                              std::shared_ptr<Segment>* out_base_segment,
                                               std::vector<DcgRowWindow>* out_windows) {
     // Open base segment for index lookups.
     FileInfo base_segment_file_info;
@@ -877,6 +880,7 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
                                    /*lake_io_opts=*/LakeIOOptions{}, tablet_manager));
 
     const rowid_t num_rows_in_target = static_cast<rowid_t>(base_segment->num_rows());
+    *out_base_segment = base_segment;
 
     out_windows->clear();
     out_windows->reserve(source_references.size());
@@ -904,11 +908,6 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
         out_windows->push_back({source_reference.old_tablet_index, window});
     }
 
-    if (out_windows->empty()) {
-        return Status::NotSupported(fmt::format(
-                "DCG rebuild: no valid row windows computed for target rssid (num_rows={})", num_rows_in_target));
-    }
-
     // Dedup windows that belong to the SAME old tablet AND have the same range
     // (e.g., an old tablet's shared rowset surfaced twice through different scans).
     // Do NOT dedup windows from different old tablets even if the range matches:
@@ -931,33 +930,16 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
     }
     *out_windows = std::move(deduped_windows);
 
-    // Coverage validation: windows must be contiguous and cover [0, num_rows_in_target).
-    //
-    // Known limitation: the synthesized gap delvec from
-    // compute_synthesized_gap_specs masks rowids that no contributing old tablet
-    // claims, but DCG rebuild does not yet consult that bitmap. A
-    // (compacted-old-tablet gap) × (DCG conflict on canonical R0) combination
-    // therefore returns NotSupported here. FE scheduling currently avoids
-    // the combo by requiring all old tablets compacted before merge for any
-    // tablet with active partial-update DCGs.
-    if ((*out_windows)[0].range.begin() != 0) {
-        return Status::NotSupported(
-                fmt::format("DCG rebuild: row window coverage gap at the start (first.begin={}, expect 0)",
-                            (*out_windows)[0].range.begin()));
-    }
-    for (size_t index = 0; index + 1 < out_windows->size(); ++index) {
-        if ((*out_windows)[index].range.end() != (*out_windows)[index + 1].range.begin()) {
-            return Status::NotSupported(fmt::format("DCG rebuild: row window coverage gap or overlap ({}->{} vs {})",
-                                                    (*out_windows)[index].range.begin(),
-                                                    (*out_windows)[index].range.end(),
-                                                    (*out_windows)[index + 1].range.begin()));
-        }
-    }
-    if (out_windows->back().range.end() != num_rows_in_target) {
-        return Status::NotSupported(
-                fmt::format("DCG rebuild: row window coverage gap at the end (last.end={}, expect {})",
-                            out_windows->back().range.end(), num_rows_in_target));
-    }
+    // Reconcile the contributor windows with the synthesized gap bitmap: a hole
+    // left by a compacted-away old tablet becomes an is_gap window when it falls
+    // entirely within |gap_bits| (those rowids are masked by merge_delvecs and
+    // never returned). Unmasked holes, distinct-owner overlaps, and zero rows
+    // surface as errors. With |gap_bits|==nullptr any hole fails, which is the
+    // original strict contiguous-coverage behavior.
+    std::vector<DcgRowWindow> reconciled_windows;
+    RETURN_IF_ERROR(tablet_reshard_helper::reconcile_windows_with_gap(*out_windows, gap_bits, num_rows_in_target,
+                                                                      &reconciled_windows));
+    *out_windows = std::move(reconciled_windows);
     return Status::OK();
 }
 
@@ -1030,7 +1012,7 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
         TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts, int64_t new_tablet_id,
         int64_t new_version, int64_t txn_id, const TabletMetadataPB& new_metadata, uint32_t target_rssid,
         const std::vector<uint32_t>& rebuild_columns, const std::vector<const DcgSurvivingEntry*>& conflicting_entries,
-        const std::vector<DcgSourceRowsetReference>& source_references) {
+        const std::vector<DcgSourceRowsetReference>& source_references, const roaring::Roaring* gap_bits) {
     TEST_SYNC_POINT_CALLBACK("merge_dcg_meta:before_rebuild", &target_rssid);
 
     // Step A — locate merged rowset + segment position for target rssid.
@@ -1064,10 +1046,11 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
 
     // Step C — compute row windows.
     std::vector<DcgRowWindow> windows;
+    std::shared_ptr<Segment> base_segment;
     RETURN_IF_ERROR(compute_row_windows_for_source_rowsets(tablet_manager, new_tablet_id, target_rowset,
                                                            target_segment_position, full_tablet_schema,
-                                                           source_references, &windows));
-    const rowid_t num_rows_in_target = windows.back().range.end();
+                                                           source_references, gap_bits, &base_segment, &windows));
+    const rowid_t num_rows_in_target = static_cast<rowid_t>(base_segment->num_rows());
 
     // For each rebuild column, pick:
     // - default donor: any conflicting entry that claims the UID (first found).
@@ -1145,6 +1128,17 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
         output_column->reserve(num_rows_in_target);
 
         for (const auto& window : windows) {
+            if (window.is_gap) {
+                // No source DCG entry claims these rows (their old tablet was
+                // compacted away). They are masked by the merge gap delvec and
+                // never returned, so fill from the canonical base segment: real,
+                // already-indexed values keep the rebuilt .cols encodings and
+                // secondary indexes valid.
+                RETURN_IF_ERROR(read_column_range_from_segment(base_segment, full_tablet_schema, unique_id,
+                                                               window.range.begin(), window.range.end(),
+                                                               output_column.get()));
+                continue;
+            }
             const DcgSurvivingEntry* selected_source = nullptr;
             auto override_iter = source_info.override_by_old_tablet_index.find(window.old_tablet_index);
             selected_source = (override_iter != source_info.override_by_old_tablet_index.end())
@@ -1209,10 +1203,35 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
     return rebuilt;
 }
 
+// Phase 0 output: per-target rowid bitmaps representing keys in the
+// shared physical segment that no contributing old tablet claims. Read-path
+// consumers:
+//   - canonical R0's segment iterator already filters by canonical.range, so
+//     gap rowids outside the convex hull are no-ops for scans.
+//   - PersistentIndexSstable::multi_get filters by the projected delvec on
+//     the sstable PB regardless of LSM block-sort order, which keeps the
+//     first-old-tablet-compacts case safe.
+//   - DCG rebuild (merge_dcg_meta) consults the same bitmap to accept gap holes
+//     in row-window coverage and fill those rows from the base segment.
+struct CanonicalGapSpec {
+    uint32_t target_rssid;
+    Roaring gap_bits;
+};
+
 Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
-                      int64_t new_tablet_id, int64_t new_version, int64_t txn_id, TabletMetadataPB* new_metadata) {
+                      int64_t new_tablet_id, int64_t new_version, int64_t txn_id,
+                      const std::vector<CanonicalGapSpec>& gap_specs, TabletMetadataPB* new_metadata) {
     std::map<uint32_t, DcgTargetWorkItem> work_by_target;
     RETURN_IF_ERROR(dcg_pass1_collect_entries_and_sources(merge_contexts, &work_by_target));
+
+    // Index synthesized gap bitmaps by target rssid so a rebuild can short-circuit
+    // its coverage check for rowids that merge_delvecs masks. Empty for non-PK
+    // tables (no gap synthesis) => every lookup misses => strict coverage.
+    std::unordered_map<uint32_t, const Roaring*> gap_bits_by_target;
+    gap_bits_by_target.reserve(gap_specs.size());
+    for (const auto& spec : gap_specs) {
+        gap_bits_by_target.emplace(spec.target_rssid, &spec.gap_bits);
+    }
 
     auto* merged_dcgs = new_metadata->mutable_dcg_meta()->mutable_dcgs();
 
@@ -1271,9 +1290,13 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
                 }
             }
 
+            const Roaring* target_gap_bits = nullptr;
+            if (auto gap_iter = gap_bits_by_target.find(target_rssid); gap_iter != gap_bits_by_target.end()) {
+                target_gap_bits = gap_iter->second;
+            }
             StatusOr<DeltaColumnGroupVerPB> rebuilt_or_status = rebuild_dcg_for_target_segment(
                     tablet_manager, merge_contexts, new_tablet_id, new_version, txn_id, *new_metadata, target_rssid,
-                    rebuild_columns, conflicting_entries, target_work.source_refs);
+                    rebuild_columns, conflicting_entries, target_work.source_refs, target_gap_bits);
             if (!rebuilt_or_status.ok()) {
                 if (rebuilt_or_status.status().is_not_supported()) {
                     g_tablet_merge_dcg_rebuild_fallback_not_supported_total << 1;
@@ -1304,19 +1327,6 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
 
     return Status::OK();
 }
-
-// Phase 0 output: per-target rowid bitmaps representing keys in the
-// shared physical segment that no contributing old tablet claims. Read-path
-// consumers:
-//   - canonical R0's segment iterator already filters by canonical.range, so
-//     gap rowids outside the convex hull are no-ops for scans.
-//   - PersistentIndexSstable::multi_get filters by the projected delvec on
-//     the sstable PB regardless of LSM block-sort order, which keeps the
-//     first-old-tablet-compacts case safe.
-struct CanonicalGapSpec {
-    uint32_t target_rssid;
-    Roaring gap_bits;
-};
 
 // Phase 0: for every PK canonical rowset that owns at least one shared
 // segment, mask the rowids whose key falls outside ⋃ contributors but inside
@@ -1451,14 +1461,10 @@ Status inject_synthesized_gaps_into_target_states(TabletManager* tablet_manager,
 }
 
 Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
-                     const CanonicalContribMap& canonical_contribs, int64_t new_version, int64_t txn_id,
+                     const std::vector<CanonicalGapSpec>& synthesized_gap_specs, int64_t new_version, int64_t txn_id,
                      TabletMetadataPB* new_metadata) {
-    // Phase 0: synthesize gap delvec bits from canonical_contribs.
-    ASSIGN_OR_RETURN(auto synthesized_gap_specs,
-                     compute_synthesized_gap_specs(tablet_manager, *new_metadata, canonical_contribs));
-    if (!synthesized_gap_specs.empty()) {
-        g_tablet_merge_gap_delvec_total << 1;
-    }
+    // Phase 0 gap bitmaps are synthesized once by the caller (merge_tablet) and
+    // shared with merge_dcg_meta so the two paths cannot diverge.
 
     // Phase 1: Collect unique delvec files across all old tablets
     std::vector<DelvecFileInfo> unique_delvec_files;
@@ -2788,17 +2794,31 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     CanonicalContribMap canonical_contribs;
     RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get(), &canonical_contribs));
 
-    // Phase 2.5: Merge schemas (must run before merge_dcg_meta, which needs
-    // historical_schemas to locate rebuild schemas for shared-segment rebuild).
+    // Phase 2.5: Merge schemas (must run before gap synthesis + merge_dcg_meta,
+    // which need historical_schemas to locate rebuild schemas for shared-segment
+    // rebuild).
     merge_schemas(merge_contexts, new_tablet_metadata.get());
+
+    // Synthesize the per-target gap bitmaps once (PK only). The same specs drive
+    // both DCG coverage-acceptance (merge_dcg_meta) and delvec masking
+    // (merge_delvecs), so the two paths cannot diverge. For non-PK tables the
+    // specs stay empty, which keeps DCG coverage strict.
+    std::vector<CanonicalGapSpec> gap_specs;
+    if (is_primary_key(*new_tablet_metadata)) {
+        ASSIGN_OR_RETURN(gap_specs,
+                         compute_synthesized_gap_specs(tablet_manager, *new_tablet_metadata, canonical_contribs));
+        if (!gap_specs.empty()) {
+            g_tablet_merge_gap_delvec_total << 1;
+        }
+    }
 
     // Phase 3: Projections (map_rssid uses shared_rssid_map + rssid_offset)
     RETURN_IF_ERROR(merge_dcg_meta(tablet_manager, merge_contexts, merging_tablet.new_tablet_id(), new_version,
-                                   txn_info.txn_id(), new_tablet_metadata.get()));
+                                   txn_info.txn_id(), gap_specs, new_tablet_metadata.get()));
 
     if (is_primary_key(*new_tablet_metadata)) {
-        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, canonical_contribs, new_version,
-                                      txn_info.txn_id(), new_tablet_metadata.get()));
+        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, gap_specs, new_version, txn_info.txn_id(),
+                                      new_tablet_metadata.get()));
     }
 
     RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -14,8 +14,11 @@
 
 #include "storage/lake/tablet_reshard_helper.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <numeric>
+#include <roaring/roaring.hh>
 
 #include "base/uid_util.h"
 #include "common/logging.h"
@@ -23,6 +26,66 @@
 #include "storage/tablet_range.h"
 
 namespace starrocks::lake::tablet_reshard_helper {
+
+namespace {
+// True iff every rowid in the half-open range [range_begin, range_end) is set
+// in |gap_bits|. An empty range is trivially covered. nullptr |gap_bits| covers
+// nothing.
+bool range_fully_masked(const roaring::Roaring* gap_bits, rowid_t range_begin, rowid_t range_end) {
+    if (range_begin >= range_end) return true;
+    if (gap_bits == nullptr) return false;
+    // containsRange(x, y) tests that every value in the half-open range [x, y)
+    // is present; it does not enumerate the range.
+    return gap_bits->containsRange(static_cast<uint64_t>(range_begin), static_cast<uint64_t>(range_end));
+}
+} // namespace
+
+Status reconcile_windows_with_gap(const std::vector<DcgRowWindow>& sorted_contributors,
+                                  const roaring::Roaring* gap_bits, rowid_t num_rows,
+                                  std::vector<DcgRowWindow>* out_windows) {
+    if (num_rows <= 0) {
+        return Status::NotSupported("DCG rebuild: target segment has 0 rows");
+    }
+    out_windows->clear();
+    // The highest rowid covered so far by an emitted (contributor or gap) window.
+    rowid_t covered_up_to = 0;
+    for (const auto& contributor : sorted_contributors) {
+        const rowid_t contributor_begin = contributor.range.begin();
+        const rowid_t contributor_end = contributor.range.end();
+        // Defensive bound check (helper is exported; guard against misuse).
+        if (contributor_begin < 0 || contributor_end > num_rows || contributor_begin > contributor_end) {
+            return Status::InternalError(fmt::format("DCG rebuild: contributor window [{}, {}) out of [0, {}]",
+                                                     contributor_begin, contributor_end, num_rows));
+        }
+        if (contributor_begin > covered_up_to) {
+            // Coverage hole ahead of this contributor: accept only if fully masked.
+            if (!range_fully_masked(gap_bits, covered_up_to, contributor_begin)) {
+                return Status::NotSupported(
+                        fmt::format("DCG rebuild: row window coverage gap [{}, {}) not masked by delvec", covered_up_to,
+                                    contributor_begin));
+            }
+            out_windows->push_back(DcgRowWindow{/*old_tablet_index=*/0,
+                                                Range<rowid_t>(covered_up_to, contributor_begin),
+                                                /*is_gap=*/true});
+        } else if (contributor_begin < covered_up_to) {
+            // Overlap between distinct owners must surface, not be collapsed.
+            return Status::NotSupported(fmt::format("DCG rebuild: row window overlap at {} (covered up to {})",
+                                                    contributor_begin, covered_up_to));
+        }
+        out_windows->push_back(contributor);
+        covered_up_to = contributor_end;
+    }
+    if (covered_up_to < num_rows) {
+        if (!range_fully_masked(gap_bits, covered_up_to, num_rows)) {
+            return Status::NotSupported(
+                    fmt::format("DCG rebuild: row window coverage gap at end [{}, {}) not masked by delvec",
+                                covered_up_to, num_rows));
+        }
+        out_windows->push_back(
+                DcgRowWindow{/*old_tablet_index=*/0, Range<rowid_t>(covered_up_to, num_rows), /*is_gap=*/true});
+    }
+    return Status::OK();
+}
 
 // Generates a fresh, non-zero global rowset uid (a 128-bit PUniqueId).
 PUniqueId make_rowset_uid() {

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -22,6 +22,11 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
+#include "storage/primitive/range.h" // Range<rowid_t>, rowid_t
+
+namespace roaring {
+class Roaring;
+} // namespace roaring
 
 namespace starrocks::lake {
 class TabletManager;
@@ -118,6 +123,28 @@ StatusOr<std::vector<TabletRangePB>> compute_disjoint_gaps_within(
 // pre-split tablet that extend beyond the merged tablet range).
 StatusOr<std::vector<TabletRangePB>> compute_non_contributed_ranges(
         const std::vector<TabletRangePB>& sorted_disjoint_children);
+
+// A row window in a DCG target segment owned by one source old tablet, or a
+// synthesized gap window (is_gap=true) whose rows are masked by the merge gap
+// delvec. Moved here from tablet_merger.cpp so reconcile_windows_with_gap below
+// is unit-testable.
+struct DcgRowWindow {
+    size_t old_tablet_index = 0;
+    Range<rowid_t> range;
+    bool is_gap = false;
+};
+
+// Walk |sorted_contributors| (ascending by range.begin(), already deduped on
+// same owner+range) and fill coverage holes with synthesized gap windows IFF
+// the hole is fully covered by |gap_bits| (the same Roaring merge_delvecs masks
+// into the delvec). A hole not fully masked, an overlap between distinct
+// owners, a contributor window outside [0, num_rows], or num_rows<=0 returns an
+// error (NotSupported / InternalError). With |gap_bits|==nullptr any hole fails,
+// byte-identical to the pre-fix strict contiguous-coverage behavior. On success,
+// |out_windows| tiles [0, num_rows) exactly (contributor + gap windows).
+Status reconcile_windows_with_gap(const std::vector<DcgRowWindow>& sorted_contributors,
+                                  const roaring::Roaring* gap_bits, rowid_t num_rows,
+                                  std::vector<DcgRowWindow>* out_windows);
 
 // Mirrors Rowset::get_seek_range() fallback chain:
 //   rowset.range if has_range, else ctx_metadata.range if has_range,

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -21,6 +21,7 @@
 #include <numeric>
 #include <optional>
 #include <random>
+#include <roaring/roaring.hh>
 
 #include "storage/datum_variant.h"
 #include "storage/types.h"
@@ -846,6 +847,85 @@ TEST_F(TabletReshardHelperTest, HasValidUid_rejects_absent_and_zero) {
     EXPECT_FALSE(has_valid_uid(rs)); // present but zero
     rs.mutable_uid()->set_lo(1);
     EXPECT_TRUE(has_valid_uid(rs));
+}
+
+namespace {
+DcgRowWindow make_window(size_t owner, rowid_t begin, rowid_t end, bool is_gap = false) {
+    return DcgRowWindow{owner, Range<rowid_t>(begin, end), is_gap};
+}
+void expect_window(const DcgRowWindow& w, rowid_t begin, rowid_t end, bool is_gap) {
+    EXPECT_EQ(w.range.begin(), begin);
+    EXPECT_EQ(w.range.end(), end);
+    EXPECT_EQ(w.is_gap, is_gap);
+}
+} // namespace
+
+TEST_F(TabletReshardHelperTest, Reconcile_NullGapBits_ContiguousOK) {
+    std::vector<DcgRowWindow> in{make_window(0, 0, 10), make_window(1, 10, 30)};
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, /*gap_bits=*/nullptr, /*num_rows=*/30, &out);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(out.size(), 2u);
+    expect_window(out[0], 0, 10, false);
+    expect_window(out[1], 10, 30, false);
+}
+
+TEST_F(TabletReshardHelperTest, Reconcile_NullGapBits_HoleFails) {
+    std::vector<DcgRowWindow> in{make_window(0, 0, 10), make_window(1, 20, 30)}; // hole [10, 20)
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, /*gap_bits=*/nullptr, /*num_rows=*/30, &out);
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(TabletReshardHelperTest, Reconcile_GapMasked_FillsGapWindow) {
+    std::vector<DcgRowWindow> in{make_window(0, 0, 10), make_window(1, 20, 30)}; // hole [10, 20)
+    roaring::Roaring gap_bits;
+    gap_bits.addRange(10, 20);
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, &gap_bits, /*num_rows=*/30, &out);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(out.size(), 3u);
+    expect_window(out[0], 0, 10, false);
+    expect_window(out[1], 10, 20, true);
+    expect_window(out[2], 20, 30, false);
+}
+
+TEST_F(TabletReshardHelperTest, Reconcile_GapPartiallyMasked_Fails) {
+    std::vector<DcgRowWindow> in{make_window(0, 0, 10), make_window(1, 20, 30)}; // hole [10, 20)
+    roaring::Roaring gap_bits;
+    gap_bits.addRange(10, 18); // misses [18, 20)
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, &gap_bits, /*num_rows=*/30, &out);
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(TabletReshardHelperTest, Reconcile_Overlap_Fails) {
+    std::vector<DcgRowWindow> in{make_window(0, 0, 20), make_window(1, 10, 30)}; // distinct owners overlap [10, 20)
+    roaring::Roaring gap_bits;
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, &gap_bits, /*num_rows=*/30, &out);
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(TabletReshardHelperTest, Reconcile_ZeroRows_Fails) {
+    std::vector<DcgRowWindow> in;
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, /*gap_bits=*/nullptr, /*num_rows=*/0, &out);
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(TabletReshardHelperTest, Reconcile_LeadingAndTrailingGap) {
+    std::vector<DcgRowWindow> in{make_window(0, 10, 20)}; // gaps [0, 10) and [20, 30)
+    roaring::Roaring gap_bits;
+    gap_bits.addRange(0, 10);
+    gap_bits.addRange(20, 30);
+    std::vector<DcgRowWindow> out;
+    auto st = reconcile_windows_with_gap(in, &gap_bits, /*num_rows=*/30, &out);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(out.size(), 3u);
+    expect_window(out[0], 0, 10, true);
+    expect_window(out[1], 10, 20, false);
+    expect_window(out[2], 20, 30, true);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -469,6 +469,157 @@ protected:
         return result;
     }
 
+    // Drive a 3-way PK merge where two surviving children update column c1 on the
+    // shared base segment (same-column DCG conflict -> rebuild) and the child at
+    // |compacted_index| has compacted its share away, leaving a gap on canonical
+    // R0. Before the gap fix the rebuild's coverage check rejected the gap with
+    // NotSupported; now it accepts the masked gap and fills those rows from the
+    // base segment. Verifies the rebuilt .cols row values (surviving children's
+    // updates on their windows, base values on the gap) and that a gap delvec
+    // masks the compacted child's rows.
+    void run_dcg_conflict_gap_rebuild_case(int compacted_index, int64_t txn_id) {
+        const int64_t base_version = 1;
+        const int64_t new_version = 2;
+        constexpr int kNumRows = 30;
+        constexpr int kRangeRows = 10; // three equal key ranges: [0,10) [10,20) [20,30)
+        constexpr int64_t kSchemaId = 4001;
+        constexpr uint32_t kSharedRowsetId = 1;
+
+        const int64_t child_ids[3] = {next_id(), next_id(), next_id()};
+        const int64_t merged_tablet = next_id();
+        for (int64_t child_id : child_ids) prepare_tablet_dirs(child_id);
+        prepare_tablet_dirs(merged_tablet);
+
+        // Base segment: c0 = row index (key == rowid), c1 = row * 10.
+        auto base_value_of = [](int row) { return row * 10; };
+        auto update_of = [](int child_index, int row) { return row + 100000 * (child_index + 1); };
+        const std::string shared_segment_name = "shared_seg.dat";
+        const uint64_t base_segment_size =
+                write_two_column_segment(merged_tablet, shared_segment_name, kNumRows, base_value_of);
+
+        auto set_key_range = [&](TabletRangePB* range, int lower_key, int upper_key) {
+            range->set_lower_bound_included(true);
+            range->set_upper_bound_included(false);
+            *range->mutable_lower_bound() = generate_sort_key(lower_key);
+            *range->mutable_upper_bound() = generate_sort_key(upper_key);
+        };
+
+        for (int i = 0; i < 3; ++i) {
+            const int lower = i * kRangeRows;
+            const int upper = (i + 1) * kRangeRows;
+            auto meta = std::make_shared<TabletMetadataPB>();
+            meta->set_id(child_ids[i]);
+            meta->set_version(base_version);
+            meta->set_next_rowset_id(10);
+            const auto [c0_uid, c1_uid] = set_two_column_pk_schema(meta.get(), kSchemaId);
+            (void)c0_uid;
+            set_key_range(meta->mutable_range(), lower, upper);
+
+            if (i == compacted_index) {
+                // Compacted child: a non-shared compaction output rowset (newer
+                // version) covering this range. No shared segment, no DCG -> its
+                // range is a gap on canonical R0.
+                auto* rowset = meta->add_rowsets();
+                rowset->set_id(2);
+                rowset->set_version(new_version);
+                rowset->set_num_rows(upper - lower);
+                rowset->set_data_size(100);
+                auto* segment_meta = rowset->add_segment_metas();
+                segment_meta->set_filename(fmt::format("compacted_{}.dat", i));
+                segment_meta->set_size(100);
+                set_key_range(rowset->mutable_range(), lower, upper);
+                (*meta->mutable_rowset_to_schema())[2] = kSchemaId;
+            } else {
+                // Surviving child: shares the base segment and updates c1 on its
+                // owned row window via a real .cols file (base copy-through
+                // elsewhere, mirroring production partial-column update output).
+                const std::string cols_name = lake::gen_cols_filename(txn_id + 1 + i);
+                auto cell_value = [&](int row) {
+                    return (row >= lower && row < upper) ? update_of(i, row) : base_value_of(row);
+                };
+                write_c1_only_cols_file(child_ids[i], cols_name, kNumRows, cell_value);
+
+                auto* rowset = meta->add_rowsets();
+                rowset->set_id(kSharedRowsetId);
+                rowset->set_version(base_version);
+                rowset->set_num_rows(kNumRows);
+                rowset->set_data_size(base_segment_size);
+                auto* segment_meta = rowset->add_segment_metas();
+                segment_meta->set_filename(shared_segment_name);
+                segment_meta->set_size(base_segment_size);
+                segment_meta->set_shared(true);
+                stamp_physical_identity_uid(rowset, shared_segment_name); // same uid across siblings => dedup
+                set_key_range(rowset->mutable_range(), lower, upper);
+                (*meta->mutable_rowset_to_schema())[kSharedRowsetId] = kSchemaId;
+
+                auto& dcg = (*meta->mutable_dcg_meta()->mutable_dcgs())[kSharedRowsetId];
+                dcg.add_column_files(cols_name);
+                dcg.add_unique_column_ids()->add_column_ids(c1_uid);
+                dcg.add_versions(1);
+                dcg.add_shared_files(false);
+            }
+            ASSERT_OK(put_tablet_metadata(meta));
+        }
+
+        ReshardingTabletInfoPB resharding_tablet;
+        auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+        for (int64_t child_id : child_ids) merging_info.add_old_tablet_ids(child_id);
+        merging_info.set_new_tablet_id(merged_tablet);
+
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+        txn_info.set_commit_time(1);
+        txn_info.set_gtid(1);
+
+        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+        // Before the gap fix this returned NotSupported; the rebuild now succeeds.
+        ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                                  txn_info, false, tablet_metadatas, tablet_ranges));
+        auto merged = tablet_metadatas.at(merged_tablet);
+        ASSERT_NE(merged, nullptr);
+
+        // Canonical R0 == the rowset that still owns a shared segment.
+        uint32_t canonical_rssid = 0;
+        for (const auto& rowset : merged->rowsets()) {
+            for (const auto& segment_meta : rowset.segment_metas()) {
+                if (segment_meta.shared()) {
+                    canonical_rssid = rowset.id();
+                    break;
+                }
+            }
+            if (canonical_rssid != 0) break;
+        }
+        ASSERT_NE(canonical_rssid, 0u);
+
+        // A synthesized gap delvec must mask the compacted child's rows on R0.
+        auto delvec_it = merged->delvec_meta().delvecs().find(canonical_rssid);
+        ASSERT_NE(delvec_it, merged->delvec_meta().delvecs().end());
+        EXPECT_GT(delvec_it->second.size(), 0u);
+
+        // Exactly one rebuilt DCG entry for c1 on canonical R0.
+        const auto& dcgs = merged->dcg_meta().dcgs();
+        auto dcg_it = dcgs.find(canonical_rssid);
+        ASSERT_TRUE(dcg_it != dcgs.end());
+        const auto& rebuilt_entry = dcg_it->second;
+        ASSERT_EQ(1, rebuilt_entry.column_files_size());
+        ASSERT_EQ(1, rebuilt_entry.unique_column_ids_size());
+        ASSERT_EQ(1, rebuilt_entry.unique_column_ids(0).column_ids_size());
+        EXPECT_EQ(1002, rebuilt_entry.unique_column_ids(0).column_ids(0));
+        ASSERT_EQ(1, rebuilt_entry.versions_size());
+        EXPECT_EQ(new_version, rebuilt_entry.versions(0));
+
+        // Rebuilt .cols values: surviving children's updates on their windows;
+        // base values on the compacted child's gap window.
+        auto values = read_c1_only_cols_file(merged_tablet, rebuilt_entry.column_files(0));
+        ASSERT_EQ(kNumRows, static_cast<int>(values.size()));
+        for (int row = 0; row < kNumRows; ++row) {
+            const int range_index = row / kRangeRows;
+            const int expected = (range_index == compacted_index) ? base_value_of(row) : update_of(range_index, row);
+            EXPECT_EQ(expected, values[row]) << "row " << row << " (range " << range_index << ")";
+        }
+    }
+
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
     std::string _test_dir;
     std::shared_ptr<lake::LocationProvider> _location_provider;
@@ -8881,6 +9032,22 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_two_children_same_
     for (int row = kBoundary; row < kNumRows; ++row) {
         EXPECT_EQ(child_b_update(row), values[row]) << "row " << row << " should carry child B's update";
     }
+}
+
+// DCG same-column conflict combined with a compacted-away child (gap) on
+// canonical R0. The rebuild must accept the masked gap window and fill it from
+// the base segment instead of returning NotSupported. Three cases exercise the
+// leading, internal, and trailing gap positions.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_with_gap_first_child_compacts) {
+    run_dcg_conflict_gap_rebuild_case(/*compacted_index=*/0, /*txn_id=*/3101);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_with_gap_middle_child_compacts) {
+    run_dcg_conflict_gap_rebuild_case(/*compacted_index=*/1, /*txn_id=*/3102);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_with_gap_last_child_compacts) {
+    run_dcg_conflict_gap_rebuild_case(/*compacted_index=*/2, /*txn_id=*/3103);
 }
 
 // When two children's DCG entries share a .cols filename but the entry


### PR DESCRIPTION
## Why I'm doing:

Shared-data range-distribution tablet **merge** had a known limitation: when a child tablet had compacted away its share before merge (leaving a row-coverage *gap* on a canonical shared rowset) **and** that same shared rowset carried a DCG (partial-column-update) **same-column conflict** that needs a physical `.cols` rebuild, `merge_tablet` returned `Status::NotSupported`.

The merge already synthesizes a *gap delvec* (`compute_synthesized_gap_specs`) that masks exactly those gap rowids, so they are never returned at read time — but the DCG rebuild's row-window coverage check did not consult that bitmap and rejected the hole. FE scheduling worked around it by requiring all children fully compacted before merging any tablet with active partial-update DCGs.

## What I'm doing:

Let the DCG rebuild consult the **same** gap bitmap that drives delvec masking, so a coverage hole that coincides with masked gap rowids is accepted instead of failing.

- Hoist `compute_synthesized_gap_specs` into `merge_tablet` (PK-only) and pass the one `std::vector<CanonicalGapSpec>` to **both** `merge_dcg_meta` and `merge_delvecs`. The bitmap that masks the delvec and the bitmap that accepts DCG coverage are now the *same object* — they cannot diverge.
- Extract the coverage logic into a pure, unit-tested `tablet_reshard_helper::reconcile_windows_with_gap`. It accepts a hole only after proving it is fully contained in `gap_bits` (`Roaring::containsRange`); unmasked holes, distinct-owner overlaps, and zero-row targets still error. A `nullptr` bitmap reproduces the original strict contiguous-coverage check verbatim.
- In `rebuild_dcg_for_target_segment`, fill the accepted gap windows from the canonical **base segment** (real, already-indexed values). The rows are provably delvec-masked and never returned, and using base values avoids any secondary/vector-index validity questions that synthetic defaults would raise.

**Core invariant:** a gap row is filled only after proving its window ⊆ `gap_bits`, and `gap_bits` is exactly what `merge_delvecs` writes to the delvec — so every filled row is provably masked.

Because gap synthesis stays PK-only and `nullptr` keeps strict coverage, non-PK and no-gap merges are byte-for-byte unchanged. The FE "compact-all-before-merge for active-DCG tablets" workaround can be dropped in a follow-up FE change (out of scope here).

Tests: 7 pure-helper unit tests for `reconcile_windows_with_gap` + 3 end-to-end gap×DCG rebuild tests (first/middle/last child compacted); existing 26 dcg/gap reshard tests unchanged. All 36 pass.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Range-distribution split/merge is a new feature gated behind `enable_range_distribution` and `tablet_reshard_enable_tablet_merge` (both default off, not yet GA); no existing user observes a change. The only effect is that a merge that previously returned `NotSupported` on this gated path now completes correctly.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
