### PR TITLE
[BugFix] Fix typo in azure_adls2_oauth2_client_endpoint config field name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3319,8 +3319,8 @@ public class Config extends ConfigBase {
     public static String azure_adls2_oauth2_client_id = "";
     @ConfField
     public static String azure_adls2_oauth2_client_secret = "";
-    @ConfField
-    public static String azure_adls2_oauth2_oauth2_client_endpoint = "";
+    @ConfField(aliases = {"azure_adls2_oauth2_oauth2_client_endpoint"})
+    public static String azure_adls2_oauth2_client_endpoint = "";
 
     // gcp gs
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -642,7 +642,7 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
                 params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET,
                         Config.azure_adls2_oauth2_client_secret);
                 params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT,
-                        Config.azure_adls2_oauth2_oauth2_client_endpoint);
+                        Config.azure_adls2_oauth2_client_endpoint);
                 break;
             case "gs":
                 params.put(CloudConfigurationConstants.GCP_GCS_ENDPOINT, Config.gcp_gcs_endpoint);

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -502,6 +502,27 @@ public class SharedDataStorageVolumeMgrTest {
         Assertions.assertEquals("sas_token",
                 sv.getCloudConfiguration().toFileStoreInfo().getAdls2FsInfo().getCredential().getSasToken());
 
+        // Test ADLS2 OAuth2 with client endpoint (was broken by a typo: azure_adls2_oauth2_oauth2_client_endpoint)
+        Config.azure_adls2_shared_key = "";
+        Config.azure_adls2_sas_token = "";
+        Config.azure_adls2_oauth2_use_managed_identity = false;
+        Config.azure_adls2_oauth2_tenant_id = "tenant_id";
+        Config.azure_adls2_oauth2_client_id = "client_id";
+        Config.azure_adls2_oauth2_client_secret = "client_secret";
+        Config.azure_adls2_oauth2_client_endpoint = "https://login.microsoftonline.com/tenant_id";
+        sdsvm.removeStorageVolume(StorageVolumeMgr.BUILTIN_STORAGE_VOLUME);
+        sdsvm.createBuiltinStorageVolume();
+        sv = sdsvm.getStorageVolumeByName(StorageVolumeMgr.BUILTIN_STORAGE_VOLUME);
+        Assertions.assertEquals("endpoint", sv.getCloudConfiguration().toFileStoreInfo().getAdls2FsInfo().getEndpoint());
+        Assertions.assertEquals("tenant_id",
+                sv.getCloudConfiguration().toFileStoreInfo().getAdls2FsInfo().getCredential().getTenantId());
+        Assertions.assertEquals("client_id",
+                sv.getCloudConfiguration().toFileStoreInfo().getAdls2FsInfo().getCredential().getClientId());
+        Assertions.assertEquals("client_secret",
+                sv.getCloudConfiguration().toFileStoreInfo().getAdls2FsInfo().getCredential().getClientSecret());
+        Assertions.assertEquals("https://login.microsoftonline.com/tenant_id",
+                sv.getCloudConfiguration().toFileStoreInfo().getAdls2FsInfo().getCredential().getAuthorityHost());
+
         Config.cloud_native_storage_type = "GS";
         Config.gcp_gcs_use_compute_engine_service_account = "true";
         Config.gcp_gcs_path = "gs://gs_path";


### PR DESCRIPTION
missing doc

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

## What problem does this PR solve?

When deploying StarRocks in `shared_data` mode with Azure ADLS2 storage using OAuth2 authentication (`cloud_native_storage_type = ADLS2`), the FE fails to start with:

```
SemanticException: Storage params is not valid {..., "azure.adls2.oauth2_client_endpoint":"", ...}
```

The `azure.adls2.oauth2_client_endpoint` parameter is always empty, even when `azure_adls2_oauth2_client_endpoint` is correctly set in `fe.conf`.

**Root cause**: `Config.java` declares the field as `azure_adls2_oauth2_oauth2_client_endpoint` (duplicate `oauth2_`), so the value from `fe.conf` is parsed under a different key, while `SharedDataStorageVolumeMgr` reads from the misnamed field and always gets an empty string.
