### PR TITLE
[BugFix][CVE] bump netty to 4.1.135.Final

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -60,7 +60,7 @@ subprojects {
         set("hive-apache.version", "3.1.2-22")
         set("hudi.version", "1.0.2")
         set("iceberg.version", "1.10.0")
-        set("io.netty.version", "4.1.133.Final")
+        set("io.netty.version", "4.1.135.Final")
         set("jackson.version", "2.21.1")
         set("jackson-annotations.version", "2.21")
         set("jetty.version", "9.4.57.v20241219")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -71,7 +71,7 @@ under the License.
         <kafka-clients.version>3.9.1</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
         <grpc.version>1.63.0</grpc.version>
-        <io.netty.version>4.1.133.Final</io.netty.version>
+        <io.netty.version>4.1.135.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
         <avro.version>1.12.0</avro.version>

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -51,7 +51,7 @@ under the License.
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <avro.version>1.11.4</avro.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
-        <io.netty.version>4.1.133.Final</io.netty.version>
+        <io.netty.version>4.1.135.Final</io.netty.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
         <bouncycastle.version>1.84</bouncycastle.version>
     </properties>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -42,7 +42,7 @@
         <jni-connector.version>1.0.0</jni-connector.version>
         <hadoop-ext.version>1.0.0</hadoop-ext.version>
         <java-utils.version>1.0.0</java-utils.version>
-        <io.netty.version>4.1.133.Final</io.netty.version>
+        <io.netty.version>4.1.135.Final</io.netty.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <nimbusds.version>9.37.2</nimbusds.version>
         <commons-io.version>2.14.0</commons-io.version>

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -32,5 +32,3 @@ scan:
     - "**/parquet-jackson-1.16.0.jar"
     # CVE-2026-2332, ignore for now
     - "**/jetty-http-9.4.58.v20250814.jar"
-    # CVE-2026-42577
-    - "**/netty-transport-native-epoll-4.1.133.Final*.jar"


### PR DESCRIPTION
Upgrade io.netty from 4.1.133.Final to 4.1.135.Final across all three Java trees (fe/, java-extensions/, fs_brokers/) to remediate the CVEs fixed after 4.1.133.Final:

- CVE-2026-45416 (io.netty:netty-handler, < 4.1.135): SNI handler pre-allocates up to 16 MiB from nine attacker-controlled bytes; repeated connections exhaust the Java heap (DoS).
- CVE-2026-44249 (io.netty:netty-handler, < 4.1.135): IPv6 subnet filter bypass via incorrect masking in IpSubnetFilterRule.compareTo.
- CVE-2026-45673 (io.netty:netty-resolver-dns, < 4.1.135): DNS cache poisoning due to predictable PRNG transaction IDs and a default static UDP source port.
- CVE-2026-45536 (io.netty:netty-transport-native-epoll/kqueue, < 4.1.135): unix-socket fd receive leaks descriptors when the peer sends two at once.

Netty is both a direct dependency (netty-all, netty-handler) and a transitive one (grpc, AWS SDK v2, arrow-memory-netty, Hadoop); all of them are forced to the patched version through the existing io.netty.version property and the netty-bom dependencyManagement / Gradle platform entries, so this is a property-only bump:

- fe/pom.xml: io.netty.version 4.1.133.Final -> 4.1.135.Final
- fe/build.gradle.kts: same bump in ext
- java-extensions/pom.xml: same bump
- fs_brokers/apache_hdfs_broker/src/pom.xml: same bump

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
