### PR TITLE
[BugFix] Hold table WRITE lock in LakeTableIndexFastPathJobBase.replay()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -474,51 +474,66 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
         if (table == null) {
             return;
         }
-        if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN
-                || jobState == JobState.RUNNING) {
-            table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
-        } else if (jobState == JobState.FINISHED_REWRITING) {
-            table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
-            // The live runRunningJob bumped each partition's nextVersion to
-            // commitVersion+1 at the FINISHED_REWRITING transition (see
-            // updateNextVersion). The edit log persists the job's state but
-            // NOT that in-memory catalog bump, so a cold-started or
-            // leader-switched FE must redo it here. Without this the
-            // partition's nextVersion stays one behind the version reserved
-            // here, and the next operation that asserts
-            // nextVersion == its own reserved commitVersion -- e.g. a
-            // following LakeTableSchemaChangeJob.replay() -> updateNextVersion
-            // -- fails its Preconditions.checkState and aborts journal replay,
-            // leaving the FE unable to start.
-            replayUpdateNextVersion(table);
-        } else if (jobState == JobState.FINISHED) {
-            // Reapply catalog mutation at replay so a cold-started FE sees
-            // the post-alter table state. The mutation is idempotent by
-            // design (add checks presence, drop is no-op on missing).
-            //
-            // Also re-bump each partition's nextVersion and visibleVersion:
-            // the live FE captured both in memory only, and the next image may
-            // have been taken before the bump landed (or before the
-            // FINISHED_REWRITING journal that carries the nextVersion bump).
-            // Both bumps are idempotent: skip a partition that already
-            // advanced past the target (replay-after-checkpoint, or a later
-            // op that moved the version on).
-            replayUpdateNextVersion(table);
-            for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
-                PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
-                if (pp != null && pp.getVisibleVersion() < e.getValue()) {
-                    pp.setVisibleVersion(e.getValue(), finishedTimeMs);
+        // Replay runs on followers/observers that serve reads concurrently
+        // with journal apply (and off the image on a cold-started or
+        // leader-switched FE). The per-partition version writes
+        // (replayUpdateNextVersion / setVisibleVersion) and the index-list
+        // mutation (applyCatalogMutation) touch shared OlapTable state, so
+        // they must be done under the table WRITE lock -- exactly as the live
+        // path (runRunningJob / runFinishedRewritingJob) and the sibling
+        // LakeTableAlterMetaJobBase.replay() already do. Acquire the lock
+        // before the try so a failed lock() does not run unLock() in finally.
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
+        try {
+            if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN
+                    || jobState == JobState.RUNNING) {
+                table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+            } else if (jobState == JobState.FINISHED_REWRITING) {
+                table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+                // The live runRunningJob bumped each partition's nextVersion to
+                // commitVersion+1 at the FINISHED_REWRITING transition (see
+                // updateNextVersion). The edit log persists the job's state but
+                // NOT that in-memory catalog bump, so a cold-started or
+                // leader-switched FE must redo it here. Without this the
+                // partition's nextVersion stays one behind the version reserved
+                // here, and the next operation that asserts
+                // nextVersion == its own reserved commitVersion -- e.g. a
+                // following LakeTableSchemaChangeJob.replay() -> updateNextVersion
+                // -- fails its Preconditions.checkState and aborts journal replay,
+                // leaving the FE unable to start.
+                replayUpdateNextVersion(table);
+            } else if (jobState == JobState.FINISHED) {
+                // Reapply catalog mutation at replay so a cold-started FE sees
+                // the post-alter table state. The mutation is idempotent by
+                // design (add checks presence, drop is no-op on missing).
+                //
+                // Also re-bump each partition's nextVersion and visibleVersion:
+                // the live FE captured both in memory only, and the next image may
+                // have been taken before the bump landed (or before the
+                // FINISHED_REWRITING journal that carries the nextVersion bump).
+                // Both bumps are idempotent: skip a partition that already
+                // advanced past the target (replay-after-checkpoint, or a later
+                // op that moved the version on).
+                replayUpdateNextVersion(table);
+                for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
+                    PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
+                    if (pp != null && pp.getVisibleVersion() < e.getValue()) {
+                        pp.setVisibleVersion(e.getValue(), finishedTimeMs);
+                    }
                 }
+                applyCatalogMutation(table);
+                table.setState(OlapTable.OlapTableState.NORMAL);
+            } else if (jobState == JobState.CANCELLED) {
+                // A job force-cancelled out of FINISHED_REWRITING has already
+                // reserved a commitVersion and bumped nextVersion on the live FE;
+                // reproduce that bump on replay too (no-op when the job was
+                // cancelled before reserving, since commitVersionMap is empty).
+                replayUpdateNextVersion(table);
+                table.setState(OlapTable.OlapTableState.NORMAL);
             }
-            applyCatalogMutation(table);
-            table.setState(OlapTable.OlapTableState.NORMAL);
-        } else if (jobState == JobState.CANCELLED) {
-            // A job force-cancelled out of FINISHED_REWRITING has already
-            // reserved a commitVersion and bumped nextVersion on the live FE;
-            // reproduce that bump on replay too (no-op when the job was
-            // cancelled before reserving, since commitVersionMap is empty).
-            replayUpdateNextVersion(table);
-            table.setState(OlapTable.OlapTableState.NORMAL);
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -484,7 +484,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
         // LakeTableAlterMetaJobBase.replay() already do. Acquire the lock
         // before the try so a failed lock() does not run unLock() in finally.
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         try {
             if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN
                     || jobState == JobState.RUNNING) {
@@ -533,7 +533,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
                 table.setState(OlapTable.OlapTableState.NORMAL);
             }
         } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
@@ -286,13 +286,10 @@ public class LakeTableIndexFastPathJobBaseTest {
 
     private void runReplay(LakeTableAddIndexJob target, LakeTableAddIndexJob other,
                            Database db, OlapTable table) {
-        GlobalStateMgr gsm = mock(GlobalStateMgr.class);
-        LocalMetastore lm = mock(LocalMetastore.class);
-        when(lm.getDb(2L)).thenReturn(db);
-        if (db != null) {
-            when(lm.getTable(2L, 3L)).thenReturn(table);
-        }
-        when(gsm.getLocalMetastore()).thenReturn(lm);
+        // replay() now takes the table WRITE lock around its catalog mutations
+        // (mirroring the live path), so the GSM mock must expose a real
+        // LockManager. Reuse the same lockable wiring as the cancelImpl tests.
+        GlobalStateMgr gsm = buildLockableGsm(db, table);
         try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class)) {
             gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
             target.replay(other);


### PR DESCRIPTION




## Why I'm doing:
replay() mutated shared OlapTable state with no lock: per-partition nextVersion/visibleVersion (replayUpdateNextVersion / setVisibleVersion), the table index list (applyCatalogMutation), and setState. The journal replay dispatch holds no db/table lock at any layer, so on followers and observers that serve reads while applying the journal these mutations race with readers holding the table READ lock (e.g. iterating the partition index collections in applyCatalogMutation).

## What I'm doing:
Wrap the state-branch logic in lockTablesWithIntensiveDbLock(WRITE), mirroring the live path (runRunningJob / runFinishedRewritingJob) and the sibling LakeTableAlterMetaJobBase.replay(); every other AlterJobV2.replay() in the codebase already holds a WRITE lock around its catalog mutations. The lock is taken before the try; job-field copies stay outside it.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
