### PR TITLE
[BugFix] Heal version chain when cancelling lake index fast-path alter in FINISHED_REWRITING

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -382,9 +382,52 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
 
     @Override
     protected boolean cancelImpl(String errMsg) {
+        return cancelImpl(errMsg, false);
+    }
+
+    @Override
+    protected boolean cancelImpl(String errMsg, boolean force) {
         if (jobState.isFinalState()) {
             return false;
         }
+
+        // A job sitting in FINISHED_REWRITING has already reserved a commit
+        // version V per partition and bumped nextVersion to V+1 (see
+        // updateNextVersion at the FINISHED_REWRITING transition), but has NOT
+        // yet published V to BE. Cancelling here without healing the version
+        // chain leaves a hole at V: the table flips back to NORMAL, the next
+        // load commits at V+1, its publish base is V, and BE can never
+        // materialize tablet_metadata_<V> for the discarded alter — so
+        // subsequent loads hang on publish forever. Mirror the sibling lake
+        // alter jobs (LakeTableAlterMetaJobBase, LakeTableSchemaChangeJob):
+        //   - a non-force cancel in FINISHED_REWRITING is REFUSED; the operator
+        //     must opt in via ADMIN SKIP COMMITTED TRANSACTION (force=true);
+        //   - a force cancel performs a no-op publish that writes V (V-1
+        //     content tagged as V) on BE, then advances FE's VisibleVersion to
+        //     V before releasing the table back to NORMAL.
+        boolean tableStillExists = tableExists();
+        if (jobState == JobState.FINISHED_REWRITING && tableStillExists && !force) {
+            return false;
+        }
+
+        boolean advanceVersionForForce = force && jobState == JobState.FINISHED_REWRITING && tableStillExists;
+        if (advanceVersionForForce) {
+            if (!lakePublishVersionWithSkip(errMsg)) {
+                // The no-op publish RPC failed; leave the job in
+                // FINISHED_REWRITING so the operator can retry
+                // CANCEL ALTER ... FORCE once whatever made the RPC fail
+                // (network, BE down, ...) is resolved.
+                return false;
+            }
+            // Mark force-skipped ONLY now that the no-op publish has actually
+            // advanced the partition version on BE. Set BEFORE the
+            // persistStateChange below so copyForPersist snapshots it into the
+            // edit log and replay re-applies the matching VisibleVersion bump.
+            // A force-cancel that never reached FINISHED_REWRITING does not get
+            // here, so the marker stays false and replay won't bump versions.
+            forceSkippedAtCommitted = true;
+        }
+
         if (batchTask != null) {
             for (AgentTask task : batchTask.getAllTasks()) {
                 AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.ALTER, task.getSignature());
@@ -392,7 +435,11 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
         }
         this.errMsg = errMsg == null ? "" : errMsg;
         this.finishedTimeMs = System.currentTimeMillis();
-        // Reset table state so subsequent alters are not blocked.
+        // Reset table state so subsequent alters are not blocked, and — for a
+        // force-cancel out of FINISHED_REWRITING — advance VisibleVersion to
+        // match the no-op publish. Both mutations are journaled atomically with
+        // the CANCELLED state (inside persistStateChange) so a replayed FE
+        // reproduces them identically via the CANCELLED replay branch.
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
             Locker locker = new Locker();
@@ -400,16 +447,90 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
             try {
                 OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                         .getTable(db.getId(), tableId);
-                if (table != null && table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE) {
-                    table.setState(OlapTable.OlapTableState.NORMAL);
-                }
+                persistStateChange(this, JobState.CANCELLED, () -> {
+                    if (table != null) {
+                        if (advanceVersionForForce) {
+                            advanceVisibleVersionForForceSkip(table, commitVersionMap);
+                        }
+                        if (table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE) {
+                            table.setState(OlapTable.OlapTableState.NORMAL);
+                        }
+                    }
+                });
             } finally {
                 locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
             }
+        } else {
+            persistStateChange(this, JobState.CANCELLED);
         }
-        persistStateChange(this, JobState.CANCELLED);
-        LOG.info("index fast-path job {} cancelled: {}", jobId, errMsg);
+        LOG.info("index fast-path job {} cancelled (force={}): {}", jobId, force, errMsg);
         return true;
