### PR TITLE
[BugFix] Rebuild vector index on shared-data partial-update segment rewrite

### DIFF
--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -76,6 +76,11 @@ struct FileInfo {
     std::shared_ptr<FileSystem> fs;
     // It is used to store the file offset of the bundle file.
     std::optional<int64_t> bundle_file_offset;
+    // IDs of vector indexes whose .vi file belongs to this segment. Populated when a segment is
+    // produced outside the normal tablet-writer flush path (e.g. the partial-update segment
+    // rewrite), so the apply path can persist them into SegmentMetadataPB::vector_index_ids and
+    // keep async builds / vacuum / reads in sync. Empty for files with no vector index.
+    std::vector<int64_t> vector_index_ids;
 
     // Cache key uniquely identifying this FileInfo as a *slice* of a physical file. Caches keyed
     // on file identity (e.g. lake metacache for Segments) must use this rather than `path` so two

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -35,11 +35,11 @@
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/vacuum.h"
+#include "storage/lake/vector_index_utils.h"
 #include "storage/rowset/segment_writer.h"
 
 namespace starrocks::lake {
 
-namespace {
 // async/sync is a table-level setting (every vector index on a given schema shares the
 // same index_build_mode). Returning bool from "any vector index has async mode" is
 // equivalent to "the table is in async mode" for this purpose.
@@ -136,7 +136,6 @@ Status fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t tab
     }
     return Status::OK();
 }
-} // namespace
 
 void collect_writer_stats(OlapWriterStatistics& writer_stats, SegmentWriter* segment_writer) {
     if (segment_writer == nullptr) {

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -183,6 +183,14 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         if (segment_meta->has_encryption_meta()) {
             segment_meta->set_encryption_meta(replace_seg.second.encryption_meta);
         }
+        // The rewrite produces a full segment; refresh its vector_index_ids to reflect the .vi the
+        // rewrite built inline (sync) or that the FE-scheduled build task will build (async). The
+        // partial segment recorded none of its own (it omitted the vector column), so without this
+        // the dest segment would carry no vector_index_ids and lose its vector index after publish.
+        segment_meta->clear_vector_index_ids();
+        for (int64_t vi_id : replace_seg.second.vector_index_ids) {
+            segment_meta->add_vector_index_ids(vi_id);
+        }
         // The rewrite file is a brand-new file private to this tablet, not shared with
         // sibling split tablets. If the original segment was marked shared during a
         // cross-publish, clear the flag so GC routes the rewrite file through the normal
@@ -1255,6 +1263,12 @@ Status MetaFileBuilder::set_final_rowset() {
         segment_meta->set_size(replace_seg.second.size.value());
         if (segment_meta->has_encryption_meta()) {
             segment_meta->set_encryption_meta(replace_seg.second.encryption_meta);
+        }
+        // See apply_opwrite: refresh vector_index_ids for the full rewrite segment so the dest
+        // segment keeps its vector index (sync .vi built inline, or async .vi to be built).
+        segment_meta->clear_vector_index_ids();
+        for (int64_t vi_id : replace_seg.second.vector_index_ids) {
+            segment_meta->add_vector_index_ids(vi_id);
         }
         // See apply_opwrite: clear the shared flag for the rewrite file, which is
         // private to this tablet and must not be GC'd through the shared-file path.

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -183,10 +183,11 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         if (segment_meta->has_encryption_meta()) {
             segment_meta->set_encryption_meta(replace_seg.second.encryption_meta);
         }
-        // The rewrite produces a full segment; refresh its vector_index_ids to reflect the .vi the
-        // rewrite built inline (sync) or that the FE-scheduled build task will build (async). The
-        // partial segment recorded none of its own (it omitted the vector column), so without this
-        // the dest segment would carry no vector_index_ids and lose its vector index after publish.
+        // The rewrite produces a full segment under a new name; the replace FileInfo carries the
+        // authoritative vector_index_ids for it (built inline / carried over from the partial
+        // segment in sync mode, or scheduled for the FE build task in async mode). Any ids copied
+        // from the partial segment's own metadata refer to .vi files keyed on the old segment
+        // name, so refresh them wholesale.
         segment_meta->clear_vector_index_ids();
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
@@ -232,9 +233,9 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
     }
     // if rowset don't contain segment files, still inc next_rowset_id
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + get_rowset_id_step(*rowset));
-    // collect trash files
+    // collect trash files: replaced partial-update segments and their segment-name-keyed .vi files
     for (const auto& orphan_file : orphan_files) {
-        DCHECK(is_segment(orphan_file.name()));
+        DCHECK(is_segment(orphan_file.name()) || is_vector_index(orphan_file.name()));
         _tablet_meta->mutable_orphan_files()->Add()->CopyFrom(orphan_file);
     }
     if (!_tablet_meta->rowset_to_schema().empty()) {
@@ -1308,9 +1309,9 @@ Status MetaFileBuilder::set_final_rowset() {
     // If rowset doesn't contain segment files, still increment next_rowset_id
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + get_rowset_id_step(*rowset));
 
-    // Collect orphan files
+    // Collect orphan files: replaced partial-update segments and their segment-name-keyed .vi files
     for (const auto& orphan_file : _pending_rowset_data.orphan_files) {
-        DCHECK(is_segment(orphan_file.name()));
+        DCHECK(is_segment(orphan_file.name()) || is_vector_index(orphan_file.name()));
         _tablet_meta->mutable_orphan_files()->Add()->CopyFrom(orphan_file);
     }
 

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -23,11 +23,13 @@
 #include "common/stack_util.h"
 #include "common/tracer.h"
 #include "fs/fs_factory.h"
+#include "fs/fs_util.h"
 #include "fs/key_cache.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "serde/column_array_serde.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
@@ -256,49 +258,39 @@ static std::vector<ColumnId> get_read_columns_ids(const TxnLogPB_OpWrite& op_wri
     return unmodified_column_ids;
 }
 
-// Decide which vector index ids to persist on the rewritten (dest) partial-update segment. The
-// dest segment is a full segment, so a vector index whose column is materialized in it needs a
-// .vi. This mirrors HorizontalGeneralTabletWriter::record_segment_vector_index_ids but for the
-// rewrite path, which has no SegmentWriter to query:
-//   - async indexes are recorded once the segment clears the deferred-build threshold (the dest
-//     segment is a standalone rewrite file, never a bundle), so the FE-scheduled build task
-//     rebuilds the .vi from the dest segment;
-//   - sync indexes are recorded only when the .vi was actually built inline by
-//     rewrite_partial_update, i.e. the indexed column is among the rewritten (unmodified) columns.
-// |rewritten_column_ids| are schema column ordinals (see get_read_columns_ids).
-static std::vector<int64_t> collect_rewrite_segment_vector_index_ids(const TabletSchemaCSPtr& schema,
-                                                                     const std::vector<ColumnId>& rewritten_column_ids,
-                                                                     bool defer_build, int64_t num_rows) {
-    auto is_rewritten = [&](uint32_t ordinal) {
-        for (auto id : rewritten_column_ids) {
-            if (id == ordinal) return true;
-        }
-        return false;
-    };
-    const uint32_t threshold = defer_build ? get_vector_index_build_threshold(schema) : 0;
-    std::vector<int64_t> ids;
-    for (uint32_t i = 0, num_cols = schema->num_columns(); i < num_cols; i++) {
-        const auto& column = schema->column(i);
-        if (!schema->has_index(column.unique_id(), IndexType::VECTOR)) {
-            continue;
-        }
-        std::unordered_map<IndexType, TabletIndex> tablet_index;
-        if (!schema->get_indexes_for_column(column.unique_id(), &tablet_index).ok()) {
-            continue;
-        }
-        auto it = tablet_index.find(IndexType::VECTOR);
-        if (it == tablet_index.end()) {
-            continue;
-        }
-        if (defer_build) {
-            if (num_rows >= static_cast<int64_t>(threshold)) {
-                ids.push_back(it->second.index_id());
-            }
-        } else if (is_rewritten(i)) {
-            ids.push_back(it->second.index_id());
-        }
+// Resolve the rewrite-path vector index options for the dest segment, mirroring the normal lake
+// writer (reset_segment_writer): location-provider-resolved .vi paths keyed on |dest_path| — also
+// filled in async mode, where they only feed id recording — plus the schema's index_build_mode
+// and deferred-build threshold.
+static StatusOr<RewriteVectorIndexOptions> resolve_rewrite_vector_index_options(const RowsetUpdateStateParams& params,
+                                                                                const std::string& dest_path) {
+    RewriteVectorIndexOptions vi_opts;
+    SegmentWriterOptions opts;
+    RETURN_IF_ERROR(fill_vector_index_file_paths(params.tablet_schema, params.tablet->id(), dest_path,
+                                                 params.tablet->tablet_mgr(), /*location_provider=*/nullptr,
+                                                 /*fs=*/nullptr, opts));
+    vi_opts.file_paths = std::move(opts.vector_index_file_paths);
+    vi_opts.defer_build = has_async_vector_index(params.tablet_schema);
+    vi_opts.build_threshold = get_vector_index_build_threshold(params.tablet_schema);
+    return vi_opts;
+}
+
+// A partial update whose update set includes a vector-indexed column raw-copies that column's
+// data into the dest segment (rewrite_partial_update creates no column writer for it), so a sync
+// .vi built inline for the src partial segment is still valid for the dest — the rewrite keeps
+// the row order. Carry it over to the dest segment name and record the id; the src ids in the
+// op_write metadata list exactly the indexes whose .vi was built on the updated columns. Async
+// mode has no src .vi to carry: the dest ids recorded by the rewrite already cover all indexes.
+static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& params,
+                                               const SegmentMetadataPB& src_seg_meta, const std::string& src_path,
+                                               const std::string& dest_path, FileInfo* file_info) {
+    for (int64_t index_id : src_seg_meta.vector_index_ids()) {
+        auto src_vi = params.tablet->segment_location(gen_vector_index_filename(src_path, index_id));
+        auto dest_vi = params.tablet->segment_location(gen_vector_index_filename(dest_path, index_id));
+        RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
+        file_info->vector_index_ids.push_back(index_id);
     }
-    return ids;
+    return Status::OK();
 }
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
@@ -527,6 +519,16 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         src.bundle_file_offset = src_seg_meta.bundle_file_offset();
     }
 
+    // The dest segment is a full rewrite, so mirror the normal lake writer's vector-index
+    // handling: sync indexes are built inline at the reader-visible location-provider path;
+    // async builds are deferred to the FE-scheduled VectorIndexBuildTask; and the dest segment's
+    // vector_index_ids are persisted via the replace FileInfo. Without this the SegmentWriter
+    // would fall back to the IndexDescriptor path (unreachable in shared-data, since reads/builds
+    // key off the segment-name path) and the dest segment would carry no vector_index_ids,
+    // silently dropping the index after publish.
+    ASSIGN_OR_RETURN(auto vector_index_opts, resolve_rewrite_vector_index_options(params, dest_path));
+    const bool defer_vector_index_build = vector_index_opts.defer_build;
+
     int64_t t_rewrite_start = MonotonicMillis();
     if (has_auto_increment_partial_update_state(params) &&
         !_auto_increment_partial_update_states[segment_id].skip_rewrite) {
@@ -535,43 +537,25 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
                 src, &file_info, params.tablet_schema, _auto_increment_partial_update_states[segment_id],
                 unmodified_column_ids,
                 has_partial_update_state(params) ? &_partial_update_states[segment_id].write_columns : nullptr,
-                params.tablet));
+                params.tablet, std::move(vector_index_opts)));
         file_info.path = dest_path;
         (*replace_segments)[segment_id] = file_info;
     } else if (has_partial_update_state(params)) {
         const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
         FileInfo file_info{.path = params.tablet->segment_location(dest_path)};
 
-        // The dest segment is a full rewrite that re-materializes the unmodified columns, which for
-        // a typical partial update include the vector column. Mirror the normal lake writer's
-        // vector-index handling so the dest segment's .vi lands at the reader-visible
-        // location-provider path and its ids are persisted: sync indexes are built inline here;
-        // async indexes are deferred to the FE-scheduled VectorIndexBuildTask. Without this the
-        // SegmentWriter would fall back to the IndexDescriptor path (unreachable in shared-data,
-        // since reads/builds key off the segment-name path) and the dest segment would carry no
-        // vector_index_ids, silently dropping the index after publish.
-        const bool defer_vector_index_build = has_async_vector_index(params.tablet_schema);
-        std::map<int64_t, std::string> vector_index_file_paths;
-        if (!defer_vector_index_build) {
-            SegmentWriterOptions vi_opts;
-            RETURN_IF_ERROR(fill_vector_index_file_paths(params.tablet_schema, params.tablet->id(), dest_path,
-                                                         params.tablet->tablet_mgr(), /*location_provider=*/nullptr,
-                                                         /*fs=*/nullptr, vi_opts));
-            vector_index_file_paths = std::move(vi_opts.vector_index_file_paths);
-        }
-
         RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(
                 src, &file_info, params.tablet_schema, unmodified_column_ids,
                 _partial_update_states[segment_id].write_columns, segment_id, partial_rowset_footer,
-                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_file_paths),
-                defer_vector_index_build));
+                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts)));
         file_info.path = dest_path;
 
