### PR TITLE
[BugFix] FILES()/LOAD respect Parquet isAdjustedToUTC=false for INT64 timestamps (backport #73674)

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -685,19 +685,16 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, DateOrDateTimeATGuard<AT>,
             }
         } else if constexpr (at_is_datetime<AT>) {
             auto timezone = concrete_type->timezone();
-            if (timezone.empty()) {
-                // Quote from https://github.com/apache/arrow/blob/4743e181596b9ee45c6b063bcf59fdf9eb72418f/cpp/src/arrow/type.h#L1217
-
-                /// If a TimestampType is constructed without a timezone (or, equivalently, if the
-                /// timezone supplied is an empty string) then the resulting Arrow field (column) is
-                /// considered "timezone-naive".  The producer of a timezone-naive column may populate
-                /// its constituent integer arrays with datetime values from any timezone; the consumer
-                /// of a timezone-naive column should make no assumptions about the interoperability or
-                /// comparability of the values of such a column with those of any other timestamp
-                /// column or datetime value.
-
-                // When the parquet timezone is empty, populate data with runtime timezone instead.
-                timezone = ctx->state->timezone();
+            const bool is_timezone_naive = timezone.empty();
+            if (is_timezone_naive) {
+                // Arrow timezone-naive = Parquet isAdjustedToUTC=false. Per
+                // Parquet LogicalTypes.md TIMESTAMP, the value must be
+                // displayed "the same way, regardless of the local time zone
+                // in effect." Use UTC so the cctz lookup yields offset=0 and
+                // convert_datetime becomes a no-op for the wall-clock case.
+                // Matches Trino's `DateTimeZone.UTC` pattern in
+                // ColumnReaderFactory.java for the same case.
+                timezone = "UTC";
             }
 
             cctz::time_zone ctz;

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -147,8 +147,20 @@ Status ParquetReaderWrap::_init_parquet_reader() {
             auto parquet_schema = _file_metadata->schema();
             for (int i = 0; i < parquet_schema->num_columns(); i++) {
                 auto column_desc = parquet_schema->Column(i);
-                std::string field_name = column_desc->path()->ToDotVector()[0];
+                const auto dot_vector = column_desc->path()->ToDotVector();
+                const std::string& field_name = dot_vector[0];
                 _map_column_nested[field_name].push_back(i);
+                // Record top-level INT96 columns so _rectify_int96_timezone() can re-tag them
+                // as UTC instants. Arrow surfaces INT96 as timezone-naive, identical to an
+                // INT64 isAdjustedToUTC=false wall-clock column, so they are otherwise
+                // indistinguishable downstream.
+                // INT96 leaves nested inside complex types (dot_vector.size() > 1) are
+                // deliberately not re-tagged: INT96 is a legacy physical type and rarely
+                // nested, and re-tagging would require rebuilding nested ArrayData trees.
+                // Such leaves are read as wall-clock (no session-timezone shift).
+                if (dot_vector.size() == 1 && column_desc->physical_type() == ::parquet::Type::INT96) {
+                    _int96_columns.insert(field_name);
+                }
             }
         }
 
@@ -318,7 +330,45 @@ Status ParquetReaderWrap::read_record_batch(const std::vector<SlotDescriptor*>& 
     return Status::OK();
 }
 
+void ParquetReaderWrap::_rectify_int96_timezone() {
+    // _batch is guaranteed non-null by the caller: get_batch() is only reached after a
+    // successful read_record_batch()/next_batch(), which always populates _batch.
+    if (_int96_columns.empty()) {
+        return;
+    }
+    auto fields = _batch->schema()->fields();
+    auto columns = _batch->columns();
+    bool changed = false;
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (fields[i]->type()->id() != arrow::Type::TIMESTAMP) {
+            continue;
+        }
+        if (_int96_columns.find(fields[i]->name()) == _int96_columns.end()) {
+            continue;
+        }
+        auto ts_type = std::static_pointer_cast<arrow::TimestampType>(fields[i]->type());
+        if (!ts_type->timezone().empty()) {
+            continue;
+        }
+        // INT96 is a UTC-normalized instant but Arrow decodes it as timezone-naive. Tag it as
+        // UTC so the downstream converter overrides it with the session timezone and shifts the
+        // value (matching the native parquet reader's Int96ToDateTimeConverter), instead of
+        // treating it as a wall-clock INT64 isAdjustedToUTC=false column. The underlying int64
+        // buffer is shared unchanged; only the Arrow type metadata gains the "UTC" zone.
+        auto utc_type = arrow::timestamp(ts_type->unit(), "UTC");
+        auto data = columns[i]->data()->Copy();
+        data->type = utc_type;
+        columns[i] = arrow::MakeArray(data);
+        fields[i] = fields[i]->WithType(utc_type);
+        changed = true;
+    }
+    if (changed) {
+        _batch = arrow::RecordBatch::Make(arrow::schema(fields), _batch->num_rows(), columns);
+    }
+}
+
 const std::shared_ptr<arrow::RecordBatch>& ParquetReaderWrap::get_batch() {
+    _rectify_int96_timezone();
     _current_line_of_batch += _batch->num_rows();
     _current_line_of_group += _batch->num_rows();
     return _batch;

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <unordered_set>
 
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
@@ -82,6 +83,11 @@ private:
     Status next_selected_row_group();
     // _init_parquet_reader initializes the underlying parquets reader.
     Status _init_parquet_reader();
+    // Re-tag INT96 timestamp columns of the current _batch as UTC. Legacy INT96 carries no
+    // isAdjustedToUTC flag and Arrow decodes it as timezone-naive, indistinguishable from an
+    // INT64 isAdjustedToUTC=false (wall-clock) column. Tagging INT96 as UTC keeps its instant
+    // semantics so the converter shifts it to the session timezone, matching the native reader.
+    void _rectify_int96_timezone();
 
     const int32_t _num_of_columns_from_file;
     int64_t _num_rows = 0;
@@ -96,6 +102,8 @@ private:
 
     // For nested column type, it's consisting of multiple physical-columns
     std::map<std::string, std::vector<int>> _map_column_nested;
+    // Top-level column names whose parquet physical type is INT96 (see _rectify_int96_timezone).
+    std::unordered_set<std::string> _int96_columns;
     std::vector<int> _parquet_column_ids;
     int _total_groups; // groups in a parquet file
     int _current_group;

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -344,13 +344,20 @@ Status ParquetScanner::convert_array_to_column(ConvertFuncTree* conv_func, size_
                                        chunk_filter, conv_ctx);
     }
 
-    // for timestamp type, state->timezone which is specified by user. convert function
-    // obtains timezone from array. thus timezone in array should be rectified to
-    // state->timezone.
+    // Per Parquet LogicalTypes.md TIMESTAMP section, an INT64 timestamp with
+    // isAdjustedToUTC=false is surfaced by Arrow as timezone-naive (empty
+    // `timezone`) and must be displayed identically regardless of session
+    // timezone. Only rectify the column timezone to the session timezone when it
+    // is already timezone-aware (non-empty Arrow tz): an isAdjustedToUTC=true
+    // column, or a top-level INT96 column that ParquetReaderWrap::_rectify_int96_timezone()
+    // re-tagged as UTC. Naive INT64 columns keep their wall-clock value and are
+    // read as UTC by the downstream converter.
     if (array->type_id() == ArrowTypeId::TIMESTAMP) {
         auto* timestamp_type = down_cast<arrow::TimestampType*>(array->type().get());
         auto& mutable_timezone = (std::string&)timestamp_type->timezone();
-        mutable_timezone = conv_ctx->state->timezone();
+        if (!mutable_timezone.empty()) {
+            mutable_timezone = conv_ctx->state->timezone();
+        }
     }
 
     uint8_t* null_data;

--- a/be/test/exec/arrow_converter_test.cpp
+++ b/be/test/exec/arrow_converter_test.cpp
@@ -984,8 +984,8 @@ PARALLEL_TEST(ArrowConverterTest, test_timestamp_convert_naive_preserves_wall_cl
         ctx.state = &state;
         ColumnPtr column = TimestampColumn::create();
         Filter filter(1, 1);
-        ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), column, 0, 0, &filter,
-                                                                 &ctx));
+        ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), column, 0, 0,
+                                                                 &filter, &ctx));
         ASSERT_EQ(down_cast<TimestampColumn*>(column.get())->get_data()[0],
                   string_to_datetime<TYPE_DATETIME>("1970-01-01 00:00:00"))
                 << "naive timestamp must not be shifted by session timezone";

