### PR TITLE
[Enhancement] Record submitUser on task runs for materialized_view_refresh_jobs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -45,6 +45,10 @@ public class ExecuteOption {
     @SerializedName("isReplay")
     private boolean isReplay = false;
 
+    // Set internally only (batch spawn), never from user-settable task properties, so the recorded
+    // submitter cannot be spoofed. Transient: persistence lives on TaskRunStatus.submitUser.
+    private transient String submitUser;
+
     public ExecuteOption(Task task) {
         this(Constants.TaskRunPriority.LOWEST.value(), task.getSource().isMergeable(), task.getProperties());
     }
@@ -106,6 +110,14 @@ public class ExecuteOption {
 
     public void setReplay(boolean replay) {
         isReplay = replay;
+    }
+
+    public String getSubmitUser() {
+        return submitUser;
+    }
+
+    public void setSubmitUser(String submitUser) {
+        this.submitUser = submitUser;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -1076,6 +1076,11 @@ public class TaskManager implements MemoryTrackable {
                         .build();
                 // TODO: To avoid the same query id collision, use a new query id instead of an old query id
                 taskRun.initStatus(status.getQueryId(), status.getCreateTime());
+                // The rebuilt run has no submitter context; keep the persisted submitter when present.
+                // Runs persisted before this field existed have none, so initStatus's "system" fallback stands.
+                if (!Strings.isNullOrEmpty(status.getSubmitUser())) {
+                    taskRun.getStatus().setSubmitUser(status.getSubmitUser());
+                }
                 if (!taskRunScheduler.addPendingTaskRun(taskRun)) {
                     LOG.warn("Submit task run to pending queue failed in follower, reject the submit:{}", taskRun);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -78,6 +78,7 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final String PINNED_REFRESH_JOB_ID = "PINNED_REFRESH_JOB_ID";
     // Carries the batch's first-run start time so LAST_FRESHNESS_CONFIRMED_AT reflects the snapshot pinned at batch start.
     public static final String MV_FRESHNESS_BASELINE_TIME = "MV_FRESHNESS_BASELINE_TIME";
+    public static final String SUBMIT_USER_SYSTEM = "system";
     // Only used in FE's UT
     public static final String IS_TEST = "__IS_TEST__";
 
@@ -565,6 +566,7 @@ public class TaskRun implements Comparable<TaskRun> {
         status.setCreateTime(created);
         status.setUser(task.getCreateUser());
         status.setUserIdentity(task.getUserIdentity());
+        status.setSubmitUser(resolveSubmitUser());
         status.setCatalogName(task.getCatalogName());
         status.setDbName(task.getDbName());
         status.setPostRun(task.getPostRun());
@@ -582,6 +584,23 @@ public class TaskRun implements Comparable<TaskRun> {
         LOG.info("init task status, task:{}, query_id:{}, create_time:{}", task.getName(), queryId, status.getCreateTime());
         this.status = status;
         return status;
+    }
+
+    // Batch follow-up runs inherit the leader's submitter through ExecuteOption (internal-only, unspoofable).
+    // Only a manual submission attributes to the session user: automatic refreshes (scheduled, or
+    // on-base-table-change which runs on the triggering DML's thread with a live ConnectContext) are the
+    // scheduler, so they must record "system" rather than the incidental session user.
+    private String resolveSubmitUser() {
+        if (executeOption != null && !Strings.isNullOrEmpty(executeOption.getSubmitUser())) {
+            return executeOption.getSubmitUser();
+        }
+        if (executeOption != null && executeOption.isManual()) {
+            ConnectContext context = ConnectContext.get();
+            if (context != null && !Strings.isNullOrEmpty(context.getQualifiedUser())) {
+                return context.getQualifiedUser();
+            }
+        }
+        return SUBMIT_USER_SYSTEM;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -295,6 +295,10 @@ public class TaskRunManager implements MemoryTrackable {
                     // prefer older create time to be better scheduler
                     if (oldTaskRun.getStatus().getCreateTime() < taskRun.getStatus().getCreateTime()) {
                         taskRun.getStatus().setCreateTime(oldTaskRun.getStatus().getCreateTime());
+                        String oldSubmitUser = oldTaskRun.getStatus().getSubmitUser();
+                        if (oldSubmitUser != null && !oldSubmitUser.isEmpty()) {
+                            taskRun.getStatus().setSubmitUser(oldSubmitUser);
+                        }
                     }
 
                     LOG.info("Merge redundant task run, oldTaskRun: {}, taskRun: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -463,6 +463,9 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         int priority = executeOption.getPriority() > Constants.TaskRunPriority.LOWEST.value() ?
                 executeOption.getPriority() : Constants.TaskRunPriority.HIGHER.value();
         ExecuteOption option = new ExecuteOption(priority, true, newProperties);
+        if (mvContext.getStatus() != null) {
+            option.setSubmitUser(mvContext.getStatus().getSubmitUser());
+        }
         logger.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}, " +
                         "priority={}, properties={}", mv.getName(), mv.getId(),
                 mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), priority, newProperties);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -344,6 +344,9 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         int priority = executeOption.getPriority() > Constants.TaskRunPriority.LOWEST.value() ?
                 executeOption.getPriority() : Constants.TaskRunPriority.HIGHER.value();
         ExecuteOption option = new ExecuteOption(priority, true, newProperties);
+        if (mvContext.getStatus() != null) {
+            option.setSubmitUser(mvContext.getStatus().getSubmitUser());
+        }
         logger.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}, " +
                         "priority={}, properties={}", mv.getName(), mv.getId(),
                 mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), priority, newProperties);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -93,6 +93,11 @@ public class TaskRunStatus implements Writable {
     @SerializedName("userIdentity")
     private UserIdentity userIdentity;
 
+    // Who triggered this run: the session user for a manual submit, "system" for scheduled/event-triggered
+    // runs; batch follow-up runs inherit the leader's value. Feeds refresh_jobs.SUBMIT_USER.
+    @SerializedName("submitUser")
+    private String submitUser;
+
     @SerializedName("expireTime")
     private long expireTime;
 
@@ -261,6 +266,14 @@ public class TaskRunStatus implements Writable {
 
     public void setUserIdentity(UserIdentity userIdentity) {
         this.userIdentity = userIdentity;
+    }
+
+    public String getSubmitUser() {
+        return submitUser;
+    }
+
+    public void setSubmitUser(String submitUser) {
+        this.submitUser = submitUser;
     }
 
     public String getPostRun() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
@@ -186,6 +186,9 @@ public class PCTRefreshRangePartitionOlapTest extends MVTestBase {
         Assertions.assertNotNull(nextTaskRun);
         Assertions.assertEquals(String.valueOf(leaderStartTime),
                 nextTaskRun.getProperties().get(TaskRun.MV_FRESHNESS_BASELINE_TIME));
+        String leaderSubmitUser = taskRun.getStatus().getSubmitUser();
+        Assertions.assertNotNull(leaderSubmitUser);
+        Assertions.assertEquals(leaderSubmitUser, nextTaskRun.getExecuteOption().getSubmitUser());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -430,6 +430,45 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void testReplayCreateTaskRunKeepsSystemFallbackWhenSubmitUserAbsent() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("submit_user_replay_absent");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus("q-old", System.currentTimeMillis());
+        // Simulate a run persisted before submitUser existed.
+        taskRun.getStatus().setSubmitUser(null);
+
+        taskManager.replayCreateTaskRun(taskRun.getStatus());
+
+        List<TaskRun> recovered = Lists.newArrayList(
+                taskManager.getTaskRunScheduler().getPendingTaskRunsByTaskId(task.getId()));
+        assertEquals(1, recovered.size());
+        assertEquals(TaskRun.SUBMIT_USER_SYSTEM, recovered.get(0).getStatus().getSubmitUser());
+    }
+
+    @Test
+    public void testReplayCreateTaskRunPreservesPersistedSubmitUser() {
+        TaskManager taskManager = new TaskManager();
+        Task task = new Task("submit_user_replay_present");
+        task.setDefinition("select 1");
+        taskManager.replayCreateTask(task);
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus("q-new", System.currentTimeMillis());
+        taskRun.getStatus().setSubmitUser("alice");
+
+        taskManager.replayCreateTaskRun(taskRun.getStatus());
+
+        List<TaskRun> recovered = Lists.newArrayList(
+                taskManager.getTaskRunScheduler().getPendingTaskRunsByTaskId(task.getId()));
+        assertEquals(1, recovered.size());
+        assertEquals("alice", recovered.get(0).getStatus().getSubmitUser());
+    }
+
+    @Test
     public void testReplayUpdateTaskRun1() {
         TaskManager taskManager = new TaskManager();
         Task task = new Task("test");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -359,6 +359,60 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void testTaskRunMergePreservesOldSubmitUser() {
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+
+        long taskId = 1;
+        long now = System.currentTimeMillis();
+
+        TaskRun oldTaskRun = makeTaskRun(taskId, task, DEFAULT_MERGE_OPTION);
+        oldTaskRun.initStatus("1", now);
+        oldTaskRun.getStatus().setSubmitUser("alice");
+
+        TaskRun newTaskRun = makeTaskRun(taskId, task, DEFAULT_MERGE_OPTION);
+        newTaskRun.initStatus("2", now + 10);
+
+        taskRunManager.arrangeTaskRun(oldTaskRun);
+        taskRunManager.arrangeTaskRun(newTaskRun);
+
+        TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
+        List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
+        Assertions.assertTrue(taskRuns != null);
+        assertEquals(1, taskRuns.size());
+        assertEquals(now, taskRuns.get(0).getStatus().getCreateTime());
+        assertEquals("alice", taskRuns.get(0).getStatus().getSubmitUser());
+    }
+
+    @Test
+    public void testTaskRunMergeKeepsFallbackWhenOldSubmitUserAbsent() {
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+
+        long taskId = 1;
+        long now = System.currentTimeMillis();
+
+        TaskRun oldTaskRun = makeTaskRun(taskId, task, DEFAULT_MERGE_OPTION);
+        oldTaskRun.initStatus("1", now);
+        oldTaskRun.getStatus().setSubmitUser(null);
+
+        TaskRun newTaskRun = makeTaskRun(taskId, task, DEFAULT_MERGE_OPTION);
+        newTaskRun.initStatus("2", now + 10);
+
+        taskRunManager.arrangeTaskRun(oldTaskRun);
+        taskRunManager.arrangeTaskRun(newTaskRun);
+
+        TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
+        List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
+        Assertions.assertTrue(taskRuns != null);
+        assertEquals(1, taskRuns.size());
+        assertEquals(now, taskRuns.get(0).getStatus().getCreateTime());
+        assertEquals(TaskRun.SUBMIT_USER_SYSTEM, taskRuns.get(0).getStatus().getSubmitUser());
+    }
+
+    @Test
     public void testTaskRunNotMerge() {
 
         TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSubmitUserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSubmitUserTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.qe.ConnectContext;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+public class TaskRunSubmitUserTest {
+
+    private static void mockConnectContext(ConnectContext context) {
+        new MockUp<ConnectContext>() {
+            @Mock
+            public ConnectContext get() {
+                return context;
+            }
+        };
+    }
+
+    private static ConnectContext contextWithUser(String user) {
+        ConnectContext context = new ConnectContext();
+        context.setQualifiedUser(user);
+        return context;
+    }
+
+    private static TaskRun taskRunWith(boolean isManual) {
+        Task task = new Task("submit_user_test_task");
+        ExecuteOption option = new ExecuteOption(task);
+        option.setManual(isManual);
+        return TaskRunBuilder.newBuilder(task).setExecuteOption(option).build();
+    }
+
+    @Test
+    public void manualSubmitRecordsSessionUser() {
+        mockConnectContext(contextWithUser("bob"));
+        TaskRun taskRun = taskRunWith(true);
+        taskRun.initStatus(UUID.randomUUID().toString(), System.currentTimeMillis());
+        Assertions.assertEquals("bob", taskRun.getStatus().getSubmitUser());
+    }
+
+    @Test
+    public void automaticRefreshRecordsSystemEvenWithLiveContext() {
+        // An on-base-table-change refresh runs on the triggering DML's thread, so ConnectContext is non-null;
+        // it must still be attributed to the scheduler, not the incidental DML user.
+        mockConnectContext(contextWithUser("bob"));
+        TaskRun taskRun = taskRunWith(false);
+        taskRun.initStatus(UUID.randomUUID().toString(), System.currentTimeMillis());
+        Assertions.assertEquals(TaskRun.SUBMIT_USER_SYSTEM, taskRun.getStatus().getSubmitUser());
+    }
+
+    @Test
+    public void manualSubmitFallsBackToSystemWithoutContext() {
+        mockConnectContext(null);
+        TaskRun taskRun = taskRunWith(true);
+        taskRun.initStatus(UUID.randomUUID().toString(), System.currentTimeMillis());
+        Assertions.assertEquals(TaskRun.SUBMIT_USER_SYSTEM, taskRun.getStatus().getSubmitUser());
+    }
+
+    @Test
+    public void batchFollowUpInheritsLeaderSubmitterOverContext() {
+        mockConnectContext(contextWithUser("not-the-submitter"));
+        Task task = new Task("submit_user_test_task");
+        ExecuteOption option = new ExecuteOption(task);
+        option.setSubmitUser("bob");
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).setExecuteOption(option).build();
+        taskRun.initStatus(UUID.randomUUID().toString(), System.currentTimeMillis());
+        Assertions.assertEquals("bob", taskRun.getStatus().getSubmitUser());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The upcoming `information_schema.materialized_view_refresh_jobs` table needs a `SUBMIT_USER` column: who triggered a refresh job — a real user issuing `REFRESH MATERIALIZED VIEW`, or the scheduler (`system`) for periodic / on-base-table-change refreshes. Today nothing on a task run records the triggering identity: `TaskRunStatus.user` is the task owner (constant per task, deprecated) and is unrelated to who submitted a particular run.

## What I'm doing:

Record the submitter on `TaskRunStatus.submitUser` (persisted with the run status; internal — deliberately NOT exposed as an `information_schema.task_runs` column):

- `TaskRun.initStatus` resolves it on the submitting thread: an inherited `SUBMIT_USER` run property wins (batch follow-up runs), else the `ConnectContext` session user (manual submit), else `"system"` (scheduler/event threads have no context).
- MV batch follow-up runs (PCT/IVM `generateNextTaskRunIfNeeded`) seed the leader's value through the run-property chain, so every run of a job records the original submitter.
- Pending-run recovery on FE restart keeps the originally persisted value instead of re-resolving without context.

Covered by unit tests (system fallback / manual ConnectContext / property inheritance precedence) and a batch-propagation assertion in the existing PCT spawn test.

Fixes #issue: N/A — internal groundwork for the refresh_jobs system table, no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
