### PR TITLE
[BugFix] Populate DATETIME_PRECISION in information_schema.COLUMNS

### DIFF
--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -389,7 +389,18 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
             // DATETIME_PRECISION
             {
                 auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(13);
-                fill_data_column_with_null(column);
+                int data_type = _desc_result.columns[_column_index].columnDesc.columnType;
+                if (data_type == TPrimitiveType::DATETIME) {
+                    // StarRocks DATETIME stores fractional seconds up to microsecond (6 digits).
+                    // Report a non-NULL precision so MySQL-protocol clients can compute COLUMN_SIZE.
+                    // The MySQL JDBC driver derives COLUMN_SIZE from DATETIME_PRECISION; a NULL here
+                    // makes COLUMN_SIZE NULL and breaks type mapping for callers such as Trino's
+                    // mysql connector (IllegalStateException: column size not present).
+                    int64_t value = 6;
+                    fill_column_with_slot<TYPE_BIGINT>(column, (void*)&value);
+                } else {
+                    fill_data_column_with_null(column);
+                }
             }
             break;
         }

--- a/test/sql/test_information_schema/R/test_column
+++ b/test/sql/test_information_schema/R/test_column
@@ -35,3 +35,31 @@ select if(count(*) > 1, "OK", "FAILED") from INFORMATION_SCHEMA.COLUMNS;
 -- result:
 OK
 -- !result
+
+-- name: test_column_datetime_precision
+CREATE TABLE `test_column_datetime_precision` (
+  `id` int NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `d` date NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+-- DATETIME_PRECISION must be non-NULL for DATETIME columns so MySQL-protocol
+-- clients (e.g. Trino's mysql connector) can derive COLUMN_SIZE; DATE and
+-- non-temporal columns stay NULL.
+select COLUMN_NAME, DATA_TYPE, DATETIME_PRECISION
+from INFORMATION_SCHEMA.COLUMNS
+where table_name = 'test_column_datetime_precision' order by ORDINAL_POSITION;
+-- result:
+id	int	None
+dt	datetime	6
+d	date	None
+-- !result
+drop table test_column_datetime_precision;
+-- result:
+-- !result

--- a/test/sql/test_information_schema/T/test_column
+++ b/test/sql/test_information_schema/T/test_column
@@ -18,3 +18,22 @@ where table_name = 'test_column_default';
 
 -- query information_schema.columns without db
 select if(count(*) > 1, "OK", "FAILED") from INFORMATION_SCHEMA.COLUMNS;
+
+-- name: test_column_datetime_precision
+CREATE TABLE `test_column_datetime_precision` (
+  `id` int NOT NULL COMMENT "",
+  `dt` datetime NOT NULL COMMENT "",
+  `d` date NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- DATETIME_PRECISION must be non-NULL for DATETIME columns so MySQL-protocol
+-- clients (e.g. Trino's mysql connector) can derive COLUMN_SIZE; DATE and
+-- non-temporal columns stay NULL.
+select COLUMN_NAME, DATA_TYPE, DATETIME_PRECISION
+from INFORMATION_SCHEMA.COLUMNS
+where table_name = 'test_column_datetime_precision' order by ORDINAL_POSITION;
+drop table test_column_datetime_precision;


### PR DESCRIPTION
## Why I'm doing:

DATETIME_PRECISION was always filled with NULL in the columns schema scanner. MySQL-protocol clients (e.g. Trino's mysql connector via the MySQL JDBC driver) derive COLUMN_SIZE from DATETIME_PRECISION, so a NULL value yields a NULL column size and breaks type mapping with 'IllegalStateException: column size not present' for any table that has a DATETIME column.

Report a fixed precision of 6 (microseconds, matching StarRocks DATETIME storage capability) for DATETIME columns; DATE and non-temporal columns remain NULL as before.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