--- a/be/test/exec/arrow_converter_test.cpp
+++ b/be/test/exec/arrow_converter_test.cpp
@@ -32,6 +32,7 @@
 #include "exec/arrow_to_starrocks_converter.h"
 #include "exec/parquet_scanner.h"
 #include "runtime/datetime_value.h"
+#include "runtime/runtime_state.h"
 #include "util/arrow/row_batch.h"
 
 #define ASSERT_STATUS_OK(stmt)    \
@@ -947,6 +948,47 @@ PARALLEL_TEST(ArrowConverterTest, test_timestamp_to_datetime) {
         auto type = std::make_shared<arrow::TimestampType>(unit, tz);
         test_datetime<ArrowTypeId::TIMESTAMP, TYPE_DATETIME, arrow::TimestampType>(type, test_cases);
         test_nullable_datetime<ArrowTypeId::TIMESTAMP, TYPE_DATETIME, arrow::TimestampType>(type, test_cases);
+    }
+}
+
+// Per Parquet LogicalTypes.md TIMESTAMP section, an INT64 timestamp with
+// isAdjustedToUTC=false is surfaced by Arrow as timezone-naive (empty
+// `timezone`) and must be displayed "the same way, regardless of the local
+// time zone in effect." Confirms that the convert path no longer applies the
+// session timezone offset to such columns.
+//
+// branch-4.0 note: ArrowConvertContext carries a RuntimeState* (`state`), not a
+// `timezone` string; the timestamp converter reads the session tz via
+// ctx->state->timezone() only when the Arrow type is timezone-aware. We build a
+// RuntimeState whose timezone() returns each session tz, point ctx.state at it,
+// and drive the same ParquetScanner::convert_array_to_column entry used in
+// production.
+PARALLEL_TEST(ArrowConverterTest, test_timestamp_convert_naive_preserves_wall_clock) {
+    auto type = std::make_shared<arrow::TimestampType>(arrow::TimeUnit::SECOND, "");
+    size_t counter = 0;
+    auto array = create_constant_datetime_array<arrow::TimestampType, false>(1, 0, type, counter);
+    ConvertFuncTree cf(get_arrow_converter(ArrowTypeId::TIMESTAMP, TYPE_DATETIME, false, false));
+    ASSERT_TRUE(cf.func != nullptr);
+
+    // The raw value (0) is 1970-01-01 00:00:00 in wall-clock semantics.
+    // No matter what session timezone is set, the result must be identical.
+    for (const auto* session_tz : {"UTC", "Asia/Shanghai", "Asia/Seoul", "America/Los_Angeles"}) {
+        SCOPED_TRACE(std::string("session_tz=") + session_tz);
+
+        TQueryGlobals query_globals;
+        query_globals.__set_time_zone(session_tz);
+        RuntimeState state(query_globals);
+        ASSERT_EQ(state.timezone(), session_tz);
+
+        ArrowConvertContext ctx;
+        ctx.state = &state;
+        ColumnPtr column = TimestampColumn::create();
+        Filter filter(1, 1);
+        ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), column, 0, 0, &filter,
+                                                                 &ctx));
+        ASSERT_EQ(down_cast<TimestampColumn*>(column.get())->get_data()[0],
+                  string_to_datetime<TYPE_DATETIME>("1970-01-01 00:00:00"))
+                << "naive timestamp must not be shifted by session timezone";
     }
 }
 

