### PR TITLE
[Enhancement] Unify lake no-SST condition update onto pk_index_execution pool

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1314,11 +1314,22 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
     std::vector<uint32_t> read_column_ids;
     read_column_ids.push_back(condition_column);
 
+    // Only parallelize when the segment iterator will actually split into more than one
+    // compare chunk. SegmentPKIterator splits at pk_index_parallel_execution_min_rows, so a
+    // rowset smaller than that yields a single chunk per segment, and comparing it inline on
+    // the publish thread is cheaper than a thread-pool round-trip. The rowset-wide row count
+    // is a safe lower bound for the per-segment count: if the whole rowset is under the
+    // threshold, every segment is too.
     std::unique_ptr<ThreadPoolToken> token;
-    if (config::enable_pk_index_parallel_execution) {
-        token = GlobalEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
+    if (config::enable_pk_index_parallel_execution &&
+        params.op_write.rowset().num_rows() >= config::pk_index_parallel_execution_min_rows) {
+        token = GlobalEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
     }
+    // TRACE_COUNTER_* reads a thread-local current trace that pool worker threads do not
+    // inherit, so counters incremented inside a submitted compare task would silently drop.
+    // Capture the publish thread's trace and re-adopt it inside each worker task.
+    Trace* parent_trace = Trace::CurrentTrace();
 
     std::mutex mutex;
     Status status = Status::OK();
@@ -1332,6 +1343,7 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         result->chunk_physical_rowid_offset = current.physical_rowid_offset;
 
         auto compare_func = [&, result, current]() {
+            ADOPT_TRACE(parent_trace);
             auto st = process_single_chunk_update_with_condition_no_sst(this, params, rowset_id, upsert_idx,
                                                                         upsert.get(), current, tablet_column,
                                                                         read_column_ids, index, result);
@@ -1348,6 +1360,7 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
                 status.update(submit_st);
             }
         } else {
+            // Single-chunk (or parallel execution disabled): compare on the publish thread.
             compare_func();
             RETURN_IF_ERROR(status);
         }

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -15,7 +15,9 @@
 #include <gtest/gtest.h>
 
 #include <random>
+#include <string_view>
 
+#include "base/debug/trace.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
 #include "column/chunk.h"
@@ -713,6 +715,90 @@ TEST_P(ConditionUpdateTest, test_condition_update_no_sst_parallel_fragmented_win
                   }
                   return c1 == c0 * 4 && c2 == c0 * 9;
               }));
+}
+
+// Trace stores counters keyed by `const char*` (pointer comparison), and the literal we
+// pass here may not share an address with the one inside update_manager.cpp across
+// translation units. Match by string value so the lookup is robust against the compiler's
+// string-pooling decisions.
+static int64_t find_trace_metric(const std::map<const char*, int64_t>& metrics, std::string_view name) {
+    for (const auto& [k, v] : metrics) {
+        if (k != nullptr && name == k) {
+            return v;
+        }
+    }
+    return 0;
+}
+
+// Guards the trace-propagation fix for the non-SST parallel compare phase. With >1
+// per-segment chunk every chunk's compare task runs on pk_index_execution_thread_pool, and
+// `process_condition_update_count` is incremented only inside that worker task. Without
+// re-adopting the publish thread's trace in the worker, the counter would land on the
+// worker's (absent) trace and be lost; asserting it is visible in the adopted trace proves
+// the counters are propagated back.
+TEST_P(ConditionUpdateTest, test_condition_update_no_sst_trace_propagation) {
+    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
+    const int64_t chunk_size = 2 * 4096; // >1 per-segment chunk so the compare runs on the pool
+    ConfigResetGuard<int64_t> guard2(&config::pk_index_parallel_execution_min_rows, 4096);
+
+    auto baseline = generate_data(chunk_size, 0, 3, 4); // baseline c1=k*3, c2=k*4
+    auto indexes = std::vector<uint32_t>(chunk_size);
+    for (int i = 0; i < chunk_size; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(baseline, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Condition update with c1 as the merge column: c1=k*4 > baseline k*3, so the new row
+    // wins on every key. Keys fully overlap the baseline so the compare path actually reads
+    // old condition values (not the all-new fast path).
+    auto update = generate_data(chunk_size, 0, 4, 5);
+    scoped_refptr<Trace> trace(new Trace);
+    {
+        ADOPT_TRACE(trace.get());
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_merge_condition("c1")
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(update, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    ASSERT_EQ(chunk_size, check(version, [](int c0, int c1, int c2) { return c1 == c0 * 4 && c2 == c0 * 5; }));
+
+    // process_condition_update_count is incremented once per chunk inside the worker task;
+    // with >1 chunk and trace propagation working it must be visible here.
+    auto metrics = trace->metrics()->Get();
+    int64_t worker_cnt = find_trace_metric(metrics, "process_condition_update_count");
+    ASSERT_GT(worker_cnt, 0) << "worker-thread trace counters were not propagated to the publish trace";
 }
 
 INSTANTIATE_TEST_SUITE_P(ConditionUpdateTest, ConditionUpdateTest, ::testing::Values(PrimaryKeyParam{true}));


### PR DESCRIPTION
## Why I'm doing:

While analysing a slow `PublishTablet` trace for a lake PK table with condition
update, the `condition_update_compare_phase_us` counter dominated (~4.5s) while
every recorded sub-operation summed to a couple of milliseconds. Two problems
surfaced:

1. The non-SST condition-merge compare phase in `_do_update_with_condition`
   submits per-chunk compare tasks to `lake_partial_update_thread_pool`, while the
   sibling SST path (`_do_update_with_condition_parallel`) and branch-4.1 both use
   `pk_index_execution_thread_pool`. The no-SST path therefore contends with
   row-mode partial-update publishes instead of staying with the other PK-index
   work, and the two condition-merge paths are inconsistent.
2. `TRACE_COUNTER_*` reads a thread-local current trace that pool worker threads do
   not inherit. Counters incremented inside the compare task were silently dropped
   from the publish trace, which is exactly why the breakdown "went dark" where the
   time was actually spent.

## What I'm doing:

In `UpdateManager::_do_update_with_condition` (non-SST path):

- **Unify the thread pool:** route the compare tasks to
  `pk_index_execution_thread_pool`, matching the SST path and branch-4.1.
- **Single-chunk fast path:** hold the first chunk's compare task; if it is the
  only chunk, run it inline on the publish thread instead of paying a thread-pool
  round-trip (the common small-publish case). Once a second chunk proves there is
  real parallel work, flush the held task and submit every chunk from then on. The
  token is always drained before returning so worker closures never outlive the
  locals they capture.
- **Propagate the trace:** capture the publish thread's `Trace::CurrentTrace()` and
  `ADOPT_TRACE` it inside each worker task, mirroring the existing pattern in
  `lake_persistent_index.cpp`. Worker-side counters (e.g.
  `process_condition_update_count`, `get_column_values`/segment-IO timings) now
  flow back into the publish trace.

Test: `test_condition_update_no_sst_trace_propagation` forces >1 per-segment chunk
so the compare runs on the pool, verifies the merge result, and asserts
`process_condition_update_count` is visible in the adopted trace (would be 0 without
the propagation fix). Existing no-SST tests already cover the single-chunk inline
path and the multi-chunk parallel path for correctness.

No user-facing, config, or interface change; this is internal task scheduling plus
observability. The inline + trace-propagation improvements would also be useful on
branch-4.1 (which already uses `pk_index_execution_thread_pool`); happy to follow up
with a backport if desired.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
