### PR TITLE
[Enhancement] ngram_search with non-constant needle

### DIFF
--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -16,6 +16,7 @@
 
 #include "column/column_hash.h"
 #include "exprs/function_context.h"
+#include "exprs/function_helper.h"
 #include "exprs/string_functions.h"
 #include "gutil/strings/fastmem.h"
 namespace starrocks {
@@ -66,12 +67,17 @@ public:
     StatusOr<ColumnPtr> static ngram_search_impl(FunctionContext* context, const Columns& columns) {
         RETURN_IF_COLUMNS_ONLY_NULL(columns);
         const auto& haystack_column = columns[0];
-
         const auto& needle_column = columns[1];
         const auto& gram_num_column = columns[2];
 
+        int gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);
+        if (gram_num <= 0) {
+            return Status::NotSupported("ngram search's third parameter must be a positive number");
+        }
+
+        // Non-constant needle: compute similarity per row, no index optimization.
         if (!needle_column->is_constant()) {
-            return Status::NotSupported("ngram search's second parameter must be const");
+            return haystack_and_needle_non_const(haystack_column, needle_column, gram_num);
         }
 
         const Slice needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
@@ -79,14 +85,8 @@ public:
             return Status::NotSupported("ngram function's second parameter is larger than 2^15");
         }
 
-        int gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);
-
-        if (gram_num <= 0) {
-            return Status::NotSupported("ngram search's third parameter must be a positive number");
-        }
-
         // needle is too small so we can not get even single Ngram, so they are not similar at all
-        if (needle.get_size() < gram_num) {
+        if (needle.get_size() < (size_t)gram_num) {
             return ColumnHelper::create_const_column<TYPE_DOUBLE>(0, haystack_column->size());
         }
 
@@ -168,6 +168,171 @@ private:
         }
 
         return i;