--- a/be/test/exec/parquet_scanner_test.cpp
+++ b/be/test/exec/parquet_scanner_test.cpp
@@ -137,7 +137,10 @@ private:
             query_options.__set_batch_size(chunk_size);
         }
         auto query_globals = TQueryGlobals();
-        query_globals.time_zone = timezone;
+        // Use the thrift setter: a plain member assignment leaves __isset.time_zone false, so
+        // RuntimeState silently falls back to the default time zone (+08:00) and the `timezone`
+        // argument never takes effect.
+        query_globals.__set_time_zone(timezone);
         RuntimeState* state = _obj_pool.add(new RuntimeState(TUniqueId(), query_options, query_globals, nullptr));
         state->set_desc_tbl(desc_tbl);
         state->init_instance_mem_tracker();
@@ -314,7 +317,7 @@ private:
     template <bool is_nullable>
     ChunkPtr get_chunk(const std::vector<std::string>& columns_from_file,
                        const std::unordered_map<size_t, ::starrocks::TExpr>& dst_slot_exprs, std::string specific_file,
-                       size_t expected_rows) {
+                       size_t expected_rows, const std::string& timezone = "UTC") {
         std::vector<std::string> file_names{std::move(specific_file)};
         const std::vector<std::string>& column_names = columns_from_file;
 
@@ -323,7 +326,7 @@ private:
 
         auto ranges = generate_ranges(file_names, columns_from_file.size(), {});
         auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {src_slot_infos, dst_slot_infos});