+    }
+
+    /** True iff this job's database and table both still exist in the catalog. */
+    private boolean tableExists() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            return false;
+        }
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId) != null;
+    }
+
+    /**
+     * No-op publish for the CANCEL ALTER TABLE ... FORCE escape hatch. Sends a
+     * publish_version RPC with {@code TxnInfoPB.no_op_publish=true} at the
+     * alter's reserved commitVersion for every tablet the job published over
+     * ({@code getAllMaterializedIndices(VISIBLE)} per partition in
+     * {@code commitVersionMap}). BE short-circuits the txn-log apply path and
+     * writes V-1 content tagged as version V, so the partition version chain
+     * advances past the cancelled alter without including any of its changes.
+     *
+     * <p>The index fast path has no shadow tablets and no rowsets to roll back,
+     * so it publishes its own dirty (visible) indices directly. Dispatch is
+     * keyed on the table's CURRENT file-bundling format (read fresh here, NOT a
+     * cached field) so V is written in the format subsequent loads expect —
+     * mirroring {@link LakeTableAlterMetaJobBase#lakePublishVersionWithSkip} and
+     * {@link LakeTableSchemaChangeJob#lakePublishVersionWithSkip}.
+     *
+     * <p>Returns false if any RPC fails or throws; the caller then leaves the
+     * job at FINISHED_REWRITING so the operator can retry CANCEL ... FORCE.
+     */
+    protected boolean lakePublishVersionWithSkip(String reason) {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            // db gone: nothing to advance.
+            return true;
+        }
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getId(), tableId);
+        if (table == null) {
+            // table gone: nothing to advance.
+            return true;
+        }
+        boolean useAggregatePublish = table.isFileBundling();
+        Map<Long, List<Tablet>> tabletsByPartition = new HashMap<>();
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
+        try {
+            for (Long ppId : commitVersionMap.keySet()) {
+                PhysicalPartition pp = table.getPhysicalPartition(ppId);
+                if (pp == null) {
+                    // partition gone (concurrent drop); nothing to advance, skip.
+                    continue;
+                }
+                List<Tablet> tablets = new ArrayList<>();
+                for (MaterializedIndex idx : pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                    tablets.addAll(idx.getTablets());
+                }
+                tabletsByPartition.put(ppId, tablets);
+            }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
+        }
+        // The index fast path's normal publish does not use a gtid (its TxnInfoPB
+        // leaves gtid=0), so pass 0 here for consistency.
+        return Utils.noOpPublishForForceSkip(jobId, reason, watershedTxnId, /*watershedGtid=*/ 0L,
+                commitVersionMap, tabletsByPartition, computeResource, useAggregatePublish);
     }
 
     @Override
@@ -454,6 +575,12 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
         this.commitVersionMap = other.commitVersionMap;
         this.errMsg = other.errMsg;
         this.finishedTimeMs = other.finishedTimeMs;
+        // FORCE-cancel audit marker. Must be copied here so the CANCELLED branch
+        // below (which reads this.forceSkippedAtCommitted) sees the persisted
+        // value when replaying onto an in-memory job loaded from a pre-cancel
+        // image. Without this copy the VisibleVersion bump is silently skipped
+        // on recovery — defeating the force-cancel version-chain repair.
+        this.forceSkippedAtCommitted = other.forceSkippedAtCommitted;
 
         // Edit-log entries persist AlterJobV2 state but NOT the OlapTable's
         // state. After a cold start, the table's state must be re-derived
@@ -530,6 +657,17 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
                 // reproduce that bump on replay too (no-op when the job was
                 // cancelled before reserving, since commitVersionMap is empty).
                 replayUpdateNextVersion(table);
+                // If the live force-cancel performed the no-op publish that wrote
+                // tablet_metadata at commitVersion on BE (forceSkippedAtCommitted),
+                // the live path also advanced partition.VisibleVersion to match.
+                // Replay must do the SAME bump via the SAME shared helper, otherwise
+                // an FE recovering from a pre-cancel image keeps
+                // VisibleVersion=commitVersion-1 and the next load's publish computes
+                // its base from the wrong version. No-op when the marker is false
+                // (a cancel that never reached FINISHED_REWRITING never published).
+                if (forceSkippedAtCommitted) {
+                    advanceVisibleVersionForForceSkip(table, commitVersionMap);
+                }
                 table.setState(OlapTable.OlapTableState.NORMAL);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -405,12 +405,21 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
         //   - a force cancel performs a no-op publish that writes V (V-1
         //     content tagged as V) on BE, then advances FE's VisibleVersion to
         //     V before releasing the table back to NORMAL.