-        const int64_t dest_num_rows = _partial_update_states[segment_id].write_columns.empty()
-                                              ? 0
-                                              : _partial_update_states[segment_id].write_columns[0]->size();
-        file_info.vector_index_ids = collect_rewrite_segment_vector_index_ids(
-                params.tablet_schema, unmodified_column_ids, defer_vector_index_build, dest_num_rows);
+        // Sync indexes on the *updated* columns are not rebuilt by the rewrite (their data is
+        // raw-copied without a column writer); carry the src partial segment's .vi over to the
+        // dest segment name instead. Async mode never has a src .vi to carry.
+        if (!defer_vector_index_build) {
+            RETURN_IF_ERROR(carry_src_segment_vector_indexes(params, src_seg_meta, src_path, dest_path, &file_info));
+        }
         (*replace_segments)[segment_id] = file_info;
     } else {
         need_rename = false;
@@ -591,6 +575,16 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
             file_meta.set_shared(src_seg_meta.shared());
         }
         orphan_files->push_back(std::move(file_meta));
+        // A sync .vi built for the replaced src segment is keyed on the src segment name and
+        // unreachable after the replace (the dest segment has its own copy); orphan it too. In
+        // async mode the src ids only marked a scheduled build — no .vi file ever existed.
+        if (!defer_vector_index_build) {
+            for (int64_t index_id : src_seg_meta.vector_index_ids()) {
+                FileMetaPB vi_meta;
+                vi_meta.set_name(gen_vector_index_filename(src_seg_meta.filename(), index_id));
+                orphan_files->push_back(std::move(vi_meta));
+            }
+        }
     }
     TRACE("end rewrite segment");
     return Status::OK();

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -32,9 +32,11 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/update_manager.h"
+#include "storage/lake/vector_index_utils.h"
 #include "storage/olap_common.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/rowset/segment_rewriter.h"
+#include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
@@ -252,6 +254,51 @@ static std::vector<ColumnId> get_read_columns_ids(const TxnLogPB_OpWrite& op_wri
     }
 
     return unmodified_column_ids;
