### PR TITLE
[BugFix][CVE] update pprof prebuilt to release/20260610 built with Go 1.25.11

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -57,7 +57,7 @@ STARCACHE_SOURCE="starcache"
 STARCACHE_MD5SUM="901cbd54823c73588a6f43e4d3b32e44"
 
 # pprof
-PPROF_DOWNLOAD="https://github.com/StarRocks/pprof/releases/download/release%2F20260520/pprof-linux-arm64"
+PPROF_DOWNLOAD="https://github.com/StarRocks/pprof/releases/download/release%2F20260610/pprof-linux-arm64"
 PPROF_NAME="pprof"
 PPROF_SOURCE="pprof"
-PPROF_MD5SUM="2787dabcc94982ee19a19439630bfd2a"
+PPROF_MD5SUM="33fc2f3b3f5d7f01ebb031749e445bbc"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -52,7 +52,7 @@ STARCACHE_SOURCE="starcache"
 STARCACHE_MD5SUM="23b115d131c8c7738c9a57c41d7b791f"
 
 # pprof
-PPROF_DOWNLOAD="https://github.com/StarRocks/pprof/releases/download/release%2F20260520/pprof-linux-amd64"
+PPROF_DOWNLOAD="https://github.com/StarRocks/pprof/releases/download/release%2F20260610/pprof-linux-amd64"
 PPROF_NAME="pprof"
 PPROF_SOURCE="pprof"
-PPROF_MD5SUM="30a62ea6859604e11c9f40efa8d9954b"
+PPROF_MD5SUM="fb2d79f0b8111e36f26785bc2503e52d"


### PR DESCRIPTION
The pprof prebuilt binaries from release/20260520 were built with Go 1.24.10, whose standard library is affected by CVEs fixed in later Go releases, notably CVE-2025-61727 and CVE-2025-61729 (crypto/x509, fixed in Go 1.24.11 / 1.25.5) and subsequent stdlib security fixes.

The release/20260610 binaries are rebuilt with Go 1.25.11, which includes all of those fixes.

Changes:
- thirdparty/vars-x86_64.sh: bump PPROF_DOWNLOAD to release/20260610 pprof-linux-amd64 and update PPROF_MD5SUM
- thirdparty/vars-aarch64.sh: bump PPROF_DOWNLOAD to release/20260610 pprof-linux-arm64 and update PPROF_MD5SUM

Both assets were downloaded and their SHA256 digests verified against the GitHub release asset digests; MD5 sums computed from the verified binaries.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