+        // commitVersionMap is populated at the RUNNING -> FINISHED_REWRITING
+        // transition, so a live FINISHED_REWRITING job always has it. Guard
+        // defensively anyway: a job deserialized via the copy ctor / replay may
+        // carry a null (or empty) map, and with no reserved version there is no
+        // version-chain hole to heal — so skip the special handling entirely
+        // (refuse nothing, publish nothing) rather than NPE in
+        // lakePublishVersionWithSkip's commitVersionMap.keySet().
+        boolean hasReservedVersion = commitVersionMap != null && !commitVersionMap.isEmpty();
         boolean tableStillExists = tableExists();
-        if (jobState == JobState.FINISHED_REWRITING && tableStillExists && !force) {
+        if (jobState == JobState.FINISHED_REWRITING && tableStillExists && hasReservedVersion && !force) {
             return false;
         }
 
-        boolean advanceVersionForForce = force && jobState == JobState.FINISHED_REWRITING && tableStillExists;
+        boolean advanceVersionForForce =
+                force && jobState == JobState.FINISHED_REWRITING && tableStillExists && hasReservedVersion;
         if (advanceVersionForForce) {
             if (!lakePublishVersionWithSkip(errMsg)) {
                 // The no-op publish RPC failed; leave the job in

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3173,8 +3173,18 @@ public class SchemaChangeHandler extends AlterHandler {
         // createReplicaLatch before entering the synchronized block — applying
         // it to a PENDING shared-nothing alter would hang until task timeout.
         // Reject up front rather than silently degrade.
+        //
+        // LakeTableIndexFastPathJobBase (lake ADD/DROP INDEX fast path) is the
+        // third lake alter family with a FINISHED_REWRITING publish-stuck mode:
+        // it reserves a commit version and bumps nextVersion at that transition,
+        // so a stuck publish leaves the same version-chain hole the other two
+        // heal on force-cancel. It extends AlterJobV2 directly (not the two bases
+        // above) and has no createReplicaLatch pre-work, so routing it through
+        // the two-arg cancel path is safe. Without it in this allowlist the
+        // fast-path job's force-cancel heal path is unreachable from SQL.
         if (force && !(schemaChangeJobV2 instanceof LakeTableSchemaChangeJobBase
-                || schemaChangeJobV2 instanceof LakeTableAlterMetaJobBase)) {
+                || schemaChangeJobV2 instanceof LakeTableAlterMetaJobBase
+                || schemaChangeJobV2 instanceof LakeTableIndexFastPathJobBase)) {
             throw new DdlException(
                     "CANCEL ALTER TABLE ... FORCE is only supported on shared-data (lake) tables. "
                             + "For shared-nothing tables, use the regular CANCEL ALTER TABLE syntax.");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
@@ -275,6 +275,204 @@ public class LakeTableIndexFastPathJobBaseTest {
         }
     }
 
+    @Test
+    public void testCancelImpl_FinishedRewriting_NonForceRefused() throws Exception {
+        // A non-force cancel out of FINISHED_REWRITING must be REFUSED: the job
+        // has reserved commit version V and bumped nextVersion to V+1 but not
+        // yet published V. Releasing the table here would leave a version-chain
+        // hole that hangs subsequent loads on publish. The operator must use the
+        // force escape hatch instead.
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "jobState", AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        GlobalStateMgr gsm = buildLockableGsm(db, table);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            assertFalse(job.cancelImpl("err", false));
+            // Still in FINISHED_REWRITING; table never released to NORMAL.
+            assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+            verify(table, never()).setState(OlapTable.OlapTableState.NORMAL);
+            assertFalse(job.isForceSkippedAtCommitted());
+        }
+    }
+
+    @Test
+    public void testCancelImpl_FinishedRewriting_ForceHealsVersionChain() throws Exception {
+        // A force cancel out of FINISHED_REWRITING must no-op publish the reserved
+        // commit version V on BE and advance FE's VisibleVersion to V before
+        // releasing the table, so the version chain is healthy when new loads
+        // race in. visibleVersion V-1 -> V.
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "jobState", AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.getState()).thenReturn(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        when(table.isFileBundling()).thenReturn(false);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        MaterializedIndex idx = mock(MaterializedIndex.class);
+        when(idx.getTablets()).thenReturn(new ArrayList<>());
+        when(pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idx));
+        when(pp.getVisibleVersion()).thenReturn(4L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        GlobalStateMgr gsm = buildLockableGsm(db, table);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.noOpPublishForForceSkip(anyLong(), any(), anyLong(), anyLong(),
+                    any(), any(), any(), anyBoolean())).thenReturn(true);
+
+            assertTrue(job.cancelImpl("force skip", true));
+
+            assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+            assertTrue(job.isForceSkippedAtCommitted());
+            // VisibleVersion advanced V-1 (4) -> V (5); table released.
+            verify(pp).setVisibleVersion(eq(5L), anyLong());
+            verify(table).setState(OlapTable.OlapTableState.NORMAL);
+        }
+    }
+
+    @Test
+    public void testCancelImpl_FinishedRewriting_ForcePublishFailsStaysRewriting() throws Exception {
+        // If the no-op publish RPC fails, the force cancel must NOT proceed:
+        // leave the job in FINISHED_REWRITING so the operator can retry, and do
+        // not mark it force-skipped (replay must not bump VisibleVersion).
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "jobState", AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.isFileBundling()).thenReturn(false);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        MaterializedIndex idx = mock(MaterializedIndex.class);
+        when(idx.getTablets()).thenReturn(new ArrayList<>());
+        when(pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idx));
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        GlobalStateMgr gsm = buildLockableGsm(db, table);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.noOpPublishForForceSkip(anyLong(), any(), anyLong(), anyLong(),
+                    any(), any(), any(), anyBoolean())).thenReturn(false);
+
+            assertFalse(job.cancelImpl("force skip", true));
+
+            assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+            assertFalse(job.isForceSkippedAtCommitted());
+            verify(pp, never()).setVisibleVersion(anyLong(), anyLong());
+            verify(table, never()).setState(OlapTable.OlapTableState.NORMAL);
+        }
+    }
+
+    @Test
+    public void testCancelImpl_FinishedRewriting_NonForceTableDroppedStillCancels() throws Exception {
+        // The FINISHED_REWRITING refusal only applies while the table still
+        // exists (&& tableStillExists). If the table was dropped, there is no
+        // version chain to heal, so even a non-force cancel must proceed.
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "jobState", AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        GlobalStateMgr gsm = buildLockableGsm(db, null); // table dropped
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            assertTrue(job.cancelImpl("err", false));
+            assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+            assertFalse(job.isForceSkippedAtCommitted());
+        }
+    }
+
+    @Test
+    public void testCancelImpl_FinishedRewriting_ForceTableDroppedSkipsPublish() throws Exception {
+        // Force cancel with the table already dropped: no no-op publish, no
+        // VisibleVersion bump, marker stays false, job still cancels. Utils must
+        // never be touched.
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "jobState", AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        GlobalStateMgr gsm = buildLockableGsm(db, null); // table dropped
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            assertTrue(job.cancelImpl("force skip", true));
+            assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+            assertFalse(job.isForceSkippedAtCommitted());
+            utilsStatic.verify(() -> Utils.noOpPublishForForceSkip(anyLong(), any(), anyLong(), anyLong(),
+                    any(), any(), any(), anyBoolean()), never());
+        }
+    }
+
+    @Test
+    public void testLakePublishVersionWithSkip_FileBundlingDispatchesAggregate() throws Exception {
+        // The no-op publish must be keyed on the table's CURRENT file-bundling
+        // format so V is written in the format subsequent loads expect:
+        // isFileBundling()==true -> useAggregatePublish=true is passed through.
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "jobState", AlterJobV2.JobState.FINISHED_REWRITING);
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.getState()).thenReturn(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        when(table.isFileBundling()).thenReturn(true);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        MaterializedIndex idx = mock(MaterializedIndex.class);
+        when(idx.getTablets()).thenReturn(new ArrayList<>());
+        when(pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idx));
+        when(pp.getVisibleVersion()).thenReturn(4L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        GlobalStateMgr gsm = buildLockableGsm(db, table);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.noOpPublishForForceSkip(anyLong(), any(), anyLong(), anyLong(),
+                    any(), any(), any(), anyBoolean())).thenReturn(true);
+
+            assertTrue(job.cancelImpl("force skip", true));
+
+            // useAggregatePublish (last arg) must be true for a file-bundling table.
+            utilsStatic.verify(() -> Utils.noOpPublishForForceSkip(anyLong(), any(), anyLong(), anyLong(),
+                    any(), any(), any(), eq(true)), times(1));
+        }
+    }
+
+    @Test
+    public void testCopyForPersist_PreservesForceSkippedMarker() throws Exception {
+        // The force-skip marker must survive copyForPersist() so it is captured
+        // in the edit log / image and replay can reproduce the VisibleVersion
+        // bump. Locks the persist link that the replay tests rely on.
+        LakeTableAddIndexJob job = newJob();
+        setField(job, "forceSkippedAtCommitted", true);
+        AlterJobV2 copy = job.copyForPersist();
+        assertTrue(copy.isForceSkippedAtCommitted());
+    }
+
     // -------- replay --------
 
     private LakeTableAddIndexJob makeReplayDriver(AlterJobV2.JobState state) throws Exception {
@@ -473,6 +671,59 @@ public class LakeTableIndexFastPathJobBaseTest {
         LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.CANCELLED);
         OlapTable table = mock(OlapTable.class);
         runReplay(target, other, new Database(2L, "db"), table);
+        verify(table).setState(OlapTable.OlapTableState.NORMAL);
+    }
+
+    @Test
+    public void testReplay_CancelledForceSkippedAdvancesVisibleVersion() throws Exception {
+        // A job force-cancelled out of FINISHED_REWRITING no-op published V on BE
+        // and the live path advanced VisibleVersion to V. Replay must reproduce
+        // BOTH the nextVersion bump and the VisibleVersion bump (forceSkipped
+        // marker copied from the persisted job), so a recovered FE matches the
+        // leader byte-for-byte.
+        LakeTableAddIndexJob target = newJob();
+        LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.CANCELLED);
+        Map<Long, Long> commitMap = new HashMap<>();
+        commitMap.put(100L, 5L);
+        setField(other, "commitVersionMap", commitMap);
+        setField(other, "forceSkippedAtCommitted", true);
+        setField(other, "finishedTimeMs", 12345L);
+
+        OlapTable table = mock(OlapTable.class);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        when(pp.getNextVersion()).thenReturn(5L);
+        when(pp.getVisibleVersion()).thenReturn(4L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        runReplay(target, other, new Database(2L, "db"), table);
+
+        assertTrue(target.isForceSkippedAtCommitted());
+        verify(pp).setNextVersion(6L);
+        verify(pp).setVisibleVersion(5L, 12345L);
+        verify(table).setState(OlapTable.OlapTableState.NORMAL);
+    }
+
+    @Test
+    public void testReplay_CancelledNotForceSkippedSkipsVisibleVersion() throws Exception {
+        // A cancel that never reached FINISHED_REWRITING (forceSkipped=false)
+        // must NOT advance VisibleVersion on replay — only the nextVersion bump
+        // (no-op when commitVersionMap is empty) and the NORMAL flip.
+        LakeTableAddIndexJob target = newJob();
+        LakeTableAddIndexJob other = makeReplayDriver(AlterJobV2.JobState.CANCELLED);
+        Map<Long, Long> commitMap = new HashMap<>();
+        commitMap.put(100L, 5L);
+        setField(other, "commitVersionMap", commitMap);
+
+        OlapTable table = mock(OlapTable.class);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        when(pp.getNextVersion()).thenReturn(5L);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        runReplay(target, other, new Database(2L, "db"), table);
+
+        assertFalse(target.isForceSkippedAtCommitted());
+        verify(pp).setNextVersion(6L);
+        verify(pp, never()).setVisibleVersion(anyLong(), anyLong());
         verify(table).setState(OlapTable.OlapTableState.NORMAL);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
@@ -179,6 +179,52 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
         verify(table, never()).setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
     }
 
