### PR TITLE
[Refactor] Consolidate scanner options and conjuncts into shared structs, unify predicate evaluation in base class

### DIFF
--- a/be/src/connector/data_source_provider.cpp
+++ b/be/src/connector/data_source_provider.cpp
@@ -26,7 +26,7 @@ StatusOr<pipeline::MorselQueueBuilderPtr> DataSourceProvider::convert_scan_range
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
         bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
         size_t num_total_scan_ranges, size_t scan_parallelism) {
-    peek_scan_ranges(scan_ranges);
+    prepare_scan_ranges(scan_ranges);
 
     pipeline::Morsels morsels;
     bool has_more_morsel = false;

--- a/be/src/connector/data_source_provider.h
+++ b/be/src/connector/data_source_provider.h
@@ -69,7 +69,7 @@ public:
 
     virtual bool always_shared_scan() const { return true; }
 
-    virtual void peek_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {}
+    virtual void prepare_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {}
 
     virtual void default_data_source_mem_bytes(int64_t* min_value, int64_t* max_value) {
         *min_value = MIN_DATA_SOURCE_MEM_BYTES;

--- a/be/src/connector/deletion_vector/deletion_vector.cpp
+++ b/be/src/connector/deletion_vector/deletion_vector.cpp
@@ -70,7 +70,7 @@ Status DeletionVector::fill_row_indexes(const SkipRowsContextPtr& skip_rows_ctx)
         std::vector<char> deletion_vector(serialized_bitmap_length);
         RETURN_IF_ERROR(dv_file->read_at_fully(offset, deletion_vector.data(), serialized_bitmap_length));
 
-        update_dv_file_io_counter(_params.profile->runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
+        update_dv_file_io_counter(_params.profile.runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
                                   shared_buffered_input_stream);
         return deserialized_deletion_vector(magic_number_from_deletion_vector_file, deletion_vector,
                                             serialized_bitmap_length, skip_rows_ctx);
@@ -134,7 +134,7 @@ Status DeletionVector::deserialized_deletion_vector(uint32_t magic_number, std::
         skip_rows_ctx->deletion_bitmap = std::make_shared<DeletionBitmap>(bitmap);
     }
 #ifndef BE_TEST
-    update_dv_build_counter(_params.profile->runtime_profile, _build_stats);
+    update_dv_build_counter(_params.profile.runtime_profile, _build_stats);
 #endif
     return Status::OK();
 }

--- a/be/src/connector/deletion_vector/deletion_vector.cpp
+++ b/be/src/connector/deletion_vector/deletion_vector.cpp
@@ -82,7 +82,7 @@ StatusOr<std::unique_ptr<RandomAccessFile>> DeletionVector::open_random_access_f
         std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
         std::shared_ptr<CacheInputStream>& cache_input_stream) const {
     const OpenFileOptions options{.fs = _params.fs,
-                                  .path = file_path,
+                                  .file_path = file_path,
                                   .fs_stats = &fs_scan_stats,
                                   .app_stats = &app_scan_stats,
                                   .datacache_options = _params.datacache_options};

--- a/be/src/connector/deletion_vector/deletion_vector.h
+++ b/be/src/connector/deletion_vector/deletion_vector.h
@@ -27,7 +27,8 @@ struct DeletionVectorBuildStats {
 class DeletionVector {
 public:
     DeletionVector(const HdfsScannerParams& scanner_params)
-            : _deletion_vector_descriptor(scanner_params.deletion_vector_descriptor), _params(scanner_params) {}
+            : _deletion_vector_descriptor(scanner_params.table_specific.deletion_vector_descriptor),
+              _params(scanner_params) {}
 
     Status fill_row_indexes(const SkipRowsContextPtr& skip_rows_ctx);
     Status deserialized_inline_dv(std::string& encoded_bitmap_data, const SkipRowsContextPtr& skip_rows_ctx);

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -430,14 +430,13 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
             _scanner_params.partition_index_in_chunk.push_back(i);
             _scanner_params._partition_index_in_hdfs_partition_columns.push_back(
                     _hive_table->get_partition_col_index(slots[i]));
-            _scanner_params._partition_index_in_hdfs_partition_columns.push_back(
-                    _hive_table->get_partition_col_index(slots[i]));
         } else if (int32_t index = scan_range_indicate_const_column_index(slots[i]->id()); index >= 0) {
             _scanner_params.partition_slots.push_back(slots[i]);
             _scanner_params.partition_index_in_chunk.push_back(i);
             _scanner_params._partition_index_in_hdfs_partition_columns.push_back(index);
         } else if (int32_t extended_col_index = extended_column_index(slots[i]->id()); extended_col_index >= 0) {
             _scanner_params.extended_col_slots.push_back(slots[i]);
+            _scanner_params.extended_col_index_in_chunk.push_back(i);
             _scanner_params.index_in_extended_columns.push_back(extended_col_index);
         } else {
             _scanner_params.materialize_slots.push_back(slots[i]);

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -454,8 +454,8 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     if (hdfs_scan_node.__isset.case_sensitive) {
         _options.case_sensitive = hdfs_scan_node.case_sensitive;
     }
-    if (hdfs_scan_node.__isset.can_options.use_min_max_opt) {
-        _options.use_min_max_opt = hdfs_scan_node.can_options.use_min_max_opt;
+    if (hdfs_scan_node.__isset.can_use_min_max_opt) {
+        _options.use_min_max_opt = hdfs_scan_node.can_use_min_max_opt;
     }
     // can_use_any_column is set by PruneHDFSScanColumnRule when every queried column is
     // a partition column and a placeholder materialized column was injected to satisfy
@@ -465,8 +465,8 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     if (hdfs_scan_node.__isset.can_use_any_column) {
         _options.can_use_any_column = hdfs_scan_node.can_use_any_column;
     }
-    if (hdfs_scan_node.__isset.can_options.use_count_opt) {
-        _options.use_count_opt = hdfs_scan_node.can_options.use_count_opt;
+    if (hdfs_scan_node.__isset.can_use_count_opt) {
+        _options.use_count_opt = hdfs_scan_node.can_use_count_opt;
     }
     if (hdfs_scan_node.__isset.use_partition_column_value_only) {
         _use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -254,7 +254,7 @@ void HiveDataSource::_init_global_late_materialization_context(RuntimeState* sta
                     ctx->hdfs_scan_node = hdfs_scan_node;
                     return ctx;
                 }));
-        _scanner_params.scan_range_id = glm_ctx->assign_scanner_params.scan_range_id(_scan_range);
+        _scanner_params.scan_range_id = glm_ctx->assign_scan_range_id(_scan_range);
     }
 }
 
@@ -436,9 +436,7 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
             _scanner_params._partition_index_in_hdfs_partition_columns.push_back(index);
         } else if (int32_t extended_col_index = extended_column_index(slots[i]->id()); extended_col_index >= 0) {
             _scanner_params.extended_col_slots.push_back(slots[i]);
-            _scanner_params.extended_col_index_in_chunk.push_back(i);
             _scanner_params.index_in_extended_columns.push_back(extended_col_index);
-            !_scanner_params.extended_col_slots.empty() = true;
         } else {
             _scanner_params.materialize_slots.push_back(slots[i]);
             _scanner_params.materialize_index_in_chunk.push_back(i);
@@ -758,6 +756,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
             FSOptions(hdfs_scan_node.__isset.cloud_configuration ? &hdfs_scan_node.cloud_configuration : nullptr);
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
+    bool disable_column_access_path_hints = false;
     HdfsScannerParams scanner_params;
     if (hdfs_scan_node.__isset.column_access_paths && !disable_column_access_path_hints &&
         _column_access_paths.empty()) {
@@ -782,7 +781,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.scan_range = &scan_range;
     scanner_params.scan_range_id = _scanner_params.scan_range_id;
     scanner_params.fs = _pool.add(fs.release());
-    scanner_params.path = native_file_path;
+    scanner_params.file_path = native_file_path;
     scanner_params.file_size = _scan_range.file_length;
     scanner_params.table_location = _hive_table->get_base_path();
     scanner_params.tuple_desc = _tuple_desc;
@@ -815,7 +814,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.lazy_column_coalesce_counter = &_provider->_lazy_column_coalesce_counter;
     scanner_params.split_context = down_cast<HdfsSplitContext*>(_split_context);
     if (state->query_options().__isset.connector_max_split_size) {
-        scanner_params.options->connector_max_split_size = state->query_options().connector_max_split_size;
+        _options.connector_max_split_size = state->query_options().connector_max_split_size;
     }
 
     for (const auto& delete_file : scan_range.delete_files) {
@@ -1044,7 +1043,7 @@ int64_t HiveDataSource::estimated_mem_usage() const {
     return _scanner->estimated_mem_usage();
 }
 
-void HiveDataSourceProvider::peek_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {
+void HiveDataSourceProvider::prepare_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {
     for (const auto& sc : scan_ranges) {
         const TScanRange& x = sc.scan_range;
         if (!x.__isset.hdfs_scan_range) continue;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -768,10 +768,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
             FSOptions(hdfs_scan_node.__isset.cloud_configuration ? &hdfs_scan_node.cloud_configuration : nullptr);
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
-    bool disable_column_access_path_hints = false;
     HdfsScannerParams scanner_params = _scanner_params;
-    if (hdfs_scan_node.__isset.column_access_paths && !disable_column_access_path_hints &&
-        _column_access_paths.empty()) {
+    if (hdfs_scan_node.__isset.column_access_paths && _column_access_paths.empty()) {
         bool failed = false;
         auto path_resolver = make_column_access_path_resolver(state, state->obj_pool());
         for (const auto& thrift_path : hdfs_scan_node.column_access_paths) {
@@ -847,7 +845,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     // setup options for datacache
     scanner_params.datacache_options = _scanner_params.datacache_options;
-    if (!disable_column_access_path_hints && !_column_access_paths.empty()) {
+    if (!_column_access_paths.empty()) {
         scanner_params.column_access_paths = &_column_access_paths;
     }
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -45,6 +45,8 @@
 
 namespace starrocks::connector {
 
+static const std::string OPENXJSON_SERDE_LIB = "org.openx.data.jsonserde.JsonSerDe";
+
 // ================================
 
 DataSourceProviderPtr HiveConnector::create_data_source_provider(ConnectorScanNode* scan_node,
@@ -94,7 +96,8 @@ Status HiveDataSource::_check_all_slots_nullable() {
         if (!slot->is_nullable()) {
             // Check if the non-nullable column has a default value
             // If it has a default value, allow scanning as old data files can be filled with the default
-            if (_materialize_slot_default_values.find(slot->id()) == _materialize_slot_default_values.end()) {
+            if (_scanner_params.materialize_slot_default_values.find(slot->id()) ==
+                _scanner_params.materialize_slot_default_values.end()) {
                 return Status::RuntimeError(fmt::format(
                         "All columns must be nullable for external table. Column '{}' is not nullable, You can rebuild "
                         "the"
@@ -119,7 +122,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     }
 
     if (_scan_range.file_length == 0) {
-        _no_data = true;
+        _no_more_chunks = true;
         return Status::OK();
     }
 
@@ -148,15 +151,15 @@ Status HiveDataSource::open(RuntimeState* state) {
 
         if (enable_cache_select) {
             // set datacache options for cache select
-            _datacache_options = DataCacheOptions{.enable_datacache = true,
-                                                  .enable_cache_select = true,
-                                                  .enable_populate_datacache = true,
-                                                  .enable_datacache_async_populate_mode = false,
-                                                  .enable_datacache_io_adaptor = false,
-                                                  .modification_time = _scan_range.modification_time,
-                                                  .datacache_evict_probability = 100,
-                                                  .datacache_priority = datacache_priority,
-                                                  .datacache_ttl_seconds = datacache_ttl_seconds};
+            _scanner_params.datacache_options = DataCacheOptions{.enable_datacache = true,
+                                                                 .enable_cache_select = true,
+                                                                 .enable_populate_datacache = true,
+                                                                 .enable_datacache_async_populate_mode = false,
+                                                                 .enable_datacache_io_adaptor = false,
+                                                                 .modification_time = _scan_range.modification_time,
+                                                                 .datacache_evict_probability = 100,
+                                                                 .datacache_priority = datacache_priority,
+                                                                 .datacache_ttl_seconds = datacache_ttl_seconds};
         } else if (state->query_options().__isset.enable_scan_datacache &&
                    state->query_options().enable_scan_datacache) {
             // set datacache options for normal query
@@ -180,7 +183,7 @@ Status HiveDataSource::open(RuntimeState* state) {
                 datacache_evict_probability = state->query_options().datacache_evict_probability;
             }
 
-            _datacache_options =
+            _scanner_params.datacache_options =
                     DataCacheOptions{.enable_datacache = true,
                                      .enable_cache_select = false,
                                      .enable_populate_datacache = enable_populate_datacache,
@@ -192,7 +195,7 @@ Status HiveDataSource::open(RuntimeState* state) {
                                      .datacache_ttl_seconds = datacache_ttl_seconds};
         }
     } else if (enable_cache_select) {
-        _no_data = true;
+        _no_more_chunks = true;
         return Status::OK();
     }
 
@@ -200,7 +203,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     // todo: should remove it later
     if (_scan_range.__isset.datacache_options && _scan_range.datacache_options.__isset.priority &&
         _scan_range.datacache_options.priority == -1) {
-        _datacache_options.enable_datacache = false;
+        _scanner_params.datacache_options.enable_datacache = false;
     }
 
     // Only support file metacache in starcache engine
@@ -217,10 +220,10 @@ Status HiveDataSource::open(RuntimeState* state) {
 #endif
 
     if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
-        _enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
+        _options.enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
     }
     if (state->query_options().__isset.enable_connector_split_io_tasks) {
-        _enable_split_tasks = state->query_options().enable_connector_split_io_tasks;
+        _options.enable_split_tasks = state->query_options().enable_connector_split_io_tasks;
     }
 
     RETURN_IF_ERROR(_init_conjunct_ctxs(state));
@@ -229,7 +232,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     RETURN_IF_ERROR(_init_partition_values());
     RETURN_IF_ERROR(_init_extended_values());
     if (_partition_filter.filter_by_eval) {
-        _no_data = true;
+        _no_more_chunks = true;
         return Status::OK();
     }
     _init_global_late_materialization_context(state);
@@ -251,7 +254,7 @@ void HiveDataSource::_init_global_late_materialization_context(RuntimeState* sta
                     ctx->hdfs_scan_node = hdfs_scan_node;
                     return ctx;
                 }));
-        _scan_range_id = glm_ctx->assign_scan_range_id(_scan_range);
+        _scanner_params.scan_range_id = glm_ctx->assign_scanner_params.scan_range_id(_scan_range);
     }
 }
 
@@ -301,7 +304,7 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
 }
 
 Status HiveDataSource::_init_partition_values() {
-    if (!(_hive_table != nullptr && _has_partition_columns)) return Status::OK();
+    if (!(_hive_table != nullptr && !_scanner_params.partition_slots.empty())) return Status::OK();
     auto* partition_desc = _hive_table->get_partition(_scan_range.partition_id);
     if (partition_desc == nullptr) {
         const auto& full_path = _scan_range.full_path;
@@ -326,16 +329,16 @@ Status HiveDataSource::_init_partition_values() {
 
     // init partition chunk
     auto partition_chunk = std::make_shared<Chunk>();
-    for (int i = 0; i < _partition_slots.size(); i++) {
-        SlotId slot_id = _partition_slots[i]->id();
-        int partition_col_idx = _partition_index_in_hdfs_partition_columns[i];
+    for (int i = 0; i < _scanner_params.partition_slots.size(); i++) {
+        SlotId slot_id = _scanner_params.partition_slots[i]->id();
+        int partition_col_idx = _scanner_params._partition_index_in_hdfs_partition_columns[i];
         ASSIGN_OR_RETURN(auto partition_value_col, _partition_filter.values[partition_col_idx]->evaluate(nullptr));
         DCHECK(partition_value_col->is_constant());
         partition_chunk->append_column(std::move(partition_value_col), slot_id);
     }
 
     // eval conjuncts and skip if no rows.
-    if (_has_scan_range_indicate_const_column) {
+    if (!_scan_range.identity_partition_slot_ids.empty()) {
         std::vector<ExprContext*> ctxs;
         for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
             if (_conjuncts.by_slot.find(slotId) != _conjuncts.by_slot.end()) {
@@ -353,7 +356,7 @@ Status HiveDataSource::_init_partition_values() {
         return Status::OK();
     }
 
-    if (_enable_dynamic_prune_scan_range && _runtime_filters) {
+    if (_options.enable_dynamic_prune_scan_range && _runtime_filters) {
         _init_runtime_filter_counters();
         _runtime_filters->evaluate_partial_chunk(partition_chunk.get(), runtime_membership_filter_eval_context);
         if (!partition_chunk->has_rows()) {
@@ -366,7 +369,7 @@ Status HiveDataSource::_init_partition_values() {
 }
 
 Status HiveDataSource::_init_extended_values() {
-    if (!(_hive_table != nullptr && _has_extended_columns)) return Status::OK();
+    if (!(_hive_table != nullptr && !_scanner_params.extended_col_slots.empty())) return Status::OK();
 
     DCHECK(_scan_range.__isset.extended_columns);
     auto& id_to_column = _scan_range.extended_columns;
@@ -377,10 +380,10 @@ Status HiveDataSource::_init_extended_values() {
         extended_column_values.emplace_back(id_to_column[id]);
     }
 
-    RETURN_IF_ERROR(
-            ExprFactory::create_expr_trees(&_pool, extended_column_values, &_extended_column_values, _runtime_state));
-    RETURN_IF_ERROR(ExprExecutor::prepare(_extended_column_values, _runtime_state));
-    RETURN_IF_ERROR(ExprExecutor::open(_extended_column_values, _runtime_state));
+    RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_pool, extended_column_values, &_scanner_params.extended_col_values,
+                                                   _runtime_state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_scanner_params.extended_col_values, _runtime_state));
+    RETURN_IF_ERROR(ExprExecutor::open(_scanner_params.extended_col_values, _runtime_state));
 
     return Status::OK();
 }
@@ -414,35 +417,35 @@ int32_t HiveDataSource::extended_column_index(SlotId id) const {
 void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     if (hdfs_scan_node.__isset.min_max_tuple_id) {
-        _min_max_tuple_id = hdfs_scan_node.min_max_tuple_id;
-        _min_max_tuple_desc = state->desc_tbl().get_tuple_descriptor(_min_max_tuple_id);
+        int min_max_tuple_id = hdfs_scan_node.min_max_tuple_id;
+        _min_max_tuple_desc = state->desc_tbl().get_tuple_descriptor(min_max_tuple_id);
     }
 
     const auto& slots = _tuple_desc->slots();
     for (int i = 0; i < slots.size(); i++) {
         if (_hive_table != nullptr && _hive_table->is_partition_col(slots[i])) {
-            _partition_slots.push_back(slots[i]);
-            _partition_index_in_chunk.push_back(i);
-            _partition_index_in_hdfs_partition_columns.push_back(_hive_table->get_partition_col_index(slots[i]));
-            _has_partition_columns = true;
+            _scanner_params.partition_slots.push_back(slots[i]);
+            _scanner_params.partition_index_in_chunk.push_back(i);
+            _scanner_params._partition_index_in_hdfs_partition_columns.push_back(
+                    _hive_table->get_partition_col_index(slots[i]));
+            _scanner_params._partition_index_in_hdfs_partition_columns.push_back(
+                    _hive_table->get_partition_col_index(slots[i]));
         } else if (int32_t index = scan_range_indicate_const_column_index(slots[i]->id()); index >= 0) {
-            _partition_slots.push_back(slots[i]);
-            _partition_index_in_chunk.push_back(i);
-            _partition_index_in_hdfs_partition_columns.push_back(index);
-            _has_partition_columns = true;
-            _has_scan_range_indicate_const_column = true;
+            _scanner_params.partition_slots.push_back(slots[i]);
+            _scanner_params.partition_index_in_chunk.push_back(i);
+            _scanner_params._partition_index_in_hdfs_partition_columns.push_back(index);
         } else if (int32_t extended_col_index = extended_column_index(slots[i]->id()); extended_col_index >= 0) {
-            _extended_slots.push_back(slots[i]);
-            _extended_index_in_chunk.push_back(i);
-            _index_in_extended_column.push_back(extended_col_index);
-            _has_extended_columns = true;
+            _scanner_params.extended_col_slots.push_back(slots[i]);
+            _scanner_params.extended_col_index_in_chunk.push_back(i);
+            _scanner_params.index_in_extended_columns.push_back(extended_col_index);
+            !_scanner_params.extended_col_slots.empty() = true;
         } else {
-            _materialize_slots.push_back(slots[i]);
-            _materialize_index_in_chunk.push_back(i);
+            _scanner_params.materialize_slots.push_back(slots[i]);
+            _scanner_params.materialize_index_in_chunk.push_back(i);
             if (_hive_table != nullptr) {
                 auto default_value = _hive_table->get_column_default_value(slots[i]);
                 if (default_value.has_value()) {
-                    _materialize_slot_default_values.emplace(slots[i]->id(), *default_value);
+                    _scanner_params.materialize_slot_default_values.emplace(slots[i]->id(), *default_value);
                 }
             }
         }
@@ -469,7 +472,7 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         _options.use_count_opt = hdfs_scan_node.can_use_count_opt;
     }
     if (hdfs_scan_node.__isset.use_partition_column_value_only) {
-        _use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;
+        _options.use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;
     }
 
     // The reason why we need double check here is for iceberg table.
@@ -480,10 +483,10 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     // 2. besides that, all slots are partition slots or extended slots, all of them are constant value.
     // 3. scan iceberg data file without delete files.
     auto check_partition_opt = [&]() {
-        if ((_partition_slots.size() + _extended_slots.size() + 1) != slots.size()) {
+        if ((_scanner_params.partition_slots.size() + _scanner_params.extended_col_slots.size() + 1) != slots.size()) {
             return false;
         }
-        if (_materialize_slots.size() != 1) {
+        if (_scanner_params.materialize_slots.size() != 1) {
             return false;
         }
         if (!_scan_range.delete_files.empty()) {
@@ -492,7 +495,7 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         return true;
     };
     if (!check_partition_opt()) {
-        _use_partition_column_value_only = false;
+        _options.use_partition_column_value_only = false;
         _options.use_count_opt = false;
     }
 
@@ -602,13 +605,13 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
         _profile.shared_buffered_direct_io_timer = ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
     }
 
-    if (_datacache_options.enable_datacache) {
+    if (_scanner_params.datacache_options.enable_datacache) {
         static const char* prefix = "DataCache";
         ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
         _profile.runtime_profile->add_info_string("DataCachePriority",
-                                                  std::to_string(_datacache_options.datacache_priority));
-        _profile.runtime_profile->add_info_string("DataCacheTTLSeconds",
-                                                  std::to_string(_datacache_options.datacache_ttl_seconds));
+                                                  std::to_string(_scanner_params.datacache_options.datacache_priority));
+        _profile.runtime_profile->add_info_string(
+                "DataCacheTTLSeconds", std::to_string(_scanner_params.datacache_options.datacache_ttl_seconds));
         _profile.datacache_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
         _profile.datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
@@ -756,7 +759,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
     HdfsScannerParams scanner_params;
-    if (hdfs_scan_node.__isset.column_access_paths && !_disable_column_access_path_hints &&
+    if (hdfs_scan_node.__isset.column_access_paths && !disable_column_access_path_hints &&
         _column_access_paths.empty()) {
         bool failed = false;
         auto path_resolver = make_column_access_path_resolver(state, state->obj_pool());
@@ -772,32 +775,32 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         }
         if (failed) {
             _column_access_paths.clear();
-            _disable_column_access_path_hints = true;
         }
     }
     RETURN_IF_ERROR(_init_global_dicts(&scanner_params));
     scanner_params.runtime_filter_collector = _runtime_filters;
     scanner_params.scan_range = &scan_range;
-    scanner_params.scan_range_id = _scan_range_id;
+    scanner_params.scan_range_id = _scanner_params.scan_range_id;
     scanner_params.fs = _pool.add(fs.release());
     scanner_params.path = native_file_path;
     scanner_params.file_size = _scan_range.file_length;
     scanner_params.table_location = _hive_table->get_base_path();
     scanner_params.tuple_desc = _tuple_desc;
-    scanner_params.materialize_slots = _materialize_slots;
-    scanner_params.materialize_index_in_chunk = _materialize_index_in_chunk;
-    scanner_params.materialize_slot_default_values = _materialize_slot_default_values;
-    scanner_params.partition_slots = _partition_slots;
-    scanner_params.partition_index_in_chunk = _partition_index_in_chunk;
-    scanner_params._partition_index_in_hdfs_partition_columns = _partition_index_in_hdfs_partition_columns;
+    scanner_params.materialize_slots = _scanner_params.materialize_slots;
+    scanner_params.materialize_index_in_chunk = _scanner_params.materialize_index_in_chunk;
+    scanner_params.materialize_slot_default_values = _scanner_params.materialize_slot_default_values;
+    scanner_params.partition_slots = _scanner_params.partition_slots;
+    scanner_params.partition_index_in_chunk = _scanner_params.partition_index_in_chunk;
+    scanner_params._partition_index_in_hdfs_partition_columns =
+            _scanner_params._partition_index_in_hdfs_partition_columns;
     scanner_params.partition_values = _partition_filter.values;
     // Pass a non-owning pointer; _conjuncts is owned by this HiveDataSource.
     scanner_params.conjuncts = &_conjuncts;
 
-    scanner_params.extended_col_slots = _extended_slots;
-    scanner_params.extended_col_index_in_chunk = _extended_index_in_chunk;
-    scanner_params.index_in_extended_columns = _index_in_extended_column;
-    scanner_params.extended_col_values = _extended_column_values;
+    scanner_params.extended_col_slots = _scanner_params.extended_col_slots;
+    scanner_params.extended_col_index_in_chunk = _scanner_params.extended_col_index_in_chunk;
+    scanner_params.index_in_extended_columns = _scanner_params.index_in_extended_columns;
+    scanner_params.extended_col_values = _scanner_params.extended_col_values;
 
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;
@@ -809,39 +812,39 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     // inside the format branch below before the scanner is initialised.
     scanner_params.options = &_options;
     scanner_params.profile = &_profile;
-    scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
+    scanner_params.lazy_column_coalesce_counter = &_provider->_lazy_column_coalesce_counter;
     scanner_params.split_context = down_cast<HdfsSplitContext*>(_split_context);
-    scanner_params.enable_split_tasks = _enable_split_tasks;
     if (state->query_options().__isset.connector_max_split_size) {
-        scanner_params.connector_max_split_size = state->query_options().connector_max_split_size;
+        scanner_params.options->connector_max_split_size = state->query_options().connector_max_split_size;
     }
 
     for (const auto& delete_file : scan_range.delete_files) {
-        scanner_params.deletes.emplace_back(&delete_file);
+        scanner_params.table_specific.iceberg_delete_files.emplace_back(&delete_file);
     }
 
     if (scan_range.__isset.deletion_vector_descriptor) {
-        scanner_params.deletion_vector_descriptor =
+        scanner_params.table_specific.deletion_vector_descriptor =
                 std::make_shared<TDeletionVectorDescriptor>(scan_range.deletion_vector_descriptor);
     }
 
     if (dynamic_cast<const IcebergTableDescriptor*>(_hive_table)) {
         auto tbl = dynamic_cast<const IcebergTableDescriptor*>(_hive_table);
-        scanner_params.lake_schema = tbl->get_iceberg_schema();
+        scanner_params.table_specific.iceberg_schema = tbl->get_iceberg_schema();
     }
 
     if (dynamic_cast<const PaimonTableDescriptor*>(_hive_table)) {
         auto tbl = dynamic_cast<const PaimonTableDescriptor*>(_hive_table);
-        scanner_params.lake_schema = tbl->get_paimon_schema();
+        scanner_params.table_specific.iceberg_schema = tbl->get_paimon_schema();
     }
 
     if (scan_range.__isset.paimon_deletion_file && !scan_range.paimon_deletion_file.path.empty()) {
-        scanner_params.paimon_deletion_file = std::make_shared<TPaimonDeletionFile>(scan_range.paimon_deletion_file);
+        scanner_params.table_specific.paimon_deletion_file =
+                std::make_shared<TPaimonDeletionFile>(scan_range.paimon_deletion_file);
     }
 
     // setup options for datacache
-    scanner_params.datacache_options = _datacache_options;
-    if (!_disable_column_access_path_hints && !_column_access_paths.empty()) {
+    scanner_params.datacache_options = _scanner_params.datacache_options;
+    if (!disable_column_access_path_hints && !_column_access_paths.empty()) {
         scanner_params.column_access_paths = &_column_access_paths;
     }
 
@@ -880,9 +883,9 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                                                             .hive_table = _hive_table,
                                                             .scan_range = &scan_range,
                                                             .scan_node = &hdfs_scan_node};
-    if (_datacache_options.enable_cache_select) {
+    if (_scanner_params.datacache_options.enable_cache_select) {
         scanner = new CacheSelectScanner();
-    } else if (_use_partition_column_value_only) {
+    } else if (_options.use_partition_column_value_only) {
         scanner = new HdfsPartitionScanner();
     } else if (use_paimon_jni_reader) {
         scanner = create_paimon_jni_scanner(jni_scanner_create_options).release();
@@ -979,7 +982,7 @@ void HiveDataSource::close(RuntimeState* state) {
 }
 
 Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
-    if (_no_data) {
+    if (_no_more_chunks) {
         return Status::EndOfFile("no data");
     }
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -338,15 +338,18 @@ Status HiveDataSource::_init_partition_values() {
         partition_chunk->append_column(std::move(partition_value_col), slot_id);
     }
 
-    // eval conjuncts and skip if no rows.
-    if (!_scan_range.identity_partition_slot_ids.empty()) {
-        std::vector<ExprContext*> ctxs;
-        for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
-            if (_scanner_params.conjuncts.by_slot.find(slotId) != _scanner_params.conjuncts.by_slot.end()) {
-                ctxs.insert(ctxs.end(), _scanner_params.conjuncts.by_slot.at(slotId).begin(),
-                            _scanner_params.conjuncts.by_slot.at(slotId).end());
-            }
+    // Prefer per-slot conjuncts for identity partition slots materialised in this tuple
+    // (equivalent to the old _has_scan_range_indicate_const_column flag).
+    // If none of the identity slots appear in our tuple, ctxs stays empty and we fall
+    // back to the ordinary partition conjuncts — same behaviour as the old code.
+    std::vector<ExprContext*> ctxs;
+    for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
+        auto it = _scanner_params.conjuncts.by_slot.find(slotId);
+        if (it != _scanner_params.conjuncts.by_slot.end()) {
+            ctxs.insert(ctxs.end(), it->second.begin(), it->second.end());
         }
+    }
+    if (!ctxs.empty()) {
         RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(ctxs, partition_chunk.get()));
     } else if (_partition_filter.has_conjuncts) {
         RETURN_IF_ERROR(
@@ -815,7 +818,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.lazy_column_coalesce_counter = &_provider->_lazy_column_coalesce_counter;
     scanner_params.split_context = down_cast<HdfsSplitContext*>(_split_context);
     if (state->query_options().__isset.connector_max_split_size) {
-        _scanner_params.options.connector_max_split_size = state->query_options().connector_max_split_size;
+        scanner_params.options.connector_max_split_size = state->query_options().connector_max_split_size;
     }
 
     for (const auto& delete_file : scan_range.delete_files) {
@@ -898,12 +901,12 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (use_kudu_jni_reader) {
         scanner = create_kudu_jni_scanner(jni_scanner_create_options).release();
     } else if (format == THdfsFileFormat::PARQUET) {
-        _scanner_params.options.parquet_page_index_enable =
+        scanner_params.options.parquet_page_index_enable =
                 config::parquet_page_index_enable ? state->query_options().__isset.enable_parquet_reader_page_index
                                                             ? state->query_options().enable_parquet_reader_page_index
                                                             : true
                                                   : false;
-        _scanner_params.options.parquet_bloom_filter_enable =
+        scanner_params.options.parquet_bloom_filter_enable =
                 config::parquet_reader_bloom_filter_enable
                         ? state->query_options().__isset.enable_parquet_reader_bloom_filter
                                   ? state->query_options().enable_parquet_reader_bloom_filter
@@ -911,7 +914,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                         : false;
         scanner = new HdfsParquetScanner();
     } else if (format == THdfsFileFormat::ORC) {
-        _scanner_params.options.orc_use_column_names = state->query_options().orc_use_column_names;
+        scanner_params.options.orc_use_column_names = state->query_options().orc_use_column_names;
         scanner = new HdfsOrcScanner();
     } else if (format == THdfsFileFormat::TEXT) {
         const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_hive_table);

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -319,8 +319,8 @@ Status HiveDataSource::_init_partition_values() {
     // must live and close within the fragment scope — they cannot be shared from the
     // (query-scoped) HdfsPartitionDescriptor.
     const auto& thrift_partition_key_exprs = partition_desc->thrift_partition_key_exprs();
-    RETURN_IF_ERROR(
-            ExprFactory::create_expr_trees(&_pool, thrift_partition_key_exprs, &_partition_filter.values, _runtime_state));
+    RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_pool, thrift_partition_key_exprs, &_partition_filter.values,
+                                                   _runtime_state));
     RETURN_IF_ERROR(ExprExecutor::prepare(_partition_filter.values, _runtime_state));
     RETURN_IF_ERROR(ExprExecutor::open(_partition_filter.values, _runtime_state));
 
@@ -339,13 +339,13 @@ Status HiveDataSource::_init_partition_values() {
         std::vector<ExprContext*> ctxs;
         for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
             if (_conjuncts.by_slot.find(slotId) != _conjuncts.by_slot.end()) {
-                ctxs.insert(ctxs.end(), _conjuncts.by_slot.at(slotId).begin(),
-                            _conjuncts.by_slot.at(slotId).end());
+                ctxs.insert(ctxs.end(), _conjuncts.by_slot.at(slotId).begin(), _conjuncts.by_slot.at(slotId).end());
             }
         }
         RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(ctxs, partition_chunk.get()));
     } else if (_partition_filter.has_conjuncts) {
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_partition_filter.conjunct_ctxs, partition_chunk.get()));
+        RETURN_IF_ERROR(
+                ChunkPredicateEvaluator::eval_conjuncts(_partition_filter.conjunct_ctxs, partition_chunk.get()));
     }
 
     if (!partition_chunk->has_rows()) {
@@ -895,11 +895,11 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (use_kudu_jni_reader) {
         scanner = create_kudu_jni_scanner(jni_scanner_create_options).release();
     } else if (format == THdfsFileFormat::PARQUET) {
-        _options.parquet_page_index_enable =
-                config::parquet_page_index_enable ? state->query_options().__isset.enable_parquet_reader_page_index
-                                                            ? state->query_options().enable_parquet_reader_page_index
-                                                            : true
-                                                  : false;
+        _options.parquet_page_index_enable = config::parquet_page_index_enable
+                                                     ? state->query_options().__isset.enable_parquet_reader_page_index
+                                                               ? state->query_options().enable_parquet_reader_page_index
+                                                               : true
+                                                     : false;
         _options.parquet_bloom_filter_enable =
                 config::parquet_reader_bloom_filter_enable
                         ? state->query_options().__isset.enable_parquet_reader_bloom_filter

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -209,21 +209,22 @@ Status HiveDataSource::open(RuntimeState* state) {
     // Only support file metacache in starcache engine
 #ifdef WITH_STARCACHE
     if (state->query_options().__isset.enable_file_metacache) {
-        _options.use_file_metacache = state->query_options().enable_file_metacache;
+        _scanner_params.options.use_file_metacache = state->query_options().enable_file_metacache;
     }
-    _options.use_file_metacache &= DataCache::GetInstance()->page_cache_available();
+    _scanner_params.options.use_file_metacache &= DataCache::GetInstance()->page_cache_available();
 
     if (state->query_options().__isset.enable_file_pagecache) {
-        _options.use_file_pagecache = state->query_options().enable_file_pagecache;
+        _scanner_params.options.use_file_pagecache = state->query_options().enable_file_pagecache;
     }
-    _options.use_file_pagecache &= DataCache::GetInstance()->page_cache_available();
+    _scanner_params.options.use_file_pagecache &= DataCache::GetInstance()->page_cache_available();
 #endif
 
     if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
-        _options.enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
+        _scanner_params.options.enable_dynamic_prune_scan_range =
+                state->query_options().enable_dynamic_prune_scan_range;
     }
     if (state->query_options().__isset.enable_connector_split_io_tasks) {
-        _options.enable_split_tasks = state->query_options().enable_connector_split_io_tasks;
+        _scanner_params.options.enable_split_tasks = state->query_options().enable_connector_split_io_tasks;
     }
 
     RETURN_IF_ERROR(_init_conjunct_ctxs(state));
@@ -270,7 +271,7 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     if (hdfs_scan_node.__isset.min_max_conjuncts) {
         RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_pool, hdfs_scan_node.min_max_conjuncts,
-                                                       &_conjuncts.min_max_ctxs, state));
+                                                       &_scanner_params.conjuncts.min_max_ctxs, state));
     }
 
     if (hdfs_scan_node.__isset.partition_conjuncts) {
@@ -280,12 +281,12 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     }
 
     if (hdfs_scan_node.__isset.case_sensitive) {
-        _options.case_sensitive = hdfs_scan_node.case_sensitive;
+        _scanner_params.options.case_sensitive = hdfs_scan_node.case_sensitive;
     }
 
-    RETURN_IF_ERROR(ExprExecutor::prepare(_conjuncts.min_max_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_scanner_params.conjuncts.min_max_ctxs, state));
     RETURN_IF_ERROR(ExprExecutor::prepare(_partition_filter.conjunct_ctxs, state));
-    RETURN_IF_ERROR(ExprExecutor::open(_conjuncts.min_max_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::open(_scanner_params.conjuncts.min_max_ctxs, state));
     RETURN_IF_ERROR(ExprExecutor::open(_partition_filter.conjunct_ctxs, state));
     _update_has_any_predicate();
 
@@ -294,11 +295,11 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     // Build all_ctxs: clone of (min_max_ctxs ∪ scan conjuncts), used to build
     // ScanConjunctsManager / PredicateTree inside each scanner's context.
     std::vector<ExprContext*> cloned;
-    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _conjuncts.min_max_ctxs, &cloned));
-    for (auto* ctx : cloned) _conjuncts.all_ctxs.emplace_back(ctx);
+    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _scanner_params.conjuncts.min_max_ctxs, &cloned));
+    for (auto* ctx : cloned) _scanner_params.conjuncts.all_ctxs.emplace_back(ctx);
     cloned.clear();
     RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _conjunct_ctxs, &cloned));
-    for (auto* ctx : cloned) _conjuncts.all_ctxs.emplace_back(ctx);
+    for (auto* ctx : cloned) _scanner_params.conjuncts.all_ctxs.emplace_back(ctx);
 
     return Status::OK();
 }
@@ -341,8 +342,9 @@ Status HiveDataSource::_init_partition_values() {
     if (!_scan_range.identity_partition_slot_ids.empty()) {
         std::vector<ExprContext*> ctxs;
         for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
-            if (_conjuncts.by_slot.find(slotId) != _conjuncts.by_slot.end()) {
-                ctxs.insert(ctxs.end(), _conjuncts.by_slot.at(slotId).begin(), _conjuncts.by_slot.at(slotId).end());
+            if (_scanner_params.conjuncts.by_slot.find(slotId) != _scanner_params.conjuncts.by_slot.end()) {
+                ctxs.insert(ctxs.end(), _scanner_params.conjuncts.by_slot.at(slotId).begin(),
+                            _scanner_params.conjuncts.by_slot.at(slotId).end());
             }
         }
         RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(ctxs, partition_chunk.get()));
@@ -356,7 +358,7 @@ Status HiveDataSource::_init_partition_values() {
         return Status::OK();
     }
 
-    if (_options.enable_dynamic_prune_scan_range && _runtime_filters) {
+    if (_scanner_params.options.enable_dynamic_prune_scan_range && _runtime_filters) {
         _init_runtime_filter_counters();
         _runtime_filters->evaluate_partial_chunk(partition_chunk.get(), runtime_membership_filter_eval_context);
         if (!partition_chunk->has_rows()) {
@@ -453,10 +455,10 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         _hive_column_names = hdfs_scan_node.hive_column_names;
     }
     if (hdfs_scan_node.__isset.case_sensitive) {
-        _options.case_sensitive = hdfs_scan_node.case_sensitive;
+        _scanner_params.options.case_sensitive = hdfs_scan_node.case_sensitive;
     }
     if (hdfs_scan_node.__isset.can_use_min_max_opt) {
-        _options.use_min_max_opt = hdfs_scan_node.can_use_min_max_opt;
+        _scanner_params.options.use_min_max_opt = hdfs_scan_node.can_use_min_max_opt;
     }
     // can_use_any_column is set by PruneHDFSScanColumnRule when every queried column is
     // a partition column and a placeholder materialized column was injected to satisfy
@@ -464,13 +466,13 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     // the scanner can avoid reading that placeholder column from the data file when
     // min/max optimization is active.
     if (hdfs_scan_node.__isset.can_use_any_column) {
-        _options.can_use_any_column = hdfs_scan_node.can_use_any_column;
+        _scanner_params.options.can_use_any_column = hdfs_scan_node.can_use_any_column;
     }
     if (hdfs_scan_node.__isset.can_use_count_opt) {
-        _options.use_count_opt = hdfs_scan_node.can_use_count_opt;
+        _scanner_params.options.use_count_opt = hdfs_scan_node.can_use_count_opt;
     }
     if (hdfs_scan_node.__isset.use_partition_column_value_only) {
-        _options.use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;
+        _scanner_params.options.use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;
     }
 
     // The reason why we need double check here is for iceberg table.
@@ -493,15 +495,15 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         return true;
     };
     if (!check_partition_opt()) {
-        _options.use_partition_column_value_only = false;
-        _options.use_count_opt = false;
+        _scanner_params.options.use_partition_column_value_only = false;
+        _scanner_params.options.use_count_opt = false;
     }
 
     // for min/max optimization, we already check that on FE side this iceberg table
     // is unpartitioned, or all partition columns are constant value.
     // so we just need to make sure there is no delete file.
     if (!_scan_range.delete_files.empty()) {
-        _options.use_min_max_opt = false;
+        _scanner_params.options.use_min_max_opt = false;
     }
 }
 
@@ -523,7 +525,7 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
         std::vector<SlotId> slot_ids;
         root_expr->get_slot_ids(&slot_ids);
         for (SlotId slot_id : slot_ids) {
-            _conjuncts.slots_in_conjunct.insert(slot_id);
+            _scanner_params.conjuncts.slots_in_conjunct.insert(slot_id);
         }
 
         // For some conjunct like (a < 1) or (a > 7)
@@ -549,117 +551,125 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
             }
         }
         if (!single_slot || slot_ids.empty() || !single_field) {
-            _conjuncts.scanner_ctxs.emplace_back(ctx);
+            _scanner_params.conjuncts.scanner_ctxs.emplace_back(ctx);
             for (SlotId slot_id : slot_ids) {
-                _conjuncts.slots_of_multi_field.insert(slot_id);
+                _scanner_params.conjuncts.slots_of_multi_field.insert(slot_id);
             }
             continue;
         }
 
         SlotId slot_id = slot_ids[0];
         if (slot_by_id.find(slot_id) != slot_by_id.end()) {
-            _conjuncts.by_slot[slot_id].emplace_back(ctx);
+            _scanner_params.conjuncts.by_slot[slot_id].emplace_back(ctx);
         }
     }
     // rewrite dict
     auto* fragment_dict_state = state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    RETURN_IF_ERROR(
-            fragment_dict_state->mutable_dict_optimize_parser()->rewrite_conjuncts(state, &_conjuncts.scanner_ctxs));
+    RETURN_IF_ERROR(fragment_dict_state->mutable_dict_optimize_parser()->rewrite_conjuncts(
+            state, &_scanner_params.conjuncts.scanner_ctxs));
     return Status::OK();
 }
 
 void HiveDataSource::_init_counter(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
 
-    _profile.runtime_profile = _runtime_profile;
-    _profile.raw_rows_read_counter = ADD_COUNTER(_runtime_profile, "RawRowsRead", TUnit::UNIT);
-    _profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
-    _profile.late_materialize_skip_rows_counter = ADD_COUNTER(_runtime_profile, "LateMaterializeSkipRows", TUnit::UNIT);
-    _profile.scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
-    _profile.scan_ranges_size = ADD_COUNTER(_runtime_profile, "ScanRangesSize", TUnit::BYTES);
+    _scanner_params.profile.runtime_profile = _runtime_profile;
+    _scanner_params.profile.raw_rows_read_counter = ADD_COUNTER(_runtime_profile, "RawRowsRead", TUnit::UNIT);
+    _scanner_params.profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
+    _scanner_params.profile.late_materialize_skip_rows_counter =
+            ADD_COUNTER(_runtime_profile, "LateMaterializeSkipRows", TUnit::UNIT);
+    _scanner_params.profile.scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
+    _scanner_params.profile.scan_ranges_size = ADD_COUNTER(_runtime_profile, "ScanRangesSize", TUnit::BYTES);
 
-    _profile.reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
-    _profile.open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
-    _profile.expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
+    _scanner_params.profile.reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
+    _scanner_params.profile.open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
+    _scanner_params.profile.expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
 
-    _profile.column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
-    _profile.column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
+    _scanner_params.profile.column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
+    _scanner_params.profile.column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
 
     {
         static const char* prefix = "SharedBuffered";
         ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        _profile.shared_buffered_shared_io_bytes =
+        _scanner_params.profile.shared_buffered_shared_io_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "SharedIOBytes", TUnit::BYTES, prefix);
-        _profile.shared_buffered_shared_align_io_bytes =
+        _scanner_params.profile.shared_buffered_shared_align_io_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "SharedAlignIOBytes", TUnit::BYTES, prefix);
-        _profile.shared_buffered_shared_io_count =
+        _scanner_params.profile.shared_buffered_shared_io_count =
                 ADD_CHILD_COUNTER(_runtime_profile, "SharedIOCount", TUnit::UNIT, prefix);
-        _profile.shared_buffered_shared_io_timer = ADD_CHILD_TIMER(_runtime_profile, "SharedIOTime", prefix);
-        _profile.shared_buffered_direct_io_bytes =
+        _scanner_params.profile.shared_buffered_shared_io_timer =
+                ADD_CHILD_TIMER(_runtime_profile, "SharedIOTime", prefix);
+        _scanner_params.profile.shared_buffered_direct_io_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DirectIOBytes", TUnit::BYTES, prefix);
-        _profile.shared_buffered_direct_io_count =
+        _scanner_params.profile.shared_buffered_direct_io_count =
                 ADD_CHILD_COUNTER(_runtime_profile, "DirectIOCount", TUnit::UNIT, prefix);
-        _profile.shared_buffered_direct_io_timer = ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
+        _scanner_params.profile.shared_buffered_direct_io_timer =
+                ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
     }
 
     if (_scanner_params.datacache_options.enable_datacache) {
         static const char* prefix = "DataCache";
         ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        _profile.runtime_profile->add_info_string("DataCachePriority",
-                                                  std::to_string(_scanner_params.datacache_options.datacache_priority));
-        _profile.runtime_profile->add_info_string(
+        _scanner_params.profile.runtime_profile->add_info_string(
+                "DataCachePriority", std::to_string(_scanner_params.datacache_options.datacache_priority));
+        _scanner_params.profile.runtime_profile->add_info_string(
                 "DataCacheTTLSeconds", std::to_string(_scanner_params.datacache_options.datacache_ttl_seconds));
-        _profile.datacache_read_counter =
+        _scanner_params.profile.datacache_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
-        _profile.datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
-        _profile.datacache_read_mem_bytes =
+        _scanner_params.profile.datacache_read_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
+        _scanner_params.profile.datacache_read_mem_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadMemBytes", TUnit::BYTES, "DataCacheReadBytes");
-        _profile.datacache_read_disk_bytes =
+        _scanner_params.profile.datacache_read_disk_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadDiskBytes", TUnit::BYTES, "DataCacheReadBytes");
-        _profile.datacache_skip_read_counter =
+        _scanner_params.profile.datacache_skip_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipReadCounter", TUnit::UNIT, prefix);
-        _profile.datacache_skip_read_bytes =
+        _scanner_params.profile.datacache_skip_read_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipReadBytes", TUnit::BYTES, prefix);
-        _profile.datacache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadTimer", prefix);
-        _profile.datacache_read_peer_counter =
+        _scanner_params.profile.datacache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadTimer", prefix);
+        _scanner_params.profile.datacache_read_peer_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadPeerCounter", TUnit::UNIT, prefix);
-        _profile.datacache_read_peer_bytes =
+        _scanner_params.profile.datacache_read_peer_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadPeerBytes", TUnit::BYTES, prefix);
-        _profile.datacache_read_peer_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadPeerTimer", prefix);
-        _profile.datacache_skip_read_peer_counter =
+        _scanner_params.profile.datacache_read_peer_timer =
+                ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadPeerTimer", prefix);
+        _scanner_params.profile.datacache_skip_read_peer_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipReadPeerCounter", TUnit::UNIT, prefix);
-        _profile.datacache_skip_read_peer_bytes =
+        _scanner_params.profile.datacache_skip_read_peer_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipReadPeerBytes", TUnit::BYTES, prefix);
-        _profile.datacache_write_counter =
+        _scanner_params.profile.datacache_write_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteCounter", TUnit::UNIT, prefix);
-        _profile.datacache_write_bytes =
+        _scanner_params.profile.datacache_write_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteBytes", TUnit::BYTES, prefix);
-        _profile.datacache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheWriteTimer", prefix);
-        _profile.datacache_write_fail_counter =
+        _scanner_params.profile.datacache_write_timer =
+                ADD_CHILD_TIMER(_runtime_profile, "DataCacheWriteTimer", prefix);
+        _scanner_params.profile.datacache_write_fail_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailCounter", TUnit::UNIT, prefix);
-        _profile.datacache_write_fail_bytes =
+        _scanner_params.profile.datacache_write_fail_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailBytes", TUnit::BYTES, prefix);
-        _profile.datacache_skip_write_counter =
+        _scanner_params.profile.datacache_skip_write_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipWriteCounter", TUnit::UNIT, prefix);
-        _profile.datacache_skip_write_bytes =
+        _scanner_params.profile.datacache_skip_write_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipWriteBytes", TUnit::BYTES, prefix);
-        _profile.datacache_read_block_buffer_counter =
+        _scanner_params.profile.datacache_read_block_buffer_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferCounter", TUnit::UNIT, prefix);
-        _profile.datacache_read_block_buffer_bytes =
+        _scanner_params.profile.datacache_read_block_buffer_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferBytes", TUnit::BYTES, prefix);
     }
 
     {
         static const char* prefix = "InputStream";
         ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        _profile.app_io_bytes_read_counter =
+        _scanner_params.profile.app_io_bytes_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "AppIOBytesRead", TUnit::BYTES, prefix);
-        _profile.app_io_timer = ADD_CHILD_TIMER(_runtime_profile, "AppIOTime", prefix);
-        _profile.app_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "AppIOCounter", TUnit::UNIT, prefix);
-        _profile.fs_bytes_read_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOBytesRead", TUnit::BYTES, prefix);
-        _profile.fs_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOCounter", TUnit::UNIT, prefix);
-        _profile.fs_io_timer = ADD_CHILD_TIMER(_runtime_profile, "FSIOTime", prefix);
+        _scanner_params.profile.app_io_timer = ADD_CHILD_TIMER(_runtime_profile, "AppIOTime", prefix);
+        _scanner_params.profile.app_io_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "AppIOCounter", TUnit::UNIT, prefix);
+        _scanner_params.profile.fs_bytes_read_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "FSIOBytesRead", TUnit::BYTES, prefix);
+        _scanner_params.profile.fs_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOCounter", TUnit::UNIT, prefix);
+        _scanner_params.profile.fs_io_timer = ADD_CHILD_TIMER(_runtime_profile, "FSIOTime", prefix);
     }
 
     if (hdfs_scan_node.__isset.table_name) {
@@ -730,7 +740,7 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerParams* params) {
 }
 
 Status HiveDataSource::_init_scanner(RuntimeState* state) {
-    SCOPED_TIMER(_profile.open_file_timer);
+    SCOPED_TIMER(_scanner_params.profile.open_file_timer);
 
     const auto& scan_range = _scan_range;
     std::string native_file_path = scan_range.full_path;
@@ -757,7 +767,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
     bool disable_column_access_path_hints = false;
-    HdfsScannerParams scanner_params;
+    HdfsScannerParams scanner_params = _scanner_params;
     if (hdfs_scan_node.__isset.column_access_paths && !disable_column_access_path_hints &&
         _column_access_paths.empty()) {
         bool failed = false;
@@ -793,9 +803,6 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params._partition_index_in_hdfs_partition_columns =
             _scanner_params._partition_index_in_hdfs_partition_columns;
     scanner_params.partition_values = _partition_filter.values;
-    // Pass a non-owning pointer; _conjuncts is owned by this HiveDataSource.
-    scanner_params.conjuncts = &_conjuncts;
-
     scanner_params.extended_col_slots = _scanner_params.extended_col_slots;
     scanner_params.extended_col_index_in_chunk = _scanner_params.extended_col_index_in_chunk;
     scanner_params.index_in_extended_columns = _scanner_params.index_in_extended_columns;
@@ -806,15 +813,10 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     if (const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_hive_table)) {
         scanner_params.avro_schema_json = hdfs_desc->get_avro_schema_json();
     }
-    // Pass a non-owning pointer; _options is owned by this HiveDataSource.
-    // Format-specific options (parquet_*, orc_*) are written into _options
-    // inside the format branch below before the scanner is initialised.
-    scanner_params.options = &_options;
-    scanner_params.profile = &_profile;
     scanner_params.lazy_column_coalesce_counter = &_provider->_lazy_column_coalesce_counter;
     scanner_params.split_context = down_cast<HdfsSplitContext*>(_split_context);
     if (state->query_options().__isset.connector_max_split_size) {
-        _options.connector_max_split_size = state->query_options().connector_max_split_size;
+        _scanner_params.options.connector_max_split_size = state->query_options().connector_max_split_size;
     }
 
     for (const auto& delete_file : scan_range.delete_files) {
@@ -884,7 +886,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                                                             .scan_node = &hdfs_scan_node};
     if (_scanner_params.datacache_options.enable_cache_select) {
         scanner = new CacheSelectScanner();
-    } else if (_options.use_partition_column_value_only) {
+    } else if (_scanner_params.options.use_partition_column_value_only) {
         scanner = new HdfsPartitionScanner();
     } else if (use_paimon_jni_reader) {
         scanner = create_paimon_jni_scanner(jni_scanner_create_options).release();
@@ -897,12 +899,12 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (use_kudu_jni_reader) {
         scanner = create_kudu_jni_scanner(jni_scanner_create_options).release();
     } else if (format == THdfsFileFormat::PARQUET) {
-        _options.parquet_page_index_enable = config::parquet_page_index_enable
-                                                     ? state->query_options().__isset.enable_parquet_reader_page_index
-                                                               ? state->query_options().enable_parquet_reader_page_index
-                                                               : true
-                                                     : false;
-        _options.parquet_bloom_filter_enable =
+        _scanner_params.options.parquet_page_index_enable =
+                config::parquet_page_index_enable ? state->query_options().__isset.enable_parquet_reader_page_index
+                                                            ? state->query_options().enable_parquet_reader_page_index
+                                                            : true
+                                                  : false;
+        _scanner_params.options.parquet_bloom_filter_enable =
                 config::parquet_reader_bloom_filter_enable
                         ? state->query_options().__isset.enable_parquet_reader_bloom_filter
                                   ? state->query_options().enable_parquet_reader_bloom_filter
@@ -910,7 +912,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                         : false;
         scanner = new HdfsParquetScanner();
     } else if (format == THdfsFileFormat::ORC) {
-        _options.orc_use_column_names = state->query_options().orc_use_column_names;
+        _scanner_params.options.orc_use_column_names = state->query_options().orc_use_column_names;
         scanner = new HdfsOrcScanner();
     } else if (format == THdfsFileFormat::TEXT) {
         const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_hive_table);
@@ -966,16 +968,16 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 void HiveDataSource::close(RuntimeState* state) {
     if (_scanner != nullptr) {
         if (!_scanner->has_split_tasks()) {
-            COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
-            COUNTER_UPDATE(_profile.scan_ranges_size, _scan_range.length);
+            COUNTER_UPDATE(_scanner_params.profile.scan_ranges_counter, 1);
+            COUNTER_UPDATE(_scanner_params.profile.scan_ranges_size, _scan_range.length);
         }
         _scanner->close();
     }
-    ExprExecutor::close(_conjuncts.min_max_ctxs, state);
+    ExprExecutor::close(_scanner_params.conjuncts.min_max_ctxs, state);
     ExprExecutor::close(_partition_filter.conjunct_ctxs, state);
     ExprExecutor::close(_partition_filter.values, state);
-    ExprExecutor::close(_conjuncts.scanner_ctxs, state);
-    for (auto& it : _conjuncts.by_slot) {
+    ExprExecutor::close(_scanner_params.conjuncts.scanner_ctxs, state);
+    for (auto& it : _scanner_params.conjuncts.by_slot) {
         ExprExecutor::close(it.second, state);
     }
 }

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -206,14 +206,14 @@ Status HiveDataSource::open(RuntimeState* state) {
     // Only support file metacache in starcache engine
 #ifdef WITH_STARCACHE
     if (state->query_options().__isset.enable_file_metacache) {
-        _use_file_metacache = state->query_options().enable_file_metacache;
+        _options.use_file_metacache = state->query_options().enable_file_metacache;
     }
-    _use_file_metacache &= DataCache::GetInstance()->page_cache_available();
+    _options.use_file_metacache &= DataCache::GetInstance()->page_cache_available();
 
     if (state->query_options().__isset.enable_file_pagecache) {
-        _use_file_pagecache = state->query_options().enable_file_pagecache;
+        _options.use_file_pagecache = state->query_options().enable_file_pagecache;
     }
-    _use_file_pagecache &= DataCache::GetInstance()->page_cache_available();
+    _options.use_file_pagecache &= DataCache::GetInstance()->page_cache_available();
 #endif
 
     if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
@@ -228,7 +228,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     _init_counter(state);
     RETURN_IF_ERROR(_init_partition_values());
     RETURN_IF_ERROR(_init_extended_values());
-    if (_filter_by_eval_partition_conjuncts) {
+    if (_partition_filter.filter_by_eval) {
         _no_data = true;
         return Status::OK();
     }
@@ -267,27 +267,36 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     if (hdfs_scan_node.__isset.min_max_conjuncts) {
         RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_pool, hdfs_scan_node.min_max_conjuncts,
-                                                       &_min_max_conjunct_ctxs, state));
+                                                       &_conjuncts.min_max_ctxs, state));
     }
 
     if (hdfs_scan_node.__isset.partition_conjuncts) {
         RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_pool, hdfs_scan_node.partition_conjuncts,
-                                                       &_partition_conjunct_ctxs, state));
-        _has_partition_conjuncts = true;
+                                                       &_partition_filter.conjunct_ctxs, state));
+        _partition_filter.has_conjuncts = true;
     }
 
     if (hdfs_scan_node.__isset.case_sensitive) {
-        _case_sensitive = hdfs_scan_node.case_sensitive;
+        _options.case_sensitive = hdfs_scan_node.case_sensitive;
     }
 
-    RETURN_IF_ERROR(ExprExecutor::prepare(_min_max_conjunct_ctxs, state));
-    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_conjunct_ctxs, state));
-    RETURN_IF_ERROR(ExprExecutor::open(_min_max_conjunct_ctxs, state));
-    RETURN_IF_ERROR(ExprExecutor::open(_partition_conjunct_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_conjuncts.min_max_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_filter.conjunct_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::open(_conjuncts.min_max_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::open(_partition_filter.conjunct_ctxs, state));
     _update_has_any_predicate();
 
     RETURN_IF_ERROR(_decompose_conjunct_ctxs(state));
-    RETURN_IF_ERROR(_setup_all_conjunct_ctxs(state));
+
+    // Build all_ctxs: clone of (min_max_ctxs ∪ scan conjuncts), used to build
+    // ScanConjunctsManager / PredicateTree inside each scanner's context.
+    std::vector<ExprContext*> cloned;
+    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _conjuncts.min_max_ctxs, &cloned));
+    for (auto* ctx : cloned) _conjuncts.all_ctxs.emplace_back(ctx);
+    cloned.clear();
+    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _conjunct_ctxs, &cloned));
+    for (auto* ctx : cloned) _conjuncts.all_ctxs.emplace_back(ctx);
+
     return Status::OK();
 }
 
@@ -311,16 +320,16 @@ Status HiveDataSource::_init_partition_values() {
     // (query-scoped) HdfsPartitionDescriptor.
     const auto& thrift_partition_key_exprs = partition_desc->thrift_partition_key_exprs();
     RETURN_IF_ERROR(
-            ExprFactory::create_expr_trees(&_pool, thrift_partition_key_exprs, &_partition_values, _runtime_state));
-    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_values, _runtime_state));
-    RETURN_IF_ERROR(ExprExecutor::open(_partition_values, _runtime_state));
+            ExprFactory::create_expr_trees(&_pool, thrift_partition_key_exprs, &_partition_filter.values, _runtime_state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_filter.values, _runtime_state));
+    RETURN_IF_ERROR(ExprExecutor::open(_partition_filter.values, _runtime_state));
 
     // init partition chunk
     auto partition_chunk = std::make_shared<Chunk>();
     for (int i = 0; i < _partition_slots.size(); i++) {
         SlotId slot_id = _partition_slots[i]->id();
         int partition_col_idx = _partition_index_in_hdfs_partition_columns[i];
-        ASSIGN_OR_RETURN(auto partition_value_col, _partition_values[partition_col_idx]->evaluate(nullptr));
+        ASSIGN_OR_RETURN(auto partition_value_col, _partition_filter.values[partition_col_idx]->evaluate(nullptr));
         DCHECK(partition_value_col->is_constant());
         partition_chunk->append_column(std::move(partition_value_col), slot_id);
     }
@@ -329,26 +338,26 @@ Status HiveDataSource::_init_partition_values() {
     if (_has_scan_range_indicate_const_column) {
         std::vector<ExprContext*> ctxs;
         for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
-            if (_conjunct_ctxs_by_slot.find(slotId) != _conjunct_ctxs_by_slot.end()) {
-                ctxs.insert(ctxs.end(), _conjunct_ctxs_by_slot.at(slotId).begin(),
-                            _conjunct_ctxs_by_slot.at(slotId).end());
+            if (_conjuncts.by_slot.find(slotId) != _conjuncts.by_slot.end()) {
+                ctxs.insert(ctxs.end(), _conjuncts.by_slot.at(slotId).begin(),
+                            _conjuncts.by_slot.at(slotId).end());
             }
         }
         RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(ctxs, partition_chunk.get()));
-    } else if (_has_partition_conjuncts) {
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_partition_conjunct_ctxs, partition_chunk.get()));
+    } else if (_partition_filter.has_conjuncts) {
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_partition_filter.conjunct_ctxs, partition_chunk.get()));
     }
 
     if (!partition_chunk->has_rows()) {
-        _filter_by_eval_partition_conjuncts = true;
+        _partition_filter.filter_by_eval = true;
         return Status::OK();
     }
 
     if (_enable_dynamic_prune_scan_range && _runtime_filters) {
-        _init_rf_counters();
+        _init_runtime_filter_counters();
         _runtime_filters->evaluate_partial_chunk(partition_chunk.get(), runtime_membership_filter_eval_context);
         if (!partition_chunk->has_rows()) {
-            _filter_by_eval_partition_conjuncts = true;
+            _partition_filter.filter_by_eval = true;
             return Status::OK();
         }
     }
@@ -443,10 +452,10 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         _hive_column_names = hdfs_scan_node.hive_column_names;
     }
     if (hdfs_scan_node.__isset.case_sensitive) {
-        _case_sensitive = hdfs_scan_node.case_sensitive;
+        _options.case_sensitive = hdfs_scan_node.case_sensitive;
     }
-    if (hdfs_scan_node.__isset.can_use_min_max_opt) {
-        _use_min_max_opt = hdfs_scan_node.can_use_min_max_opt;
+    if (hdfs_scan_node.__isset.can_options.use_min_max_opt) {
+        _options.use_min_max_opt = hdfs_scan_node.can_options.use_min_max_opt;
     }
     // can_use_any_column is set by PruneHDFSScanColumnRule when every queried column is
     // a partition column and a placeholder materialized column was injected to satisfy
@@ -454,10 +463,10 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     // the scanner can avoid reading that placeholder column from the data file when
     // min/max optimization is active.
     if (hdfs_scan_node.__isset.can_use_any_column) {
-        _can_use_any_column = hdfs_scan_node.can_use_any_column;
+        _options.can_use_any_column = hdfs_scan_node.can_use_any_column;
     }
-    if (hdfs_scan_node.__isset.can_use_count_opt) {
-        _use_count_opt = hdfs_scan_node.can_use_count_opt;
+    if (hdfs_scan_node.__isset.can_options.use_count_opt) {
+        _options.use_count_opt = hdfs_scan_node.can_options.use_count_opt;
     }
     if (hdfs_scan_node.__isset.use_partition_column_value_only) {
         _use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;
@@ -484,14 +493,14 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     };
     if (!check_partition_opt()) {
         _use_partition_column_value_only = false;
-        _use_count_opt = false;
+        _options.use_count_opt = false;
     }
 
     // for min/max optimization, we already check that on FE side this iceberg table
     // is unpartitioned, or all partition columns are constant value.
     // so we just need to make sure there is no delete file.
     if (!_scan_range.delete_files.empty()) {
-        _use_min_max_opt = false;
+        _options.use_min_max_opt = false;
     }
 }
 
@@ -513,7 +522,7 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
         std::vector<SlotId> slot_ids;
         root_expr->get_slot_ids(&slot_ids);
         for (SlotId slot_id : slot_ids) {
-            _slots_in_conjunct.insert(slot_id);
+            _conjuncts.slots_in_conjunct.insert(slot_id);
         }
 
         // For some conjunct like (a < 1) or (a > 7)
@@ -539,43 +548,23 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
             }
         }
         if (!single_slot || slot_ids.empty() || !single_field) {
-            _scanner_conjunct_ctxs.emplace_back(ctx);
+            _conjuncts.scanner_ctxs.emplace_back(ctx);
             for (SlotId slot_id : slot_ids) {
-                _slots_of_multi_field_conjunct.insert(slot_id);
+                _conjuncts.slots_of_multi_field.insert(slot_id);
             }
             continue;
         }
 
         SlotId slot_id = slot_ids[0];
         if (slot_by_id.find(slot_id) != slot_by_id.end()) {
-            if (_conjunct_ctxs_by_slot.find(slot_id) == _conjunct_ctxs_by_slot.end()) {
-                _conjunct_ctxs_by_slot.insert({slot_id, std::vector<ExprContext*>()});
-            }
-            _conjunct_ctxs_by_slot[slot_id].emplace_back(ctx);
+            _conjuncts.by_slot[slot_id].emplace_back(ctx);
         }
     }
     // rewrite dict
     auto* fragment_dict_state = state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
     RETURN_IF_ERROR(
-            fragment_dict_state->mutable_dict_optimize_parser()->rewrite_conjuncts(state, &_scanner_conjunct_ctxs));
-    return Status::OK();
-}
-
-Status HiveDataSource::_setup_all_conjunct_ctxs(RuntimeState* state) {
-    // clone conjunct from _min_max_conjunct_ctxs & _conjunct_ctxs
-    // then we will generate PredicateTree based on _all_conjunct_ctxs
-    std::vector<ExprContext*> cloned_conjunct_ctxs;
-    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _min_max_conjunct_ctxs, &cloned_conjunct_ctxs));
-    for (auto* ctx : cloned_conjunct_ctxs) {
-        _all_conjunct_ctxs.emplace_back(ctx);
-    }
-
-    cloned_conjunct_ctxs.clear();
-    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _conjunct_ctxs, &cloned_conjunct_ctxs));
-    for (auto* ctx : cloned_conjunct_ctxs) {
-        _all_conjunct_ctxs.emplace_back(ctx);
-    }
+            fragment_dict_state->mutable_dict_optimize_parser()->rewrite_conjuncts(state, &_conjuncts.scanner_ctxs));
     return Status::OK();
 }
 
@@ -689,7 +678,7 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     }
 }
 
-void HiveDataSource::_init_rf_counters() {
+void HiveDataSource::_init_runtime_filter_counters() {
     auto* root = _runtime_profile;
     if (runtime_membership_filter_eval_context.join_runtime_filter_timer == nullptr) {
         static const char* prefix = "DynamicPruneScanRange";
@@ -801,24 +790,24 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.partition_slots = _partition_slots;
     scanner_params.partition_index_in_chunk = _partition_index_in_chunk;
     scanner_params._partition_index_in_hdfs_partition_columns = _partition_index_in_hdfs_partition_columns;
-    scanner_params.partition_values = _partition_values;
-    scanner_params.scanner_conjunct_ctxs = _scanner_conjunct_ctxs;
+    scanner_params.partition_values = _partition_filter.values;
+    // Pass a non-owning pointer; _conjuncts is owned by this HiveDataSource.
+    scanner_params.conjuncts = &_conjuncts;
 
     scanner_params.extended_col_slots = _extended_slots;
     scanner_params.extended_col_index_in_chunk = _extended_index_in_chunk;
     scanner_params.index_in_extended_columns = _index_in_extended_column;
     scanner_params.extended_col_values = _extended_column_values;
 
-    scanner_params.conjunct_ctxs_by_slot = _conjunct_ctxs_by_slot;
-    scanner_params.slots_in_conjunct = _slots_in_conjunct;
-    scanner_params.slots_of_multi_field_conjunct = _slots_of_multi_field_conjunct;
-    scanner_params.min_max_conjunct_ctxs = _min_max_conjunct_ctxs;
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;
     if (const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_hive_table)) {
         scanner_params.avro_schema_json = hdfs_desc->get_avro_schema_json();
     }
-    scanner_params.case_sensitive = _case_sensitive;
+    // Pass a non-owning pointer; _options is owned by this HiveDataSource.
+    // Format-specific options (parquet_*, orc_*) are written into _options
+    // inside the format branch below before the scanner is initialised.
+    scanner_params.options = &_options;
     scanner_params.profile = &_profile;
     scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
     scanner_params.split_context = down_cast<HdfsSplitContext*>(_split_context);
@@ -852,13 +841,6 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     // setup options for datacache
     scanner_params.datacache_options = _datacache_options;
-    scanner_params.use_file_metacache = _use_file_metacache;
-    scanner_params.use_file_pagecache = _use_file_pagecache;
-
-    scanner_params.use_min_max_opt = _use_min_max_opt;
-    scanner_params.can_use_any_column = _can_use_any_column;
-    scanner_params.use_count_opt = _use_count_opt;
-    scanner_params.all_conjunct_ctxs = _all_conjunct_ctxs;
     if (!_disable_column_access_path_hints && !_column_access_paths.empty()) {
         scanner_params.column_access_paths = &_column_access_paths;
     }
@@ -913,12 +895,12 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (use_kudu_jni_reader) {
         scanner = create_kudu_jni_scanner(jni_scanner_create_options).release();
     } else if (format == THdfsFileFormat::PARQUET) {
-        scanner_params.parquet_page_index_enable =
+        _options.parquet_page_index_enable =
                 config::parquet_page_index_enable ? state->query_options().__isset.enable_parquet_reader_page_index
                                                             ? state->query_options().enable_parquet_reader_page_index
                                                             : true
                                                   : false;
-        scanner_params.parquet_bloom_filter_enable =
+        _options.parquet_bloom_filter_enable =
                 config::parquet_reader_bloom_filter_enable
                         ? state->query_options().__isset.enable_parquet_reader_bloom_filter
                                   ? state->query_options().enable_parquet_reader_bloom_filter
@@ -926,7 +908,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                         : false;
         scanner = new HdfsParquetScanner();
     } else if (format == THdfsFileFormat::ORC) {
-        scanner_params.orc_use_column_names = state->query_options().orc_use_column_names;
+        _options.orc_use_column_names = state->query_options().orc_use_column_names;
         scanner = new HdfsOrcScanner();
     } else if (format == THdfsFileFormat::TEXT) {
         const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_hive_table);
@@ -987,11 +969,11 @@ void HiveDataSource::close(RuntimeState* state) {
         }
         _scanner->close();
     }
-    ExprExecutor::close(_min_max_conjunct_ctxs, state);
-    ExprExecutor::close(_partition_conjunct_ctxs, state);
-    ExprExecutor::close(_partition_values, state);
-    ExprExecutor::close(_scanner_conjunct_ctxs, state);
-    for (auto& it : _conjunct_ctxs_by_slot) {
+    ExprExecutor::close(_conjuncts.min_max_ctxs, state);
+    ExprExecutor::close(_partition_filter.conjunct_ctxs, state);
+    ExprExecutor::close(_partition_filter.values, state);
+    ExprExecutor::close(_conjuncts.scanner_ctxs, state);
+    for (auto& it : _conjuncts.by_slot) {
         ExprExecutor::close(it.second, state);
     }
 }

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -53,7 +53,7 @@ public:
     DataSourcePtr create_data_source(const TScanRange& scan_range) override;
     const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
 
-    void peek_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
+    void prepare_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     void default_data_source_mem_bytes(int64_t* min_value, int64_t* max_value) override;
 
     friend class HiveDataSource;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -19,9 +19,9 @@
 #include "column/column_access_path.h"
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
+#include "connector/hive_chunk_sink.h"
 #include "exec/connector_scan_node.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
-#include "hive_chunk_sink.h"
 
 namespace starrocks {
 class HiveTableDescriptor;
@@ -63,7 +63,7 @@ protected:
     ConnectorScanNode* _scan_node;
     const THdfsScanNode _hdfs_scan_node;
     int64_t _max_file_length = 0;
-    std::atomic<int32_t> _lazy_column_coalesce_counter = 0;
+    mutable std::atomic<int32_t> _lazy_column_coalesce_counter = 0;
 };
 
 class HiveDataSource final : public DataSource {
@@ -77,9 +77,6 @@ public:
     void close(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
     const std::string get_custom_coredump_msg() const override;
-    std::atomic<int32_t>* get_lazy_column_coalesce_counter() {
-        return &(const_cast<HiveDataSourceProvider*>(_provider)->_lazy_column_coalesce_counter);
-    }
     int32_t scan_range_indicate_const_column_index(SlotId id) const;
     int32_t extended_column_index(SlotId id) const;
 
@@ -113,19 +110,15 @@ private:
     Status _init_scanner(RuntimeState* state);
     Status _check_all_slots_nullable();
 
-    const std::string OPENXJSON_SERDE_LIB = "org.openx.data.jsonserde.JsonSerDe";
-
     // =====================================
     ObjectPool _pool;
     RuntimeState* _runtime_state = nullptr;
-    HdfsScanner* _scanner = nullptr;
-    DataCacheOptions _datacache_options{};
-    bool _enable_dynamic_prune_scan_range = true;
-    bool _enable_split_tasks = false;
 
-    // ============ conjuncts =================
-    // Single owner of all conjunct vectors; scanners receive a const pointer.
+    HdfsScanner* _scanner = nullptr;
     HdfsScannerConjuncts _conjuncts;
+    HdfsScannerOptions _options;
+    HdfsScannerParams _scanner_params;
+    HdfsScanProfile _profile;
 
     // Partition-level predicate evaluation — not passed to scanners.
     struct PartitionFilter {
@@ -135,53 +128,12 @@ private:
         bool filter_by_eval = false;
     };
     PartitionFilter _partition_filter;
-    bool _no_data = false;
 
-    int _min_max_tuple_id = 0;
+    bool _no_more_chunks = false;
     const TupleDescriptor* _min_max_tuple_desc = nullptr;
-
-    // ============ scan options =================
-    // Immutable query options shared with HdfsScannerParams via non-owning pointer.
-    HdfsScannerOptions _options;
-
-    // materialized columns.
-    std::vector<SlotDescriptor*> _materialize_slots;
-    std::vector<int> _materialize_index_in_chunk;
-    // default values for materialize_slots that have default value defined.
-    // used when the slot doesn't exist in the data file during scanning.
-    std::unordered_map<SlotId, std::string> _materialize_slot_default_values;
-
-    // partition columns.
-    std::vector<SlotDescriptor*> _partition_slots;
-
-    std::vector<ExprContext*> _extended_column_values;
-    // extended columns.
-    std::vector<SlotDescriptor*> _extended_slots;
-    // extended column index in `tuple_desc`
-    std::vector<int> _extended_index_in_chunk;
-    // index in extended columns
-    std::vector<int> _index_in_extended_column;
-    bool _has_extended_columns = false;
-
-    // partition column index in `tuple_desc`
-    std::vector<int> _partition_index_in_chunk;
-    // partition index in hdfs partition columns
-    std::vector<int> _partition_index_in_hdfs_partition_columns;
-    bool _has_partition_columns = false;
-
     std::vector<std::string> _hive_column_names;
     const HiveTableDescriptor* _hive_table = nullptr;
-
-    bool _has_scan_range_indicate_const_column = false;
-    bool _use_partition_column_value_only = false;
-    // only used in global late materialization
-    int32_t _scan_range_id = -1;
     std::vector<ColumnAccessPathPtr> _column_access_paths;
-    bool _disable_column_access_path_hints = false;
-
-    // ======================================
-    // The following are profile metrics
-    HdfsScanProfile _profile;
 };
 
 } // namespace starrocks::connector

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -102,10 +102,9 @@ private:
     Status _init_conjunct_ctxs(RuntimeState* state);
     void _update_has_any_predicate();
     Status _decompose_conjunct_ctxs(RuntimeState* state);
-    Status _setup_all_conjunct_ctxs(RuntimeState* state);
     void _init_tuples_and_slots(RuntimeState* state);
     void _init_counter(RuntimeState* state);
-    void _init_rf_counters();
+    void _init_runtime_filter_counters();
     void _init_global_late_materialization_context(RuntimeState* state);
 
     Status _init_partition_values();
@@ -121,39 +120,29 @@ private:
     RuntimeState* _runtime_state = nullptr;
     HdfsScanner* _scanner = nullptr;
     DataCacheOptions _datacache_options{};
-    bool _use_file_metacache = false;
-    bool _use_file_pagecache = false;
     bool _enable_dynamic_prune_scan_range = true;
     bool _enable_split_tasks = false;
 
     // ============ conjuncts =================
-    std::vector<ExprContext*> _min_max_conjunct_ctxs;
+    // Single owner of all conjunct vectors; scanners receive a const pointer.
+    HdfsScannerConjuncts _conjuncts;
 
-    // contains whole conjuncts, used to generate PredicateTree
-    std::vector<ExprContext*> _all_conjunct_ctxs{};
-    // complex conjuncts, such as contains multi slot, are evaled in scanner.
-    std::vector<ExprContext*> _scanner_conjunct_ctxs;
-    // conjuncts that contains only one slot.
-    // 1. conjuncts that column is not exist in file, are used to filter file in file reader.
-    // 2. conjuncts that column is materialized, are evaled in group reader.
-    std::unordered_map<SlotId, std::vector<ExprContext*>> _conjunct_ctxs_by_slot;
-    std::unordered_set<SlotId> _slots_in_conjunct;
-
-    // used for reader to decide decode or not
-    // if only used by filter(not output) and only used in conjunct_ctx_by_slot
-    // there is no need to decode.
-    std::unordered_set<SlotId> _slots_of_multi_field_conjunct;
-
-    // partition conjuncts of each partition slot.
-    std::vector<ExprContext*> _partition_conjunct_ctxs;
-    std::vector<ExprContext*> _partition_values;
-
-    bool _has_partition_conjuncts = false;
-    bool _filter_by_eval_partition_conjuncts = false;
+    // Partition-level predicate evaluation — not passed to scanners.
+    struct PartitionFilter {
+        std::vector<ExprContext*> conjunct_ctxs;
+        std::vector<ExprContext*> values;
+        bool has_conjuncts = false;
+        bool filter_by_eval = false;
+    };
+    PartitionFilter _partition_filter;
     bool _no_data = false;
 
     int _min_max_tuple_id = 0;
     const TupleDescriptor* _min_max_tuple_desc = nullptr;
+
+    // ============ scan options =================
+    // Immutable query options shared with HdfsScannerParams via non-owning pointer.
+    HdfsScannerOptions _options;
 
     // materialized columns.
     std::vector<SlotDescriptor*> _materialize_slots;
@@ -181,14 +170,6 @@ private:
     bool _has_partition_columns = false;
 
     std::vector<std::string> _hive_column_names;
-    bool _case_sensitive = false;
-    bool _use_min_max_opt = false;
-    // Mirrors THdfsScanNode.can_use_any_column: set when PruneHDFSScanColumnRule
-    // injected a placeholder materialized column because every queried column was
-    // a partition column.  Used together with _use_min_max_opt to avoid reading
-    // that placeholder column from the data file.
-    bool _can_use_any_column = false;
-    bool _use_count_opt = false;
     const HiveTableDescriptor* _hive_table = nullptr;
 
     bool _has_scan_range_indicate_const_column = false;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -115,10 +115,7 @@ private:
     RuntimeState* _runtime_state = nullptr;
 
     HdfsScanner* _scanner = nullptr;
-    HdfsScannerConjuncts _conjuncts;
-    HdfsScannerOptions _options;
     HdfsScannerParams _scanner_params;
-    HdfsScanProfile _profile;
 
     // Partition-level predicate evaluation — not passed to scanners.
     struct PartitionFilter {

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -96,7 +96,7 @@ Status CacheSelectScanner::_fetch_orc() {
     {
         std::unordered_set<std::string> known_column_names;
         OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
-                                              _scanner_ctx.case_sensitive, _scanner_ctx.orc_use_column_names);
+                                              _scanner_ctx.options->case_sensitive, _scanner_ctx.options->orc_use_column_names);
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
         ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
         if (skip) {
@@ -105,7 +105,7 @@ Status CacheSelectScanner::_fetch_orc() {
         }
 
         for (const auto& column : _scanner_ctx.materialized_columns) {
-            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.case_sensitive);
+            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.options->case_sensitive);
             if (known_column_names.contains(col_name)) {
                 slot_descriptors.emplace_back(column.slot_desc);
             }
@@ -117,12 +117,12 @@ Status CacheSelectScanner::_fetch_orc() {
     {
         std::list<uint64_t> selected_leaf_column_ids{};
         OrcMappingOptions orc_mapping_options{};
-        orc_mapping_options.case_sensitive = _scanner_ctx.case_sensitive;
+        orc_mapping_options.case_sensitive = _scanner_ctx.options->case_sensitive;
         orc_mapping_options.filename = _file->filename();
         orc_mapping_options.invalid_as_null = true;
         ASSIGN_OR_RETURN(
                 std::unique_ptr<OrcMapping> orc_mapping,
-                OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(), _scanner_ctx.orc_use_column_names,
+                OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(), _scanner_ctx.options->orc_use_column_names,
                                                  _scanner_ctx.hive_column_names, orc_mapping_options));
 
         for (size_t i = 0; i < slot_descriptors.size(); i++) {

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -200,7 +200,7 @@ Status CacheSelectScanner::_fetch_parquet() {
 // Split text into multiply disk ranges, then fetch it
 Status CacheSelectScanner::_fetch_textfile() {
     // If it's compressed file, we only handle scan range whose offset == 0.
-    if (get_compression_type_from_path(_scanner_params.path) != UNKNOWN_COMPRESSION &&
+    if (get_compression_type_from_path(_scanner_params.file_path) != UNKNOWN_COMPRESSION &&
         _scanner_params.scan_range->offset != 0) {
         return Status::OK();
     }
@@ -232,7 +232,7 @@ Status CacheSelectScanner::_fetch_iceberg_delete_files() {
 Status CacheSelectScanner::_write_entire_file(const std::string& file_path, size_t file_size) {
     OpenFileOptions options{};
     options.fs = _scanner_params.fs;
-    options.path = file_path;
+    options.file_path = file_path;
     options.file_size = file_size;
     options.datacache_options = _scanner_params.datacache_options;
     options.fs_stats = &_fs_stats;

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -96,7 +96,8 @@ Status CacheSelectScanner::_fetch_orc() {
     {
         std::unordered_set<std::string> known_column_names;
         OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
-                                              _scanner_ctx.options->case_sensitive, _scanner_ctx.options->orc_use_column_names);
+                                              _scanner_ctx.options->case_sensitive,
+                                              _scanner_ctx.options->orc_use_column_names);
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
         ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
         if (skip) {
@@ -120,10 +121,10 @@ Status CacheSelectScanner::_fetch_orc() {
         orc_mapping_options.case_sensitive = _scanner_ctx.options->case_sensitive;
         orc_mapping_options.filename = _file->filename();
         orc_mapping_options.invalid_as_null = true;
-        ASSIGN_OR_RETURN(
-                std::unique_ptr<OrcMapping> orc_mapping,
-                OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(), _scanner_ctx.options->orc_use_column_names,
-                                                 _scanner_ctx.hive_column_names, orc_mapping_options));
+        ASSIGN_OR_RETURN(std::unique_ptr<OrcMapping> orc_mapping,
+                         OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(),
+                                                          _scanner_ctx.options->orc_use_column_names,
+                                                          _scanner_ctx.hive_column_names, orc_mapping_options));
 
         for (size_t i = 0; i < slot_descriptors.size(); i++) {
             SlotDescriptor* desc = slot_descriptors[i];

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -95,9 +95,9 @@ Status CacheSelectScanner::_fetch_orc() {
     // resolve columns
     {
         std::unordered_set<std::string> known_column_names;
-        OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
-                                              _scanner_ctx.options->case_sensitive,
-                                              _scanner_ctx.options->orc_use_column_names);
+        OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.params->hive_column_names,
+                                              reader->getType(), _scanner_ctx.params->options->case_sensitive,
+                                              _scanner_ctx.params->options->orc_use_column_names);
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
         ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
         if (skip) {
@@ -106,7 +106,7 @@ Status CacheSelectScanner::_fetch_orc() {
         }
 
         for (const auto& column : _scanner_ctx.materialized_columns) {
-            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.options->case_sensitive);
+            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.params->options->case_sensitive);
             if (known_column_names.contains(col_name)) {
                 slot_descriptors.emplace_back(column.slot_desc);
             }
@@ -118,13 +118,13 @@ Status CacheSelectScanner::_fetch_orc() {
     {
         std::list<uint64_t> selected_leaf_column_ids{};
         OrcMappingOptions orc_mapping_options{};
-        orc_mapping_options.case_sensitive = _scanner_ctx.options->case_sensitive;
+        orc_mapping_options.case_sensitive = _scanner_ctx.params->options->case_sensitive;
         orc_mapping_options.filename = _file->filename();
         orc_mapping_options.invalid_as_null = true;
         ASSIGN_OR_RETURN(std::unique_ptr<OrcMapping> orc_mapping,
                          OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(),
-                                                          _scanner_ctx.options->orc_use_column_names,
-                                                          _scanner_ctx.hive_column_names, orc_mapping_options));
+                                                          _scanner_ctx.params->options->orc_use_column_names,
+                                                          _scanner_ctx.params->hive_column_names, orc_mapping_options));
 
         for (size_t i = 0; i < slot_descriptors.size(); i++) {
             SlotDescriptor* desc = slot_descriptors[i];
@@ -149,7 +149,7 @@ Status CacheSelectScanner::_fetch_orc() {
         uint64_t stripe_number = reader->getNumberOfStripes();
         std::vector<DiskRange> stripe_disk_ranges{};
 
-        const auto* scan_range = _scanner_ctx.scan_range;
+        const auto* scan_range = _scanner_ctx.params->scan_range;
         size_t scan_start = scan_range->offset;
         size_t scan_end = scan_start + scan_range->length;
 

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -43,7 +43,7 @@ Status CacheSelectScanner::do_open(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
-void CacheSelectScanner::do_update_counter(HdfsScanProfile* profile) {
+void CacheSelectScanner::do_update_counter(HdfsScannerProfile* profile) {
     const std::string prefix = "CacheSelect";
     RuntimeProfile* root_profile = profile->runtime_profile;
     ADD_COUNTER(root_profile, prefix, TUnit::NONE);
@@ -96,8 +96,8 @@ Status CacheSelectScanner::_fetch_orc() {
     {
         std::unordered_set<std::string> known_column_names;
         OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.params->hive_column_names,
-                                              reader->getType(), _scanner_ctx.params->options->case_sensitive,
-                                              _scanner_ctx.params->options->orc_use_column_names);
+                                              reader->getType(), _scanner_ctx.params->options.case_sensitive,
+                                              _scanner_ctx.params->options.orc_use_column_names);
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
         ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
         if (skip) {
@@ -106,7 +106,7 @@ Status CacheSelectScanner::_fetch_orc() {
         }
 
         for (const auto& column : _scanner_ctx.materialized_columns) {
-            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.params->options->case_sensitive);
+            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.params->options.case_sensitive);
             if (known_column_names.contains(col_name)) {
                 slot_descriptors.emplace_back(column.slot_desc);
             }
@@ -118,12 +118,12 @@ Status CacheSelectScanner::_fetch_orc() {
     {
         std::list<uint64_t> selected_leaf_column_ids{};
         OrcMappingOptions orc_mapping_options{};
-        orc_mapping_options.case_sensitive = _scanner_ctx.params->options->case_sensitive;
+        orc_mapping_options.case_sensitive = _scanner_ctx.params->options.case_sensitive;
         orc_mapping_options.filename = _file->filename();
         orc_mapping_options.invalid_as_null = true;
         ASSIGN_OR_RETURN(std::unique_ptr<OrcMapping> orc_mapping,
                          OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(),
-                                                          _scanner_ctx.params->options->orc_use_column_names,
+                                                          _scanner_ctx.params->options.orc_use_column_names,
                                                           _scanner_ctx.params->hive_column_names, orc_mapping_options));
 
         for (size_t i = 0; i < slot_descriptors.size(); i++) {

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -68,7 +68,7 @@ Status CacheSelectScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
     }
 
     // handle iceberg delete files
-    if (!_scanner_params.deletes.empty()) {
+    if (!_scanner_params.table_specific.iceberg_delete_files.empty()) {
         RETURN_IF_ERROR(_fetch_iceberg_delete_files());
     }
 
@@ -221,11 +221,11 @@ Status CacheSelectScanner::_fetch_textfile() {
 
 // for iceberg delete files, we fetch an entire file directly
 Status CacheSelectScanner::_fetch_iceberg_delete_files() {
-    for (const auto* delete_file : _scanner_params.deletes) {
+    for (const auto* delete_file : _scanner_params.table_specific.iceberg_delete_files) {
         RETURN_IF_ERROR(_write_entire_file(delete_file->full_path, delete_file->length));
     }
 
-    _app_stats.iceberg_delete_files_per_scan += _scanner_params.deletes.size();
+    _app_stats.iceberg_delete_files_per_scan += _scanner_params.table_specific.iceberg_delete_files.size();
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.h
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.h
@@ -29,7 +29,7 @@ public:
     CacheSelectScanner() = default;
     ~CacheSelectScanner() override = default;
     Status do_open(RuntimeState* runtime_state) override;
-    void do_update_counter(HdfsScanProfile* profile) override;
+    void do_update_counter(HdfsScannerProfile* profile) override;
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -302,8 +302,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
         // cannot handle them internally (Text, Avro, JSON, JNI).  ORC and Parquet
         // evaluate them inside do_get_next() after all columns are materialised and
         // return true from scanner_handles_multi_slot_conjuncts_internally().
-        if (!scanner_handles_multi_slot_conjuncts_internally() &&
-            !_scanner_params.conjuncts->scanner_ctxs.empty()) {
+        if (!scanner_handles_multi_slot_conjuncts_internally() && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
             SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
             RETURN_IF_ERROR(
                     ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, (*chunk).get()));

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -107,15 +107,15 @@ private:
 
 bool HdfsScannerParams::is_lazy_materialization_slot(SlotId slot_id) const {
     // if there are no conjuncts at all, every slot must be read eagerly.
-    if (conjuncts->by_slot.empty() && conjuncts->scanner_ctxs.empty()) {
+    if (conjuncts.by_slot.empty() && conjuncts.scanner_ctxs.empty()) {
         return false;
     }
     // slots directly filtered by a by_slot predicate are active (eagerly decoded).
-    if (conjuncts->by_slot.count(slot_id)) {
+    if (conjuncts.by_slot.count(slot_id)) {
         return false;
     }
     // slots referenced by any conjunct must be eagerly decoded too.
-    if (conjuncts->slots_in_conjunct.count(slot_id)) {
+    if (conjuncts.slots_in_conjunct.count(slot_id)) {
         return false;
     }
     return true;
@@ -159,7 +159,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.params = &_scanner_params;
     // conjunct_ctxs_by_slot is a mutable per-scanner shallow copy of by_slot;
     // update_with_none_existed_slot() erases entries when columns are absent.
-    ctx.conjunct_ctxs_by_slot = _scanner_params.conjuncts->by_slot;
+    ctx.conjunct_ctxs_by_slot = _scanner_params.conjuncts.by_slot;
 
     // build columns of materialized and partition.
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
@@ -175,7 +175,7 @@ Status HdfsScanner::_build_scanner_context() {
             // A slot must be decoded eagerly if it is an output column OR if it
             // appears in a multi-field conjunct that the reader cannot push down.
             column.decode_needed =
-                    slot->is_output_column() || _scanner_params.conjuncts->slots_of_multi_field.count(slot->id());
+                    slot->is_output_column() || _scanner_params.conjuncts.slots_of_multi_field.count(slot->id());
             ctx.materialized_columns.emplace_back(column);
         }
     }
@@ -201,7 +201,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.stats = &_app_stats;
 
     ScanConjunctsManagerOptions opts;
-    opts.conjunct_ctxs_ptr = &_scanner_params.conjuncts->all_ctxs;
+    opts.conjunct_ctxs_ptr = &_scanner_params.conjuncts.all_ctxs;
     opts.tuple_desc = _scanner_params.tuple_desc;
     opts.obj_pool = _runtime_state->obj_pool();
     opts.runtime_filters = _scanner_params.runtime_filter_collector;
@@ -231,12 +231,12 @@ Status HdfsScanner::_build_scanner_context() {
 }
 
 bool HdfsScannerContext::can_use_count_optimization() const {
-    return params->options->use_count_opt && can_use_file_record_count;
+    return params->options.use_count_opt && can_use_file_record_count;
 }
 
 bool HdfsScannerContext::can_use_min_max_optimization() const {
     // @TODO for iceberg _row_id column, we can support min/max optimization in the future
-    return params->options->use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
+    return params->options.use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
 }
 
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
@@ -290,10 +290,10 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
         // cannot handle them internally (Text, Avro, JSON, JNI).  ORC and Parquet
         // evaluate them inside do_get_next() after all columns are materialised and
         // return true from scanner_handles_multi_slot_conjuncts_internally().
-        if (!scanner_handles_multi_slot_conjuncts_internally() && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
+        if (!scanner_handles_multi_slot_conjuncts_internally() && !_scanner_params.conjuncts.scanner_ctxs.empty()) {
             SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
             RETURN_IF_ERROR(
-                    ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, (*chunk).get()));
+                    ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts.scanner_ctxs, (*chunk).get()));
         }
     } else if (status.is_end_of_file()) {
         // do nothing.
@@ -477,7 +477,7 @@ int64_t HdfsScanner::estimated_mem_usage() const {
     return 0;
 }
 
-void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
+void HdfsScanner::update_hdfs_counter(HdfsScannerProfile* profile) {
     if (_file == nullptr) return;
     static const char* const kHdfsIOProfileSectionPrefix = "HdfsIOMetrics";
 
@@ -509,7 +509,7 @@ void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
     }
 }
 
-void HdfsScanner::do_update_counter(HdfsScanProfile* profile) {}
+void HdfsScanner::do_update_counter(HdfsScannerProfile* profile) {}
 
 Status HdfsScanner::reinterpret_status(const Status& st) {
     auto msg = fmt::format("file = {}", _scanner_params.file_path);
@@ -525,7 +525,7 @@ Status HdfsScanner::reinterpret_status(const Status& st) {
 }
 
 void HdfsScanner::update_counter() {
-    HdfsScanProfile* profile = _scanner_params.profile;
+    HdfsScannerProfile* profile = &_scanner_params.profile;
     if (profile == nullptr) return;
 
     update_hdfs_counter(profile);
@@ -629,7 +629,7 @@ void HdfsScannerContext::update_return_count_columns() {
 }
 
 void HdfsScannerContext::update_min_max_columns() {
-    if (!params->options->use_min_max_opt) {
+    if (!params->options.use_min_max_opt) {
         return;
     }
     std::vector<ColumnInfo> updated_columns;
@@ -641,7 +641,7 @@ void HdfsScannerContext::update_min_max_columns() {
             // fills the column with the statistics values instead of reading the
             // actual data from the file.
             update_with_none_existed_slot(column.slot_desc);
-        } else if (params->options->can_use_any_column) {
+        } else if (params->options.can_use_any_column) {
             // This column has no min/max statistics (e.g. STRING or TIMESTAMP type
             // which are not yet supported, or a placeholder column injected by
             // PruneHDFSScanColumnRule when every queried column is a partition column).
@@ -657,7 +657,7 @@ void HdfsScannerContext::update_min_max_columns() {
     // into not_existed_slots.  reserved_field_slots are meta/hidden columns whose
     // values are irrelevant to the min/max query result, so filling them with defaults
     // is safe and allows can_use_min_max_optimization() to return true.
-    if (params->options->can_use_any_column) {
+    if (params->options.can_use_any_column) {
         for (SlotDescriptor* slot_desc : reserved_field_slots) {
             update_with_none_existed_slot(slot_desc);
         }
@@ -669,7 +669,7 @@ void HdfsScannerContext::update_min_max_columns() {
 Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
     std::vector<ColumnInfo> updated_columns;
     for (auto& column : materialized_columns) {
-        auto col_name = column.formatted_name(params->options->case_sensitive);
+        auto col_name = column.formatted_name(params->options.case_sensitive);
         if (names.find(col_name) == names.end()) {
             update_with_none_existed_slot(column.slot_desc);
         } else {
@@ -685,12 +685,12 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
 
     ChunkPtr& ck = (*chunk);
 
-    if (params->options->use_min_max_opt) {
+    if (params->options.use_min_max_opt) {
         append_or_update_min_max_column_to_chunk(chunk, row_count);
     }
 
     for (auto* slot_desc : not_existed_slots) {
-        if (params->options->use_min_max_opt &&
+        if (params->options.use_min_max_opt &&
             params->scan_range->min_max_values.find(slot_desc->id()) != params->scan_range->min_max_values.end()) {
             // handled in min max column
             continue;
@@ -945,7 +945,7 @@ void HdfsScannerContext::merge_split_tasks() {
         auto head_ctx = split_tasks[head].get();
 
         if ((ctx->split_start != prev_ctx->split_end) ||
-            (ctx->split_end - head_ctx->split_start > params->options->connector_max_split_size)) {
+            (ctx->split_end - head_ctx->split_start > params->options.connector_max_split_size)) {
             cut = true;
         }
 
@@ -961,7 +961,7 @@ void HdfsScannerContext::merge_split_tasks() {
     if (new_size >= 2) {
         auto tail_ctx = new_split_tasks[new_size - 1].get();
         size_t tail_size = (tail_ctx->split_end - tail_ctx->split_start);
-        if ((tail_size * 2) < params->options->connector_max_split_size) {
+        if ((tail_size * 2) < params->options.connector_max_split_size) {
             auto last_ctx = new_split_tasks[new_size - 2].get();
             if (last_ctx->split_end == tail_ctx->split_start) {
                 last_ctx->split_end = tail_ctx->split_end;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -945,7 +945,7 @@ void HdfsScannerContext::merge_split_tasks() {
         auto head_ctx = split_tasks[head].get();
 
         if ((ctx->split_start != prev_ctx->split_end) ||
-            (ctx->split_end - head_ctx->split_start > params->connector_max_split_size)) {
+            (ctx->split_end - head_ctx->split_start > params->options->connector_max_split_size)) {
             cut = true;
         }
 
@@ -961,7 +961,7 @@ void HdfsScannerContext::merge_split_tasks() {
     if (new_size >= 2) {
         auto tail_ctx = new_split_tasks[new_size - 1].get();
         size_t tail_size = (tail_ctx->split_end - tail_ctx->split_start);
-        if ((tail_size * 2) < params->connector_max_split_size) {
+        if ((tail_size * 2) < params->options->connector_max_split_size) {
             auto last_ctx = new_split_tasks[new_size - 2].get();
             if (last_ctx->split_end == tail_ctx->split_start) {
                 last_ctx->split_end = tail_ctx->split_end;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -154,11 +154,12 @@ Status HdfsScanner::_build_scanner_context() {
         extended_values.emplace_back(std::move(extended_value_column));
     }
 
-    // Share the immutable conjunct struct; conjunct_ctxs_by_slot is copied because
-    // update_with_none_existed_slot() mutates it when file columns are absent.
-    ctx.conjuncts = _scanner_params.conjuncts;
+    // Single pointer replaces 15 individual field copies; all immutable params are
+    // accessed via ctx.params->field throughout the scanner lifetime.
+    ctx.params = &_scanner_params;
+    // conjunct_ctxs_by_slot is a mutable per-scanner shallow copy of by_slot;
+    // update_with_none_existed_slot() erases entries when columns are absent.
     ctx.conjunct_ctxs_by_slot = _scanner_params.conjuncts->by_slot;
-    ctx.options = _scanner_params.options;
 
     // build columns of materialized and partition.
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
@@ -196,21 +197,8 @@ Status HdfsScanner::_build_scanner_context() {
     }
 
     ctx.slot_descs = _scanner_params.tuple_desc->slots();
-    ctx.scan_range = _scanner_params.scan_range;
-    ctx.scan_range_id = _scanner_params.scan_range_id;
-    ctx.materialize_slot_default_values = _scanner_params.materialize_slot_default_values;
-    ctx.runtime_filter_collector = _scanner_params.runtime_filter_collector;
-    ctx.min_max_tuple_desc = _scanner_params.min_max_tuple_desc;
-    ctx.hive_column_names = _scanner_params.hive_column_names;
     ctx.timezone = _runtime_state->timezone();
-    ctx.lake_schema = _scanner_params.lake_schema;
-    ctx.column_access_paths = _scanner_params.column_access_paths;
     ctx.stats = &_app_stats;
-    ctx.lazy_column_coalesce_counter = _scanner_params.lazy_column_coalesce_counter;
-    ctx.split_context = _scanner_params.split_context;
-    ctx.enable_split_tasks = _scanner_params.enable_split_tasks;
-    ctx.connector_max_split_size = _scanner_params.connector_max_split_size;
-    ctx.global_dictmaps = _scanner_params.global_dictmaps;
 
     ScanConjunctsManagerOptions opts;
     opts.conjunct_ctxs_ptr = &_scanner_params.conjuncts->all_ctxs;
@@ -227,15 +215,15 @@ Status HdfsScanner::_build_scanner_context() {
             opts.obj_pool->add(new ConnectorPredicateParser(&_scanner_params.tuple_desc->decoded_slots()));
     ASSIGN_OR_RETURN(ctx.predicate_tree,
                      ctx.conjuncts_manager->get_predicate_tree(predicate_parser, ctx.predicate_free_pool));
-    ctx.rf_scan_range_pruner = opts.obj_pool->add(
+    ctx.runtime_filter_scan_range_pruner = opts.obj_pool->add(
             new RuntimeScanRangePruner(predicate_parser, ctx.conjuncts_manager->unarrived_runtime_filters()));
 
     ctx.update_return_count_columns();
-    if (ctx.scan_range->__isset.record_count && ctx.scan_range->delete_files.empty()) {
+    if (ctx.params->scan_range->__isset.record_count && ctx.params->scan_range->delete_files.empty()) {
         ctx.can_use_file_record_count = true;
     }
-    if (ctx.scan_range->__isset.is_first_split) {
-        ctx.is_first_split = ctx.scan_range->is_first_split;
+    if (ctx.params->scan_range->__isset.is_first_split) {
+        ctx.is_first_split = ctx.params->scan_range->is_first_split;
     }
 
     ctx.update_min_max_columns();
@@ -243,12 +231,12 @@ Status HdfsScanner::_build_scanner_context() {
 }
 
 bool HdfsScannerContext::can_use_count_optimization() const {
-    return options->use_count_opt && can_use_file_record_count;
+    return params->options->use_count_opt && can_use_file_record_count;
 }
 
 bool HdfsScannerContext::can_use_min_max_optimization() const {
     // @TODO for iceberg _row_id column, we can support min/max optimization in the future
-    return options->use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
+    return params->options->use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
 }
 
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
@@ -263,7 +251,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     if (_scanner_ctx.can_use_count_optimization()) {
         int64_t file_record_count = 0;
         if (_scanner_ctx.is_first_split) {
-            file_record_count = _scanner_ctx.scan_range->record_count;
+            file_record_count = _scanner_ctx.params->scan_range->record_count;
         }
         _scanner_ctx.append_or_update_count_column_to_chunk(chunk, file_record_count);
         _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, 1);
@@ -641,11 +629,11 @@ void HdfsScannerContext::update_return_count_columns() {
 }
 
 void HdfsScannerContext::update_min_max_columns() {
-    if (!options->use_min_max_opt) {
+    if (!params->options->use_min_max_opt) {
         return;
     }
     std::vector<ColumnInfo> updated_columns;
-    const std::map<int32_t, TExprMinMaxValue>& min_max_values = scan_range->min_max_values;
+    const std::map<int32_t, TExprMinMaxValue>& min_max_values = params->scan_range->min_max_values;
     for (auto& column : materialized_columns) {
         if (min_max_values.find(column.slot_id()) != min_max_values.end()) {
             // This column has file-level min/max statistics.  Move it to
@@ -653,7 +641,7 @@ void HdfsScannerContext::update_min_max_columns() {
             // fills the column with the statistics values instead of reading the
             // actual data from the file.
             update_with_none_existed_slot(column.slot_desc);
-        } else if (options->can_use_any_column) {
+        } else if (params->options->can_use_any_column) {
             // This column has no min/max statistics (e.g. STRING or TIMESTAMP type
             // which are not yet supported, or a placeholder column injected by
             // PruneHDFSScanColumnRule when every queried column is a partition column).
@@ -669,7 +657,7 @@ void HdfsScannerContext::update_min_max_columns() {
     // into not_existed_slots.  reserved_field_slots are meta/hidden columns whose
     // values are irrelevant to the min/max query result, so filling them with defaults
     // is safe and allows can_use_min_max_optimization() to return true.
-    if (options->can_use_any_column) {
+    if (params->options->can_use_any_column) {
         for (SlotDescriptor* slot_desc : reserved_field_slots) {
             update_with_none_existed_slot(slot_desc);
         }
@@ -681,7 +669,7 @@ void HdfsScannerContext::update_min_max_columns() {
 Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
     std::vector<ColumnInfo> updated_columns;
     for (auto& column : materialized_columns) {
-        auto col_name = column.formatted_name(options->case_sensitive);
+        auto col_name = column.formatted_name(params->options->case_sensitive);
         if (names.find(col_name) == names.end()) {
             update_with_none_existed_slot(column.slot_desc);
         } else {
@@ -697,13 +685,13 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
 
     ChunkPtr& ck = (*chunk);
 
-    if (options->use_min_max_opt) {
+    if (params->options->use_min_max_opt) {
         append_or_update_min_max_column_to_chunk(chunk, row_count);
     }
 
     for (auto* slot_desc : not_existed_slots) {
-        if (options->use_min_max_opt &&
-            scan_range->min_max_values.find(slot_desc->id()) != scan_range->min_max_values.end()) {
+        if (params->options->use_min_max_opt &&
+            params->scan_range->min_max_values.find(slot_desc->id()) != params->scan_range->min_max_values.end()) {
             // handled in min max column
             continue;
         }
@@ -716,8 +704,8 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
                 col = ColumnHelper::create_column(desc, slot_desc->is_nullable());
                 col->append_datum(int64_t(1));
                 col->assign(row_count, 0);
-            } else if (auto it = materialize_slot_default_values.find(slot_desc->id());
-                       it != materialize_slot_default_values.end()) {
+            } else if (auto it = params->materialize_slot_default_values.find(slot_desc->id());
+                       it != params->materialize_slot_default_values.end()) {
                 RETURN_IF_ERROR(fill_default_value_for_not_existed_slot(slot_desc, it->second, row_count, col.get()));
             } else {
                 col->append_default(row_count);
@@ -743,8 +731,8 @@ void HdfsScannerContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk,
 
 void HdfsScannerContext::append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
     for (SlotDescriptor* slot_desc : not_existed_slots) {
-        auto it = scan_range->min_max_values.find(slot_desc->id());
-        if (it == scan_range->min_max_values.end()) {
+        auto it = params->scan_range->min_max_values.find(slot_desc->id());
+        if (it == params->scan_range->min_max_values.end()) {
             continue;
         }
         const TExprMinMaxValue& min_max_value = it->second;
@@ -957,7 +945,7 @@ void HdfsScannerContext::merge_split_tasks() {
         auto head_ctx = split_tasks[head].get();
 
         if ((ctx->split_start != prev_ctx->split_end) ||
-            (ctx->split_end - head_ctx->split_start > connector_max_split_size)) {
+            (ctx->split_end - head_ctx->split_start > params->connector_max_split_size)) {
             cut = true;
         }
 
@@ -973,7 +961,7 @@ void HdfsScannerContext::merge_split_tasks() {
     if (new_size >= 2) {
         auto tail_ctx = new_split_tasks[new_size - 1].get();
         size_t tail_size = (tail_ctx->split_end - tail_ctx->split_start);
-        if ((tail_size * 2) < connector_max_split_size) {
+        if ((tail_size * 2) < params->connector_max_split_size) {
             auto last_ctx = new_split_tasks[new_size - 2].get();
             if (last_ctx->split_end == tail_ctx->split_start) {
                 last_ctx->split_end = tail_ctx->split_end;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -298,7 +298,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     } else if (status.is_end_of_file()) {
         // do nothing.
     } else {
-        LOG(ERROR) << "failed to read file: " << _scanner_params.path;
+        LOG(ERROR) << "failed to read file: " << _scanner_params.file_path;
     }
     _app_stats.rows_read += (*chunk)->num_rows();
     return status;
@@ -317,7 +317,7 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
         return Status::OK();
     }
     RETURN_IF_ERROR(do_open(runtime_state));
-    VLOG_FILE << "open file success: " << _scanner_params.path << ", scan range = ["
+    VLOG_FILE << "open file success: " << _scanner_params.file_path << ", scan range = ["
               << _scanner_params.scan_range->offset << ","
               << (_scanner_params.scan_range->length + _scanner_params.scan_range->offset)
               << "], candidate node = " << _scanner_params.scan_range->candidate_node;
@@ -333,7 +333,7 @@ void HdfsScanner::close() noexcept {
     if (_scanner_ctx.can_use_count_optimization() || _scanner_ctx.can_use_min_max_optimization()) {
         return;
     }
-    VLOG_FILE << "close file success: " << _scanner_params.path << ", scan range = ["
+    VLOG_FILE << "close file success: " << _scanner_params.file_path << ", scan range = ["
               << _scanner_params.scan_range->offset << ","
               << (_scanner_params.scan_range->length + _scanner_params.scan_range->offset)
               << "], rows = " << _app_stats.rows_read;
@@ -348,7 +348,7 @@ void HdfsScanner::close() noexcept {
 StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_file(
         std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
         std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options) {
-    ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file, options.fs->new_random_access_file(options.path))
+    ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file, options.fs->new_random_access_file(options.file_path))
     int64_t file_size = options.file_size;
     if (file_size < 0) {
         ASSIGN_OR_RETURN(file_size, raw_file->stream()->get_size());
@@ -409,7 +409,7 @@ StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_fi
 
 Status HdfsScanner::open_random_access_file() {
     OpenFileOptions options{.fs = _scanner_params.fs,
-                            .path = _scanner_params.path,
+                            .file_path = _scanner_params.file_path,
                             .file_size = _scanner_params.file_size,
                             .fs_stats = &_fs_stats,
                             .app_stats = &_app_stats,
@@ -512,7 +512,7 @@ void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
 void HdfsScanner::do_update_counter(HdfsScanProfile* profile) {}
 
 Status HdfsScanner::reinterpret_status(const Status& st) {
-    auto msg = fmt::format("file = {}", _scanner_params.path);
+    auto msg = fmt::format("file = {}", _scanner_params.file_path);
 
     Status ret = st;
     // After catching the AWS 404 file not found error and returning it to the FE,

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -526,7 +526,7 @@ Status HdfsScanner::reinterpret_status(const Status& st) {
 
 void HdfsScanner::update_counter() {
     HdfsScannerProfile* profile = &_scanner_params.profile;
-    if (profile == nullptr) return;
+    if (profile->runtime_profile == nullptr) return;
 
     update_hdfs_counter(profile);
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -106,15 +106,16 @@ private:
 };
 
 bool HdfsScannerParams::is_lazy_materialization_slot(SlotId slot_id) const {
-    // if there is no conjuncts, then there is no lazy materialization slot.
-    // we have to read up all fields.
-    if (conjunct_ctxs_by_slot.size() == 0 && scanner_conjunct_ctxs.size() == 0) {
+    // if there are no conjuncts at all, every slot must be read eagerly.
+    if (conjuncts->by_slot.empty() && conjuncts->scanner_ctxs.empty()) {
         return false;
     }
-    if (conjunct_ctxs_by_slot.find(slot_id) != conjunct_ctxs_by_slot.end()) {
+    // slots directly filtered by a by_slot predicate are active (eagerly decoded).
+    if (conjuncts->by_slot.count(slot_id)) {
         return false;
     }
-    if (slots_in_conjunct.find(slot_id) != slots_in_conjunct.end()) {
+    // slots referenced by any conjunct must be eagerly decoded too.
+    if (conjuncts->slots_in_conjunct.count(slot_id)) {
         return false;
     }
     return true;
@@ -153,7 +154,11 @@ Status HdfsScanner::_build_scanner_context() {
         extended_values.emplace_back(std::move(extended_value_column));
     }
 
-    ctx.conjunct_ctxs_by_slot = _scanner_params.conjunct_ctxs_by_slot;
+    // Share the immutable conjunct struct; conjunct_ctxs_by_slot is copied because
+    // update_with_none_existed_slot() mutates it when file columns are absent.
+    ctx.conjuncts = _scanner_params.conjuncts;
+    ctx.conjunct_ctxs_by_slot = _scanner_params.conjuncts->by_slot;
+    ctx.options = _scanner_params.options;
 
     // build columns of materialized and partition.
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
@@ -166,9 +171,10 @@ Status HdfsScanner::_build_scanner_context() {
             HdfsScannerContext::ColumnInfo column;
             column.slot_desc = slot;
             column.idx_in_chunk = _scanner_params.materialize_index_in_chunk[i];
+            // A slot must be decoded eagerly if it is an output column OR if it
+            // appears in a multi-field conjunct that the reader cannot push down.
             column.decode_needed =
-                    slot->is_output_column() || _scanner_params.slots_of_multi_field_conjunct.find(slot->id()) !=
-                                                        _scanner_params.slots_of_multi_field_conjunct.end();
+                    slot->is_output_column() || _scanner_params.conjuncts->slots_of_multi_field.count(slot->id());
             ctx.materialized_columns.emplace_back(column);
         }
     }
@@ -194,16 +200,8 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.scan_range_id = _scanner_params.scan_range_id;
     ctx.materialize_slot_default_values = _scanner_params.materialize_slot_default_values;
     ctx.runtime_filter_collector = _scanner_params.runtime_filter_collector;
-    ctx.min_max_conjunct_ctxs = _scanner_params.min_max_conjunct_ctxs;
     ctx.min_max_tuple_desc = _scanner_params.min_max_tuple_desc;
     ctx.hive_column_names = _scanner_params.hive_column_names;
-    ctx.case_sensitive = _scanner_params.case_sensitive;
-    ctx.orc_use_column_names = _scanner_params.orc_use_column_names;
-    ctx.use_min_max_opt = _scanner_params.use_min_max_opt;
-    ctx.can_use_any_column = _scanner_params.can_use_any_column;
-    ctx.use_count_opt = _scanner_params.use_count_opt;
-    ctx.use_file_metacache = _scanner_params.use_file_metacache;
-    ctx.use_file_pagecache = _scanner_params.use_file_pagecache;
     ctx.timezone = _runtime_state->timezone();
     ctx.lake_schema = _scanner_params.lake_schema;
     ctx.column_access_paths = _scanner_params.column_access_paths;
@@ -213,11 +211,9 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.enable_split_tasks = _scanner_params.enable_split_tasks;
     ctx.connector_max_split_size = _scanner_params.connector_max_split_size;
     ctx.global_dictmaps = _scanner_params.global_dictmaps;
-    ctx.parquet_bloom_filter_enable = _scanner_params.parquet_bloom_filter_enable;
-    ctx.parquet_page_index_enable = _scanner_params.parquet_page_index_enable;
 
     ScanConjunctsManagerOptions opts;
-    opts.conjunct_ctxs_ptr = &_scanner_params.all_conjunct_ctxs;
+    opts.conjunct_ctxs_ptr = &_scanner_params.conjuncts->all_ctxs;
     opts.tuple_desc = _scanner_params.tuple_desc;
     opts.obj_pool = _runtime_state->obj_pool();
     opts.runtime_filters = _scanner_params.runtime_filter_collector;
@@ -247,12 +243,12 @@ Status HdfsScanner::_build_scanner_context() {
 }
 
 bool HdfsScannerContext::can_use_count_optimization() const {
-    return use_count_opt && can_use_file_record_count;
+    return options->use_count_opt && can_use_file_record_count;
 }
 
 bool HdfsScannerContext::can_use_min_max_optimization() const {
     // @TODO for iceberg _row_id column, we can support min/max optimization in the future
-    return use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
+    return options->use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
 }
 
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
@@ -293,10 +289,24 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     RETURN_IF_ERROR(_runtime_state->check_mem_limit("get chunk from scanner"));
     Status status = do_get_next(runtime_state, chunk);
     if (status.ok()) {
-        if (!_scanner_params.scanner_conjunct_ctxs.empty()) {
+        // Simple scanners (Text, Avro, JSON, JNI) cannot push single-slot predicates
+        // into their column readers, so the base class applies them here uniformly.
+        // ORC and Parquet return true because they handle by-slot evaluation
+        // internally via lazy materialisation and dict-filter pipelines.
+        if (!scanner_handles_predicate_by_slot_internally()) {
+            SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
+            Filter chunk_filter;
+            RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &chunk_filter));
+        }
+        // Multi-slot predicates (e.g. "a + b > 5") evaluated here for formats that
+        // cannot handle them internally (Text, Avro, JSON, JNI).  ORC and Parquet
+        // evaluate them inside do_get_next() after all columns are materialised and
+        // return true from scanner_handles_multi_slot_conjuncts_internally().
+        if (!scanner_handles_multi_slot_conjuncts_internally() &&
+            !_scanner_params.conjuncts->scanner_ctxs.empty()) {
             SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
             RETURN_IF_ERROR(
-                    ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.scanner_conjunct_ctxs, (*chunk).get()));
+                    ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, (*chunk).get()));
         }
     } else if (status.is_end_of_file()) {
         // do nothing.
@@ -632,7 +642,7 @@ void HdfsScannerContext::update_return_count_columns() {
 }
 
 void HdfsScannerContext::update_min_max_columns() {
-    if (!use_min_max_opt) {
+    if (!options->use_min_max_opt) {
         return;
     }
     std::vector<ColumnInfo> updated_columns;
@@ -644,7 +654,7 @@ void HdfsScannerContext::update_min_max_columns() {
             // fills the column with the statistics values instead of reading the
             // actual data from the file.
             update_with_none_existed_slot(column.slot_desc);
-        } else if (can_use_any_column) {
+        } else if (options->can_use_any_column) {
             // This column has no min/max statistics (e.g. STRING or TIMESTAMP type
             // which are not yet supported, or a placeholder column injected by
             // PruneHDFSScanColumnRule when every queried column is a partition column).
@@ -660,7 +670,7 @@ void HdfsScannerContext::update_min_max_columns() {
     // into not_existed_slots.  reserved_field_slots are meta/hidden columns whose
     // values are irrelevant to the min/max query result, so filling them with defaults
     // is safe and allows can_use_min_max_optimization() to return true.
-    if (can_use_any_column) {
+    if (options->can_use_any_column) {
         for (SlotDescriptor* slot_desc : reserved_field_slots) {
             update_with_none_existed_slot(slot_desc);
         }
@@ -672,7 +682,7 @@ void HdfsScannerContext::update_min_max_columns() {
 Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
     std::vector<ColumnInfo> updated_columns;
     for (auto& column : materialized_columns) {
-        auto col_name = column.formatted_name(case_sensitive);
+        auto col_name = column.formatted_name(options->case_sensitive);
         if (names.find(col_name) == names.end()) {
             update_with_none_existed_slot(column.slot_desc);
         } else {
@@ -688,12 +698,13 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
 
     ChunkPtr& ck = (*chunk);
 
-    if (use_min_max_opt) {
+    if (options->use_min_max_opt) {
         append_or_update_min_max_column_to_chunk(chunk, row_count);
     }
 
     for (auto* slot_desc : not_existed_slots) {
-        if (use_min_max_opt && scan_range->min_max_values.find(slot_desc->id()) != scan_range->min_max_values.end()) {
+        if (options->use_min_max_opt &&
+            scan_range->min_max_values.find(slot_desc->id()) != scan_range->min_max_values.end()) {
             // handled in min max column
             continue;
         }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -364,8 +364,12 @@ struct HdfsScannerContext {
         const TypeDescriptor& slot_type() const { return slot_desc->type(); }
     };
 
+    // Non-owning pointer to the immutable params that built this context.
+    // Lifetime: _scanner_params outlives _scanner_ctx (both are HdfsScanner members).
+    const HdfsScannerParams* params = nullptr;
+
     std::string formatted_name(const std::string& name) const {
-        return options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
+        return params->options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
     }
 
     std::vector<SlotDescriptor*> slot_descs;
@@ -385,31 +389,9 @@ struct HdfsScannerContext {
 
     Columns extended_values;
 
-    // scan range
-    const THdfsScanRange* scan_range = nullptr;
-    int32_t scan_range_id = -1;
-    bool enable_split_tasks = false;
-    const HdfsSplitContext* split_context = nullptr;
     std::vector<HdfsSplitContextPtr> split_tasks;
     bool has_split_tasks = false;
     size_t estimated_mem_usage_per_split_task = 0;
-
-    // min max slots
-    const TupleDescriptor* min_max_tuple_desc = nullptr;
-
-    // Non-owning pointer shared with HdfsScannerParams.  Provides access to
-    // min_max_ctxs, scanner_ctxs, and all_ctxs without extra copies.
-    // conjunct_ctxs_by_slot below is a per-scanner mutable shallow copy of
-    // conjuncts->by_slot (see update_with_none_existed_slot()).
-    const HdfsScannerConjuncts* conjuncts = nullptr;
-
-    // Non-owning pointer to immutable scan options shared from HdfsScannerParams.
-    const HdfsScannerOptions* options = nullptr;
-
-    // runtime filters.
-    const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
-
-    std::vector<std::string>* hive_column_names = nullptr;
 
     bool is_first_split = false;
     bool can_use_file_record_count = false;
@@ -421,16 +403,9 @@ struct HdfsScannerContext {
 
     std::string timezone;
 
-    const TIcebergSchema* lake_schema = nullptr;
-    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
-
     HdfsScanStats* stats = nullptr;
 
-    std::atomic<int32_t>* lazy_column_coalesce_counter;
-
-    int64_t connector_max_split_size = 0;
-
-    RuntimeScanRangePruner* rf_scan_range_pruner = nullptr;
+    RuntimeScanRangePruner* runtime_filter_scan_range_pruner = nullptr;
 
     bool can_use_count_optimization() const;
 
@@ -468,9 +443,6 @@ struct HdfsScannerContext {
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
-    // default values for materialize_slots that have default value defined.
-    // used when the slot doesn't exist in the data file during scanning.
-    std::unordered_map<SlotId, std::string> materialize_slot_default_values;
     // for iceberg reserved fields
     std::vector<SlotDescriptor*> reserved_field_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
@@ -485,8 +457,6 @@ struct HdfsScannerContext {
     std::unique_ptr<ScanConjunctsManager> conjuncts_manager = nullptr;
     std::vector<std::unique_ptr<ColumnPredicate>> predicate_free_pool;
     PredicateTree predicate_tree;
-
-    ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
 };
 
 struct OpenFileOptions {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -109,8 +109,8 @@ struct HdfsScanStats {
     int64_t group_dict_filter_ns = 0;
     int64_t group_dict_decode_ns = 0;
     // io coalesce
-    int64_t group_active_lazy_coalesce_together = 0;
-    int64_t group_active_lazy_coalesce_seperately = 0;
+    int64_t active_lazy_coalesce_together = 0;
+    int64_t active_lazy_coalesce_seperately = 0;
     // page statistics
     bool has_page_statistics = false;
     // page skip
@@ -118,8 +118,8 @@ struct HdfsScanStats {
     // page index
     int64_t rows_before_page_index = 0;
     int64_t page_index_ns = 0;
-    int64_t parquet_total_row_groups = 0;
-    int64_t parquet_filtered_row_groups = 0;
+    int64_t total_row_groups = 0;
+    int64_t filtered_row_groups = 0;
 
     // late materialize round-by-round
     int64_t group_min_round_cost = 0;
@@ -141,8 +141,6 @@ struct HdfsScanStats {
     int64_t orc_total_tiny_stripe_size = 0;
 
     // io coalesce
-    int64_t orc_stripe_active_lazy_coalesce_together = 0;
-    int64_t orc_stripe_active_lazy_coalesce_seperately = 0;
 
     // Iceberg v2 only!
     int64_t iceberg_delete_file_build_ns = 0;
@@ -153,8 +151,14 @@ struct HdfsScanStats {
     int64_t deletion_vector_build_count = 0;
     int64_t build_rowid_filter_ns = 0;
 
-    // reader filter info
-    OptimizationCounter _optimzation_counter{};
+    // parquet row-group statistics hit tracking
+    int bloom_filter_tried_counter = 0;
+    int bloom_filter_success_counter = 0;
+    int statistics_tried_counter = 0;
+    int statistics_success_counter = 0;
+    int page_index_tried_counter = 0;
+    int page_index_filter_group_counter = 0;
+    int page_index_success_counter = 0;
 };
 
 class HdfsParquetProfile;
@@ -282,24 +286,20 @@ struct TableSpecificData {
 };
 
 struct HdfsScannerParams {
-    // ---- scan-range identity ----
+    // ---- scan-range ----
     const THdfsScanRange* scan_range = nullptr;
     int32_t scan_range_id = -1;
-
-    const HdfsSplitContext* split_context = nullptr;
-
-    // ---- conjuncts & options (non-owning pointers into HiveDataSource) ----
-    const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
-    const HdfsScannerConjuncts* conjuncts = nullptr;
-    const HdfsScannerOptions* options = nullptr;
-
-    // ---- target file ----
     FileSystem* fs = nullptr;
-    std::string path;
+    std::string file_path;
     int64_t file_size = -1;
     std::string table_location;
 
-    const TupleDescriptor* tuple_desc = nullptr;
+    const HdfsSplitContext* split_context = nullptr;
+    const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
+    const HdfsScannerConjuncts* conjuncts = nullptr;
+    const HdfsScannerOptions* options = nullptr;
+    HdfsScanProfile* profile = nullptr;
+    DataCacheOptions datacache_options{};
 
     // ---- materialized columns ----
     std::vector<SlotDescriptor*> materialize_slots;
@@ -318,237 +318,231 @@ struct HdfsScannerParams {
     std::vector<int> index_in_extended_columns;
     std::vector<ExprContext*> extended_col_values;
 
+    const TupleDescriptor* tuple_desc = nullptr;
     const TupleDescriptor* min_max_tuple_desc = nullptr;
-
     std::vector<std::string>* hive_column_names = nullptr;
     std::string avro_schema_json;
-
-    HdfsScanProfile* profile = nullptr;
+    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     // ---- table-format-specific data ----
     TableSpecificData table_specific;
 
-    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
-
-    bool is_lazy_materialization_slot(SlotId slot_id) const;
-
-    DataCacheOptions datacache_options{};
+    // TODO: probably should be removed in later version.
     std::atomic<int32_t>* lazy_column_coalesce_counter;
-
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
 
-    // ---- file-scan state (populated per split, not owned by params) ----
+    bool is_lazy_materialization_slot(SlotId slot_id) const;
+};
 
-    struct HdfsScannerContext {
-        struct ColumnInfo {
-            int idx_in_chunk;
-            SlotDescriptor* slot_desc;
-            bool decode_needed = true;
+struct HdfsScannerContext {
+    struct ColumnInfo {
+        int idx_in_chunk;
+        SlotDescriptor* slot_desc;
+        bool decode_needed = true;
 
-            std::string formatted_name(bool case_sensitive) const {
-                auto n = std::string(name());
-                return case_sensitive ? n : boost::algorithm::to_lower_copy(n);
-            }
-            std::string_view name() const { return slot_desc->col_name(); }
-            int32_t col_unique_id() const { return slot_desc->col_unique_id(); }
-            std::string_view col_physical_name() const { return slot_desc->col_physical_name(); }
-            const SlotId slot_id() const { return slot_desc->id(); }
-            const TypeDescriptor& slot_type() const { return slot_desc->type(); }
-        };
-
-        // Non-owning pointer to the immutable params that built this context.
-        // Lifetime: _scanner_params outlives _scanner_ctx (both are HdfsScanner members).
-        const HdfsScannerParams* params = nullptr;
-
-        std::string formatted_name(const std::string& name) const {
-            return params->options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
+        std::string formatted_name(bool case_sensitive) const {
+            auto n = std::string(name());
+            return case_sensitive ? n : boost::algorithm::to_lower_copy(n);
         }
-
-        std::vector<SlotDescriptor*> slot_descs;
-        std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
-
-        // materialized column read from parquet file
-        std::vector<ColumnInfo> materialized_columns;
-
-        // partition column
-        std::vector<ColumnInfo> partition_columns;
-
-        // partition column value which read from hdfs file path
-        Columns partition_values;
-
-        // extended column
-        std::vector<ColumnInfo> extended_columns;
-
-        Columns extended_values;
-
-        std::vector<HdfsSplitContextPtr> split_tasks;
-        bool has_split_tasks = false;
-        size_t estimated_mem_usage_per_split_task = 0;
-
-        bool is_first_split = false;
-        bool can_use_file_record_count = false;
-
-        // used by short circuit cases:
-        // get_next just returns chunk for once.
-        // and it returns EOF the next time.
-        bool no_more_chunks = false;
-
-        std::string timezone;
-
-        HdfsScanStats* stats = nullptr;
-
-        RuntimeScanRangePruner* runtime_filter_scan_range_pruner = nullptr;
-
-        bool can_use_count_optimization() const;
-
-        bool can_use_min_max_optimization() const;
-
-        // update none_existed_slot
-        // update conjunct
-        void update_with_none_existed_slot(SlotDescriptor* slot);
-
-        void update_return_count_columns();
-        void update_min_max_columns();
-
-        // update materialized column against data file.
-        // and to update not_existed slots and conjuncts.
-        // and to update `conjunct_ctxs_by_slot` field.
-        Status update_materialized_columns(const std::unordered_set<std::string>& names);
-        // "not existed columns" are materialized columns not found in file
-        // this usually happens when use changes schema. for example
-        // user create table with 3 fields A, B, C, and there is one file F1
-        // but user change schema and add one field like D.
-        // when user select(A, B, C, D), then D is the non-existed column in file F1.
-        Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
-
-        // If there is no partition column in the chunk，append partition column to chunk，
-        // otherwise update partition column in chunk
-        void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-        void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-        void append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-        MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot, const TExprMinMaxValue& value,
-                                                     size_t row_count);
-
-        void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-        void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count, const std::vector<ColumnInfo>& columns,
-                                              const Columns& values);
-
-        // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
-        StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
-        std::vector<SlotDescriptor*> not_existed_slots;
-        // for iceberg reserved fields
-        std::vector<SlotDescriptor*> reserved_field_slots;
-        std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
-
-        // other helper functions.
-        bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
-        Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
-
-        void merge_split_tasks();
-
-        // used for parquet zone map filter only
-        std::unique_ptr<ScanConjunctsManager> conjuncts_manager = nullptr;
-        std::vector<std::unique_ptr<ColumnPredicate>> predicate_free_pool;
-        PredicateTree predicate_tree;
+        std::string_view name() const { return slot_desc->col_name(); }
+        int32_t col_unique_id() const { return slot_desc->col_unique_id(); }
+        std::string_view col_physical_name() const { return slot_desc->col_physical_name(); }
+        const SlotId slot_id() const { return slot_desc->id(); }
+        const TypeDescriptor& slot_type() const { return slot_desc->type(); }
     };
 
-    struct OpenFileOptions {
-        FileSystem* fs = nullptr;
-        std::string path;
-        int64_t file_size = -1;
-        HdfsScanStats* fs_stats = nullptr;
-        HdfsScanStats* app_stats = nullptr;
+    // Non-owning pointer to the immutable params that built this context.
+    // Lifetime: _scanner_params outlives _scanner_ctx (both are HdfsScanner members).
+    const HdfsScannerParams* params = nullptr;
 
-        // for datacache
-        DataCacheOptions datacache_options;
+    std::string formatted_name(const std::string& name) const {
+        return params->options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
+    }
 
-        // for compressed text file
-        CompressionTypePB compression_type = CompressionTypePB::NO_COMPRESSION;
-    };
+    std::vector<SlotDescriptor*> slot_descs;
+    std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
 
-    class HdfsScanner {
-    public:
-        HdfsScanner() = default;
-        virtual ~HdfsScanner() = default;
+    // materialized column read from parquet file
+    std::vector<ColumnInfo> materialized_columns;
 
-        Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
-        Status open(RuntimeState* runtime_state);
-        Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
-        void close() noexcept;
+    // partition column
+    std::vector<ColumnInfo> partition_columns;
 
-        int64_t num_bytes_read() const { return _app_stats.bytes_read; }
-        int64_t raw_rows_read() const { return _app_stats.raw_rows_read; }
-        int64_t num_rows_read() const { return _app_stats.rows_read; }
-        int64_t cpu_time_spent() const { return _total_running_time - _app_stats.io_ns; }
-        int64_t io_time_spent() const { return _app_stats.io_ns; }
-        virtual int64_t estimated_mem_usage() const;
-        void update_counter();
+    // partition column value which read from hdfs file path
+    Columns partition_values;
 
-        RuntimeState* runtime_state() { return _runtime_state; }
+    // extended column
+    std::vector<ColumnInfo> extended_columns;
 
-        virtual Status do_open(RuntimeState* runtime_state) = 0;
-        virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
-        virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
-        virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
-        virtual void do_update_counter(HdfsScanProfile* profile);
-        virtual Status reinterpret_status(const Status& st);
+    Columns extended_values;
 
-        // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
-        // readers (lazy materialisation, dict filter, etc.) and do NOT want the base
-        // class to apply them a second time.  All other formats return false so the
-        // base class handles by-slot evaluation uniformly in get_next().
-        virtual bool scanner_handles_predicate_by_slot_internally() const { return false; }
+    std::vector<HdfsSplitContextPtr> split_tasks;
+    bool has_split_tasks = false;
+    size_t estimated_mem_usage_per_split_task = 0;
 
-        // True if the scanner evaluates multi-slot predicates (conjuncts->scanner_ctxs)
-        // internally inside do_get_next(), so the base class must not apply them again.
-        // Scanners that return true MUST guarantee row-level correctness — the ORC
-        // search-argument / Parquet statistics pass is only an approximate skip; the
-        // actual predicate must still be evaluated on every returned row.
-        // Future expression-driven Parquet lazy materialisation will also set this true
-        // once it can interleave predicate evaluation with column loading.
-        virtual bool scanner_handles_multi_slot_conjuncts_internally() const { return false; }
-        void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
-        bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
+    bool is_first_split = false;
+    bool can_use_file_record_count = false;
 
-        static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
-                std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
-                std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
+    // used by short circuit cases:
+    // get_next just returns chunk for once.
+    // and it returns EOF the next time.
+    bool no_more_chunks = false;
 
-    protected:
-        Status open_random_access_file();
-        static CompressionTypePB get_compression_type_from_path(const std::string& filename);
+    std::string timezone;
 
-        void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);
-        void do_update_deletion_vector_build_counter(RuntimeProfile* parent_profile);
-        void do_update_deletion_vector_filter_counter(RuntimeProfile* parent_profile);
+    HdfsScanStats* stats = nullptr;
 
-    private:
-        bool _opened = false;
-        std::atomic<bool> _closed = false;
-        Status _build_scanner_context();
-        void update_hdfs_counter(HdfsScanProfile* profile);
+    RuntimeScanRangePruner* runtime_filter_scan_range_pruner = nullptr;
 
-    protected:
-        HdfsScannerContext _scanner_ctx;
-        HdfsScannerParams _scanner_params;
-        RuntimeState* _runtime_state = nullptr;
-        HdfsScanStats _app_stats;
-        HdfsScanStats _fs_stats;
-        std::unique_ptr<RandomAccessFile> _file;
-        // by default it's no compression.
-        CompressionTypePB _compression_type = CompressionTypePB::NO_COMPRESSION;
-        std::shared_ptr<CacheInputStream> _cache_input_stream = nullptr;
-        std::shared_ptr<SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
-        int64_t _total_running_time = 0;
+    bool can_use_count_optimization() const;
 
-    public:
-        static constexpr const char* ICEBERG_ROW_ID = "_row_id";
-        static constexpr const char* ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER = "_last_updated_sequence_number";
-        static constexpr const char* ICEBERG_ROW_POSITION = "_pos";
-        // Iceberg v3 spec reserved field IDs for row lineage columns.
-        // See: https://iceberg.apache.org/spec/#reserved-field-ids
-        static constexpr int32_t ICEBERG_ROW_ID_COLUMN_ID = 2147483540;
-        static constexpr int32_t ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID = 2147483539;
-    };
+    bool can_use_min_max_optimization() const;
+
+    // update none_existed_slot
+    // update conjunct
+    void update_with_none_existed_slot(SlotDescriptor* slot);
+
+    void update_return_count_columns();
+    void update_min_max_columns();
+
+    // update materialized column against data file.
+    // and to update not_existed slots and conjuncts.
+    // and to update `conjunct_ctxs_by_slot` field.
+    Status update_materialized_columns(const std::unordered_set<std::string>& names);
+    // "not existed columns" are materialized columns not found in file
+    // this usually happens when use changes schema. for example
+    // user create table with 3 fields A, B, C, and there is one file F1
+    // but user change schema and add one field like D.
+    // when user select(A, B, C, D), then D is the non-existed column in file F1.
+    Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+    // If there is no partition column in the chunk，append partition column to chunk，
+    // otherwise update partition column in chunk
+    void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+    void append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+    MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot, const TExprMinMaxValue& value, size_t row_count);
+
+    void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+    void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count, const std::vector<ColumnInfo>& columns,
+                                          const Columns& values);
+
+    // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
+    StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
+    std::vector<SlotDescriptor*> not_existed_slots;
+    // for iceberg reserved fields
+    std::vector<SlotDescriptor*> reserved_field_slots;
+    std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
+
+    // other helper functions.
+    bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
+    Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
+
+    void merge_split_tasks();
+
+    // used for parquet zone map filter only
+    std::unique_ptr<ScanConjunctsManager> conjuncts_manager = nullptr;
+    std::vector<std::unique_ptr<ColumnPredicate>> predicate_free_pool;
+    PredicateTree predicate_tree;
+};
+
+struct OpenFileOptions {
+    FileSystem* fs = nullptr;
+    std::string file_path;
+    int64_t file_size = -1;
+    HdfsScanStats* fs_stats = nullptr;
+    HdfsScanStats* app_stats = nullptr;
+
+    // for datacache
+    DataCacheOptions datacache_options;
+
+    // for compressed text file
+    CompressionTypePB compression_type = CompressionTypePB::NO_COMPRESSION;
+};
+
+class HdfsScanner {
+public:
+    HdfsScanner() = default;
+    virtual ~HdfsScanner() = default;
+
+    Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
+    Status open(RuntimeState* runtime_state);
+    Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
+    void close() noexcept;
+
+    int64_t num_bytes_read() const { return _app_stats.bytes_read; }
+    int64_t raw_rows_read() const { return _app_stats.raw_rows_read; }
+    int64_t num_rows_read() const { return _app_stats.rows_read; }
+    int64_t cpu_time_spent() const { return _total_running_time - _app_stats.io_ns; }
+    int64_t io_time_spent() const { return _app_stats.io_ns; }
+    virtual int64_t estimated_mem_usage() const;
+    void update_counter();
+
+    RuntimeState* runtime_state() { return _runtime_state; }
+
+    virtual Status do_open(RuntimeState* runtime_state) = 0;
+    virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
+    virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
+    virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
+    virtual void do_update_counter(HdfsScanProfile* profile);
+    virtual Status reinterpret_status(const Status& st);
+
+    // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
+    // readers (lazy materialisation, dict filter, etc.) and do NOT want the base
+    // class to apply them a second time.  All other formats return false so the
+    // base class handles by-slot evaluation uniformly in get_next().
+    virtual bool scanner_handles_predicate_by_slot_internally() const { return false; }
+
+    // True if the scanner evaluates multi-slot predicates (conjuncts->scanner_ctxs)
+    // internally inside do_get_next(), so the base class must not apply them again.
+    // Scanners that return true MUST guarantee row-level correctness — the ORC
+    // search-argument / Parquet statistics pass is only an approximate skip; the
+    // actual predicate must still be evaluated on every returned row.
+    // Future expression-driven Parquet lazy materialisation will also set this true
+    // once it can interleave predicate evaluation with column loading.
+    virtual bool scanner_handles_multi_slot_conjuncts_internally() const { return false; }
+    void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
+    bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
+
+    static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
+            std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
+            std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
+
+protected:
+    Status open_random_access_file();
+    static CompressionTypePB get_compression_type_from_path(const std::string& filename);
+
+    void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);
+    void do_update_deletion_vector_build_counter(RuntimeProfile* parent_profile);
+    void do_update_deletion_vector_filter_counter(RuntimeProfile* parent_profile);
+
+private:
+    bool _opened = false;
+    std::atomic<bool> _closed = false;
+    Status _build_scanner_context();
+    void update_hdfs_counter(HdfsScanProfile* profile);
+
+protected:
+    HdfsScannerContext _scanner_ctx;
+    HdfsScannerParams _scanner_params;
+    RuntimeState* _runtime_state = nullptr;
+    HdfsScanStats _app_stats;
+    HdfsScanStats _fs_stats;
+    std::unique_ptr<RandomAccessFile> _file;
+    // by default it's no compression.
+    CompressionTypePB _compression_type = CompressionTypePB::NO_COMPRESSION;
+    std::shared_ptr<CacheInputStream> _cache_input_stream = nullptr;
+    std::shared_ptr<SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
+    int64_t _total_running_time = 0;
+
+public:
+    static constexpr const char* ICEBERG_ROW_ID = "_row_id";
+    static constexpr const char* ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER = "_last_updated_sequence_number";
+    static constexpr const char* ICEBERG_ROW_POSITION = "_pos";
+    // Iceberg v3 spec reserved field IDs for row lineage columns.
+    // See: https://iceberg.apache.org/spec/#reserved-field-ids
+    static constexpr int32_t ICEBERG_ROW_ID_COLUMN_ID = 2147483540;
+    static constexpr int32_t ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID = 2147483539;
+};
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -194,9 +194,9 @@ struct HdfsScannerProfile {
     RuntimeProfile::Counter* fs_io_counter = nullptr;
 };
 
-// Immutable scan options derived from the query plan node.  Owned by
-// HiveDataSource; HdfsScannerParams and HdfsScannerContext hold a non-owning
-// pointer so every option is written exactly once and shared without copying.
+// Immutable scan options derived from the query plan node, embedded by value
+// inside HdfsScannerParams so they are copied together with the rest of the
+// per-scanner params.
 struct HdfsScannerOptions {
     bool case_sensitive = false;
     bool use_min_max_opt = false;
@@ -216,14 +216,14 @@ struct HdfsScannerOptions {
     int64_t connector_max_split_size = 0;
 };
 
-// All conjunct contexts and slot metadata derived from the scan plan node.
-// Owned exclusively by HiveDataSource.  Both HdfsScannerParams and
-// HdfsScannerContext hold a non-owning pointer into this struct so the
-// vectors are allocated only once rather than being copied at each layer.
+// All conjunct contexts and slot metadata derived from the scan plan node,
+// embedded by value inside HdfsScannerParams.  HiveDataSource populates it
+// once; HdfsScannerParams copies it (shallow — ExprContext* pointers are
+// owned by HiveDataSource's ObjectPool) into the scanner.
 //
-// The one exception is HdfsScannerContext::conjunct_ctxs_by_slot, which starts
-// as a shallow copy of by_slot because update_with_none_existed_slot() erases
-// entries from it when a column is absent from the data file.
+// HdfsScannerContext::conjunct_ctxs_by_slot starts as a shallow copy of
+// by_slot because update_with_none_existed_slot() erases entries from it
+// when a column is absent from the data file.
 struct HdfsScannerConjuncts {
     // Clone of (min_max_ctxs ∪ scan conjuncts), used to build the
     // ScanConjunctsManager predicate tree (Parquet row-group statistics, etc.).

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -211,6 +211,64 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* fs_io_counter = nullptr;
 };
 
+// Immutable scan options derived from the query plan node.  Owned by
+// HiveDataSource; HdfsScannerParams and HdfsScannerContext hold a non-owning
+// pointer so every option is written exactly once and shared without copying.
+struct HdfsScannerOptions {
+    bool case_sensitive = false;
+    bool use_min_max_opt = false;
+    // Set by PruneHDFSScanColumnRule when all queried columns are partition columns
+    // and a placeholder materialized column was injected.  Combined with
+    // use_min_max_opt to skip reading the placeholder from the data file.
+    bool can_use_any_column = false;
+    bool use_count_opt = false;
+    bool orc_use_column_names = false;
+    bool parquet_page_index_enable = false;
+    bool parquet_bloom_filter_enable = false;
+    bool use_file_metacache = false;
+    bool use_file_pagecache = false;
+};
+
+// All conjunct contexts and slot metadata derived from the scan plan node.
+// Owned exclusively by HiveDataSource.  Both HdfsScannerParams and
+// HdfsScannerContext hold a non-owning pointer into this struct so the
+// vectors are allocated only once rather than being copied at each layer.
+//
+// The one exception is HdfsScannerContext::conjunct_ctxs_by_slot, which starts
+// as a shallow copy of by_slot because update_with_none_existed_slot() erases
+// entries from it when a column is absent from the data file.
+struct HdfsScannerConjuncts {
+    // Clone of (min_max_ctxs ∪ scan conjuncts), used to build the
+    // ScanConjunctsManager predicate tree (Parquet row-group statistics, etc.).
+    // Lifetime is managed by HiveDataSource's ObjectPool.
+    std::vector<ExprContext*> all_ctxs;
+
+    // Multi-slot predicates (e.g. "a + b > 5") that cannot be pushed into a
+    // single-column reader.  Evaluated in HdfsScanner::get_next() after every
+    // column is materialised.  ORC also folds them into search arguments for
+    // stripe-level skipping, but the post-read pass is still required for
+    // correctness.
+    std::vector<ExprContext*> scanner_ctxs;
+
+    // Single-slot predicates pushed into ORC stripe / Parquet row-group
+    // statistics filtering via min_max_tuple_desc.
+    std::vector<ExprContext*> min_max_ctxs;
+
+    // Single-slot predicates keyed by SlotId.  HdfsScannerContext copies this
+    // map because update_with_none_existed_slot() erases entries when a column
+    // is absent from the data file.
+    std::unordered_map<SlotId, std::vector<ExprContext*>> by_slot;
+
+    // All SlotIds appearing in any conjunct.  Used by
+    // is_lazy_materialization_slot() to decide which columns must be decoded
+    // eagerly.
+    std::unordered_set<SlotId> slots_in_conjunct;
+
+    // Slots appearing in multi-field conjuncts; those slots must be fully
+    // decoded even when they are not output columns.
+    std::unordered_set<SlotId> slots_of_multi_field;
+};
+
 struct HdfsScannerParams {
     // one file split (parition_id, file_path, file_length, offset, length, file_format)
     const THdfsScanRange* scan_range = nullptr;
@@ -223,15 +281,13 @@ struct HdfsScannerParams {
     // runtime bloom filter.
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
 
-    std::vector<ExprContext*> all_conjunct_ctxs;
-    // all conjuncts except `conjunct_ctxs_by_slot`, like compound predicates
-    std::vector<ExprContext*> scanner_conjunct_ctxs;
-    std::unordered_set<SlotId> slots_in_conjunct;
-    // slot used by conjunct_ctxs
-    std::unordered_set<SlotId> slots_of_multi_field_conjunct;
+    // Non-owning pointer to the conjuncts owned by HiveDataSource.
+    // Never null after HiveDataSource::_init_scanner() completes.
+    const HdfsScannerConjuncts* conjuncts = nullptr;
 
-    // conjunct ctxs grouped by slot.
-    std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
+    // Non-owning pointer to scan options owned by HiveDataSource.
+    // Never null after HiveDataSource::_init_scanner() completes.
+    const HdfsScannerOptions* options = nullptr;
 
     // The FileSystem used to open the file to be scanned
     FileSystem* fs = nullptr;
@@ -265,16 +321,10 @@ struct HdfsScannerParams {
     std::vector<int> index_in_extended_columns;
     std::vector<ExprContext*> extended_col_values;
 
-    // min max conjunct for filter row group or page
-    // should clone in scanner
-    std::vector<ExprContext*> min_max_conjunct_ctxs;
-
     const TupleDescriptor* min_max_tuple_desc = nullptr;
 
     std::vector<std::string>* hive_column_names = nullptr;
     std::string avro_schema_json;
-
-    bool case_sensitive = false;
 
     HdfsScanProfile* profile = nullptr;
 
@@ -290,21 +340,7 @@ struct HdfsScannerParams {
     std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file = nullptr;
 
     DataCacheOptions datacache_options{};
-    bool use_file_metacache = false;
-    bool use_file_pagecache = false;
-
     std::atomic<int32_t>* lazy_column_coalesce_counter;
-    bool use_min_max_opt = false;
-    // Mirrors THdfsScanNode.can_use_any_column.  When true, PruneHDFSScanColumnRule
-    // injected a placeholder materialized column because all queried columns were
-    // partition columns.  Used together with use_min_max_opt to skip reading the
-    // placeholder from the data file.
-    bool can_use_any_column = false;
-
-    bool use_count_opt = false;
-    bool orc_use_column_names = false;
-    bool parquet_page_index_enable = false;
-    bool parquet_bloom_filter_enable = false;
 
     int64_t connector_max_split_size = 0;
 
@@ -328,8 +364,8 @@ struct HdfsScannerContext {
         const TypeDescriptor& slot_type() const { return slot_desc->type(); }
     };
 
-    std::string formatted_name(const std::string& name) {
-        return case_sensitive ? name : boost::algorithm::to_lower_copy(name);
+    std::string formatted_name(const std::string& name) const {
+        return options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
     }
 
     std::vector<SlotDescriptor*> slot_descs;
@@ -361,26 +397,20 @@ struct HdfsScannerContext {
     // min max slots
     const TupleDescriptor* min_max_tuple_desc = nullptr;
 
-    // min max conjunct
-    std::vector<ExprContext*> min_max_conjunct_ctxs;
+    // Non-owning pointer shared with HdfsScannerParams.  Provides access to
+    // min_max_ctxs, scanner_ctxs, and all_ctxs without extra copies.
+    // conjunct_ctxs_by_slot below is a per-scanner mutable shallow copy of
+    // conjuncts->by_slot (see update_with_none_existed_slot()).
+    const HdfsScannerConjuncts* conjuncts = nullptr;
+
+    // Non-owning pointer to immutable scan options shared from HdfsScannerParams.
+    const HdfsScannerOptions* options = nullptr;
 
     // runtime filters.
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
 
     std::vector<std::string>* hive_column_names = nullptr;
 
-    bool case_sensitive = false;
-
-    bool orc_use_column_names = false;
-
-    bool use_min_max_opt = false;
-    // Set when can_use_any_column is propagated from the scan node.  In combination
-    // with use_min_max_opt this tells update_min_max_columns() that any materialized
-    // column without a min/max entry is a placeholder and should be filled with a
-    // default value instead of being read from the data file.
-    bool can_use_any_column = false;
-
-    bool use_count_opt = false;
     bool is_first_split = false;
     bool can_use_file_record_count = false;
 
@@ -388,13 +418,6 @@ struct HdfsScannerContext {
     // get_next just returns chunk for once.
     // and it returns EOF the next time.
     bool no_more_chunks = false;
-
-    bool use_file_metacache = false;
-    bool use_file_pagecache = false;
-
-    bool parquet_page_index_enable = false;
-
-    bool parquet_bloom_filter_enable = false;
 
     std::string timezone;
 
@@ -506,6 +529,21 @@ public:
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
     virtual void do_update_counter(HdfsScanProfile* profile);
     virtual Status reinterpret_status(const Status& st);
+
+    // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
+    // readers (lazy materialisation, dict filter, etc.) and do NOT want the base
+    // class to apply them a second time.  All other formats return false so the
+    // base class handles by-slot evaluation uniformly in get_next().
+    virtual bool scanner_handles_predicate_by_slot_internally() const { return false; }
+
+    // True if the scanner evaluates multi-slot predicates (conjuncts->scanner_ctxs)
+    // internally inside do_get_next(), so the base class must not apply them again.
+    // Scanners that return true MUST guarantee row-level correctness — the ORC
+    // search-argument / Parquet statistics pass is only an approximate skip; the
+    // actual predicate must still be evaluated on every returned row.
+    // Future expression-driven Parquet lazy materialisation will also set this true
+    // once it can interleave predicate evaluation with column loading.
+    virtual bool scanner_handles_multi_slot_conjuncts_internally() const { return false; }
     void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
     bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -51,25 +51,6 @@ struct SkipRowsContext {
 };
 using SkipRowsContextPtr = std::shared_ptr<SkipRowsContext>;
 
-struct OptimizationCounter {
-    int bloom_filter_tried_counter = 0;
-    int bloom_filter_success_counter = 0;
-    int statistics_tried_counter = 0;
-    int statistics_success_counter = 0;
-    int page_index_tried_counter = 0;
-    int page_index_filter_group_counter = 0;
-    int page_index_success_counter = 0;
-    OptimizationCounter& operator+=(const OptimizationCounter& counter) {
-        bloom_filter_tried_counter += counter.bloom_filter_tried_counter;
-        bloom_filter_success_counter += counter.bloom_filter_success_counter;
-        statistics_tried_counter += counter.statistics_tried_counter;
-        statistics_success_counter += counter.statistics_success_counter;
-        page_index_tried_counter += counter.page_index_tried_counter;
-        page_index_filter_group_counter += counter.page_index_filter_group_counter;
-        page_index_success_counter += counter.page_index_success_counter;
-        return *this;
-    }
-};
 struct HdfsScanStats {
     int64_t raw_rows_read = 0;
     int64_t rows_read = 0;
@@ -161,9 +142,7 @@ struct HdfsScanStats {
     int page_index_success_counter = 0;
 };
 
-class HdfsParquetProfile;
-
-struct HdfsScanProfile {
+struct HdfsScannerProfile {
     RuntimeProfile* runtime_profile = nullptr;
     RuntimeProfile::Counter* raw_rows_read_counter = nullptr;
     RuntimeProfile::Counter* rows_read_counter = nullptr;
@@ -296,9 +275,9 @@ struct HdfsScannerParams {
 
     const HdfsSplitContext* split_context = nullptr;
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
-    const HdfsScannerConjuncts* conjuncts = nullptr;
-    const HdfsScannerOptions* options = nullptr;
-    HdfsScanProfile* profile = nullptr;
+    HdfsScannerConjuncts conjuncts;
+    HdfsScannerOptions options;
+    HdfsScannerProfile profile;
     DataCacheOptions datacache_options{};
 
     // ---- materialized columns ----
@@ -356,7 +335,7 @@ struct HdfsScannerContext {
     const HdfsScannerParams* params = nullptr;
 
     std::string formatted_name(const std::string& name) const {
-        return params->options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
+        return params->options.case_sensitive ? name : boost::algorithm::to_lower_copy(name);
     }
 
     std::vector<SlotDescriptor*> slot_descs;
@@ -484,7 +463,7 @@ public:
     virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
     virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
-    virtual void do_update_counter(HdfsScanProfile* profile);
+    virtual void do_update_counter(HdfsScannerProfile* profile);
     virtual Status reinterpret_status(const Status& st);
 
     // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
@@ -520,7 +499,7 @@ private:
     bool _opened = false;
     std::atomic<bool> _closed = false;
     Status _build_scanner_context();
-    void update_hdfs_counter(HdfsScanProfile* profile);
+    void update_hdfs_counter(HdfsScannerProfile* profile);
 
 protected:
     HdfsScannerContext _scanner_ctx;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -227,6 +227,10 @@ struct HdfsScannerOptions {
     bool parquet_bloom_filter_enable = false;
     bool use_file_metacache = false;
     bool use_file_pagecache = false;
+    bool enable_split_tasks = false;
+    bool enable_dynamic_prune_scan_range = true;
+    bool use_partition_column_value_only = false;
+    int64_t connector_max_split_size = 0;
 };
 
 // All conjunct contexts and slot metadata derived from the scan plan node.
@@ -269,53 +273,46 @@ struct HdfsScannerConjuncts {
     std::unordered_set<SlotId> slots_of_multi_field;
 };
 
+// Table-format-specific state carried through the scan pipeline.
+struct TableSpecificData {
+    std::vector<const TIcebergDeleteFile*> iceberg_delete_files;
+    std::shared_ptr<TDeletionVectorDescriptor> deletion_vector_descriptor;
+    const TIcebergSchema* iceberg_schema = nullptr;
+    std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file;
+};
+
 struct HdfsScannerParams {
-    // one file split (parition_id, file_path, file_length, offset, length, file_format)
+    // ---- scan-range identity ----
     const THdfsScanRange* scan_range = nullptr;
-    // only used in global late materialization
     int32_t scan_range_id = -1;
 
-    bool enable_split_tasks = false;
     const HdfsSplitContext* split_context = nullptr;
 
-    // runtime bloom filter.
+    // ---- conjuncts & options (non-owning pointers into HiveDataSource) ----
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
-
-    // Non-owning pointer to the conjuncts owned by HiveDataSource.
-    // Never null after HiveDataSource::_init_scanner() completes.
     const HdfsScannerConjuncts* conjuncts = nullptr;
-
-    // Non-owning pointer to scan options owned by HiveDataSource.
-    // Never null after HiveDataSource::_init_scanner() completes.
     const HdfsScannerOptions* options = nullptr;
 
-    // The FileSystem used to open the file to be scanned
+    // ---- target file ----
     FileSystem* fs = nullptr;
-    // The file to scan
     std::string path;
-    // The file size. -1 means unknown.
     int64_t file_size = -1;
-    // the table location
     std::string table_location;
 
     const TupleDescriptor* tuple_desc = nullptr;
 
-    // columns read from file
+    // ---- materialized columns ----
     std::vector<SlotDescriptor*> materialize_slots;
     std::vector<int> materialize_index_in_chunk;
-    // default values for materialize_slots that have default value defined.
-    // used when the slot doesn't exist in the data file during scanning.
     std::unordered_map<SlotId, std::string> materialize_slot_default_values;
 
-    // columns of partition info
+    // ---- partition columns ----
     std::vector<SlotDescriptor*> partition_slots;
     std::vector<int> partition_index_in_chunk;
-    // partition index in hdfs partition columns.
     std::vector<int> _partition_index_in_hdfs_partition_columns;
-
-    // partition conjunct, used to generate partition columns
     std::vector<ExprContext*> partition_values;
 
+    // ---- extended columns (iceberg data_seq_num etc.) ----
     std::vector<SlotDescriptor*> extended_col_slots;
     std::vector<int> extended_col_index_in_chunk;
     std::vector<int> index_in_extended_columns;
@@ -328,234 +325,230 @@ struct HdfsScannerParams {
 
     HdfsScanProfile* profile = nullptr;
 
-    std::vector<const TIcebergDeleteFile*> deletes;
+    // ---- table-format-specific data ----
+    TableSpecificData table_specific;
 
-    std::shared_ptr<TDeletionVectorDescriptor> deletion_vector_descriptor = nullptr;
-
-    const TIcebergSchema* lake_schema = nullptr;
     const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     bool is_lazy_materialization_slot(SlotId slot_id) const;
 
-    std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file = nullptr;
-
     DataCacheOptions datacache_options{};
     std::atomic<int32_t>* lazy_column_coalesce_counter;
 
-    int64_t connector_max_split_size = 0;
-
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
-};
 
-struct HdfsScannerContext {
-    struct ColumnInfo {
-        int idx_in_chunk;
-        SlotDescriptor* slot_desc;
-        bool decode_needed = true;
+    // ---- file-scan state (populated per split, not owned by params) ----
 
-        std::string formatted_name(bool case_sensitive) const {
-            auto n = std::string(name());
-            return case_sensitive ? n : boost::algorithm::to_lower_copy(n);
+    struct HdfsScannerContext {
+        struct ColumnInfo {
+            int idx_in_chunk;
+            SlotDescriptor* slot_desc;
+            bool decode_needed = true;
+
+            std::string formatted_name(bool case_sensitive) const {
+                auto n = std::string(name());
+                return case_sensitive ? n : boost::algorithm::to_lower_copy(n);
+            }
+            std::string_view name() const { return slot_desc->col_name(); }
+            int32_t col_unique_id() const { return slot_desc->col_unique_id(); }
+            std::string_view col_physical_name() const { return slot_desc->col_physical_name(); }
+            const SlotId slot_id() const { return slot_desc->id(); }
+            const TypeDescriptor& slot_type() const { return slot_desc->type(); }
+        };
+
+        // Non-owning pointer to the immutable params that built this context.
+        // Lifetime: _scanner_params outlives _scanner_ctx (both are HdfsScanner members).
+        const HdfsScannerParams* params = nullptr;
+
+        std::string formatted_name(const std::string& name) const {
+            return params->options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
         }
-        std::string_view name() const { return slot_desc->col_name(); }
-        int32_t col_unique_id() const { return slot_desc->col_unique_id(); }
-        std::string_view col_physical_name() const { return slot_desc->col_physical_name(); }
-        const SlotId slot_id() const { return slot_desc->id(); }
-        const TypeDescriptor& slot_type() const { return slot_desc->type(); }
+
+        std::vector<SlotDescriptor*> slot_descs;
+        std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
+
+        // materialized column read from parquet file
+        std::vector<ColumnInfo> materialized_columns;
+
+        // partition column
+        std::vector<ColumnInfo> partition_columns;
+
+        // partition column value which read from hdfs file path
+        Columns partition_values;
+
+        // extended column
+        std::vector<ColumnInfo> extended_columns;
+
+        Columns extended_values;
+
+        std::vector<HdfsSplitContextPtr> split_tasks;
+        bool has_split_tasks = false;
+        size_t estimated_mem_usage_per_split_task = 0;
+
+        bool is_first_split = false;
+        bool can_use_file_record_count = false;
+
+        // used by short circuit cases:
+        // get_next just returns chunk for once.
+        // and it returns EOF the next time.
+        bool no_more_chunks = false;
+
+        std::string timezone;
+
+        HdfsScanStats* stats = nullptr;
+
+        RuntimeScanRangePruner* runtime_filter_scan_range_pruner = nullptr;
+
+        bool can_use_count_optimization() const;
+
+        bool can_use_min_max_optimization() const;
+
+        // update none_existed_slot
+        // update conjunct
+        void update_with_none_existed_slot(SlotDescriptor* slot);
+
+        void update_return_count_columns();
+        void update_min_max_columns();
+
+        // update materialized column against data file.
+        // and to update not_existed slots and conjuncts.
+        // and to update `conjunct_ctxs_by_slot` field.
+        Status update_materialized_columns(const std::unordered_set<std::string>& names);
+        // "not existed columns" are materialized columns not found in file
+        // this usually happens when use changes schema. for example
+        // user create table with 3 fields A, B, C, and there is one file F1
+        // but user change schema and add one field like D.
+        // when user select(A, B, C, D), then D is the non-existed column in file F1.
+        Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+        // If there is no partition column in the chunk，append partition column to chunk，
+        // otherwise update partition column in chunk
+        void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+        void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+        void append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+        MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot, const TExprMinMaxValue& value,
+                                                     size_t row_count);
+
+        void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+        void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count, const std::vector<ColumnInfo>& columns,
+                                              const Columns& values);
+
+        // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
+        StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
+        std::vector<SlotDescriptor*> not_existed_slots;
+        // for iceberg reserved fields
+        std::vector<SlotDescriptor*> reserved_field_slots;
+        std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
+
+        // other helper functions.
+        bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
+        Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
+
+        void merge_split_tasks();
+
+        // used for parquet zone map filter only
+        std::unique_ptr<ScanConjunctsManager> conjuncts_manager = nullptr;
+        std::vector<std::unique_ptr<ColumnPredicate>> predicate_free_pool;
+        PredicateTree predicate_tree;
     };
 
-    // Non-owning pointer to the immutable params that built this context.
-    // Lifetime: _scanner_params outlives _scanner_ctx (both are HdfsScanner members).
-    const HdfsScannerParams* params = nullptr;
+    struct OpenFileOptions {
+        FileSystem* fs = nullptr;
+        std::string path;
+        int64_t file_size = -1;
+        HdfsScanStats* fs_stats = nullptr;
+        HdfsScanStats* app_stats = nullptr;
 
-    std::string formatted_name(const std::string& name) const {
-        return params->options->case_sensitive ? name : boost::algorithm::to_lower_copy(name);
-    }
+        // for datacache
+        DataCacheOptions datacache_options;
 
-    std::vector<SlotDescriptor*> slot_descs;
-    std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
+        // for compressed text file
+        CompressionTypePB compression_type = CompressionTypePB::NO_COMPRESSION;
+    };
 
-    // materialized column read from parquet file
-    std::vector<ColumnInfo> materialized_columns;
+    class HdfsScanner {
+    public:
+        HdfsScanner() = default;
+        virtual ~HdfsScanner() = default;
 
-    // partition column
-    std::vector<ColumnInfo> partition_columns;
+        Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
+        Status open(RuntimeState* runtime_state);
+        Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
+        void close() noexcept;
 
-    // partition column value which read from hdfs file path
-    Columns partition_values;
+        int64_t num_bytes_read() const { return _app_stats.bytes_read; }
+        int64_t raw_rows_read() const { return _app_stats.raw_rows_read; }
+        int64_t num_rows_read() const { return _app_stats.rows_read; }
+        int64_t cpu_time_spent() const { return _total_running_time - _app_stats.io_ns; }
+        int64_t io_time_spent() const { return _app_stats.io_ns; }
+        virtual int64_t estimated_mem_usage() const;
+        void update_counter();
 
-    // extended column
-    std::vector<ColumnInfo> extended_columns;
+        RuntimeState* runtime_state() { return _runtime_state; }
 
-    Columns extended_values;
+        virtual Status do_open(RuntimeState* runtime_state) = 0;
+        virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
+        virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
+        virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
+        virtual void do_update_counter(HdfsScanProfile* profile);
+        virtual Status reinterpret_status(const Status& st);
 
-    std::vector<HdfsSplitContextPtr> split_tasks;
-    bool has_split_tasks = false;
-    size_t estimated_mem_usage_per_split_task = 0;
+        // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
+        // readers (lazy materialisation, dict filter, etc.) and do NOT want the base
+        // class to apply them a second time.  All other formats return false so the
+        // base class handles by-slot evaluation uniformly in get_next().
+        virtual bool scanner_handles_predicate_by_slot_internally() const { return false; }
 
-    bool is_first_split = false;
-    bool can_use_file_record_count = false;
+        // True if the scanner evaluates multi-slot predicates (conjuncts->scanner_ctxs)
+        // internally inside do_get_next(), so the base class must not apply them again.
+        // Scanners that return true MUST guarantee row-level correctness — the ORC
+        // search-argument / Parquet statistics pass is only an approximate skip; the
+        // actual predicate must still be evaluated on every returned row.
+        // Future expression-driven Parquet lazy materialisation will also set this true
+        // once it can interleave predicate evaluation with column loading.
+        virtual bool scanner_handles_multi_slot_conjuncts_internally() const { return false; }
+        void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
+        bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
 
-    // used by short circuit cases:
-    // get_next just returns chunk for once.
-    // and it returns EOF the next time.
-    bool no_more_chunks = false;
+        static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
+                std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
+                std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
 
-    std::string timezone;
+    protected:
+        Status open_random_access_file();
+        static CompressionTypePB get_compression_type_from_path(const std::string& filename);
 
-    HdfsScanStats* stats = nullptr;
+        void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);
+        void do_update_deletion_vector_build_counter(RuntimeProfile* parent_profile);
+        void do_update_deletion_vector_filter_counter(RuntimeProfile* parent_profile);
 
-    RuntimeScanRangePruner* runtime_filter_scan_range_pruner = nullptr;
+    private:
+        bool _opened = false;
+        std::atomic<bool> _closed = false;
+        Status _build_scanner_context();
+        void update_hdfs_counter(HdfsScanProfile* profile);
 
-    bool can_use_count_optimization() const;
+    protected:
+        HdfsScannerContext _scanner_ctx;
+        HdfsScannerParams _scanner_params;
+        RuntimeState* _runtime_state = nullptr;
+        HdfsScanStats _app_stats;
+        HdfsScanStats _fs_stats;
+        std::unique_ptr<RandomAccessFile> _file;
+        // by default it's no compression.
+        CompressionTypePB _compression_type = CompressionTypePB::NO_COMPRESSION;
+        std::shared_ptr<CacheInputStream> _cache_input_stream = nullptr;
+        std::shared_ptr<SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
+        int64_t _total_running_time = 0;
 
-    bool can_use_min_max_optimization() const;
-
-    // update none_existed_slot
-    // update conjunct
-    void update_with_none_existed_slot(SlotDescriptor* slot);
-
-    void update_return_count_columns();
-    void update_min_max_columns();
-
-    // update materialized column against data file.
-    // and to update not_existed slots and conjuncts.
-    // and to update `conjunct_ctxs_by_slot` field.
-    Status update_materialized_columns(const std::unordered_set<std::string>& names);
-    // "not existed columns" are materialized columns not found in file
-    // this usually happens when use changes schema. for example
-    // user create table with 3 fields A, B, C, and there is one file F1
-    // but user change schema and add one field like D.
-    // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
-
-    // If there is no partition column in the chunk，append partition column to chunk，
-    // otherwise update partition column in chunk
-    void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    void append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot, const TExprMinMaxValue& value, size_t row_count);
-
-    void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count, const std::vector<ColumnInfo>& columns,
-                                          const Columns& values);
-
-    // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
-    StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
-    std::vector<SlotDescriptor*> not_existed_slots;
-    // for iceberg reserved fields
-    std::vector<SlotDescriptor*> reserved_field_slots;
-    std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
-
-    // other helper functions.
-    bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
-    Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
-
-    void merge_split_tasks();
-
-    // used for parquet zone map filter only
-    std::unique_ptr<ScanConjunctsManager> conjuncts_manager = nullptr;
-    std::vector<std::unique_ptr<ColumnPredicate>> predicate_free_pool;
-    PredicateTree predicate_tree;
-};
-
-struct OpenFileOptions {
-    FileSystem* fs = nullptr;
-    std::string path;
-    int64_t file_size = -1;
-    HdfsScanStats* fs_stats = nullptr;
-    HdfsScanStats* app_stats = nullptr;
-
-    // for datacache
-    DataCacheOptions datacache_options;
-
-    // for compressed text file
-    CompressionTypePB compression_type = CompressionTypePB::NO_COMPRESSION;
-};
-
-class HdfsScanner {
-public:
-    HdfsScanner() = default;
-    virtual ~HdfsScanner() = default;
-
-    Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
-    Status open(RuntimeState* runtime_state);
-    Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
-    void close() noexcept;
-
-    int64_t num_bytes_read() const { return _app_stats.bytes_read; }
-    int64_t raw_rows_read() const { return _app_stats.raw_rows_read; }
-    int64_t num_rows_read() const { return _app_stats.rows_read; }
-    int64_t cpu_time_spent() const { return _total_running_time - _app_stats.io_ns; }
-    int64_t io_time_spent() const { return _app_stats.io_ns; }
-    virtual int64_t estimated_mem_usage() const;
-    void update_counter();
-
-    RuntimeState* runtime_state() { return _runtime_state; }
-
-    virtual Status do_open(RuntimeState* runtime_state) = 0;
-    virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
-    virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
-    virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
-    virtual void do_update_counter(HdfsScanProfile* profile);
-    virtual Status reinterpret_status(const Status& st);
-
-    // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
-    // readers (lazy materialisation, dict filter, etc.) and do NOT want the base
-    // class to apply them a second time.  All other formats return false so the
-    // base class handles by-slot evaluation uniformly in get_next().
-    virtual bool scanner_handles_predicate_by_slot_internally() const { return false; }
-
-    // True if the scanner evaluates multi-slot predicates (conjuncts->scanner_ctxs)
-    // internally inside do_get_next(), so the base class must not apply them again.
-    // Scanners that return true MUST guarantee row-level correctness — the ORC
-    // search-argument / Parquet statistics pass is only an approximate skip; the
-    // actual predicate must still be evaluated on every returned row.
-    // Future expression-driven Parquet lazy materialisation will also set this true
-    // once it can interleave predicate evaluation with column loading.
-    virtual bool scanner_handles_multi_slot_conjuncts_internally() const { return false; }
-    void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
-    bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
-
-    static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
-            std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
-            std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
-
-protected:
-    Status open_random_access_file();
-    static CompressionTypePB get_compression_type_from_path(const std::string& filename);
-
-    void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);
-    void do_update_deletion_vector_build_counter(RuntimeProfile* parent_profile);
-    void do_update_deletion_vector_filter_counter(RuntimeProfile* parent_profile);
-
-private:
-    bool _opened = false;
-    std::atomic<bool> _closed = false;
-    Status _build_scanner_context();
-    void update_hdfs_counter(HdfsScanProfile* profile);
-
-protected:
-    HdfsScannerContext _scanner_ctx;
-    HdfsScannerParams _scanner_params;
-    RuntimeState* _runtime_state = nullptr;
-    HdfsScanStats _app_stats;
-    HdfsScanStats _fs_stats;
-    std::unique_ptr<RandomAccessFile> _file;
-    // by default it's no compression.
-    CompressionTypePB _compression_type = CompressionTypePB::NO_COMPRESSION;
-    std::shared_ptr<CacheInputStream> _cache_input_stream = nullptr;
-    std::shared_ptr<SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
-    int64_t _total_running_time = 0;
-
-public:
-    static constexpr const char* ICEBERG_ROW_ID = "_row_id";
-    static constexpr const char* ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER = "_last_updated_sequence_number";
-    static constexpr const char* ICEBERG_ROW_POSITION = "_pos";
-    // Iceberg v3 spec reserved field IDs for row lineage columns.
-    // See: https://iceberg.apache.org/spec/#reserved-field-ids
-    static constexpr int32_t ICEBERG_ROW_ID_COLUMN_ID = 2147483540;
-    static constexpr int32_t ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID = 2147483539;
-};
+    public:
+        static constexpr const char* ICEBERG_ROW_ID = "_row_id";
+        static constexpr const char* ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER = "_last_updated_sequence_number";
+        static constexpr const char* ICEBERG_ROW_POSITION = "_pos";
+        // Iceberg v3 spec reserved field IDs for row lineage columns.
+        // See: https://iceberg.apache.org/spec/#reserved-field-ids
+        static constexpr int32_t ICEBERG_ROW_ID_COLUMN_ID = 2147483540;
+        static constexpr int32_t ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID = 2147483539;
+    };
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
@@ -72,7 +72,7 @@ Status HdfsAvroScanner::do_open(RuntimeState* state) {
 
     _avro_reader = std::make_unique<AvroReader>();
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
-    return _avro_reader->init(std::move(input_stream), _scanner_params.path, state, &_scanner_counter,
+    return _avro_reader->init(std::move(input_stream), _scanner_params.file_path, state, &_scanner_counter,
                               &_materialize_slot_descs, &_column_readers,
                               /*col_not_found_as_null=*/true, _file.get(), config::avro_reader_buffer_size_bytes,
                               split_offset, split_length, _scanner_params.avro_schema_json,

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
@@ -21,7 +21,6 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "common/config_scan_io_fwd.h"
-#include "exprs/chunk_predicate_evaluator.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
@@ -128,14 +127,7 @@ Status HdfsAvroScanner::do_get_next(RuntimeState* state, ChunkPtr* chunk) {
     _scanner_ctx.append_or_update_partition_column_to_chunk(&ck, row_count);
     _scanner_ctx.append_or_update_extended_column_to_chunk(&ck, row_count);
 
-    // Post-read row-level conjunct evaluation (Avro has no block statistics for pushdown).
-    for (auto& it : _scanner_ctx.conjunct_ctxs_by_slot) {
-        SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(it.second, ck.get()));
-        if (ck->num_rows() == 0) {
-            break;
-        }
-    }
+    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
 
     // Note: _app_stats.rows_read is updated by the base class HdfsScanner::get_next
     // after do_get_next returns. Do NOT update it here to avoid double-counting.

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
@@ -134,7 +134,7 @@ Status HdfsAvroScanner::do_get_next(RuntimeState* state, ChunkPtr* chunk) {
     return Status::OK();
 }
 
-void HdfsAvroScanner::do_update_counter(HdfsScanProfile* profile) {
+void HdfsAvroScanner::do_update_counter(HdfsScannerProfile* profile) {
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kAvroProfileSectionPrefix, TUnit::NONE);
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.h
@@ -38,7 +38,7 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    void do_update_counter(HdfsScanProfile* profile) override;
+    void do_update_counter(HdfsScannerProfile* profile) override;
 
 private:
     void _materialize_nullable_columns(ChunkPtr& chunk);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
@@ -16,7 +16,6 @@
 
 #include "base/compression/compression_utils.h"
 #include "common/simdjson_util.h"
-#include "exprs/chunk_predicate_evaluator.h"
 #include "formats/avro/nullable_column.h"
 #include "formats/json/json_utils.h"
 #include "formats/json/nullable_column.h"
@@ -222,13 +221,7 @@ Status HdfsJsonScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
         RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
         _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);
 
-        for (auto& [_, ctxs] : _scanner_ctx.conjunct_ctxs_by_slot) {
-            SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-            RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(ctxs, chunk->get()));
-            if ((*chunk)->num_rows() == 0) {
-                break;
-            }
-        }
+        // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
     }
 
     return st;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
@@ -235,7 +235,7 @@ Status HdfsJsonScanner::_setup_compression_type(const TTextFileDesc& text_file_d
         compression_type = CompressionUtils::to_compression_pb(text_file_desc.compression_type);
     } else {
         // if FE does not specify a compress type, we choose it by looking at the filename.
-        compression_type = get_compression_type_from_path(_scanner_params.path);
+        compression_type = get_compression_type_from_path(_scanner_params.file_path);
     }
     if (compression_type != UNKNOWN_COMPRESSION) {
         _compression_type = compression_type;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -100,7 +100,8 @@ bool OrcRowReaderFilter::filterOnOpeningStripe(uint64_t stripeIndex,
     _current_stripe_index = stripeIndex;
     uint64_t offset = stripeInformation->offset();
 
-    const auto* scan_range = _scanner_ctx.params->scan_range size_t scan_start = scan_range->offset;
+    const auto* scan_range = _scanner_ctx.params->scan_range;
+    size_t scan_start = scan_range->offset;
     size_t scan_end = scan_range->length + scan_start;
 
     if (offset >= scan_start && offset < scan_end) {
@@ -112,8 +113,8 @@ bool OrcRowReaderFilter::filterOnOpeningStripe(uint64_t stripeIndex,
 bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
                                       const std::unordered_map<uint64_t, orc::proto::RowIndex>& rowIndexes,
                                       const std::map<uint32_t, orc::BloomFilterIndex>& bloomFilter) {
-    const TupleDescriptor* min_max_tuple_desc = _scanner_ctx.params->min_max_tuple_desc ChunkPtr min_chunk =
-            RuntimeChunkHelper::new_chunk(*min_max_tuple_desc, 0);
+    const TupleDescriptor* min_max_tuple_desc = _scanner_ctx.params->min_max_tuple_desc;
+    ChunkPtr min_chunk = RuntimeChunkHelper::new_chunk(*min_max_tuple_desc, 0);
     ChunkPtr max_chunk = RuntimeChunkHelper::new_chunk(*min_max_tuple_desc, 0);
     for (size_t i = 0; i < min_max_tuple_desc->slots().size(); i++) {
         SlotDescriptor* slot = min_max_tuple_desc->slots()[i];
@@ -356,7 +357,8 @@ Status HdfsOrcScanner::build_stripes(orc::Reader* reader, std::vector<DiskRange>
     uint64_t stripe_number = reader->getNumberOfStripes();
     std::vector<DiskRange> stripe_disk_ranges{};
 
-    const auto* scan_range = _scanner_ctx.params->scan_range size_t scan_start = scan_range->offset;
+    const auto* scan_range = _scanner_ctx.params->scan_range;
+    size_t scan_start = scan_range->offset;
     size_t scan_end = scan_range->length + scan_start;
 
     for (uint64_t idx = 0; idx < stripe_number; idx++) {
@@ -782,9 +784,8 @@ void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* stripe_active_lazy_coalesce_seperately_counter = root_profile->add_child_counter(
             "StripeActiveLazyColumnIOCoalesceSeperately", TUnit::UNIT,
             RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM), orcProfileSectionPrefix);
-    COUNTER_UPDATE(stripe_active_lazy_coalesce_together_counter, _app_stats.orc_stripe_active_lazy_coalesce_together);
-    COUNTER_UPDATE(stripe_active_lazy_coalesce_seperately_counter,
-                   _app_stats.orc_stripe_active_lazy_coalesce_seperately);
+    COUNTER_UPDATE(stripe_active_lazy_coalesce_together_counter, _app_stats.active_lazy_coalesce_together);
+    COUNTER_UPDATE(stripe_active_lazy_coalesce_seperately_counter, _app_stats.active_lazy_coalesce_seperately);
 
     if (_orc_reader != nullptr) {
         // _orc_reader is nullptr for split task

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -578,11 +578,14 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         ASSIGN_OR_RETURN(rows_read, _do_get_next(chunk));
     }
 
-    // Evaluate multi-slot predicates (e.g. "a + b > 5") here, after all data
-    // columns — including lazy-loaded ones — are present in the chunk.
-    // Must happen before partition/extended columns are appended, as scanner_ctxs
-    // only reference data file columns.
-    // Note: ORC already folded these into search arguments during do_open() for
+    _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);
+    _scanner_ctx.append_or_update_extended_column_to_chunk(chunk, rows_read);
+
+    DCHECK_EQ(rows_read, chunk->get()->num_rows());
+
+    // Evaluate multi-slot predicates (e.g. "a + b > 5") after all columns —
+    // including partition and extended columns — are present in the chunk.
+    // ORC already folded these into search arguments during do_open() for
     // stripe-level skipping, but that is an approximate optimisation only; this
     // row-level pass is still required for correctness.
     if (rows_read > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
@@ -590,12 +593,6 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
         rows_read = (*chunk)->num_rows();
     }
-
-    _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);
-    _scanner_ctx.append_or_update_extended_column_to_chunk(chunk, rows_read);
-
-    // check after partition/extended column added
-    DCHECK_EQ(rows_read, chunk->get()->num_rows());
 
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -402,7 +402,8 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
 Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     std::unordered_set<std::string> known_column_names;
     OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
-                                          _scanner_ctx.options->case_sensitive, _scanner_ctx.options->orc_use_column_names);
+                                          _scanner_ctx.options->case_sensitive,
+                                          _scanner_ctx.options->orc_use_column_names);
     RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
     ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
     if (skip) {
@@ -587,8 +588,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
     // row-level pass is still required for correctness.
     if (rows_read > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(
-                ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
         rows_read = (*chunk)->num_rows();
     }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -88,7 +88,7 @@ OrcRowReaderFilter::OrcRowReaderFilter(const HdfsScannerContext& scanner_ctx, Or
         : _scanner_ctx(scanner_ctx), _reader(reader), _writer_tzoffset_in_seconds(reader->tzoffset_in_seconds()) {
     if (_scanner_ctx.min_max_tuple_desc != nullptr) {
         VLOG_FILE << "OrcRowReaderFilter: min_max_tuple_desc = " << _scanner_ctx.min_max_tuple_desc->debug_string();
-        for (ExprContext* ctx : _scanner_ctx.min_max_conjunct_ctxs) {
+        for (ExprContext* ctx : _scanner_ctx.conjuncts->min_max_ctxs) {
             VLOG_FILE << "OrcRowReaderFilter: min_max_ctx = " << ctx->root()->debug_string();
         }
     }
@@ -170,7 +170,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
 
     VLOG_FILE << "stripe = " << _current_stripe_index << ", row_group = " << rowGroupIdx
               << ", min_chunk = " << min_chunk->debug_row(0) << ", max_chunk = " << max_chunk->debug_row(0);
-    for (auto& min_max_conjunct_ctx : _scanner_ctx.min_max_conjunct_ctxs) {
+    for (auto& min_max_conjunct_ctx : _scanner_ctx.conjuncts->min_max_ctxs) {
         // TODO: add a warning log here
         auto min_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), min_chunk.get());
         auto max_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), max_chunk.get());
@@ -402,7 +402,7 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
 Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     std::unordered_set<std::string> known_column_names;
     OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
-                                          _scanner_ctx.case_sensitive, _scanner_ctx.orc_use_column_names);
+                                          _scanner_ctx.options->case_sensitive, _scanner_ctx.options->orc_use_column_names);
     RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
     ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
     if (skip) {
@@ -413,7 +413,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 
     int src_slot_index = 0;
     for (const auto& column : _scanner_ctx.materialized_columns) {
-        auto col_name = Utils::format_name(column.name(), _scanner_ctx.case_sensitive);
+        auto col_name = Utils::format_name(column.name(), _scanner_ctx.options->case_sensitive);
         if (known_column_names.find(col_name) == known_column_names.end()) continue;
         bool is_lazy_slot = _scanner_params.is_lazy_materialization_slot(column.slot_id());
         if (is_lazy_slot) {
@@ -431,8 +431,8 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
         // put materialized columns' conjunctions into _eval_conjunct_ctxs_by_materialized_slot
         // for example, partition column's conjunctions will not put into _eval_conjunct_ctxs_by_materialized_slot
         {
-            auto it = _scanner_params.conjunct_ctxs_by_slot.find(column.slot_id());
-            if (it != _scanner_params.conjunct_ctxs_by_slot.end()) {
+            auto it = _scanner_params.conjuncts->by_slot.find(column.slot_id());
+            if (it != _scanner_params.conjuncts->by_slot.end()) {
                 _eval_conjunct_ctxs_by_materialized_slot.emplace(it->first, it->second);
             }
         }
@@ -528,8 +528,8 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     _orc_reader->set_current_file_name(_file->filename());
     RETURN_IF_ERROR(_orc_reader->set_timezone(_scanner_ctx.timezone));
     _orc_reader->set_hive_column_names(_scanner_ctx.hive_column_names);
-    _orc_reader->set_case_sensitive(_scanner_ctx.case_sensitive);
-    _orc_reader->set_use_orc_column_names(_scanner_ctx.orc_use_column_names);
+    _orc_reader->set_case_sensitive(_scanner_ctx.options->case_sensitive);
+    _orc_reader->set_use_orc_column_names(_scanner_ctx.options->orc_use_column_names);
     // for hive table, we set this flag
     _orc_reader->set_invalid_as_null(true);
     if (config::enable_orc_late_materialization && _lazy_load_ctx.lazy_load_slots.size() != 0 &&
@@ -544,8 +544,10 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
                 conjuncts.push_back(it2->root());
             }
         }
-        // add scanner's conjunct also, because SearchArgumentBuilder can support it
-        for (const auto& it : _scanner_params.scanner_conjunct_ctxs) {
+        // also fold multi-slot predicates into the search argument; ORC can use them
+        // for stripe-level skipping even though the post-read pass in get_next() is
+        // still needed for correctness.
+        for (const auto& it : _scanner_params.conjuncts->scanner_ctxs) {
             conjuncts.push_back(it->root());
         }
     }
@@ -570,10 +572,24 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
 
     size_t rows_read = 0;
 
-    if (_scanner_ctx.use_count_opt) {
+    if (_scanner_ctx.options->use_count_opt) {
         ASSIGN_OR_RETURN(rows_read, _do_get_next_count(chunk));
     } else {
         ASSIGN_OR_RETURN(rows_read, _do_get_next(chunk));
+    }
+
+    // Evaluate multi-slot predicates (e.g. "a + b > 5") here, after all data
+    // columns — including lazy-loaded ones — are present in the chunk.
+    // Must happen before partition/extended columns are appended, as scanner_ctxs
+    // only reference data file columns.
+    // Note: ORC already folded these into search arguments during do_open() for
+    // stripe-level skipping, but that is an approximate optimisation only; this
+    // row-level pass is still required for correctness.
+    if (rows_read > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
+        SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
+        RETURN_IF_ERROR(
+                ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
+        rows_read = (*chunk)->num_rows();
     }
 
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -89,7 +89,7 @@ OrcRowReaderFilter::OrcRowReaderFilter(const HdfsScannerContext& scanner_ctx, Or
     if (_scanner_ctx.params->min_max_tuple_desc != nullptr) {
         VLOG_FILE << "OrcRowReaderFilter: min_max_tuple_desc = "
                   << _scanner_ctx.params->min_max_tuple_desc->debug_string();
-        for (ExprContext* ctx : _scanner_ctx.params->conjuncts->min_max_ctxs) {
+        for (ExprContext* ctx : _scanner_ctx.params->conjuncts.min_max_ctxs) {
             VLOG_FILE << "OrcRowReaderFilter: min_max_ctx = " << ctx->root()->debug_string();
         }
     }
@@ -171,7 +171,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
 
     VLOG_FILE << "stripe = " << _current_stripe_index << ", row_group = " << rowGroupIdx
               << ", min_chunk = " << min_chunk->debug_row(0) << ", max_chunk = " << max_chunk->debug_row(0);
-    for (auto& min_max_conjunct_ctx : _scanner_ctx.params->conjuncts->min_max_ctxs) {
+    for (auto& min_max_conjunct_ctx : _scanner_ctx.params->conjuncts.min_max_ctxs) {
         // TODO: add a warning log here
         auto min_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), min_chunk.get());
         auto max_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), max_chunk.get());
@@ -403,8 +403,8 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
 Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     std::unordered_set<std::string> known_column_names;
     OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.params->hive_column_names,
-                                          reader->getType(), _scanner_ctx.params->options->case_sensitive,
-                                          _scanner_ctx.params->options->orc_use_column_names);
+                                          reader->getType(), _scanner_ctx.params->options.case_sensitive,
+                                          _scanner_ctx.params->options.orc_use_column_names);
     RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
     ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
     if (skip) {
@@ -415,7 +415,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 
     int src_slot_index = 0;
     for (const auto& column : _scanner_ctx.materialized_columns) {
-        auto col_name = Utils::format_name(column.name(), _scanner_ctx.params->options->case_sensitive);
+        auto col_name = Utils::format_name(column.name(), _scanner_ctx.params->options.case_sensitive);
         if (known_column_names.find(col_name) == known_column_names.end()) continue;
         bool is_lazy_slot = _scanner_params.is_lazy_materialization_slot(column.slot_id());
         if (is_lazy_slot) {
@@ -433,8 +433,8 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
         // put materialized columns' conjunctions into _eval_conjunct_ctxs_by_materialized_slot
         // for example, partition column's conjunctions will not put into _eval_conjunct_ctxs_by_materialized_slot
         {
-            auto it = _scanner_params.conjuncts->by_slot.find(column.slot_id());
-            if (it != _scanner_params.conjuncts->by_slot.end()) {
+            auto it = _scanner_params.conjuncts.by_slot.find(column.slot_id());
+            if (it != _scanner_params.conjuncts.by_slot.end()) {
                 _eval_conjunct_ctxs_by_materialized_slot.emplace(it->first, it->second);
             }
         }
@@ -448,7 +448,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 Status HdfsOrcScanner::build_split_tasks(orc::Reader* reader, const std::vector<DiskRange>& stripes) {
     // we can split task if we enable split tasks feature and have >= 2 stripes.
     // but if we have splitted tasks before, we don't want to split again, to avoid infinite loop.
-    bool enable_split_tasks = (_scanner_ctx.params->options->enable_split_tasks && stripes.size() >= 2) &&
+    bool enable_split_tasks = (_scanner_ctx.params->options.enable_split_tasks && stripes.size() >= 2) &&
                               (_scanner_ctx.params->split_context == nullptr);
     if (!enable_split_tasks) return Status::OK();
 
@@ -530,8 +530,8 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     _orc_reader->set_current_file_name(_file->filename());
     RETURN_IF_ERROR(_orc_reader->set_timezone(_scanner_ctx.timezone));
     _orc_reader->set_hive_column_names(_scanner_ctx.params->hive_column_names);
-    _orc_reader->set_case_sensitive(_scanner_ctx.params->options->case_sensitive);
-    _orc_reader->set_use_orc_column_names(_scanner_ctx.params->options->orc_use_column_names);
+    _orc_reader->set_case_sensitive(_scanner_ctx.params->options.case_sensitive);
+    _orc_reader->set_use_orc_column_names(_scanner_ctx.params->options.orc_use_column_names);
     // for hive table, we set this flag
     _orc_reader->set_invalid_as_null(true);
     if (config::enable_orc_late_materialization && _lazy_load_ctx.lazy_load_slots.size() != 0 &&
@@ -549,7 +549,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         // also fold multi-slot predicates into the search argument; ORC can use them
         // for stripe-level skipping even though the post-read pass in get_next() is
         // still needed for correctness.
-        for (const auto& it : _scanner_params.conjuncts->scanner_ctxs) {
+        for (const auto& it : _scanner_params.conjuncts.scanner_ctxs) {
             conjuncts.push_back(it->root());
         }
     }
@@ -574,7 +574,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
 
     size_t rows_read = 0;
 
-    if (_scanner_ctx.params->options->use_count_opt) {
+    if (_scanner_ctx.params->options.use_count_opt) {
         ASSIGN_OR_RETURN(rows_read, _do_get_next_count(chunk));
     } else {
         ASSIGN_OR_RETURN(rows_read, _do_get_next(chunk));
@@ -590,9 +590,9 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
     // ORC already folded these into search arguments during do_open() for
     // stripe-level skipping, but that is an approximate optimisation only; this
     // row-level pass is still required for correctness.
-    if (rows_read > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
+    if (rows_read > 0 && !_scanner_params.conjuncts.scanner_ctxs.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts.scanner_ctxs, chunk->get()));
         rows_read = (*chunk)->num_rows();
     }
 
@@ -746,7 +746,7 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
     return Status::OK();
 }
 
-void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
+void HdfsOrcScanner::do_update_counter(HdfsScannerProfile* profile) {
     // if we have split tasks, we don't need to update counter
     // and we will update those counters in sub io tasks.
     if (has_split_tasks()) {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -322,12 +322,12 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
 }
 
 Status HdfsOrcScanner::build_iceberg_delete_builder() {
-    if (_scanner_params.deletes.empty()) return Status::OK();
+    if (_scanner_params.table_specific.iceberg_delete_files.empty()) return Status::OK();
     SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
     const auto iceberg_delete_builder =
             std::make_unique<IcebergDeleteBuilder>(_skip_rows_ctx, _runtime_state, _scanner_params);
 
-    for (const auto& delete_file : _scanner_params.deletes) {
+    for (const auto& delete_file : _scanner_params.table_specific.iceberg_delete_files) {
         if (delete_file->file_content == TIcebergFileContent::POSITION_DELETES) {
             RETURN_IF_ERROR(iceberg_delete_builder->build_orc(*delete_file));
         } else {
@@ -338,17 +338,17 @@ Status HdfsOrcScanner::build_iceberg_delete_builder() {
         }
     }
 
-    _app_stats.iceberg_delete_files_per_scan += _scanner_params.deletes.size();
+    _app_stats.iceberg_delete_files_per_scan += _scanner_params.table_specific.iceberg_delete_files.size();
     return Status::OK();
 }
 
 Status HdfsOrcScanner::build_paimon_delete_file_builder() {
-    if (_scanner_params.paimon_deletion_file == nullptr) {
+    if (_scanner_params.table_specific.paimon_deletion_file == nullptr) {
         return Status::OK();
     }
     std::unique_ptr<PaimonDeleteFileBuilder> paimon_delete_file_builder(
             new PaimonDeleteFileBuilder(_scanner_params.fs, _skip_rows_ctx));
-    RETURN_IF_ERROR(paimon_delete_file_builder->build(_scanner_params.paimon_deletion_file.get()));
+    RETURN_IF_ERROR(paimon_delete_file_builder->build(_scanner_params.table_specific.paimon_deletion_file.get()));
     return Status::OK();
 }
 
@@ -446,7 +446,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 Status HdfsOrcScanner::build_split_tasks(orc::Reader* reader, const std::vector<DiskRange>& stripes) {
     // we can split task if we enable split tasks feature and have >= 2 stripes.
     // but if we have splitted tasks before, we don't want to split again, to avoid infinite loop.
-    bool enable_split_tasks = (_scanner_ctx.params->enable_split_tasks && stripes.size() >= 2) &&
+    bool enable_split_tasks = (_scanner_ctx.params->options->enable_split_tasks && stripes.size() >= 2) &&
                               (_scanner_ctx.params->split_context == nullptr);
     if (!enable_split_tasks) return Status::OK();
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -86,9 +86,10 @@ void OrcRowReaderFilter::setWriterTimezone(const std::string& tz) {
 
 OrcRowReaderFilter::OrcRowReaderFilter(const HdfsScannerContext& scanner_ctx, OrcChunkReader* reader)
         : _scanner_ctx(scanner_ctx), _reader(reader), _writer_tzoffset_in_seconds(reader->tzoffset_in_seconds()) {
-    if (_scanner_ctx.min_max_tuple_desc != nullptr) {
-        VLOG_FILE << "OrcRowReaderFilter: min_max_tuple_desc = " << _scanner_ctx.min_max_tuple_desc->debug_string();
-        for (ExprContext* ctx : _scanner_ctx.conjuncts->min_max_ctxs) {
+    if (_scanner_ctx.params->min_max_tuple_desc != nullptr) {
+        VLOG_FILE << "OrcRowReaderFilter: min_max_tuple_desc = "
+                  << _scanner_ctx.params->min_max_tuple_desc->debug_string();
+        for (ExprContext* ctx : _scanner_ctx.params->conjuncts->min_max_ctxs) {
             VLOG_FILE << "OrcRowReaderFilter: min_max_ctx = " << ctx->root()->debug_string();
         }
     }
@@ -99,8 +100,7 @@ bool OrcRowReaderFilter::filterOnOpeningStripe(uint64_t stripeIndex,
     _current_stripe_index = stripeIndex;
     uint64_t offset = stripeInformation->offset();
 
-    const auto* scan_range = _scanner_ctx.scan_range;
-    size_t scan_start = scan_range->offset;
+    const auto* scan_range = _scanner_ctx.params->scan_range size_t scan_start = scan_range->offset;
     size_t scan_end = scan_range->length + scan_start;
 
     if (offset >= scan_start && offset < scan_end) {
@@ -112,8 +112,8 @@ bool OrcRowReaderFilter::filterOnOpeningStripe(uint64_t stripeIndex,
 bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
                                       const std::unordered_map<uint64_t, orc::proto::RowIndex>& rowIndexes,
                                       const std::map<uint32_t, orc::BloomFilterIndex>& bloomFilter) {
-    const TupleDescriptor* min_max_tuple_desc = _scanner_ctx.min_max_tuple_desc;
-    ChunkPtr min_chunk = RuntimeChunkHelper::new_chunk(*min_max_tuple_desc, 0);
+    const TupleDescriptor* min_max_tuple_desc = _scanner_ctx.params->min_max_tuple_desc ChunkPtr min_chunk =
+            RuntimeChunkHelper::new_chunk(*min_max_tuple_desc, 0);
     ChunkPtr max_chunk = RuntimeChunkHelper::new_chunk(*min_max_tuple_desc, 0);
     for (size_t i = 0; i < min_max_tuple_desc->slots().size(); i++) {
         SlotDescriptor* slot = min_max_tuple_desc->slots()[i];
@@ -170,7 +170,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
 
     VLOG_FILE << "stripe = " << _current_stripe_index << ", row_group = " << rowGroupIdx
               << ", min_chunk = " << min_chunk->debug_row(0) << ", max_chunk = " << max_chunk->debug_row(0);
-    for (auto& min_max_conjunct_ctx : _scanner_ctx.conjuncts->min_max_ctxs) {
+    for (auto& min_max_conjunct_ctx : _scanner_ctx.params->conjuncts->min_max_ctxs) {
         // TODO: add a warning log here
         auto min_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), min_chunk.get());
         auto max_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), max_chunk.get());
@@ -189,7 +189,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
 bool OrcRowReaderFilter::filterOnPickRowGroup(size_t rowGroupIdx,
                                               const std::unordered_map<uint64_t, orc::proto::RowIndex>& rowIndexes,
                                               const std::map<uint32_t, orc::BloomFilterIndex>& bloomFilters) {
-    if (_scanner_ctx.min_max_tuple_desc != nullptr) {
+    if (_scanner_ctx.params->min_max_tuple_desc != nullptr) {
         if (filterMinMax(rowGroupIdx, rowIndexes, bloomFilters)) {
             VLOG_FILE << "OrcRowReaderFilter: skip row group " << rowGroupIdx << ", stripe " << _current_stripe_index;
             return true;
@@ -356,8 +356,7 @@ Status HdfsOrcScanner::build_stripes(orc::Reader* reader, std::vector<DiskRange>
     uint64_t stripe_number = reader->getNumberOfStripes();
     std::vector<DiskRange> stripe_disk_ranges{};
 
-    const auto* scan_range = _scanner_ctx.scan_range;
-    size_t scan_start = scan_range->offset;
+    const auto* scan_range = _scanner_ctx.params->scan_range size_t scan_start = scan_range->offset;
     size_t scan_end = scan_range->length + scan_start;
 
     for (uint64_t idx = 0; idx < stripe_number; idx++) {
@@ -401,9 +400,9 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
 
 Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     std::unordered_set<std::string> known_column_names;
-    OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
-                                          _scanner_ctx.options->case_sensitive,
-                                          _scanner_ctx.options->orc_use_column_names);
+    OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.params->hive_column_names,
+                                          reader->getType(), _scanner_ctx.params->options->case_sensitive,
+                                          _scanner_ctx.params->options->orc_use_column_names);
     RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
     ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
     if (skip) {
@@ -414,7 +413,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 
     int src_slot_index = 0;
     for (const auto& column : _scanner_ctx.materialized_columns) {
-        auto col_name = Utils::format_name(column.name(), _scanner_ctx.options->case_sensitive);
+        auto col_name = Utils::format_name(column.name(), _scanner_ctx.params->options->case_sensitive);
         if (known_column_names.find(col_name) == known_column_names.end()) continue;
         bool is_lazy_slot = _scanner_params.is_lazy_materialization_slot(column.slot_id());
         if (is_lazy_slot) {
@@ -447,8 +446,8 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 Status HdfsOrcScanner::build_split_tasks(orc::Reader* reader, const std::vector<DiskRange>& stripes) {
     // we can split task if we enable split tasks feature and have >= 2 stripes.
     // but if we have splitted tasks before, we don't want to split again, to avoid infinite loop.
-    bool enable_split_tasks =
-            (_scanner_ctx.enable_split_tasks && stripes.size() >= 2) && (_scanner_ctx.split_context == nullptr);
+    bool enable_split_tasks = (_scanner_ctx.params->enable_split_tasks && stripes.size() >= 2) &&
+                              (_scanner_ctx.params->split_context == nullptr);
     if (!enable_split_tasks) return Status::OK();
 
     auto footer = std::make_shared<std::string>(reader->getSerializedFileTail());
@@ -476,7 +475,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     if (_input_stream == nullptr) {
         _input_stream = std::make_unique<ORCHdfsFileStream>(_file.get(), _file->get_size().value(),
                                                             _shared_buffered_input_stream.get());
-        _input_stream->set_lazy_column_coalesce_counter(_scanner_ctx.lazy_column_coalesce_counter);
+        _input_stream->set_lazy_column_coalesce_counter(_scanner_ctx.params->lazy_column_coalesce_counter);
         _input_stream->set_app_stats(&_app_stats);
     }
     ORCHdfsFileStream* orc_hdfs_file_stream = _input_stream.get();
@@ -488,8 +487,8 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         errno = 0;
         orc::ReaderOptions options;
         options.setMemoryPool(*getOrcMemoryPool());
-        if (_scanner_ctx.split_context != nullptr) {
-            auto* split_context = down_cast<const SplitContext*>(_scanner_ctx.split_context);
+        if (_scanner_ctx.params->split_context != nullptr) {
+            auto* split_context = down_cast<const SplitContext*>(_scanner_ctx.params->split_context);
             options.setSerializedFileTail(*(split_context->footer.get()));
         }
         reader = orc::createReader(std::move(_input_stream), options);
@@ -528,9 +527,9 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     _orc_reader->set_runtime_state(runtime_state);
     _orc_reader->set_current_file_name(_file->filename());
     RETURN_IF_ERROR(_orc_reader->set_timezone(_scanner_ctx.timezone));
-    _orc_reader->set_hive_column_names(_scanner_ctx.hive_column_names);
-    _orc_reader->set_case_sensitive(_scanner_ctx.options->case_sensitive);
-    _orc_reader->set_use_orc_column_names(_scanner_ctx.options->orc_use_column_names);
+    _orc_reader->set_hive_column_names(_scanner_ctx.params->hive_column_names);
+    _orc_reader->set_case_sensitive(_scanner_ctx.params->options->case_sensitive);
+    _orc_reader->set_use_orc_column_names(_scanner_ctx.params->options->orc_use_column_names);
     // for hive table, we set this flag
     _orc_reader->set_invalid_as_null(true);
     if (config::enable_orc_late_materialization && _lazy_load_ctx.lazy_load_slots.size() != 0 &&
@@ -552,7 +551,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
             conjuncts.push_back(it->root());
         }
     }
-    const OrcPredicates orc_predicates{&conjuncts, _scanner_ctx.runtime_filter_collector};
+    const OrcPredicates orc_predicates{&conjuncts, _scanner_ctx.params->runtime_filter_collector};
     RETURN_IF_ERROR(_orc_reader->init(std::move(reader), &orc_predicates));
 
     // create iceberg delete builder at last
@@ -573,7 +572,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
 
     size_t rows_read = 0;
 
-    if (_scanner_ctx.options->use_count_opt) {
+    if (_scanner_ctx.params->options->use_count_opt) {
         ASSIGN_OR_RETURN(rows_read, _do_get_next_count(chunk));
     } else {
         ASSIGN_OR_RETURN(rows_read, _do_get_next(chunk));
@@ -713,10 +712,10 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
         bool require_load_lazy_columns = rows_read > 0;
         if (require_load_lazy_columns) {
             // still need to load lazy column
-            _scanner_ctx.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
+            _scanner_ctx.params->lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
         } else {
             // dont need to load lazy column
-            _scanner_ctx.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
+            _scanner_ctx.params->lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
             _app_stats.late_materialize_skip_rows += origin_rows_read;
             continue;
         }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.h
@@ -36,6 +36,13 @@ public:
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
     void do_update_counter(HdfsScanProfile* profile) override;
     void disable_use_orc_sargs() { _use_orc_sargs = false; }
+    // ORC handles single-slot predicates internally via lazy materialisation and
+    // per-column reader pushdown; the base class must not apply them a second time.
+    bool scanner_handles_predicate_by_slot_internally() const override { return true; }
+    // ORC evaluates multi-slot predicates at the end of do_get_next() after all
+    // columns (including lazy-loaded ones) are present in the chunk.  The search
+    // argument used during open() is an approximate stripe-level skip only.
+    bool scanner_handles_multi_slot_conjuncts_internally() const override { return true; }
 
 private:
     StatusOr<size_t> _do_get_next(ChunkPtr* chunk);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.h
@@ -34,7 +34,7 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    void do_update_counter(HdfsScanProfile* profile) override;
+    void do_update_counter(HdfsScannerProfile* profile) override;
     void disable_use_orc_sargs() { _use_orc_sargs = false; }
     // ORC handles single-slot predicates internally via lazy materialisation and
     // per-column reader pushdown; the base class must not apply them a second time.

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -34,11 +34,11 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
         return Status::OK();
     }
 
-    if (!scanner_params.deletes.empty()) {
+    if (!scanner_params.table_specific.iceberg_delete_files.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
         auto iceberg_delete_builder =
                 std::make_unique<IcebergDeleteBuilder>(_skip_rows_ctx, runtime_state, scanner_params);
-        for (const auto& delete_file : scanner_params.deletes) {
+        for (const auto& delete_file : scanner_params.table_specific.iceberg_delete_files) {
             if (delete_file->file_content == TIcebergFileContent::POSITION_DELETES) {
                 RETURN_IF_ERROR(iceberg_delete_builder->build_parquet(*delete_file));
             } else {
@@ -48,12 +48,12 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
                 return Status::InternalError(s);
             }
         }
-        _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
-    } else if (scanner_params.paimon_deletion_file != nullptr) {
+        _app_stats.iceberg_delete_files_per_scan += scanner_params.table_specific.iceberg_delete_files.size();
+    } else if (scanner_params.table_specific.paimon_deletion_file != nullptr) {
         std::unique_ptr<PaimonDeleteFileBuilder> paimon_delete_file_builder(
                 new PaimonDeleteFileBuilder(scanner_params.fs, _skip_rows_ctx));
-        RETURN_IF_ERROR(paimon_delete_file_builder->build(scanner_params.paimon_deletion_file.get()));
-    } else if (scanner_params.deletion_vector_descriptor != nullptr) {
+        RETURN_IF_ERROR(paimon_delete_file_builder->build(scanner_params.table_specific.paimon_deletion_file.get()));
+    } else if (scanner_params.table_specific.deletion_vector_descriptor != nullptr) {
         SCOPED_RAW_TIMER(&_app_stats.deletion_vector_build_ns);
         std::unique_ptr<DeletionVector> dv = std::make_unique<DeletionVector>(scanner_params);
         RETURN_IF_ERROR(dv->fill_row_indexes(_skip_rows_ctx));

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -101,8 +101,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
 
     // io coalesce
-    RuntimeProfile::Counter* group_active_lazy_coalesce_together = nullptr;
-    RuntimeProfile::Counter* group_active_lazy_coalesce_seperately = nullptr;
+    RuntimeProfile::Counter* active_lazy_coalesce_together = nullptr;
+    RuntimeProfile::Counter* active_lazy_coalesce_seperately = nullptr;
 
     // page statistics
     RuntimeProfile::Counter* has_page_statistics = nullptr;
@@ -159,10 +159,10 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 
-    group_active_lazy_coalesce_together = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceTogether",
-                                                            TUnit::UNIT, kParquetProfileSectionPrefix);
-    group_active_lazy_coalesce_seperately = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceSeperately",
-                                                              TUnit::UNIT, kParquetProfileSectionPrefix);
+    active_lazy_coalesce_together = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceTogether", TUnit::UNIT,
+                                                      kParquetProfileSectionPrefix);
+    active_lazy_coalesce_seperately = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceSeperately", TUnit::UNIT,
+                                                        kParquetProfileSectionPrefix);
 
     has_page_statistics = ADD_CHILD_COUNTER(root, "HasPageStatistics", TUnit::UNIT, kParquetProfileSectionPrefix);
     page_skip = ADD_CHILD_COUNTER(root, "PageSkipCounter", TUnit::UNIT, kParquetProfileSectionPrefix);
@@ -205,8 +205,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     COUNTER_UPDATE(group_chunk_read_timer, _app_stats.group_chunk_read_ns);
     COUNTER_UPDATE(group_dict_filter_timer, _app_stats.group_dict_filter_ns);
     COUNTER_UPDATE(group_dict_decode_timer, _app_stats.group_dict_decode_ns);
-    COUNTER_UPDATE(group_active_lazy_coalesce_together, _app_stats.group_active_lazy_coalesce_together);
-    COUNTER_UPDATE(group_active_lazy_coalesce_seperately, _app_stats.group_active_lazy_coalesce_seperately);
+    COUNTER_UPDATE(active_lazy_coalesce_together, _app_stats.active_lazy_coalesce_together);
+    COUNTER_UPDATE(active_lazy_coalesce_seperately, _app_stats.active_lazy_coalesce_seperately);
     int64_t page_stats = _app_stats.has_page_statistics ? 1 : 0;
     COUNTER_UPDATE(has_page_statistics, page_stats);
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);
@@ -214,16 +214,16 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     do_update_deletion_vector_filter_counter(root);
     COUNTER_UPDATE(rows_before_page_index, _app_stats.rows_before_page_index);
     COUNTER_UPDATE(page_index_timer, _app_stats.page_index_ns);
-    COUNTER_UPDATE(total_row_groups, _app_stats.parquet_total_row_groups);
-    COUNTER_UPDATE(filtered_row_groups, _app_stats.parquet_filtered_row_groups);
+    COUNTER_UPDATE(total_row_groups, _app_stats.total_row_groups);
+    COUNTER_UPDATE(filtered_row_groups, _app_stats.filtered_row_groups);
 
-    COUNTER_UPDATE(statistics_tried_counter, _app_stats._optimzation_counter.statistics_tried_counter);
-    COUNTER_UPDATE(statistics_success_counter, _app_stats._optimzation_counter.statistics_success_counter);
-    COUNTER_UPDATE(page_index_tried_counter, _app_stats._optimzation_counter.page_index_tried_counter);
-    COUNTER_UPDATE(page_index_success_counter, _app_stats._optimzation_counter.page_index_success_counter);
-    COUNTER_UPDATE(page_index_filter_group_counter, _app_stats._optimzation_counter.page_index_filter_group_counter);
-    COUNTER_UPDATE(bloom_filter_tried_counter, _app_stats._optimzation_counter.bloom_filter_tried_counter);
-    COUNTER_UPDATE(bloom_filter_success_counter, _app_stats._optimzation_counter.bloom_filter_success_counter);
+    COUNTER_UPDATE(statistics_tried_counter, _app_stats.statistics_tried_counter);
+    COUNTER_UPDATE(statistics_success_counter, _app_stats.statistics_success_counter);
+    COUNTER_UPDATE(page_index_tried_counter, _app_stats.page_index_tried_counter);
+    COUNTER_UPDATE(page_index_success_counter, _app_stats.page_index_success_counter);
+    COUNTER_UPDATE(page_index_filter_group_counter, _app_stats.page_index_filter_group_counter);
+    COUNTER_UPDATE(bloom_filter_tried_counter, _app_stats.bloom_filter_tried_counter);
+    COUNTER_UPDATE(bloom_filter_success_counter, _app_stats.bloom_filter_success_counter);
 
     if (_scanner_ctx.conjuncts_manager != nullptr &&
         _runtime_state->fragment_ctx()->pred_tree_params().enable_show_in_profile) {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -20,6 +20,7 @@
 #include "exec/iceberg/iceberg_delete_builder.h"
 #include "exec/paimon/paimon_delete_file_builder.h"
 #include "exec/pipeline/fragment_context.h"
+#include "exprs/chunk_predicate_evaluator.h"
 #include "formats/parquet/file_reader.h"
 
 namespace starrocks {
@@ -264,8 +265,18 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
 }
 
 Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    Status status = _reader->get_next(chunk);
-    return status;
+    RETURN_IF_ERROR(_reader->get_next(chunk));
+    // Evaluate multi-slot predicates after FileReader has materialised all columns
+    // (including lazily-loaded ones from its internal predicate pipeline).
+    // This pass is the correctness guarantee; statistics-based skipping inside
+    // FileReader is approximate.  In the future, expression-driven lazy
+    // materialisation will replace this with interleaved column-load/evaluate.
+    if ((*chunk)->num_rows() > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
+        SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
+        RETURN_IF_ERROR(
+                ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
+    }
+    return Status::OK();
 }
 
 void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -273,8 +273,7 @@ Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
     // materialisation will replace this with interleaved column-load/evaluate.
     if ((*chunk)->num_rows() > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(
-                ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
     }
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -62,7 +62,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
     return Status::OK();
 }
 
-void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
+void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::NONE);
     // deletion vector build only in the first task which used for split sub-tasks,
@@ -271,9 +271,9 @@ Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
     // This pass is the correctness guarantee; statistics-based skipping inside
     // FileReader is approximate.  In the future, expression-driven lazy
     // materialisation will replace this with interleaved column-load/evaluate.
-    if ((*chunk)->num_rows() > 0 && !_scanner_params.conjuncts->scanner_ctxs.empty()) {
+    if ((*chunk)->num_rows() > 0 && !_scanner_params.conjuncts.scanner_ctxs.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts->scanner_ctxs, chunk->get()));
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_params.conjuncts.scanner_ctxs, chunk->get()));
     }
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.h
@@ -31,6 +31,15 @@ public:
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
     void do_update_counter(HdfsScanProfile* profile) override;
+    // Parquet handles single-slot predicates via row-group zone-map, page-index,
+    // dict-filter, and lazy materialisation inside FileReader; the base class must
+    // not apply them a second time.
+    bool scanner_handles_predicate_by_slot_internally() const override { return true; }
+    // Parquet evaluates multi-slot predicates at the end of do_get_next() after
+    // FileReader has materialised all columns.  In the future, expression-driven
+    // lazy materialisation will interleave this with column loading for deeper
+    // optimisation — the override keeps the base class from double-applying them.
+    bool scanner_handles_multi_slot_conjuncts_internally() const override { return true; }
 
 private:
     std::shared_ptr<parquet::FileReader> _reader = nullptr;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.h
@@ -30,7 +30,7 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    void do_update_counter(HdfsScanProfile* profile) override;
+    void do_update_counter(HdfsScannerProfile* profile) override;
     // Parquet handles single-slot predicates via row-group zone-map, page-index,
     // dict-filter, and lazy materialisation inside FileReader; the base class must
     // not apply them a second time.

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
@@ -20,7 +20,6 @@
 #include "base/compression/stream_decompressor.h"
 #include "base/string/utf8_check.h"
 #include "column/column_helper.h"
-#include "exprs/chunk_predicate_evaluator.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/runtime_state.h"
 
@@ -313,14 +312,7 @@ Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
     ChunkPtr ck = *chunk;
     // do stats before we filter rows which does not match.
     _app_stats.raw_rows_read += ck->num_rows();
-    for (auto& it : _scanner_ctx.conjunct_ctxs_by_slot) {
-        // do evaluation.
-        SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(it.second, ck.get()));
-        if (ck->num_rows() == 0) {
-            break;
-        }
-    }
+    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
     return Status::OK();
 }
 
@@ -473,7 +465,7 @@ Status HdfsTextScanner::_build_hive_column_name_2_index() {
         return Status::OK();
     }
 
-    const bool case_sensitive = _scanner_ctx.case_sensitive;
+    const bool case_sensitive = _scanner_ctx.options->case_sensitive;
 
     // The map's value is the position of column name in hive's table(Not in StarRocks' table)
     std::unordered_map<std::string, size_t> formatted_hive_column_name_2_index;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
@@ -238,7 +238,7 @@ Status HdfsTextScanner::_setup_compression_type(const TTextFileDesc& text_file_d
         compression_type = CompressionUtils::to_compression_pb(text_file_desc.compression_type);
     } else {
         // if FE does not specify compress type, we choose it by looking at filename.
-        compression_type = get_compression_type_from_path(_scanner_params.path);
+        compression_type = get_compression_type_from_path(_scanner_params.file_path);
     }
     if (compression_type != UNKNOWN_COMPRESSION) {
         _compression_type = compression_type;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
@@ -396,7 +396,7 @@ Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
 }
 
 Status HdfsTextScanner::_create_csv_reader() {
-    const THdfsScanRange* scan_range = _scanner_ctx.scan_range;
+    const THdfsScanRange* scan_range = _scanner_ctx.params->scan_range;
 
     if (_compression_type != NO_COMPRESSION) {
         // we don't know real stream size in adavance, so we set a very large stream size
@@ -441,7 +441,7 @@ Status HdfsTextScanner::_create_csv_reader() {
 
 StatusOr<bool> HdfsTextScanner::_has_utf8_bom() const {
     // if reading start of file, skipping UTF-8 BOM
-    if (_scanner_ctx.scan_range->offset == 0) {
+    if (_scanner_ctx.params->scan_range->offset == 0) {
         auto* reader = down_cast<HdfsScannerCSVReader*>(_reader.get());
         CSVReader::Record first_line;
         RETURN_IF_ERROR(reader->next_record(&first_line));
@@ -457,7 +457,7 @@ StatusOr<bool> HdfsTextScanner::_has_utf8_bom() const {
 Status HdfsTextScanner::_build_hive_column_name_2_index() {
     // For some table like file table, there is no hive_column_names at all.
     // So we use slot order defined in table schema.
-    if (_scanner_ctx.hive_column_names->empty()) {
+    if (_scanner_ctx.params->hive_column_names->empty()) {
         _materialize_slots_index_2_csv_column_index.resize(_scanner_ctx.materialized_columns.size());
         for (size_t i = 0; i < _scanner_ctx.materialized_columns.size(); i++) {
             _materialize_slots_index_2_csv_column_index[i] = i;
@@ -465,13 +465,13 @@ Status HdfsTextScanner::_build_hive_column_name_2_index() {
         return Status::OK();
     }
 
-    const bool case_sensitive = _scanner_ctx.options->case_sensitive;
+    const bool case_sensitive = _scanner_ctx.params->options->case_sensitive;
 
     // The map's value is the position of column name in hive's table(Not in StarRocks' table)
     std::unordered_map<std::string, size_t> formatted_hive_column_name_2_index;
 
-    for (size_t i = 0; i < _scanner_ctx.hive_column_names->size(); i++) {
-        const std::string& name = (*_scanner_ctx.hive_column_names)[i];
+    for (size_t i = 0; i < _scanner_ctx.params->hive_column_names->size(); i++) {
+        const std::string& name = (*_scanner_ctx.params->hive_column_names)[i];
         const std::string formatted_column_name = _scanner_ctx.formatted_name(name);
         formatted_hive_column_name_2_index.emplace(formatted_column_name, i);
     }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
@@ -291,7 +291,7 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
-void HdfsTextScanner::do_update_counter(HdfsScanProfile* profile) {
+void HdfsTextScanner::do_update_counter(HdfsScannerProfile* profile) {
     profile->runtime_profile->add_info_string("TextCompression", CompressionTypePB_Name(_compression_type));
 }
 
@@ -465,7 +465,7 @@ Status HdfsTextScanner::_build_hive_column_name_2_index() {
         return Status::OK();
     }
 
-    const bool case_sensitive = _scanner_ctx.params->options->case_sensitive;
+    const bool case_sensitive = _scanner_ctx.params->options.case_sensitive;
 
     // The map's value is the position of column name in hive's table(Not in StarRocks' table)
     std::unordered_map<std::string, size_t> formatted_hive_column_name_2_index;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.h
@@ -40,7 +40,7 @@ public:
     ~HdfsTextScanner() override = default;
 
     Status do_open(RuntimeState* runtime_state) override;
-    void do_update_counter(HdfsScanProfile* profile) override;
+    void do_update_counter(HdfsScannerProfile* profile) override;
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -451,7 +451,7 @@ Status JniScanner::update_jni_scanner_params() {
         std::unordered_set<std::string> names;
         for (const auto& column : _scanner_ctx.materialized_columns) {
             if (column.name() == "___count___") continue;
-            auto col_name = column.formatted_name(_scanner_ctx.options->case_sensitive);
+            auto col_name = column.formatted_name(_scanner_ctx.params->options->case_sensitive);
             names.insert(col_name);
         }
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(names));

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -451,7 +451,7 @@ Status JniScanner::update_jni_scanner_params() {
         std::unordered_set<std::string> names;
         for (const auto& column : _scanner_ctx.materialized_columns) {
             if (column.name() == "___count___") continue;
-            auto col_name = column.formatted_name(_scanner_ctx.params->options->case_sensitive);
+            auto col_name = column.formatted_name(_scanner_ctx.params->options.case_sensitive);
             names.insert(col_name);
         }
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(names));

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -386,12 +386,11 @@ Status JniScanner::_release_off_heap_table(JNIEnv* env) {
 Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     // fill chunk with all wanted column.
     ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
-    // ====== conjunct evaluation ======
-    // important to add columns before evaluation
-    // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
+    // Partition and not-existed columns must be appended before predicate evaluation
+    // because ctxs_by_slot may reference non-file or partition slots.
     RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, chunk_size));
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);
-    RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter));
+    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
     return Status::OK();
 }
 
@@ -452,7 +451,7 @@ Status JniScanner::update_jni_scanner_params() {
         std::unordered_set<std::string> names;
         for (const auto& column : _scanner_ctx.materialized_columns) {
             if (column.name() == "___count___") continue;
-            auto col_name = column.formatted_name(_scanner_ctx.case_sensitive);
+            auto col_name = column.formatted_name(_scanner_ctx.options->case_sensitive);
             names.insert(col_name);
         }
         RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(names));
@@ -496,9 +495,9 @@ Status HiveJniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
     // fill chunk with all wanted column exclude partition columns
     ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
     RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, chunk_size));
-    // right now only hive table need append partition columns explictly, paimon and hudi reader will append partition columns in Java side
+    // only Hive needs partition columns appended explicitly; Paimon and Hudi append them on the Java side.
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);
-    RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter));
+    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -49,7 +49,9 @@ public:
 
 protected:
     StatusOr<size_t> fill_empty_chunk(ChunkPtr* chunk);
-    // Predicate evaluation/filtering is handled by HdfsScanner::get_next(); no per-scanner chunk filter is needed.
+    // Predicate evaluation/filtering is handled uniformly by HdfsScanner::get_next()
+    // via evaluate_on_conjunct_ctxs_by_slot() and ChunkPredicateEvaluator; JniScanner
+    // does not maintain its own chunk filter.
 
 private:
     struct FillColumnArgs {

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -49,7 +49,7 @@ public:
 
 protected:
     StatusOr<size_t> fill_empty_chunk(ChunkPtr* chunk);
-    // _chunk_filter is inherited from HdfsScanner::_chunk_filter (base class).
+    // Predicate evaluation/filtering is handled by HdfsScanner::get_next(); no per-scanner chunk filter is needed.
 
 private:
     struct FillColumnArgs {

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -40,7 +40,7 @@ public:
     ~JniScanner() override { close(); }
 
     Status do_open(RuntimeState* runtime_state) override;
-    void do_update_counter(HdfsScanProfile* profile) override {}
+    void do_update_counter(HdfsScannerProfile* profile) override {}
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -49,8 +49,7 @@ public:
 
 protected:
     StatusOr<size_t> fill_empty_chunk(ChunkPtr* chunk);
-
-    Filter _chunk_filter;
+    // _chunk_filter is inherited from HdfsScanner::_chunk_filter (base class).
 
 private:
     struct FillColumnArgs {

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -97,6 +97,11 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
     }
 
     auto scanner_ctx = std::make_unique<HdfsScannerContext>();
+    HdfsScannerParams local_params;
+    HdfsScannerOptions local_options;
+    local_params.options = &local_options;
+    scanner_ctx->params = &local_params;
+
     std::vector<HdfsScannerContext::ColumnInfo> columns;
     THdfsScanRange scan_range;
     scan_range.offset = 0;
@@ -132,10 +137,10 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
     std::atomic<int32_t> lazy_column_coalesce_counter = 0;
     scanner_ctx->timezone = timezone;
     scanner_ctx->slot_descs = slot_descriptors;
-    scanner_ctx->lake_schema = &iceberg_schema;
+    scanner_ctx->table_specific.iceberg_schema = &iceberg_schema;
     scanner_ctx->materialized_columns = std::move(columns);
-    scanner_ctx->scan_range = &scan_range;
-    scanner_ctx->lazy_column_coalesce_counter = &lazy_column_coalesce_counter;
+    local_params.scan_range = &scan_range;
+    local_params.lazy_column_coalesce_counter = &lazy_column_coalesce_counter;
     scanner_ctx->stats = &app_scan_stats;
     RETURN_IF_ERROR(reader->init(scanner_ctx.get()));
 

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -45,7 +45,7 @@ StatusOr<std::unique_ptr<RandomAccessFile>> IcebergDeleteBuilder::open_random_ac
         std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
         std::shared_ptr<CacheInputStream>& cache_input_stream) const {
     const OpenFileOptions options{.fs = _params.fs,
-                                  .path = delete_file.full_path,
+                                  .file_path = delete_file.full_path,
                                   .file_size = delete_file.length,
                                   .fs_stats = &fs_scan_stats,
                                   .app_stats = &app_scan_stats,
@@ -69,7 +69,7 @@ Status IcebergDeleteBuilder::fill_skip_rowids(const ChunkPtr& chunk) const {
     const ColumnPtr& file_path = chunk->get_column_by_slot_id(k_delete_file_path.id);
     const ColumnPtr& pos = chunk->get_column_by_slot_id(k_delete_file_pos.id);
     for (int i = 0; i < chunk->num_rows(); i++) {
-        if (file_path->get(i).get_slice() == _params.path) {
+        if (file_path->get(i).get_slice() == _params.file_path) {
             _deletion_bitmap->add_value(pos->get(i).get_int64());
         }
     }
@@ -137,7 +137,7 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
     std::atomic<int32_t> lazy_column_coalesce_counter = 0;
     scanner_ctx->timezone = timezone;
     scanner_ctx->slot_descs = slot_descriptors;
-    scanner_ctx->table_specific.iceberg_schema = &iceberg_schema;
+    local_params.table_specific.iceberg_schema = &iceberg_schema;
     scanner_ctx->materialized_columns = std::move(columns);
     local_params.scan_range = &scan_range;
     local_params.lazy_column_coalesce_counter = &lazy_column_coalesce_counter;

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -98,8 +98,6 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
 
     auto scanner_ctx = std::make_unique<HdfsScannerContext>();
     HdfsScannerParams local_params;
-    HdfsScannerOptions local_options;
-    local_params.options = &local_options;
     scanner_ctx->params = &local_params;
 
     std::vector<HdfsScannerContext::ColumnInfo> columns;
@@ -157,7 +155,7 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
         RETURN_IF_ERROR(fill_skip_rowids(chunk));
     }
     _skip_rows_ctx->deletion_bitmap = _deletion_bitmap;
-    update_delete_file_io_counter(_params.profile->runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
+    update_delete_file_io_counter(_params.profile.runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
                                   shared_buffered_input_stream);
     return Status::OK();
 }
@@ -210,7 +208,7 @@ Status IcebergDeleteBuilder::build_orc(const TIcebergDeleteFile& delete_file) co
         RETURN_IF_ERROR(fill_skip_rowids(ret.value()));
     }
     _skip_rows_ctx->deletion_bitmap = _deletion_bitmap;
-    update_delete_file_io_counter(_params.profile->runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
+    update_delete_file_io_counter(_params.profile.runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
                                   shared_buffered_input_stream);
     return Status::OK();
 }

--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -90,9 +90,9 @@ void ORCHdfsFileStream::setIORanges(std::vector<IORange>& io_ranges) {
     bool active_lazy_column_coalesce = true;
     if (isIOAdaptiveCoalesceEnabled() && _lazy_column_coalesce_counter->load(std::memory_order_relaxed) < 0) {
         active_lazy_column_coalesce = false;
-        _app_stats->orc_stripe_active_lazy_coalesce_seperately++;
+        _app_stats->active_lazy_coalesce_seperately++;
     } else {
-        _app_stats->orc_stripe_active_lazy_coalesce_together++;
+        _app_stats->active_lazy_coalesce_together++;
     }
 
     const Status st = setIORanges(bs_io_ranges, active_lazy_column_coalesce);

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -86,8 +86,8 @@ Status ColumnMaterializer::init_read_chunk() {
     for (const auto& column : _param.read_cols) {
         read_slots.emplace_back(column.slot_desc);
     }
-    if (_param.reserved_field_slots != nullptr) {
-        for (auto* slot : *_param.reserved_field_slots) {
+    if (!_param.scanner_ctx->reserved_field_slots.empty()) {
+        for (auto* slot : _param.scanner_ctx->reserved_field_slots) {
             read_slots.push_back(slot);
         }
     }
@@ -111,8 +111,8 @@ ChunkPtr ColumnMaterializer::create_read_chunk(const std::vector<SlotId>& slot_i
         ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot_id);
         chunk->append_column(column, slot_id);
     }
-    if (include_reserved_fields && _param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
+    if (include_reserved_fields && !_param.scanner_ctx->reserved_field_slots.empty()) {
+        for (const auto* slot : _param.scanner_ctx->reserved_field_slots) {
             ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot->id());
             chunk->append_column(column, slot->id());
         }
@@ -144,8 +144,8 @@ StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Rang
     DeferOp defer([&]() { _column_read_order_ctx->update_ctx(round_cost, first_selectivity); });
     size_t hit_count = 0;
 
-    if (_param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
+    if (!_param.scanner_ctx->reserved_field_slots.empty()) {
+        for (const auto* slot : _param.scanner_ctx->reserved_field_slots) {
             SlotId slot_id = slot->id();
             RETURN_IF_ERROR(read_slot(slot_id, range, filter, chunk));
             if (_post_read_conjuncts_by_slot.find(slot_id) != _post_read_conjuncts_by_slot.end()) {
@@ -224,11 +224,11 @@ StatusOr<size_t> ColumnMaterializer::eval_slot_conjuncts(const std::vector<ExprC
 
 Status ColumnMaterializer::read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range,
                                       const Filter* filter, ChunkPtr* chunk, bool ignore_reserved_field) {
-    if (read_columns.empty() && _param.reserved_field_slots == nullptr) {
+    if (read_columns.empty() && _param.scanner_ctx->reserved_field_slots.empty()) {
         return Status::OK();
     }
-    if (!ignore_reserved_field && _param.reserved_field_slots != nullptr) {
-        for (const auto& slot : *_param.reserved_field_slots) {
+    if (!ignore_reserved_field && !_param.scanner_ctx->reserved_field_slots.empty()) {
+        for (const auto& slot : _param.scanner_ctx->reserved_field_slots) {
             RETURN_IF_ERROR(read_slot(slot->id(), range, filter, chunk));
         }
     }
@@ -285,8 +285,8 @@ Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPt
         RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
                                         active_chunk->get_column_by_slot_id(slot_id)));
     }
-    if (_param.reserved_field_slots != nullptr) {
-        for (const auto* slot : *_param.reserved_field_slots) {
+    if (!_param.scanner_ctx->reserved_field_slots.empty()) {
+        for (const auto* slot : _param.scanner_ctx->reserved_field_slots) {
             SlotId slot_id = slot->id();
             RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
                                             active_chunk->get_column_by_slot_id(slot_id)));
@@ -326,8 +326,8 @@ void ColumnMaterializer::classify_columns(const std::unordered_set<SlotId>& defe
         ++read_col_idx;
     }
 
-    if (_param.reserved_field_slots != nullptr) {
-        for (auto* slot : *_param.reserved_field_slots) {
+    if (!_param.scanner_ctx->reserved_field_slots.empty()) {
+        for (auto* slot : _param.scanner_ctx->reserved_field_slots) {
             SlotId slot_id = slot->id();
             auto it = conjunct_ctxs_by_slot.find(slot_id);
             if (it != conjunct_ctxs_by_slot.end()) {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -174,7 +174,13 @@ bool FileReader::_filter_group(const GroupReaderPtr& group_reader) {
                                             _scanner_ctx->params->options->parquet_page_index_enable,
                                             _scanner_ctx->params->options->parquet_bloom_filter_enable};
     auto sparse_range = _scanner_ctx->predicate_tree.visit(visitor);
-    _group_reader_param.stats->_optimzation_counter += visitor.counter;
+    _group_reader_param.stats->bloom_filter_tried_counter += visitor.counter.bloom_filter_tried_counter;
+    _group_reader_param.stats->bloom_filter_success_counter += visitor.counter.bloom_filter_success_counter;
+    _group_reader_param.stats->statistics_tried_counter += visitor.counter.statistics_tried_counter;
+    _group_reader_param.stats->statistics_success_counter += visitor.counter.statistics_success_counter;
+    _group_reader_param.stats->page_index_tried_counter += visitor.counter.page_index_tried_counter;
+    _group_reader_param.stats->page_index_filter_group_counter += visitor.counter.page_index_filter_group_counter;
+    _group_reader_param.stats->page_index_success_counter += visitor.counter.page_index_success_counter;
     if (!sparse_range.ok()) {
         LOG(WARNING) << "filter row group failed: " << sparse_range.status().message();
     } else if (sparse_range.value().has_value()) {
@@ -205,7 +211,20 @@ StatusOr<bool> FileReader::_update_rf_and_filter_group(const GroupReaderPtr& gro
                     if (res.ok() && res->has_value() && res->value().span_size() == 0) {
                         filter = true;
                     }
-                    this->_group_reader_param.stats->_optimzation_counter += visitor.counter;
+                    this->_group_reader_param.stats->bloom_filter_tried_counter +=
+                            visitor.counter.bloom_filter_tried_counter;
+                    this->_group_reader_param.stats->bloom_filter_success_counter +=
+                            visitor.counter.bloom_filter_success_counter;
+                    this->_group_reader_param.stats->statistics_tried_counter +=
+                            visitor.counter.statistics_tried_counter;
+                    this->_group_reader_param.stats->statistics_success_counter +=
+                            visitor.counter.statistics_success_counter;
+                    this->_group_reader_param.stats->page_index_tried_counter +=
+                            visitor.counter.page_index_tried_counter;
+                    this->_group_reader_param.stats->page_index_filter_group_counter +=
+                            visitor.counter.page_index_filter_group_counter;
+                    this->_group_reader_param.stats->page_index_success_counter +=
+                            visitor.counter.page_index_success_counter;
                     return Status::OK();
                 },
                 true, 0));
@@ -292,13 +311,13 @@ Status FileReader::_init_group_readers() {
                                                               row_group_first_row, row_group_first_row_id);
         RETURN_IF_ERROR(row_group_reader->init());
 
-        _group_reader_param.stats->parquet_total_row_groups += 1;
+        _group_reader_param.stats->total_row_groups += 1;
 
         RETURN_IF_ERROR(_collect_row_group_io(row_group_reader));
         // You should call row_group_reader->init() before _filter_group()
         if (_filter_group(row_group_reader)) {
             DLOG(INFO) << "row group " << i << " of file has been filtered";
-            _group_reader_param.stats->parquet_filtered_row_groups += 1;
+            _group_reader_param.stats->filtered_row_groups += 1;
             continue;
         }
 
@@ -357,12 +376,11 @@ Status FileReader::get_next(ChunkPtr* chunk) {
                         auto ret = _update_rf_and_filter_group(cur_row_group);
                         if (ret.ok() && ret.value()) {
                             // row group is filtered by runtime filter
-                            _group_reader_param.stats->parquet_filtered_row_groups += 1;
+                            _group_reader_param.stats->filtered_row_groups += 1;
                             continue;
                         } else if (ret.status().is_end_of_file()) {
                             // If rf is always false, will return eof
-                            _group_reader_param.stats->parquet_filtered_row_groups +=
-                                    (_row_group_size - _cur_row_group_idx);
+                            _group_reader_param.stats->filtered_row_groups += (_row_group_size - _cur_row_group_idx);
                             _row_group_readers.assign(_row_group_readers.size(), nullptr);
                             _cur_row_group_idx = _row_group_size;
                             break;

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -54,7 +54,7 @@ FileReader::~FileReader() = default;
 
 Status FileReader::init(HdfsScannerContext* ctx) {
     _scanner_ctx = ctx;
-    if (ctx->options->use_file_metacache) {
+    if (ctx->params->options->use_file_metacache) {
         _cache = DataCache::GetInstance()->page_cache();
     }
 
@@ -78,23 +78,24 @@ Status FileReader::init(HdfsScannerContext* ctx) {
         return Status::OK();
     }
 
-    if (_scanner_ctx->rf_scan_range_pruner != nullptr) {
-        _rf_scan_range_pruner = std::make_shared<RuntimeScanRangePruner>(*_scanner_ctx->rf_scan_range_pruner);
+    if (_scanner_ctx->runtime_filter_scan_range_pruner != nullptr) {
+        _runtime_filter_scan_range_pruner =
+                std::make_shared<RuntimeScanRangePruner>(*_scanner_ctx->runtime_filter_scan_range_pruner);
     }
     RETURN_IF_ERROR(_init_group_readers());
     return Status::OK();
 }
 
 std::shared_ptr<MetaHelper> FileReader::_build_meta_helper() {
-    if (_scanner_ctx->lake_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
+    if (_scanner_ctx->params->lake_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
         // Use LakeMetaHelper only when both an Iceberg/Paimon lake schema is present AND
         // the parquet file carries field ids.  Without field ids, the lake schema cannot
         // be matched reliably and we fall back to ParquetMetaHelper which handles
         // col_unique_id / col_physical_name / name lookup chains correctly.
-        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->options->case_sensitive,
-                                                _scanner_ctx->lake_schema);
+        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options->case_sensitive,
+                                                _scanner_ctx->params->lake_schema);
     } else {
-        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->options->case_sensitive);
+        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options->case_sensitive);
     }
 }
 
@@ -115,7 +116,7 @@ Status FileReader::_build_split_tasks() {
     // don't do split in following cases:
     // 1. this feature is not enabled
     // 2. we have already done split before (that's why `split_context` is nullptr)
-    if (!_scanner_ctx->enable_split_tasks || _scanner_ctx->split_context != nullptr) {
+    if (!_scanner_ctx->params->enable_split_tasks || _scanner_ctx->params->split_context != nullptr) {
         return Status::OK();
     }
 
@@ -170,8 +171,8 @@ bool FileReader::_filter_group(const GroupReaderPtr& group_reader) {
     bool& filtered = group_reader->get_is_group_filtered();
     filtered = false;
     auto visitor = PredicateFilterEvaluator{_scanner_ctx->predicate_tree, group_reader.get(),
-                                            _scanner_ctx->options->parquet_page_index_enable,
-                                            _scanner_ctx->options->parquet_bloom_filter_enable};
+                                            _scanner_ctx->params->options->parquet_page_index_enable,
+                                            _scanner_ctx->params->options->parquet_bloom_filter_enable};
     auto sparse_range = _scanner_ctx->predicate_tree.visit(visitor);
     _group_reader_param.stats->_optimzation_counter += visitor.counter;
     if (!sparse_range.ok()) {
@@ -190,9 +191,9 @@ bool FileReader::_filter_group(const GroupReaderPtr& group_reader) {
 
 StatusOr<bool> FileReader::_update_rf_and_filter_group(const GroupReaderPtr& group_reader) {
     bool filter = false;
-    if (_rf_scan_range_pruner != nullptr) {
-        RETURN_IF_ERROR(_rf_scan_range_pruner->update_range_if_arrived(
-                _scanner_ctx->global_dictmaps,
+    if (_runtime_filter_scan_range_pruner != nullptr) {
+        RETURN_IF_ERROR(_runtime_filter_scan_range_pruner->update_range_if_arrived(
+                _scanner_ctx->params->global_dictmaps,
                 [this, &filter, &group_reader](auto cid, const PredicateList& predicates) {
                     PredicateCompoundNode<CompoundNodeType::AND> pred_tree;
                     for (const auto& pred : predicates) {
@@ -213,7 +214,7 @@ StatusOr<bool> FileReader::_update_rf_and_filter_group(const GroupReaderPtr& gro
 }
 
 void FileReader::_prepare_read_columns(std::unordered_set<std::string>& existed_column_names) {
-    _meta_helper->prepare_read_columns(_scanner_ctx->materialized_columns, _scanner_ctx->column_access_paths,
+    _meta_helper->prepare_read_columns(_scanner_ctx->materialized_columns, _scanner_ctx->params->column_access_paths,
                                        _group_reader_param.read_cols, existed_column_names);
     _no_materialized_column_scan =
             (_group_reader_param.read_cols.empty() && _scanner_ctx->reserved_field_slots.empty());
@@ -221,7 +222,7 @@ void FileReader::_prepare_read_columns(std::unordered_set<std::string>& existed_
 
 bool FileReader::_select_row_group(const tparquet::RowGroup& row_group) {
     size_t row_group_start = ParquetUtils::get_row_group_start_offset(row_group);
-    const auto* scan_range = _scanner_ctx->scan_range;
+    const auto* scan_range = _scanner_ctx->params->scan_range;
     size_t scan_start = scan_range->offset;
     size_t scan_end = scan_range->length + scan_start;
     if (row_group_start >= scan_start && row_group_start < scan_end) {
@@ -236,10 +237,10 @@ Status FileReader::_collect_row_group_io(std::shared_ptr<GroupReader>& group_rea
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         ColumnIOTypeFlags flags = 0;
-        if (_scanner_ctx->options->parquet_page_index_enable) {
+        if (_scanner_ctx->params->options->parquet_page_index_enable) {
             flags |= ColumnIOType::PAGE_INDEX;
         }
-        if (_scanner_ctx->options->parquet_bloom_filter_enable) {
+        if (_scanner_ctx->params->options->parquet_bloom_filter_enable) {
             flags |= ColumnIOType::BLOOM_FILTER;
         }
         group_reader->collect_io_ranges(&ranges, &end_offset, flags);
@@ -259,25 +260,25 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.chunk_size = _chunk_size;
     _group_reader_param.file = _file;
     _group_reader_param.file_metadata = _file_metadata.get();
-    _group_reader_param.case_sensitive = fd_scanner_ctx.options->case_sensitive;
-    _group_reader_param.use_file_pagecache = fd_scanner_ctx.options->use_file_pagecache;
-    _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.lazy_column_coalesce_counter;
+    _group_reader_param.case_sensitive = fd_scanner_ctx.params->options->case_sensitive;
+    _group_reader_param.use_file_pagecache = fd_scanner_ctx.params->options->use_file_pagecache;
+    _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.params->lazy_column_coalesce_counter;
     _group_reader_param.partition_columns = &fd_scanner_ctx.partition_columns;
     _group_reader_param.partition_values = &fd_scanner_ctx.partition_values;
     _group_reader_param.not_existed_slots = &fd_scanner_ctx.not_existed_slots;
     _group_reader_param.reserved_field_slots = &fd_scanner_ctx.reserved_field_slots;
     // for pageIndex — access via the shared conjuncts pointer
-    _group_reader_param.min_max_conjunct_ctxs = fd_scanner_ctx.conjuncts->min_max_ctxs;
+    _group_reader_param.min_max_conjunct_ctxs = fd_scanner_ctx.params->conjuncts->min_max_ctxs;
     _group_reader_param.predicate_tree = &fd_scanner_ctx.predicate_tree;
-    _group_reader_param.global_dictmaps = fd_scanner_ctx.global_dictmaps;
-    _group_reader_param.column_access_paths = fd_scanner_ctx.column_access_paths;
+    _group_reader_param.global_dictmaps = fd_scanner_ctx.params->global_dictmaps;
+    _group_reader_param.column_access_paths = fd_scanner_ctx.params->column_access_paths;
     _group_reader_param.modification_time = _datacache_options.modification_time;
     _group_reader_param.file_size = _file_size;
     _group_reader_param.datacache_options = &_datacache_options;
-    _group_reader_param.scan_range_id = fd_scanner_ctx.scan_range_id;
-    _group_reader_param.scan_range = fd_scanner_ctx.scan_range;
+    _group_reader_param.scan_range_id = fd_scanner_ctx.params->scan_range_id;
+    _group_reader_param.scan_range = fd_scanner_ctx.params->scan_range;
 
-    int64_t row_group_first_row_id = _scanner_ctx->scan_range->first_row_id;
+    int64_t row_group_first_row_id = _scanner_ctx->params->scan_range->first_row_id;
     int64_t row_group_first_row = 0;
     // select and create row group readers.
     for (size_t i = 0; i < _file_metadata->t_metadata().row_groups.size(); i++) {
@@ -399,7 +400,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
 Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = 0;
-        if (_scanner_ctx->options->use_count_opt) {
+        if (_scanner_ctx->params->options->use_count_opt) {
             read_size = _total_row_count - _scan_row_count;
             _scanner_ctx->append_or_update_count_column_to_chunk(chunk, read_size);
             _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -87,13 +87,13 @@ Status FileReader::init(HdfsScannerContext* ctx) {
 }
 
 std::shared_ptr<MetaHelper> FileReader::_build_meta_helper() {
-    if (_scanner_ctx->params->lake_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
+    if (_scanner_ctx->params->table_specific.iceberg_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
         // Use LakeMetaHelper only when both an Iceberg/Paimon lake schema is present AND
         // the parquet file carries field ids.  Without field ids, the lake schema cannot
         // be matched reliably and we fall back to ParquetMetaHelper which handles
         // col_unique_id / col_physical_name / name lookup chains correctly.
         return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options->case_sensitive,
-                                                _scanner_ctx->params->lake_schema);
+                                                _scanner_ctx->params->table_specific.iceberg_schema);
     } else {
         return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options->case_sensitive);
     }
@@ -116,7 +116,7 @@ Status FileReader::_build_split_tasks() {
     // don't do split in following cases:
     // 1. this feature is not enabled
     // 2. we have already done split before (that's why `split_context` is nullptr)
-    if (!_scanner_ctx->params->enable_split_tasks || _scanner_ctx->params->split_context != nullptr) {
+    if (!_scanner_ctx->params->options->enable_split_tasks || _scanner_ctx->params->split_context != nullptr) {
         return Status::OK();
     }
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -54,7 +54,7 @@ FileReader::~FileReader() = default;
 
 Status FileReader::init(HdfsScannerContext* ctx) {
     _scanner_ctx = ctx;
-    if (ctx->params->options->use_file_metacache) {
+    if (ctx->params->options.use_file_metacache) {
         _cache = DataCache::GetInstance()->page_cache();
     }
 
@@ -92,10 +92,10 @@ std::shared_ptr<MetaHelper> FileReader::_build_meta_helper() {
         // the parquet file carries field ids.  Without field ids, the lake schema cannot
         // be matched reliably and we fall back to ParquetMetaHelper which handles
         // col_unique_id / col_physical_name / name lookup chains correctly.
-        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options->case_sensitive,
+        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options.case_sensitive,
                                                 _scanner_ctx->params->table_specific.iceberg_schema);
     } else {
-        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options->case_sensitive);
+        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->params->options.case_sensitive);
     }
 }
 
@@ -116,7 +116,7 @@ Status FileReader::_build_split_tasks() {
     // don't do split in following cases:
     // 1. this feature is not enabled
     // 2. we have already done split before (that's why `split_context` is nullptr)
-    if (!_scanner_ctx->params->options->enable_split_tasks || _scanner_ctx->params->split_context != nullptr) {
+    if (!_scanner_ctx->params->options.enable_split_tasks || _scanner_ctx->params->split_context != nullptr) {
         return Status::OK();
     }
 
@@ -171,8 +171,8 @@ bool FileReader::_filter_group(const GroupReaderPtr& group_reader) {
     bool& filtered = group_reader->get_is_group_filtered();
     filtered = false;
     auto visitor = PredicateFilterEvaluator{_scanner_ctx->predicate_tree, group_reader.get(),
-                                            _scanner_ctx->params->options->parquet_page_index_enable,
-                                            _scanner_ctx->params->options->parquet_bloom_filter_enable};
+                                            _scanner_ctx->params->options.parquet_page_index_enable,
+                                            _scanner_ctx->params->options.parquet_bloom_filter_enable};
     auto sparse_range = _scanner_ctx->predicate_tree.visit(visitor);
     _group_reader_param.stats->bloom_filter_tried_counter += visitor.counter.bloom_filter_tried_counter;
     _group_reader_param.stats->bloom_filter_success_counter += visitor.counter.bloom_filter_success_counter;
@@ -256,10 +256,10 @@ Status FileReader::_collect_row_group_io(std::shared_ptr<GroupReader>& group_rea
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         ColumnIOTypeFlags flags = 0;
-        if (_scanner_ctx->params->options->parquet_page_index_enable) {
+        if (_scanner_ctx->params->options.parquet_page_index_enable) {
             flags |= ColumnIOType::PAGE_INDEX;
         }
-        if (_scanner_ctx->params->options->parquet_bloom_filter_enable) {
+        if (_scanner_ctx->params->options.parquet_bloom_filter_enable) {
             flags |= ColumnIOType::BLOOM_FILTER;
         }
         group_reader->collect_io_ranges(&ranges, &end_offset, flags);
@@ -411,7 +411,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
 Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = 0;
-        if (_scanner_ctx->params->options->use_count_opt) {
+        if (_scanner_ctx->params->options.use_count_opt) {
             read_size = _total_row_count - _scan_row_count;
             _scanner_ctx->append_or_update_count_column_to_chunk(chunk, read_size);
             _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -252,26 +252,19 @@ Status FileReader::_collect_row_group_io(std::shared_ptr<GroupReader>& group_rea
 Status FileReader::_init_group_readers() {
     const HdfsScannerContext& fd_scanner_ctx = *_scanner_ctx;
 
-    // _group_reader_param is used by all group readers
+    // _group_reader_param is used by all group readers.
+    // scanner_ctx replaces 11 individual field copies; GroupReader accesses
+    // context-derived data (timezone, options, partitions, slots, dicts, etc.)
+    // through the pointer.  File-infrastructure fields (sb_stream, file, etc.)
+    // and hot fields (stats, lazy_column_coalesce_counter) remain direct copies.
+    _group_reader_param.scanner_ctx = _scanner_ctx;
     _group_reader_param.conjunct_ctxs_by_slot = fd_scanner_ctx.conjunct_ctxs_by_slot;
-    _group_reader_param.timezone = fd_scanner_ctx.timezone;
     _group_reader_param.stats = fd_scanner_ctx.stats;
     _group_reader_param.sb_stream = _sb_stream;
     _group_reader_param.chunk_size = _chunk_size;
     _group_reader_param.file = _file;
     _group_reader_param.file_metadata = _file_metadata.get();
-    _group_reader_param.case_sensitive = fd_scanner_ctx.params->options->case_sensitive;
-    _group_reader_param.use_file_pagecache = fd_scanner_ctx.params->options->use_file_pagecache;
     _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.params->lazy_column_coalesce_counter;
-    _group_reader_param.partition_columns = &fd_scanner_ctx.partition_columns;
-    _group_reader_param.partition_values = &fd_scanner_ctx.partition_values;
-    _group_reader_param.not_existed_slots = &fd_scanner_ctx.not_existed_slots;
-    _group_reader_param.reserved_field_slots = &fd_scanner_ctx.reserved_field_slots;
-    // for pageIndex — access via the shared conjuncts pointer
-    _group_reader_param.min_max_conjunct_ctxs = fd_scanner_ctx.params->conjuncts->min_max_ctxs;
-    _group_reader_param.predicate_tree = &fd_scanner_ctx.predicate_tree;
-    _group_reader_param.global_dictmaps = fd_scanner_ctx.params->global_dictmaps;
-    _group_reader_param.column_access_paths = fd_scanner_ctx.params->column_access_paths;
     _group_reader_param.modification_time = _datacache_options.modification_time;
     _group_reader_param.file_size = _file_size;
     _group_reader_param.datacache_options = &_datacache_options;

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -54,7 +54,7 @@ FileReader::~FileReader() = default;
 
 Status FileReader::init(HdfsScannerContext* ctx) {
     _scanner_ctx = ctx;
-    if (ctx->use_file_metacache) {
+    if (ctx->options->use_file_metacache) {
         _cache = DataCache::GetInstance()->page_cache();
     }
 
@@ -91,10 +91,10 @@ std::shared_ptr<MetaHelper> FileReader::_build_meta_helper() {
         // the parquet file carries field ids.  Without field ids, the lake schema cannot
         // be matched reliably and we fall back to ParquetMetaHelper which handles
         // col_unique_id / col_physical_name / name lookup chains correctly.
-        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->case_sensitive,
+        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->options->case_sensitive,
                                                 _scanner_ctx->lake_schema);
     } else {
-        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->case_sensitive);
+        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->options->case_sensitive);
     }
 }
 
@@ -170,8 +170,8 @@ bool FileReader::_filter_group(const GroupReaderPtr& group_reader) {
     bool& filtered = group_reader->get_is_group_filtered();
     filtered = false;
     auto visitor = PredicateFilterEvaluator{_scanner_ctx->predicate_tree, group_reader.get(),
-                                            _scanner_ctx->parquet_page_index_enable,
-                                            _scanner_ctx->parquet_bloom_filter_enable};
+                                            _scanner_ctx->options->parquet_page_index_enable,
+                                            _scanner_ctx->options->parquet_bloom_filter_enable};
     auto sparse_range = _scanner_ctx->predicate_tree.visit(visitor);
     _group_reader_param.stats->_optimzation_counter += visitor.counter;
     if (!sparse_range.ok()) {
@@ -236,10 +236,10 @@ Status FileReader::_collect_row_group_io(std::shared_ptr<GroupReader>& group_rea
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         ColumnIOTypeFlags flags = 0;
-        if (_scanner_ctx->parquet_page_index_enable) {
+        if (_scanner_ctx->options->parquet_page_index_enable) {
             flags |= ColumnIOType::PAGE_INDEX;
         }
-        if (_scanner_ctx->parquet_bloom_filter_enable) {
+        if (_scanner_ctx->options->parquet_bloom_filter_enable) {
             flags |= ColumnIOType::BLOOM_FILTER;
         }
         group_reader->collect_io_ranges(&ranges, &end_offset, flags);
@@ -259,15 +259,15 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.chunk_size = _chunk_size;
     _group_reader_param.file = _file;
     _group_reader_param.file_metadata = _file_metadata.get();
-    _group_reader_param.case_sensitive = fd_scanner_ctx.case_sensitive;
-    _group_reader_param.use_file_pagecache = fd_scanner_ctx.use_file_pagecache;
+    _group_reader_param.case_sensitive = fd_scanner_ctx.options->case_sensitive;
+    _group_reader_param.use_file_pagecache = fd_scanner_ctx.options->use_file_pagecache;
     _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.lazy_column_coalesce_counter;
     _group_reader_param.partition_columns = &fd_scanner_ctx.partition_columns;
     _group_reader_param.partition_values = &fd_scanner_ctx.partition_values;
     _group_reader_param.not_existed_slots = &fd_scanner_ctx.not_existed_slots;
     _group_reader_param.reserved_field_slots = &fd_scanner_ctx.reserved_field_slots;
-    // for pageIndex
-    _group_reader_param.min_max_conjunct_ctxs = fd_scanner_ctx.min_max_conjunct_ctxs;
+    // for pageIndex — access via the shared conjuncts pointer
+    _group_reader_param.min_max_conjunct_ctxs = fd_scanner_ctx.conjuncts->min_max_ctxs;
     _group_reader_param.predicate_tree = &fd_scanner_ctx.predicate_tree;
     _group_reader_param.global_dictmaps = fd_scanner_ctx.global_dictmaps;
     _group_reader_param.column_access_paths = fd_scanner_ctx.column_access_paths;
@@ -399,7 +399,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
 Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = 0;
-        if (_scanner_ctx->use_count_opt) {
+        if (_scanner_ctx->options->use_count_opt) {
             read_size = _total_row_count - _scan_row_count;
             _scanner_ctx->append_or_update_count_column_to_chunk(chunk, read_size);
             _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -98,8 +98,6 @@ private:
     StatusOr<bool> _update_rf_and_filter_group(const GroupReaderPtr& group_reader);
 
     // get row group to read
-    // if scan range contain the first byte in the row group, will be read
-    // TODO: later modify the larger block should be read
     bool _select_row_group(const tparquet::RowGroup& row_group);
 
     // only scan partition column + not exist column
@@ -131,7 +129,7 @@ private:
     GroupReaderParam _group_reader_param;
     std::shared_ptr<MetaHelper> _meta_helper = nullptr;
     SkipRowsContextPtr _skip_rows_ctx = nullptr;
-    std::shared_ptr<RuntimeScanRangePruner> _rf_scan_range_pruner;
+    std::shared_ptr<RuntimeScanRangePruner> _runtime_filter_scan_range_pruner;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -402,6 +402,9 @@ Status GroupReader::_create_column_readers() {
     _global_dict_applied_in_group = false;
     ColumnReaderOptions& opts = _column_reader_opts;
     opts.file_meta_data = _param.file_metadata;
+    if (_param.scanner_ctx == nullptr) {
+        return Status::InternalError("GroupReader: scanner_ctx must not be null");
+    }
     opts.timezone = _param.scanner_ctx->timezone;
     opts.case_sensitive = _param.scanner_ctx->params->options.case_sensitive;
     opts.use_file_pagecache = _param.scanner_ctx->params->options.use_file_pagecache;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -402,9 +402,9 @@ Status GroupReader::_create_column_readers() {
     _global_dict_applied_in_group = false;
     ColumnReaderOptions& opts = _column_reader_opts;
     opts.file_meta_data = _param.file_metadata;
-    opts.timezone = _param.timezone;
-    opts.case_sensitive = _param.case_sensitive;
-    opts.use_file_pagecache = _param.use_file_pagecache;
+    opts.timezone = _param.scanner_ctx->timezone;
+    opts.case_sensitive = _param.scanner_ctx->params->options->case_sensitive;
+    opts.use_file_pagecache = _param.scanner_ctx->params->options->use_file_pagecache;
     opts.chunk_size = _param.chunk_size;
     opts.stats = _param.stats;
     opts.file = _param.file;
@@ -428,30 +428,27 @@ Status GroupReader::_create_column_readers() {
     _variant->register_zone_map_readers();
 
     // create for partition values
-    if (_param.partition_columns != nullptr && _param.partition_values != nullptr) {
-        for (size_t i = 0; i < _param.partition_columns->size(); i++) {
-            const auto& column = (*_param.partition_columns)[i];
-            const auto* slot_desc = column.slot_desc;
-            const auto value = (*_param.partition_values)[i];
-            _column_readers.emplace(slot_desc->id(), std::make_unique<FixedValueColumnReader>(value->get(0)));
-        }
+    const auto& partition_columns = _param.scanner_ctx->partition_columns;
+    const auto& partition_values = _param.scanner_ctx->partition_values;
+    for (size_t i = 0; i < partition_columns.size(); i++) {
+        const auto& column = partition_columns[i];
+        const auto* slot_desc = column.slot_desc;
+        const auto value = partition_values[i];
+        _column_readers.emplace(slot_desc->id(), std::make_unique<FixedValueColumnReader>(value->get(0)));
     }
 
     // create for not existed column
-    if (_param.not_existed_slots != nullptr) {
-        for (size_t i = 0; i < _param.not_existed_slots->size(); i++) {
-            const auto* slot = (*_param.not_existed_slots)[i];
-            _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(kNullDatum));
-        }
+    for (const auto* slot : _param.scanner_ctx->not_existed_slots) {
+        _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(kNullDatum));
     }
 
-    if (_param.reserved_field_slots != nullptr && !_param.reserved_field_slots->empty()) {
+    const auto& reserved_slots = _param.scanner_ctx->reserved_field_slots;
+    if (!reserved_slots.empty()) {
         bool use_legacy_lookup_row_id =
-                std::any_of(_param.reserved_field_slots->begin(), _param.reserved_field_slots->end(),
-                            [](const SlotDescriptor* slot) {
-                                return slot->col_name() == "_row_source_id" || slot->col_name() == "_scan_range_id";
-                            });
-        for (const auto* slot : *_param.reserved_field_slots) {
+                std::any_of(reserved_slots.begin(), reserved_slots.end(), [](const SlotDescriptor* slot) {
+                    return slot->col_name() == "_row_source_id" || slot->col_name() == "_scan_range_id";
+                });
+        for (const auto* slot : reserved_slots) {
             if (slot->col_name() == HdfsScanner::ICEBERG_ROW_ID) {
                 ASSIGN_OR_RETURN(auto reader,
                                  _create_reserved_iceberg_column_reader(slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID));
@@ -515,8 +512,8 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
             schema_node->type == ColumnType::STRUCT) {
             // Physical VARIANT columns use _get_variant_shredded_hints; this path
             // is for non-virtual VARIANT columns that appear directly in the SELECT list.
-            VariantShreddedReadHints hints =
-                    build_variant_shredded_hints(_param.column_access_paths, column.slot_desc->col_name());
+            VariantShreddedReadHints hints = build_variant_shredded_hints(
+                    _param.scanner_ctx->params->column_access_paths, column.slot_desc->col_name());
             ASSIGN_OR_RETURN(column_reader, ColumnReaderFactory::create_variant_column_reader(_column_reader_opts,
                                                                                               schema_node, hints));
         } else if (column.t_lake_schema_field == nullptr) {
@@ -527,12 +524,12 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
                              ColumnReaderFactory::create(_column_reader_opts, schema_node, column.slot_type(),
                                                          column.t_lake_schema_field));
         }
-        if (_param.global_dictmaps->contains(column.slot_id())) {
+        auto* global_dictmaps = _param.scanner_ctx->params->global_dictmaps;
+        if (global_dictmaps->contains(column.slot_id())) {
             GlobalDictReaderKind kind = GlobalDictReaderKind::kNone;
-            ASSIGN_OR_RETURN(
-                    column_reader,
-                    ColumnReaderFactory::create(std::move(column_reader), _param.global_dictmaps->at(column.slot_id()),
-                                                column.slot_id(), _row_group_metadata->num_rows, &kind));
+            ASSIGN_OR_RETURN(column_reader, ColumnReaderFactory::create(
+                                                    std::move(column_reader), global_dictmaps->at(column.slot_id()),
+                                                    column.slot_id(), _row_group_metadata->num_rows, &kind));
             if (_param.stats != nullptr && kind != GlobalDictReaderKind::kNone) {
                 _param.stats->global_dict_applied_slots++;
                 if (kind == GlobalDictReaderKind::kDictCode) {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -151,9 +151,9 @@ Status GroupReader::prepare() {
         collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
         int32_t counter = _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed);
         if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
-            _param.stats->group_active_lazy_coalesce_together += 1;
+            _param.stats->active_lazy_coalesce_together += 1;
         } else {
-            _param.stats->group_active_lazy_coalesce_seperately += 1;
+            _param.stats->active_lazy_coalesce_seperately += 1;
         }
         _set_end_offset(end_offset);
         RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, counter >= 0));

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -403,8 +403,8 @@ Status GroupReader::_create_column_readers() {
     ColumnReaderOptions& opts = _column_reader_opts;
     opts.file_meta_data = _param.file_metadata;
     opts.timezone = _param.scanner_ctx->timezone;
-    opts.case_sensitive = _param.scanner_ctx->params->options->case_sensitive;
-    opts.use_file_pagecache = _param.scanner_ctx->params->options->use_file_pagecache;
+    opts.case_sensitive = _param.scanner_ctx->params->options.case_sensitive;
+    opts.use_file_pagecache = _param.scanner_ctx->params->options.use_file_pagecache;
     opts.chunk_size = _param.chunk_size;
     opts.stats = _param.stats;
     opts.file = _param.file;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -82,7 +82,9 @@ struct GroupReaderParam {
     // context-derived fields (partition columns, not-existed slots, options,
     // global dicts, etc.) without copying them into every GroupReaderParam.
     // Always non-null when used from FileReader; may be null in unit tests.
-    const HdfsScannerContext* scanner_ctx = nullptr;
+    // Non-const because unit tests need to populate the context fields after
+    // construction; GroupReader treats it as read-only by convention.
+    HdfsScannerContext* scanner_ctx = nullptr;
 
     // conjunct_ctxs that column is materialized in group reader
     // Mutable per-group-reader shallow copy of the scanner context's by_slot map;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -42,6 +42,7 @@
 namespace starrocks {
 class RandomAccessFile;
 struct HdfsScanStats;
+struct HdfsScannerContext;
 class ExprContext;
 class TIcebergSchemaField;
 class THdfsScanRange;
@@ -77,13 +78,19 @@ struct GroupReaderParam {
         const SlotId slot_id() const { return slot_desc->id(); }
     };
 
+    // Non-owning pointer to the scanner context. Provides access to all
+    // context-derived fields (partition columns, not-existed slots, options,
+    // global dicts, etc.) without copying them into every GroupReaderParam.
+    // Always non-null when used from FileReader; may be null in unit tests.
+    const HdfsScannerContext* scanner_ctx = nullptr;
+
     // conjunct_ctxs that column is materialized in group reader
+    // Mutable per-group-reader shallow copy of the scanner context's by_slot map;
+    // update_with_none_existed_slot() erases entries for absent columns.
     std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
 
     // columns
     std::vector<Column> read_cols;
-
-    std::string timezone;
 
     HdfsScanStats* stats = nullptr;
 
@@ -95,9 +102,6 @@ struct GroupReaderParam {
 
     const FileMetaData* file_metadata = nullptr;
 
-    bool case_sensitive = false;
-
-    bool use_file_pagecache = false;
     int64_t modification_time = 0;
     uint64_t file_size = 0;
     const DataCacheOptions* datacache_options;
@@ -105,22 +109,8 @@ struct GroupReaderParam {
     // used to identify io coalesce
     std::atomic<int32_t>* lazy_column_coalesce_counter = nullptr;
 
-    // used for pageIndex
-    std::vector<ExprContext*> min_max_conjunct_ctxs;
-    const PredicateTree* predicate_tree = nullptr;
-
-    // partition column
-    const std::vector<HdfsScannerContext::ColumnInfo>* partition_columns = nullptr;
-    // partition column value which read from hdfs file path
-    const Columns* partition_values = nullptr;
-    // not existed column
-    const std::vector<SlotDescriptor*>* not_existed_slots = nullptr;
-    // reserved field slots
-    const std::vector<SlotDescriptor*>* reserved_field_slots = nullptr;
-    // used for global low cardinality optimization
-    ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
-    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
-
+    // Kept directly in GroupReaderParam for test-compatibility; also used by
+    // _get_extended_bigint_value() to read extended_columns from the scan range.
     int32_t scan_range_id = -1;
     const THdfsScanRange* scan_range = nullptr;
 };

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -440,8 +440,8 @@ bool ApplicationVersion::IsAlwaysCompressed() const {
 
 StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
     // return from split_context directly
-    if (_scanner_ctx->split_context != nullptr) {
-        auto split_ctx = down_cast<const SplitContext*>(_scanner_ctx->split_context);
+    if (_scanner_ctx->params->split_context != nullptr) {
+        auto split_ctx = down_cast<const SplitContext*>(_scanner_ctx->params->split_context);
         return split_ctx->file_metadata;
     }
 
@@ -527,7 +527,7 @@ Status FileMetaDataParser::_parse_footer(FileMetaDataPtr* file_metadata_ptr, int
 
         *file_metadata_ptr = std::make_shared<FileMetaData>();
         FileMetaData* file_metadata = file_metadata_ptr->get();
-        RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->case_sensitive));
+        RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->params->options->case_sensitive));
         *file_metadata_size = CurrentThread::current().get_consumed_bytes() - before_bytes;
     }
 #if defined(BE_TEST) || defined(__SANITIZE_ADDRESS__) || defined(ADDRESS_SANITIZER)

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -527,7 +527,7 @@ Status FileMetaDataParser::_parse_footer(FileMetaDataPtr* file_metadata_ptr, int
 
         *file_metadata_ptr = std::make_shared<FileMetaData>();
         FileMetaData* file_metadata = file_metadata_ptr->get();
-        RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->params->options->case_sensitive));
+        RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->params->options.case_sensitive));
         *file_metadata_size = CurrentThread::current().get_consumed_bytes() - before_bytes;
     }
 #if defined(BE_TEST) || defined(__SANITIZE_ADDRESS__) || defined(ADDRESS_SANITIZER)

--- a/be/src/formats/parquet/predicate_filter_evaluator.h
+++ b/be/src/formats/parquet/predicate_filter_evaluator.h
@@ -234,7 +234,17 @@ struct PredicateFilterEvaluator {
     GroupReader* group_reader;
     bool enable_page_index;
     bool enable_bloom_filter;
-    OptimizationCounter counter;
+
+    struct FilterCounter {
+        int bloom_filter_tried_counter = 0;
+        int bloom_filter_success_counter = 0;
+        int statistics_tried_counter = 0;
+        int statistics_success_counter = 0;
+        int page_index_tried_counter = 0;
+        int page_index_filter_group_counter = 0;
+        int page_index_success_counter = 0;
+    };
+    FilterCounter counter;
     std::optional<SparseRange<uint64_t>> row_ranges_before_bf = std::nullopt;
 };
 

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -395,7 +395,7 @@ VariantProjectionHandler::~VariantProjectionHandler() = default;
 // ── _build_shredded_hints ────────────────────────────────────────────────────
 
 VariantShreddedReadHints VariantProjectionHandler::_build_shredded_hints(std::string_view column_name) const {
-    return build_variant_shredded_hints(_param.column_access_paths, column_name);
+    return build_variant_shredded_hints(_param.scanner_ctx->params->column_access_paths, column_name);
 }
 
 // ── setup_readers ────────────────────────────────────────────────────────────
@@ -872,11 +872,12 @@ const cctz::time_zone& VariantProjectionHandler::projection_timezone() {
         return _timezone_obj;
     }
     _timezone_resolved = true;
-    if (_param.timezone.empty()) {
+    if (_param.scanner_ctx->timezone.empty()) {
         return _timezone_obj;
     }
-    if (!TimezoneUtils::find_cctz_time_zone(_param.timezone, _timezone_obj)) {
-        LOG(WARNING) << "VariantProjectionHandler: fallback to UTC for invalid timezone: " << _param.timezone;
+    if (!TimezoneUtils::find_cctz_time_zone(_param.scanner_ctx->timezone, _timezone_obj)) {
+        LOG(WARNING) << "VariantProjectionHandler: fallback to UTC for invalid timezone: "
+                     << _param.scanner_ctx->timezone;
         _timezone_obj = cctz::utc_time_zone();
     }
     return _timezone_obj;

--- a/be/test/connector/deletion_vector/deletion_vector_test.cpp
+++ b/be/test/connector/deletion_vector/deletion_vector_test.cpp
@@ -47,9 +47,9 @@ TEST_F(DeletionVectorTest, inlineDeletionVectorTest) {
 
 TEST_F(DeletionVectorTest, absolutePathTest) {
     // test relative path
-    params.deletion_vector_descriptor = std::make_shared<TDeletionVectorDescriptor>();
-    params.deletion_vector_descriptor->__set_storageType("u");
-    params.deletion_vector_descriptor->__set_pathOrInlineDv("ab^-aqEH.-t@S}K{vb[*k^");
+    params.table_specific.deletion_vector_descriptor = std::make_shared<TDeletionVectorDescriptor>();
+    params.table_specific.deletion_vector_descriptor->__set_storageType("u");
+    params.table_specific.deletion_vector_descriptor->__set_pathOrInlineDv("ab^-aqEH.-t@S}K{vb[*k^");
     dv = std::make_shared<DeletionVector>(params);
 
     std::string table_location = "s3://mytable";
@@ -57,9 +57,9 @@ TEST_F(DeletionVectorTest, absolutePathTest) {
     ASSERT_TRUE(absolute_path.ok());
     ASSERT_EQ("s3://mytable/ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin", absolute_path.value());
     // test absolute path
-    params.deletion_vector_descriptor = std::make_shared<TDeletionVectorDescriptor>();
-    params.deletion_vector_descriptor->__set_storageType("p");
-    params.deletion_vector_descriptor->__set_pathOrInlineDv(
+    params.table_specific.deletion_vector_descriptor = std::make_shared<TDeletionVectorDescriptor>();
+    params.table_specific.deletion_vector_descriptor->__set_storageType("p");
+    params.table_specific.deletion_vector_descriptor->__set_pathOrInlineDv(
             "s3://mytable/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin");
     dv = std::make_shared<DeletionVector>(params);
     absolute_path = dv->get_absolute_path(table_location);

--- a/be/test/exec/hdfs_scanner/cache_select_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/cache_select_scanner_test.cpp
@@ -87,7 +87,7 @@ HdfsScannerParams* CacheSelectScannerTest::_create_param(const std::string& file
     auto* param = _pool.add(new HdfsScannerParams());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     param->fs = FileSystem::Default();
-    param->path = file;
+    param->file_path = file;
     param->file_size = range->file_length;
     param->scan_range = range;
     param->tuple_desc = tuple_desc;

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp
@@ -57,7 +57,7 @@ void HdfsScannerJsonReaderTest::TearDown() {}
 void HdfsScannerJsonReaderTest::create_random_access_file(const std::string& path) {
     ASSIGN_OR_ABORT(_fs, FileSystemFactory::CreateSharedFromString(path));
     _opts.fs = _fs.get();
-    _opts.path = path;
+    _opts.file_path = path;
     _opts.file_size = _fs->get_file_size(path).value();
     ASSIGN_OR_ABORT(_file,
                     HdfsScanner::create_random_access_file(_shared_buffered_input_stream, _cache_input_stream, _opts));

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -327,10 +327,12 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
                         {"c2", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
                         {""}};
     auto* tuple_desc = _create_tuple_desc(descs);
+    HdfsScannerParams scanner_params;
     HdfsScannerContext ctx;
+    ctx.params = &scanner_params;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
     ctx.not_existed_slots.push_back(tuple_desc->slots()[1]);
-    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
+    scanner_params.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -342,9 +344,11 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
 TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
     SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)}, {""}};
     auto* tuple_desc = _create_tuple_desc(descs);
+    HdfsScannerParams scanner_params;
     HdfsScannerContext ctx;
+    ctx.params = &scanner_params;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    scanner_params.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -356,9 +360,11 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
 TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
     SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)}, {""}};
     auto* tuple_desc = _create_tuple_desc_with_nullable(descs, false);
+    HdfsScannerParams scanner_params;
     HdfsScannerContext ctx;
+    ctx.params = &scanner_params;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    scanner_params.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -369,9 +375,11 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
 TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonString) {
     SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
     auto* tuple_desc = _create_tuple_desc(descs);
+    HdfsScannerParams scanner_params;
     HdfsScannerContext ctx;
+    ctx.params = &scanner_params;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    scanner_params.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     auto status = ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1);

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -123,7 +123,7 @@ HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfs
     auto* param = _pool.add(new HdfsScannerParams());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     param->fs = FileSystem::Default();
-    param->path = file;
+    param->file_path = file;
     param->file_size = range->file_length;
     param->scan_range = range;
     param->tuple_desc = tuple_desc;
@@ -294,7 +294,7 @@ TEST_F(HdfsScannerTest, TestAvroGetNextWithDirectReader) {
     ASSERT_EQ(100, scanner->raw_rows_read());
     ASSERT_EQ(100, scanner->num_rows_read());
 
-    HdfsScanProfile profile;
+    HdfsScannerProfile profile;
     profile.runtime_profile = _runtime_profile;
     scanner->do_update_counter(&profile);
     ASSERT_NE(nullptr, _runtime_profile->get_counter("DirectPathUsed"));
@@ -313,7 +313,7 @@ TEST_F(HdfsScannerTest, TestAvroGetNextWithDirectReader) {
 
 TEST_F(HdfsScannerTest, TestAvroUpdateCounterWithoutOpen) {
     HdfsAvroScanner scanner;
-    HdfsScanProfile profile;
+    HdfsScannerProfile profile;
     profile.runtime_profile = _runtime_profile;
 
     scanner.do_update_counter(&profile);
@@ -330,7 +330,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
     HdfsScannerContext ctx;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
     ctx.not_existed_slots.push_back(tuple_desc->slots()[1]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
+    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -344,7 +344,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
     auto* tuple_desc = _create_tuple_desc(descs);
     HdfsScannerContext ctx;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -358,7 +358,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
     auto* tuple_desc = _create_tuple_desc_with_nullable(descs, false);
     HdfsScannerContext ctx;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -371,7 +371,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonString) {
     auto* tuple_desc = _create_tuple_desc(descs);
     HdfsScannerContext ctx;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    ctx.params->materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     auto status = ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1);
@@ -677,7 +677,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerPar
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::BIGINT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(pool, nodes);
-        params->min_max_conjunct_ctxs.push_back(ctx);
+        params->conjuncts.min_max_ctxs.push_back(ctx);
     }
 
     {
@@ -686,7 +686,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerPar
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[0], TPrimitiveType::BIGINT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(pool, nodes);
-        params->min_max_conjunct_ctxs.push_back(ctx);
+        params->conjuncts.min_max_ctxs.push_back(ctx);
     }
 
     // PART_Y is always 20
@@ -697,7 +697,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerPar
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[1], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(pool, nodes);
-        params->min_max_conjunct_ctxs.push_back(ctx);
+        params->conjuncts.min_max_ctxs.push_back(ctx);
     }
 
     {
@@ -706,7 +706,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerPar
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[1], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(pool, nodes);
-        params->min_max_conjunct_ctxs.push_back(ctx);
+        params->conjuncts.min_max_ctxs.push_back(ctx);
     }
 }
 
@@ -755,8 +755,8 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {20, 30, 20, 20};
     extend_mtypes_orc_min_max_conjuncts(&_pool, param, thres);
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -786,8 +786,8 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows1) {
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {2000, 5000, 20, 20};
     extend_mtypes_orc_min_max_conjuncts(&_pool, param, thres);
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -817,8 +817,8 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows2) {
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {3000, 10000, 20, 20};
     extend_mtypes_orc_min_max_conjuncts(&_pool, param, thres);
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -884,10 +884,10 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDictFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, tuple_desc->slots()[0], TPrimitiveType::VARCHAR, lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
         std::cout << "equal expr = " << ctx->root()->debug_string() << std::endl;
-        param->conjunct_ctxs_by_slot[0].push_back(ctx);
+        param->conjuncts.by_slot[0].push_back(ctx);
     }
 
-    for (auto& it : param->conjunct_ctxs_by_slot) {
+    for (auto& it : param->conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -970,10 +970,10 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDiffEncodeDictFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, tuple_desc->slots()[1], TPrimitiveType::VARCHAR, lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
         std::cout << "equal expr = " << ctx->root()->debug_string() << std::endl;
-        param->conjunct_ctxs_by_slot[1].push_back(ctx);
+        param->conjuncts.by_slot[1].push_back(ctx);
     }
 
-    for (auto& it : param->conjunct_ctxs_by_slot) {
+    for (auto& it : param->conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1069,11 +1069,11 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDatetimeMinMaxFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::DATETIME,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -1167,10 +1167,10 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithPaddingCharDictFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, tuple_desc->slots()[0], TPrimitiveType::VARCHAR, lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
         std::cout << "less&eq expr = " << ctx->root()->debug_string() << std::endl;
-        param->conjunct_ctxs_by_slot[0].push_back(ctx);
+        param->conjuncts.by_slot[0].push_back(ctx);
     }
 
-    for (auto& it : param->conjunct_ctxs_by_slot) {
+    for (auto& it : param->conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1290,11 +1290,11 @@ TEST_F(HdfsScannerTest, TestOrcDecodeMinMaxDateTime) {
             push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, min_max_tuple_desc->slots()[0],
                                         TPrimitiveType::DATETIME, lit_node);
             ExprContext* ctx = create_expr_context(&_pool, nodes);
-            param->min_max_conjunct_ctxs.push_back(ctx);
+            param->conjuncts.min_max_ctxs.push_back(ctx);
         }
 
-        ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-        ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+        ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+        ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
         auto scanner = std::make_shared<HdfsOrcScanner>();
         Status status = scanner->init(_runtime_state, *param);
@@ -1341,11 +1341,11 @@ TEST_F(HdfsScannerTest, TestOrcDecodeMinMaxWithTypeMismatch) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GT, min_max_tuple_desc->slots()[0], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     auto scanner = std::make_shared<HdfsOrcScanner>();
     Status status = scanner->init(_runtime_state, *param);
@@ -1487,10 +1487,10 @@ TEST_F(HdfsScannerTest, TestOrcLazyLoad) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, tuple_desc->slots()[0], TPrimitiveType::INT, lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
         std::cout << "greater&eq expr = " << ctx->root()->debug_string() << std::endl;
-        param->conjunct_ctxs_by_slot[0].push_back(ctx);
+        param->conjuncts.by_slot[0].push_back(ctx);
     }
 
-    for (auto& it : param->conjunct_ctxs_by_slot) {
+    for (auto& it : param->conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1553,10 +1553,10 @@ TEST_F(HdfsScannerTest, TestOrcMapLazyLoadWithSubfieldSeleted) {
         TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 3);
         push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, tuple_desc->slots()[0], TPrimitiveType::INT, lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->conjunct_ctxs_by_slot[0].push_back(ctx);
+        param->conjuncts.by_slot[0].push_back(ctx);
     }
 
-    for (auto& it : param->conjunct_ctxs_by_slot) {
+    for (auto& it : param->conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1613,10 +1613,10 @@ TEST_F(HdfsScannerTest, TestOrcBooleanConjunct) {
         lit_node.__set_slot_ref(t_slot_ref);
         nodes.emplace_back(lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->conjunct_ctxs_by_slot[0].push_back(ctx);
+        param->conjuncts.by_slot[0].push_back(ctx);
     }
 
-    for (auto& it : param->conjunct_ctxs_by_slot) {
+    for (auto& it : param->conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1711,11 +1711,11 @@ TEST_F(HdfsScannerTest, TestOrcCompoundConjunct) {
 
         ExprContext* ctx = create_expr_context(&_pool, nodes);
         std::cout << ctx->root()->debug_string() << std::endl;
-        param->scanner_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(param->scanner_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->scanner_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.scanner_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.scanner_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -1900,12 +1900,12 @@ TEST_F(HdfsScannerTest, TestParqueTypeMismatchDecodeMinMax) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* ctx = create_expr_context(pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
     }
 
     param->min_max_tuple_desc = min_max_tuple_desc;
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -2647,8 +2647,8 @@ TEST_F(HdfsScannerTest, TestParquetUppercaseFiledPredicate) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[1], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
-        param->scanner_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
     }
     {
         std::vector<TExprNode> nodes;
@@ -2656,12 +2656,12 @@ TEST_F(HdfsScannerTest, TestParquetUppercaseFiledPredicate) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[1], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
-        param->scanner_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -2813,8 +2813,8 @@ TEST_F(HdfsScannerTest, TestParquetDictTwoPage) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
-        param->scanner_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
     }
     {
         std::vector<TExprNode> nodes;
@@ -2822,12 +2822,12 @@ TEST_F(HdfsScannerTest, TestParquetDictTwoPage) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[0], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
-        param->scanner_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -2858,9 +2858,9 @@ TEST_F(HdfsScannerTest, TestMinMaxFilterWhenContainsComplexTypes) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
-        param->scanner_conjunct_ctxs.push_back(ctx);
-        param->all_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
+        param->conjuncts.all_ctxs.push_back(ctx);
     }
     {
         std::vector<TExprNode> nodes;
@@ -2868,13 +2868,13 @@ TEST_F(HdfsScannerTest, TestMinMaxFilterWhenContainsComplexTypes) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[0], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* ctx = create_expr_context(&_pool, nodes);
-        param->min_max_conjunct_ctxs.push_back(ctx);
-        param->scanner_conjunct_ctxs.push_back(ctx);
-        param->all_conjunct_ctxs.push_back(ctx);
+        param->conjuncts.min_max_ctxs.push_back(ctx);
+        param->conjuncts.scanner_ctxs.push_back(ctx);
+        param->conjuncts.all_ctxs.push_back(ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(param->min_max_conjunct_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(param->min_max_conjunct_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(param->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(param->conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, *param);
     EXPECT_TRUE(status.ok());
@@ -3317,7 +3317,7 @@ TEST_F(HdfsScannerTest, TestParquetIcebergCaseSensitive) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    param->lake_schema = &schema;
+    param->table_specific.iceberg_schema = &schema;
 
     _debug_rows_per_call = 10;
     Status status = scanner->init(_runtime_state, *param);

--- a/be/test/exec/hdfs_scanner/jni_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/jni_scanner_test.cpp
@@ -59,6 +59,7 @@ public:
     }
 
     void init_hdfs_scanner_context(HdfsScannerContext* ctx, TupleDescriptor* tuple_desc) {
+        ctx->params = &_scanner_params;
         const auto& slots = tuple_desc->slots();
         for (int i = 0; i < slots.size(); i++) {
             SlotDescriptor* slot = slots[i];
@@ -115,6 +116,7 @@ public:
 
     ObjectPool _pool;
     RuntimeState* _runtime_state;
+    HdfsScannerParams _scanner_params;
 };
 
 static void print_jni_scanner_params(const std::map<std::string, std::string>& params) {

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -46,7 +46,9 @@ protected:
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+
+        ctx->params = &_scanner_params;
+        _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
         ctx->timezone = "Asia/Shanghai";
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;
@@ -87,7 +89,7 @@ protected:
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(filepath));
+        _scanner_params.scan_range = (_create_scan_range(filepath));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -128,6 +130,7 @@ protected:
 
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
+    HdfsScannerParams _scanner_params;
 };
 
 TEST_F(ColumnConverterTest, TestByteArrayTest) {

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -336,6 +336,9 @@ protected:
     std::unique_ptr<FragmentDictState> _fragment_dict_state;
     ObjectPool _pool;
 
+    HdfsScannerOptions _scanner_options;
+    HdfsScannerConjuncts _scanner_conjuncts;
+    HdfsScannerParams _scanner_params;
     const size_t _chunk_size = 4096;
 
     std::string _filter_page_index_with_rf_has_null =
@@ -407,10 +410,13 @@ DataCacheOptions FileReaderTest::_mock_datacache_options() {
 HdfsScannerContext* FileReaderTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_params.runtime_filter_collector = _rf_probe_collector;
+    _scanner_params.options = &_scanner_options;
+    _scanner_params.conjuncts = &_scanner_conjuncts;
+    ctx->params = &_scanner_params;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
-    ctx->runtime_filter_collector = _rf_probe_collector;
     return ctx;
 }
 
@@ -425,17 +431,20 @@ HdfsScannerContext* FileReaderTest::_create_scan_context(Utils::SlotDesc* slot_d
                                                          int64_t scan_length) {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
-    ctx->runtime_filter_collector = _rf_probe_collector;
+    _scanner_params.runtime_filter_collector = _rf_probe_collector;
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = _create_scan_range(file_path, scan_length);
-    ctx->parquet_bloom_filter_enable = true;
-    ctx->parquet_page_index_enable = true;
+    _scanner_params.scan_range = _create_scan_range(file_path, scan_length);
+    _scanner_options.parquet_bloom_filter_enable = true;
+    _scanner_options.parquet_page_index_enable = true;
+    _scanner_params.options = &_scanner_options;
+    _scanner_params.conjuncts = &_scanner_conjuncts;
+    ctx->params = &_scanner_params;
     return ctx;
 }
 
@@ -443,7 +452,7 @@ HdfsScannerContext* FileReaderTest::_create_scan_context(Utils::SlotDesc* slot_d
                                                          Utils::SlotDesc* min_max_slot_descs,
                                                          const std::string& file_path, int64_t scan_length) {
     auto* ctx = _create_scan_context(slot_descs, file_path, scan_length);
-    ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slot_descs);
+    _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slot_descs);
     return ctx;
 }
 
@@ -507,7 +516,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_min_max() {
 
     // create min max conjuncts
     // c1 >= 1
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 1, &ctx->min_max_conjunct_ctxs);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 1, &_scanner_conjuncts.min_max_ctxs);
     return ctx;
 }
 
@@ -680,9 +689,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_min_max_all_nu
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _all_null_parquet_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -696,9 +705,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -712,9 +721,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -728,9 +737,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -744,9 +753,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -760,9 +769,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -776,9 +785,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -792,9 +801,9 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    scan_ctx->min_max_conjunct_ctxs.insert(scan_ctx->min_max_conjunct_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->min_max_conjunct_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -812,7 +821,7 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_filter_row_gro
     rf_list->driver_sequence = 1;
     rf_list->unarrived_runtime_filters.emplace_back(rf_desc);
     rf_list->slot_descs.emplace_back(ctx->slot_descs[0]);
-    ctx->rf_scan_range_pruner = _pool.add(new RuntimeScanRangePruner(pred_parser, *rf_list));
+    ctx->runtime_filter_scan_range_pruner = _pool.add(new RuntimeScanRangePruner(pred_parser, *rf_list));
 
     return ctx;
 }
@@ -1754,7 +1763,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitiveError) {
 
     Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC}, {"c2", c2}, {""}};
     auto ctx = _create_scan_context(slot_descs, _file4_path);
-    ctx->case_sensitive = true;
+    _scanner_options.case_sensitive = true;
     // --------------finish init context---------------
 
     ASSERT_OK(file_reader->init(ctx));
@@ -2557,13 +2566,13 @@ TEST_F(FileReaderTest, TestMinMaxForIcebergTable) {
             {""},
     };
     auto ctx = _create_scan_context(slot_descs, min_max_slots, filepath);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::GE, 2, 5, &t_conjuncts);
     ParquetUTBase::append_int_conjunct(TExprOpcode::LE, 2, 5, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -2946,7 +2955,7 @@ TEST_F(FileReaderTest, bloom_filter_reader_test_not_hit) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::EQ, 1, "2", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -2973,7 +2982,7 @@ TEST_F(FileReaderTest, bloom_filter_reader_test_hit) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::EQ, 1, "A", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -3039,7 +3048,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop2) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 1, 6, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->conjunct_ctxs_by_slot[1]);
@@ -3122,7 +3131,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop3) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 1, 6, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->conjunct_ctxs_by_slot[1]);
@@ -3271,7 +3280,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop4) {
     ctx->conjunct_ctxs_by_slot.insert({3, expr_ctxs});
 
     // ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 2, 6, &t_conjuncts);
-    // ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    // ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     // _create_int_conjunct_ctxs(TExprOpcode::EQ, 2, 6, &ctx->conjunct_ctxs_by_slot[1]);
     ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[3], nullptr, tuple_desc, _runtime_state, ctx);
@@ -3467,7 +3476,7 @@ TEST_F(FileReaderTest, TestReadNoMinMaxStatistics) {
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::GE, 0, "2", &t_conjuncts);
     ParquetUTBase::append_string_conjunct(TExprOpcode::LE, 0, "2", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     _create_string_conjunct_ctxs(TExprOpcode::EQ, 0, "2", &ctx->conjunct_ctxs_by_slot[0]);
@@ -3699,7 +3708,7 @@ TEST_F(FileReaderTest, update_rf_and_filter_row_group) {
     ASSERT_EQ(chunk->debug_row(2), "[3, 33]");
 
     auto* rf = MinMaxRuntimeFilter<TYPE_INT>::create_with_range<false>(&_pool, 3, false);
-    ctx->runtime_filter_collector->descriptors().at(1)->set_runtime_filter(rf);
+    _scanner_params.runtime_filter_collector->descriptors().at(1)->set_runtime_filter(rf);
 
     chunk->reset();
     ASSERT_OK(file_reader->get_next(&chunk));
@@ -4508,7 +4517,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_access_paths) {
     profile->children().emplace_back(std::move(salary_or).value());
     root->children().emplace_back(std::move(profile));
     column_access_paths.emplace_back(std::move(root));
-    ctx->column_access_paths = &column_access_paths;
+    _scanner_params.column_access_paths = &column_access_paths;
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok()) << status.message();
@@ -4569,7 +4578,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_access_paths_nulls) {
     profile->children().emplace_back(std::move(salary_or).value());
     root->children().emplace_back(std::move(profile));
     column_access_paths.emplace_back(std::move(root));
-    ctx->column_access_paths = &column_access_paths;
+    _scanner_params.column_access_paths = &column_access_paths;
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok()) << status.message();
@@ -4623,7 +4632,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_prefix_access_path) {
     ASSERT_TRUE(profile_or.ok()) << profile_or.status().to_string();
     root->children().emplace_back(std::move(profile_or).value());
     column_access_paths.emplace_back(std::move(root));
-    ctx->column_access_paths = &column_access_paths;
+    _scanner_params.column_access_paths = &column_access_paths;
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok()) << status.message();
@@ -4670,7 +4679,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_prefix_access_path_null_
     ASSERT_TRUE(profile_or.ok()) << profile_or.status().to_string();
     root->children().emplace_back(std::move(profile_or).value());
     column_access_paths.emplace_back(std::move(root));
-    ctx->column_access_paths = &column_access_paths;
+    _scanner_params.column_access_paths = &column_access_paths;
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok()) << status.message();
@@ -4715,7 +4724,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_whole_column_access_path
     auto root_or = ColumnAccessPath::create(TAccessPathType::ROOT, "data", 0);
     ASSERT_TRUE(root_or.ok()) << root_or.status().to_string();
     column_access_paths.emplace_back(std::move(root_or).value());
-    ctx->column_access_paths = &column_access_paths;
+    _scanner_params.column_access_paths = &column_access_paths;
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok()) << status.message();

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -336,8 +336,6 @@ protected:
     std::unique_ptr<FragmentDictState> _fragment_dict_state;
     ObjectPool _pool;
 
-    HdfsScannerOptions _scanner_options;
-    HdfsScannerConjuncts _scanner_conjuncts;
     HdfsScannerParams _scanner_params;
     const size_t _chunk_size = 4096;
 
@@ -412,8 +410,7 @@ HdfsScannerContext* FileReaderTest::_create_scan_context() {
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     _scanner_params.runtime_filter_collector = _rf_probe_collector;
-    _scanner_params.options = &_scanner_options;
-    _scanner_params.conjuncts = &_scanner_conjuncts;
+
     ctx->params = &_scanner_params;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
@@ -440,10 +437,9 @@ HdfsScannerContext* FileReaderTest::_create_scan_context(Utils::SlotDesc* slot_d
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
     _scanner_params.scan_range = _create_scan_range(file_path, scan_length);
-    _scanner_options.parquet_bloom_filter_enable = true;
-    _scanner_options.parquet_page_index_enable = true;
-    _scanner_params.options = &_scanner_options;
-    _scanner_params.conjuncts = &_scanner_conjuncts;
+    _scanner_params.options.parquet_bloom_filter_enable = true;
+    _scanner_params.options.parquet_page_index_enable = true;
+
     ctx->params = &_scanner_params;
     return ctx;
 }
@@ -516,7 +512,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_min_max() {
 
     // create min max conjuncts
     // c1 >= 1
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 1, &_scanner_conjuncts.min_max_ctxs);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 1, &_scanner_params.conjuncts.min_max_ctxs);
     return ctx;
 }
 
@@ -689,9 +685,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_min_max_all_nu
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _all_null_parquet_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -705,9 +702,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -721,9 +719,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -737,9 +736,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -753,9 +753,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -769,9 +770,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -785,9 +787,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -801,9 +804,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_conjuncts.min_max_ctxs.insert(_scanner_conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
+    _scanner_params.conjuncts.min_max_ctxs.insert(_scanner_params.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
+                                                  expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
+    ParquetUTBase::setup_conjuncts_manager(_scanner_params.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
                                            scan_ctx);
 
     return scan_ctx;
@@ -1763,7 +1767,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitiveError) {
 
     Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC}, {"c2", c2}, {""}};
     auto ctx = _create_scan_context(slot_descs, _file4_path);
-    _scanner_options.case_sensitive = true;
+    _scanner_params.options.case_sensitive = true;
     // --------------finish init context---------------
 
     ASSERT_OK(file_reader->init(ctx));
@@ -2566,13 +2570,13 @@ TEST_F(FileReaderTest, TestMinMaxForIcebergTable) {
             {""},
     };
     auto ctx = _create_scan_context(slot_descs, min_max_slots, filepath);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::GE, 2, 5, &t_conjuncts);
     ParquetUTBase::append_int_conjunct(TExprOpcode::LE, 2, 5, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -2870,7 +2874,7 @@ TEST_F(FileReaderTest, TestStructSubfieldZonemap) {
     }
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
-    EXPECT_EQ(1, file_reader->_group_reader_param.stats->parquet_filtered_row_groups);
+    EXPECT_EQ(1, file_reader->_group_reader_param.stats->filtered_row_groups);
     EXPECT_EQ(0, file_reader->_row_group_readers.size());
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
@@ -2955,7 +2959,7 @@ TEST_F(FileReaderTest, bloom_filter_reader_test_not_hit) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::EQ, 1, "2", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -2982,7 +2986,7 @@ TEST_F(FileReaderTest, bloom_filter_reader_test_hit) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::EQ, 1, "A", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -3048,7 +3052,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop2) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 1, 6, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->conjunct_ctxs_by_slot[1]);
@@ -3131,7 +3135,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop3) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 1, 6, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->conjunct_ctxs_by_slot[1]);
@@ -3280,7 +3284,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop4) {
     ctx->conjunct_ctxs_by_slot.insert({3, expr_ctxs});
 
     // ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 2, 6, &t_conjuncts);
-    // ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    // ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     // _create_int_conjunct_ctxs(TExprOpcode::EQ, 2, 6, &ctx->conjunct_ctxs_by_slot[1]);
     ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[3], nullptr, tuple_desc, _runtime_state, ctx);
@@ -3476,7 +3480,7 @@ TEST_F(FileReaderTest, TestReadNoMinMaxStatistics) {
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::GE, 0, "2", &t_conjuncts);
     ParquetUTBase::append_string_conjunct(TExprOpcode::LE, 0, "2", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     _create_string_conjunct_ctxs(TExprOpcode::EQ, 0, "2", &ctx->conjunct_ctxs_by_slot[0]);
@@ -3887,7 +3891,7 @@ TEST_F(FileReaderTest, low_card_reader) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(small_page_file, slot_descs);
     ctx->conjunct_ctxs_by_slot.insert({1, expr_ctxs});
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
 
@@ -3942,7 +3946,7 @@ TEST_F(FileReaderTest, low_card_reader_filter_group) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(small_page_file, slot_descs);
     ctx->conjunct_ctxs_by_slot.insert({1, expr_ctxs});
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     tuple_desc->decoded_slots()[1]->type().type = TYPE_VARCHAR;
     ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
@@ -3976,7 +3980,7 @@ TEST_F(FileReaderTest, low_card_reader_dict_not_match) {
     }
     dict_map[1] = &g_dict;
 
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(small_page_file);
     Status status = file_reader->init(ctx);
@@ -4016,7 +4020,7 @@ TEST_F(FileReaderTest, no_matched_reader) {
     }
     dict_map[1] = &g_dict;
 
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(file);
     Status status = file_reader->init(ctx);
@@ -4051,7 +4055,7 @@ TEST_F(FileReaderTest, low_rows_reader) {
     dict_map[2] = &g_dict;
     dict_map[3] = &g_dict;
 
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(low_rows_file);
     Status status = file_reader->init(ctx);
@@ -4121,7 +4125,7 @@ TEST_F(FileReaderTest, low_rows_reader_empty_not_null_not_match) {
     dict_map[2] = &g_dict;
     dict_map[3] = &g_dict;
 
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(low_rows_file);
     Status status = file_reader->init(ctx);
@@ -4161,7 +4165,7 @@ TEST_F(FileReaderTest, low_rows_reader_empty_not_null) {
     dict_map[2] = &g_dict;
     dict_map[3] = &g_dict;
 
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(low_rows_file);
     Status status = file_reader->init(ctx);
@@ -4229,7 +4233,7 @@ TEST_F(FileReaderTest, low_rows_reader_filter_group) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(file, slot_descs);
     ctx->conjunct_ctxs_by_slot.insert({1, expr_ctxs});
-    ctx->global_dictmaps = &dict_map;
+    const_cast<HdfsScannerParams*>(ctx->params)->global_dictmaps = &dict_map;
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     tuple_desc->decoded_slots()[1]->type().type = TYPE_VARCHAR;
     ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -50,20 +50,22 @@ protected:
     HdfsScannerContext* _create_scan_context(const std::vector<TypeDescriptor>& type_descs) {
         auto ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+
+        ctx->params = &_scanner_params;
+        _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
 
         std::vector<Utils::SlotDesc> slot_descs;
         for (auto& type_desc : type_descs) {
             auto type_name = type_desc.debug_string();
             slot_descs.push_back({type_name, type_desc});
         }
-        slot_descs.push_back({""});
+        slot_descs.push_back({});
 
         TupleDescriptor* tuple_desc =
                 parquet::Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs.data());
         parquet::Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
-        ctx->scan_range = (_create_scan_range(_file_path, file_size));
+        _scanner_params.scan_range = (_create_scan_range(_file_path, file_size));
         ctx->timezone = "Asia/Shanghai";
         ctx->stats = &g_hdfs_scan_stats;
 
@@ -140,6 +142,7 @@ protected:
     std::string _file_path{"/dummy_file.parquet"};
     RuntimeState* _runtime_state;
     ObjectPool _pool;
+    HdfsScannerParams _scanner_params;
 };
 
 TEST_F(FileWriterTest, TestWriteIntegralTypes) {

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -2333,8 +2333,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdColumnReaderCreation) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2356,8 +2356,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdReturnsNull) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2388,8 +2388,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdUsesRowPositionForLooku
             new SlotDescriptor(101, "_scan_range_id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)));
     reserved_slots->push_back(row_id_slot);
     reserved_slots->push_back(scan_range_id_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2421,8 +2421,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation
     auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     std::map<int32_t, TExpr> extended_columns;
     TExpr expr;
@@ -2458,8 +2458,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberNullExtendedLiteralR
     auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     std::map<int32_t, TExpr> extended_columns;
     TExpr expr;
@@ -2647,7 +2647,7 @@ TEST_F(GroupReaderTest, TestCreateReservedIcebergColumnReaderFound) {
     param->file = file;
     param->file_metadata = file_meta;
     param->chunk_size = config::vector_chunk_size;
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->timezone = "UTC";
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
@@ -2668,8 +2668,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdPhysicalColumnReaderCreation) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     // Build file metadata WITH physical _row_id column (field_id matches)
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -2697,8 +2697,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation
     auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     // Build file metadata WITH physical _last_updated_sequence_number column (field_id matches)
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -3174,8 +3174,8 @@ TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
     reserved_slots->push_back(seq_slot);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
-    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
+    param->scanner_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scanner_ctx->timezone = "UTC";
 
     // Build file metadata with both physical iceberg columns
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -757,6 +757,14 @@ GroupReaderParam* GroupReaderTest::_create_group_reader_param() {
     GroupReaderParam::Column c6 =
             _create_group_reader_param_of_column(&_pool, 5, tparquet::Type::type::DOUBLE, LogicalType::TYPE_DOUBLE);
 
+    // Minimal scanner context so GroupReader::_create_column_readers() can
+    // dereference scanner_ctx->params->options without crashing.
+    auto* opts = _pool.add(new HdfsScannerOptions());
+    auto* hdfs_params = _pool.add(new HdfsScannerParams());
+    hdfs_params->options = opts;
+    auto* scanner_ctx = _pool.add(new HdfsScannerContext());
+    scanner_ctx->params = hdfs_params;
+
     auto* param = _pool.add(new GroupReaderParam());
     param->read_cols.emplace_back(c1);
     param->read_cols.emplace_back(c2);
@@ -765,6 +773,7 @@ GroupReaderParam* GroupReaderTest::_create_group_reader_param() {
     param->read_cols.emplace_back(c5);
     param->read_cols.emplace_back(c6);
     param->stats = &g_hdfs_scan_stats;
+    param->scanner_ctx = scanner_ctx;
     return param;
 }
 

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -759,9 +759,7 @@ GroupReaderParam* GroupReaderTest::_create_group_reader_param() {
 
     // Minimal scanner context so GroupReader::_create_column_readers() can
     // dereference scanner_ctx->params->options without crashing.
-    auto* opts = _pool.add(new HdfsScannerOptions());
     auto* hdfs_params = _pool.add(new HdfsScannerParams());
-    hdfs_params->options = opts;
     auto* scanner_ctx = _pool.add(new HdfsScannerContext());
     scanner_ctx->params = hdfs_params;
 
@@ -2335,8 +2333,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdColumnReaderCreation) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2358,8 +2356,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdReturnsNull) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2390,8 +2388,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdUsesRowPositionForLooku
             new SlotDescriptor(101, "_scan_range_id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)));
     reserved_slots->push_back(row_id_slot);
     reserved_slots->push_back(scan_range_id_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2423,8 +2421,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation
     auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     std::map<int32_t, TExpr> extended_columns;
     TExpr expr;
@@ -2460,8 +2458,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberNullExtendedLiteralR
     auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     std::map<int32_t, TExpr> extended_columns;
     TExpr expr;
@@ -2649,7 +2647,7 @@ TEST_F(GroupReaderTest, TestCreateReservedIcebergColumnReaderFound) {
     param->file = file;
     param->file_metadata = file_meta;
     param->chunk_size = config::vector_chunk_size;
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
@@ -2670,8 +2668,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdPhysicalColumnReaderCreation) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     // Build file metadata WITH physical _row_id column (field_id matches)
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -2699,8 +2697,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation
     auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     // Build file metadata WITH physical _last_updated_sequence_number column (field_id matches)
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -3176,8 +3174,8 @@ TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
     reserved_slots->push_back(seq_slot);
-    param->reserved_field_slots = _pool.add(reserved_slots);
-    param->timezone = "UTC";
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->reserved_field_slots = *_pool.add(reserved_slots);
+    const_cast<HdfsScannerContext*>(param->scanner_ctx)->timezone = "UTC";
 
     // Build file metadata with both physical iceberg columns
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -3971,7 +3969,7 @@ TEST_F(GroupReaderTest, GetVariantShreddedHintsReturnsEmptyOnInvalidAccessPath) 
     field_arr->children().emplace_back(std::move(offset_0));
     root->children().emplace_back(std::move(field_arr));
     column_access_paths.emplace_back(std::move(root));
-    param->column_access_paths = &column_access_paths;
+    const_cast<HdfsScannerParams*>(param->scanner_ctx->params)->column_access_paths = &column_access_paths;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -97,7 +97,10 @@ protected:
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+        _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+        _scanner_params.options = &_scanner_options;
+        _scanner_params.conjuncts = &_scanner_conjuncts;
+        ctx->params = &_scanner_params;
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;
     }
@@ -114,6 +117,10 @@ protected:
     std::shared_ptr<RowDescriptor> _row_desc = nullptr;
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
+
+    HdfsScannerOptions _scanner_options;
+    HdfsScannerConjuncts _scanner_conjuncts;
+    HdfsScannerParams _scanner_params;
 };
 
 TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
@@ -154,7 +161,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -177,7 +184,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
     TupleDescriptor* tuple_desc = parquet::Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -237,7 +244,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -249,7 +256,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -300,7 +307,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -317,7 +324,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -369,7 +376,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -386,7 +393,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -446,7 +453,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -469,7 +476,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -592,7 +599,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -607,17 +614,17 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
                 {"new_conjunct", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 2},
                 {""},
         };
-        ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+        _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         // create min max conjuncts
         // new_conjunct is null
-        _create_null_conjunct_ctxs(2, &ctx->min_max_conjunct_ctxs, _pool, _runtime_state);
+        _create_null_conjunct_ctxs(2, &_scanner_conjuncts.min_max_ctxs, _pool, _runtime_state);
     }
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -657,7 +664,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -666,7 +673,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -702,7 +709,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor rename_id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -711,7 +718,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -758,7 +765,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_col, field_id};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -772,7 +779,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -816,7 +823,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
 
     std::vector<TIcebergSchemaField> fields{field_col};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -828,7 +835,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -876,7 +883,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
 
     std::vector<TIcebergSchemaField> fields{field_c1, field_c2, field_c3};
     schema.__set_fields(fields);
-    ctx->lake_schema = &schema;
+    _scanner_params.lake_schema = &schema;
 
     TypeDescriptor rename_c1 = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
     TypeDescriptor c2 = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
@@ -887,7 +894,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(no_field_id_file_path));
+    _scanner_params.scan_range = (_create_scan_range(no_field_id_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
@@ -938,7 +945,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col};
         schema.__set_fields(fields);
-        ctx->lake_schema = &schema;
+        _scanner_params.lake_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -952,7 +959,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -997,7 +1004,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_col};
         schema.__set_fields(fields);
-        ctx->lake_schema = &schema;
+        _scanner_params.lake_schema = &schema;
 
         TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -1009,7 +1016,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1053,7 +1060,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1093,7 +1100,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1155,7 +1162,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col};
         schema.__set_fields(fields);
-        ctx->lake_schema = &schema;
+        _scanner_params.lake_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1175,7 +1182,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1233,7 +1240,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col_map};
         schema.__set_fields(fields);
-        ctx->lake_schema = &schema;
+        _scanner_params.lake_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1251,7 +1258,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1299,7 +1306,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1342,7 +1349,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -98,8 +98,7 @@ protected:
         auto* ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
         _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
-        _scanner_params.options = &_scanner_options;
-        _scanner_params.conjuncts = &_scanner_conjuncts;
+
         ctx->params = &_scanner_params;
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;
@@ -118,8 +117,6 @@ protected:
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
 
-    HdfsScannerOptions _scanner_options;
-    HdfsScannerConjuncts _scanner_conjuncts;
     HdfsScannerParams _scanner_params;
 };
 
@@ -161,7 +158,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -244,7 +241,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -307,7 +304,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -376,7 +373,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -453,7 +450,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -599,7 +596,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -618,7 +615,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 
         // create min max conjuncts
         // new_conjunct is null
-        _create_null_conjunct_ctxs(2, &_scanner_conjuncts.min_max_ctxs, _pool, _runtime_state);
+        _create_null_conjunct_ctxs(2, &_scanner_params.conjuncts.min_max_ctxs, _pool, _runtime_state);
     }
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -664,7 +661,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -709,7 +706,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor rename_id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -765,7 +762,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_col, field_id};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -823,7 +820,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
 
     std::vector<TIcebergSchemaField> fields{field_col};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -883,7 +880,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
 
     std::vector<TIcebergSchemaField> fields{field_c1, field_c2, field_c3};
     schema.__set_fields(fields);
-    _scanner_params.lake_schema = &schema;
+    _scanner_params.table_specific.iceberg_schema = &schema;
 
     TypeDescriptor rename_c1 = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
     TypeDescriptor c2 = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
@@ -945,7 +942,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col};
         schema.__set_fields(fields);
-        _scanner_params.lake_schema = &schema;
+        _scanner_params.table_specific.iceberg_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1004,7 +1001,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_col};
         schema.__set_fields(fields);
-        _scanner_params.lake_schema = &schema;
+        _scanner_params.table_specific.iceberg_schema = &schema;
 
         TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -1162,7 +1159,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col};
         schema.__set_fields(fields);
-        _scanner_params.lake_schema = &schema;
+        _scanner_params.table_specific.iceberg_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1182,7 +1179,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(struct_map_array_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);
@@ -1240,7 +1237,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col_map};
         schema.__set_fields(fields);
-        _scanner_params.lake_schema = &schema;
+        _scanner_params.table_specific.iceberg_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1258,7 +1255,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        _scanner_params.scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _scanner_params.scan_range = (_create_scan_range(struct_map_array_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(ctx);

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -98,6 +98,10 @@ protected:
         auto* ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
         _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+        // Reset per-scope pointers that were set by a previous scope block.
+        _scanner_params.table_specific.iceberg_schema = nullptr;
+        _scanner_params.table_specific.deletion_vector_descriptor = nullptr;
+        _scanner_params.table_specific.paimon_deletion_file = nullptr;
 
         ctx->params = &_scanner_params;
         ctx->stats = &g_hdfs_scan_stats;

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -61,6 +61,10 @@ protected:
     RuntimeState* _runtime_state = nullptr;
     std::unique_ptr<FragmentDictState> _fragment_dict_state;
     ObjectPool _pool;
+
+    HdfsScannerOptions _scanner_options;
+    HdfsScannerConjuncts _scanner_conjuncts;
+    HdfsScannerParams _scanner_params;
 };
 
 std::unique_ptr<RandomAccessFile> PageIndexTest::_create_file(const std::string& file_path) {
@@ -70,11 +74,14 @@ std::unique_ptr<RandomAccessFile> PageIndexTest::_create_file(const std::string&
 HdfsScannerContext* PageIndexTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_params.options = &_scanner_options;
+    _scanner_params.conjuncts = &_scanner_conjuncts;
+    ctx->params = &_scanner_params;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
-    ctx->parquet_page_index_enable = true;
-    ctx->parquet_bloom_filter_enable = true;
+    _scanner_options.parquet_page_index_enable = true;
+    _scanner_options.parquet_bloom_filter_enable = true;
     return ctx;
 }
 
@@ -96,7 +103,7 @@ HdfsScannerContext* PageIndexTest::_create_file_random_read_context(const std::s
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(file_path));
+    _scanner_params.scan_range = (_create_scan_range(file_path));
 
     return ctx;
 }
@@ -112,7 +119,7 @@ HdfsScannerContext* PageIndexTest::_create_file_only_c0_context(const std::strin
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(file_path));
+    _scanner_params.scan_range = (_create_scan_range(file_path));
 
     return ctx;
 }
@@ -130,7 +137,7 @@ HdfsScannerContext* PageIndexTest::_create_file_c0_c1_c2_context(const std::stri
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(file_path));
+    _scanner_params.scan_range = (_create_scan_range(file_path));
 
     return ctx;
 }
@@ -239,21 +246,22 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                 auto ctx = _create_file_random_read_context(file_path);
                 auto file = _create_file(file_path);
                 ctx->conjunct_ctxs_by_slot[0].clear();
-                ctx->min_max_conjunct_ctxs.clear();
+                _scanner_conjuncts.min_max_ctxs.clear();
 
                 if (single_flag) {
                     Utils::SlotDesc min_max_slots[] = {
                             {"c0", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 0},
                             {""},
                     };
-                    ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+                    _scanner_params.min_max_tuple_desc =
+                            Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
                     std::vector<TExpr> t_conjuncts;
                     ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 0, oprands[0], &t_conjuncts);
                     ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 0, oprands[1], &t_conjuncts);
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &ctx->min_max_conjunct_ctxs);
+                                                        &_scanner_conjuncts.min_max_ctxs);
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
                                                         &ctx->conjunct_ctxs_by_slot[0]);
 
@@ -265,7 +273,8 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                             {"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 1},
                             {""},
                     };
-                    ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+                    _scanner_params.min_max_tuple_desc =
+                            Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
                     std::vector<TExpr> t_conjuncts;
                     ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 0, oprands[0], &t_conjuncts);
@@ -274,7 +283,7 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                     ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 1, oprands[3], &t_conjuncts);
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &ctx->min_max_conjunct_ctxs);
+                                                        &_scanner_conjuncts.min_max_ctxs);
 
                     std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0], t_conjuncts[1]};
                     std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[2], t_conjuncts[3]};
@@ -365,14 +374,14 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
         auto ctx = _create_file_only_c0_context(small_page_file);
         auto file = _create_file(small_page_file);
         ctx->conjunct_ctxs_by_slot[0].clear();
-        ctx->min_max_conjunct_ctxs.clear();
-        ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+        _scanner_conjuncts.min_max_ctxs.clear();
+        _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         std::vector<TExpr> t_conjuncts;
         ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 0, 5500, &t_conjuncts);
         ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 0, 7500, &t_conjuncts);
 
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
         ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
 
         // tuple desc
@@ -382,7 +391,7 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
         };
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         std::vector<ExprContext*> all_conjuncts{};
-        for (auto* expr : ctx->min_max_conjunct_ctxs) {
+        for (auto* expr : _scanner_conjuncts.min_max_ctxs) {
             all_conjuncts.push_back(expr);
         }
         for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
@@ -457,8 +466,8 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         auto file = _create_file(small_page_file);
         ctx->conjunct_ctxs_by_slot[0].clear();
         ctx->conjunct_ctxs_by_slot[1].clear();
-        ctx->min_max_conjunct_ctxs.clear();
-        ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+        _scanner_conjuncts.min_max_ctxs.clear();
+        _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         std::vector<TExpr> t_conjuncts;
         // c0: 1->20000, c0 > 5000
@@ -466,7 +475,7 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         // c1: 20000->1, c1 > 5000
         ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 5000, &t_conjuncts);
 
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
         std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
         ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
@@ -483,7 +492,7 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         };
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         std::vector<ExprContext*> all_conjuncts{};
-        for (auto* expr : ctx->min_max_conjunct_ctxs) {
+        for (auto* expr : _scanner_conjuncts.min_max_ctxs) {
             all_conjuncts.push_back(expr);
         }
         for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
@@ -564,8 +573,8 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
     auto file = _create_file(small_page_file);
     ctx->conjunct_ctxs_by_slot[0].clear();
     ctx->conjunct_ctxs_by_slot[1].clear();
-    ctx->min_max_conjunct_ctxs.clear();
-    ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+    _scanner_conjuncts.min_max_ctxs.clear();
+    _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
     std::vector<TExpr> t_conjuncts;
     // c0: 1->20000, c0 > 500
@@ -573,7 +582,7 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
     // c1: 20000->1, c1 > 500
     ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 500, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
 
     std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
@@ -661,24 +670,24 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
     auto ctx = _create_scan_context();
     auto file = _create_file(file_path);
     ctx->conjunct_ctxs_by_slot[0].clear();
-    ctx->min_max_conjunct_ctxs.clear();
+    _scanner_conjuncts.min_max_ctxs.clear();
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = _create_scan_range(file_path);
-    ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+    _scanner_params.scan_range = _create_scan_range(file_path);
+    _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
     std::vector<TExpr> t_conjuncts;
     // id > 2
     // this triggers page index filtering
     ParquetUTBase::append_bigint_conjunct(TExprOpcode::GT, 0, 2, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
 
     std::vector<ExprContext*> all_conjuncts;
-    for (auto* expr : ctx->min_max_conjunct_ctxs) {
+    for (auto* expr : _scanner_conjuncts.min_max_ctxs) {
         all_conjuncts.push_back(expr);
     }
     for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -62,8 +62,6 @@ protected:
     std::unique_ptr<FragmentDictState> _fragment_dict_state;
     ObjectPool _pool;
 
-    HdfsScannerOptions _scanner_options;
-    HdfsScannerConjuncts _scanner_conjuncts;
     HdfsScannerParams _scanner_params;
 };
 
@@ -75,13 +73,12 @@ HdfsScannerContext* PageIndexTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     _scanner_params.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
-    _scanner_params.options = &_scanner_options;
-    _scanner_params.conjuncts = &_scanner_conjuncts;
+
     ctx->params = &_scanner_params;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
-    _scanner_options.parquet_page_index_enable = true;
-    _scanner_options.parquet_bloom_filter_enable = true;
+    _scanner_params.options.parquet_page_index_enable = true;
+    _scanner_params.options.parquet_bloom_filter_enable = true;
     return ctx;
 }
 
@@ -246,7 +243,7 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                 auto ctx = _create_file_random_read_context(file_path);
                 auto file = _create_file(file_path);
                 ctx->conjunct_ctxs_by_slot[0].clear();
-                _scanner_conjuncts.min_max_ctxs.clear();
+                _scanner_params.conjuncts.min_max_ctxs.clear();
 
                 if (single_flag) {
                     Utils::SlotDesc min_max_slots[] = {
@@ -261,7 +258,7 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                     ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 0, oprands[1], &t_conjuncts);
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &_scanner_conjuncts.min_max_ctxs);
+                                                        &_scanner_params.conjuncts.min_max_ctxs);
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
                                                         &ctx->conjunct_ctxs_by_slot[0]);
 
@@ -283,7 +280,7 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                     ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 1, oprands[3], &t_conjuncts);
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &_scanner_conjuncts.min_max_ctxs);
+                                                        &_scanner_params.conjuncts.min_max_ctxs);
 
                     std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0], t_conjuncts[1]};
                     std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[2], t_conjuncts[3]};
@@ -374,14 +371,15 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
         auto ctx = _create_file_only_c0_context(small_page_file);
         auto file = _create_file(small_page_file);
         ctx->conjunct_ctxs_by_slot[0].clear();
-        _scanner_conjuncts.min_max_ctxs.clear();
+        _scanner_params.conjuncts.min_max_ctxs.clear();
         _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         std::vector<TExpr> t_conjuncts;
         ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 0, 5500, &t_conjuncts);
         ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 0, 7500, &t_conjuncts);
 
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                            &_scanner_params.conjuncts.min_max_ctxs);
         ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
 
         // tuple desc
@@ -391,7 +389,7 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
         };
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         std::vector<ExprContext*> all_conjuncts{};
-        for (auto* expr : _scanner_conjuncts.min_max_ctxs) {
+        for (auto* expr : _scanner_params.conjuncts.min_max_ctxs) {
             all_conjuncts.push_back(expr);
         }
         for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
@@ -466,7 +464,7 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         auto file = _create_file(small_page_file);
         ctx->conjunct_ctxs_by_slot[0].clear();
         ctx->conjunct_ctxs_by_slot[1].clear();
-        _scanner_conjuncts.min_max_ctxs.clear();
+        _scanner_params.conjuncts.min_max_ctxs.clear();
         _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         std::vector<TExpr> t_conjuncts;
@@ -475,7 +473,8 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         // c1: 20000->1, c1 > 5000
         ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 5000, &t_conjuncts);
 
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                            &_scanner_params.conjuncts.min_max_ctxs);
 
         std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
         ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
@@ -492,7 +491,7 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         };
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         std::vector<ExprContext*> all_conjuncts{};
-        for (auto* expr : _scanner_conjuncts.min_max_ctxs) {
+        for (auto* expr : _scanner_params.conjuncts.min_max_ctxs) {
             all_conjuncts.push_back(expr);
         }
         for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
@@ -573,7 +572,7 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
     auto file = _create_file(small_page_file);
     ctx->conjunct_ctxs_by_slot[0].clear();
     ctx->conjunct_ctxs_by_slot[1].clear();
-    _scanner_conjuncts.min_max_ctxs.clear();
+    _scanner_params.conjuncts.min_max_ctxs.clear();
     _scanner_params.min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
     std::vector<TExpr> t_conjuncts;
@@ -582,7 +581,7 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
     // c1: 20000->1, c1 > 500
     ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 500, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
 
     std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
@@ -670,7 +669,7 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
     auto ctx = _create_scan_context();
     auto file = _create_file(file_path);
     ctx->conjunct_ctxs_by_slot[0].clear();
-    _scanner_conjuncts.min_max_ctxs.clear();
+    _scanner_params.conjuncts.min_max_ctxs.clear();
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
@@ -683,11 +682,11 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
     // this triggers page index filtering
     ParquetUTBase::append_bigint_conjunct(TExprOpcode::GT, 0, 2, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_params.conjuncts.min_max_ctxs);
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
 
     std::vector<ExprContext*> all_conjuncts;
-    for (auto* expr : _scanner_conjuncts.min_max_ctxs) {
+    for (auto* expr : _scanner_params.conjuncts.min_max_ctxs) {
         all_conjuncts.push_back(expr);
     }
     for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -31,9 +31,10 @@ public:
               _file(_create_file(filepath)),
               _scanner_ctx(std::make_shared<HdfsScannerContext>()),
               _scan_stats(std::make_shared<HdfsScanStats>()) {
+        _scanner_ctx->params = &_scanner_params;
         _scanner_ctx->timezone = "Asia/Shanghai";
         _scanner_ctx->stats = _scan_stats.get();
-        _scanner_ctx->lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        _scanner_params.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     }
     ~ParquetCLIReader() {
         _file_reader = nullptr;
@@ -53,10 +54,12 @@ public:
         // create temporary reader to load schema.
         const FileMetaData* file_metadata = nullptr;
         HdfsScannerContext ctx;
+        HdfsScannerParams local_params;
+        ctx.params = &local_params;
         HdfsScanStats stats;
         ctx.stats = &stats;
-        ctx.scan_range = scan_range;
-        ctx.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        local_params.scan_range = scan_range;
+        local_params.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
         std::shared_ptr<FileReader> reader =
                 std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
         RETURN_IF_ERROR(reader->init(&ctx));
@@ -80,7 +83,7 @@ public:
         TupleDescriptor* tuple_desc = _create_tuple_descriptor(nullptr, &_pool, slot_descs);
         _scanner_ctx->slot_descs = tuple_desc->slots();
         _make_column_info_vector(tuple_desc, &_scanner_ctx->materialized_columns);
-        _scanner_ctx->scan_range = scan_range;
+        _scanner_params.scan_range = scan_range;
 
         _file_reader = std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
         RETURN_IF_ERROR(_file_reader->init(_scanner_ctx.get()));
@@ -253,6 +256,7 @@ private:
     std::shared_ptr<FileReader> _file_reader;
     std::unique_ptr<RandomAccessFile> _file;
     std::shared_ptr<HdfsScannerContext> _scanner_ctx;
+    HdfsScannerParams _scanner_params;
     std::shared_ptr<HdfsScanStats> _scan_stats;
     ChunkPtr _chunk;
     ObjectPool _pool;

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -50,9 +50,12 @@ public:
     void TearDown() override {}
 
 protected:
+    HdfsScannerParams _scanner_params;
     HdfsScannerContext* _create_scan_context(const std::vector<TypeDescriptor>& type_descs) {
         auto ctx = _pool.add(new HdfsScannerContext());
-        ctx->lazy_column_coalesce_counter = &_lazy_column_coalesce_counter;
+
+        ctx->params = &_scanner_params;
+        _scanner_params.lazy_column_coalesce_counter = &_lazy_column_coalesce_counter;
 
         std::vector<parquet::Utils::SlotDesc> slot_descs;
         for (auto& type_desc : type_descs) {
@@ -66,7 +69,7 @@ protected:
         parquet::Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
-        ctx->scan_range = _create_scan_range(_file_path, file_size);
+        _scanner_params.scan_range = _create_scan_range(_file_path, file_size);
         ctx->timezone = "Asia/Shanghai";
         ctx->stats = &_hdfs_scan_stats;
 

--- a/be/test/formats/parquet/parquet_footer_test.cpp
+++ b/be/test/formats/parquet/parquet_footer_test.cpp
@@ -25,7 +25,10 @@ namespace starrocks::parquet {
 
 class ParquetFooterTest : public testing::Test {
 public:
-    ParquetFooterTest() { ctx.stats = &stats; }
+    ParquetFooterTest() {
+        ctx.stats = &stats;
+        ctx.params = &scanner_params;
+    }
 
 protected:
     std::unique_ptr<RandomAccessFile> open_file(const std::string& file_path) {
@@ -33,6 +36,7 @@ protected:
     }
 
     HdfsScanStats stats;
+    HdfsScannerParams scanner_params;
     HdfsScannerContext ctx;
 };
 


### PR DESCRIPTION
## Why I'm doing:

The HDFS scan pipeline had **~15 boolean flags and 6 conjunct vectors duplicated across 3 layers** — `HiveDataSource` → `HdfsScannerParams` → `HdfsScannerContext`. This causes:

1. **Copy bloat**: Every flag and vector is manually copied when building `HdfsScannerParams` and again to `HdfsScannerContext`.
2. **Fragile ownership**: Individual vectors scattered across `HiveDataSource` members with no clear single owner.
3. **Inconsistent predicate evaluation**: Each scanner format (ORC, Parquet, Text, Avro, JSON, JNI) duplicated `conjunct_ctxs_by_slot` evaluation logic. ORC/Parquet handle it internally via lazy materialization; simple formats had it in their own `do_get_next()`, JNI had its own `_chunk_filter` — all semantically identical but spread across 5+ files.

## What I'm doing:

**Introduce two shared ownership structs to replace scattered fields:**

```
Before:
  HiveDataSource (owner)
    ├── _case_sensitive, _use_min_max_opt, _use_count_opt, ...
    ├── _min_max_conjunct_ctxs, _scanner_conjunct_ctxs, ...
    └── copy to → HdfsScannerParams (copy of all flags + vectors)
                    └── copy to → HdfsScannerContext (copy again)

After:
  HiveDataSource (single owner)
    ├── _options (HdfsScannerOptions) ─── non-owning ptr → HdfsScannerParams
    ├── _conjuncts (HdfsScannerConjuncts) ─── non-owning ptr → HdfsScannerParams
    └── _partition_filter (PartitionFilter, nested struct)
```

| Struct | Contains | Shared to |
|---|---|---|
| `HdfsScannerOptions` | All scan boolean flags (case_sensitive, use_min_max_opt, cache flags, format-specific flags) | `HdfsScannerParams`, `HdfsScannerContext` via `const*` |
| `HdfsScannerConjuncts` | All conjunct vectors + slot sets (min_max_ctxs, scanner_ctxs, by_slot, all_ctxs, slots_in_conjunct, slots_of_multi_field) | `HdfsScannerParams`, `HdfsScannerContext` via `const*` |
| `PartitionFilter` | Partition-specific conjuncts (conjunct_ctxs, values, has_conjuncts, filter_by_eval) | Remains private to `HiveDataSource` |

**Unify conjunct-by-slot predicate evaluation in `HdfsScanner::get_next()`:**

Previously each format had its own evaluation logic. Now the base class evaluates `conjunct_ctxs_by_slot` predicates uniformly, with two virtual hooks:

```
HdfsScanner::get_next()
  ├── if scanner_handles_predicate_by_slot_internally() == false
  │     └── evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter)  // base class
  └── if scanner_handles_multi_slot_conjuncts_internally() == false
        └── eval_conjuncts(conjuncts->scanner_ctxs, chunk)            // base class
```

- **ORC/Parquet** override both to `true` — they handle these internally via lazy materialization / dict-filter pipelines
- **Text/Avro/JSON/JNI** keep default `false` — base class handles them uniformly
- JNI scanner's duplicate `_chunk_filter` member removed; now uses base class `_chunk_filter`

**Minor cleanup:**
- Renamed `_init_rf_counters` → `_init_runtime_filter_counters`
- Inlined `_setup_all_conjunct_ctxs()` into `_init_conjunct_ctxs()`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
