### PR TITLE
[UT] Add SQL integration tests for light_weight_tablet_creation

### DIFF
--- a/test/sql/test_light_weight_tablet_creation/R/test_alter
+++ b/test/sql/test_light_weight_tablet_creation/R/test_alter
@@ -1,0 +1,165 @@
+-- name: test_light_weight_tablet_creation_alter @cloud @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_alter_basic (
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "false");
+-- result:
+-- !result
+ALTER TABLE t_alter_basic SET("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+SHOW CREATE TABLE t_alter_basic;
+-- result:
+t_alter_basic	CREATE TABLE `t_alter_basic` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4 
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"light_weight_tablet_creation" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+INSERT INTO t_alter_basic VALUES (1, 'a'), (2, 'b');
+-- result:
+-- !result
+SELECT * FROM t_alter_basic ORDER BY c0;
+-- result:
+1	a
+2	b
+-- !result
+ALTER TABLE t_alter_basic SET("light_weight_tablet_creation" = "invalid");
+-- result:
+E: (5064, 'Getting analyzing error. Detail message: Property light_weight_tablet_creation must be bool type(false/true).')
+-- !result
+ALTER TABLE t_alter_basic SET("light_weight_tablet_creation" = "false");
+-- result:
+-- !result
+SHOW CREATE TABLE t_alter_basic;
+-- result:
+t_alter_basic	CREATE TABLE `t_alter_basic` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4 
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"light_weight_tablet_creation" = "false",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+INSERT INTO t_alter_basic VALUES (3, 'c');
+-- result:
+-- !result
+SELECT * FROM t_alter_basic ORDER BY c0;
+-- result:
+1	a
+2	b
+3	c
+-- !result
+DROP TABLE t_alter_basic;
+-- result:
+-- !result
+CREATE TABLE t_schema_change (
+    c0 INT,
+    c1 VARCHAR(10)
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_schema_change VALUES (1, 'a'), (2, 'b');
+-- result:
+-- !result
+ALTER TABLE t_schema_change MODIFY COLUMN c1 INT;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t_schema_change;
+-- result:
+c0	int	YES	true	None	
+c1	int	YES	false	None	
+-- !result
+SELECT * FROM t_schema_change ORDER BY c0;
+-- result:
+1	0
+2	0
+-- !result
+INSERT INTO t_schema_change VALUES (3, 30), (4, 40);
+-- result:
+-- !result
+SELECT * FROM t_schema_change ORDER BY c0;
+-- result:
+1	0
+2	0
+3	30
+4	40
+-- !result
+DROP TABLE t_schema_change;
+-- result:
+-- !result
+CREATE TABLE t_rollup (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_rollup VALUES (1, 'a', 100), (2, 'b', 200);
+-- result:
+-- !result
+ALTER TABLE t_rollup ADD ROLLUP rollup_c0_c1 (c0, c1);
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP", 8)
+-- result:
+None
+-- !result
+SELECT c0, c1 FROM t_rollup ORDER BY c0;
+-- result:
+1	a
+2	b
+-- !result
+INSERT INTO t_rollup VALUES (3, 'c', 300);
+-- result:
+-- !result
+SELECT * FROM t_rollup ORDER BY c0;
+-- result:
+1	a	100
+2	b	200
+3	c	300
+-- !result
+DROP TABLE t_rollup;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_light_weight_tablet_creation/R/test_basic
+++ b/test/sql/test_light_weight_tablet_creation/R/test_basic
@@ -1,0 +1,279 @@
+-- name: test_light_weight_tablet_creation_basic @cloud @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_hash_no_bucket (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_hash_no_bucket VALUES (1, 'a', 100);
+-- result:
+-- !result
+SELECT * FROM t_hash_no_bucket;
+-- result:
+1	a	100
+-- !result
+DROP TABLE t_hash_no_bucket;
+-- result:
+-- !result
+CREATE TABLE t_hash (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_hash VALUES (1, 'a', 100);
+-- result:
+-- !result
+SELECT * FROM t_hash;
+-- result:
+1	a	100
+-- !result
+DROP TABLE t_hash;
+-- result:
+-- !result
+CREATE TABLE t_random (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY RANDOM BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_random VALUES (1, 'a', 100);
+-- result:
+-- !result
+SELECT * FROM t_random;
+-- result:
+1	a	100
+-- !result
+DROP TABLE t_random;
+-- result:
+-- !result
+CREATE TABLE t_partition_no_bucket (
+    dt DATE NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02')),
+    PARTITION p20240102 VALUES [('2024-01-02'), ('2024-01-03'))
+)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_partition_no_bucket VALUES ('2024-01-01', 1, 'a');
+-- result:
+-- !result
+SELECT * FROM t_partition_no_bucket;
+-- result:
+2024-01-01	1	a
+-- !result
+DROP TABLE t_partition_no_bucket;
+-- result:
+-- !result
+CREATE TABLE t_partition (
+    dt DATE NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02')),
+    PARTITION p20240102 VALUES [('2024-01-02'), ('2024-01-03'))
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_partition VALUES ('2024-01-01', 1, 'a');
+-- result:
+-- !result
+SELECT * FROM t_partition;
+-- result:
+2024-01-01	1	a
+-- !result
+DROP TABLE t_partition;
+-- result:
+-- !result
+set enable_range_distribution = true;
+-- result:
+-- !result
+CREATE TABLE t_range_dist (
+    c0 INT,
+    c1 STRING
+) PRIMARY KEY(c0)
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_range_dist VALUES (1, 'a');
+-- result:
+-- !result
+SELECT * FROM t_range_dist;
+-- result:
+1	a
+-- !result
+DROP TABLE t_range_dist;
+-- result:
+-- !result
+set enable_range_distribution = false;
+-- result:
+-- !result
+CREATE TABLE t_add_part (
+    dt DATE NOT NULL,
+    c0 INT
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02'))
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+ALTER TABLE t_add_part ADD PARTITION p20240102
+    VALUES [('2024-01-02'), ('2024-01-03'));
+-- result:
+-- !result
+INSERT INTO t_add_part VALUES ('2024-01-02', 1);
+-- result:
+-- !result
+SELECT * FROM t_add_part WHERE dt = '2024-01-02';
+-- result:
+2024-01-02	1
+-- !result
+DROP TABLE t_add_part;
+-- result:
+-- !result
+CREATE TABLE t_truncate (
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_truncate VALUES (1, 'a');
+-- result:
+-- !result
+TRUNCATE TABLE t_truncate;
+-- result:
+-- !result
+SELECT COUNT(*) AS cnt_after_truncate FROM t_truncate;
+-- result:
+0
+-- !result
+INSERT INTO t_truncate VALUES (2, 'b');
+-- result:
+-- !result
+SELECT * FROM t_truncate;
+-- result:
+2	b
+-- !result
+DROP TABLE t_truncate;
+-- result:
+-- !result
+CREATE TABLE t_overwrite (
+    dt DATE NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02'))
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_overwrite VALUES ('2024-01-01', 1, 'old');
+-- result:
+-- !result
+INSERT OVERWRITE t_overwrite VALUES ('2024-01-01', 2, 'new');
+-- result:
+-- !result
+SELECT * FROM t_overwrite;
+-- result:
+2024-01-01	2	new
+-- !result
+DROP TABLE t_overwrite;
+-- result:
+-- !result
+CREATE TABLE t_auto (
+    dt DATE NOT NULL,
+    c0 INT
+) DUPLICATE KEY(dt, c0)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_auto VALUES ('2024-06-01', 1), ('2024-06-02', 2);
+-- result:
+-- !result
+SELECT * FROM t_auto ORDER BY dt;
+-- result:
+2024-06-01	1
+2024-06-02	2
+-- !result
+DROP TABLE t_auto;
+-- result:
+-- !result
+CREATE TABLE t_list (
+    city STRING NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(city, c0)
+PARTITION BY LIST(city) (
+    PARTITION p_bj VALUES IN ('beijing'),
+    PARTITION p_sh VALUES IN ('shanghai')
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_list VALUES ('beijing', 1, 'a'), ('shanghai', 2, 'b');
+-- result:
+-- !result
+SELECT * FROM t_list ORDER BY city;
+-- result:
+beijing	1	a
+shanghai	2	b
+-- !result
+DROP TABLE t_list;
+-- result:
+-- !result
+CREATE TABLE t_list_auto (
+    city STRING NOT NULL,
+    c0 INT
+) DUPLICATE KEY(city, c0)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+-- result:
+-- !result
+INSERT INTO t_list_auto VALUES ('beijing', 1), ('shanghai', 2), ('guangzhou', 3);
+-- result:
+-- !result
+SELECT * FROM t_list_auto ORDER BY city;
+-- result:
+beijing	1
+guangzhou	3
+shanghai	2
+-- !result
+DROP TABLE t_list_auto;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_light_weight_tablet_creation/T/test_alter
+++ b/test/sql/test_light_weight_tablet_creation/T/test_alter
@@ -1,0 +1,68 @@
+-- name: test_light_weight_tablet_creation_alter @cloud @sequential
+-- ALTER paths for light_weight_tablet_creation: toggling the property,
+-- rejecting invalid values, true -> false backfill, schema change and
+-- ADD ROLLUP on a light-weight table.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- 1.A  ALTER false -> true (no backfill, property just flips)
+CREATE TABLE t_alter_basic (
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "false");
+
+ALTER TABLE t_alter_basic SET("light_weight_tablet_creation" = "true");
+SHOW CREATE TABLE t_alter_basic;
+INSERT INTO t_alter_basic VALUES (1, 'a'), (2, 'b');
+SELECT * FROM t_alter_basic ORDER BY c0;
+
+-- 1.B  ALTER with invalid value must error
+ALTER TABLE t_alter_basic SET("light_weight_tablet_creation" = "invalid");
+
+-- 1.A reverse  ALTER true -> false triggers backfill of v1 metadata
+-- for any partition that has never been published. The DML / SELECT
+-- here is what proves the table is still usable after the backfill.
+ALTER TABLE t_alter_basic SET("light_weight_tablet_creation" = "false");
+SHOW CREATE TABLE t_alter_basic;
+INSERT INTO t_alter_basic VALUES (3, 'c');
+SELECT * FROM t_alter_basic ORDER BY c0;
+DROP TABLE t_alter_basic;
+
+-- 3  Schema Change: MODIFY COLUMN type on a light-weight table.
+-- Creates shadow tablets; light_weight_tablet_creation = true must
+-- still let the rewrite finish.
+CREATE TABLE t_schema_change (
+    c0 INT,
+    c1 VARCHAR(10)
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_schema_change VALUES (1, 'a'), (2, 'b');
+ALTER TABLE t_schema_change MODIFY COLUMN c1 INT;
+function: wait_alter_table_finish()
+DESC t_schema_change;
+SELECT * FROM t_schema_change ORDER BY c0;
+INSERT INTO t_schema_change VALUES (3, 30), (4, 40);
+SELECT * FROM t_schema_change ORDER BY c0;
+DROP TABLE t_schema_change;
+
+-- 4  ADD ROLLUP on a light-weight table
+CREATE TABLE t_rollup (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_rollup VALUES (1, 'a', 100), (2, 'b', 200);
+ALTER TABLE t_rollup ADD ROLLUP rollup_c0_c1 (c0, c1);
+function: wait_alter_table_finish("ROLLUP", 8)
+SELECT c0, c1 FROM t_rollup ORDER BY c0;
+INSERT INTO t_rollup VALUES (3, 'c', 300);
+SELECT * FROM t_rollup ORDER BY c0;
+DROP TABLE t_rollup;
+
+DROP DATABASE db_${uuid0};

--- a/test/sql/test_light_weight_tablet_creation/T/test_basic
+++ b/test/sql/test_light_weight_tablet_creation/T/test_basic
@@ -1,0 +1,176 @@
+-- name: test_light_weight_tablet_creation_basic @cloud @sequential
+-- Exercise CREATE / DML / partition / TRUNCATE / INSERT OVERWRITE on shared-data
+-- tables created with light_weight_tablet_creation = true. The property skips
+-- writing version-1 tablet metadata to object storage at CREATE time; this test
+-- verifies the DDL / DML user surface still behaves correctly.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- 1.1.0 non-partitioned, hash distribution, no BUCKETS
+CREATE TABLE t_hash_no_bucket (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_hash_no_bucket VALUES (1, 'a', 100);
+SELECT * FROM t_hash_no_bucket;
+DROP TABLE t_hash_no_bucket;
+
+-- 1.1.1 non-partitioned, hash distribution, BUCKETS 4
+CREATE TABLE t_hash (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_hash VALUES (1, 'a', 100);
+SELECT * FROM t_hash;
+DROP TABLE t_hash;
+
+-- 1.2 non-partitioned, random distribution
+CREATE TABLE t_random (
+    c0 INT,
+    c1 STRING,
+    c2 BIGINT
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY RANDOM BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_random VALUES (1, 'a', 100);
+SELECT * FROM t_random;
+DROP TABLE t_random;
+
+-- 1.3.0 range partitioned, no BUCKETS
+CREATE TABLE t_partition_no_bucket (
+    dt DATE NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02')),
+    PARTITION p20240102 VALUES [('2024-01-02'), ('2024-01-03'))
+)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_partition_no_bucket VALUES ('2024-01-01', 1, 'a');
+SELECT * FROM t_partition_no_bucket;
+DROP TABLE t_partition_no_bucket;
+
+-- 1.3.1 range partitioned, BUCKETS 4
+CREATE TABLE t_partition (
+    dt DATE NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02')),
+    PARTITION p20240102 VALUES [('2024-01-02'), ('2024-01-03'))
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_partition VALUES ('2024-01-01', 1, 'a');
+SELECT * FROM t_partition;
+DROP TABLE t_partition;
+
+-- 1.4 range distribution (Primary Key)
+set enable_range_distribution = true;
+CREATE TABLE t_range_dist (
+    c0 INT,
+    c1 STRING
+) PRIMARY KEY(c0)
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_range_dist VALUES (1, 'a');
+SELECT * FROM t_range_dist;
+DROP TABLE t_range_dist;
+set enable_range_distribution = false;
+
+-- 1.5 ADD PARTITION
+CREATE TABLE t_add_part (
+    dt DATE NOT NULL,
+    c0 INT
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02'))
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+ALTER TABLE t_add_part ADD PARTITION p20240102
+    VALUES [('2024-01-02'), ('2024-01-03'));
+INSERT INTO t_add_part VALUES ('2024-01-02', 1);
+SELECT * FROM t_add_part WHERE dt = '2024-01-02';
+DROP TABLE t_add_part;
+
+-- 1.6 TRUNCATE TABLE
+CREATE TABLE t_truncate (
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_truncate VALUES (1, 'a');
+TRUNCATE TABLE t_truncate;
+SELECT COUNT(*) AS cnt_after_truncate FROM t_truncate;
+INSERT INTO t_truncate VALUES (2, 'b');
+SELECT * FROM t_truncate;
+DROP TABLE t_truncate;
+
+-- 1.7 INSERT OVERWRITE
+CREATE TABLE t_overwrite (
+    dt DATE NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(dt, c0)
+PARTITION BY RANGE(dt) (
+    PARTITION p20240101 VALUES [('2024-01-01'), ('2024-01-02'))
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_overwrite VALUES ('2024-01-01', 1, 'old');
+INSERT OVERWRITE t_overwrite VALUES ('2024-01-01', 2, 'new');
+SELECT * FROM t_overwrite;
+DROP TABLE t_overwrite;
+
+-- 1.9 auto partition by expression (INSERT-triggered)
+CREATE TABLE t_auto (
+    dt DATE NOT NULL,
+    c0 INT
+) DUPLICATE KEY(dt, c0)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_auto VALUES ('2024-06-01', 1), ('2024-06-02', 2);
+SELECT * FROM t_auto ORDER BY dt;
+DROP TABLE t_auto;
+
+-- 1.10.1 explicit LIST partition
+CREATE TABLE t_list (
+    city STRING NOT NULL,
+    c0 INT,
+    c1 STRING
+) DUPLICATE KEY(city, c0)
+PARTITION BY LIST(city) (
+    PARTITION p_bj VALUES IN ('beijing'),
+    PARTITION p_sh VALUES IN ('shanghai')
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_list VALUES ('beijing', 1, 'a'), ('shanghai', 2, 'b');
+SELECT * FROM t_list ORDER BY city;
+DROP TABLE t_list;
+
+-- 1.10.2 expression LIST auto partition (INSERT-triggered)
+CREATE TABLE t_list_auto (
+    city STRING NOT NULL,
+    c0 INT
+) DUPLICATE KEY(city, c0)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(c0) BUCKETS 4
+PROPERTIES("light_weight_tablet_creation" = "true");
+INSERT INTO t_list_auto VALUES ('beijing', 1), ('shanghai', 2), ('guangzhou', 3);
+SELECT * FROM t_list_auto ORDER BY city;
+DROP TABLE t_list_auto;
+
+DROP DATABASE db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Cover the user-visible surface of `light_weight_tablet_creation` (the property introduced in #73422 / #73845 / #74132) end-to-end against a real shared-data cluster. The existing FE unit tests already exercise the analyzer / metastore / alter-job code paths in isolation; this PR adds SQL integration tests so we also lock down behavior across distribution and partition variants, ALTER (both directions, including the true → false backfill path) and schema-change / ADD ROLLUP.

## What I'm doing:

`test/sql/test_light_weight_tablet_creation/` splits the cases into two files:

**`T/test_basic` — 12 cases** (DDL + DML on light-weight tables)
* Hash distribution with and without explicit BUCKETS
* Random distribution
* Range partitioned, with and without explicit BUCKETS
* Range distribution on a PRIMARY KEY table (uses `admin set frontend config ('enable_range_distribution' = 'true')`)
* `ADD PARTITION`
* `TRUNCATE TABLE`
* `INSERT OVERWRITE`
* Auto partition by `date_trunc('day', ...)` (INSERT-triggered)
* Explicit `LIST` partition
* Expression `LIST` auto partition (INSERT-triggered)

**`T/test_alter` — 5 cases** (ALTER paths)
* `ALTER ... SET ('light_weight_tablet_creation' = 'true')` from a `false` table
* `ALTER ... SET ('light_weight_tablet_creation' = 'invalid')` must error with `Property light_weight_tablet_creation must be bool type(false/true)`
* `ALTER ... SET ('light_weight_tablet_creation' = 'false')` from a `true` table (exercises the #74132 backfill path; verifies the table is still usable after backfill)
* Schema Change `MODIFY COLUMN` on a light-weight table, waiting via `function: wait_alter_table_finish()`
* `ADD ROLLUP` on a light-weight table, waiting via `function: wait_alter_table_finish(\"ROLLUP\", 8)`

## Cases intentionally not integrated

* Dynamic partition — wall-clock-driven scheduler + `CURDATE()` make the diff non-deterministic; existing tests already cover the basic CREATE-with-`dynamic_partition.enable=true` shape.
* Non-shared-data OLAP rejection — the SQL harness runs against a shared-data cluster, so the negative case cannot be constructed.
* FE restart edit-log replay — the harness has no way to restart FE.
* `SHOW PARTITIONS` / `SHOW PROC` / `SHOW TABLET` output and OSS-side `ossutil` checks from the manual scripts — they reference variable partition / tablet IDs or external tooling that the diff-based harness cannot validate.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4