+    @Test
+    public void testFastPathJobsAreInForceCancelAllowlist() throws Exception {
+        // Regression for the FORCE dispatch gap: SchemaChangeHandler.cancel()
+        // only routes CANCEL ALTER TABLE ... FORCE into cancel(reason, true)
+        // when the job is an instanceof LakeTableSchemaChangeJobBase,
+        // LakeTableAlterMetaJobBase, OR LakeTableIndexFastPathJobBase. The
+        // fast-path ADD/DROP INDEX jobs reserve a commit version at
+        // FINISHED_REWRITING and heal the version chain only on force-cancel,
+        // so they MUST match the third predicate — otherwise their heal path
+        // is unreachable from SQL and a publish-stuck job can never be cleared.
+        // Build the real jobs through the handler and assert the allowlist
+        // predicate holds for the concrete subclasses.
+        SchemaChangeHandler handler = newHandler();
+
+        OlapTable addTable = stubLakeTable("c1");
+        IndexDef addDef = new IndexDef("ix_a", Collections.singletonList("c1"),
+                IndexDef.IndexType.BITMAP, "", new HashMap<>());
+        Method addBuilder = privateMethod("tryBuildLakeAddIndexJob", Database.class, OlapTable.class, List.class);
+
+        Index existing = new Index(101L, "ix_a", Collections.singletonList(ColumnId.create("c1")),
+                IndexDef.IndexType.BITMAP, "", new HashMap<>());
+        OlapTable dropTable = stubLakeTable("c1");
+        when(dropTable.getIndexes()).thenReturn(new ArrayList<>(Collections.singletonList(existing)));
+        Method dropBuilder = privateMethod("tryBuildLakeDropIndexJob", Database.class, OlapTable.class, List.class);
+
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> rmStatic = Mockito.mockStatic(RunMode.class)) {
+            // Build the gsm mock fully BEFORE passing it to thenReturn: stubGsm()
+            // does its own when()/thenReturn stubbing, which must not run nested
+            // inside the outer thenReturn(...) call (Mockito UnfinishedStubbing).
+            GlobalStateMgr gsm = stubGsm();
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            rmStatic.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
+
+            Object addJob = invoke(addBuilder, handler, stubDb(), addTable,
+                    Collections.<AlterClause>singletonList(new CreateIndexClause(addDef)));
+            Object dropJob = invoke(dropBuilder, handler, stubDb(), dropTable,
+                    Collections.<AlterClause>singletonList(new DropIndexClause("ix_a")));
+
+            assertTrue(addJob instanceof LakeTableIndexFastPathJobBase,
+                    "ADD INDEX fast-path job must be in the FORCE-cancel allowlist family");
+            assertTrue(dropJob instanceof LakeTableIndexFastPathJobBase,
+                    "DROP INDEX fast-path job must be in the FORCE-cancel allowlist family");
+        }
+    }
+
     // ============================================================
     // tryBuildLakeDropIndexJob
     // ============================================================


