### PR TITLE
[Tool] AI SR Skills: parse all three reviewer lines from assign-pr-reviewer skill

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -72,20 +72,30 @@ jobs:
             exit 0
           fi
 
-          extract() {
-            # $1 is the literal field label (without trailing colon).
-            # LLM may wrap the line or value in **bold**; strip leading * and
-            # then keep only valid GitHub login chars (so @, backticks, quotes
-            # all get dropped).
+          # $1 is the literal field label (without trailing colon). LLM may
+          # wrap the line or value in **bold**; strip leading * and trailing
+          # markdown, then keep only the relevant slug chars. Two variants:
+          #   extract_user  -- GitHub login: [A-Za-z0-9-]
+          #   extract_team  -- team ref: [A-Za-z0-9-] plus '/' so a qualified
+          #                    `org/team-slug` is preserved intact. Using the
+          #                    user regex on a qualified team would truncate
+          #                    at the first '/', losing the team segment.
+          extract_user() {
             local key="$1"
             grep -iE "^\**${key}:" "$ai_output" | tail -1 \
               | sed -E "s|^\**[^:]*:\**[[:space:]]*||" \
               | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1
           }
+          extract_team() {
+            local key="$1"
+            grep -iE "^\**${key}:" "$ai_output" | tail -1 \
+              | sed -E "s|^\**[^:]*:\**[[:space:]]*||" \
+              | grep -oE '[A-Za-z0-9][A-Za-z0-9/-]*' | head -1
+          }
 
-          owner=$(extract "Recommended reviewer")
-          affinity=$(extract "Affinity reviewer")
-          global=$(extract "Global reviewer")
+          owner=$(extract_user "Recommended reviewer")
+          affinity=$(extract_user "Affinity reviewer")
+          global=$(extract_team "Global reviewer")
           author=$(gh pr view "$PR" -R "$REPO" --json author -q '.author.login' 2>/dev/null || true)
 
           assign_user() {
@@ -167,15 +177,15 @@ jobs:
             exit 0
           fi
 
-          extract() {
+          extract_user() {
             local key="$1"
             grep -iE "^\**${key}:" "$ai_output" | tail -1 \
               | sed -E "s|^\**[^:]*:\**[[:space:]]*||" \
               | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1
           }
 
-          owner=$(extract "Recommended reviewer")
-          affinity=$(extract "Affinity reviewer")
+          owner=$(extract_user "Recommended reviewer")
+          affinity=$(extract_user "Affinity reviewer")
           # De-dup + drop empty/none, preserve owner-before-affinity order.
           reviewers=$(printf '%s\n%s\n' "$owner" "$affinity" \
             | awk 'NF && $0!="none" && !seen[$0]++')

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -78,30 +78,78 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # The skill runs inside claude-cli docker where `gh` is unavailable,
-          # so it can only print "Recommended reviewer: <login>" and asks for
-          # manual assignment. Host runner has `gh` + GITHUB_TOKEN, so attach
-          # the reviewer here instead. Idempotent: gh ignores duplicates.
+          # so it can only print recommendation lines and asks for manual
+          # assignment. Host runner has `gh` + GITHUB_TOKEN, so attach the
+          # reviewers here instead. Idempotent: gh ignores duplicates.
+          #
+          # The skill (starrocks-skills/starrocks-assign-pr-reviewer) emits up
+          # to three lines (see SKILL.md "Output Template"):
+          #   Recommended reviewer: <owner login | none>
+          #   Affinity reviewer: <login | none>
+          #   Global reviewer: <team slug | none>
+          # Assign every non-"none" output. The first two are individual logins;
+          # "Global reviewer" is a team and `gh` requires the org/team form.
           ai_output="${RUNNER_TEMP}/ai_output.txt"
           if [ ! -f "$ai_output" ]; then
             echo "no ai_output, skip"
             exit 0
           fi
-          reviewer=$(grep -iE '^\**Recommended reviewer:' "$ai_output" | tail -1 \
-            | sed -E 's/^\**[Rr]ecommended reviewer:\**[[:space:]]*//' \
-            | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1 || true)
-          if [ -z "$reviewer" ] || [ "$reviewer" = "none" ]; then
-            echo "no reviewer extracted, skip"
-            exit 0
-          fi
-          # Self-review guard: GitHub rejects request-review from the PR author.
+
+          extract() {
+            # $1 is the literal field label (without trailing colon).
+            # LLM may wrap the line or value in **bold**; strip leading * and
+            # then keep only valid GitHub login chars (so @, backticks, quotes
+            # all get dropped).
+            local key="$1"
+            grep -iE "^\**${key}:" "$ai_output" | tail -1 \
+              | sed -E "s|^\**[^:]*:\**[[:space:]]*||" \
+              | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1
+          }
+
+          owner=$(extract "Recommended reviewer")
+          affinity=$(extract "Affinity reviewer")
+          global=$(extract "Global reviewer")
           author=$(gh pr view "$PR" -R "$REPO" --json author -q '.author.login' 2>/dev/null || true)
-          if [ -n "$author" ] && [ "$reviewer" = "$author" ]; then
-            echo "skip: recommended reviewer ($reviewer) is the PR author"
-            exit 0
+
+          assign_user() {
+            local r="$1"
+            if [ -z "$r" ] || [ "$r" = "none" ]; then
+              return
+            fi
+            # Self-review guard: GitHub rejects request-review from the author.
+            if [ -n "$author" ] && [ "$r" = "$author" ]; then
+              echo "skip: $r is the PR author"
+              return
+            fi
+            echo "Assigning user: $r"
+            gh pr edit "$PR" -R "$REPO" --add-reviewer "$r" \
+              || echo "WARN: add-reviewer $r failed (permissions, already a reviewer, or transient API error)"
+          }
+
+          assign_team() {
+            local t="$1"
+            if [ -z "$t" ] || [ "$t" = "none" ]; then
+              return
+            fi
+            # gh expects team form `org/team-slug`. If the skill already emits
+            # a qualified form, use it as-is; otherwise default to the org.
+            case "$t" in
+              */*) ;;
+              *)   t="StarRocks/$t" ;;
+            esac
+            echo "Assigning team: $t"
+            gh pr edit "$PR" -R "$REPO" --add-reviewer "$t" \
+              || echo "WARN: add-reviewer $t failed (permissions, already a reviewer, or transient API error)"
+          }
+
+          assign_user "$owner"
+          # De-dup: if affinity == owner, the second call would be a no-op API
+          # round-trip; skip it locally for clarity.
+          if [ -n "$affinity" ] && [ "$affinity" = "$owner" ]; then
+            affinity=""
           fi
-          echo "Assigning reviewer: $reviewer"
-          gh pr edit "$PR" -R "$REPO" --add-reviewer "$reviewer" \
-            || echo "WARN: gh pr edit --add-reviewer failed (permissions, already a reviewer, or transient API error)"
+          assign_user "$affinity"
+          assign_team "$global"
 
       - name: Notify Slack
         env:
@@ -117,20 +165,37 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool
           cd ci-tool && git pull
 
-          # Parse the primary reviewer from the skill's output.
-          # The skill prints: "Recommended reviewer: <login>"
-          # (see starrocks-skills/starrocks-assign-pr-reviewer/SKILL.md "Output Template").
-          # The LLM often wraps the line/value in markdown bold or italics
-          # (e.g. **Recommended reviewer: kevincai**, Recommended reviewer: **kevincai**).
-          # Tolerate optional leading *, then extract only valid GitHub login chars
-          # ([A-Za-z0-9-]) to drop @, **, backticks, etc.
+          # Parse owner + affinity reviewers from the skill output. The skill
+          # (starrocks-skills/starrocks-assign-pr-reviewer/SKILL.md "Output
+          # Template") emits:
+          #   Recommended reviewer: <owner login | none>
+          #   Affinity reviewer: <login | none>
+          #   Global reviewer: <team slug | none>
+          # Slack-mention both individuals. "Global reviewer" is intentionally
+          # skipped here -- it is a team, and member_slack.json is keyed by
+          # individual login, so we cannot resolve a Slack user-group ID.
+          # The LLM may wrap the line/value in markdown (e.g.
+          # **Recommended reviewer: kevincai**, Recommended reviewer:
+          # **kevincai**); tolerate optional leading * and extract only valid
+          # GitHub login chars to drop @, **, backticks, quotes.
           ai_output="${RUNNER_TEMP}/ai_output.txt"
-          reviewers=""
-          if [ -f "$ai_output" ]; then
-            reviewers=$(grep -iE '^\**Recommended reviewer:' "$ai_output" | tail -1 \
-              | sed -E 's/^\**[Rr]ecommended reviewer:\**[[:space:]]*//' \
-              | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1 || true)
+          if [ ! -f "$ai_output" ]; then
+            echo "no ai_output, skip Slack notification"
+            exit 0
           fi
+
+          extract() {
+            local key="$1"
+            grep -iE "^\**${key}:" "$ai_output" | tail -1 \
+              | sed -E "s|^\**[^:]*:\**[[:space:]]*||" \
+              | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1
+          }
+
+          owner=$(extract "Recommended reviewer")
+          affinity=$(extract "Affinity reviewer")
+          # De-dup + drop empty/none, preserve owner-before-affinity order.
+          reviewers=$(printf '%s\n%s\n' "$owner" "$affinity" \
+            | awk 'NF && $0!="none" && !seen[$0]++')
 
           if [ -z "$reviewers" ]; then
             echo "Could not extract AI-assigned reviewers from output, skip Slack notification"

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -109,10 +109,16 @@ jobs:
               return
             fi
             # gh expects team form `org/team-slug`. If the skill already emits
-            # a qualified form, use it as-is; otherwise default to the org.
+            # a qualified form, use it as-is; otherwise scope to the current
+            # repo's org. This file is synced to both StarRocks/starrocks and
+            # CelerData/celerdata-enterprise, and each org has its own
+            # `global-reviewer` team -- StarRocks/global-reviewer vs
+            # CelerData/global-reviewer. Hardcoding one org would route the
+            # wrong team in the other repo, so derive org from $REPO
+            # (`<owner>/<repo>`) at runtime.
             case "$t" in
               */*) ;;
-              *)   t="StarRocks/$t" ;;
+              *)   t="${REPO%%/*}/${t}" ;;
             esac
             echo "Assigning team: $t"
             gh pr edit "$PR" -R "$REPO" --add-reviewer "$t" \

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -27,29 +27,6 @@ jobs:
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-')
     steps:
-      - name: Sync skills to latest
-        run: |
-          set -e
-          SKILL_REPO="$HOME/starrocks-skills"
-          SKILL_DEST="$HOME/.claude/skills"
-
-          if [ -d "$SKILL_REPO/.git" ]; then
-            cd "$SKILL_REPO" && git pull --ff-only --quiet \
-              || echo "WARN: git pull failed, using current checkout"
-          else
-            echo "WARN: $SKILL_REPO is not a git checkout, skip pull"
-          fi
-
-          mkdir -p "$SKILL_DEST"
-          for skill_dir in "$SKILL_REPO"/*/; do
-            [ -d "$skill_dir" ] || continue
-            name=$(basename "$skill_dir")
-            rsync -a --delete "$skill_dir" "$SKILL_DEST/$name/"
-          done
-
-          echo "Skills synced to $SKILL_DEST:"
-          ls -1 "$SKILL_DEST"
-
       - name: Recommend Reviewer (AI)
         run: |
           echo "=== DEBUG ==="


### PR DESCRIPTION
## Why I'm doing:

The `starrocks-assign-pr-reviewer` skill in
[StarRocks/starrocks-skills](https://github.com/StarRocks/starrocks-skills/tree/main/starrocks-assign-pr-reviewer)
now emits **three** reviewer lines (see SKILL.md "Output Template"):

```
Recommended reviewer: <owner login | none>
Affinity reviewer:    <login | none>
Global reviewer:      <team slug | none>
```

But `.github/workflows/ai-sr-skills.yml` was written when the skill only
emitted the first line, so today the workflow silently drops the
affinity reviewer and the `global-reviewer` team. PRs that the skill
judges to need two engineering reviewers plus broad project
coordination end up with only one reviewer attached, and the Slack
notification only mentions one person.

## What I'm doing:

Refactor the **Apply Reviewer** and **Notify Slack** steps in
`.github/workflows/ai-sr-skills.yml` to consume all three outputs:

- Share a single `extract` helper that tolerates LLM markdown noise
  (e.g. `**Recommended reviewer:** kevincai`, `Affinity reviewer:
  **stdpain**`) by stripping leading `*`s and keeping only valid GitHub
  login chars.
- **Apply Reviewer**: assign owner + affinity (individuals) **and**
  global (team). The self-review guard runs per individual; team form
  is normalized to `org/team-slug` (e.g. `global-reviewer` →
  `StarRocks/global-reviewer`) before calling `gh pr edit`.
- **Notify Slack**: @ owner + affinity (de-duplicated). The global
  team is intentionally not @-mentioned in Slack -- `conf/member_slack.json`
  is keyed by individual GitHub login and has no team mapping. The team
  is still attached on the PR itself via the Apply Reviewer step.

`none` outputs and missing lines are skipped, preserving the existing
docs-only / test-only PR behavior where the skill outputs
`Recommended reviewer: none` and no engineering reviewer is recommended.

Tested the extract helper locally against three variants of the
skill's output (clean, bold-wrapped lines/values, partial outputs);
all parse correctly.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5