### PR TITLE
[Tool] Fix gen_build_version.py failure on python 3.6

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -56,12 +56,13 @@ def get_hostname():
     if os.path.exists('/.dockerenv'):
         return "docker"
     try:
+        # use universal_newlines instead of text for python3.6 compatibility
         res = subprocess.run(
             ["hostname", "-f"],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            text=True)
+            universal_newlines=True)
     except FileNotFoundError:
         return platform.node() or "unknown"
 


### PR DESCRIPTION
subprocess.run(text=True) requires python 3.7+; build hosts running python 3.6 fail with "TypeError: __init__() got an unexpected keyword argument 'text'". Use the pre-3.7 equivalent universal_newlines=True, which behaves identically on all python 3 versions.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