+    }
+
+    // Like calculateMapWithNeedle but also populates recover_info with each gram's hash (resized to gram count).
+    // Caller must guarantee needle.get_size() >= gram_num and that needle is already lowercased
+    // for case-insensitive variants (lowercasing is the caller's responsibility).
+    size_t static calculateMapWithNeedleAndRecoverInfo(std::vector<NgramHash>& map, const Slice& needle,
+                                                       size_t gram_num, std::vector<NgramHash>& recover_info) {
+        size_t needle_length = needle.get_size();
+        const char* cur_char_ptr = needle.get_data();
+
+        size_t gram_count = needle_length - gram_num + 1;
+        recover_info.resize(gram_count);
+        for (size_t i = 0; i < gram_count; i++) {
+            NgramHash h = getAsciiHash(cur_char_ptr + i, gram_num);
+            map[h]++;
+            recover_info[i] = h;
+        }
+        return gram_count;
+    }
+
+    // Distance calculation that leaves map modified (matched entries are decremented).
+    // Caller must invoke recoverNeedleNgramMap or clearNeedleNgramMap before the next use of map.
+    size_t static calculateDistanceWithHaystackWithoutRecoverMap(std::vector<NgramHash>& map, const Slice& haystack,
+                                                                 size_t needle_gram_count, size_t gram_num) {
+        size_t haystack_length = haystack.get_size();
+        const char* ptr = haystack.get_data();
+        for (size_t i = 0; i + gram_num <= haystack_length; i++) {
+            NgramHash cur_hash = getAsciiHash(ptr + i, gram_num);
+            if (map[cur_hash] > 0) {
+                needle_gram_count--;
+                map[cur_hash]--;
+            }
+        }
+        return needle_gram_count;
+    }
+
+    // Restores map to the needle's original frequency state after a distance calculation dirtied it.
+    // Uses recover_info built by calculateMapWithNeedleAndRecoverInfo.
+    // Does nothing when recover_info is empty.
+    void static recoverNeedleNgramMap(std::vector<NgramHash>& map, const std::vector<NgramHash>& recover_info) {
+        // Zero all needle-related entries (removes both the original build and any distance-calc dirt),
+        // then increment each entry back to its original count.
+        for (auto h : recover_info) map[h] = 0;
+        for (auto h : recover_info) map[h]++;
+    }
+
+    // Sets all needle-related map entries to zero, leaving map ready for a new needle.
+    // Does nothing when recover_info is empty.
+    void static clearNeedleNgramMap(std::vector<NgramHash>& map, const std::vector<NgramHash>& recover_info) {
+        for (auto h : recover_info) map[h] = 0;
+    }
+
+    // Per-row ngram similarity when needle is non-constant.  No index pre-filtering applies.
+    ColumnPtr static haystack_and_needle_non_const(const ColumnPtr& haystack_column, const ColumnPtr& needle_column,
+                                                   size_t gram_num) {
+        ColumnPtr haystackPtr = haystack_column;
+        ColumnPtr needlePtr = needle_column;
+
+        // Check is_constant() before is_nullable(): ConstColumn::is_nullable() delegates to
+        // its inner data column, so a constant-null haystack reports is_nullable()==true while
+        // is_constant()==true.  Unwrapping via NullableColumn in that case is an invalid
+        // downcast and produces UB (garbage size → huge allocation → std::length_error).
+        bool haystack_is_const = haystack_column->is_constant();
+        if (haystack_is_const) {
+            haystackPtr = ColumnHelper::as_column<ConstColumn>(haystack_column)->data_column();
+            if (haystackPtr->is_nullable()) {
+                haystackPtr = ColumnHelper::as_column<NullableColumn>(haystackPtr)->data_column();
+            }
+        } else if (haystack_column->is_nullable()) {
+            haystackPtr = ColumnHelper::as_column<NullableColumn>(haystack_column)->data_column();
+        }
+        if (needle_column->is_nullable()) {
+            needlePtr = ColumnHelper::as_column<NullableColumn>(needle_column)->data_column();
+        }
+
+        // Do NOT lowercase columns in-place: they may be referenced by other expressions or output.
+        // Both needle and haystack are lowercased per-row at the top of the loop below.
+
+        const BinaryColumn* haystack_raw = ColumnHelper::as_raw_column<BinaryColumn>(haystackPtr);
+        const BinaryColumn* needle_raw = ColumnHelper::as_raw_column<BinaryColumn>(needlePtr);
+        // Use the original column for chunk_size: ConstColumn::size() returns the logical
+        // chunk size (_size field), while haystack_raw->size() after unwrapping is always 1.
+        size_t chunk_size = haystack_column->size();
+        auto res = RunTimeColumnType<TYPE_DOUBLE>::create(chunk_size);
+
+        std::vector<NgramHash> row_map(MAP_SIZE, 0);
+        std::vector<NgramHash> recover_info;
+        recover_info.reserve(MAX_STRING_SIZE);
+
+        Slice prev_needle;
+        // Owns the lowercased bytes of prev_needle in case_insensitive mode; unused otherwise.
+        [[maybe_unused]] std::string prev_needle_buf;
+        size_t needle_gram_count = 0;
+
+        for (size_t i = 0; i < chunk_size; i++) {
+            const Slice& raw_needle = needle_raw->get_slice(i);
+            // When haystack is constant its data column has exactly one element (index 0).
+            const Slice& raw_haystack = haystack_raw->get_slice(haystack_is_const ? 0 : i);
+
+            // Lowercase needle and haystack at the top of every iteration for case-insensitive.
+            // Normalising the needle here (rather than only inside the map-build functions) ensures
+            // the same_needle comparison uses the canonical form, so "ABC" and "abc" are correctly
+            // treated as the same needle and the row_map is reused instead of rebuilt.
+            Slice cur_needle_slice = raw_needle;
+            Slice cur_haystack_slice = raw_haystack;
+            std::string needle_lc_buf, haystack_lc_buf;
+            if constexpr (case_insensitive) {
+                tolower(raw_needle, needle_lc_buf);
+                cur_needle_slice = Slice(needle_lc_buf.c_str(), needle_lc_buf.size());
+                tolower(raw_haystack, haystack_lc_buf);
+                cur_haystack_slice = Slice(haystack_lc_buf.c_str(), haystack_lc_buf.size());
+            }
+
+            // recover_info empty ⟹ no valid needle processed yet ⟹ row_map is all-zeros.
+            // Otherwise row_map may be dirty (decremented by the previous distance calculation)
+            // and will be cleaned up below: recoverNeedleNgramMap for same needle, or
+            // clearNeedleNgramMap + rebuild for a new needle.
+            bool same_needle = (!recover_info.empty() && cur_needle_slice == prev_needle);
+
+            if (same_needle) {
+                // Same needle: row_map may be dirty from the previous distance calculation.
+                // Restore it to the needle's original frequency state before reuse.
+                recoverNeedleNgramMap(row_map, recover_info);
+            } else {
+                // Needle changed: clear old entries (handles both dirty and clean map states)
+                // and build fresh for the new needle.
+                clearNeedleNgramMap(row_map, recover_info);
+                if (cur_needle_slice.get_size() >= gram_num && cur_needle_slice.get_size() <= MAX_STRING_SIZE) {
+                    needle_gram_count =
+                            calculateMapWithNeedleAndRecoverInfo(row_map, cur_needle_slice, gram_num, recover_info);
+                } else {
+                    recover_info.resize(0);
+                    needle_gram_count = 0;
+                }
+                // Persist the current needle for the next iteration's same_needle check.
+                // In case_insensitive mode the needle is lowercased, so prev_needle must own
+                // its bytes (needle_lc_buf is about to go out of scope).
+                if constexpr (case_insensitive) {
+                    prev_needle_buf = std::move(needle_lc_buf);
+                    prev_needle = Slice(prev_needle_buf.c_str(), prev_needle_buf.size());
+                } else {
+                    prev_needle = cur_needle_slice; // points into the column buffer — stable
+                }
+            }
+
+            if (cur_haystack_slice.get_size() > MAX_STRING_SIZE || needle_gram_count == 0) {
+                res->get_data()[i] = 0;
+                continue;
+            }
+
+            // Distance calculation leaves row_map dirty (matched entries are decremented).
+            // The next iteration handles cleanup: recoverNeedleNgramMap if same needle,
+            // clearNeedleNgramMap + rebuild if needle changes.
+            size_t not_matched = calculateDistanceWithHaystackWithoutRecoverMap(row_map, cur_haystack_slice,
+                                                                                needle_gram_count, gram_num);
+
+            res->get_data()[i] = 1.0f - not_matched * 1.0f / std::max(needle_gram_count, (size_t)1);
+        }
+
+        // Merge null masks from haystack and needle via the standard helper.
+        NullColumnPtr merged_null = FunctionHelper::union_nullable_column(haystack_column, needle_column);
+        if (merged_null != nullptr) {
+            return NullableColumn::create(std::move(res), std::move(merged_null));
+        }
+        return res;
     }
 
     ColumnPtr static haystack_vector_and_needle_const(const ColumnPtr& haystack_column, std::vector<NgramHash>& map,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -179,6 +179,7 @@ set(EXEC_FILES
         ./exprs/string_fn_trim_test.cpp
         ./exprs/string_fn_money_format_decimal_test.cpp
         ./exprs/string_fn_url_extract_parameter_test.cpp
+        ./exprs/string_fn_ngram_test.cpp
         ./exprs/time_functions_test.cpp
         ./exprs/utility_functions_test.cpp
         ./exprs/runtime_filter_test.cpp

--- a/be/test/exprs/string_fn_ngram_test.cpp
+++ b/be/test/exprs/string_fn_ngram_test.cpp
@@ -1,0 +1,272 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "exprs/function_context.h"
+#include "exprs/string_functions.h"
+
+namespace starrocks {
+
+class NgramFunctionNonConstNeedleTest : public ::testing::Test {};
+
+// Build a ConstColumn<TYPE_INT> with value v and logical size n (for gram_num param).
+static ColumnPtr make_gram_num_col(int v, size_t n) {
+    auto inner = Int32Column::create();
+    inner->append(v);
+    return ConstColumn::create(std::move(inner), n);
+}
+
+// Both haystack and needle are plain non-nullable vectors.  Result must be
+// in [0,1] and equal the expected 2/3 similarity for this input pair.
+//
+// needle = "abcdef" (grams with n=4: "abcd","bcde","cdef")
+// haystack = "abcde12"  (grams: "abcd","bcde","cde1","de12")
+// 2 of 3 needle grams appear in haystack → similarity = 2/3.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_vector_both) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 5;
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        haystack->append("abcde12");
+        needle->append("abcdef");
+    }
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(std::move(needle));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+    float expected = 1.0f - 1.0f / 3.0f;
+    for (size_t i = 0; i < N; i++) {
+        double sim = v->get_data()[i];
+        EXPECT_GE(sim, 0.0);
+        EXPECT_LE(sim, 1.0);
+        EXPECT_NEAR(sim, expected, 1e-5f);
+    }
+}
+
+// Result must match manually computed expected value of 2/3 across multiple rows.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_result_matches_const_needle) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 3;
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        haystack->append("abcde12");
+        needle->append("abcdef");
+    }
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(std::move(needle));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+    float expected = 1.0f - 1.0f / 3.0f;
+    for (size_t i = 0; i < N; i++) {
+        EXPECT_NEAR(v->get_data()[i], expected, 1e-5f);
+    }
+}
+
+// When needle column is nullable the result must be nullable and null positions
+// must align with the needle's null mask.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_nullable_needle) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 6;
+    auto haystack = BinaryColumn::create();
+    auto needle_data = BinaryColumn::create();
+    auto needle_null = NullColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        haystack->append("abcde12");
+        needle_data->append("abcdef");
+        needle_null->append(i % 2 == 1 ? 1 : 0); // odd rows are null
+    }
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(NullableColumn::create(std::move(needle_data), std::move(needle_null)));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_TRUE(result->is_nullable());
+
+    auto* nullable = ColumnHelper::as_raw_column<NullableColumn>(result);
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(nullable->data_column());
+    float expected = 1.0f - 1.0f / 3.0f;
+    for (size_t i = 0; i < N; i++) {
+        if (i % 2 == 1) {
+            EXPECT_TRUE(result->is_null(i)) << "row " << i << " should be null";
+        } else {
+            EXPECT_FALSE(result->is_null(i)) << "row " << i << " should not be null";
+            EXPECT_NEAR(v->get_data()[i], expected, 1e-5f);
+        }
+    }
+}
+
+// Case-insensitive: "ABCDEF" and "abcdef" needles must yield the same
+// similarity against a lowercase haystack.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_case_insensitive) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 4;
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        haystack->append("abcde12");
+        needle->append(i % 2 == 0 ? "ABCDEF" : "abcdef");
+    }
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(std::move(needle));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search_case_insensitive(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+    float expected = 1.0f - 1.0f / 3.0f;
+    for (size_t i = 0; i < N; i++) {
+        EXPECT_NEAR(v->get_data()[i], expected, 1e-5f);
+    }
+}
+
+// When needle length < gram_num no grams can be built → similarity = 0 every row.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_needle_too_small) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 4;
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        haystack->append("abcde12");
+        needle->append("ab"); // length 2 < gram_num 4
+    }
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(std::move(needle));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+    for (size_t i = 0; i < N; i++) {
+        EXPECT_DOUBLE_EQ(0.0, v->get_data()[i]);
+    }
+}
+
+// The row_map is recovered between rows that share the same needle.  Verify
+// that the result is identical across all rows even though each row dirtied
+// the map via the distance calculation.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_map_reuse_correctness) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 10;
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        haystack->append("abcde12");
+        needle->append("abcdef");
+    }
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(std::move(needle));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+    float expected = 1.0f - 1.0f / 3.0f;
+    for (size_t i = 0; i < N; i++) {
+        EXPECT_NEAR(v->get_data()[i], expected, 1e-5f) << "map reuse broken at row " << i;
+    }
+}
+
+// valid needle → too-small needle → valid needle again.
+// Verifies that the map is correctly cleared when needle shrinks below
+// gram_num and correctly rebuilt when a valid needle follows.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_valid_toosmall_valid_sequence) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    haystack->append("abcde12"); // row 0: valid needle
+    needle->append("abcdef");
+    haystack->append("abcde12"); // row 1: needle too small
+    needle->append("ab");
+    haystack->append("abcde12"); // row 2: valid needle again
+    needle->append("abcdef");
+
+    Columns cols;
+    cols.emplace_back(std::move(haystack));
+    cols.emplace_back(std::move(needle));
+    cols.emplace_back(make_gram_num_col(4, 3));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(3u, result->size());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+    float expected_valid = 1.0f - 1.0f / 3.0f;
+    EXPECT_NEAR(v->get_data()[0], expected_valid, 1e-5f);
+    EXPECT_DOUBLE_EQ(0.0, v->get_data()[1]);
+    EXPECT_NEAR(v->get_data()[2], expected_valid, 1e-5f);
+}
+
+// Both haystack and needle are nullable.  Result null mask must be the OR
+// of both input null masks.
+TEST_F(NgramFunctionNonConstNeedleTest, NonConstNeedle_both_nullable) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    const size_t N = 6;
+    auto hs_data = BinaryColumn::create();
+    auto hs_null = NullColumn::create();
+    auto nd_data = BinaryColumn::create();
+    auto nd_null = NullColumn::create();
+    for (size_t i = 0; i < N; i++) {
+        hs_data->append("abcde12");
+        hs_null->append(i % 3 == 0 ? 1 : 0); // rows 0,3 null
+        nd_data->append("abcdef");
+        nd_null->append(i % 3 == 1 ? 1 : 0); // rows 1,4 null
+    }
+    Columns cols;
+    cols.emplace_back(NullableColumn::create(std::move(hs_data), std::move(hs_null)));
+    cols.emplace_back(NullableColumn::create(std::move(nd_data), std::move(nd_null)));
+    cols.emplace_back(make_gram_num_col(4, N));
+
+    ColumnPtr result = StringFunctions::ngram_search(ctx.get(), cols).value();
+    ASSERT_EQ(N, result->size());
+    ASSERT_TRUE(result->is_nullable());
+
+    for (size_t i = 0; i < N; i++) {
+        bool hs_is_null = (i % 3 == 0);
+        bool nd_is_null = (i % 3 == 1);
+        if (hs_is_null || nd_is_null) {
+            EXPECT_TRUE(result->is_null(i)) << "row " << i << " should be null";
+        } else {
+            EXPECT_FALSE(result->is_null(i)) << "row " << i << " should not be null";
+        }
+    }
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -162,15 +162,15 @@ public class FunctionAnalyzer {
 
         if (FunctionSet.INDEX_ONLY_FUNCTIONS.contains(fnName)) {
             if (!functionCallExpr.getChild(0).getType().isStringType() ||
-                    !functionCallExpr.getChild(0).getType().isStringType()) {
+                    !functionCallExpr.getChild(1).getType().isStringType()) {
                 throw new SemanticException(
                         fnName + " function 's first parameter and second parameter must be string type",
                         functionCallExpr.getPos());
             }
 
-            if (!functionCallExpr.getChild(1).isConstant() || !functionCallExpr.getChild(2).isConstant()) {
+            if (!functionCallExpr.getChild(2).isConstant()) {
                 throw new SemanticException(
-                        fnName + " function 's second parameter and third parameter must be constant",
+                        fnName + " function 's third parameter must be constant",
                         functionCallExpr.getPos());
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -613,9 +613,18 @@ public class AnalyzeExprTest {
 
     @Test
     public void testNgramSearch() {
+        // missing gram_num argument
         analyzeFail("select ngram_search('abc', 'a')");
+        // non-string first parameter
         analyzeFail("select ngram_search(date('2020-06-23'), \"2020\", 4);");
-        analyzeFail("select ngram_search(th,th,4) from tall;");
+        // non-string haystack column (th is datetime in tall)
+        analyzeFail("select ngram_search(th, th, 4) from tall;");
+        // non-string non-constant needle must also be rejected (type check, not constant check)
+        analyzeFail("select ngram_search(ta, th, 4) from tall;");
+        // non-constant needle is now allowed
+        analyzeSuccess("select ngram_search(ta, ta, 4) from tall;");
+        // non-constant gram_num is still rejected
+        analyzeFail("select ngram_search(ta, ta, tc) from tall;");
     }
 
 }

--- a/test/sql/test_index/R/test_ngram_non_const_needle
+++ b/test/sql/test_index/R/test_ngram_non_const_needle
@@ -1,0 +1,97 @@
+-- name: test_ngram_non_const_needle
+CREATE TABLE t_ngram (
+    haystack VARCHAR(100) NOT NULL,
+    needle   VARCHAR(100) NOT NULL
+) PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_ngram values
+    ('abcde',   'abcde'),
+    ('abcde',   'xyzwv'),
+    ('abcdfg',  'abcde'),
+    ('chinese', 'chinese');
+-- result:
+-- !result
+select ngram_search(haystack, needle, 4) as sim from t_ngram order by sim desc, haystack, needle;
+-- result:
+1.0
+1.0
+0.5
+0.0
+-- !result
+select haystack, ngram_search(haystack, 'abcde', 4) = ngram_search(haystack, needle, 4) as parity
+from t_ngram where needle = 'abcde' order by haystack;
+-- result:
+abcde	1
+abcdfg	1
+-- !result
+CREATE TABLE t_ngram_null (
+    haystack VARCHAR(100),
+    needle   VARCHAR(100)
+) PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_ngram_null values
+    ('abcde', 'abcde'),
+    ('abcde', null),
+    ('xyzwv', 'abcde');
+-- result:
+-- !result
+select ngram_search(haystack, needle, 4) as sim
+from t_ngram_null where needle is not null order by sim;
+-- result:
+0.0
+1.0
+-- !result
+select ngram_search(haystack, needle, 4) is null as is_null
+from t_ngram_null where needle is null;
+-- result:
+1
+-- !result
+-- name: test_ngram_non_const_needle_case_insensitive
+CREATE TABLE t_ngram_ci (
+    haystack VARCHAR(100) NOT NULL,
+    needle   VARCHAR(100) NOT NULL
+) PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_ngram_ci values
+    ('Hello',   'hello'),
+    ('CHINESE', 'chinese'),
+    ('abcde',   'ABCDE');
+-- result:
+-- !result
+select ngram_search_case_insensitive(haystack, needle, 4) as sim
+from t_ngram_ci order by sim desc, haystack;
+-- result:
+1.0
+1.0
+1.0
+-- !result
+select ngram_search(haystack, needle, 4) as sim
+from t_ngram_ci order by sim desc, haystack;
+-- result:
+0.5
+0.0
+0.0
+-- !result
+CREATE TABLE t_ngram_idx (
+    haystack VARCHAR(100) NOT NULL,
+    needle   VARCHAR(100) NOT NULL,
+    INDEX idx_haystack(haystack) USING NGRAMBF ("gram_num" = "4", "bloom_filter_fpp" = "0.05")
+) PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_ngram_idx values
+    ('chinese', 'chinese'),
+    ('chineaaaa', 'chinese'),
+    ('tonightisgreadnight', 'chinese');
+-- result:
+-- !result
+select haystack, ngram_search(haystack, needle, 4) as sim
+from t_ngram_idx order by sim desc, haystack;
+-- result:
+chinese	1.0
+chineaaaa	0.5
+tonightisgreadnight	0.0
+-- !result

--- a/test/sql/test_index/T/test_ngram_non_const_needle
+++ b/test/sql/test_index/T/test_ngram_non_const_needle
@@ -1,0 +1,76 @@
+-- name: test_ngram_non_const_needle
+-- Basic non-constant needle: similarity values and parity with constant-needle path.
+CREATE TABLE t_ngram (
+    haystack VARCHAR(100) NOT NULL,
+    needle   VARCHAR(100) NOT NULL
+) PROPERTIES ("replication_num" = "1");
+
+insert into t_ngram values
+    ('abcde',   'abcde'),
+    ('abcde',   'xyzwv'),
+    ('abcdfg',  'abcde'),
+    ('chinese', 'chinese');
+
+-- non-constant needle returns correct similarity for each row
+select ngram_search(haystack, needle, 4) as sim from t_ngram order by sim desc, haystack, needle;
+
+-- non-constant needle produces the same result as the constant-needle path,
+-- including the partial-overlap row (sim=0.5) to catch any float/double discrepancy
+select haystack, ngram_search(haystack, 'abcde', 4) = ngram_search(haystack, needle, 4) as parity
+from t_ngram where needle = 'abcde' order by haystack;
+
+-- NULL needle must propagate as a NULL result.
+
+CREATE TABLE t_ngram_null (
+    haystack VARCHAR(100),
+    needle   VARCHAR(100)
+) PROPERTIES ("replication_num" = "1");
+
+insert into t_ngram_null values
+    ('abcde', 'abcde'),
+    ('abcde', null),
+    ('xyzwv', 'abcde');
+
+-- non-null rows produce normal similarity values
+select ngram_search(haystack, needle, 4) as sim
+from t_ngram_null where needle is not null order by sim;
+
+-- null needle yields a null result
+select ngram_search(haystack, needle, 4) is null as is_null
+from t_ngram_null where needle is null;
+
+-- name: test_ngram_non_const_needle_case_insensitive
+CREATE TABLE t_ngram_ci (
+    haystack VARCHAR(100) NOT NULL,
+    needle   VARCHAR(100) NOT NULL
+) PROPERTIES ("replication_num" = "1");
+
+insert into t_ngram_ci values
+    ('Hello',   'hello'),
+    ('CHINESE', 'chinese'),
+    ('abcde',   'ABCDE');
+
+-- case-insensitive: upper/lower pair is similarity 1.0
+select ngram_search_case_insensitive(haystack, needle, 4) as sim
+from t_ngram_ci order by sim desc, haystack;
+
+-- case-sensitive: same pairs differ in case so similarity is reduced
+select ngram_search(haystack, needle, 4) as sim
+from t_ngram_ci order by sim desc, haystack;
+
+-- Non-constant needle must not be pushed down to the ngram bloom filter index.
+-- The query must still return correct results even when an index exists on haystack column.
+CREATE TABLE t_ngram_idx (
+    haystack VARCHAR(100) NOT NULL,
+    needle   VARCHAR(100) NOT NULL,
+    INDEX idx_haystack(haystack) USING NGRAMBF ("gram_num" = "4", "bloom_filter_fpp" = "0.05")
+) PROPERTIES ("replication_num" = "1");
+
+insert into t_ngram_idx values
+    ('chinese', 'chinese'),
+    ('chineaaaa', 'chinese'),
+    ('tonightisgreadnight', 'chinese');
+
+-- with index present, non-constant needle must still return the full result set correctly
+select haystack, ngram_search(haystack, needle, 4) as sim
+from t_ngram_idx order by sim desc, haystack;

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -499,7 +499,11 @@ select ngram_search(rowkey, "e6249ba1-5b54-46bf-bfaf-89d69094b757",4) as a from 
 -- !result
 select ngram_search("000073a7-274f-46bf-bfaf-678868cc26cd",rowkey,4) from string_table;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 7 to line 1, column 67. Detail message: ngram_search function 's second parameter and third parameter must be constant.")
+1.0
+0.24242424964904785
+0.15151512622833252
+0.1818181872367859
+0.21212118864059448
 -- !result
 select ngram_search("chi","chi",0);
 -- result:


### PR DESCRIPTION
## Why I'm doing:

In previous version, the 2nd argment of ngram_search(haystack, needle, ngram_length) -- nendle must be contant string, in this pr, needle can be variable.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
