### PR TITLE
[BugFix] Notify pipeline observers on missed operator state transitions

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -27,6 +27,7 @@ bool AggregateDistinctBlockingSourceOperator::is_finished() const {
 }
 
 Status AggregateDistinctBlockingSourceOperator::set_finished(RuntimeState* state) {
+    auto notify = _aggregator->defer_notify_sink();
     return _aggregator->set_finished();
 }
 

--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
@@ -48,6 +48,7 @@ bool SortedAggregateStreamingSinkOperator::is_finished() const {
 }
 
 Status SortedAggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {
+    auto notify = _aggregator->defer_notify_source();
     _is_finished = true;
     ASSIGN_OR_RETURN(auto res, _aggregator->pull_eos_chunk());
     DCHECK(_accumulator.need_input());

--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_source_operator.cpp
@@ -56,6 +56,7 @@ Status SortedAggregateStreamingSourceOperator::set_finishing(RuntimeState* state
 }
 
 Status SortedAggregateStreamingSourceOperator::set_finished(RuntimeState* state) {
+    auto notify = _aggregator->defer_notify_sink();
     return _aggregator->set_finished();
 }
 

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -37,7 +37,10 @@ public:
 
     bool is_finished() const override { return _except_ctx->is_probe_finished() && _except_ctx->is_output_finished(); }
 
-    Status set_finished(RuntimeState* state) override { return _except_ctx->set_finished(); }
+    Status set_finished(RuntimeState* state) override {
+        auto notify = _except_ctx->observable().defer_notify_sink();
+        return _except_ctx->set_finished();
+    }
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
@@ -70,6 +70,7 @@ StatusOr<ChunkPtr> LocalParallelMergeSortSourceOperator::pull_chunk(RuntimeState
 }
 
 Status LocalParallelMergeSortSourceOperator::set_finished(RuntimeState* state) {
+    auto defer = _sort_context->defer_notify_sink();
     _sort_context->cancel();
     return _sort_context->set_finished();
 }


### PR DESCRIPTION
## Why I'm doing:

Several pipeline operators flip their finished state without notifying the shared context's observers, so under the event scheduler the peer driver can stall until a timeout. Add the defer_notify_* calls that the sibling operators in each family already use:

- SortedAggregateStreamingSinkOperator::set_finishing -> defer_notify_source
- SortedAggregateStreamingSourceOperator::set_finished -> defer_notify_sink
- AggregateDistinctBlockingSourceOperator::set_finished -> defer_notify_sink
- LocalParallelMergeSortSourceOperator::set_finished -> defer_notify_sink
- ExceptOutputSourceOperator::set_finished -> defer_notify_sink

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
