### PR TITLE
[BugFix] Materialize sort-key schema only for colocate-aware tablet split

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -662,18 +662,25 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
-    // Resolve the sort-key arity from the materialized TabletSchema, not the raw TabletSchemaPB.
-    // A range-distributed table created without an explicit ORDER BY (e.g. a PRIMARY KEY table)
-    // leaves sort_key_idxes empty in the PB; the "empty sort_key_idxes => sort key is the key
-    // columns" convention (which the FE mirrors in MetaUtils.getRangeDistributionColumns) is only
-    // applied when the schema is materialized. Reading the raw PB here would see arity 0 and reject
-    // every colocate split, silently falling back to an identical tablet so the oversized tablet
-    // never splits. This mirrors the external-boundaries path's use of GlobalTabletSchemaMap.
-    auto tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_metadata->schema()).first;
-    const int32_t sort_key_arity = static_cast<int32_t>(tablet_schema->sort_key_idxes().size());
-    if (colocate_column_count < 0 || colocate_column_count > sort_key_arity) {
-        return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}, sort key arity is {}",
-                                                   colocate_column_count, sort_key_arity));
+    if (colocate_column_count < 0) {
+        return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}", colocate_column_count));
+    }
+    // Only a colocate-aware split needs the sort-key arity. Resolve it from the materialized
+    // TabletSchema (which applies the "empty sort_key_idxes => sort key is the key columns"
+    // convention that the FE mirrors in MetaUtils.getRangeDistributionColumns) rather than the raw
+    // TabletSchemaPB: a range-distributed table created without an explicit ORDER BY (e.g. a
+    // PRIMARY KEY table) leaves sort_key_idxes empty in the PB, so reading the raw arity (0) would
+    // reject every colocate split and silently fall back to an identical tablet. A non-colocate
+    // split (colocate_column_count == 0) must not pay this materialization, and must not require a
+    // schema id (GlobalTabletSchemaMap::emplace DCHECKs a valid id, which synthetic test metadata
+    // and any non-registered schema may lack).
+    if (colocate_column_count > 0) {
+        auto tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_metadata->schema()).first;
+        const int32_t sort_key_arity = static_cast<int32_t>(tablet_schema->sort_key_idxes().size());
+        if (colocate_column_count > sort_key_arity) {
+            return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}, sort key arity is {}",
+                                                       colocate_column_count, sort_key_arity));
+        }
     }
 
     std::vector<SegmentSplitInfo> segments;


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #74409. That PR made `get_tablet_split_ranges_impl` validate `colocate_column_count` against a **materialized** `TabletSchema` (so PRIMARY KEY / no-explicit-`ORDER BY` range-colocate tables, whose raw `sort_key_idxes` is empty, are no longer wrongly rejected and silently degraded to an identical, un-split tablet). But it did the materialization **unconditionally**, which has two problems on the non-colocate split path:

- A non-colocate split (`colocate_column_count == 0`) does not need the sort-key arity at all, yet now materializes the schema (and pollutes the global schema map) on every split.
- `GlobalTabletSchemaMap::emplace` has a `DCHECK_NE(invalid_id(), id)`. Synthetic metadata without a schema id (e.g. `LakeTabletReshardTest.test_tablet_splitting`) therefore **aborts the BE unit tests in a DEBUG build**. This is exactly what failed the branch-4.1 backport CI (#74491), which runs a DEBUG build. The #74409 main CI happened to run with `DCHECK` compiled out, so it didn't catch this.

## What I'm doing:

Gate the materialization and the arity check on `colocate_column_count > 0`. A non-colocate split keeps its original behavior (it never consulted the sort-key arity), and the colocate-aware path is unchanged. This removes the needless per-split materialization and the debug-build abort, and keeps `main` consistent with the branch-4.1 fix.

No new test: the colocate path is already covered by `tablet_splitter_test.cpp::data_driven_colocate_split_resolves_empty_sort_key_idxes` (added in #74409), and the non-colocate path is exercised by `LakeTabletReshardTest.test_tablet_splitting` (which aborts in a DEBUG build without this gate).

The equivalent gating is already carried by the branch-4.1 backport (#74491), so this PR does **not** need to be backported to 4.1.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch


<!-- Follow-up to #74409; equivalent gating already merged in #74491 (4.1). -->