-        auto scanner = create_parquet_scanner("UTC", desc_tbl, dst_slot_exprs, ranges);
+        auto scanner = create_parquet_scanner(timezone, desc_tbl, dst_slot_exprs, ranges);
 
         ChunkPtr result;
         auto check = [&](const ChunkPtr& chunk) {
@@ -988,8 +991,11 @@ TEST_F(ParquetScannerTest, test_arrow_null) {
 
 TEST_F(ParquetScannerTest, int96_timestamp) {
     const std::string parquet_file_name = test_exec_dir + "/test_data/parquet_data/int96_timestamp.parquet";
+    // INT96 stores UTC-normalized instants; under the UTC session used by get_chunk they render
+    // as-is. The previous baselines (23:59:59.009999 / 15:04:05) were the same instants rendered
+    // in +08:00 — the harness ignored the timezone argument before query_globals.__set_time_zone.
     std::vector<std::tuple<std::string, std::vector<std::string>>> test_cases = {
-            {"col_datetime", {"9999-12-31 23:59:59.009999", "2006-01-02 15:04:05"}}};
+            {"col_datetime", {"9999-12-31 15:59:59.009999", "2006-01-02 07:04:05"}}};
 
     std::vector<std::string> columns_from_path;
     std::vector<std::string> path_values;
@@ -1006,6 +1012,60 @@ TEST_F(ParquetScannerTest, int96_timestamp) {
             std::string result = col->debug_item(i);
             std::string expect = expected[i];
             EXPECT_EQ(expect, result);
+        }
+    }
+}
+
+// Regression for the INT96 session-timezone shift on the Arrow FILES()/LOAD path
+// (ParquetReaderWrap::_rectify_int96_timezone, see be/src/exec/parquet_reader.cpp).
+//
+// INT96 is a UTC-normalized instant that Arrow decodes timezone-naive, byte-identical
+// to an INT64 isAdjustedToUTC=false wall-clock column. The reader re-tags top-level
+// INT96 columns as "UTC" so the arrow->starrocks converter overrides them with the
+// session timezone and shifts the value (matching the native parquet reader's
+// Int96ToDateTimeConverter), instead of leaving them at wall-clock like a genuinely
+// naive INT64 column. This test reads the same int96_timestamp.parquet under both a
+// UTC session and a non-UTC session and asserts the shift is applied.
+//
+// int96_timestamp.parquet stores the UTC-normalized instants:
+//   row 0: 9999-12-31 15:59:59.009999
+//   row 1: 2006-01-02 07:04:05
+// A fixed -08:00 session must move every instant 8 hours earlier; the rendered
+// wall-clock therefore shifts by -8h relative to the UTC baseline (row 1 crosses
+// midnight into the previous day). A non-shifting (buggy) reader would render
+// identical values regardless of session timezone.
+TEST_F(ParquetScannerTest, int96_timestamp_session_timezone_shift) {
+    const std::string parquet_file_name = test_exec_dir + "/test_data/parquet_data/int96_timestamp.parquet";
+    const std::vector<std::string> column_names{"col_datetime"};
+    const std::unordered_map<size_t, TExpr> slot_map;
+
+    // Baseline: the UTC session renders the raw UTC-normalized instants.
+    const std::vector<std::string> utc_expected{"9999-12-31 15:59:59.009999", "2006-01-02 07:04:05"};
+    {
+        ChunkPtr chunk = get_chunk<true>(column_names, slot_map, parquet_file_name, 2, "UTC");
+        ASSERT_EQ(1, chunk->num_columns());
+        auto col = chunk->columns()[0];
+        ASSERT_EQ(2, col->size());
+        for (int i = 0; i < col->size(); i++) {
+            EXPECT_EQ(utc_expected[i], col->debug_item(i));
+        }
+    }
+
+    // Non-UTC session: the same instants must be shifted by the session offset.
+    // A fixed offset avoids DST ambiguity.
+    const std::vector<std::string> shifted_expected{"9999-12-31 07:59:59.009999", "2006-01-01 23:04:05"};
+    {
+        ChunkPtr chunk = get_chunk<true>(column_names, slot_map, parquet_file_name, 2, "-08:00");
+        ASSERT_EQ(1, chunk->num_columns());
+        auto col = chunk->columns()[0];
+        ASSERT_EQ(2, col->size());
+        for (int i = 0; i < col->size(); i++) {
+            const std::string result = col->debug_item(i);
+            EXPECT_EQ(shifted_expected[i], result);
+            // Explicit timezone-aware regression guard: the non-UTC render must differ
+            // from the UTC baseline, i.e. the session-tz shift was actually applied.
+            EXPECT_NE(utc_expected[i], result)
+                    << "INT96 value at row " << i << " was not shifted by the session timezone";
         }
     }
 }