+}
+
+// Decide which vector index ids to persist on the rewritten (dest) partial-update segment. The
+// dest segment is a full segment, so a vector index whose column is materialized in it needs a
+// .vi. This mirrors HorizontalGeneralTabletWriter::record_segment_vector_index_ids but for the
+// rewrite path, which has no SegmentWriter to query:
+//   - async indexes are recorded once the segment clears the deferred-build threshold (the dest
+//     segment is a standalone rewrite file, never a bundle), so the FE-scheduled build task
+//     rebuilds the .vi from the dest segment;
+//   - sync indexes are recorded only when the .vi was actually built inline by
+//     rewrite_partial_update, i.e. the indexed column is among the rewritten (unmodified) columns.
+// |rewritten_column_ids| are schema column ordinals (see get_read_columns_ids).
+static std::vector<int64_t> collect_rewrite_segment_vector_index_ids(const TabletSchemaCSPtr& schema,
+                                                                     const std::vector<ColumnId>& rewritten_column_ids,
+                                                                     bool defer_build, int64_t num_rows) {
+    auto is_rewritten = [&](uint32_t ordinal) {
+        for (auto id : rewritten_column_ids) {
+            if (id == ordinal) return true;
+        }
+        return false;
+    };
+    const uint32_t threshold = defer_build ? get_vector_index_build_threshold(schema) : 0;
+    std::vector<int64_t> ids;
+    for (uint32_t i = 0, num_cols = schema->num_columns(); i < num_cols; i++) {
+        const auto& column = schema->column(i);
+        if (!schema->has_index(column.unique_id(), IndexType::VECTOR)) {
+            continue;
+        }
+        std::unordered_map<IndexType, TabletIndex> tablet_index;
+        if (!schema->get_indexes_for_column(column.unique_id(), &tablet_index).ok()) {
+            continue;
+        }
+        auto it = tablet_index.find(IndexType::VECTOR);
+        if (it == tablet_index.end()) {
+            continue;
+        }
+        if (defer_build) {
+            if (num_rows >= static_cast<int64_t>(threshold)) {
+                ids.push_back(it->second.index_id());
+            }
+        } else if (is_rewritten(i)) {
+            ids.push_back(it->second.index_id());
+        }
+    }
+    return ids;
 }
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
@@ -494,11 +541,37 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     } else if (has_partial_update_state(params)) {
         const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
         FileInfo file_info{.path = params.tablet->segment_location(dest_path)};
+
+        // The dest segment is a full rewrite that re-materializes the unmodified columns, which for
+        // a typical partial update include the vector column. Mirror the normal lake writer's
+        // vector-index handling so the dest segment's .vi lands at the reader-visible
+        // location-provider path and its ids are persisted: sync indexes are built inline here;
+        // async indexes are deferred to the FE-scheduled VectorIndexBuildTask. Without this the
+        // SegmentWriter would fall back to the IndexDescriptor path (unreachable in shared-data,
+        // since reads/builds key off the segment-name path) and the dest segment would carry no
+        // vector_index_ids, silently dropping the index after publish.
+        const bool defer_vector_index_build = has_async_vector_index(params.tablet_schema);
+        std::map<int64_t, std::string> vector_index_file_paths;
+        if (!defer_vector_index_build) {
+            SegmentWriterOptions vi_opts;
+            RETURN_IF_ERROR(fill_vector_index_file_paths(params.tablet_schema, params.tablet->id(), dest_path,
+                                                         params.tablet->tablet_mgr(), /*location_provider=*/nullptr,
+                                                         /*fs=*/nullptr, vi_opts));
+            vector_index_file_paths = std::move(vi_opts.vector_index_file_paths);
+        }
+
         RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(
                 src, &file_info, params.tablet_schema, unmodified_column_ids,
                 _partial_update_states[segment_id].write_columns, segment_id, partial_rowset_footer,
-                {root_path, std::to_string(rowset_meta.id())}));
+                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_file_paths),
+                defer_vector_index_build));
         file_info.path = dest_path;
+
+        const int64_t dest_num_rows = _partial_update_states[segment_id].write_columns.empty()
+                                              ? 0
+                                              : _partial_update_states[segment_id].write_columns[0]->size();
+        file_info.vector_index_ids = collect_rewrite_segment_vector_index_ids(
+                params.tablet_schema, unmodified_column_ids, defer_vector_index_build, dest_num_rows);
         (*replace_segments)[segment_id] = file_info;
     } else {
         need_rename = false;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -552,9 +552,17 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
 
         // Sync indexes on the *updated* columns are not rebuilt by the rewrite (their data is
         // raw-copied without a column writer); carry the src partial segment's .vi over to the
-        // dest segment name instead. Async mode never has a src .vi to carry.
+        // dest segment name instead. Async mode normally needs no carry — the rewrite records the
+        // scheduled ids itself — except on the copy-only fast path (no unmodified columns left,
+        // reachable when a schema change lands between the partial write and its publish): there
+        // the rewrite never sees a SegmentWriter, so carry the src's scheduled ids (async has no
+        // .vi file to copy) lest the metadata refresh wipe them.
         if (!defer_vector_index_build) {
             RETURN_IF_ERROR(carry_src_segment_vector_indexes(params, src_seg_meta, src_path, dest_path, &file_info));
+        } else if (unmodified_column_ids.empty()) {
+            for (int64_t index_id : src_seg_meta.vector_index_ids()) {
+                file_info.vector_index_ids.push_back(index_id);
+            }
         }
         (*replace_segments)[segment_id] = file_info;
     } else {

--- a/be/src/storage/lake/vector_index_utils.h
+++ b/be/src/storage/lake/vector_index_utils.h
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include "common/status.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks {
+struct SegmentWriterOptions;
+class FileSystem;
+
+namespace lake {
+class TabletManager;
+class LocationProvider;
+
+// async/sync is effectively a table-level setting: every vector index on a given schema shares the
+// same index_build_mode, so "any vector index is async" is equivalent to "the table builds vector
+// indexes asynchronously" for scheduling purposes.
+bool has_async_vector_index(const TabletSchemaCSPtr& schema);
+
+// Returns the configured deferred-build row-count threshold for the schema's vector index, or the
+// config default (config_vector_index_default_build_threshold) when unset or unparsable.
+uint32_t get_vector_index_build_threshold(const TabletSchemaCSPtr& schema);
+
+// For each column with a vector index, resolve the full segment-level path for the upcoming .vi
+// file (keyed on |segment_name| via the location provider, or the tablet manager fallback) and
+// stash it in |opts.vector_index_file_paths|. The SegmentWriter picks these up to direct tenann's
+// writer at object storage. Leaving the map empty would make SegmentWriter fall back to the
+// IndexDescriptor-based path, which in shared-data mode is not reachable via the location provider.
+Status fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t tablet_id, std::string_view segment_name,
+                                    TabletManager* tablet_mgr, LocationProvider* location_provider, FileSystem* fs,
+                                    SegmentWriterOptions& opts);
+
+} // namespace lake
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -28,7 +28,9 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
                                                const std::shared_ptr<const TabletSchema>& tschema,
                                                std::vector<uint32_t>& column_ids, MutableColumns& columns,
                                                uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
