### PR TITLE
[BugFix] Narrow DB-WRITE locks to table-scoped intensive WRITE (shared-nothing)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -780,8 +780,11 @@ public class LeaderImpl {
                 return;
             }
 
+            // Setting a single replica's path hash is table-local; scope the WRITE to that table
+            // instead of taking a full DB WRITE that would block every other table in the DB.
+            long tableId = tabletMeta.getTableId();
             Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.WRITE);
+            locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
             try {
                 // local migration just set path hash
                 Replica replica =
@@ -789,7 +792,7 @@ public class LeaderImpl {
                 Preconditions.checkArgument(reportedTablet.isSetPath_hash());
                 replica.setPathHash(reportedTablet.getPath_hash());
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
+                locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
             }
         } finally {
             AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.STORAGE_MEDIUM_MIGRATE, task.getSignature());

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -188,6 +188,12 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
      */
     private static final long MAX_REPORT_HANDLING_TIME_LOGGING_THRESHOLD_MS = 3000;
 
+    // Max time deleteFromMeta holds the table write lock before yielding it (release + re-acquire),
+    // so a long delete walk does not block other operations on the same table. Non-final so tests
+    // can force the periodic relock path.
+    @VisibleForTesting
+    protected static long maxDbWLockHoldingTimeMs = 1000L;
+
     private static final Logger LOG = LogManager.getLogger(ReportHandler.class);
     private static final Set<ReportType> RESOURCE_REPORT_TYPES =
             EnumSet.of(ReportType.RESOURCE_GROUP_REPORT, ReportType.RESOURCE_USAGE_REPORT);
@@ -493,7 +499,8 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         // (db id, table id) -> tablet id
         ListMultimap<Pair<Long, Long>, Long> tabletSyncMap = ArrayListMultimap.create();
         // db id -> tablet id
-        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
+        // (dbId, tableId) -> tabletIds, so deletion can lock a single table at a time.
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
         // tablet ids which schema hash is valid
         Set<Long> foundTabletsWithValidSchema = new HashSet<Long>();
         // storage medium -> tablet id
@@ -575,7 +582,7 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
     public static void tabletReport(long backendId, Map<Long, TTablet> backendTablets,
                                     final HashMap<Long, TStorageMedium> storageMediumMap,
                                     ListMultimap<Pair<Long, Long>, Long> tabletSyncMap,
-                                    ListMultimap<Long, Long> tabletDeleteFromMeta,
+                                    Table<Long, Long, List<Long>> tabletDeleteFromMeta,
                                     Set<Long> foundTabletsWithValidSchema,
                                     ListMultimap<TStorageMedium, Long> tabletMigrationMap,
                                     Map<Long, Map<Long, Map<Long, TPartitionVersionInfo>>> transactionsToPublish,
@@ -774,7 +781,12 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                 // 2. (meta - be)
                 // may need delete from meta
                 LOG.debug("backend[{}] does not report tablet[{}-{}]", backendId, tabletId, tabletMeta);
-                tabletDeleteFromMeta.put(tabletMeta.getDbId(), tabletId);
+                List<Long> tabletIds = tabletDeleteFromMeta.get(tabletMeta.getDbId(), tabletMeta.getTableId());
+                if (tabletIds == null) {
+                    tabletIds = Lists.newArrayList();
+                    tabletDeleteFromMeta.put(tabletMeta.getDbId(), tabletMeta.getTableId(), tabletIds);
+                }
+                tabletIds.add(tabletId);
             }
         } // end for replicaMetaWithBackend
 
@@ -782,7 +794,7 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         LOG.info("finished to do tablet diff with backend[{}]. sync: {}. metaDel: {}. foundValid: {}. "
                         + " migration: {}. found invalid transactions {}. found republish transactions {} "
                         + " cost: {} ms", backendId, tabletSyncMap.size(),
-                tabletDeleteFromMeta.size(), foundTabletsWithValidSchema.size(),
+                tabletDeleteFromMeta.values().stream().mapToInt(List::size).sum(), foundTabletsWithValidSchema.size(),
                 tabletMigrationMap.size(), transactionsToClear.size(), transactionsToPublish.size(), (end - start));
     }
 