### PR DESCRIPTION
## Why I'm doing:

Cancelling a lake-table index fast-path `ALTER TABLE ... ADD/DROP INDEX` (handled by `LakeTableIndexFastPathJobBase` on shared-data tables) while the job is in `FINISHED_REWRITING` corrupts the version chain and **hangs all subsequent loads on that table forever**.

On `RUNNING -> FINISHED_REWRITING` the job reserves a commit version `V` for each partition and bumps `nextVersion` to `V+1`, but `V` is **not yet published to BE** and FE `visibleVersion` is still `V-1`. If the job is cancelled in `FINISHED_REWRITING` — which can happen **without any manual force-cancel**, e.g. a publish timeout in `runFinishedRewritingJob` throws `AlterCancelException` and auto-cancels via `run()` — the fast-path cancel releases the table straight back to `NORMAL` without a no-op publish and without advancing `visibleVersion`. This leaves `nextVersion=V+1`, `visibleVersion=V-1`, and no `tablet_metadata_<V>` on BE. Later loads commit at `V+1` whose publish base is the missing `V`, so they can never publish and hang in `COMMITTED`.

`LakeTableIndexFastPathJobBase` is the only lake `AlterJobV2` subclass missing the guard that its siblings `LakeTableAlterMetaJobBase` and `LakeTableSchemaChangeJob` already implement (and which their code comments document as introduced precisely to avoid this measured failure).

