### PR TITLE
[BugFix] scope replica row-count update to table lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
@@ -87,6 +87,13 @@ public class MetaRecoveryDaemon extends LeaderDaemon {
                 continue;
             }
 
+            // Deliberate full-DB READ (not the table-scoped intensive path): this walk iterates
+            // every table and reads per-table internal state (partitions -> indices -> tablets ->
+            // replica versions) over the unbounded table set, which is the case the lock rubric
+            // assigns to plain lockDatabase(READ). It also only runs under
+            // Config.metadata_enable_recovery_mode, where a coherent DB-wide view of partition
+            // versions is wanted and concurrent DDL should not race the repair; the IX-blocking
+            // that READ imposes is acceptable (and desirable) in that mode.
             Locker locker = new Locker();
             locker.lockDatabase(database.getId(), LockType.READ);
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.TraceManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -54,6 +55,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -205,8 +207,19 @@ public class PublishVersionTask extends AgentTask {
         if (!droppedTablets.isEmpty()) {
             LOG.info("during publish version some tablets were dropped(maybe by alter), tabletIds={}", droppedTablets);
         }
+        // This callback runs on every load transaction's publish completion and only mutates
+        // Replica state of the tables these tablets belong to. Take a table-scoped intensive
+        // lock instead of a full DB-WRITE so unrelated tables in the same DB are not serialized.
+        Set<Long> tableIdSet = new HashSet<>();
+        for (TabletMeta tabletMeta : tablets.getTabletMetaList(tabletIds)) {
+            long tableId = tabletMeta.getTableId();
+            if (tableId != TabletInvertedIndex.NOT_EXIST_VALUE) {
+                tableIdSet.add(tableId);
+            }
+        }
+        List<Long> tableIdList = new ArrayList<>(tableIdSet);
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
+        locker.lockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
         try {
             // TODO: persistent replica version
             for (int i = 0; i < tabletVersions.size(); i++) {
@@ -221,7 +234,7 @@ public class PublishVersionTask extends AgentTask {
                 replica.updateRowCount(reportedVersion, minReadableVersion, replica.getDataSize(), replica.getRowCount());
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
             if (span != null) {
                 span.addEvent("update_replica_version_finish");
             }


### PR DESCRIPTION
updateReplicaVersions ran under a full DB-WRITE lock on every load transaction publish-version callback, serializing all tables in the DB even though the critical section only mutates Replica row counts for the tables those tablets belong to.

Resolve the distinct table ids from the reported tablets via the inverted index and acquire lockTablesWithIntensiveDbLock(WRITE) instead. WRITE intensity is preserved; only the scope narrows, so unrelated tables in the same DB no longer block on each publish.

Also document why MetaRecoveryDaemon.recover() deliberately keeps a full-DB READ lock: it walks every table's per-table state over the unbounded table set (the rubric's plain-READ case) and only runs under metadata_enable_recovery_mode, where a coherent DB-wide view is wanted.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