@@ -1205,7 +1217,7 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         } // end for dbs
     }
 
-    protected static void deleteFromMeta(ListMultimap<Long, Long> tabletDeleteFromMeta, long backendId,
+    protected static void deleteFromMeta(Table<Long, Long, List<Long>> tabletDeleteFromMeta, long backendId,
                                        long backendReportVersion) {
         AgentBatchTask createReplicaBatchTask = new AgentBatchTask();
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
@@ -1215,35 +1227,51 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                 .getClusterInfo().getBackend(backendId).getDisks().values()) {
             hashToDiskInfo.put(diskInfo.getPathHash(), diskInfo);
         }
-        final long MAX_DB_WLOCK_HOLDING_TIME_MS = 1000L;
         List<LocalTablet> deleteTablets = new ArrayList<>();
         List<ReplicaPersistInfo> replicaPersistInfoList = new ArrayList<>();
-        DB_TRAVERSE:
-        for (Long dbId : tabletDeleteFromMeta.keySet()) {
+        // tabletDeleteFromMeta is grouped by (dbId, tableId), so each batch of doomed tablets is
+        // table-local. Scope the WRITE to that single table with an intensive lock instead of a
+        // full DB WRITE that would block every other table on this frequent BE-report path. The
+        // genuinely destructive delete happens in a later batch-delete callback outside this lock,
+        // guarded by LocalTablet's own tablet write lock.
+        TABLE_TRAVERSE:
+        for (Table.Cell<Long, Long, List<Long>> cell : tabletDeleteFromMeta.cellSet()) {
+            long dbId = cell.getRowKey();
+            long tableId = cell.getColumnKey();
             Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbId);
             if (db == null) {
                 continue;
             }
+            List<Long> tabletIds = cell.getValue();
             Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.WRITE);
+            locker.lockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
+            boolean locked = true;
             long lockStartTime = System.currentTimeMillis();
             try {
                 int deleteCounter = 0;
-                List<Long> tabletIds = tabletDeleteFromMeta.get(dbId);
+                // Snapshot tablet metadata only after acquiring the table lock. A concurrent
+                // truncate/drop cannot run while we hold the lock, so the loop never acts on
+                // tablets that were removed from TabletInvertedIndex while we waited for the lock.
+                // Refreshed after every periodic relock for the same reason.
                 List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
                 for (int i = 0; i < tabletMetaList.size(); i++) {
-                    // Because we need to write bdb with db write lock hold,
+                    // Because we need to write bdb with the table write lock hold,
                     // to avoid block other threads too long, we periodically release and
-                    // acquire the db write lock (every MAX_DB_WLOCK_HOLDING_TIME_MS milliseconds).
+                    // acquire the table write lock (every maxDbWLockHoldingTimeMs milliseconds).
                     long currentTime = System.currentTimeMillis();
-                    if (currentTime - lockStartTime > MAX_DB_WLOCK_HOLDING_TIME_MS) {
-                        locker.unLockDatabase(db.getId(), LockType.WRITE);
+                    if (currentTime - lockStartTime > maxDbWLockHoldingTimeMs) {
+                        locker.unLockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
+                        locked = false;
                         db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbId);
                         if (db == null) {
-                            continue DB_TRAVERSE;
+                            continue TABLE_TRAVERSE;
                         }
-                        locker.lockDatabase(db.getId(), LockType.WRITE);
+                        locker.lockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
+                        locked = true;
                         lockStartTime = currentTime;
+                        // Re-read metadata under the freshly re-acquired lock so we never act on
+                        // tablets that were truncated/dropped while the lock was released.
+                        tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
                     }
 
                     TabletMeta tabletMeta = tabletMetaList.get(i);
@@ -1251,7 +1279,6 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                         continue;
                     }
                     long tabletId = tabletIds.get(i);
-                    long tableId = tabletMeta.getTableId();
                     long partitionId = tabletMeta.getPhysicalPartitionId();
 
                     LOG.debug("delete tablet {} in partition {} of table {} in db {} from meta. backend[{}]",
@@ -1435,11 +1462,13 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                                 currentBackendReportVersion);
                     }
                 } // end for tabletMetas