## What I'm doing:

Mirror the sibling lake alter jobs' cancel handling in `LakeTableIndexFastPathJobBase`:

- Override the force-aware `cancelImpl(String errMsg, boolean force)`:
  - While in `FINISHED_REWRITING`, a non-force cancel is rejected (`return false`) — the operator must force (`ADMIN SKIP ...`).
  - A force cancel out of `FINISHED_REWRITING` first runs a no-op publish (new `lakePublishVersionWithSkip`) of the reserved version `V` for every partition's `VISIBLE` materialized-index tablets (publish format follows the table's current `isFileBundling()`), then advances `visibleVersion` to `V` via the shared `AlterJobV2.advanceVisibleVersionForForceSkip` inside the locked `persistStateChange` closure, before releasing the table to `NORMAL`. If the no-op publish RPC fails, the job stays in `FINISHED_REWRITING` for operator retry.
- Set `forceSkippedAtCommitted=true` before `persistStateChange` so `copyForPersist` records it and replay on follower FEs reproduces the same version advance, keeping leader and follower FEs consistent.

FE-only change; no on-disk format or interface change.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: cancelling a lake index fast-path alter in `FINISHED_REWRITING` now requires force (`ADMIN SKIP ...`); a force cancel performs a no-op publish + version advance to heal the version chain — bringing this job in line with the other lake alter jobs.
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
