### PR TITLE
[Tool] Fall back to compute nodes in update_be_config endpoint discovery

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3172,9 +3172,20 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         res = self.execute_sql("show backends;", ori=True)
         tools.assert_true(res["status"], res["msg"])
+        rows = list(res["result"])
+
+        # Shared-data clusters run compute nodes (possibly alongside backends);
+        # a config update must reach every worker, so take the union of both
+        # lists. On shared-nothing clusters the compute-node list is empty and
+        # behavior is unchanged.
+        res = self.execute_sql("show compute nodes;", ori=True)
+        tools.assert_true(res["status"], res["msg"])
+        rows.extend(res["result"])
+
+        tools.assert_true(len(rows) > 0, "no backends or compute nodes found")
 
         backends = []
-        for row in res["result"]:
+        for row in rows:
             backends.append(
                 {
                     "host": row[1],


### PR DESCRIPTION
## Why I'm doing:
On shared-data clusters all nodes are compute nodes: `SHOW BACKENDS` returns zero
rows, so `update_be_config()` in the SQL-test framework iterates an empty endpoint
list and silently succeeds as a no-op (its per-node status assert sits inside the
never-running loop). Every SQL case that flips BE configs through this helper
quietly validates default-config behavior on such clusters instead of what it
claims to test.

## What I'm doing:
Fall back to `SHOW COMPUTE NODES` in `_get_backend_http_endpoints()` when
`SHOW BACKENDS` is empty (the column layout of the two commands is identical),
and assert that at least one endpoint was found, so an empty node list fails
loudly instead of false-greening.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
