### PR TITLE
[Enhancement] use std::string::resize_and_overwrite in stl_string_resize_uninitialized

### DIFF
--- a/be/src/base/container/raw_container.h
+++ b/be/src/base/container/raw_container.h
@@ -196,10 +196,7 @@ inline void stl_vector_resize_uninitialized(Container* vec, size_t reserve_size,
 }
 
 inline void stl_string_resize_uninitialized(std::string* str, size_t new_size) {
-    using DstType __attribute__((may_alias)) = RawString;
-    reinterpret_cast<DstType*>(str)->resize(new_size);
-    // Compiler memory barrier to prevent instruction reordering across the resize operation
-    asm volatile("" : : : "memory");
+    str->resize_and_overwrite(new_size, [=](char* buff, size_t _) { return new_size; });
 }
 
 } // namespace starrocks::raw


### PR DESCRIPTION
## Why I'm doing:

C++23 provides resize_and_overwrite, which resizes a string without zero-initializing the new storage. Use it instead of reinterpret_cast'ing to RawString to avoid the unnecessary initialization.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