-                LOG.info("delete {} replica(s) from globalStateMgr in db[{}]", deleteCounter, dbId);
+                LOG.info("delete {} replica(s) from globalStateMgr in db[{}] table[{}]", deleteCounter, dbId, tableId);
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
+                if (locked) {
+                    locker.unLockTableWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
+                }
             }
-        } // end for dbs
+        } // end for (db, table) cells
 
         if (!deleteTablets.isEmpty()) {
             // no need to be protected by db lock, if the related meta is dropped, the replay code will ignore that tablet

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3034,18 +3034,20 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             Multimap<Long, Long> tableIdToPartitionIds = changedPartitionsMap.get(dbId);
 
-            // use try lock to avoid blocking a long time.
-            // if block too long, backend report rpc will timeout.
-            // TODO: remove the DB level WRITE lock
-            Locker locker = new Locker();
-            if (!locker.tryLockDatabase(db.getId(), LockType.WRITE, Database.TRY_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                LOG.warn("try get db {}-{} write lock but failed when checking backend storage medium",
-                        db.getFullName(), dbId);
-                continue;
-            }
-            Preconditions.checkState(locker.isDbWriteLockHeldByCurrentThread(db));
-            try {
-                for (Long tableId : tableIdToPartitionIds.keySet()) {
+            for (Long tableId : tableIdToPartitionIds.keySet()) {
+                // The DataProperty mutation only touches this table's partitions, so scope the
+                // WRITE to the single table. Use a per-table try lock with timeout to avoid
+                // blocking a long time; if block too long the backend report rpc would time out.
+                // The lock wraps the log-and-apply phase so the synchronous WAL callback stays
+                // protected.
+                Locker locker = new Locker();
+                if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE,
+                        Database.TRY_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("try get db {}-{} table {} write lock but failed when checking backend storage medium",
+                            db.getFullName(), dbId, tableId);
+                    continue;
+                }
+                try {
                     Table table = getTable(db.getId(), tableId);
                     if (table == null) {
                         continue;
@@ -3078,10 +3080,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                             storageMediumMap.put(partitionId, TStorageMedium.HDD);
                         }
                     } // end for partitions
-                } // end for tables
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
-            }
+                } finally {
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+                }
+            } // end for tables
         } // end for dbs
         return storageMediumMap;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/LeaderImplStorageMigrationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/LeaderImplStorageMigrationTest.java
@@ -1,0 +1,154 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.leader;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.system.Backend;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.StorageMediaMigrationTask;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LeaderImplStorageMigrationTest {
+    private static final String DB_NAME = "test_finish_storage_migration";
+    private static final long DB_ID = 80001L;
+    private static final long TABLE_ID = 80002L;
+    private static final long PARTITION_ID = 80004L;
+    private static final long PHYSICAL_PARTITION_ID = 80005L;
+    private static final long INDEX_ID = 80006L;
+    private static final long TABLET_ID = 80007L;
+    private static final long BACKEND_ID = 80008L;
+    private static final long REPLICA_ID = 80009L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        Backend backend = new Backend(BACKEND_ID, "127.0.0.1", 9050);
+        backend.setAlive(true);
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static OlapTable createOlapTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns,
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1,
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new java.util.HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testFinishStorageMigrationSetsPathHash() throws Exception {
+        // 1. Register table and add tablet/replica to the inverted index so finishStorageMigration
+        //    can resolve the db/table and locate the replica.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        long newPathHash = 123456789L;
+        Assertions.assertNotEquals(newPathHash, replica.getPathHash());
+
+        // 2. Build a successful finish request carrying the new path hash.
+        TFinishTaskRequest request = new TFinishTaskRequest();
+        request.setTask_status(new TStatus(TStatusCode.OK));
+        TTabletInfo tabletInfo = new TTabletInfo();
+        tabletInfo.setTablet_id(TABLET_ID);
+        tabletInfo.setPath_hash(newPathHash);
+        request.setFinish_tablet_infos(Lists.newArrayList(tabletInfo));
+
+        StorageMediaMigrationTask task =
+                new StorageMediaMigrationTask(BACKEND_ID, TABLET_ID, 0, TStorageMedium.HDD, false);
+
+        // 3. Invoke the private finishStorageMigration: it takes the table-scoped WRITE lock and
+        //    sets the replica path hash.
+        LeaderImpl leader = new LeaderImpl();
+        Method method = LeaderImpl.class.getDeclaredMethod("finishStorageMigration",
+                AgentTask.class, TFinishTaskRequest.class);
+        method.setAccessible(true);
+        method.invoke(leader, task, request);
+
+        Assertions.assertEquals(newPathHash, replica.getPathHash());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerEditLogTest.java
@@ -15,8 +15,11 @@
 package com.starrocks.leader;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Table;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
@@ -168,8 +171,8 @@ public class ReportHandlerEditLogTest {
         Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID_2));
 
         // 2. Construct tabletDeleteFromMeta - tablet should be deleted from meta
-        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
-        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLE_ID, Lists.newArrayList(TABLET_ID));
         
         // 3. Call deleteFromMeta directly
         // Since disks are empty, diskInfo will be null, so version check won't execute