@@ -1088,10 +1148,14 @@ TEST_F(ParquetScannerTest, get_file_schema) {
 
 TEST_F(ParquetScannerTest, datetime) {
     const std::string parquet_file_name = test_exec_dir + "/test_data/parquet_data/datetime.parquet";
+    // datetime.parquet stores isAdjustedToUTC=true instants (07:04:05 UTC, written as 15:04:05
+    // Asia/Shanghai); under the UTC session used by get_chunk they render as 07:04:05. The
+    // previous 15:04:05 baselines were the +08:00 renders of the same instants — the harness
+    // ignored the timezone argument before query_globals.__set_time_zone.
     std::vector<std::tuple<std::string, std::vector<std::string>>> test_cases = {
             {"col_datetime",
-             {"2006-01-02 15:04:05", "2006-01-02 15:04:05.900000", "2006-01-02 15:04:05.999900",
-              "2006-01-02 15:04:05.999990", "2006-01-02 15:04:05.999999"}}};
+             {"2006-01-02 07:04:05", "2006-01-02 07:04:05.900000", "2006-01-02 07:04:05.999900",
+              "2006-01-02 07:04:05.999990", "2006-01-02 07:04:05.999999"}}};
 
     std::vector<std::string> columns_from_path;
     std::vector<std::string> path_values;