-                                               SegmentFileMark segment_file_mark) {
+                                               SegmentFileMark segment_file_mark,
+                                               std::map<int64_t, std::string> vector_index_file_paths,
+                                               bool defer_vector_index_build) {
     constexpr size_t kBufferSize = 1024 * 1024; // 1 MB
     if (UNLIKELY(column_ids.empty())) {
         // In shared-nothing mode, this size can be null, and we don't need it so it's ok to return zero;
@@ -70,6 +72,13 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
 
     SegmentWriterOptions opts;
     opts.segment_file_mark = std::move(segment_file_mark);
+    // Direct how vector indexes on the rewritten columns are produced. Shared-data sync mode
+    // passes location-provider-resolved .vi paths so the SegmentWriter writes them at the
+    // reader-visible path (instead of the empty-segment_file_mark IndexDescriptor fallback, which
+    // is unreachable via the location provider); async mode sets defer so .vi generation is left
+    // to the FE-scheduled VectorIndexBuildTask. Shared-nothing leaves both at their defaults.
+    opts.vector_index_file_paths = std::move(vector_index_file_paths);
+    opts.defer_vector_index_build = defer_vector_index_build;
     SegmentWriter writer(std::move(wfile), segment_id, tschema, opts);
     RETURN_IF_ERROR(writer.init(column_ids, false, &footer));
 

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -24,13 +24,30 @@ namespace starrocks {
 
 SegmentRewriter::SegmentRewriter() = default;
 
+// Mirror of HorizontalGeneralTabletWriter::record_segment_vector_index_ids for the rewrite path:
+// persist on the dest FileInfo the ids of vector indexes whose .vi the dest segment will have —
+// built inline by this writer (sync) or produced later by the FE-scheduled build task (async,
+// above the deferred-build threshold; a dest rewrite file is never a bundle). The ids come from
+// the caller-resolved path map, so shared-nothing callers (empty map) record nothing.
+static void record_rewrite_vector_index_ids(const SegmentWriter& writer, FileInfo* dest) {
+    if (writer.defer_vector_index_build()) {
+        if (writer.num_rows() < writer.vector_index_build_threshold()) {
+            return;
+        }
+    } else if (!writer.has_vector_index_written()) {
+        return;
+    }
+    for (const auto& [index_id, _] : writer.vector_index_file_paths()) {
+        dest->vector_index_ids.push_back(index_id);
+    }
+}
+
 Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                                const std::shared_ptr<const TabletSchema>& tschema,
                                                std::vector<uint32_t>& column_ids, MutableColumns& columns,
                                                uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
                                                SegmentFileMark segment_file_mark,
-                                               std::map<int64_t, std::string> vector_index_file_paths,
-                                               bool defer_vector_index_build) {
+                                               RewriteVectorIndexOptions vector_index_opts) {
     constexpr size_t kBufferSize = 1024 * 1024; // 1 MB
     if (UNLIKELY(column_ids.empty())) {
         // In shared-nothing mode, this size can be null, and we don't need it so it's ok to return zero;
@@ -76,9 +93,10 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
     // passes location-provider-resolved .vi paths so the SegmentWriter writes them at the
     // reader-visible path (instead of the empty-segment_file_mark IndexDescriptor fallback, which
     // is unreachable via the location provider); async mode sets defer so .vi generation is left
-    // to the FE-scheduled VectorIndexBuildTask. Shared-nothing leaves both at their defaults.
-    opts.vector_index_file_paths = std::move(vector_index_file_paths);
-    opts.defer_vector_index_build = defer_vector_index_build;
+    // to the FE-scheduled VectorIndexBuildTask. Shared-nothing leaves all at their defaults.
+    opts.vector_index_file_paths = std::move(vector_index_opts.file_paths);
+    opts.defer_vector_index_build = vector_index_opts.defer_build;
+    opts.vector_index_build_threshold = vector_index_opts.build_threshold;
     SegmentWriter writer(std::move(wfile), segment_id, tschema, opts);
     RETURN_IF_ERROR(writer.init(column_ids, false, &footer));
 
@@ -94,6 +112,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
     TEST_ERROR_POINT("SegmentRewriter::rewrite1");
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
+    record_rewrite_vector_index_ids(writer, dest);
     dest->size = segment_file_size;
     return Status::OK();
 }
@@ -198,7 +217,7 @@ Status SegmentRewriter::rewrite_auto_increment_lake(
         const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
         starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
         const std::vector<uint32_t>& unmodified_column_ids, MutableColumns* unmodified_column_data,
-        const starrocks::lake::Tablet* tablet) {
+        const starrocks::lake::Tablet* tablet, RewriteVectorIndexOptions vector_index_opts) {
     if (unmodified_column_ids.size() == 0) {
         DCHECK_EQ(unmodified_column_data, nullptr);
     }
@@ -277,8 +296,13 @@ Status SegmentRewriter::rewrite_auto_increment_lake(
         }
     }
 
-    // Write a complete segment file
+    // Write a complete segment file. All columns (including any vector-indexed one) go through
+    // column writers here, so unlike rewrite_partial_update the inline (sync) vector index build
+    // covers the whole schema; see RewriteVectorIndexOptions for the shared-data/-nothing split.
     SegmentWriterOptions opts;
+    opts.vector_index_file_paths = std::move(vector_index_opts.file_paths);
+    opts.defer_vector_index_build = vector_index_opts.defer_build;
+    opts.vector_index_build_threshold = vector_index_opts.build_threshold;
     SegmentWriter writer(std::move(wfile), segment_id, tschema, opts);
     RETURN_IF_ERROR(writer.init());
 
@@ -289,6 +313,7 @@ Status SegmentRewriter::rewrite_auto_increment_lake(
     TEST_ERROR_POINT("SegmentRewriter::rewrite3");
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
+    record_rewrite_vector_index_ids(writer, dest);
     dest->size = segment_file_size;
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -27,11 +29,19 @@ public:
     // read from src, write to dest
     // this function will read data from src_file and write to dest file first
     // then append write_column to dest file
+    //
+    // |vector_index_file_paths| / |defer_vector_index_build| direct how vector indexes on the
+    // rewritten columns are produced. Shared-data callers pass the location-provider-resolved .vi
+    // paths (sync mode, so the SegmentWriter builds .vi at the reader-visible path instead of the
+    // IndexDescriptor fallback) or set defer=true (async mode, so .vi is left to the FE-scheduled
+    // build task). Shared-nothing callers leave the defaults: an empty map and defer=false.
     static Status rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                          const std::shared_ptr<const TabletSchema>& tschema,
                                          std::vector<uint32_t>& column_ids, MutableColumns& columns,
                                          uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
-                                         SegmentFileMark segment_file_mark = {});
+                                         SegmentFileMark segment_file_mark = {},
+                                         std::map<int64_t, std::string> vector_index_file_paths = {},
+                                         bool defer_vector_index_build = false);
     static Status rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                          const TabletSchemaCSPtr& tschema,
                                          AutoIncrementPartialUpdateState& auto_increment_partial_update_state,

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -20,6 +20,19 @@ class TabletSchema;
 
 class Column;
 
+// Directs how the segment rewrite produces vector indexes for the dest segment. Shared-data
+// callers fill the location-provider-resolved .vi paths (keyed on the dest segment name) plus the
+// schema's index_build_mode/threshold; the rewrite then mirrors the normal lake writer: sync
+// indexes are built inline at the reader-visible path, async builds are deferred to the
+// FE-scheduled VectorIndexBuildTask, and the actually-produced/scheduled index ids are recorded
+// on the dest FileInfo. Shared-nothing callers leave the defaults (empty paths, sync, threshold
+// 0): the SegmentWriter then uses its IndexDescriptor fallback paths and no ids are recorded.
+struct RewriteVectorIndexOptions {
+    std::map<int64_t, std::string> file_paths;
+    bool defer_build = false;
+    uint32_t build_threshold = 0;
+};
+
 class SegmentRewriter {
 public:
     SegmentRewriter();
@@ -29,19 +42,12 @@ public:
     // read from src, write to dest
     // this function will read data from src_file and write to dest file first
     // then append write_column to dest file
-    //
-    // |vector_index_file_paths| / |defer_vector_index_build| direct how vector indexes on the
-    // rewritten columns are produced. Shared-data callers pass the location-provider-resolved .vi
-    // paths (sync mode, so the SegmentWriter builds .vi at the reader-visible path instead of the
-    // IndexDescriptor fallback) or set defer=true (async mode, so .vi is left to the FE-scheduled
-    // build task). Shared-nothing callers leave the defaults: an empty map and defer=false.
     static Status rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                          const std::shared_ptr<const TabletSchema>& tschema,
                                          std::vector<uint32_t>& column_ids, MutableColumns& columns,
                                          uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
                                          SegmentFileMark segment_file_mark = {},
-                                         std::map<int64_t, std::string> vector_index_file_paths = {},
-                                         bool defer_vector_index_build = false);
+                                         RewriteVectorIndexOptions vector_index_opts = {});
     static Status rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                          const TabletSchemaCSPtr& tschema,
                                          AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
@@ -51,7 +57,7 @@ public:
             const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
             starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
             const std::vector<uint32_t>& unmodified_column_ids, MutableColumns* unmodified_column_data,
-            const starrocks::lake::Tablet* tablet);
+            const starrocks::lake::Tablet* tablet, RewriteVectorIndexOptions vector_index_opts = {});
 };
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -468,6 +468,7 @@ SET(DW_TEST_FILES
     ./storage/lake/meta_file_test.cpp
     ./storage/lake/lake_proto_normalizer_test.cpp
     ./storage/lake/partial_update_test.cpp
+    ./storage/lake/partial_update_vector_index_test.cpp
     ./storage/lake/persistent_index_memtable_test.cpp
     ./storage/lake/persistent_index_sstable_test.cpp
     ./storage/lake/primary_key_compaction_task_test.cpp

--- a/be/test/storage/lake/partial_update_vector_index_test.cpp
+++ b/be/test/storage/lake/partial_update_vector_index_test.cpp
@@ -60,11 +60,13 @@ protected:
     constexpr static int32_t kKeyUid = 1;
     constexpr static int32_t kValueUid = 2;
     constexpr static int32_t kVecUid = 3;
+    constexpr static int32_t kExtraUid = 5;
 
     // PK schema: c0 INT key | c1 BIGINT (optionally auto-increment) | c2 ARRAY<FLOAT> with a
-    // vector index. index_build_mode: sync by default, async with the given threshold when
-    // |async_threshold| > 0.
-    void create_tablet(bool auto_increment, uint32_t async_threshold) {
+    // vector index | optionally c3 BIGINT (so a partial update can cover c0..c2 and a later
+    // schema drop of c3 leaves no unmodified columns). index_build_mode: sync by default, async
+    // with the given threshold when |async_threshold| > 0.
+    void create_tablet(bool auto_increment, uint32_t async_threshold, bool with_extra_column = false) {
         _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
@@ -105,6 +107,16 @@ protected:
         child->set_name("element");
         child->set_type("FLOAT");
         child->set_is_nullable(true);
+
+        if (with_extra_column) {
+            auto c3 = schema->add_column();
+            c3->set_unique_id(kExtraUid);
+            c3->set_name("c3");
+            c3->set_type("BIGINT");
+            c3->set_is_key(false);
+            c3->set_is_nullable(false);
+            c3->set_aggregation("REPLACE");
+        }
 
         auto* idx = schema->add_table_indices();
         idx->set_index_id(kIndexId);
@@ -164,8 +176,16 @@ protected:
         auto c1 = Int64Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
-        return Chunk({std::move(c0), std::move(c1), build_vector_column(kChunkSize, /*bias=*/0.1f)},
-                     Chunk::SlotHashMap{{0, 0}, {1, 1}, {2, 2}});
+        Columns columns{std::move(c0), std::move(c1), build_vector_column(kChunkSize, /*bias=*/0.1f)};
+        Chunk::SlotHashMap slot_map{{0, 0}, {1, 1}, {2, 2}};
+        if (_tablet_schema->num_columns() == 4) {
+            auto c3 = Int64Column::create();
+            std::vector<int64_t> v3(kChunkSize, 7);
+            c3->append_numbers(v3.data(), v3.size() * sizeof(int64_t));
+            columns.emplace_back(std::move(c3));
+            slot_map[3] = 3;
+        }
+        return Chunk(std::move(columns), slot_map);
     }
 
     int64_t write_full(int64_t version) {
@@ -189,9 +209,9 @@ protected:
         return version + 1;
     }
 
-    // Row-mode partial update through the given slots; triggers rewrite_segment at publish.
-    int64_t partial_update(int64_t version, std::vector<SlotDescriptor*>* slots, Chunk& chunk,
-                           bool miss_auto_increment) {
+    // Row-mode partial update write only (no publish); returns the txn id so a test can mutate
+    // state (e.g. drop a column from the tablet metadata) before publishing.
+    int64_t partial_update_txn(std::vector<SlotDescriptor*>* slots, Chunk& chunk, bool miss_auto_increment) {
         auto indexes = std::vector<uint32_t>(kChunkSize);
         std::iota(indexes.begin(), indexes.end(), 0);
         auto txn_id = next_id();
@@ -211,6 +231,13 @@ protected:
         CHECK_OK(delta_writer->write(chunk, indexes.data(), indexes.size()));
         CHECK_OK(delta_writer->finish_with_txnlog());
         delta_writer->close();
+        return txn_id;
+    }
+
+    // Row-mode partial update through the given slots; triggers rewrite_segment at publish.
+    int64_t partial_update(int64_t version, std::vector<SlotDescriptor*>* slots, Chunk& chunk,
+                           bool miss_auto_increment) {
+        auto txn_id = partial_update_txn(slots, chunk, miss_auto_increment);
         CHECK_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
         return version + 1;
     }
@@ -472,6 +499,55 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_builds_sync
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
     check_vector_data(version, /*bias=*/0.1f);
+}
+
+// Copy-only rewrite (async): when a schema change drops the only column the partial update left
+// unmodified between the write and its publish, rewrite_partial_update degenerates to a raw file
+// copy and records no ids itself. The src partial segment's scheduled async ids must be carried
+// onto the dest segment instead of being wiped by the metadata refresh — the FE build task and
+// vacuum key off them.
+TEST_F(LakePartialUpdateVectorIndexTest, test_async_copy_only_rewrite_keeps_scheduled_ids) {
+    create_tablet(/*auto_increment=*/false, /*async_threshold=*/1, /*with_extra_column=*/true);
+
+    auto version = write_full(1);
+
+    // Partial update covering c0..c2 (c3 stays unmodified), including the vector column, so the
+    // src partial segment records the async index id at write time (rows >= threshold).
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    TypeDescriptor array_type(LogicalType::TYPE_ARRAY);
+    array_type.children.emplace_back(LogicalType::TYPE_FLOAT);
+    slots.emplace_back(2, "c2", array_type);
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1], &slots[2]};
+    std::vector<int> v0(kChunkSize);
+    std::vector<int64_t> v1(kChunkSize, 200);
+    std::iota(v0.begin(), v0.end(), 0);
+    auto c0 = Int32Column::create();
+    auto c1 = Int64Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+    Chunk chunk({std::move(c0), std::move(c1), build_vector_column(kChunkSize, /*bias=*/0.5f)},
+                Chunk::SlotHashMap{{0, 0}, {1, 1}, {2, 2}});
+    auto txn_id = partial_update_txn(&slot_ptrs, chunk, /*miss_auto_increment=*/false);
+
+    // Fast schema evolution drops c3 before the publish: the publish-time schema now has no
+    // column outside the update set, so unmodified_column_ids is empty and the rewrite takes the
+    // copy-only fast path.
+    {
+        auto base = _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version).value();
+        auto mutated = std::make_shared<TabletMetadata>(*base);
+        auto* schema = mutated->mutable_schema();
+        ASSERT_EQ(schema->column(3).unique_id(), kExtraUid);
+        schema->mutable_column()->RemoveLast();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*mutated));
+    }
+    CHECK_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
+    version = version + 1;
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
+    ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/partial_update_vector_index_test.cpp
+++ b/be/test/storage/lake/partial_update_vector_index_test.cpp
@@ -1,0 +1,477 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
+#include "column/array_column.h"
+#include "column/chunk.h"
+#include "column/chunk_factory.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "common/config_vector_index_fwd.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/test_util.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+// Publish-level tests for vector index preservation across the shared-data partial-update
+// segment rewrite (RowsetUpdateState::rewrite_segment): the rewritten (dest) segment must end
+// up with the right SegmentMetadataPB::vector_index_ids, footer vector_index_storage_type and,
+// for sync indexes, a .vi artifact at the segment-name-keyed location-provider path. Covers
+// both rewrite branches (SegmentRewriter::rewrite_partial_update and rewrite_auto_increment_lake)
+// in sync and async index_build_mode, above and below the deferred-build threshold.
+class LakePartialUpdateVectorIndexTest : public TestBase {
+public:
+    LakePartialUpdateVectorIndexTest() : TestBase(kTestDirectory) {}
+
+    void SetUp() override { clear_and_init_test_dir(); }
+
+    void TearDown() override {
+        EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
+        remove_test_dir_or_die();
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_partial_update_vector_index";
+    constexpr static int kChunkSize = 12;
+    constexpr static int64_t kIndexId = 77;
+    constexpr static int32_t kKeyUid = 1;
+    constexpr static int32_t kValueUid = 2;
+    constexpr static int32_t kVecUid = 3;
+
+    // PK schema: c0 INT key | c1 BIGINT (optionally auto-increment) | c2 ARRAY<FLOAT> with a
+    // vector index. index_build_mode: sync by default, async with the given threshold when
+    // |async_threshold| > 0.
+    void create_tablet(bool auto_increment, uint32_t async_threshold) {
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_next_rowset_id(1);
+
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        c0->set_unique_id(kKeyUid);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+
+        auto c1 = schema->add_column();
+        c1->set_unique_id(kValueUid);
+        c1->set_name("c1");
+        c1->set_type("BIGINT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_is_auto_increment(auto_increment);
+        c1->set_aggregation("REPLACE");
+
+        // Vector index requires a non-nullable outer array column with a nullable element
+        // (DCHECK in ArrayColumnWriter::append / VectorIndexWriter).
+        auto c2 = schema->add_column();
+        c2->set_unique_id(kVecUid);
+        c2->set_name("c2");
+        c2->set_type("ARRAY");
+        c2->set_is_key(false);
+        c2->set_is_nullable(false);
+        c2->set_aggregation("REPLACE");
+        auto* child = c2->add_children_columns();
+        child->set_unique_id(4);
+        child->set_name("element");
+        child->set_type("FLOAT");
+        child->set_is_nullable(true);
+
+        auto* idx = schema->add_table_indices();
+        idx->set_index_id(kIndexId);
+        idx->set_index_name("vec_idx");
+        idx->set_index_type(IndexType::VECTOR);
+        idx->add_col_unique_id(kVecUid);
+        std::string mode_props;
+        if (async_threshold > 0) {
+            mode_props = R"(,
+                "index_build_mode": "async",
+                "index_build_threshold": ")" +
+                         std::to_string(async_threshold) + R"(")";
+        }
+        std::string props_json = R"({
+            "common_properties": {
+                "index_type": "hnsw",
+                "dim": "3",
+                "is_vector_normed": "false",
+                "metric_type": "l2_distance")" +
+                                 mode_props + R"(
+            },
+            "index_properties": {
+                "efconstruction": "40",
+                "m": "16"
+            }
+        })";
+        idx->set_index_properties(props_json);
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+        CHECK_OK(_tablet_mgr->create_schema_file(_tablet_metadata->id(), _tablet_metadata->schema()));
+    }
+
+    static ColumnPtr build_vector_column(int num_rows, float bias) {
+        auto element = FixedLengthColumn<float>::create();
+        auto nulls = NullColumn::create();
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        for (int i = 0; i < num_rows; ++i) {
+            for (int d = 0; d < 3; ++d) {
+                element->append(static_cast<float>(i) + bias + static_cast<float>(d) / 10.0f);
+                nulls->append(0);
+            }
+            offsets->append((i + 1) * 3);
+        }
+        auto nullable = NullableColumn::create(std::move(element), std::move(nulls));
+        return ArrayColumn::create(std::move(nullable), std::move(offsets));
+    }
+
+    Chunk full_chunk() {
+        std::vector<int> v0(kChunkSize);
+        std::vector<int64_t> v1(kChunkSize);
+        std::iota(v0.begin(), v0.end(), 0);
+        std::iota(v1.begin(), v1.end(), 1);
+        auto c0 = Int32Column::create();
+        auto c1 = Int64Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+        return Chunk({std::move(c0), std::move(c1), build_vector_column(kChunkSize, /*bias=*/0.1f)},
+                     Chunk::SlotHashMap{{0, 0}, {1, 1}, {2, 2}});
+    }
+
+    int64_t write_full(int64_t version) {
+        auto chunk = full_chunk();
+        auto indexes = std::vector<uint32_t>(kChunkSize);
+        std::iota(indexes.begin(), indexes.end(), 0);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(_tablet_metadata->id())
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(kPartitionId)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        CHECK_OK(delta_writer->open());
+        CHECK_OK(delta_writer->write(chunk, indexes.data(), indexes.size()));
+        CHECK_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        CHECK_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
+        return version + 1;
+    }
+
+    // Row-mode partial update through the given slots; triggers rewrite_segment at publish.
+    int64_t partial_update(int64_t version, std::vector<SlotDescriptor*>* slots, Chunk& chunk,
+                           bool miss_auto_increment) {
+        auto indexes = std::vector<uint32_t>(kChunkSize);
+        std::iota(indexes.begin(), indexes.end(), 0);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(_tablet_metadata->id())
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(kPartitionId)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(slots)
+                                                   .set_partial_update_mode(PartialUpdateMode::ROW_MODE)
+                                                   .set_miss_auto_increment_column(miss_auto_increment)
+                                                   .set_table_id(next_id())
+                                                   .build());
+        CHECK_OK(delta_writer->open());
+        CHECK_OK(delta_writer->write(chunk, indexes.data(), indexes.size()));
+        CHECK_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        CHECK_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
+        return version + 1;
+    }
+
+    SegmentMetadataPB rewritten_segment_meta(int64_t version) {
+        auto metadata = _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version).value();
+        CHECK_GT(metadata->rowsets_size(), 0);
+        const auto& rowset = metadata->rowsets(metadata->rowsets_size() - 1);
+        CHECK_GT(rowset.segment_metas_size(), 0);
+        return rowset.segment_metas(0);
+    }
+
+    std::string vi_location(const std::string& segment_name) {
+        return _tablet_mgr->segment_location(_tablet_metadata->id(), gen_vector_index_filename(segment_name, kIndexId));
+    }
+
+    SegmentFooterPB read_footer(const std::string& segment_name) {
+        auto path = _tablet_mgr->segment_location(_tablet_metadata->id(), segment_name);
+        ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+        SegmentFooterPB footer;
+        CHECK_OK(Segment::parse_segment_footer(rf.get(), &footer, nullptr, nullptr).status());
+        return footer;
+    }
+
+    // Read back the whole table and verify the vector column carries the expected per-row bias.
+    void check_vector_data(int64_t version, float bias) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        ASSERT_OK(reader->prepare());
+        ASSERT_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkFactory::new_chunk(*_schema, 128);
+        int64_t rows = 0;
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            ASSERT_OK(st);
+            for (int i = 0; i < chunk->num_rows(); ++i) {
+                int key = chunk->columns()[0]->get(i).get_int32();
+                auto arr = chunk->columns()[2]->get(i).get_array();
+                ASSERT_EQ(arr.size(), 3);
+                ASSERT_FLOAT_EQ(arr[0].get_float(), static_cast<float>(key) + bias);
+            }
+            rows += chunk->num_rows();
+            chunk->reset();
+        }
+        ASSERT_EQ(rows, kChunkSize);
+    }
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    constexpr static int64_t kPartitionId = 7561;
+};
+
+// Baseline for the main fix: a sync vector index must be rebuilt inline by the partial-update
+// rewrite — dest segment records the index id and the .vi lands at the segment-name-keyed path.
+TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_builds_vi_for_unmodified_vector_column) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+    create_tablet(/*auto_increment=*/false, /*async_threshold=*/0);
+
+    auto version = write_full(1);
+
+    // Partial update of (c0, c1): the vector column c2 is unmodified and re-materialized.
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1]};
+    std::vector<int> v0(kChunkSize);
+    std::vector<int64_t> v1(kChunkSize);
+    std::iota(v0.begin(), v0.end(), 0);
+    std::iota(v1.begin(), v1.end(), 100);
+    auto c0 = Int32Column::create();
+    auto c1 = Int64Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+    Chunk chunk({std::move(c0), std::move(c1)}, Chunk::SlotHashMap{{0, 0}, {1, 1}});
+    version = partial_update(version, &slot_ptrs, chunk, /*miss_auto_increment=*/false);
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
+    ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
+                                                               : Status::NotFound(vi_location(seg_meta.filename())));
+    ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
+    check_vector_data(version, /*bias=*/0.1f);
+}
+
+// Async index above the deferred-build threshold: the rewritten segment must record the index id
+// (the FE-scheduled build task keys off it) and mark the footer STANDALONE.
+TEST_F(LakePartialUpdateVectorIndexTest, test_async_rewrite_above_threshold_records_ids) {
+    create_tablet(/*auto_increment=*/false, /*async_threshold=*/1);
+
+    auto version = write_full(1);
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1]};
+    std::vector<int> v0(kChunkSize);
+    std::vector<int64_t> v1(kChunkSize);
+    std::iota(v0.begin(), v0.end(), 0);
+    std::iota(v1.begin(), v1.end(), 100);
+    auto c0 = Int32Column::create();
+    auto c1 = Int64Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+    Chunk chunk({std::move(c0), std::move(c1)}, Chunk::SlotHashMap{{0, 0}, {1, 1}});
+    version = partial_update(version, &slot_ptrs, chunk, /*miss_auto_increment=*/false);
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
+    ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
+}
+
+// Async index below the deferred-build threshold: no build task will run for the rewritten
+// segment, so it must record no ids AND mark the footer NONE — a STANDALONE footer would send
+// every query looking for a .vi that will never exist.
+TEST_F(LakePartialUpdateVectorIndexTest, test_async_rewrite_below_threshold_marks_footer_none) {
+    create_tablet(/*auto_increment=*/false, /*async_threshold=*/1000);
+
+    auto version = write_full(1);
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1]};
+    std::vector<int> v0(kChunkSize);
+    std::vector<int64_t> v1(kChunkSize);
+    std::iota(v0.begin(), v0.end(), 0);
+    std::iota(v1.begin(), v1.end(), 100);
+    auto c0 = Int32Column::create();
+    auto c1 = Int64Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+    Chunk chunk({std::move(c0), std::move(c1)}, Chunk::SlotHashMap{{0, 0}, {1, 1}});
+    version = partial_update(version, &slot_ptrs, chunk, /*miss_auto_increment=*/false);
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 0);
+    ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_NONE);
+}
+
+// The update set includes the vector column itself (sync mode): the raw-copied vector data in the
+// dest segment is identical to the src partial segment's, so its .vi must be carried over to the
+// dest segment name and the id recorded — otherwise the index is silently lost.
+TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_carries_vi_for_updated_vector_column) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+    create_tablet(/*auto_increment=*/false, /*async_threshold=*/0);
+
+    auto version = write_full(1);
+
+    // Partial update of (c0, c2): the vector column is load-provided; c1 is re-materialized.
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    TypeDescriptor array_type(LogicalType::TYPE_ARRAY);
+    array_type.children.emplace_back(LogicalType::TYPE_FLOAT);
+    slots.emplace_back(1, "c2", array_type);
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1]};
+    std::vector<int> v0(kChunkSize);
+    std::iota(v0.begin(), v0.end(), 0);
+    auto c0 = Int32Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    Chunk chunk({std::move(c0), build_vector_column(kChunkSize, /*bias=*/0.5f)}, Chunk::SlotHashMap{{0, 0}, {1, 1}});
+    version = partial_update(version, &slot_ptrs, chunk, /*miss_auto_increment=*/false);
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
+    ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
+                                                               : Status::NotFound(vi_location(seg_meta.filename())));
+    // The vector column is raw-copied (no column writer), so the footer flag may stay unset; what
+    // matters for reads is that it is not an explicit NONE, which would skip the carried .vi.
+    auto footer = read_footer(seg_meta.filename());
+    ASSERT_FALSE(footer.has_vector_index_storage_type() &&
+                 footer.vector_index_storage_type() == VECTOR_INDEX_STORAGE_NONE);
+    check_vector_data(version, /*bias=*/0.5f);
+}
+
+// Auto-increment rewrite branch (rewrite_auto_increment_lake), async mode: the dest segment is a
+// full rewrite re-materializing the vector column, so the id must survive publish — the publish
+// path previously cleared it, dropping the FE-scheduled build for the rewritten data.
+TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_keeps_async_vector_index) {
+    create_tablet(/*auto_increment=*/true, /*async_threshold=*/1);
+
+    auto version = write_full(1);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("StorageEngine::get_next_increment_id_interval.1", [](void* arg) {
+        auto& meta = *(std::shared_ptr<AutoIncrementMeta>*)(arg);
+        meta->min = 1;
+        meta->max = kChunkSize * 2;
+    });
+
+    // Partial update of (c0, c1) with c1 = 0 meaning "fill from the auto-increment allocator";
+    // the vector column c2 is unmodified and re-materialized by rewrite_auto_increment_lake.
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1]};
+    std::vector<int> v0(kChunkSize);
+    std::vector<int64_t> v1(kChunkSize, 0);
+    std::iota(v0.begin(), v0.end(), 0);
+    auto c0 = Int32Column::create();
+    auto c1 = Int64Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+    Chunk chunk({std::move(c0), std::move(c1)}, Chunk::SlotHashMap{{0, 0}, {1, 1}});
+    version = partial_update(version, &slot_ptrs, chunk, /*miss_auto_increment=*/true);
+
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
+    ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
+    check_vector_data(version, /*bias=*/0.1f);
+}
+
+// Auto-increment rewrite branch, sync mode: the .vi must be built inline at the dest
+// segment-name-keyed path and the id recorded, mirroring the rewrite_partial_update branch.
+TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_builds_sync_vector_index) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+    create_tablet(/*auto_increment=*/true, /*async_threshold=*/0);
+
+    auto version = write_full(1);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("StorageEngine::get_next_increment_id_interval.1", [](void* arg) {
+        auto& meta = *(std::shared_ptr<AutoIncrementMeta>*)(arg);
+        meta->min = 1;
+        meta->max = kChunkSize * 2;
+    });
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    std::vector<SlotDescriptor*> slot_ptrs{&slots[0], &slots[1]};
+    std::vector<int> v0(kChunkSize);
+    std::vector<int64_t> v1(kChunkSize, 0);
+    std::iota(v0.begin(), v0.end(), 0);
+    auto c0 = Int32Column::create();
+    auto c1 = Int64Column::create();
+    c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1->append_numbers(v1.data(), v1.size() * sizeof(int64_t));
+    Chunk chunk({std::move(c0), std::move(c1)}, Chunk::SlotHashMap{{0, 0}, {1, 1}});
+    version = partial_update(version, &slot_ptrs, chunk, /*miss_auto_increment=*/true);
+
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    auto seg_meta = rewritten_segment_meta(version);
+    ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
+    ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
+                                                               : Status::NotFound(vi_location(seg_meta.filename())));
+    ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
+    check_vector_data(version, /*bias=*/0.1f);
+}
+
+} // namespace starrocks::lake