@@ -240,6 +243,51 @@ public class ReportHandlerEditLogTest {
     }
 
     @Test
+    public void testDeleteFromMetaPeriodicRelock() throws Exception {
+        // Forcing maxDbWLockHoldingTimeMs negative makes the periodic release/re-acquire of the
+        // table write lock trigger on the first iteration, exercising the relock path. The delete
+        // must still succeed after the lock is yielded and re-taken.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+
+        Replica replica1 = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica1.updateVersionInfo(2, 2, 2);
+        replica1.setDeferReplicaDeleteToNextReport(false); // Allow immediate deletion
+        tablet.addReplica(replica1);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica1);
+
+        Replica replica2 = new Replica(REPLICA_ID_2, BACKEND_ID_2, 0, Replica.ReplicaState.NORMAL);
+        replica2.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica2);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica2);
+
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLE_ID, Lists.newArrayList(TABLET_ID));
+
+        long savedThreshold = ReportHandler.maxDbWLockHoldingTimeMs;
+        ReportHandler.maxDbWLockHoldingTimeMs = -1L;
+        try {
+            ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, 1L);
+        } finally {
+            ReportHandler.maxDbWLockHoldingTimeMs = savedThreshold;
+        }
+
+        // The relock must not disrupt the delete: the replica on BACKEND_ID is removed.
+        Assertions.assertEquals(1, tablet.getImmutableReplicas().size());
+        Assertions.assertNull(tablet.getReplicaByBackendId(BACKEND_ID));
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID_2));
+    }
+
+    @Test
     public void testDeleteFromMetaSingleReplicaSetBad() throws Exception {
         // Test deleteFromMeta with single replica - should setBad instead of delete
         // 1. Create table with tablet and single replica
@@ -266,8 +314,8 @@ public class ReportHandlerEditLogTest {
         Assertions.assertFalse(tablet.getReplicaByBackendId(BACKEND_ID).isBad());
 
         // 2. Construct tabletDeleteFromMeta - tablet should be deleted from meta
-        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
-        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLE_ID, Lists.newArrayList(TABLET_ID));
         
         // 3. Call deleteFromMeta directly
         // Since disks are empty, diskInfo will be null, so version check won't execute
@@ -483,8 +531,8 @@ public class ReportHandlerEditLogTest {
         GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
 
         // 3. Construct tabletDeleteFromMeta - tablet should be deleted from meta
-        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
-        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLE_ID, Lists.newArrayList(TABLET_ID));
         
         // 4. Call deleteFromMeta and expect exception
         long backendReportVersion = 1L;
@@ -543,8 +591,8 @@ public class ReportHandlerEditLogTest {
         GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
 
         // 3. Construct tabletDeleteFromMeta - tablet should be deleted from meta
-        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
-        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLE_ID, Lists.newArrayList(TABLET_ID));
         
         // 4. Call deleteFromMeta and expect exception
         long backendReportVersion = 1L;
@@ -704,8 +752,8 @@ public class ReportHandlerEditLogTest {
                         .getBackend(BACKEND_ID).getDisks().get("/data1").getPathHash(),
                 "test setup: ONLINE disk pathHash must match the replica");
 
-        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
-        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        Table<Long, Long, List<Long>> tabletDeleteFromMeta = HashBasedTable.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLE_ID, Lists.newArrayList(TABLET_ID));
 
         long staleReportVersion = 50L;
         ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, staleReportVersion);

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
@@ -111,6 +111,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME;
@@ -2097,5 +2098,43 @@ public class LocalMetastoreSimpleOpsEditLogTest {
         // 4. Verify storage medium remains unchanged after exception
         // The method catches exceptions internally, so the partition should remain as SSD
         Assertions.assertEquals(TStorageMedium.SSD, partitionInfo.getDataProperty(partition.getId()).getStorageMedium());
+    }
+
+    @Test
+    public void testGetPartitionIdToStorageMediumMapTryLockTimeout() throws Exception {
+        // 1. Create table with an SSD partition whose cooldown already expired, so phase 2 of
+        //    getPartitionIdToStorageMediumMap tries to take the per-table WRITE lock.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        Partition partition = table.getPartition(PARTITION_ID);
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        com.starrocks.catalog.DataProperty expiredSSDProperty = new com.starrocks.catalog.DataProperty(
+                TStorageMedium.SSD, System.currentTimeMillis() - 1000); // Expired
+        partitionInfo.setDataProperty(partition.getId(), expiredSSDProperty);
+
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.SSD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+
+        // 2. Make the phase-2 per-table try lock fail (as if it timed out). Phase 1 uses the
+        //    blocking lockTableWithIntensiveDbLock, which is left untouched so candidates are still
+        //    collected; only the phase-2 tryLock is forced to return false.
+        new MockUp<Locker>() {
+            @Mock
+            public boolean tryLockTableWithIntensiveDbLock(Long dbId, Long tableId, LockType lockType,
+                                                           long timeout, TimeUnit unit) {
+                return false;
+            }
+        };
+
+        // 3. Execute getPartitionIdToStorageMediumMap - phase 2 cannot acquire the lock, so the
+        //    expired partition is skipped: it is neither added to the map nor changed to HDD.
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Map<Long, TStorageMedium> storageMediumMap = metastore.getPartitionIdToStorageMediumMap();
+
+        Assertions.assertFalse(storageMediumMap.containsKey(PARTITION_ID));
+        Assertions.assertEquals(TStorageMedium.SSD,
+                partitionInfo.getDataProperty(partition.getId()).getStorageMedium());
     }
 }


### PR DESCRIPTION
These changes are specific to shared-nothing mode. deleteFromMeta, finishStorageMigration, and getPartitionIdToStorageMediumMap each took a full lockDatabase(WRITE) for work that only touches specific tables, blocking every unrelated table in the DB on frequent BE-report and cooldown-daemon paths.

- deleteFromMeta: re-organize tabletDeleteFromMeta as a (dbId, tableId) ->
  tabletIds table so the catalog walk is grouped per table, and lock just that
  single table with lockTableWithIntensiveDbLock. Periodic relock operates on
  the single table; a locked flag guards the finally against double-unlock/NPE
  on the db-dropped relock path. Deferred batch-delete still relies on
  LocalTablet's own tablet write lock.
- finishStorageMigration: lockTableWithIntensiveDbLock on the replica's table for the single setPathHash.
- getPartitionIdToStorageMediumMap: take a per-table tryLockTableWithIntensiveDbLock with timeout inside the table loop (skip that table on timeout) instead of one DB WRITE over all changed tables; the lock wraps the log-and-apply phase so the synchronous WAL callback stays protected. Drop the obsolete DB-write Preconditions check and TODO.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