--- a/docs/en/sql-reference/sql-functions/table-functions/files.md
+++ b/docs/en/sql-reference/sql-functions/table-functions/files.md
@@ -136,6 +136,18 @@ Example of the Parquet format:
 "parquet.version" = "2.6"                 -- for unloading only
 ```
 
+When reading Parquet files (for example, via `FILES()` or Broker Load), StarRocks maps the Parquet TIMESTAMP logical type to DATETIME according to the type's `isAdjustedToUTC` attribute:
+
+- **Instant Semantics**: If `isAdjustedToUTC` is `true`, the value identifies an instant on the timeline normalized to UTC. StarRocks converts it to the wall-clock reading in the current session time zone.
+- **Local Semantics**: If `isAdjustedToUTC` is `false`, the value is a wall-clock reading without a time zone. StarRocks returns it as written, regardless of the session time zone.
+- The legacy INT96 physical type carries no `isAdjustedToUTC` attribute. StarRocks treats a top-level INT96 column as an instant normalized to UTC and converts it to the session time zone. An INT96 timestamp nested inside a STRUCT, ARRAY, or MAP is read as a wall-clock value with no session time zone shift.
+
+:::note
+
+**Behavior change**: In earlier versions, StarRocks shifted timestamps with Local Semantics (`isAdjustedToUTC` = `false`) by the session time zone offset on read. Such values are now returned as written. If your session time zone is not UTC, the same file now returns different values than in earlier versions. The new values are correct per the Parquet specification.
+
+:::
+
 ###### `parquet.use_legacy_encoding`
 
 Controls the encoding technique used for DATETIME and DECIMAL data types. Valid values: `true` and `false` (default). This property is only supported for data unloading.

--- a/docs/ja/sql-reference/sql-functions/table-functions/files.md
+++ b/docs/ja/sql-reference/sql-functions/table-functions/files.md
@@ -1,6 +1,7 @@
 ---
 displayed_sidebar: docs
 toc_max_heading_level: 5
+description: "リモートストレージ内のデータファイルを定義し、データのロードおよびアンロードに使用します。"
 ---
 
 # `FILES`
@@ -135,6 +136,18 @@ Parquet 形式の例:
 "parquet.use_legacy_encoding" = "true",   -- アンロードのみ
 "parquet.version" = "2.6"                 -- アンロードのみ
 ```
+
+Parquet ファイルを読み取る際（たとえば `FILES()` または Broker Load を使用）、StarRocks は Parquet TIMESTAMP 論理型をその `isAdjustedToUTC` 属性に従って DATETIME にマッピングします:
+
+- **インスタントセマンティクス**: `isAdjustedToUTC` が `true` の場合、その値は UTC に正規化されたタイムライン上の瞬間を特定します。StarRocks は現在のセッションタイムゾーンにおける壁時計時刻に変換します。
+- **ローカルセマンティクス**: `isAdjustedToUTC` が `false` の場合、その値はタイムゾーンを持たない壁時計時刻です。StarRocks はセッションタイムゾーンに関係なく、書き込まれたままの値を返します。
+- レガシーな INT96 物理型は `isAdjustedToUTC` 属性を持ちません。StarRocks はトップレベルの INT96 列を UTC に正規化された瞬間として扱い、セッションタイムゾーンに変換します。STRUCT、ARRAY、または MAP 内にネストされた INT96 タイムスタンプは、セッションタイムゾーンによるシフトなしで壁時計時刻として読み取られます。
+
+:::note
+
+**動作変更**: 以前のバージョンでは、StarRocks はローカルセマンティクス（`isAdjustedToUTC` が `false`）のタイムスタンプを読み取る際、セッションタイムゾーンのオフセット分だけ値をシフトしていました。現在は書き込まれたままの値が返されます。セッションタイムゾーンが UTC でない場合、同じファイルから返される値は以前のバージョンと異なります（現在の動作は Parquet 仕様に準拠しています）。
+
+:::
 
 ###### `parquet.use_legacy_encoding`
 

--- a/docs/zh/sql-reference/sql-functions/table-functions/files.md
+++ b/docs/zh/sql-reference/sql-functions/table-functions/files.md
@@ -1,6 +1,7 @@
 ---
 displayed_sidebar: docs
 toc_max_heading_level: 5
+description: "定义远程存储中的数据文件，用于导入和导出数据。"
 ---
 
 # `FILES`
