### PR TITLE
Restore flag during cluster startup

### DIFF
--- a/docker/dockerfiles/fe/fe_entrypoint.sh
+++ b/docker/dockerfiles/fe/fe_entrypoint.sh
@@ -251,6 +251,9 @@ start_fe_no_meta()
     if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
         opts+=" --logconsole"
     fi
+    if [[ "${RESTORE_CLUSTER_SNAPSHOT}" == "true" ]] ; then
+             opts+=" --cluster_snapshot"
+    fi
     log_stderr "first start with no meta run start_fe.sh with additional options: '$opts'"
     $STARROCKS_HOME/bin/start_fe.sh $opts
 }


### PR DESCRIPTION
## Why I'm doing:
Cluster restore fails because the -cluster_snapshot flag is not passed to the startup script during restore.
## What I'm doing:
Added a check in fe_entrypoint.sh to append --cluster_snapshot to the start_fe.sh arguments when RESTORE_CLUSTER_SNAPSHOT=true so the Java process starts in disaster recovery mode

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
