### PR TITLE
[BugFix] Keep key attribute on MODIFY COLUMN for DUPLICATE/UNIQUE tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -779,6 +779,13 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on column in Unique data model table: " +
                         modColumn.getName());
             }
+            Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
+            if (baseColumn != null && baseColumn.isKey()) {
+                // backward compatibility, same as the PRIMARY KEY branch: the key set of a unique table is
+                // fixed at creation time and cannot be changed by MODIFY COLUMN, so keep an existing key
+                // column as a key column when the KEY keyword is omitted in the modify column clause.
+                modColumn.setIsKey(true);
+            }
             if (!modColumn.isKey()) {
                 modColumn.setAggregationType(AggregateType.REPLACE, true);
             }
@@ -786,6 +793,13 @@ public class SchemaChangeHandler extends AlterHandler {
             if (null != modColumn.getAggregationType()) {
                 throw new DdlException("Can not assign aggregation method on column in Duplicate data model table: " +
                         modColumn.getName());
+            }
+            Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
+            if (baseColumn != null && baseColumn.isKey()) {
+                // backward compatibility, same as the PRIMARY KEY branch: the key set of a duplicate table is
+                // fixed at creation time and cannot be changed by MODIFY COLUMN, so keep an existing key
+                // column as a key column when the KEY keyword is omitted in the modify column clause.
+                modColumn.setIsKey(true);
             }
             if (!modColumn.isKey()) {
                 modColumn.setAggregationType(AggregateType.NONE, true);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -727,6 +727,48 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
+    private static Column findColumnInSchema(List<Column> schema, String columnName) {
+        if (schema == null) {
+            return null;
+        }
+        for (Column column : schema) {
+            if (column.getName().equalsIgnoreCase(columnName)) {
+                return column;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * For UNIQUE/DUPLICATE tables the key set of an index is fixed at creation time and cannot be changed by
+     * MODIFY COLUMN. When the user omits the KEY keyword (e.g. only changing a comment), keep an existing key
+     * column as a key column. Because the column clause was analyzed (in {@code buildColumnForModify}) with
+     * isKey=false, the key-only constraints that {@code ColumnDefAnalyzer} enforces were skipped, so re-apply
+     * them here: a non-nullable key stays non-nullable, and the (possibly changed) type must still be a valid
+     * key-column type.
+     */
+    private static void keepKeyAttributeIfOmitted(Column modColumn, Column existingColumn) throws DdlException {
+        if (existingColumn == null || !existingColumn.isKey() || modColumn.isKey()) {
+            return;
+        }
+        modColumn.setIsKey(true);
+        if (!existingColumn.isAllowNull()) {
+            // checkSchemaChangeAllowed() only rejects nullable -> non-nullable, so without this an omitted
+            // NOT NULL would silently relax a non-nullable key column to nullable.
+            modColumn.setIsAllowNull(false);
+        }
+        if (!modColumn.getType().canDistributedBy()) {
+            // Mirror the key-column type check in ColumnDefAnalyzer that was skipped during analysis.
+            if (modColumn.getType().isFloatingPointType()) {
+                throw new DdlException(String.format(
+                        "Invalid data type of key column '%s': '%s', use decimal instead",
+                        modColumn.getName(), modColumn.getType()));
+            }
+            throw new DdlException(String.format(
+                    "Invalid data type of key column '%s': '%s'", modColumn.getName(), modColumn.getType()));
+        }
+    }
+
     // User can modify column type and column position
     private boolean processModifyColumn(ModifyColumnClause alterClause, OlapTable olapTable,
                                         Map<Long, LinkedList<Column>> indexMetaIdToSchema,
@@ -736,6 +778,29 @@ public class SchemaChangeHandler extends AlterHandler {
         // But fast schema evolution for widening varchar length can be performed in both shared data and share nothing.
         boolean fastSchemaEvolution = RunMode.isSharedDataMode() && olapTable.getUseFastSchemaEvolution();
         Column modColumn = buildColumnForModify(alterClause.getColumnDef(), olapTable);
+
+        ColumnPosition columnPos = alterClause.getColPos();
+        String targetIndexName = alterClause.getRollupName();
+        checkIndexExists(olapTable, targetIndexName);
+
+        String baseIndexName = olapTable.getName();
+        checkAssignedTargetIndexName(baseIndexName, targetIndexName);
+
+        if (targetIndexName != null && columnPos == null) {
+            throw new DdlException("Do not need to specify index name when just modifying column type");
+        }
+
+        String indexNameForFindingColumn = targetIndexName;
+        if (indexNameForFindingColumn == null) {
+            indexNameForFindingColumn = baseIndexName;
+        }
+
+        long indexMetaIdForFindingColumn = olapTable.getIndexMetaIdByName(indexNameForFindingColumn);
+        // Resolve the schema of the index actually being modified. The key set can differ between the
+        // base index and a rollup (a base-table key column may be a value column in a rollup), so the
+        // backward-compatibility key restoration below must consult this schema rather than the base index.
+        List<Column> schemaForFinding = indexMetaIdToSchema.get(indexMetaIdForFindingColumn);
+
         if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
             Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
             if (baseColumn != null) {
@@ -779,13 +844,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on column in Unique data model table: " +
                         modColumn.getName());
             }
-            Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
-            if (baseColumn != null && baseColumn.isKey()) {
-                // backward compatibility, same as the PRIMARY KEY branch: the key set of a unique table is
-                // fixed at creation time and cannot be changed by MODIFY COLUMN, so keep an existing key
-                // column as a key column when the KEY keyword is omitted in the modify column clause.
-                modColumn.setIsKey(true);
-            }
+            keepKeyAttributeIfOmitted(modColumn, findColumnInSchema(schemaForFinding, modColumn.getName()));
             if (!modColumn.isKey()) {
                 modColumn.setAggregationType(AggregateType.REPLACE, true);
             }
@@ -794,13 +853,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on column in Duplicate data model table: " +
                         modColumn.getName());
             }
-            Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
-            if (baseColumn != null && baseColumn.isKey()) {
-                // backward compatibility, same as the PRIMARY KEY branch: the key set of a duplicate table is
-                // fixed at creation time and cannot be changed by MODIFY COLUMN, so keep an existing key
-                // column as a key column when the KEY keyword is omitted in the modify column clause.
-                modColumn.setIsKey(true);
-            }
+            keepKeyAttributeIfOmitted(modColumn, findColumnInSchema(schemaForFinding, modColumn.getName()));
             if (!modColumn.isKey()) {
                 modColumn.setAggregationType(AggregateType.NONE, true);
             }
@@ -821,26 +874,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
 
-        ColumnPosition columnPos = alterClause.getColPos();
-        String targetIndexName = alterClause.getRollupName();
-        checkIndexExists(olapTable, targetIndexName);
-
-        String baseIndexName = olapTable.getName();
-        checkAssignedTargetIndexName(baseIndexName, targetIndexName);
-
-        if (targetIndexName != null && columnPos == null) {
-            throw new DdlException("Do not need to specify index name when just modifying column type");
-        }
-
-        String indexNameForFindingColumn = targetIndexName;
-        if (indexNameForFindingColumn == null) {
-            indexNameForFindingColumn = baseIndexName;
-        }
-
-        long indexMetaIdForFindingColumn = olapTable.getIndexMetaIdByName(indexNameForFindingColumn);
-
         // find modified column
-        List<Column> schemaForFinding = indexMetaIdToSchema.get(indexMetaIdForFindingColumn);
         String newColName = modColumn.getName();
         boolean hasColPos = (columnPos != null && !columnPos.isFirst());
         boolean found = false;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -571,7 +571,8 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         }
 
         if (this.aggregationType != other.aggregationType) {
-            throw new DdlException("Can not change aggregation type");
+            throw new DdlException("Can not change aggregation type of column '" + other.getName()
+                    + "' from " + this.aggregationType + " to " + other.aggregationType);
         }
         if (this.aggStateDesc != null && !this.aggStateDesc.equals(other.aggStateDesc)) {
             throw new DdlException("Can not change aggregation state desc type");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/ModifyKeyColumnKeepKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/ModifyKeyColumnKeepKeyTest.java
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for StarRocks/starrocks#74553.
+ *
+ * On DUPLICATE / UNIQUE tables the key set is fixed at table creation time and
+ * cannot be changed by MODIFY COLUMN. Modifying only the comment (or only the
+ * type) of an existing key column without restating the {@code KEY} keyword must
+ * therefore keep it a key column, exactly as PRIMARY KEY and AGGREGATE KEY tables
+ * already do. Before the fix the DUPLICATE / UNIQUE branches implicitly turned the
+ * key column into a value column and assigned it an aggregation type, which then
+ * failed with the misleading {@code "Can not change aggregation type"}.
+ */
+public class ModifyKeyColumnKeepKeyTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        starRocksAssert.dropDatabase("test");
+    }
+
+    @Test
+    public void testModifyDuplicateKeyColumnCommentKeepsKey() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_dup_keep_key (id int not null, name varchar(12) not null, v float not null)\n" +
+                "DUPLICATE KEY(id, name)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "properties('replication_num' = '1');");
+
+        // Change ONLY the comment of the key column `name`, keeping the exact same type
+        // and omitting the KEY keyword. This used to fail with "Can not change aggregation type";
+        // alterTable() propagates that failure, so reaching here without throwing is the assertion.
+        starRocksAssert.alterTable(
+                "alter table t_dup_keep_key modify column name varchar(12) comment 'full name'");
+    }
+
+    @Test
+    public void testModifyUniqueKeyColumnCommentKeepsKey() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_uniq_keep_key (id int not null, name varchar(12) not null, v float not null)\n" +
+                "UNIQUE KEY(id, name)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "properties('replication_num' = '1');");
+
+        starRocksAssert.alterTable(
+                "alter table t_uniq_keep_key modify column name varchar(12) comment 'full name'");
+    }
+
+    /**
+     * Even with the key-attribute restoration, a genuine aggregation-type change on
+     * an AGGREGATE table value column still legitimately fails. The error message must
+     * now carry context (column name + from->to) instead of the context-free original.
+     */
+    @Test
+    public void testGenuineAggregationChangeHasActionableMessage() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_agg_change (k int, v int sum)\n" +
+                "AGGREGATE KEY(k)\n" +
+                "DISTRIBUTED BY HASH(k) BUCKETS 1\n" +
+                "properties('replication_num' = '1');");
+
+        // The SCHEMA_CHANGE alter path catches StarRocksException and re-throws it as
+        // AlterJobException carrying only the message (no cause), so assert on the
+        // top-level message rather than walking the cause chain.
+        Throwable exception = assertThrows(Throwable.class, () ->
+                starRocksAssert.alterTable(
+                        "alter table t_agg_change modify column v int max"));
+        String message = exception.getMessage().toLowerCase(Locale.ROOT);
+        assertTrue(message.contains("can not change aggregation type"),
+                "Expected aggregation-type language in: " + exception.getMessage());
+        // The column is reported through its shadow alias (e.g. __starrocks_shadow_v) during
+        // schema change, so match the column suffix rather than an exact quoted name.
+        assertTrue(message.contains("column '") && message.contains("v'"),
+                "Expected offending column name in: " + exception.getMessage());
+        assertTrue(message.contains("sum") && message.contains("max"),
+                "Expected from->to (sum->max) in: " + exception.getMessage());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/ModifyKeyColumnKeepKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/ModifyKeyColumnKeepKeyTest.java
@@ -14,7 +14,10 @@
 
 package com.starrocks.alter;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -22,7 +25,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,6 +88,52 @@ public class ModifyKeyColumnKeepKeyTest {
     }
 
     /**
+     * Restoring the omitted KEY attribute must also restore the key-only constraints that
+     * {@code ColumnDefAnalyzer} would have enforced. Otherwise, because the clause is analyzed with
+     * isKey=false and {@code Column#checkSchemaChangeAllowed} only rejects nullable -> non-nullable,
+     * omitting NOT NULL on a non-nullable key column would silently relax it to nullable.
+     */
+    @Test
+    public void testModifyKeyColumnOmittingNotNullKeepsNotNull() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_keep_notnull (id int not null, name varchar(12) not null, v int not null)\n" +
+                "DUPLICATE KEY(id, name)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "properties('replication_num' = '1');");
+
+        // Omit both KEY and NOT NULL on the existing NOT NULL key column `name`.
+        starRocksAssert.alterTable(
+                "alter table t_keep_notnull modify column name varchar(20) comment 'full name'");
+        waitForSchemaChangeDone();
+
+        Column name = getColumn("t_keep_notnull", "name");
+        assertTrue(name.isKey(), "key column `name` must remain a key column");
+        assertFalse(name.isAllowNull(), "NOT NULL key column `name` must not be silently relaxed to nullable");
+    }
+
+    /**
+     * Restoring the omitted KEY attribute must re-apply the key-column type check skipped during
+     * analysis. Changing a key column to a floating-point type (a valid scalar schema change, but an
+     * invalid key type) must be rejected instead of producing a floating-point key column.
+     */
+    @Test
+    public void testModifyKeyColumnToFloatingPointTypeRejected() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_float_key (k1 int not null, k2 int not null, v int not null)\n" +
+                "DUPLICATE KEY(k1, k2)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                "properties('replication_num' = '1');");
+
+        Throwable exception = assertThrows(Throwable.class, () ->
+                starRocksAssert.alterTable("alter table t_float_key modify column k2 double not null"));
+        String message = exception.getMessage().toLowerCase(Locale.ROOT);
+        assertTrue(message.contains("invalid data type of key column"),
+                "Expected key-type rejection in: " + exception.getMessage());
+        assertTrue(message.contains("k2"),
+                "Expected offending column name in: " + exception.getMessage());
+    }
+
+    /**
      * Even with the key-attribute restoration, a genuine aggregation-type change on
      * an AGGREGATE table value column still legitimately fails. The error message must
      * now carry context (column name + from->to) instead of the context-free original.
@@ -109,5 +161,26 @@ public class ModifyKeyColumnKeepKeyTest {
                 "Expected offending column name in: " + exception.getMessage());
         assertTrue(message.contains("sum") && message.contains("max"),
                 "Expected from->to (sum->max) in: " + exception.getMessage());
+    }
+
+    private static void waitForSchemaChangeDone() throws InterruptedException {
+        Map<Long, AlterJobV2> alterJobs =
+                GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        for (AlterJobV2 alterJob : alterJobs.values()) {
+            int retry = 0;
+            while (!alterJob.getJobState().isFinalState() && retry++ < 120) {
+                Thread.sleep(1000);
+            }
+            assertTrue(alterJob.getJobState() == AlterJobV2.JobState.FINISHED,
+                    "schema change job did not finish: " + alterJob.getJobState());
+        }
+    }
+
+    private static Column getColumn(String tableName, String columnName) {
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable("test", tableName);
+        Column column = table.getColumn(columnName);
+        assertNotNull(column, "column `" + columnName + "` not found on table `" + tableName + "`");
+        return column;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`MODIFY COLUMN` on an existing **key** column of a DUPLICATE or UNIQUE table silently dropped the key attribute when the `KEY` keyword was omitted (for example, when changing only a column comment), and then failed with the misleading error `Can not change aggregation type` — even though the user never specified any aggregation type.

```sql
CREATE TABLE test_db.t (
  id   INT          NOT NULL,
  name VARCHAR(12)  NOT NULL,
  v    FLOAT        NOT NULL
)
DUPLICATE KEY(id, name)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES ("replication_num" = "1");

-- Change ONLY the comment of the key column `name`, keeping the same type:
ALTER TABLE test_db.t MODIFY COLUMN name VARCHAR(12) COMMENT 'full name';
-- ERROR 1064 (HY000): Can not change aggregation type
```

The same reproduces on UNIQUE KEY tables. Workaround was to explicitly restate `KEY`.

**Root cause:** `SchemaChangeHandler#processModifyColumn` derives the key attribute per table model. PRIMARY KEY tables restore the key flag from the base column for backward compatibility, and AGGREGATE KEY tables do so implicitly (no aggregate ⇒ key). The DUPLICATE and UNIQUE branches did neither: with `KEY` omitted, `modColumn.isKey()` was `false`, so the column was assigned an implicit aggregation type (`NONE` / `REPLACE`). `Column#checkSchemaChangeAllowed` then compared it against the original key column (`aggregationType == null`) and threw. The key set of DUPLICATE/UNIQUE tables is fixed at creation time and cannot be changed by `MODIFY COLUMN`, so a key column should never be implicitly turned into a value column.

## What I'm doing:

1. **Primary fix** — in the UNIQUE and DUPLICATE branches of `processModifyColumn`, restore `isKey` from the base column when `KEY` is omitted, mirroring the documented backward-compatibility behavior of the PRIMARY KEY branch. After this, the repro succeeds without restating `KEY`, and key-attribute handling is consistent across all four table models (PRIMARY / AGGREGATE / UNIQUE / DUPLICATE).

2. **Secondary fix** — make the aggregation-type mismatch error in `Column#checkSchemaChangeAllowed` actionable by including the column name and the `from → to` aggregation types, matching the sibling type-change message in the same method. This still fires for a genuine aggregation change (e.g. AGGREGATE value column `SUM` → `MAX`).

Added `ModifyKeyColumnKeepKeyTest` covering: DUPLICATE key-column comment change, UNIQUE key-column comment change, and the improved actionable message on a genuine AGGREGATE aggregation change. All 3 pass.

Fixes #74553

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