--- a/test/sql/test_vector_index/R/test_shared_data_pk_partial_update_vector_index
+++ b/test/sql/test_vector_index/R/test_shared_data_pk_partial_update_vector_index
@@ -1,0 +1,108 @@
+-- name: test_sd_pk_partial_update_vector_index_sync @cloud
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
+-- result:
+-- !result
+create database db_sd_pk_pu_vidx_sync_${uuid0};
+-- result:
+-- !result
+use db_sd_pk_pu_vidx_sync_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t (
+    id BIGINT NOT NULL,
+    val INT NOT NULL,
+    v ARRAY<FLOAT> NOT NULL,
+    INDEX idx_v (v) USING VECTOR ("index_type" = "hnsw", "dim" = "4", "metric_type" = "l2_distance", "is_vector_normed" = "false", "M" = "16", "efconstruction" = "40")
+) PRIMARY KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1, 10, [1,0,0,0]), (2, 20, [0,1,0,0]), (3, 30, [0,0,1,0]), (4, 40, [0,0,0,1]);
+-- result:
+-- !result
+function: assert_explain_verbose_contains('select id from t order by approx_l2_distance([1,0,0,0], v) limit 1', 'VECTORINDEX: ON')
+-- result:
+None
+-- !result
+select id, val from t order by approx_l2_distance([1,0,0,0], v) limit 1;
+-- result:
+1	10
+-- !result
+set enable_insert_partial_update = true;
+-- result:
+-- !result
+set partial_update_mode = "row";
+-- result:
+-- !result
+insert into t (id, val) values (1, 111), (2, 222);
+-- result:
+-- !result
+select id, val from t order by id;
+-- result:
+1	111
+2	222
+3	30
+4	40
+-- !result
+function: assert_explain_verbose_contains('select id from t order by approx_l2_distance([1,0,0,0], v) limit 1', 'VECTORINDEX: ON')
+-- result:
+None
+-- !result
+select id, val from t order by approx_l2_distance([1,0,0,0], v) limit 1;
+-- result:
+1	111
+-- !result
+select id, val from t order by approx_l2_distance([0,1,0,0], v) limit 1;
+-- result:
+2	222
+-- !result
+drop database db_sd_pk_pu_vidx_sync_${uuid0} force;
+-- result:
+-- !result
+-- name: test_sd_pk_partial_update_vector_index_async @cloud
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
+-- result:
+-- !result
+create database db_sd_pk_pu_vidx_async_${uuid0};
+-- result:
+-- !result
+use db_sd_pk_pu_vidx_async_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t (
+    id BIGINT NOT NULL,
+    val INT NOT NULL,
+    v ARRAY<FLOAT> NOT NULL,
+    INDEX idx_v (v) USING VECTOR ("index_type" = "hnsw", "dim" = "4", "metric_type" = "l2_distance", "is_vector_normed" = "false", "M" = "16", "efconstruction" = "40", "index_build_mode" = "async")
+) PRIMARY KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into t values (1, 10, [1,0,0,0]), (2, 20, [0,1,0,0]), (3, 30, [0,0,1,0]), (4, 40, [0,0,0,1]);
+-- result:
+-- !result
+set enable_insert_partial_update = true;
+-- result:
+-- !result
+set partial_update_mode = "row";
+-- result:
+-- !result
+insert into t (id, val) values (1, 111), (2, 222);
+-- result:
+-- !result
+select id, val from t order by id;
+-- result:
+1	111
+2	222
+3	30
+4	40
+-- !result
+select id, val from t order by approx_l2_distance([1,0,0,0], v) limit 1;
+-- result:
+1	111
+-- !result
+select id, val from t order by approx_l2_distance([0,1,0,0], v) limit 1;
+-- result:
+2	222
+-- !result
+drop database db_sd_pk_pu_vidx_async_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_vector_index/T/test_shared_data_pk_partial_update_vector_index
+++ b/test/sql/test_vector_index/T/test_shared_data_pk_partial_update_vector_index
@@ -1,0 +1,49 @@
+-- name: test_sd_pk_partial_update_vector_index_sync @cloud
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
+create database db_sd_pk_pu_vidx_sync_${uuid0};
+use db_sd_pk_pu_vidx_sync_${uuid0};
+CREATE TABLE t (
+    id BIGINT NOT NULL,
+    val INT NOT NULL,
+    v ARRAY<FLOAT> NOT NULL,
+    INDEX idx_v (v) USING VECTOR ("index_type" = "hnsw", "dim" = "4", "metric_type" = "l2_distance", "is_vector_normed" = "false", "M" = "16", "efconstruction" = "40")
+) PRIMARY KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+insert into t values (1, 10, [1,0,0,0]), (2, 20, [0,1,0,0]), (3, 30, [0,0,1,0]), (4, 40, [0,0,0,1]);
+function: assert_explain_verbose_contains('select id from t order by approx_l2_distance([1,0,0,0], v) limit 1', 'VECTORINDEX: ON')
+select id, val from t order by approx_l2_distance([1,0,0,0], v) limit 1;
+-- Row-mode partial update omitting the vector column rewrites the segment and re-materializes v.
+-- Before the fix the rewritten (dest) segment's .vi went to the empty-segment_file_mark
+-- IndexDescriptor fallback path (unreachable in shared-data), so the publish would hang/error and
+-- the dest segment lost its vector index. The sync index must now be rebuilt inline at the
+-- location-provider path and the query must still use it with correct results.
+set enable_insert_partial_update = true;
+set partial_update_mode = "row";
+insert into t (id, val) values (1, 111), (2, 222);
+select id, val from t order by id;
+function: assert_explain_verbose_contains('select id from t order by approx_l2_distance([1,0,0,0], v) limit 1', 'VECTORINDEX: ON')
+select id, val from t order by approx_l2_distance([1,0,0,0], v) limit 1;
+select id, val from t order by approx_l2_distance([0,1,0,0], v) limit 1;
+drop database db_sd_pk_pu_vidx_sync_${uuid0} force;
+
+-- name: test_sd_pk_partial_update_vector_index_async @cloud
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
+create database db_sd_pk_pu_vidx_async_${uuid0};
+use db_sd_pk_pu_vidx_async_${uuid0};
+CREATE TABLE t (
+    id BIGINT NOT NULL,
+    val INT NOT NULL,
+    v ARRAY<FLOAT> NOT NULL,
+    INDEX idx_v (v) USING VECTOR ("index_type" = "hnsw", "dim" = "4", "metric_type" = "l2_distance", "is_vector_normed" = "false", "M" = "16", "efconstruction" = "40", "index_build_mode" = "async")
+) PRIMARY KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+insert into t values (1, 10, [1,0,0,0]), (2, 20, [0,1,0,0]), (3, 30, [0,0,1,0]), (4, 40, [0,0,0,1]);
+-- For an async index the rewrite must defer the build (not crash) and record vector_index_ids on
+-- the dest segment so the FE-scheduled VectorIndexBuildTask rebuilds the .vi. Results stay correct
+-- either way (brute-force fallback until the async .vi lands), so this case mainly asserts the
+-- partial-update publish completes and the rewritten rows are preserved.
+set enable_insert_partial_update = true;
+set partial_update_mode = "row";
+insert into t (id, val) values (1, 111), (2, 222);
+select id, val from t order by id;
+select id, val from t order by approx_l2_distance([1,0,0,0], v) limit 1;
+select id, val from t order by approx_l2_distance([0,1,0,0], v) limit 1;
+drop database db_sd_pk_pu_vidx_async_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

