### PR TITLE
[Enhancement] Record IVM source version/timestamp ranges in MV task run EXTRA_MESSAGE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -213,6 +213,16 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
+    public Optional<Long> getVersionCommitTimeMillis(String dbName, Table table, long version) {
+        ConnectorMetadata metadata = metadataOfTable(table);
+        if (metadata == null) {
+            metadata = metadataOfDb(dbName);
+        }
+
+        return metadata.getVersionCommitTimeMillis(dbName, table, version);
+    }
+
+    @Override
     public boolean tableExists(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfDb(dbName);
         return metadata.tableExists(context, dbName, tblName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -194,6 +194,15 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
+    /**
+     * Commit time of {@code version} (the table's own version space, e.g. an Iceberg snapshot id)
+     * in epoch millis, or empty when it cannot be resolved (unknown/expired version, or a format
+     * with no per-version commit time).
+     */
+    default Optional<Long> getVersionCommitTimeMillis(String dbName, Table table, long version) {
+        return Optional.empty();
+    }
+
     default boolean tableExists(ConnectContext context, String dbName, String tblName) {
         return listTableNames(context, dbName).contains(tblName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -858,6 +858,12 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public Optional<Long> getVersionCommitTimeMillis(String dbName, Table table, long version) {
+        Snapshot snapshot = ((IcebergTable) table).getNativeTable().snapshot(version);
+        return snapshot == null ? Optional.empty() : Optional.of(snapshot.timestampMillis());
+    }
+
+    @Override
     public TvrVersionRange getTableVersionRange(String dbName, Table table,
                                                 Optional<ConnectorTableVersion> startVersion,
                                                 Optional<ConnectorTableVersion> endVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -165,6 +165,12 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     }
 
     @Override
+    public Optional<Long> getVersionCommitTimeMillis(String dbName, Table table, long version) {
+        ConnectorMetadata metadata = metadataOfTable(table);
+        return metadata.getVersionCommitTimeMillis(dbName, table, version);
+    }
+
+    @Override
     public List<String> listDbNames(ConnectContext context) {
         return hiveMetadata.listDbNames(context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -16,6 +16,7 @@ package com.starrocks.scheduler.mv.ivm;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.starrocks.catalog.BaseTableInfo;
@@ -50,7 +51,9 @@ import com.starrocks.scheduler.TaskRunContext;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshProcessor;
+import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -154,7 +157,48 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         try (Timer ignored = Tracers.watchScope("MVRefreshPrepareRefreshPlan")) {
             insertStmt = prepareRefreshPlan();
         }
+        recordImvSourceRangesOnTaskRun();
         return new ProcessExecPlan(Constants.TaskRunState.SUCCESS, mvContext.getExecPlan(), insertStmt);
+    }
+
+    /**
+     * Record the staged TVR version range and snapshot commit times per base table on the task
+     * run's extra message, surfaced via information_schema.task_runs.EXTRA_MESSAGE.
+     * Must stay after prepareRefreshPlan(): recording earlier leaves stale ranges on the task
+     * run when the hybrid processor falls back to PCT on an IVM planning failure.
+     */
+    private void recordImvSourceRangesOnTaskRun() {
+        updateTaskRunStatus(status -> {
+            Map<String, Map<String, String>> versionRanges = Maps.newHashMap();
+            Map<String, Map<String, String>> timestampRanges = Maps.newHashMap();
+            for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+                TvrVersionRange delta = ((TvrTableSnapshotInfo) snapshotInfo).getTvrSnapshot();
+                if (delta == null) {
+                    continue;
+                }
+                BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
+                String tableFullName = baseTableInfo.getReadableString();
+                // TvrVersion.toString() renders the MIN/MAX sentinels as "MIN"/"MAX"
+                versionRanges.put(tableFullName, ImmutableMap.of(
+                        "start", delta.from().toString(),
+                        "end", delta.to().toString()));
+                timestampRanges.put(tableFullName,
+                        resolveCommitTimeRange(baseTableInfo.getDbName(), snapshotInfo.getBaseTable(), delta));
+            }
+            MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
+            extraMessage.setImvSourceVersionRange(versionRanges);
+            extraMessage.setImvSourceTimestampRange(timestampRanges);
+        });
+    }
+
+    private static Map<String, String> resolveCommitTimeRange(String dbName, Table table, TvrVersionRange delta) {
+        Map<String, String> commitTimes = Maps.newLinkedHashMap();
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        delta.start().flatMap(version -> metadataMgr.getVersionCommitTimeMillis(dbName, table, version))
+                .ifPresent(time -> commitTimes.put("start", String.valueOf(time)));
+        delta.end().flatMap(version -> metadataMgr.getVersionCommitTimeMillis(dbName, table, version))
+                .ifPresent(time -> commitTimes.put("end", String.valueOf(time)));
+        return commitTimes;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -82,6 +82,13 @@ public class MVTaskRunExtraMessage implements Writable {
     @SerializedName("pinnedSnapshotIdMap")
     private Map<String, Long> pinnedSnapshotIdMap = Maps.newHashMap();
 
+    // For IVM refreshes: per base table ("catalog.db.tbl"), the consumed TVR version range
+    // {start, end} and the matching snapshot commit times in epoch millis (empty when unresolvable).
+    @SerializedName("imvSourceVersionRange")
+    private Map<String, Map<String, String>> imvSourceVersionRange = Maps.newHashMap();
+    @SerializedName("imvSourceTimestampRange")
+    private Map<String, Map<String, String>> imvSourceTimestampRange = Maps.newHashMap();
+
     public MVTaskRunExtraMessage() {
     }
 
@@ -219,6 +226,24 @@ public class MVTaskRunExtraMessage implements Writable {
 
     public void setPinnedSnapshotIdMap(Map<String, Long> pinnedSnapshotIdMap) {
         this.pinnedSnapshotIdMap = MvUtils.shrinkToSize(pinnedSnapshotIdMap,
+                Config.max_mv_task_run_meta_message_values_length);
+    }
+
+    public Map<String, Map<String, String>> getImvSourceVersionRange() {
+        return imvSourceVersionRange;
+    }
+
+    public void setImvSourceVersionRange(Map<String, Map<String, String>> imvSourceVersionRange) {
+        this.imvSourceVersionRange = MvUtils.shrinkToSize(imvSourceVersionRange,
+                Config.max_mv_task_run_meta_message_values_length);
+    }
+
+    public Map<String, Map<String, String>> getImvSourceTimestampRange() {
+        return imvSourceTimestampRange;
+    }
+
+    public void setImvSourceTimestampRange(Map<String, Map<String, String>> imvSourceTimestampRange) {
+        this.imvSourceTimestampRange = MvUtils.shrinkToSize(imvSourceTimestampRange,
                 Config.max_mv_task_run_meta_message_values_length);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -573,6 +573,11 @@ public class MetadataMgr {
                 .orElse(TvrTableSnapshot.empty());
     }
 
+    public Optional<Long> getVersionCommitTimeMillis(String dbName, Table table, long version) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
+        return connectorMetadata.flatMap(metadata -> metadata.getVersionCommitTimeMillis(dbName, table, version));
+    }
+
     public Optional<Database> getDatabase(ConnectContext context, BaseTableInfo baseTableInfo) {
         if (baseTableInfo.isInternalCatalog()) {
             return Optional.ofNullable(getDb(baseTableInfo.getDbId()));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -289,5 +290,26 @@ public class CatalogConnectorMetadataTest {
 
         TvrTableSnapshot actual = catalogConnectorMetadata.acquireTvrSnapshot("test_db", table, mvId);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void testGetVersionCommitTimeMillisDelegatesToChild(@Mocked ConnectorMetadata connectorMetadata,
+                                                        @Mocked Table table) {
+        Optional<Long> expected = Optional.of(1781000000000L);
+        new Expectations() {
+            {
+                connectorMetadata.getVersionCommitTimeMillis("test_db", table, 42L);
+                result = expected;
+                times = 1;
+            }
+        };
+
+        CatalogConnectorMetadata catalogConnectorMetadata = new CatalogConnectorMetadata(
+                connectorMetadata,
+                informationSchemaMetadata,
+                metaMetadata
+        );
+
+        assertEquals(expected, catalogConnectorMetadata.getVersionCommitTimeMillis("test_db", table, 42L));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -245,6 +245,23 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testGetVersionCommitTimeMillis() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
+        mockedNativeTableA.refresh();
+        Snapshot snapshot = mockedNativeTableA.currentSnapshot();
+        IcebergTable table = new IcebergTable(1, "tableA", CATALOG_NAME, CATALOG_NAME, "iceberg_db",
+                "tableA", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        Assertions.assertEquals(Optional.of(snapshot.timestampMillis()),
+                metadata.getVersionCommitTimeMillis("iceberg_db", table, snapshot.snapshotId()));
+        Assertions.assertEquals(Optional.empty(),
+                metadata.getVersionCommitTimeMillis("iceberg_db", table, snapshot.snapshotId() + 1));
+    }
+
+    @Test
     public void testGetDB(@Mocked IcebergHiveCatalog icebergHiveCatalog) {
         String db = "db";
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.types.Types;
@@ -641,6 +642,12 @@ public class MockIcebergMetadata implements ConnectorMetadata {
 
     public TvrTableSnapshot getCurrentTvrSnapshot(String dbName, com.starrocks.catalog.Table table) {
         return TvrTableSnapshot.of(TvrVersion.of(1L));
+    }
+
+    @Override
+    public Optional<Long> getVersionCommitTimeMillis(String dbName, com.starrocks.catalog.Table table, long version) {
+        Snapshot snapshot = ((IcebergTable) table).getNativeTable().snapshot(version);
+        return snapshot == null ? Optional.empty() : Optional.of(snapshot.timestampMillis());
     }
 
     // ConnectorMetadata's default returns TvrTableSnapshot.empty(), which leaves the planned scan

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -57,6 +57,7 @@ import org.wildfly.common.Assert;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
 import static com.starrocks.catalog.Table.TableType.HIVE;
@@ -578,5 +579,24 @@ public class UnifiedMetadataTest {
 
         TvrTableSnapshot actual = unifiedMetadata.acquireTvrSnapshot("test_db", icebergTable, mvId);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetVersionCommitTimeMillisRoutesByTableType(@Mocked IcebergTable icebergTable) {
+        Optional<Long> expected = Optional.of(1781000000000L);
+        new Expectations() {
+            {
+                icebergTable.getType();
+                result = ICEBERG;
+                minTimes = 1;
+            }
+            {
+                icebergMetadata.getVersionCommitTimeMillis("test_db", icebergTable, 42L);
+                result = expected;
+                times = 1;
+            }
+        };
+
+        assertEquals(expected, unifiedMetadata.getVersionCommitTimeMillis("test_db", icebergTable, 42L));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -17,12 +17,14 @@ package com.starrocks.scheduler.mv.ivm;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.tvr.TvrDeltaStats;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
@@ -34,10 +36,14 @@ import com.starrocks.scheduler.mv.hybrid.MVHybridRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
@@ -1309,6 +1315,129 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Long snapshotId = pinnedSnapshotIdMap.values().iterator().next();
         Assertions.assertEquals(2L, snapshotId.longValue(),
                 "pinnedSnapshotIdMap value should match the PCT-synced snapshot id");
+    }
+
+    /**
+     * Verify the TVR version range consumed per base table is recorded on the task run's extra
+     * message so it is visible via information_schema.task_runs.EXTRA_MESSAGE.
+     */
+    @Test
+    public void testImvSourceVersionRangeRecordedOnExtraMessage() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        seedTvrBaselineAtVersionZero(mv);
+        // Synthetic version: no Iceberg snapshot with this id exists on the mock native table,
+        // so commit-time resolution must degrade to an empty per-table map.
+        advanceTableVersionTo(999999L);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofMonotonic(
+                        TvrTableDelta.of(TvrVersion.of(0L), TvrVersion.of(999999L)),
+                        TvrDeltaStats.EMPTY)));
+
+        MVTaskRunProcessor processor = getMVTaskRunProcessor(mv);
+        Assertions.assertInstanceOf(MVIVMRefreshProcessor.class, processor.getMVRefreshProcessor());
+
+        MVTaskRunExtraMessage extraMessage =
+                processor.getMvTaskRunContext().getStatus().getMvTaskRunExtraMessage();
+        Map<String, Map<String, String>> versionRanges = extraMessage.getImvSourceVersionRange();
+        Assertions.assertEquals(Map.of("start", "0", "end", "999999"),
+                versionRanges.get("iceberg0.unpartitioned_db.t0"),
+                "imvSourceVersionRange should record the consumed TVR range, got: " + versionRanges);
+        Assertions.assertTrue(extraMessage.toString().contains("\"imvSourceVersionRange\""),
+                "extra message JSON should contain imvSourceVersionRange: " + extraMessage);
+
+        Map<String, String> timestampRange =
+                extraMessage.getImvSourceTimestampRange().get("iceberg0.unpartitioned_db.t0");
+        Assertions.assertNotNull(timestampRange,
+                "imvSourceTimestampRange should have an entry per staged base table");
+        Assertions.assertTrue(timestampRange.isEmpty(),
+                "unresolvable snapshot ids should degrade to an empty map, got: " + timestampRange);
+    }
+
+    /**
+     * When IVM planning fails after the TVR deltas were staged and the hybrid processor falls
+     * back to PCT, the task run must not keep source ranges from the abandoned IVM attempt.
+     */
+    @Test
+    public void testImvSourceRangesNotRecordedOnPctFallback() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        seedTvrBaselineAtVersionZero(mv);
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofMonotonic(
+                        TvrTableDelta.of(TvrVersion.of(0L), TvrVersion.of(2L)),
+                        TvrDeltaStats.EMPTY)));
+        // Fail IVM plan generation after the TVR deltas were staged; the PCT fallback
+        // builds its plan from getTaskDefinition() and is unaffected.
+        new MockUp<MaterializedView>() {
+            @Mock
+            public String getIVMTaskDefinition() {
+                throw new SemanticException("injected IVM plan failure");
+            }
+        };
+
+        MVTaskRunProcessor processor = getMVTaskRunProcessor(mv);
+        Assertions.assertInstanceOf(MVHybridRefreshProcessor.class, processor.getMVRefreshProcessor());
+        MVHybridRefreshProcessor hybrid = (MVHybridRefreshProcessor) processor.getMVRefreshProcessor();
+        Assertions.assertInstanceOf(MVPCTRefreshProcessor.class, hybrid.getCurrentProcessor());
+
+        MVTaskRunExtraMessage extraMessage =
+                processor.getMvTaskRunContext().getStatus().getMvTaskRunExtraMessage();
+        Assertions.assertTrue(extraMessage.getImvSourceVersionRange().isEmpty(),
+                "PCT fallback must not keep IVM source ranges, got: "
+                        + extraMessage.getImvSourceVersionRange());
+        Assertions.assertTrue(extraMessage.getImvSourceTimestampRange().isEmpty(),
+                "PCT fallback must not keep IVM source timestamps, got: "
+                        + extraMessage.getImvSourceTimestampRange());
+    }
+
+    /**
+     * Verify commit times of the consumed snapshot range are recorded as imvSourceTimestampRange
+     * when the source snapshots are resolvable on the native Iceberg table.
+     */
+    @Test
+    public void testImvSourceTimestampRangeRecordedOnExtraMessage() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental", "`date`", null);
+
+        MockIcebergMetadata mockIcebergMetadata =
+                (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+        org.apache.iceberg.Table nativeTable = ((IcebergTable) MvUtils.getTableWithIdentifier(
+                mv.getBaseTableInfos().get(0)).get()).getNativeTable();
+        // Two real Iceberg commits so both range endpoints have resolvable commit times.
+        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 10, "date=2020-01-02");
+        long startSnapshotId = nativeTable.currentSnapshot().snapshotId();
+        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 10, "date=2020-01-03");
+        long endSnapshotId = nativeTable.currentSnapshot().snapshotId();
+
+        Map<BaseTableInfo, TvrVersionRange> tvrMap = mv.getRefreshScheme().getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap();
+        for (BaseTableInfo info : mv.getBaseTableInfos()) {
+            tvrMap.put(info, TvrTableSnapshot.of(startSnapshotId));
+        }
+        advanceTableVersionTo(endSnapshotId);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofMonotonic(
+                        TvrTableDelta.of(TvrVersion.of(startSnapshotId), TvrVersion.of(endSnapshotId)),
+                        TvrDeltaStats.EMPTY)));
+
+        MVTaskRunProcessor processor = getMVTaskRunProcessor(mv);
+        Assertions.assertInstanceOf(MVIVMRefreshProcessor.class, processor.getMVRefreshProcessor());
+
+        MVTaskRunExtraMessage extraMessage =
+                processor.getMvTaskRunContext().getStatus().getMvTaskRunExtraMessage();
+        String tableKey = "iceberg0.partitioned_db.t1";
+        Assertions.assertEquals(
+                Map.of("start", String.valueOf(startSnapshotId), "end", String.valueOf(endSnapshotId)),
+                extraMessage.getImvSourceVersionRange().get(tableKey),
+                "got: " + extraMessage.getImvSourceVersionRange());
+        Assertions.assertEquals(
+                Map.of("start", String.valueOf(nativeTable.snapshot(startSnapshotId).timestampMillis()),
+                        "end", String.valueOf(nativeTable.snapshot(endSnapshotId).timestampMillis())),
+                extraMessage.getImvSourceTimestampRange().get(tableKey),
+                "got: " + extraMessage.getImvSourceTimestampRange());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessageTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.scheduler.persist;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.common.Config;
@@ -111,5 +112,37 @@ public class MVTaskRunExtraMessageTest {
         message.setBasePartitionsToRefreshMap(basePartitionsToRefreshMap);
         Assertions.assertTrue(message.getBasePartitionsToRefreshMap().size() ==
                 Config.max_mv_task_run_meta_message_values_length);
+    }
+
+    @Test
+    public void testImvSourceRangesShrunkToConfiguredSize() {
+        Map<String, Map<String, String>> versionRanges = Maps.newHashMap();
+        Map<String, Map<String, String>> timestampRanges = Maps.newHashMap();
+        for (int i = 0; i < Config.max_mv_task_run_meta_message_values_length + 10; i++) {
+            versionRanges.put("catalog.db.table" + i, ImmutableMap.of("start", "1", "end", "2"));
+            timestampRanges.put("catalog.db.table" + i, ImmutableMap.of("start", "1000", "end", "2000"));
+        }
+        MVTaskRunExtraMessage message = new MVTaskRunExtraMessage();
+        message.setImvSourceVersionRange(versionRanges);
+        message.setImvSourceTimestampRange(timestampRanges);
+        Assertions.assertEquals(Config.max_mv_task_run_meta_message_values_length,
+                message.getImvSourceVersionRange().size());
+        Assertions.assertEquals(Config.max_mv_task_run_meta_message_values_length,
+                message.getImvSourceTimestampRange().size());
+    }
+
+    @Test
+    public void testImvSourceRangesSerializedToJson() {
+        MVTaskRunExtraMessage message = new MVTaskRunExtraMessage();
+        message.setImvSourceVersionRange(
+                ImmutableMap.of("iceberg.db.tbl", ImmutableMap.of("start", "100", "end", "128")));
+        message.setImvSourceTimestampRange(
+                ImmutableMap.of("iceberg.db.tbl", ImmutableMap.of("start", "1717999999000", "end", "1718000000000")));
+        String json = message.toString();
+        Assertions.assertTrue(json.contains(
+                "\"imvSourceVersionRange\":{\"iceberg.db.tbl\":{\"start\":\"100\",\"end\":\"128\"}}"), json);
+        Assertions.assertTrue(json.contains(
+                "\"imvSourceTimestampRange\":{\"iceberg.db.tbl\":" +
+                        "{\"start\":\"1717999999000\",\"end\":\"1718000000000\"}}"), json);
     }
 }

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_task_run_source_range
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_task_run_source_range
@@ -1,0 +1,84 @@
+-- name: test_ivm_task_run_source_range
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t_src (k int, v bigint);
+-- result:
+-- !result
+insert into t_src values (1, 10), (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src;
+-- result:
+-- !result
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND EXTRA_MESSAGE LIKE '%"imvSourceVersionRange":{"mv_iceberg_%';
+-- result:
+0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src values (3, 30);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL' AND EXTRA_MESSAGE LIKE concat('%"imvSourceVersionRange":{"mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src":{"start":"', (SELECT cast(snapshot_id as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NULL), '","end":"', (SELECT cast(snapshot_id as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NOT NULL), '"}}%');
+-- result:
+1
+-- !result
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL' AND EXTRA_MESSAGE LIKE concat('%"imvSourceTimestampRange":{"mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src":{"start":"', (SELECT cast(unix_timestamp(committed_at) as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NULL), '%","end":"', (SELECT cast(unix_timestamp(committed_at) as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NOT NULL), '%');
+-- result:
+1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_task_run_source_range
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_task_run_source_range
@@ -1,0 +1,49 @@
+-- name: test_ivm_task_run_source_range
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table t_src (k int, v bigint);
+insert into t_src values (1, 10), (2, 20);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src;
+
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+
+-- First refresh builds the PCT baseline: no IVM source range is recorded.
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND EXTRA_MESSAGE LIKE '%"imvSourceVersionRange":{"mv_iceberg_%';
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src values (3, 30);
+
+-- Incremental refresh records the consumed snapshot range: start must equal the
+-- PCT-anchored first snapshot (parent_id IS NULL), end the second (appended) one.
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL' AND EXTRA_MESSAGE LIKE concat('%"imvSourceVersionRange":{"mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src":{"start":"', (SELECT cast(snapshot_id as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NULL), '","end":"', (SELECT cast(snapshot_id as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NOT NULL), '"}}%');
+-- Recorded commit times are epoch millis; their second-level prefix must match
+-- the committed_at of the corresponding snapshots.
+SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL' AND EXTRA_MESSAGE LIKE concat('%"imvSourceTimestampRange":{"mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src":{"start":"', (SELECT cast(unix_timestamp(committed_at) as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NULL), '%","end":"', (SELECT cast(unix_timestamp(committed_at) as varchar) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src$snapshots WHERE parent_id IS NOT NULL), '%');
+
+drop materialized view test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_src force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

An incremental (IVM) materialized view refresh consumes a specific snapshot range from each base table, but that range is currently only visible in FE logs. Exposing it on the task run makes every refresh auditable via `information_schema.task_runs.EXTRA_MESSAGE` ("which slice of the source did this refresh consume?"), and it is the data source for the `IMV_SOURCE_*` columns of the planned MV refresh-jobs system table.

## What I'm doing:

Record two new JSON sub-fields in the MV task run extra message for every IVM refresh, right after `MVIVMRefreshProcessor` stages the per-table TVR deltas:

- `imvSourceVersionRange`: `{"catalog.db.tbl": {"start": "100", "end": "128"}}` — the TVR version (snapshot id) range consumed from each base table. `TvrVersion` MIN/MAX sentinels are rendered as `"MIN"`/`"MAX"` (readable, instead of leaking `Long.MIN_VALUE`/`Long.MAX_VALUE` literals).
- `imvSourceTimestampRange`: same shape, values are the commit times of those versions in epoch millis. Resolution is delegated to `Table.getVersionCommitTimeMillis(version)` — a polymorphic seam whose base implementation returns empty and which each table format overrides (Iceberg resolves the snapshot's commit time); endpoints that cannot be resolved (sentinel versions, expired/unknown snapshots, formats with no version commit time) are omitted, so a table degrades to `{}` instead of failing the refresh. This keeps `MVIVMRefreshProcessor` format-agnostic, so other IVM-capable table formats only need to override that one method.

Recording goes through the existing best-effort `updateTaskRunStatus()` helper (null-guarded, exception-swallowing), so it can never fail a refresh. Both setters cap map entries with `MvUtils.shrinkToSize`, mirroring `pinnedSnapshotIdMap`. PCT runs leave both fields as `{}`.

Example after an incremental refresh:

```sql
SELECT get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange')
FROM information_schema.task_runs ORDER BY FINISH_TIME DESC LIMIT 1;
-- {"iceberg_cat.mv_db.t1":{"start":"4912319873255147742","end":"6987413294356100802"}}
```

Tests:
- FE UT: `MVTaskRunExtraMessageTest` (shrink-to-size + JSON serialization of the new fields), `IVMBasedMvRefreshProcessorIcebergTest#testImvSourceVersionRangeRecordedOnExtraMessage` (range values + degradation to `{}` for unresolvable snapshots, plus the empty base-`Table` resolution), `#testImvSourceTimestampRangeRecordedOnExtraMessage` (commit times against real Iceberg snapshots on the mock catalog), and `#testImvSourceRangesNotRecordedOnPctFallback` (no stale ranges when hybrid falls back to PCT).
- SQL: `test_ivm_task_run_source_range` — PCT baseline run records nothing; incremental run records both ranges.

Fixes #issue: N/A — observability enhancement, no tracking issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
