### PR TITLE
[BugFix] Propagate partition consumer errors in ChunksPartitioner

### DIFF
--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -153,11 +153,10 @@ private:
                                      NewPartitionCallback&& new_partition_cb,
                                      PartitionChunkConsumer&& partition_chunk_consumer) {
         if (!_is_passthrough) {
-            ASSIGN_OR_RETURN(_is_passthrough,
-                             hash_map_with_key.template append_chunk<EnablePassthrough>(
-                                     chunk, _partition_columns, _mem_pool, _obj_pool.get(),
-                                     std::forward<NewPartitionCallback>(new_partition_cb),
-                                     std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
+            ASSIGN_OR_RETURN(_is_passthrough, hash_map_with_key.template append_chunk<EnablePassthrough>(
+                                                      chunk, _partition_columns, _mem_pool, _obj_pool.get(),
+                                                      std::forward<NewPartitionCallback>(new_partition_cb),
+                                                      std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
         }
         if (_is_passthrough) {
             _limited_buffer->push(chunk);

--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -58,8 +58,9 @@ public:
     //      The chunk added to the hash map.
     // @new_partition_cb: void(size_t partition_idx)
     //      called when coming a new key not in the hash map.
-    // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
+    // @partition_chunk_consumer: Status(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
+    //      A non-ok status aborts the offer and is returned to the caller.
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     Status offer(const ChunkPtr& chunk, NewPartitionCallback&& new_partition_cb,
                  PartitionChunkConsumer&& partition_chunk_consumer) {
@@ -74,11 +75,13 @@ public:
             }
         }
 
-        TRY_CATCH_BAD_ALLOC(_hash_map_variant.visit([&](auto& hash_map_with_key) {
-            _split_chunk_by_partition<EnablePassthrough>(
+        Status status = Status::OK();
+        TRY_CATCH_BAD_ALLOC(status = _hash_map_variant.visit([&](auto& hash_map_with_key) -> Status {
+            return _split_chunk_by_partition<EnablePassthrough>(
                     *hash_map_with_key, chunk, std::forward<NewPartitionCallback>(new_partition_cb),
                     std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         }));
+        RETURN_IF_ERROR(status);
 
         return Status::OK();
     }
@@ -103,25 +106,29 @@ public:
 
     // Consumers consume from the hash map
     // @Params:
-    // @consumer: bool consumer(int32_t partition_idx, const ChunkPtr& chunk)
-    //      The return value of the consumer denote whether to continue or not
+    // @consumer: StatusOr<bool> consumer(int32_t partition_idx, const ChunkPtr& chunk)
+    //      The bool result denotes whether to continue consuming or not; a non-ok status aborts
+    //      consumption and is returned to the caller.
     template <typename Consumer>
     Status consume_from_hash_map(Consumer&& consumer) {
         if (is_hash_map_eos()) {
             return Status::OK();
         }
 
-        TRY_CATCH_BAD_ALLOC(_hash_map_variant.visit([&](auto& hash_map_with_key) {
+        Status status = Status::OK();
+        TRY_CATCH_BAD_ALLOC(status = _hash_map_variant.visit([&](auto& hash_map_with_key) -> Status {
             // First, fetch chunks from hash map
-            bool continue_consume;
-            _fetch_chunks_from_hash_map(*hash_map_with_key, consumer, continue_consume);
+            bool continue_consume = true;
+            RETURN_IF_ERROR(_fetch_chunks_from_hash_map(*hash_map_with_key, consumer, continue_consume));
+            // Second, fetch chunks from null_key_value if any
             if (continue_consume && _hash_map_eos) {
-                // Second, fetch chunks from null_key_value if any
                 if constexpr (std::decay_t<decltype(*hash_map_with_key)>::is_nullable) {
-                    _fetch_chunks_from_null_key_value(*hash_map_with_key, consumer);
+                    RETURN_IF_ERROR(_fetch_chunks_from_null_key_value(*hash_map_with_key, consumer));
                 }
             }
+            return Status::OK();
         }));
+        RETURN_IF_ERROR(status);
 
         if (is_hash_map_eos()) {
             _hash_map_variant.reset();
@@ -142,26 +149,28 @@ private:
 
     template <bool EnablePassthrough, typename HashMapWithKey, typename NewPartitionCallback,
               typename PartitionChunkConsumer>
-    void _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk,
-                                   NewPartitionCallback&& new_partition_cb,
-                                   PartitionChunkConsumer&& partition_chunk_consumer) {
+    Status _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk,
+                                     NewPartitionCallback&& new_partition_cb,
+                                     PartitionChunkConsumer&& partition_chunk_consumer) {
         if (!_is_passthrough) {
-            _is_passthrough = hash_map_with_key.template append_chunk<EnablePassthrough>(
-                    chunk, _partition_columns, _mem_pool, _obj_pool.get(),
-                    std::forward<NewPartitionCallback>(new_partition_cb),
-                    std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            ASSIGN_OR_RETURN(_is_passthrough,
+                             hash_map_with_key.template append_chunk<EnablePassthrough>(
+                                     chunk, _partition_columns, _mem_pool, _obj_pool.get(),
+                                     std::forward<NewPartitionCallback>(new_partition_cb),
+                                     std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
         }
         if (_is_passthrough) {
             _limited_buffer->push(chunk);
         }
+        return Status::OK();
     }
 
-    // Fetch chunks from hash map, return true if reaches eos
+    // Fetch chunks from hash map; sets continue_consume=false if the consumer asks to suspend.
     template <typename HashMapWithKey, typename Consumer>
-    void _fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer, bool& continue_consume) {
+    Status _fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer, bool& continue_consume) {
         continue_consume = true;
         if (_hash_map_eos) {
-            return;
+            return Status::OK();
         }
         if (!_partition_it.has_value()) {
             _partition_it = hash_map_with_key.hash_map.begin();
@@ -195,10 +204,11 @@ private:
             auto chunk_end = chunks.end();
 
             while (chunk_it != chunk_end) {
-                if (!consumer(partition_idx, *chunk_it++)) {
+                ASSIGN_OR_RETURN(bool keep_consuming, consumer(partition_idx, *chunk_it++));
+                if (!keep_consuming) {
                     // Fetch suspend, and it may proceed the next call.
                     continue_consume = false;
-                    return;
+                    return Status::OK();
                 }
             }
 
@@ -207,13 +217,14 @@ private:
             ++partition_it;
             _chunk_it.reset();
         }
+        return Status::OK();
     }
 
-    // Fetch chunks from HashMapWithKey.null_key_value, return true if reaches eos
+    // Fetch chunks from HashMapWithKey.null_key_value
     template <typename HashMapWithKey, typename Consumer>
-    void _fetch_chunks_from_null_key_value(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
+    Status _fetch_chunks_from_null_key_value(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
         if (_null_key_eos) {
-            return;
+            return Status::OK();
         }
 
         std::vector<ChunkPtr>& chunks = hash_map_with_key.null_key_value.chunks;
@@ -237,11 +248,13 @@ private:
         });
 
         while (chunk_it != chunk_end) {
-            if (!consumer(hash_map_with_key.kNullKeyPartitionIdx, *chunk_it++)) {
+            ASSIGN_OR_RETURN(bool keep_consuming, consumer(hash_map_with_key.kNullKeyPartitionIdx, *chunk_it++));
+            if (!keep_consuming) {
                 // Fetch suspend, and it may proceed the next call.
-                return;
+                return Status::OK();
             }
         }
+        return Status::OK();
     }
 
     const bool _has_nullable_partition_column;

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -525,15 +525,15 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
         RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk,
                 [&](uint32_t offset) {
-            return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
+                    return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
                 },
                 [&](const KeyType& key) {
-            uint8_t* pos = mem_pool->allocate(key.size);
-            strings::memcpy_inlined(pos, key.data, key.size);
-            return Slice{pos, key.size};
+                    uint8_t* pos = mem_pool->allocate(key.size);
+                    strings::memcpy_inlined(pos, key.data, key.size);
+                    return Slice{pos, key.size};
                 },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
 
         return is_passthrough;
     }
@@ -596,12 +596,10 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
         }
 
         RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
-                hash_map, chunk, [&](uint32_t offset) {
-            return keys[offset]; },
-                [&](const FixedSizeSliceKey& key) {
-            return key; }, obj_pool,
+                hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
+                [&](const FixedSizeSliceKey& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
 
         return is_passthrough;
     }

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -384,8 +384,8 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase<false, fal
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
-                                ObjectPool* obj_pool,
-                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
+                                ObjectPool* obj_pool, NewPartitionCallback&& new_partition_cb,
+                                PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<const ColumnType*>(key_columns[0].get());
         const auto key_column_data = key_column->immutable_data();
@@ -410,8 +410,8 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase<tr
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
-                                ObjectPool* obj_pool,
-                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
+                                ObjectPool* obj_pool, NewPartitionCallback&& new_partition_cb,
+                                PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<const NullableColumn>(key_columns[0].get());
         const auto key_column_data =
@@ -434,8 +434,8 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase<false, fal
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
-                                ObjectPool* obj_pool,
-                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
+                                ObjectPool* obj_pool, NewPartitionCallback&& new_partition_cb,
+                                PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<const BinaryColumn*>(key_columns[0].get());
         RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
@@ -461,8 +461,8 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase<tr
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
-                                ObjectPool* obj_pool,
-                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
+                                ObjectPool* obj_pool, NewPartitionCallback&& new_partition_cb,
+                                PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<const BinaryColumn*>(nullable_key_column->data_column().get());
@@ -500,8 +500,8 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
-                                ObjectPool* obj_pool,
-                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
+                                ObjectPool* obj_pool, NewPartitionCallback&& new_partition_cb,
+                                PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_passthrough) {
             return is_passthrough;
         }
@@ -525,12 +525,12 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
         RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk,
                 [&](uint32_t offset) {
-                    return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
+            return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
                 },
                 [&](const KeyType& key) {
-                    uint8_t* pos = mem_pool->allocate(key.size);
-                    strings::memcpy_inlined(pos, key.data, key.size);
-                    return Slice{pos, key.size};
+            uint8_t* pos = mem_pool->allocate(key.size);
+            strings::memcpy_inlined(pos, key.data, key.size);
+            return Slice{pos, key.size};
                 },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
@@ -569,8 +569,8 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
-                                ObjectPool* obj_pool,
-                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
+                                ObjectPool* obj_pool, NewPartitionCallback&& new_partition_cb,
+                                PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(fixed_byte_size != -1);
 
         if (is_passthrough) {
@@ -596,8 +596,10 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
         }
 
         RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
-                hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
-                [&](const FixedSizeSliceKey& key) { return key; }, obj_pool,
+                hash_map, chunk, [&](uint32_t offset) {
+            return keys[offset]; },
+                [&](const FixedSizeSliceKey& key) {
+            return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -23,6 +23,7 @@
 #include "column/hash_set.h"
 #include "column/runtime_type_traits.h"
 #include "column/vectorized_fwd.h"
+#include "common/statusor.h"
 #include "gutil/strings/fastmem.h"
 #include "runtime/mem_pool.h"
 
@@ -123,25 +124,26 @@ protected:
     }
 
     template <typename PartitionChunkConsumer>
-    void consume_full_chunks(PartitionChunks& value, PartitionChunkConsumer&& partition_chunk_consumer) {
+    Status consume_full_chunks(PartitionChunks& value, PartitionChunkConsumer&& partition_chunk_consumer) {
         if (value.chunks.empty()) {
-            return;
+            return Status::OK();
         }
 
         size_t num_chunks = value.chunks.size();
         for (int i = 0; i < num_chunks - 1; ++i) {
-            partition_chunk_consumer(value.partition_idx, std::move(value.chunks[i]));
+            RETURN_IF_ERROR(partition_chunk_consumer(value.partition_idx, std::move(value.chunks[i])));
         }
 
         if (value.remain_size == 0 || is_passthrough) {
             // The last chunk is also full.
-            partition_chunk_consumer(value.partition_idx, std::move(value.chunks[num_chunks - 1]));
+            RETURN_IF_ERROR(partition_chunk_consumer(value.partition_idx, std::move(value.chunks[num_chunks - 1])));
             value.chunks.clear();
         } else if (num_chunks > 1) {
             // Shrink chunks to only contain the last non-full chunk.
             value.chunks[0] = std::move(value.chunks[num_chunks - 1]);
             value.chunks.resize(1);
         }
+        return Status::OK();
     }
 
     template <bool EnablePassthrough, typename HashMap>
@@ -169,16 +171,16 @@ protected:
     //      used to load key for number type or slice type.
     // @new_partition_cb: void(size_t partition_idx)
     //      called when coming a new key not in the hash map.
-    // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
+    // @partition_chunk_consumer: Status(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
     template <bool EnablePassthrough, typename HashMap, typename KeyLoader, typename KeyAllocator,
               typename NewPartitionCallback, typename PartitionChunkConsumer>
-    void append_chunk_for_one_key(HashMap& hash_map, const ChunkPtr& chunk, KeyLoader&& key_loader,
-                                  KeyAllocator&& key_allocator, ObjectPool* obj_pool,
-                                  NewPartitionCallback&& new_partition_cb,
-                                  PartitionChunkConsumer&& partition_chunk_consumer) {
+    Status append_chunk_for_one_key(HashMap& hash_map, const ChunkPtr& chunk, KeyLoader&& key_loader,
+                                    KeyAllocator&& key_allocator, ObjectPool* obj_pool,
+                                    NewPartitionCallback&& new_partition_cb,
+                                    PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_passthrough) {
-            return;
+            return Status::OK();
         }
 
         phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
@@ -226,7 +228,8 @@ protected:
 
         if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(partition_chunk_consumer)>>) {
             for (const auto& key : visited_keys) {
-                consume_full_chunks(*(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                RETURN_IF_ERROR(consume_full_chunks(*(hash_map[key]),
+                                                    std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
             }
         }
 
@@ -237,6 +240,7 @@ protected:
             }
             chunk->check_or_die();
         }
+        return Status::OK();
     }
 
     // Append chunk to the hash_map for one nullable key
@@ -249,17 +253,17 @@ protected:
     //      used to load key for number type or slice type.
     // @new_partition_cb: void(size_t partition_idx)
     //      called when coming a new key not in the hash map.
-    // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
+    // @partition_chunk_consumer: Status(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
     template <bool EnablePassthrough, typename HashMap, typename KeyLoader, typename KeyAllocator,
               typename NewPartitionCallback, typename PartitionChunkConsumer>
-    void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, const ChunkPtr& chunk,
-                                           const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
-                                           KeyAllocator&& key_allocator, ObjectPool* obj_pool,
-                                           NewPartitionCallback&& new_partition_cb,
-                                           PartitionChunkConsumer&& partition_chunk_consumer) {
+    Status append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, const ChunkPtr& chunk,
+                                             const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
+                                             KeyAllocator&& key_allocator, ObjectPool* obj_pool,
+                                             NewPartitionCallback&& new_partition_cb,
+                                             PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_passthrough) {
-            return;
+            return Status::OK();
         }
 
         if (!init_null_key_partition) {
@@ -293,7 +297,8 @@ protected:
             total_num_rows += size;
 
             if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(partition_chunk_consumer)>>) {
-                consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                RETURN_IF_ERROR(consume_full_chunks(null_key_value,
+                                                    std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
             }
         } else {
             phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
@@ -349,10 +354,11 @@ protected:
 
             if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(partition_chunk_consumer)>>) {
                 for (const auto& key : visited_keys) {
-                    consume_full_chunks(*(hash_map[key]),
-                                        std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                    RETURN_IF_ERROR(consume_full_chunks(
+                            *(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
                 }
-                consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                RETURN_IF_ERROR(consume_full_chunks(null_key_value,
+                                                    std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
             }
 
             // The first i rows has been pushed into hash_map
@@ -363,6 +369,7 @@ protected:
                 chunk->check_or_die();
             }
         }
+        return Status::OK();
     }
 };
 
@@ -376,16 +383,17 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase<false, fal
     PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+    StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
+                                ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<const ColumnType*>(key_columns[0].get());
         const auto key_column_data = key_column->immutable_data();
-        append_chunk_for_one_key<EnablePassthrough>(
+        RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
                 [](const FieldType& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
         return is_passthrough;
     }
 };
@@ -401,17 +409,18 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase<tr
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+    StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
+                                ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<const NullableColumn>(key_columns[0].get());
         const auto key_column_data =
                 down_cast<const ColumnType*>(nullable_key_column->data_column().get())->immutable_data();
-        append_chunk_for_one_nullable_key<EnablePassthrough>(
+        RETURN_IF_ERROR(append_chunk_for_one_nullable_key<EnablePassthrough>(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
         return is_passthrough;
     }
 };
@@ -424,11 +433,12 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase<false, fal
     PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+    StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
+                                ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<const BinaryColumn*>(key_columns[0].get());
-        append_chunk_for_one_key<EnablePassthrough>(
+        RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk, [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
                     uint8_t* pos = mem_pool->allocate(key.size);
@@ -436,7 +446,7 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase<false, fal
                     return Slice{pos, key.size};
                 },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
         return is_passthrough;
     }
 };
@@ -450,12 +460,13 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase<tr
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+    StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
+                                ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<const BinaryColumn*>(nullable_key_column->data_column().get());
-        append_chunk_for_one_nullable_key<EnablePassthrough>(
+        RETURN_IF_ERROR(append_chunk_for_one_nullable_key<EnablePassthrough>(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
@@ -464,7 +475,7 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase<tr
                     return Slice{pos, key.size};
                 },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));
         return is_passthrough;
     }
 };
@@ -488,7 +499,8 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
               buffer(inner_mem_pool->allocate(max_one_row_size * chunk_size)) {}
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+    StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
+                                ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_passthrough) {
             return is_passthrough;
@@ -510,7 +522,7 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
             key_column->serialize_batch(buffer, slice_sizes, num_rows, max_one_row_size);
         }
 
-        append_chunk_for_one_key<EnablePassthrough>(
+        RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk,
                 [&](uint32_t offset) {
                     return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
@@ -556,7 +568,8 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
     }
 
     template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+    StatusOr<bool> append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool,
+                                ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(fixed_byte_size != -1);
 
@@ -582,7 +595,7 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
             }
         }
 
-        append_chunk_for_one_key<EnablePassthrough>(
+        RETURN_IF_ERROR(append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
                 [&](const FixedSizeSliceKey& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),

--- a/be/src/exec/pipeline/hash_partition_context.cpp
+++ b/be/src/exec/pipeline/hash_partition_context.cpp
@@ -69,10 +69,11 @@ bool HashPartitionContext::is_finished() {
 
 StatusOr<ChunkPtr> HashPartitionContext::pull_one_chunk(RuntimeState* state) {
     if (!_chunks_partitioner->is_hash_map_eos()) {
-        RETURN_IF_ERROR(_chunks_partitioner->consume_from_hash_map([&](int32_t partition_idx, ChunkPtr& chunk) {
-            _acc.push(chunk);
-            return _acc.need_input();
-        }));
+        RETURN_IF_ERROR(_chunks_partitioner->consume_from_hash_map(
+                [&](int32_t partition_idx, ChunkPtr& chunk) -> StatusOr<bool> {
+                    _acc.push(chunk);
+                    return _acc.need_input();
+                }));
         if (_chunks_partitioner->is_hash_map_eos()) {
             _acc.finalize();
         }

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -198,11 +198,12 @@ Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* st
                             &_pre_agg->_agg_fn_ctxs, agg_states, _pre_agg.get()));
                 }
             },
-            [this, state](size_t partition_idx, const ChunkPtr& chunk) {
-                (void)_chunks_sorters[partition_idx]->update(state, chunk);
+            [this, state](size_t partition_idx, const ChunkPtr& chunk) -> Status {
+                RETURN_IF_ERROR(_chunks_sorters[partition_idx]->update(state, chunk));
                 if (_enable_pre_agg) {
-                    (void)compute_agg_state(chunk.get(), partition_idx);
+                    RETURN_IF_ERROR(compute_agg_state(chunk.get(), partition_idx));
                 }
+                return Status::OK();
             }));
     if (_chunks_partitioner->is_passthrough()) {
         RETURN_IF_ERROR(transfer_all_chunks_from_partitioner_to_sorters(state));
@@ -224,12 +225,13 @@ Status LocalPartitionTopnContext::transfer_all_chunks_from_partitioner_to_sorter
     }
 
     _partition_num = _chunks_partitioner->num_partitions();
-    RETURN_IF_ERROR(
-            _chunks_partitioner->consume_from_hash_map([this, state](int32_t partition_idx, const ChunkPtr& chunk) {
-                (void)_chunks_sorters[partition_idx]->update(state, chunk);
+    RETURN_IF_ERROR(_chunks_partitioner->consume_from_hash_map(
+            [this, state](int32_t partition_idx, const ChunkPtr& chunk) -> StatusOr<bool> {
+                RETURN_IF_ERROR(_chunks_sorters[partition_idx]->update(state, chunk));
                 if (_enable_pre_agg) {
-                    (void)compute_agg_state(chunk.get(), partition_idx);
+                    RETURN_IF_ERROR(compute_agg_state(chunk.get(), partition_idx));
                 }
+                // Keep consuming all partitions.
                 return true;
             }));
 


### PR DESCRIPTION
## Why I'm doing:

LocalPartitionTopnContext discarded the Status returned by ChunksSorter::update and compute_agg_state inside the ChunksPartitioner consumer callbacks via (void). A failed sort or pre-aggregation state update (e.g. MemLimitExceeded) was silently swallowed, so a partitioned TopN could return wrong or partial results without surfacing any error.

The root cause is that the partitioner consumer callbacks could not report errors: offer's partition_chunk_consumer returned void and consume_from_hash_map's consumer returned a bare bool used only for continue/suspend flow control. Fix the contract so consumers can propagate Status:

- offer's partition_chunk_consumer now returns Status. Thread it through _split_chunk_by_partition and PartitionHashMap's append_chunk / append_chunk_for_one_key / append_chunk_for_one_nullable_key / consume_full_chunks; append_chunk now returns StatusOr<bool> (the bool still carries is_passthrough).
- consume_from_hash_map's consumer now returns StatusOr<bool>: the bool keeps the existing continue/suspend semantics, while a non-ok status aborts consumption and is returned to the caller.
- The hash-map-variant visitors return Status directly (visit forwards std::visit's result).

Update both callers (local partition TopN and hash partition) to return errors directly from their consumers instead of swallowing them.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
