### PR TITLE
[BugFix] Fix lock mismatch in blockingAddTabletCtxToScheduler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -57,7 +57,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.common.util.concurrent.lock.YieldableLock;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -737,17 +737,15 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                  ColocateTableIndex colocateIndex,
                                  TabletScheduler tabletScheduler) {
         long checkStartTime = System.currentTimeMillis();
-        long lockTotalTime = 0;
-        long waitTotalTimeMs = 0;
         List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
         Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(groupId.dbId);
         if (db == null) {
-            return new ColocateMatchResult(lockTotalTime, Status.UNKNOWN);
+            return new ColocateMatchResult(0, Status.UNKNOWN);
         }
 
         List<Set<Long>> backendBucketsSeq = colocateIndex.getBackendsPerBucketSeqSet(groupId);
         if (backendBucketsSeq.isEmpty()) {
-            return new ColocateMatchResult(lockTotalTime, Status.UNKNOWN);
+            return new ColocateMatchResult(0, Status.UNKNOWN);
         }
 
         boolean isGroupStable = true;
@@ -756,9 +754,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
         boolean disableColocateBalance = Config.tablet_sched_disable_colocate_balance;
         SystemInfoService infoService = globalStateMgr.getNodeMgr().getClusterInfo();
         int partitionChecked = 0;
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
-        long lockStart = System.nanoTime();
+        YieldableLock lock = YieldableLock.lockDatabase(db.getId(), LockType.READ);
         try {
             TABLE:
             for (Long tableId : tableIds) {
@@ -782,13 +778,10 @@ public class ColocateTableBalancer extends LeaderDaemon {
                     }
 
                     if (partitionChecked % partitionBatchNum == 0) {
-                        lockTotalTime += System.nanoTime() - lockStart;
                         // release lock, so that lock can be acquired by other threads.
-                        locker.unLockDatabase(db.getId(), LockType.READ);
-                        locker.lockDatabase(db.getId(), LockType.READ);
-                        lockStart = System.nanoTime();
+                        lock.refresh();
                         if (globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(groupId.dbId) == null) {
-                            return new ColocateMatchResult(lockTotalTime, Status.UNKNOWN);
+                            return new ColocateMatchResult(lock.getHeldTimeNs(), Status.UNKNOWN);
                         }
                         if (globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, olapTable.getId()) == null) {
                             continue TABLE;
@@ -875,15 +868,15 @@ public class ColocateTableBalancer extends LeaderDaemon {
 
                                         // For bad replica, we ignore the size limit of scheduler queue
                                         Pair<Boolean, Long> result =
-                                                tabletScheduler.blockingAddTabletCtxToScheduler(db, tabletCtx,
+                                                tabletScheduler.blockingAddTabletCtxToScheduler(tabletCtx,
                                                         needToForceRepair(st, tablet,
-                                                                bucketSeq) || isPartitionUrgent /* forcefully add or not */);
+                                                                bucketSeq) || isPartitionUrgent /* forcefully add or not */,
+                                                        lock);
                                         if (LOG.isDebugEnabled() && result.first &&
                                                 st == TabletHealthStatus.COLOCATE_MISMATCH) {
                                             logDebugInfoForColocateMismatch(bucketSeq, tablet);
                                         }
 
-                                        waitTotalTimeMs += result.second;
                                         if (result.first && tabletCtx.isRelocationForRepair()) {
                                             LOG.info("add tablet relocation task to scheduler, tablet id: {}, " +
                                                             "bucket sequence before: {}, bucket sequence now: {}",
@@ -919,11 +912,12 @@ public class ColocateTableBalancer extends LeaderDaemon {
             } // end for tables
 
         } finally {
-            lockTotalTime += System.nanoTime() - lockStart;
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            lock.close();
         }
 
-        return new ColocateMatchResult(lockTotalTime - waitTotalTimeMs * 1000000,
+        // The scope tracks actually-held time, so the blocking-add wait windows are
+        // already excluded.
+        return new ColocateMatchResult(lock.getHeldTimeNs(),
                 isGroupStable ? Status.STABLE : Status.UNSTABLE);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -61,6 +61,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.common.util.concurrent.lock.YieldableLock;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -338,13 +339,9 @@ public class TabletChecker extends LeaderDaemon {
         LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
         List<Long> aliveBeIdsInCluster;
 
-        Locker locker = new Locker();
-        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-        boolean locked = true;
-        long lockStartTime = 0L;
+        YieldableLock lock = YieldableLock.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        lockStat.lockAcquireCount++;
         try {
-            lockStat.lockAcquireCount++;
-            lockStartTime = System.currentTimeMillis();
             aliveBeIdsInCluster = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
 
             if (metastore.getTableIncludeRecycleBin(db, table.getId()) == null) {
@@ -398,7 +395,7 @@ public class TabletChecker extends LeaderDaemon {
 
                 TabletCheckerStat partitionTabletCheckerStat =
                         doCheckOnePartition(db, olapTbl, physicalPartition, replicaNum, aliveBeIdsInCluster,
-                                isPartitionUrgent);
+                                isPartitionUrgent, lock);
                 totStat.accumulateStat(partitionTabletCheckerStat);
 
                 if (totStat.isUrgentPartitionHealthy && isPartitionUrgent) {
@@ -409,19 +406,13 @@ public class TabletChecker extends LeaderDaemon {
                     removeFromUrgentTable(new RepairTabletInfo(db.getId(),
                             olapTbl.getId(), Lists.newArrayList(physicalPartition.getId())));
                 }
-                long lockElapsedTime = System.currentTimeMillis() - lockStartTime;
-                if (lockElapsedTime >= maxLockHoldTimeMs) {
-                    locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-                    locked = false;
+                if (lock.getCurrentHoldTimeMs() >= maxLockHoldTimeMs) {
+                    LOG.debug("lock time for one cycle reached the limit {}, release lock.", maxLockHoldTimeMs);
                     lockStat.proactiveReleaseCount++;
 
-                    LOG.debug("lock time for one cycle reached the limit {}, release lock.", maxLockHoldTimeMs);
-                    lockStat.lockHoldTotalTime += lockElapsedTime;
-
-                    locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-                    locked = true;
+                    // Step aside so that queued metadata operations can cut in.
+                    lock.refresh();
                     lockStat.lockAcquireCount++;
-                    lockStartTime = System.currentTimeMillis();
                     if (metastore.getTableIncludeRecycleBin(db, table.getId()) == null) {
                         // Get the table by tableId again, ensure it still exists under the lock.
                         return;
@@ -432,10 +423,10 @@ public class TabletChecker extends LeaderDaemon {
                 }
             }
         } finally {
-            if (locked) {
-                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-                lockStat.lockHoldTotalTime += System.currentTimeMillis() - lockStartTime;
-            }
+            lock.close();
+            // The scope tracks actually-held time, so yielded windows (proactive releases
+            // and blocking-add waits) and failed re-acquisitions are not counted.
+            lockStat.lockHoldTotalTime += lock.getHeldTimeMs();
         }
     }
 
@@ -461,7 +452,7 @@ public class TabletChecker extends LeaderDaemon {
 
     private TabletCheckerStat doCheckOnePartition(Database db, OlapTable olapTbl, PhysicalPartition physicalPartition,
                                                   int replicaNum, List<Long> aliveBeIdsInCluster,
-                                                  boolean isPartitionUrgent) {
+                                                  boolean isPartitionUrgent, YieldableLock heldLock) {
         TabletCheckerStat partitionTabletCheckerStat = new TabletCheckerStat();
         Multimap<String, String> locations = olapTbl.getLocation();
         boolean isLabelLocationTable = locations != null;
@@ -549,8 +540,8 @@ public class TabletChecker extends LeaderDaemon {
                     }
 
                     Pair<Boolean, Long> result =
-                            tabletScheduler.blockingAddTabletCtxToScheduler(db, tabletSchedCtx,
-                                    isPartitionUrgent);
+                            tabletScheduler.blockingAddTabletCtxToScheduler(tabletSchedCtx, isPartitionUrgent,
+                                    heldLock);
                     partitionTabletCheckerStat.waitTotalTime += result.second;
                     if (result.first) {
                         partitionTabletCheckerStat.addToSchedulerTabletNum++;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -73,6 +73,7 @@ import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.common.util.concurrent.lock.YieldableLock;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -323,29 +324,29 @@ public class TabletScheduler extends LeaderDaemon {
         return AddResult.ADDED;
     }
 
-    public Pair<Boolean, Long> blockingAddTabletCtxToScheduler(Database db, TabletSchedCtx tabletSchedCtx,
-                                                               boolean forceAdd) {
-        Locker locker = new Locker();
+    /**
+     * Add the tablet ctx to the scheduler, blocking the caller while the scheduler is full.
+     * The given lock scope is the metadata locks the caller holds while iterating tablets:
+     * it is yielded during each wait, so that metadata operations on the db/table are not
+     * blocked behind a full scheduler. As after every {@link YieldableLock} yield, the
+     * caller must re-validate metadata read before this call.
+     */
+    public Pair<Boolean, Long> blockingAddTabletCtxToScheduler(TabletSchedCtx tabletSchedCtx, boolean forceAdd,
+                                                               YieldableLock heldLock) {
         // p.first: added or not, p.second: total sleep time in ms
         Pair<Boolean, Long> result = new Pair<>(false, 0L);
         try {
-            do {
-                AddResult res = addTablet(tabletSchedCtx, forceAdd /* force or not */);
-                if (res == AddResult.LIMIT_EXCEED) {
-                    locker.unLockDatabase(db.getId(), LockType.READ);
-                    // It's ok to sleep a relative long time here so that the scheduler will spare more
-                    // slots after the sleep and the following adding won't block.
-                    Thread.sleep(BLOCKING_ADD_SLEEP_DURATION_MS);
-                    result.second += BLOCKING_ADD_SLEEP_DURATION_MS;
-                    locker.lockDatabase(db.getId(), LockType.READ);
-                } else {
-                    result.first = (res == AddResult.ADDED);
-                    break;
-                }
-            } while (true);
+            AddResult res;
+            while ((res = addTablet(tabletSchedCtx, forceAdd /* force or not */)) == AddResult.LIMIT_EXCEED) {
+                // It's ok to sleep a relative long time here so that the scheduler will spare more
+                // slots after the sleep and the following adding won't block.
+                heldLock.sleepUnlocked(BLOCKING_ADD_SLEEP_DURATION_MS);
+                result.second += BLOCKING_ADD_SLEEP_DURATION_MS;
+            }
+            result.first = (res == AddResult.ADDED);
         } catch (InterruptedException e) {
+            // heldLock has already been re-acquired by sleepUnlocked().
             LOG.warn("Failed to execute blockingAddTabletCtxToScheduler", e);
-            locker.lockDatabase(db.getId(), LockType.READ);
         }
 
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/YieldableLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/YieldableLock.java
@@ -1,0 +1,154 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util.concurrent.lock;
+
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A metadata lock scope that keeps both sides of the lock lifecycle in one place: the
+ * locks are acquired on construction, re-acquired after every temporary release, and
+ * released on {@link #close()}. It is meant for long-running scan paths (e.g. tablet
+ * checking) that must periodically step aside for other metadata operations
+ * ({@link #refresh()}) or wait for some external condition without holding any
+ * metadata lock ({@link #sleepUnlocked(long)}).
+ *
+ * Outside of those two methods the locks are always held until {@link #close()}, so
+ * a scope can be handed to a callee as proof of lock ownership without exposing raw
+ * unlock entry points. After {@link #refresh()} or {@link #sleepUnlocked(long)}
+ * returns, the locks have been re-acquired from scratch: the caller must re-validate
+ * any metadata read before the call, because the db, table or partition may have been
+ * dropped or altered in between.
+ *
+ * The scope also tracks how long its locks have actually been held, see
+ * {@link #getHeldTimeNs()}, so callers can report lock-hold statistics without
+ * keeping their own timing around the yields (which would wrongly count yielded
+ * windows or failed re-acquisitions as hold time).
+ *
+ * Instances are not thread-safe and must only be used by the creating thread, like
+ * the underlying {@link Locker}.
+ */
+public class YieldableLock implements AutoCloseable {
+    private final Locker locker = new Locker();
+    private final long dbId;
+    /* Null when this scope is a plain database lock. */
+    private final Long tableId;
+    private final LockType lockType;
+    private boolean locked;
+    /* System.nanoTime() of the most recent acquisition, valid while locked. */
+    private long lastAcquireTimeNs;
+    /* Total held time over all completed hold segments. */
+    private long heldTimeNs;
+
+    private YieldableLock(long dbId, Long tableId, LockType lockType) {
+        this.dbId = dbId;
+        this.tableId = tableId;
+        this.lockType = lockType;
+        lock();
+    }
+
+    /**
+     * Acquire a plain database lock scope, see {@link Locker#lockDatabase}.
+     */
+    public static YieldableLock lockDatabase(long dbId, LockType lockType) {
+        return new YieldableLock(dbId, null, lockType);
+    }
+
+    /**
+     * Acquire an intensive table lock scope (intention lock on the database plus the
+     * lock on the table), see {@link Locker#lockTableWithIntensiveDbLock}.
+     */
+    public static YieldableLock lockTableWithIntensiveDbLock(long dbId, long tableId, LockType lockType) {
+        return new YieldableLock(dbId, tableId, lockType);
+    }
+
+    /**
+     * Release the locks and immediately re-acquire them, so that queued waiters can
+     * cut in. The caller must re-validate cached metadata afterwards.
+     */
+    public void refresh() {
+        Preconditions.checkState(locked, "lock scope is not held");
+        unlock();
+        lock();
+    }
+
+    /**
+     * Sleep with the locks released and re-acquire them before returning, also when
+     * the sleep is interrupted. The caller must re-validate cached metadata
+     * afterwards.
+     */
+    public void sleepUnlocked(long sleepMs) throws InterruptedException {
+        Preconditions.checkState(locked, "lock scope is not held");
+        unlock();
+        try {
+            Thread.sleep(sleepMs);
+        } finally {
+            lock();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (locked) {
+            unlock();
+        }
+    }
+
+    /**
+     * Total time the locks have been held by this scope in nanoseconds, including the
+     * current hold segment while the scope is held. Yielded windows and the time after
+     * a failed re-acquisition are not counted.
+     */
+    public long getHeldTimeNs() {
+        return heldTimeNs + (locked ? System.nanoTime() - lastAcquireTimeNs : 0);
+    }
+
+    /**
+     * Same as {@link #getHeldTimeNs()}, in milliseconds.
+     */
+    public long getHeldTimeMs() {
+        return TimeUnit.NANOSECONDS.toMillis(getHeldTimeNs());
+    }
+
+    /**
+     * Time since the locks were last (re-)acquired in milliseconds, 0 when not held.
+     */
+    public long getCurrentHoldTimeMs() {
+        return locked ? TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastAcquireTimeNs) : 0;
+    }
+
+    private void lock() {
+        if (tableId == null) {
+            locker.lockDatabase(dbId, lockType);
+        } else {
+            locker.lockTableWithIntensiveDbLock(dbId, tableId, lockType);
+        }
+        lastAcquireTimeNs = System.nanoTime();
+        locked = true;
+    }
+
+    private void unlock() {
+        // Clear the flag first: if a release fails halfway, close() must not try to
+        // release again (preferring a leaked lock over an unbalanced release).
+        locked = false;
+        heldTimeNs += System.nanoTime() - lastAcquireTimeNs;
+        if (tableId == null) {
+            locker.unLockDatabase(dbId, lockType);
+        } else {
+            locker.unLockTableWithIntensiveDbLock(dbId, tableId, lockType);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -43,6 +43,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.lock.LockManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.common.util.concurrent.lock.YieldableLock;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.persist.EditLog;
 import com.starrocks.qe.VariableMgr;
@@ -84,6 +85,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.starrocks.sql.ast.KeysType.DUP_KEYS;
 
@@ -302,13 +305,9 @@ public class TabletSchedulerTest {
 
         new Thread(() -> {
             for (int i = 0; i < 10; i++) {
-                Locker locker = new Locker();
                 tabletSchedCtxList.get(i).setOrigPriority(TabletSchedCtx.Priority.NORMAL);
-                try {
-                    locker.lockDatabase(goodDB.getId(), LockType.READ);
-                    tabletScheduler.blockingAddTabletCtxToScheduler(goodDB, tabletSchedCtxList.get(i), false);
-                } finally {
-                    locker.unLockDatabase(goodDB.getId(), LockType.READ);
+                try (YieldableLock lock = YieldableLock.lockDatabase(goodDB.getId(), LockType.READ)) {
+                    tabletScheduler.blockingAddTabletCtxToScheduler(tabletSchedCtxList.get(i), false, lock);
                 }
             }
         }, "testAddCtx").start();
@@ -316,6 +315,72 @@ public class TabletSchedulerTest {
         Thread.sleep(2000);
         tabletScheduler.removeOneFromPendingQ();
         Thread.sleep(1000);
+        Assertions.assertEquals(9, tabletScheduler.getPendingTabletsInfo(100).size());
+
+        Config.tablet_sched_max_scheduling_tablets = oldVal;
+    }
+
+    @Test
+    public void testPendingAddTabletCtxWithIntensiveTableLock() throws InterruptedException {
+        int oldVal = Config.tablet_sched_max_scheduling_tablets;
+        Config.tablet_sched_max_scheduling_tablets = 8;
+
+        TabletScheduler tabletScheduler = new TabletScheduler(tabletSchedulerStat);
+        Database db = new Database(20, "db20");
+        Table table = new Table(40, "tbl40", Table.TableType.OLAP, new ArrayList<>());
+        Partition partition = new Partition(60, 66, "p60", new MaterializedIndex(), null);
+
+        List<TabletSchedCtx> tabletSchedCtxList = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            TabletSchedCtx ctx = new TabletSchedCtx(
+                    TabletSchedCtx.Type.REPAIR,
+                    db.getId(),
+                    table.getId(),
+                    partition.getId(),
+                    1,
+                    i,
+                    System.currentTimeMillis(),
+                    systemInfoService);
+            ctx.setOrigPriority(TabletSchedCtx.Priority.NORMAL);
+            tabletSchedCtxList.add(ctx);
+        }
+
+        // Mimic TabletChecker.checkOneTable(): add tablet ctxs while holding an intensive
+        // table READ lock scope (INTENTION_SHARED on the db + READ on the table). The blocking
+        // add must yield exactly this scope while waiting; releasing any other lock shape would
+        // die with IllegalMonitorStateException once the queue is full.
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread addThread = new Thread(() -> {
+            try {
+                for (int i = 0; i < 10; i++) {
+                    try (YieldableLock lock = YieldableLock.lockTableWithIntensiveDbLock(
+                            db.getId(), table.getId(), LockType.READ)) {
+                        tabletScheduler.blockingAddTabletCtxToScheduler(tabletSchedCtxList.get(i), false, lock);
+                    }
+                }
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        }, "testAddCtxWithTableLock");
+        addThread.start();
+
+        Thread.sleep(2000);
+        // The adding thread is now blocked on the last tablet ctx and must have released both
+        // of its locks during the wait: a db WRITE lock (conflicts with INTENTION_SHARED) and
+        // an intensive table WRITE lock (conflicts with table READ) must be acquirable.
+        Locker probeLocker = new Locker();
+        Assertions.assertTrue(
+                probeLocker.tryLockDatabase(db.getId(), LockType.WRITE, 2000, TimeUnit.MILLISECONDS));
+        probeLocker.unLockDatabase(db.getId(), LockType.WRITE);
+        Assertions.assertTrue(probeLocker.tryLockTableWithIntensiveDbLock(
+                db.getId(), table.getId(), LockType.WRITE, 2000, TimeUnit.MILLISECONDS));
+        probeLocker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
+
+        // Free one slot so the blocked add can complete and the thread can exit.
+        tabletScheduler.removeOneFromPendingQ();
+        addThread.join(10000);
+        Assertions.assertFalse(addThread.isAlive());
+        Assertions.assertNull(error.get(), "blocking add must not throw: " + error.get());
         Assertions.assertEquals(9, tabletScheduler.getPendingTabletsInfo(100).size());
 
         Config.tablet_sched_max_scheduling_tablets = oldVal;

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/YieldableLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/YieldableLockTest.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.lock;
+
+import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.common.util.concurrent.lock.YieldableLock;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class YieldableLockTest {
+    private static final long DB_ID = 1L;
+    private static final long TABLE_ID = 2L;
+
+    @BeforeEach
+    public void setUp() {
+        GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
+    }
+
+    @Test
+    public void testDatabaseScopeLifecycle() {
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+
+        YieldableLock lock = YieldableLock.lockDatabase(DB_ID, LockType.READ);
+        Assertions.assertTrue(lockManager.isOwner(DB_ID, new Locker(), LockType.READ));
+
+        lock.refresh();
+        Assertions.assertTrue(lockManager.isOwner(DB_ID, new Locker(), LockType.READ));
+
+        lock.close();
+        Assertions.assertFalse(lockManager.isOwner(DB_ID, new Locker(), LockType.READ));
+
+        // close() is idempotent, but yielding a closed scope is a programming error
+        lock.close();
+        Assertions.assertThrows(IllegalStateException.class, lock::refresh);
+        Assertions.assertThrows(IllegalStateException.class, () -> lock.sleepUnlocked(1));
+    }
+
+    @Test
+    public void testTableScopeLifecycle() throws InterruptedException {
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+
+        YieldableLock lock = YieldableLock.lockTableWithIntensiveDbLock(DB_ID, TABLE_ID, LockType.READ);
+        Assertions.assertTrue(lockManager.isOwner(DB_ID, new Locker(), LockType.INTENTION_SHARED));
+        Assertions.assertTrue(lockManager.isOwner(TABLE_ID, new Locker(), LockType.READ));
+
+        lock.sleepUnlocked(1);
+        Assertions.assertTrue(lockManager.isOwner(DB_ID, new Locker(), LockType.INTENTION_SHARED));
+        Assertions.assertTrue(lockManager.isOwner(TABLE_ID, new Locker(), LockType.READ));
+
+        lock.close();
+        Assertions.assertFalse(lockManager.isOwner(DB_ID, new Locker(), LockType.INTENTION_SHARED));
+        Assertions.assertFalse(lockManager.isOwner(TABLE_ID, new Locker(), LockType.READ));
+    }
+
+    @Test
+    public void testHeldTimeExcludesYieldedWindows() throws InterruptedException {
+        YieldableLock lock = YieldableLock.lockDatabase(DB_ID, LockType.READ);
+        lock.sleepUnlocked(150);
+        lock.close();
+        // Only the brief held segments before and after the yield count, never the
+        // sleep itself.
+        Assertions.assertTrue(lock.getHeldTimeNs() > 0);
+        Assertions.assertTrue(lock.getHeldTimeMs() < 150);
+        Assertions.assertEquals(0, lock.getCurrentHoldTimeMs());
+        // After close() the total is stable.
+        Assertions.assertEquals(lock.getHeldTimeNs(), lock.getHeldTimeNs());
+    }
+
+    @Test
+    public void testSleepUnlockedReacquiresOnInterrupt() {
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+
+        try (YieldableLock lock = YieldableLock.lockTableWithIntensiveDbLock(DB_ID, TABLE_ID, LockType.READ)) {
+            Thread.currentThread().interrupt();
+            Assertions.assertThrows(InterruptedException.class, () -> lock.sleepUnlocked(10000));
+            // The locks must have been re-acquired before the interrupt propagated.
+            Assertions.assertTrue(lockManager.isOwner(DB_ID, new Locker(), LockType.INTENTION_SHARED));
+            Assertions.assertTrue(lockManager.isOwner(TABLE_ID, new Locker(), LockType.READ));
+        }
+        Assertions.assertFalse(lockManager.isOwner(DB_ID, new Locker(), LockType.INTENTION_SHARED));
+        Assertions.assertFalse(lockManager.isOwner(TABLE_ID, new Locker(), LockType.READ));
+    }
+}


### PR DESCRIPTION
PR #65237 turned TabletChecker.doCheck() to an intensive table READ lock (IS on the db + READ on the table), but
blockingAddTabletCtxToScheduler still released/re-acquired a plain db READ lock when the scheduler queue exceeded
tablet_sched_max_scheduling_tablets. On the checker path the thread owns (locker, INTENTION_SHARED) on the db rid, so MultiUserLock.release found no owner for (locker, READ) and threw IllegalMonitorStateException, which escaped the helper (it catches only InterruptedException) and aborted the whole checker round at the first LIMIT_EXCEED tablet: remaining dbs were skipped and cleanInvalidUrgentTable() never ran.

The root problem is structural: the scheduler released and re-acquired locks that its callers had acquired, based on an unchecked assumption about the lock shape. Introduce YieldableLock, a metadata lock scope that keeps the whole lock lifecycle in one class: it acquires the locks on construction (plain db lock or intensive table lock), re-acquires them after every temporary release (refresh() to let queued waiters cut in, sleepUnlocked() to wait without holding metadata locks, re-acquiring even on interrupt), and releases them on an idempotent close().

blockingAddTabletCtxToScheduler now takes the caller's lock scope and yields it while waiting for free scheduler slots; it no longer knows anything about lock shapes and cannot release locks the caller does not hold. TabletChecker.checkOneTable and ColocateTableBalancer's doMatchOneGroup use the same scope for their periodic mid-scan lock release instead of hand-rolled unlock/relock pairs and locked-flag bookkeeping.

The scope also tracks how long its locks are actually held, and the checker's lock-hold statistics and the balancer's per-group lock time are taken from the scope instead of caller-side timestamps. They now exclude yielded windows (proactive releases and blocking-add waits) and failed re-acquisitions, which the old bookkeeping mis-counted as hold time; the balancer no longer needs its approximate wait-time subtraction either.

Add YieldableLockTest covering scope lifecycle for both lock shapes, idempotent close, rejection of yields after close, re-acquisition when the sleep is interrupted, and held-time tracking across yields. Add a TabletScheduler regression test that mimics the checker lock shape: the blocked add must not throw, must release both the db IS and table READ locks while waiting (verified by acquiring conflicting WRITE locks from another thread), and must complete once a slot is freed.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
