### PR TITLE
[BugFix] Mask tencent.cos and iceberg.jdbc.password in SHOW CREATE CATALOG

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -32,6 +32,7 @@ public class IcebergCatalogProperties {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final String HIVE_METASTORE_TIMEOUT = "hive.metastore.timeout";
     public static final String ICEBERG_CUSTOM_PROPERTIES_PREFIX = "iceberg.catalog.";
+    public static final String ICEBERG_JDBC_PASSWORD = "jdbc.password";
     public static final String ENABLE_ICEBERG_METADATA_CACHE = "enable_iceberg_metadata_cache";
     public static final String ENABLE_ICEBERG_TABLE_CACHE = "enable_iceberg_table_cache";
     public static final String ICEBERG_META_CACHE_TTL = "iceberg_meta_cache_ttl_sec"; // implicit for user

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -60,6 +60,10 @@ public class CredentialUtil {
         doMask(properties, CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT);
         doMask(properties, CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT);
 
+        // Mask for tencent's credential
+        doMask(properties, CloudConfigurationConstants.TENCENT_COS_ACCESS_KEY);
+        doMask(properties, CloudConfigurationConstants.TENCENT_COS_SECRET_KEY);
+
         // Mask for iceberg rest catalog credential
         doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
                 OAuth2SecurityConfig.OAUTH2_CREDENTIAL);
@@ -69,6 +73,10 @@ public class CredentialUtil {
                 AwsProperties.REST_ACCESS_KEY_ID);
         doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
                 AwsProperties.REST_SECRET_ACCESS_KEY);
+
+        // Mask for iceberg jdbc catalog credential
+        doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                IcebergCatalogProperties.ICEBERG_JDBC_PASSWORD);
 
         // Mask for odps catalog credential
         doMask(properties, OdpsProperties.ACCESS_ID);

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -92,14 +92,14 @@ public class CredentialUtilTest {
     @Test
     public void testMaskHuaweiOBSCredential() {
         Map<String, String> properties = new HashMap<>();
-        
+
         // Test underscore format
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY, "AKIAIOSFODNN7EXAMPLE");
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
         CredentialUtil.maskCredential(properties);
         Assertions.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY));
         Assertions.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY));
-        
+
         // Test dot format
         properties.clear();
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT, "AKIAIOSFODNN7EXAMPLE");
@@ -107,6 +107,27 @@ public class CredentialUtilTest {
         CredentialUtil.maskCredential(properties);
         Assertions.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT));
         Assertions.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT));
+    }
+
+    @Test
+    public void testMaskTencentCOSCredential() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CloudConfigurationConstants.TENCENT_COS_ACCESS_KEY, "test_cos_access_key");
+        properties.put(CloudConfigurationConstants.TENCENT_COS_SECRET_KEY, "test_cos_secret_key");
+        CredentialUtil.maskCredential(properties);
+        Assertions.assertEquals("te******ey", properties.get(CloudConfigurationConstants.TENCENT_COS_ACCESS_KEY));
+        Assertions.assertEquals("te******ey", properties.get(CloudConfigurationConstants.TENCENT_COS_SECRET_KEY));
+    }
+
+    @Test
+    public void testMaskIcebergJdbcCatalogPassword() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                IcebergCatalogProperties.ICEBERG_JDBC_PASSWORD, "12345678");
+        CredentialUtil.maskCredential(properties);
+        Assertions.assertEquals("12******78", properties.get(
+                IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                        IcebergCatalogProperties.ICEBERG_JDBC_PASSWORD));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Mask `tencent.cos.access_key`, `tencent.cos.secret_key` and `iceberg.catalog.jdbc.password` while show create catalog

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
