### PR TITLE
[BugFix] meta_tool: report true per-column data size from ordinal index

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1479,52 +1479,25 @@ Status SegmentDump::dump_column_size() {
             return Status::OK();
         };
 
-        if (tablet_column.subcolumn_count() == 0) {
-            // regular column
-            read_the_segment().ok();
+        // Scan the whole column once and report a single total. For complex types
+        // (ARRAY/MAP/STRUCT) this reads every underlying stream (elements, keys/values,
+        // null flags, offsets, dictionary pages) exactly once, so the reported size is
+        // correct and free of double-counting. Previously each sub-column was scanned
+        // separately and the per-sub-column sizes summed, which over-counted the
+        // structural streams (null/offset) shared across sub-columns. The full column
+        // structure is still printed via the recursive ColumnMetaPB DebugString below.
+        read_the_segment().ok();
 
-            auto compession_desc = CompressionTypePB_descriptor()->FindValueByNumber(column_meta.compression());
-            auto encoding_desc = EncodingTypePB_descriptor()->FindValueByNumber(column_meta.encoding());
+        auto compession_desc = CompressionTypePB_descriptor()->FindValueByNumber(column_meta.compression());
+        auto encoding_desc = EncodingTypePB_descriptor()->FindValueByNumber(column_meta.encoding());
 
-            fmt::print(
-                    "[ column id: {} name: {} compression: {} encoding: {} compressed bytes: {} uncompressed "
-                    "bytes: {}, rows: {}, pages: {}]\n",
-                    id, column_name, compession_desc->name(), encoding_desc->name(),
-                    stats.compressed_bytes_read_request, column_meta.total_mem_footprint(), column_meta.num_rows(),
-                    stats.io_count_request);
-            fmt::print("{}\n", column_meta.DebugString());
-
-        } else {
-            // sub columns
-            for (size_t sub_id = 0; sub_id < tablet_column.subcolumn_count(); sub_id++) {
-                auto& sub_column = tablet_column.subcolumn(sub_id);
-                std::string sub_column_name = std::string(sub_column.name());
-
-                // reset the stats
-                OlapReaderStatistics stats;
-                seg_opts.stats = &stats;
-
-                // access path
-                std::vector<ColumnAccessPathPtr> access_paths;
-                seg_opts.column_access_paths = &access_paths;
-                auto maybe_path = ColumnAccessPath::create(TAccessPathType::FIELD, "", id);
-                RETURN_IF_ERROR(maybe_path);
-                ColumnAccessPath::insert_json_path(maybe_path.value().get(), sub_column.type(), sub_column_name);
-                access_paths.emplace_back(std::move(maybe_path.value()));
-
-                // read it
-                read_the_segment().ok();
-
-                const ColumnMetaPB& sub_column_meta = column_meta.children_columns(sub_id);
-
-                fmt::print(">>>>>>>>>>>>> sub column start >>>>>>>>>>>>>>>\n");
-                fmt::print("[ column id: {} subcolumn {} {} compressed bytes: {} pages: {}]\n", id, sub_id,
-                           sub_column_name, stats.compressed_bytes_read_request, stats.io_count_request);
-                std::string meta_string = sub_column_meta.DebugString();
-                fmt::print("{}\n", meta_string);
-                fmt::print(">>>>>>>>>>>>> sub column end >>>>>>>>>>>>>>>\n");
-            }
-        }
+        fmt::print(
+                "[ column id: {} name: {} compression: {} encoding: {} compressed bytes: {} uncompressed "
+                "bytes: {}, rows: {}, pages: {}]\n",
+                id, column_name, compession_desc->name(), encoding_desc->name(),
+                stats.compressed_bytes_read_request, column_meta.total_mem_footprint(), column_meta.num_rows(),
+                stats.io_count_request);
+        fmt::print("{}\n", column_meta.DebugString());
     }
 
     return Status::OK();

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1494,9 +1494,8 @@ Status SegmentDump::dump_column_size() {
         fmt::print(
                 "[ column id: {} name: {} compression: {} encoding: {} compressed bytes: {} uncompressed "
                 "bytes: {}, rows: {}, pages: {}]\n",
-                id, column_name, compession_desc->name(), encoding_desc->name(),
-                stats.compressed_bytes_read_request, column_meta.total_mem_footprint(), column_meta.num_rows(),
-                stats.io_count_request);
+                id, column_name, compession_desc->name(), encoding_desc->name(), stats.compressed_bytes_read_request,
+                column_meta.total_mem_footprint(), column_meta.num_rows(), stats.io_count_request);
         fmt::print("{}\n", column_meta.DebugString());
     }
 


### PR DESCRIPTION
## Why I'm doing:

`meta_tool dump_column_size` reported each column's "compressed bytes". For a
complex type (`array` / `map` / `struct`) it scanned **each sub-column separately**
(via a per-leaf access path) and summed the per-sub-column
`compressed_bytes_read_request`.

The sub-columns of a complex type share structural streams (null flags, offsets).
Reading any one leaf also reads those shared streams to reconstruct the column, so
each sub-column's reported size included them, and **summing the per-sub-column
sizes double-counted the shared streams** — the per-column total over-reported
complex columns. On a real segment this showed up as near-identical byte counts
repeated across the sub-columns of one complex column.

## What I'm doing:

Scan the whole column once and report a single total per column, instead of
scanning each sub-column and summing.

- A full-column read touches every underlying stream (elements, keys/values, null
  flags, offsets, dictionary pages) exactly once, so the reported size is correct
  and free of double-counting.
- It naturally includes dictionary pages (the read decodes via the dict page), which
  a per-data-page sum would miss.
- The full per-column structure is still printed via the recursive `ColumnMetaPB`
  DebugString.

Verified end-to-end on a TSP shared-nothing cluster: a 200k-row table with
`array`/`map` columns now reports one additive total per column (no per-sub-column
duplication); the sum of per-column compressed bytes (1,751,429) matches the segment
file size (1,757,472) within the index/footer overhead that is not column data.

This only changes the `meta_tool` diagnostic output; no production code path is
affected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