A row-mode partial update on a shared-data (lake) primary-key table that has a vector index rewrites the touched segment through `SegmentRewriter::rewrite_partial_update`, which constructed a bare `SegmentWriterOptions`. The rewritten (dest) segment therefore resolved its `.vi` to the empty-`segment_file_mark` `IndexDescriptor` fallback path — unreachable in shared-data, where reads, async builds and vacuum all key off the segment-name path via the location provider — and never recorded `vector_index_ids` in its segment metadata. The vector index for the rewritten data was silently lost: queries fell back to exact brute-force (correct results, but a full-table scan instead of an index lookup), async builds were never scheduled, and sync `.vi` files were never reclaimed by vacuum.

This is the vector-index twin of #73773, which fixed the same bare-options defect for GIN inverted indexes. GIN uses the `IndexDescriptor` path in both shared-nothing and shared-data, so that lake-side fix sufficed for it; shared-data vector indexes instead use the segment-name location-provider scheme, so they need this additional handling.

## What I'm doing:

Mirror the normal lake writer's vector-index handling in the partial-update rewrite path, preserving sync/async semantics: for a sync index the location-provider `.vi` paths are resolved so the `SegmentWriter` builds `.vi` inline at the reader-visible path; for an async index the build is deferred to the FE-scheduled `VectorIndexBuildTask`; and `vector_index_ids` is recorded on the dest segment in `MetaFileBuilder` so reads, async builds and vacuum stay consistent. The change touches `storage/lake/rowset_update_state.cpp`, `storage/rowset/segment_rewriter.{h,cpp}`, `storage/lake/meta_file.cpp`, `fs/fs.h`, and a new `storage/lake/vector_index_utils.h` that exposes the shared lake vector-index helpers.

Verified on a shared-data cluster (50k rows, HNSW). After a row-mode partial update of all rows, the ANN query's leaf `OLAP_SCAN` scans all 50k rows (brute-force) on an unpatched BE versus only the `limit` with this fix:

```
-- unpatched BE: OLAP_SCAN OutputRows: 50.000K (50000)   <- index lost
-- patched   BE: OLAP_SCAN OutputRows: 10                 <- index used
```

Related: #73773

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5