@@ -135,6 +136,18 @@ Parquet 格式示例：
 "parquet.use_legacy_encoding" = "true",   -- 仅用于导出
 "parquet.version" = "2.6"                 -- 仅用于导出
 ```
+
+在读取 Parquet 文件时（例如使用 `FILES()` 或 Broker Load），StarRocks 会根据 Parquet TIMESTAMP 逻辑类型的 `isAdjustedToUTC` 属性将其映射为 DATETIME：
+
+- **即时语义**：如果 `isAdjustedToUTC` 为 `true`，该值标识时间轴上一个已归一化为 UTC 的时刻。StarRocks 会将其转换为当前会话时区下的本地时间。
+- **本地语义**：如果 `isAdjustedToUTC` 为 `false`，该值是一个不带时区的本地时间。StarRocks 按原样返回该值，不受会话时区影响。
+- 旧版 INT96 物理类型不携带 `isAdjustedToUTC` 属性。StarRocks 将顶层 INT96 列视为已归一化为 UTC 的时刻，并转换为会话时区下的本地时间。嵌套在 STRUCT、ARRAY 或 MAP 中的 INT96 时间戳将按不带时区的本地时间读取，不进行会话时区转换。
+
+:::note
+
+**行为变更**：在早期版本中，StarRocks 在读取本地语义（`isAdjustedToUTC` 为 `false`）的时间戳时会按会话时区偏移量进行平移。当前版本会按写入的原值返回。如果会话时区不是 UTC，同一文件返回的值将与早期版本不同（当前行为符合 Parquet 规范）。
+
+:::
 
 ###### `parquet.use_legacy_encoding`
 


### PR DESCRIPTION
## Why I'm doing:

Backport of #73674 to `branch-4.0`. The mergify auto-backport (#74644) was closed because the cherry-pick of 1481abcc57ef73aeeec61b6ccd4c77d1a4d805e9 conflicted with this branch's source layout; this PR replaces it with a manually resolved cherry-pick of the same change set.

Backports the fix for #73672 (FILES()/LOAD shifted Parquet INT64 `isAdjustedToUTC=false` timestamps by the session time zone).

## What I'm doing:

Commit 1 is the cherry-pick of #73674 resolved for this branch:

- main moved the Arrow converter to `be/src/column/arrow/`; this branch keeps `be/src/exec/arrow_to_starrocks_converter.cpp`, where the timezone-naive (empty Arrow tz) fallback now resolves to `"UTC"` instead of the session time zone.
- The unconditional session-timezone rectify that #73674 guards lives in `ParquetScanner::convert_array_to_column` (`be/src/exec/parquet_scanner.cpp`) on this branch — the converter-side block from #50448 is not on release branches — so the `isAdjustedToUTC=false` guard is applied there: only rectify the Arrow column time zone when it is already timezone-aware.
- `be/src/exec/parquet_reader.cpp/.h` (top-level INT96 re-tagged as UTC via `_rectify_int96_timezone()` so INT96 keeps the session-timezone shift) and `docs/{en,zh,ja}` `files.md` apply as on main.
- `convert_array_to_column` takes `ColumnPtr&` on this branch (main/branch-4.1 take `Column*`), so the adapted converter test follows this branch's existing call pattern.

Commit 2 adapts the two regression tests from #73674 to this branch's test helpers: `ArrowConvertContext` carries a `RuntimeState*` here (not a `timezone` string), so the converter test injects the session time zone through `RuntimeState(TQueryGlobals.__set_time_zone)` and drives the production entry `ParquetScanner::convert_array_to_column`; the scanner test helper gets the `get_chunk` timezone parameter and the `query_globals.__set_time_zone` fix from #73674, with the `int96_timestamp`/`datetime` baselines refreshed to their true-UTC renders.

The touched source and test files are identical between branch-4.0 and branch-3.5; the same four BE UTs were verified locally on branch-3.5 (and on branch-4.1).

Identical change set is backported to the other release branches — branch-4.1: #74671, branch-3.5: #74673 — only file paths and test-helper details differ per branch.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr