### PR TITLE
[BugFix] Fix ADMIN SHOW REPLICA STATUS missing-replica row column mismatch (backport #74393)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -166,17 +166,19 @@ public class MetadataViewer {
                             // get missing replicas
                             for (int i = 0; i < count; ++i) {
                                 List<String> row = Lists.newArrayList();
-                                row.add(String.valueOf(tabletId));
-                                row.add("-1");
-                                row.add("-1");
-                                row.add("-1");
-                                row.add("-1");
-                                row.add("-1");
-                                row.add("-1");
-                                row.add("-1");
-                                row.add(FeConstants.NULL_STRING);
-                                row.add(FeConstants.NULL_STRING);
-                                row.add(ReplicaStatus.MISSING.name());
+                                row.add(String.valueOf(tabletId));     // TabletId
+                                row.add("-1");                         // ReplicaId
+                                row.add("-1");                         // BackendId
+                                row.add("-1");                         // Version
+                                row.add("-1");                         // LastFailedVersion
+                                row.add("-1");                         // LastSuccessVersion
+                                row.add("-1");                         // CommittedVersion
+                                row.add("-1");                         // SchemaHash
+                                row.add(FeConstants.NULL_STRING);      // VersionNum
+                                row.add(FeConstants.NULL_STRING);      // IsBad
+                                row.add(FeConstants.NULL_STRING);      // IsSetBadForce
+                                row.add(FeConstants.NULL_STRING);      // State
+                                row.add(ReplicaStatus.MISSING.name()); // Status
                                 result.add(row);
                             }
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
@@ -36,12 +36,17 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TableRef;
 import com.starrocks.backup.CatalogMocker;
 import com.starrocks.catalog.Replica.ReplicaStatus;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultMetaFactory;
+import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.system.SystemInfoService;
 import mockit.Expectations;
@@ -179,6 +184,46 @@ public class MetadataViewerTest {
         Object[] args = new Object[] {CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME, null};
         List<List<String>> result = (List<List<String>>) getTabletDistributionMethod.invoke(null, args);
         Assertions.assertEquals(3, result.size());
+    }
+
+    @Test
+    public void testMissingReplicaRowMatchesMetadataColumnCount() throws Exception {
+        // Regression for the MySQL protocol desync: when a tablet has fewer replicas than
+        // replicationNum, the MISSING-replica branch must emit exactly as many cells as the
+        // ADMIN SHOW REPLICA STATUS result metadata declares. A short row corrupts the
+        // length-encoded row stream and hangs/disconnects the client.
+
+        // Force replicationNum (3 replicas exist) to 4 so the MISSING branch produces one phantom row.
+        PartitionInfo partitionInfo =
+                ((OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME)).getPartitionInfo();
+        new Expectations(partitionInfo) {
+            {
+                partitionInfo.getReplicationNum(anyLong);
+                result = (short) 4;
+            }
+        };
+
+        TableName tableName = new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME);
+        TableRef tableRef = new TableRef(tableName, null);
+        AdminShowReplicaStatusStmt stmt = new AdminShowReplicaStatusStmt(tableRef, null);
+
+        List<List<String>> result = MetadataViewer.getTabletStatus(stmt);
+
+        ShowResultSetMetaData meta = new ShowResultMetaFactory().getMetadata(stmt);
+        int expectedColumnCount = meta.getColumnCount();
+        int statusIdx = meta.getColumnIdx("Status");
+
+        // 3 existing replicas + 1 missing replica.
+        Assertions.assertEquals(4, result.size());
+        boolean sawMissing = false;
+        for (List<String> row : result) {
+            Assertions.assertEquals(expectedColumnCount, row.size(),
+                    "every row must have the same cell count as the declared metadata; row=" + row);
+            if (ReplicaStatus.MISSING.name().equals(row.get(statusIdx))) {
+                sawMissing = true;
+            }
+        }
+        Assertions.assertTrue(sawMissing, "expected at least one MISSING replica row");
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

  The result metadata for `ADMIN SHOW REPLICA STATUS` declares 13 columns and
  the existing-replica branch emits 13 cells, but the MISSING (phantom)
  replica branch emitted only 11, omitting `IsSetBadForce` and `State` and
  mislabeling the trailing status value.

  `sendShowResult` writes exactly row.size() length-encoded values with no
  padding against the 13-column header, so any result set containing a
  MISSING row desyncs the MySQL length-encoded row stream and hangs or
  disconnects the client.

## What I'm doing:

  Emit all 13 aligned cells in the MISSING branch (`IsSetBadForce` and `State`
  as NULL) so every row matches the declared metadata. Add a regression
  test that forces the MISSING branch and asserts each row's cell count
  equals the metadata column count.

https://github.com/StarRocks/starrocks/pull/74393

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

