### PR TITLE
[BugFix] prevent task manager from writing illegal edit log for taskRun (backport #73882)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -349,9 +349,17 @@ public class TaskRunManager implements MemoryTrackable {
 
             Future<?> future = taskRun.getFuture();
             if (future.isDone()) {
-                taskRunScheduler.removeRunningTask(taskId);
                 LOG.info("Task run is done from state RUNNING to {}, {}", taskRun.getStatus().getState(), taskRun);
 
+                if (!taskRun.getStatus().getState().isFinishState()) {
+                    LOG.warn("TaskRun future is done but state is still {} (not finish state), " +
+                            "likely a transient race between kill/cancel path and async execution thread; " +
+                            "will retry on next scheduler tick. queryId={}, taskId={}",
+                            taskRun.getStatus().getState(), taskRun.getStatus().getQueryId(), taskId);
+                    continue;
+                }
+
+                taskRunScheduler.removeRunningTask(taskId);
                 taskRunHistory.addHistory(taskRun.getStatus());
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());


### PR DESCRIPTION
## Why I'm doing:

<img width="2292" height="276" alt="image" src="https://github.com/user-attachments/assets/d14fe8ba-fba3-4e50-bf6c-3e95fe004570" />
transform from running to running is an illegal edit log, this may cause taskRun is finished, but always hold in the runningTaskRunMap. Thus the next task will trust the previous task is still running, and trasnform to  merged state unexpectedly.

In Detail [https://github.com/StarRocks/starrocks/issues/73879](https://github.com/StarRocks/starrocks/issues/73879)

## What I'm doing:
Do some defense check. Before writing the edit log, check the condition first.

Fixes https://github.com/StarRocks/starrocks/pull/73882

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Backport note:

Resolved the TaskRunManager.java conflict by preserving the release branch edit-log API and applying the finish-state guard before removing the running task.

Validation:
- `./run-fe-ut.sh --test com.starrocks.scheduler.TaskRunManagerTest -j1`

