### PR TITLE
[Tool] flip branch-4.1 status from open to feature-freeze

### DIFF
--- a/.github/.status
+++ b/.github/.status
@@ -1,1 +1,1 @@
-open
+feature-freeze


### PR DESCRIPTION
## Why I'm doing:
branch-4.1 has entered the release stabilization window — new `[Feature]` PRs should no longer land directly on this branch.

## What I'm doing:
Flip `.github/.status` on branch-4.1 from `open` to `feature-freeze`. After merge:

- `ci-pipeline.yml` / `ci-pipeline-branch.yml` will block any new `[Feature]` PR targeting branch-4.1 with the comment `⚠️ Branch in feature-freeze state, [Feature] PRs are not allowed!`
- `[BugFix]` / `[Enhancement]` / `[Refactor]` / `[Doc]` / `[UT]` / `[Tool]` remain allowed.
- `[Tool]` PRs are always exempt from status gates (which is why this PR can land).
- repo-sync will propagate the file to the downstream fork branch-4.1, so the same gate fires there.

State machine (per `ci-pipeline-branch.yml`):

| `.github/.status` value | Blocks | Notes |
|---|---|---|
| `open` | nothing | current value on branch-4.1 |
| `feature-freeze` | `[Feature]` | **target** |
| `bugfix-only` | `[Feature]` + `[Enhancement]` | currently used on branch-4.0 / 3.5 / 3.4 |
| `code-freeze` | everything except `[Bugfix]` or CVE | release-cut |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

