### PR TITLE
[BugFix] Keep auto-merge above pre-split parallelism floor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
@@ -71,7 +71,14 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
                     + " in table " + db.getFullName() + '.' + table.getName());
         }
 
-        Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = createReshardingPhysicalPartitions();
+        // Compute the parallelism floor before acquiring the table lock — it touches warehouse / node
+        // state and must not be coupled to the table READ lock held inside createReshardingPhysicalPartitions.
+        // Only the size-based auto-merge path is floor-gated; explicit tablet-group merges skip the lookup.
+        int parallelismFloor = (mergeTabletClause.getTabletGroupList() == null)
+                ? TabletReshardUtils.computeParallelismFloor(table.getId())
+                : 0;
+        Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions =
+                createReshardingPhysicalPartitions(parallelismFloor);
         if (reshardingPhysicalPartitions.isEmpty()) {
             throw new StarRocksException("No tablets need to merge in table "
                     + db.getFullName() + '.' + table.getName());
@@ -84,7 +91,8 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
     /*
      * Create physical partition contexts for all tablets that need to merge.
      */
-    private Map<Long, ReshardingPhysicalPartition> createReshardingPhysicalPartitions() throws StarRocksException {
+    private Map<Long, ReshardingPhysicalPartition> createReshardingPhysicalPartitions(
+            int parallelismFloor) throws StarRocksException {
         Preconditions.checkState(mergeTabletClause.getPartitionNames() == null ||
                 mergeTabletClause.getTabletGroupList() == null);
 
@@ -150,7 +158,7 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
                     Map<Long, ReshardingMaterializedIndex> reshardingIndexes = new HashMap<>();
                     for (MaterializedIndex oldIndex : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
                         List<List<Long>> mergeTabletGroupsForIndex =
-                                createMergeTabletGroups(physicalPartition, oldIndex, targetSize);
+                                createMergeTabletGroups(physicalPartition, oldIndex, targetSize, parallelismFloor);
                         if (mergeTabletGroupsForIndex.isEmpty()) {
                             continue;
                         }
@@ -253,7 +261,7 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
     }
 
     private List<List<Long>> createMergeTabletGroups(
-            PhysicalPartition physicalPartition, MaterializedIndex oldIndex, long targetSize) {
+            PhysicalPartition physicalPartition, MaterializedIndex oldIndex, long targetSize, int parallelismFloor) {
         // pairThresh: a single tablet at or above this is excluded from merging — aligned with
         //             TabletReshardUtils.needMerge() so a tablet that on its own already satisfies
         //             the new size band cannot be picked up as a merge candidate.
@@ -265,6 +273,15 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
         // MaterializedIndex tablets are already ordered by range.
         List<Tablet> orderedTablets = oldIndex.getTablets();
         List<List<Long>> mergeTabletGroups = new ArrayList<>();
+
+        // Never merge this index below the parallelism floor: keeping at least `parallelismFloor`
+        // tablets preserves the count pre-split established for scan/write parallelism, otherwise
+        // auto-merge would undo pre-split. Merging a group of k tablets removes k-1 tablets, so the
+        // total reduction across all groups must not exceed (current tablet count - floor).
+        int mergeBudget = orderedTablets.size() - parallelismFloor;
+        if (mergeBudget <= 0) {
+            return mergeTabletGroups;
+        }
 
         List<Long> currentTabletGroup = new ArrayList<>();
         long currentSize = 0;
@@ -286,12 +303,29 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
                 continue;
             }
 
+            // Step order below matters and must be preserved: (1) budget-exhaustion break, then
+            // (2) mergeCap flush, then (3) budget decrement + add. Adding a second-or-later member
+            // to the current group removes one more tablet, which consumes one unit of merge budget;
+            // a fresh first member (empty group, e.g. right after a cap flush) is free. Once the
+            // budget is exhausted, stop growing groups so the index settles exactly at the floor.
+            // Tablets not visited after this break — and any not placed in a >=2 group — are emitted
+            // as identical (unmerged) tablets by createReshardingTablets, so breaking here is safe.
+            if (!currentTabletGroup.isEmpty() && mergeBudget <= 0) {
+                flushMergeTabletGroup(mergeTabletGroups, currentTabletGroup);
+                currentTabletGroup = new ArrayList<>();
+                currentSize = 0;
+                break;
+            }
+
             if (currentSize + dataSize > mergeCap) {
                 flushMergeTabletGroup(mergeTabletGroups, currentTabletGroup);
                 currentTabletGroup = new ArrayList<>();
                 currentSize = 0;
             }
 
+            if (!currentTabletGroup.isEmpty()) {
+                mergeBudget--;
+            }
             currentTabletGroup.add(tablet.getId());
             currentSize += dataSize;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -16,6 +16,8 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.common.Config;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 
 public class TabletReshardUtils {
 
@@ -116,5 +118,43 @@ public class TabletReshardUtils {
         long n = (remainder >= halfTargetCeil) ? quotient + 1 : quotient;
         n = Math.max(2L, n);
         return (int) Math.min((long) Config.tablet_reshard_max_split_count, n);
+    }
+
+    /**
+     * Total number of compute nodes provisioned in the given warehouse resource (>= 1). Uses
+     * getAllComputeNodeIds (NOT the alive/blocklist-filtered set) so a transient node restart or
+     * blocklist entry does not change reshard layout decisions. Shared by pre-split (which sizes a
+     * new partition to at least this many tablets) and auto-merge (whose floor is derived from it),
+     * keeping the two consistent. Throws ErrorReportException (unchecked) if the warehouse resource
+     * no longer exists.
+     */
+    public static int computeNodeCount(ComputeResource computeResource) {
+        return Math.max(1, GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                .getAllComputeNodeIds(computeResource).size());
+    }
+
+    /**
+     * Minimum number of tablets an index must keep so steady-state auto-merge does not collapse the
+     * tablet count below the parallelism level pre-split established. Pure clamp logic, split out for
+     * testability. When maxSplitCount < 2 there is no multi-tablet pre-split layout to preserve
+     * (TabletPreSplitCoordinator#selectTabletCount requires maxSplitCount >= 2), so no floor applies.
+     */
+    @VisibleForTesting
+    static int parallelismFloor(int computeNodeCount, int maxSplitCount) {
+        if (maxSplitCount < 2) {
+            return 1;
+        }
+        return Math.max(2, Math.min(computeNodeCount, maxSplitCount));
+    }
+
+    /**
+     * Parallelism floor for a table's auto-merge. getBackgroundComputeResource(tableId) resolves the
+     * table's import warehouse in the enterprise build and the default warehouse in the open-source
+     * build. Returns a value in [1, tablet_reshard_max_split_count].
+     */
+    public static int computeParallelismFloor(long tableId) {
+        ComputeResource computeResource =
+                GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
+        return parallelismFloor(computeNodeCount(computeResource), Config.tablet_reshard_max_split_count);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
@@ -14,13 +14,13 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.load.BrokerFileGroup;
-import com.starrocks.planner.LoadScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.common.MetaUtils;
@@ -199,8 +199,7 @@ public final class BrokerLoadPreSplitHook {
             ConnectContext context, Database database, OlapTable targetTable, BrokerDesc brokerDesc,
             List<BrokerFileGroup> fileGroups, List<List<TBrokerFileStatus>> fileStatuses,
             ComputeResource computeResource, BooleanSupplier shouldAbort) {
-        int activeComputeNodeCount = Math.max(1,
-                LoadScanNode.getAvailableComputeNodes(computeResource).size());
+        int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(computeResource);
         long fileTotalBytes = sumFileBytes(fileStatuses);
         BrokerLoadScanContext scanContext = new BrokerLoadScanContext(
                 brokerDesc, fileGroups, fileStatuses, computeResource);
@@ -274,8 +273,7 @@ public final class BrokerLoadPreSplitHook {
             ComputeResource computeResource, BooleanSupplier shouldAbort) {
         BrokerLoadScanContext scanContext = new BrokerLoadScanContext(
                 brokerDesc, fileGroups, fileStatuses, computeResource);
-        int activeComputeNodeCount = Math.max(1,
-                LoadScanNode.getAvailableComputeNodes(computeResource).size());
+        int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(computeResource);
         long fileTotalBytes = sumFileBytes(fileStatuses);
 
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesPreSplitHook.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.Column;
@@ -24,7 +25,6 @@ import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.planner.LoadScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -217,8 +217,7 @@ public final class InsertFromFilesPreSplitHook {
     private static void runMultiPartitionFlow(
             Database database, OlapTable table, TableFunctionTable sourceTable, ConnectContext context) {
         ComputeResource computeResource = context.getCurrentComputeResource();
-        int activeComputeNodeCount = Math.max(1,
-                LoadScanNode.getAvailableComputeNodes(computeResource).size());
+        int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(computeResource);
         long fileTotalBytes = sumFileBytes(sourceTable);
 
         SampleSet samples = runDataTierSampler(table, sourceTable, computeResource);
@@ -509,8 +508,7 @@ public final class InsertFromFilesPreSplitHook {
             PreSplitTargets.EligibleTarget target, TableFunctionTable sourceTable, ConnectContext context) {
         ComputeResource computeResource = context.getCurrentComputeResource();
         InsertFromFilesScanContext scanContext = new InsertFromFilesScanContext(sourceTable, computeResource);
-        int activeComputeNodeCount = Math.max(1,
-                LoadScanNode.getAvailableComputeNodes(computeResource).size());
+        int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(computeResource);
         long fileTotalBytes = sumFileBytes(sourceTable);
 
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -205,9 +205,8 @@ public final class TabletPreSplitCoordinator {
      * {@link SkipReason#TIMEOUT_PRE_SUBMIT}, {@link SkipReason#SAMPLE_FAILED},
      * {@link SkipReason#NO_USEFUL_CUTS}, {@link SkipReason#SUBMIT_FAILED}.
      *
-     * @param activeComputeNodeCount compute nodes available to the load after
-     *                               warehouse/blocklist filtering (passed to the
-     *                               pipeline's internal tablet-count selector).
+     * @param activeComputeNodeCount total provisioned compute nodes in the load's warehouse
+     *                               (passed to the pipeline's internal tablet-count selector).
      */
     public static PreSplitOutcome submitAsynchronously(
             Database database, OlapTable table, long physicalPartitionId, ScanContext scanContext,
@@ -482,8 +481,8 @@ public final class TabletPreSplitCoordinator {
      *
      * @param estimates              full-input estimates from the sampler. Only
      *                               {@link Estimates#totalBytes} is read.
-     * @param activeComputeNodeCount compute nodes available to the load, after
-     *                               warehouse/blocklist filtering. Must be {@code >= 1}.
+     * @param activeComputeNodeCount total provisioned compute nodes in the load's warehouse.
+     *                               Must be {@code >= 1}.
      */
     static int selectTabletCount(Estimates estimates, int activeComputeNodeCount) {
         Objects.requireNonNull(estimates, "estimates");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -141,6 +141,7 @@ public class TabletStatMgr extends FrontendDaemon {
                 Map<Pair<Long, Long>, Long> indexRowCountMap = Maps.newHashMap();
                 // NOTE: calculate the row first with read lock, then update the stats with write lock
                 OlapTable olapTable = (OlapTable) table;
+                int parallelismFloor = resolveMergeParallelismFloor(db, olapTable);
                 locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
                 try {
                     for (Partition partition : olapTable.getAllPartitions()) {
@@ -150,9 +151,17 @@ public class TabletStatMgr extends FrontendDaemon {
                             for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(
                                     IndexExtState.VISIBLE)) {
                                 long indexRowCount = 0L;
+                                List<Tablet> tablets = index.getTablets();
+                                // Only an index above the parallelism floor contributes the merge signal
+                                // (minAdjacentTabletPairSize); otherwise auto-merge could shrink it below the
+                                // tablet count pre-split established for parallelism (and would churn empty
+                                // merge jobs every cycle). Split detection (maxTabletSize) is never gated.
+                                // MergeTabletJobFactory's per-index merge budget re-enforces the same floor
+                                // inside an admitted job, so the floor holds even for manual size-based merges.
+                                boolean eligibleForMerge = tablets.size() > parallelismFloor;
                                 long prevFreshTabletSize = -1L;
                                 // NOTE: can take a rather long time to iterate lots of tablets
-                                for (Tablet tablet : index.getTablets()) {
+                                for (Tablet tablet : tablets) {
                                     indexRowCount += tablet.getRowCount(version);
                                     long dataSize = tablet.getDataSize(true);
                                     maxTabletSize = Math.max(maxTabletSize, dataSize);
@@ -161,7 +170,7 @@ public class TabletStatMgr extends FrontendDaemon {
                                         prevFreshTabletSize = -1L;
                                         continue;
                                     }
-                                    if (prevFreshTabletSize >= 0) {
+                                    if (prevFreshTabletSize >= 0 && eligibleForMerge) {
                                         minAdjacentTabletPairSize = Math.min(minAdjacentTabletPairSize,
                                                 prevFreshTabletSize + dataSize);
                                     }
@@ -210,6 +219,26 @@ public class TabletStatMgr extends FrontendDaemon {
         LOG.info("finished to update index row num of all databases. cost: {} ms",
                 (System.currentTimeMillis() - start));
         lastWorkTimestamp = LocalDateTime.now();
+    }
+
+    /**
+     * Minimum tablet count auto-merge must keep per index for {@code table}. Returns 0 ("not
+     * floor-gated") for tables that never auto-merge (non-cloud-native or non-range-distribution),
+     * and also on lookup failure so a single table's warehouse error cannot abort the daemon cycle.
+     * Called before the table lock since it resolves warehouse/compute-node state.
+     */
+    private static int resolveMergeParallelismFloor(Database db, OlapTable table) {
+        if (!table.isCloudNativeTableOrMaterializedView() || !table.isRangeDistribution()) {
+            return 0;
+        }
+        try {
+            return TabletReshardUtils.computeParallelismFloor(table.getId());
+        } catch (RuntimeException e) {
+            LOG.warn("Parallelism floor unavailable for table {}.{}; "
+                            + "auto-merge will not be floor-gated for this table.",
+                    db.getFullName(), table.getName(), e);
+            return 0;
+        }
     }
 
     private static void triggerTabletReshard(Database db, OlapTable table,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -766,7 +767,9 @@ public class MergeTabletJobTest {
         long[] sizes = {40L, 90L, 30L, 30L};
         for (int i = 0; i < orderedTablets.size(); i++) {
             LakeTablet tablet = (LakeTablet) orderedTablets.get(i);
-            tablet.setDataSize(sizes[i]);
+            // Tablets beyond the first 4 get a large size so they are excluded from merging
+            // (>= pairThresh = 80) and do not affect the expected merge groups.
+            tablet.setDataSize(i < sizes.length ? sizes[i] : 200L);
             tablet.setDataSizeUpdateTime(visibleVersionTime);
         }
 
@@ -800,6 +803,103 @@ public class MergeTabletJobTest {
         clause.setTabletReshardTargetSize(-1L);
         MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
         Assertions.assertThrows(StarRocksException.class, factory::createTabletReshardJob);
+    }
+
+    @Test
+    public void testMergeTabletJobFactoryStopsAtParallelismFloor() throws Exception {
+        ensureTabletCount(5);
+        // floor = parallelismFloor(4, 1024) = max(2, min(4, 1024)) = 4; 5 tiny fresh tablets
+        // => budget = 5 - 4 = 1 => exactly one adjacent pair may merge, the rest must stay split.
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<Long> getAllComputeNodeIds(ComputeResource computeResource) {
+                // computeNodeCount only reads .size(), so the id values are irrelevant — only count 4 matters.
+                return Collections.nCopies(4, 1L);
+            }
+        };
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+        List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
+        for (Tablet orderedTablet : orderedTablets) {
+            LakeTablet tablet = (LakeTablet) orderedTablet;
+            tablet.setDataSize(10L);
+            tablet.setDataSizeUpdateTime(visibleVersionTime);
+        }
+
+        MergeTabletClause clause = new MergeTabletClause();
+        clause.setTabletReshardTargetSize(100L);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        MergeTabletJob mergeJob = (MergeTabletJob) factory.createTabletReshardJob();
+
+        ReshardingMaterializedIndex reshardingIndex = mergeJob.getReshardingPhysicalPartitions()
+                .get(physicalPartition.getId()).getReshardingIndexes().get(oldIndex.getId());
+        Assertions.assertNotNull(reshardingIndex);
+
+        List<List<Long>> mergedTabletGroups = new ArrayList<>();
+        for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+            if (reshardingTablet.getMergingTablet() != null) {
+                mergedTabletGroups.add(reshardingTablet.getMergingTablet().getOldTabletIds());
+            }
+        }
+        Assertions.assertEquals(
+                List.of(List.of(orderedTablets.get(0).getId(), orderedTablets.get(1).getId())),
+                mergedTabletGroups);
+    }
+
+    @Test
+    public void testMergeTabletJobFactoryNoMergeBelowParallelismFloor() throws Exception {
+        ensureTabletCount(3);
+        // floor = parallelismFloor(5, 1024) = max(2, min(5, 1024)) = 5 > 3 tablets
+        // => budget = 3 - 5 <= 0 => nothing merges.
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<Long> getAllComputeNodeIds(ComputeResource computeResource) {
+                // computeNodeCount only reads .size(), so the id values are irrelevant — only count 5 matters.
+                return Collections.nCopies(5, 1L);
+            }
+        };
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
+        for (Tablet orderedTablet : oldIndex.getTablets()) {
+            LakeTablet tablet = (LakeTablet) orderedTablet;
+            tablet.setDataSize(10L);
+            tablet.setDataSizeUpdateTime(visibleVersionTime);
+        }
+
+        MergeTabletClause clause = new MergeTabletClause();
+        clause.setTabletReshardTargetSize(100L);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        Assertions.assertThrows(StarRocksException.class, factory::createTabletReshardJob);
+    }
+
+    @Test
+    public void testManualTabletGroupMergeSkipsParallelismFloorLookup() throws Exception {
+        ensureTabletCount(3);
+        // Explicit tablet-group merges must NOT consult the warehouse CN count; even if the lookup
+        // throws, the manual merge still succeeds (the floor only applies to size-based auto-merge).
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<Long> getAllComputeNodeIds(ComputeResource computeResource) {
+                throw new RuntimeException("CN lookup must not be called for manual tablet-group merge");
+            }
+        };
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+        List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        long firstTabletId = orderedTablets.get(0).getId();
+        long secondTabletId = orderedTablets.get(1).getId();
+
+        TabletGroupList tabletGroupList = new TabletGroupList(List.of(List.of(firstTabletId, secondTabletId)));
+        MergeTabletClause clause = new MergeTabletClause(null, tabletGroupList, null);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        MergeTabletJob mergeJob = (MergeTabletJob) factory.createTabletReshardJob();
+
+        Assertions.assertNotNull(mergeJob.getReshardingPhysicalPartitions().get(physicalPartition.getId()));
     }
 
     private TabletReshardJob createSplitTabletReshardJob() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -190,6 +190,22 @@ public class TabletReshardUtilsTest {
         assertEquals(Config.tablet_reshard_max_split_count, TabletReshardUtils.calcSplitCount(data, t));
     }
 
+    @Test
+    public void parallelismFloor_clampsAndBounds() {
+        // typical: floor follows compute node count
+        assertEquals(4, TabletReshardUtils.parallelismFloor(4, 1024));
+        // upper clamp at max split count
+        assertEquals(1024, TabletReshardUtils.parallelismFloor(2000, 1024));
+        // lower bound at 2 (matches pre-split's clamp(...,2,...))
+        assertEquals(2, TabletReshardUtils.parallelismFloor(1, 1024));
+        assertEquals(2, TabletReshardUtils.parallelismFloor(2, 1024));
+        // zero-node edge: computeNodeCount guarantees >= 1 in practice, but floor still holds
+        assertEquals(2, TabletReshardUtils.parallelismFloor(0, 1024));
+        // max split count < 2 => pre-split disabled => no floor (degrades to 1)
+        assertEquals(1, TabletReshardUtils.parallelismFloor(5, 1));
+        assertEquals(1, TabletReshardUtils.parallelismFloor(5, 0));
+    }
+
     /**
      * Static check of the convergence invariants. These two inequalities are what prevent
      * split↔merge oscillation. If they ever fail, the algorithm can ping-pong indefinitely.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -149,13 +150,13 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
         SampleSet sampledRows = new SampleSet(List.of(), List.of(), Estimates.ZERO);
 
-        try (MockedStatic<TabletPreSplitCoordinator> coordinator =
-                     Mockito.mockStatic(TabletPreSplitCoordinator.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(sampledRows))) {
-
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
             // Non-empty grouped list -> submitForPartitionsCombined is invoked.
             grouper.when(() -> PartitionSampleGrouper.group(
@@ -200,8 +201,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             SampleSet sampledRows = new SampleSet(List.of(), List.of(), Estimates.ZERO);
             AtomicReference<SampleRequest> capturedRequest = new AtomicReference<>();
 
-            try (MockedStatic<TabletPreSplitCoordinator> coordinator =
-                         Mockito.mockStatic(TabletPreSplitCoordinator.class);
+            try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                    MockedStatic<TabletPreSplitCoordinator> coordinator =
+                            Mockito.mockStatic(TabletPreSplitCoordinator.class);
                     MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                     MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                     MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
@@ -209,7 +211,6 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                                 capturedRequest.set(invocation.getArgument(0));
                                 return sampledRows;
                             }))) {
-
                 metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
                 grouper.when(() -> PartitionSampleGrouper.group(
                                 any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
@@ -245,8 +246,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
         List<Column> sortKey = List.of(bigintColumn("sort_col"));
         when(table.getPartitionInfo().getPartitionColumns(any())).thenReturn(List.of(bigintColumn("p_col")));
 
-        try (MockedStatic<TabletPreSplitCoordinator> coordinator =
-                     Mockito.mockStatic(TabletPreSplitCoordinator.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
@@ -278,8 +280,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
         List<Column> sortKey = List.of(bigintColumn("sort_col"));
         when(table.getPartitionInfo().getPartitionColumns(any())).thenReturn(List.of(bigintColumn("p_col")));
 
-        try (MockedStatic<TabletPreSplitCoordinator> coordinator =
-                     Mockito.mockStatic(TabletPreSplitCoordinator.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
@@ -311,8 +314,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
         SampleSet sampledRows = new SampleSet(List.of(), List.of(), Estimates.ZERO);
 
-        try (MockedStatic<TabletPreSplitCoordinator> coordinator =
-                     Mockito.mockStatic(TabletPreSplitCoordinator.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesPreSplitHookPartitionedTest.java
@@ -18,6 +18,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -28,7 +29,6 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.Metric.MetricUnit;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.planner.LoadScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
@@ -473,15 +473,13 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
         SampleSet samples = new SampleSet(List.of(), List.of(), Estimates.ZERO);
         TabletReshardJob combinedJob = mock(TabletReshardJob.class);
 
-        try (MockedStatic<LoadScanNode> loadScanNode = Mockito.mockStatic(LoadScanNode.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedStatic<TabletPreSplitCoordinator> coordinator =
                         Mockito.mockStatic(TabletPreSplitCoordinator.class);
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
-            loadScanNode.when(() -> LoadScanNode.getAvailableComputeNodes(any())).thenReturn(List.of());
-
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
                     .thenReturn(List.of(bigintColumn("sort_col")));
             grouper.when(() -> PartitionSampleGrouper.group(
@@ -525,7 +523,7 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
             SampleSet samples = new SampleSet(List.of(), List.of(), Estimates.ZERO);
             AtomicReference<SampleRequest> capturedRequest = new AtomicReference<>();
 
-            try (MockedStatic<LoadScanNode> loadScanNode = Mockito.mockStatic(LoadScanNode.class);
+            try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
                     MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                     MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                     MockedStatic<TabletPreSplitCoordinator> coordinator =
@@ -535,7 +533,6 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
                                 capturedRequest.set(invocation.getArgument(0));
                                 return samples;
                             }))) {
-                loadScanNode.when(() -> LoadScanNode.getAvailableComputeNodes(any())).thenReturn(List.of());
                 metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
                         .thenReturn(List.of(bigintColumn("sort_col")));
                 // Empty grouped list -> short-circuits after the sample; we only need
@@ -572,7 +569,7 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
         TabletReshardJobMgr reshardMgr = mock(TabletReshardJobMgr.class);
 
         try (MockedStatic<GlobalStateMgr> gsm = Mockito.mockStatic(GlobalStateMgr.class);
-                MockedStatic<LoadScanNode> loadScanNode = Mockito.mockStatic(LoadScanNode.class);
+                MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedStatic<TabletPreSplitCoordinator> coordinator =
@@ -582,7 +579,6 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
             GlobalStateMgr globalState = mock(GlobalStateMgr.class);
             when(globalState.getTabletReshardJobMgr()).thenReturn(reshardMgr);
             gsm.when(GlobalStateMgr::getCurrentState).thenReturn(globalState);
-            loadScanNode.when(() -> LoadScanNode.getAvailableComputeNodes(any())).thenReturn(List.of());
 
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
                     .thenReturn(List.of(bigintColumn("sort_col")));
@@ -614,7 +610,7 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
         ConnectContext context = mockConnectContextWithSessionPreSplit(true);
         when(context.getCurrentComputeResource()).thenReturn(mock(ComputeResource.class));
 
-        try (MockedStatic<LoadScanNode> loadScanNode = Mockito.mockStatic(LoadScanNode.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedStatic<TabletPreSplitCoordinator> coordinator =
@@ -622,7 +618,6 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class)))
                                 .thenThrow(new StarRocksException("synthetic sample failure")))) {
-            loadScanNode.when(() -> LoadScanNode.getAvailableComputeNodes(any())).thenReturn(List.of());
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
                     .thenReturn(List.of(bigintColumn("sort_col")));
 
@@ -648,14 +643,13 @@ public class InsertFromFilesPreSplitHookPartitionedTest {
 
         SampleSet samples = new SampleSet(List.of(), List.of(), Estimates.ZERO);
 
-        try (MockedStatic<LoadScanNode> loadScanNode = Mockito.mockStatic(LoadScanNode.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
                 MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
                 MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedStatic<TabletPreSplitCoordinator> coordinator =
                         Mockito.mockStatic(TabletPreSplitCoordinator.class);
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
-            loadScanNode.when(() -> LoadScanNode.getAvailableComputeNodes(any())).thenReturn(List.of());
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
                     .thenReturn(List.of(bigintColumn("sort_col")));
             grouper.when(() -> PartitionSampleGrouper.group(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
@@ -109,6 +110,18 @@ final class PresplitTestSupport {
         Mockito.when(sessionVariable.isEnableTabletPreSplit()).thenReturn(enablePreSplit);
         Mockito.when(context.getSessionVariable()).thenReturn(sessionVariable);
         return context;
+    }
+
+    /**
+     * Stub {@link TabletReshardUtils#computeNodeCount} to return a fixed count while delegating every
+     * other static method to its real implementation. The returned MockedStatic MUST be closed by the
+     * caller — declare it in a try-with-resources.
+     */
+    static MockedStatic<TabletReshardUtils> stubComputeNodeCount(int count) {
+        MockedStatic<TabletReshardUtils> reshardUtils =
+                Mockito.mockStatic(TabletReshardUtils.class, Mockito.CALLS_REAL_METHODS);
+        reshardUtils.when(() -> TabletReshardUtils.computeNodeCount(any())).thenReturn(count);
+        return reshardUtils;
     }
 
     static TBrokerFileStatus brokerFileStatus(String path, long size) {


### PR DESCRIPTION
## Why I'm doing:

Range-distribution tables in shared-data mode support sample-based tablet pre-split, which sizes a new partition to `max(computeNodeCount, ceil(totalBytes / tablet_reshard_target_size))` tablets so data spreads across compute nodes for scan/write parallelism. The steady-state auto-merge daemon (`TabletStatMgr` → `TabletReshardUtils.needMerge` → `MergeTabletJobFactory`) only looked at tablet size and would merge those small pre-split tablets back together whenever a partition's data was small (roughly `totalBytes < 0.4 * tablet_reshard_target_size * computeNodeCount`), undoing pre-split and causing split/merge churn.

## What I'm doing:

- Introduce a per-index "parallelism floor" so auto-merge never reduces an index below the tablet count pre-split established for parallelism:
  - `MergeTabletJobFactory` computes the floor before taking the table lock (only for size-based auto-merge; manual `ALTER ... MERGE <tablet groups>` is not floor-gated) and enforces a per-index merge budget of `currentTabletCount - floor`, so a merge can never drop an index below the floor.
  - `TabletStatMgr` only feeds the table-wide merge signal from indexes whose tablet count is above the floor, so at-floor tables no longer trigger empty merge jobs every stat cycle. The per-table floor computation is guarded so it cannot abort the daemon cycle.
- Unify pre-split and the merge floor on one stable compute-node-count metric: `WarehouseManager.getAllComputeNodeIds` (total provisioned nodes) instead of the alive/blocklist-filtered `getAvailableComputeNodes`. This keeps the layout decision stable, so a transient node restart/blocklist cannot lower the floor and irreversibly shrink a partition's parallelism. The floor is `clamp(computeNodeCount, 2, tablet_reshard_max_split_count)`.

Auto-split is unchanged (it only ever increases tablet count). No new config or metric is added.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5