### PR TITLE
[Enhancement] Reduce copies and allocations in spill restore path

### DIFF
--- a/be/src/compute_env/spill/block_manager.h
+++ b/be/src/compute_env/spill/block_manager.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 
+#include "base/container/raw_container.h"
 #include "base/metrics.h"
 #include "base/string/slice.h"
 #include "common/runtime_profile.h"
@@ -105,11 +106,24 @@ public:
     // if the Block has reached the end, should return EndOfFile status
     virtual Status read_fully(void* data, int64_t count);
 
+    // read exactly `count` bytes like read_fully, but prefer returning a
+    // zero-copy view into the internal read buffer. When the data cannot be
+    // served from the buffer (buffer read disabled or `count` exceeds the
+    // buffer capacity), the bytes are copied into `fallback` and the returned
+    // slice points into it. The returned slice is invalidated by any
+    // subsequent read on this reader and by any other use of `fallback`, so
+    // it must be fully consumed before either is touched again and must not
+    // be stored.
+    [[nodiscard]] StatusOr<Slice> read_view(raw::RawString* fallback, int64_t count);
+
     virtual std::string debug_string() = 0;
 
     virtual const Block* block() const = 0;
 
 protected:
+    Status _init_readable();
+    void _update_io_metrics(int64_t io_ns, int64_t read_len);
+
     const Block* _block = nullptr;
     std::unique_ptr<io::InputStreamWrapper> _readable;
     size_t _length = 0;

--- a/be/src/compute_env/spill/block_reader.cpp
+++ b/be/src/compute_env/spill/block_reader.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstring>
+
 #include "base/string/slice.h"
 #include "common/statusor.h"
 #include "compute_env/spill/block_manager.h"
@@ -52,7 +54,19 @@ StatusOr<int64_t> try_to_read_from_file(io::InputStreamWrapper* readable, void* 
     return total_read;
 }
 
-Status BlockReader::read_fully(void* data, int64_t count) {
+void BlockReader::_update_io_metrics(int64_t io_ns, int64_t read_len) {
+    COUNTER_UPDATE(_options.read_io_timer, io_ns);
+    COUNTER_UPDATE(_options.read_io_count, 1);
+    COUNTER_UPDATE(_options.read_io_bytes, read_len);
+    if (_options.global_read_io_duration_ns != nullptr) {
+        _options.global_read_io_duration_ns->increment(io_ns);
+    }
+    if (_options.global_read_bytes != nullptr) {
+        _options.global_read_bytes->increment(read_len);
+    }
+}
+
+Status BlockReader::_init_readable() {
     if (_readable == nullptr) {
         ASSIGN_OR_RETURN(_readable, _block->get_readable());
         _length = _block->size();
@@ -62,6 +76,11 @@ Status BlockReader::read_fully(void* data, int64_t count) {
             _buffer = std::make_unique<uint8_t[]>(_options.max_buffer_bytes);
         }
     }
+    return Status::OK();
+}
+
+Status BlockReader::read_fully(void* data, int64_t count) {
+    RETURN_IF_ERROR(_init_readable());
 
     if (_offset + count > _length) {
         return Status::EndOfFile("no more data in this block");
@@ -90,15 +109,7 @@ Status BlockReader::read_fully(void* data, int64_t count) {
                     SCOPED_RAW_TIMER(&io_ns);
                     ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), offset, length_need_read));
                 }
-                COUNTER_UPDATE(_options.read_io_timer, io_ns);
-                COUNTER_UPDATE(_options.read_io_count, 1);
-                COUNTER_UPDATE(_options.read_io_bytes, read_len);
-                if (_options.global_read_io_duration_ns != nullptr) {
-                    _options.global_read_io_duration_ns->increment(io_ns);
-                }
-                if (_options.global_read_bytes != nullptr) {
-                    _options.global_read_bytes->increment(read_len);
-                }
+                _update_io_metrics(io_ns, read_len);
                 _slice.clear();
             } else {
                 // refill buffer, then read res data from buffer
@@ -109,15 +120,7 @@ Status BlockReader::read_fully(void* data, int64_t count) {
                     ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), _buffer.get(),
                                                                      _options.max_buffer_bytes, length_need_read));
                 }
-                COUNTER_UPDATE(_options.read_io_timer, io_ns);
-                COUNTER_UPDATE(_options.read_io_count, 1);
-                COUNTER_UPDATE(_options.read_io_bytes, read_len);
-                if (_options.global_read_io_duration_ns != nullptr) {
-                    _options.global_read_io_duration_ns->increment(io_ns);
-                }
-                if (_options.global_read_bytes != nullptr) {
-                    _options.global_read_bytes->increment(read_len);
-                }
+                _update_io_metrics(io_ns, read_len);
                 _slice = Slice(_buffer.get(), read_len);
                 std::memcpy(offset, _slice.data, length_need_read);
                 _slice.remove_prefix(length_need_read);
@@ -130,18 +133,53 @@ Status BlockReader::read_fully(void* data, int64_t count) {
             SCOPED_RAW_TIMER(&io_ns);
             ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), data, count));
         }
-        COUNTER_UPDATE(_options.read_io_timer, io_ns);
-        COUNTER_UPDATE(_options.read_io_count, 1);
-        COUNTER_UPDATE(_options.read_io_bytes, read_len);
-        if (_options.global_read_io_duration_ns != nullptr) {
-            _options.global_read_io_duration_ns->increment(io_ns);
-        }
-        if (_options.global_read_bytes != nullptr) {
-            _options.global_read_bytes->increment(read_len);
-        }
+        _update_io_metrics(io_ns, read_len);
     }
     _offset += count;
     return Status::OK();
+}
+
+StatusOr<Slice> BlockReader::read_view(raw::RawString* fallback, int64_t count) {
+    RETURN_IF_ERROR(_init_readable());
+
+    // `count` typically comes from a size field read from disk; a corrupted
+    // value can be negative here and would defeat the unsigned bounds checks
+    // below, so fail fast instead
+    if (count < 0) {
+        return Status::InternalError(fmt::format("invalid read size {}", count));
+    }
+    if (_offset + count > _length) {
+        return Status::EndOfFile("no more data in this block");
+    }
+
+    if (_options.enable_buffer_read && static_cast<int64_t>(_options.max_buffer_bytes) >= count) {
+        int64_t length_in_buffer = _slice.size;
+        if (length_in_buffer < count) {
+            // move the buffered tail to the head of the buffer (regions may
+            // overlap), then refill the rest from the file
+            if (length_in_buffer > 0) {
+                std::memmove(_buffer.get(), _slice.data, length_in_buffer);
+            }
+            int64_t io_ns = 0;
+            int64_t read_len = 0;
+            {
+                SCOPED_RAW_TIMER(&io_ns);
+                ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), _buffer.get() + length_in_buffer,
+                                                                 _options.max_buffer_bytes - length_in_buffer,
+                                                                 count - length_in_buffer));
+            }
+            _update_io_metrics(io_ns, read_len);
+            _slice = Slice(_buffer.get(), length_in_buffer + read_len);
+        }
+        Slice view(_slice.data, count);
+        _slice.remove_prefix(count);
+        _offset += count;
+        return view;
+    }
+
+    fallback->resize(count);
+    RETURN_IF_ERROR(read_fully(fallback->data(), count));
+    return Slice(fallback->data(), count);
 }
 
 } // namespace starrocks::spill

--- a/be/src/compute_env/spill/data_stream.cpp
+++ b/be/src/compute_env/spill/data_stream.cpp
@@ -148,7 +148,7 @@ Status DataTranster::transfer(workgroup::YieldContext& yield_ctx, RuntimeState* 
     // read data from input stream and append to output stream
     bool need_aligned = state->spill_enable_direct_io();
     auto task_context = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
-    SerdeContext read_ctx;
+    SerdeContext& read_ctx = task_context->serde_ctx;
     while (true) {
         SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
         if (!input_stream->is_ready()) {

--- a/be/src/compute_env/spill/input_stream.cpp
+++ b/be/src/compute_env/spill/input_stream.cpp
@@ -25,6 +25,15 @@
 
 #include "base/concurrency/blocking_queue.hpp"
 #include "base/utility/defer_op.h"
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/column_visitor_adapter.h"
+#include "column/const_column.h"
+#include "column/decimalv3_column.h"
+#include "column/fixed_length_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/object_column.h"
 #include "common/status.h"
 #include "compute_env/sorting/sorted_chunks_merger.h"
 #include "compute_env/spill/block_manager.h"
@@ -89,10 +98,74 @@ StatusOr<ChunkUniquePtr> UnionAllSpilledInputStream::get_next(workgroup::YieldCo
     return Status::EndOfFile("eos");
 }
 
+namespace {
+// Checks that no ColumnPtr anywhere in a column tree is shared with another
+// holder, so the column can be handed out for in-place mutation without
+// copying. Column types not listed here (struct, json, variant,
+// adaptive-nullable, any future type) are conservatively treated as shared.
+class ExclusiveOwnershipChecker final : public ColumnVisitorAdapter<ExclusiveOwnershipChecker> {
+public:
+    ExclusiveOwnershipChecker() : ColumnVisitorAdapter(this) {}
+
+    template <typename PtrT>
+    bool exclusive(const PtrT& column) {
+        // a non-ok accept means the visitor base rejected an unknown type,
+        // which counts as shared as well
+        return column->use_count() == 1 && column->accept(this).ok() && !_shared_found;
+    }
+
+    Status do_visit(const NullableColumn& column) {
+        _shared_found |= !exclusive(column.data_column()) || !exclusive(column.null_column());
+        return Status::OK();
+    }
+    Status do_visit(const ConstColumn& column) {
+        _shared_found |= !exclusive(column.data_column());
+        return Status::OK();
+    }
+    Status do_visit(const ArrayColumn& column) {
+        _shared_found |= !exclusive(column.elements_column()) || !exclusive(column.offsets_column());
+        return Status::OK();
+    }
+    Status do_visit(const MapColumn& column) {
+        _shared_found |= !exclusive(column.keys_column()) || !exclusive(column.values_column()) ||
+                         !exclusive(column.offsets_column());
+        return Status::OK();
+    }
+    template <typename T>
+    Status do_visit(const BinaryColumnBase<T>& column) {
+        return Status::OK();
+    }
+    // the leaf overloads must take the exact dispatched types: a base-class
+    // template like FixedLengthColumnBase<T> only matches with conversion
+    // rank and would lose overload resolution to the generic catch-all below
+    template <typename T>
+    Status do_visit(const FixedLengthColumn<T>& column) {
+        return Status::OK();
+    }
+    template <typename T>
+    Status do_visit(const DecimalV3Column<T>& column) {
+        return Status::OK();
+    }
+    template <typename T>
+    Status do_visit(const ObjectColumn<T>& column) {
+        return Status::OK();
+    }
+    template <typename ColumnT>
+    Status do_visit(const ColumnT&) {
+        _shared_found = true;
+        return Status::OK();
+    }
+
+private:
+    bool _shared_found = false;
+};
+} // namespace
+
 // The raw chunk input stream. all chunks are in memory.
 class RawChunkInputStream final : public SpillInputStream {
 public:
-    RawChunkInputStream(std::vector<ChunkPtr> chunks, Spiller* spiller) : _chunks(std::move(chunks)) {
+    RawChunkInputStream(std::vector<ChunkPtr> chunks, Spiller* spiller)
+            : _chunks(std::move(chunks)), _spiller(spiller) {
         for (const auto& chunk : _chunks) {
             _total_rows += chunk->num_rows();
         }
@@ -107,6 +180,7 @@ private:
     size_t _read_rows{};
     size_t _read_idx{};
     std::vector<ChunkPtr> _chunks;
+    Spiller* _spiller = nullptr;
     DECLARE_RACE_DETECTOR(detect_get_next)
 };
 
@@ -116,10 +190,34 @@ StatusOr<ChunkUniquePtr> RawChunkInputStream::get_next(workgroup::YieldContext& 
         DCHECK_EQ(_total_rows, _read_rows);
         return Status::EndOfFile("eos");
     }
-    // TODO: make ChunkPtr could convert to ChunkUniquePtr to avoid unused memory copy
-    auto res = std::move(_chunks[_read_idx++])->clone_unique();
+    auto chunk = std::move(_chunks[_read_idx++]);
+    // consumers are allowed to mutate the returned chunk in place, so the
+    // chunk can only be handed over without copying when its whole column
+    // tree is exclusively owned
+    bool exclusive = chunk.use_count() == 1;
+    if (exclusive) {
+        ExclusiveOwnershipChecker checker;
+        for (const auto& column : chunk->columns()) {
+            if (!checker.exclusive(column)) {
+                exclusive = false;
+                break;
+            }
+        }
+    }
+    ChunkUniquePtr res;
+    if (exclusive) {
+        res = std::make_unique<Chunk>(std::move(*chunk));
+    } else {
+        res = chunk->clone_unique();
+    }
     _read_rows += res->num_rows();
-    _chunks[_read_idx - 1].reset();
+    if (_spiller != nullptr) {
+        const auto& metrics = _spiller->metrics();
+        if (metrics.restore_from_mem_table_rows != nullptr) {
+            COUNTER_UPDATE(metrics.restore_from_mem_table_rows, res->num_rows());
+            COUNTER_UPDATE(metrics.restore_from_mem_table_bytes, res->bytes_usage());
+        }
+    }
 
     return res;
 }
@@ -137,8 +235,8 @@ InputStreamPtr SpillInputStream::union_all(std::vector<InputStreamPtr>& _streams
     return std::make_shared<UnionAllSpilledInputStream>(_streams);
 }
 
-InputStreamPtr SpillInputStream::as_stream(const std::vector<ChunkPtr>& chunks, Spiller* spiller) {
-    return detail::make_raw_chunk_input_stream(chunks, spiller);
+InputStreamPtr SpillInputStream::as_stream(std::vector<ChunkPtr> chunks, Spiller* spiller) {
+    return detail::make_raw_chunk_input_stream(std::move(chunks), spiller);
 }
 
 class BufferedInputStream : public SpillInputStream {

--- a/be/src/compute_env/spill/input_stream.h
+++ b/be/src/compute_env/spill/input_stream.h
@@ -52,7 +52,7 @@ public:
 
     static InputStreamPtr union_all(const InputStreamPtr& left, const InputStreamPtr& right);
     static InputStreamPtr union_all(std::vector<InputStreamPtr>& _streams);
-    static InputStreamPtr as_stream(const std::vector<ChunkPtr>& chunks, Spiller* spiller);
+    static InputStreamPtr as_stream(std::vector<ChunkPtr> chunks, Spiller* spiller);
 
 private:
     std::atomic_bool _eof = false;

--- a/be/src/compute_env/spill/mem_table.cpp
+++ b/be/src/compute_env/spill/mem_table.cpp
@@ -48,6 +48,7 @@ bool UnorderedMemTable::is_empty() {
 Status UnorderedMemTable::append(ChunkPtr chunk) {
     DCHECK(!_is_done);
     DCHECK(chunk != nullptr);
+    _consumed_by_exclusive_read = false;
     auto chunk_mem_usage = chunk->memory_usage();
     _tracker->consume(chunk_mem_usage);
     COUNTER_ADD(_spiller->metrics().mem_table_peak_memory_usage, chunk_mem_usage);
@@ -68,6 +69,7 @@ Status UnorderedMemTable::append(ChunkPtr chunk) {
 
 Status UnorderedMemTable::append_selective(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
     DCHECK(!_is_done);
+    _consumed_by_exclusive_read = false;
     if (_chunks.empty() || _chunks.back()->num_rows() + size > _runtime_state->chunk_size()) {
         _chunks.emplace_back(src.clone_empty());
         _tracker->consume(_chunks.back()->memory_usage());
@@ -90,7 +92,6 @@ Status UnorderedMemTable::finalize(workgroup::YieldContext& yield_ctx, const Spi
     SCOPED_TIMER(_spiller->metrics().mem_table_finalize_timer);
     auto& serde = _spiller->serde();
     {
-        SerdeContext serde_ctx;
         auto io_ctx = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
         bool need_aligned = _runtime_state->spill_enable_direct_io();
         while (_processed_index < _chunks.size()) {
@@ -102,7 +103,7 @@ Status UnorderedMemTable::finalize(workgroup::YieldContext& yield_ctx, const Spi
             }
             SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
             auto chunk = _chunks[_processed_index++];
-            RETURN_IF_ERROR(serde->serialize(_runtime_state, serde_ctx, chunk, output, need_aligned));
+            RETURN_IF_ERROR(serde->serialize(_runtime_state, io_ctx->serde_ctx, chunk, output, need_aligned));
             RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
         }
     }
@@ -114,13 +115,28 @@ void UnorderedMemTable::reset() {
     SpillableMemTable::reset();
     _chunks.clear();
     _processed_index = 0;
+    _consumed_by_exclusive_read = false;
 }
 
-StatusOr<std::shared_ptr<SpillInputStream>> UnorderedMemTable::as_input_stream(bool shared) {
-    if (shared) {
+StatusOr<std::shared_ptr<SpillInputStream>> UnorderedMemTable::as_input_stream(MemTableReadMode mode) {
+    if (mode == MemTableReadMode::SHARED) {
+        // the mem table keeps its chunks, the stream serves copies so that it
+        // can be consumed by multiple readers
         return SpillInputStream::as_stream(_chunks, _spiller);
     } else {
-        return SpillInputStream::as_stream(_chunks, _spiller);
+        // exclusive read: hand the chunks over to the stream so they can be
+        // returned without copying and freed incrementally as they are
+        // consumed.
+        // The tracker consumption is deliberately kept: the chunks are still
+        // alive inside the stream, and releasing the accounting here would
+        // understate spill memory while they are being consumed. It is
+        // released when the mem table is reset or destroyed — the same
+        // timeline as when the mem table itself kept the chunks until then.
+        auto stream = SpillInputStream::as_stream(std::move(_chunks), _spiller);
+        _chunks.clear();
+        _processed_index = 0;
+        _consumed_by_exclusive_read = true;
+        return stream;
     }
 }
 
@@ -170,7 +186,6 @@ Status OrderedMemTable::finalize(workgroup::YieldContext& yield_ctx, const Spill
     // seriealize data, store result into _block
     auto& serde = _spiller->serde();
 
-    SerdeContext serde_ctx;
     auto io_ctx = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
     while (!_chunk_slice.empty()) {
         if (!(output->is_remote() ^ io_ctx->use_local_io_executor)) {
@@ -183,7 +198,7 @@ Status OrderedMemTable::finalize(workgroup::YieldContext& yield_ctx, const Spill
         ChunkPtr chunk = _chunk_slice.cutoff(_runtime_state->chunk_size());
         bool need_aligned = _runtime_state->spill_enable_direct_io();
 
-        RETURN_IF_ERROR(serde->serialize(_runtime_state, serde_ctx, chunk, output, need_aligned));
+        RETURN_IF_ERROR(serde->serialize(_runtime_state, io_ctx->serde_ctx, chunk, output, need_aligned));
         RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
     }
     TRACE_SPILL_LOG << fmt::format("finalize spillable ordered memtable done, rows[{}]", num_rows());

--- a/be/src/compute_env/spill/mem_table.h
+++ b/be/src/compute_env/spill/mem_table.h
@@ -32,6 +32,16 @@
 
 namespace starrocks::spill {
 using FlushCallBack = std::function<Status(const ChunkPtr&)>;
+
+// how a mem table's in-memory chunks are exposed as an input stream
+enum class MemTableReadMode {
+    // the mem table keeps its chunks; the stream serves deep copies, so
+    // multiple readers can each see all rows
+    SHARED,
+    // destructive: the chunks are handed over to the (single) stream without
+    // copying and the mem table is left empty
+    EXCLUSIVE,
+};
 //  This component is the intermediate buffer for our spill data, which may be ordered or unordered,
 // depending on the requirements of the upper layer
 
@@ -79,7 +89,7 @@ public:
     // NOTE: The implementation of `finalize` needs to ensure reentrancy in order to implement io task yield mechanism
     virtual Status finalize(workgroup::YieldContext& yield_ctx, const SpillOutputDataStreamPtr& block) = 0;
 
-    virtual StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) {
+    virtual StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(MemTableReadMode mode) {
         return Status::NotSupported("unsupport to call as_input_stream");
     }
 
@@ -89,6 +99,10 @@ public:
 
     // mem table is done. we can't append data any more
     bool is_done() const { return _is_done; }
+
+    // whether the in-memory chunks were destructively handed over to a
+    // non-shared input stream and no data has been appended since
+    virtual bool consumed_by_exclusive_read() const { return false; }
 
 protected:
     RuntimeState* _runtime_state;
@@ -114,13 +128,16 @@ public:
     Status finalize(workgroup::YieldContext& yield_ctx, const SpillOutputDataStreamPtr& output) override;
     void reset() override;
 
-    StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) override;
+    StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(MemTableReadMode mode) override;
+
+    bool consumed_by_exclusive_read() const override { return _consumed_by_exclusive_read; }
 
     std::vector<ChunkPtr>& get_chunks() { return _chunks; }
 
 private:
     size_t _processed_index = 0;
     std::vector<ChunkPtr> _chunks;
+    bool _consumed_by_exclusive_read = false;
 };
 
 class OrderedMemTable final : public SpillableMemTable {

--- a/be/src/compute_env/spill/serde.cpp
+++ b/be/src/compute_env/spill/serde.cpp
@@ -179,27 +179,27 @@ StatusOr<ChunkUniquePtr> ColumnarSerde::deserialize(SerdeContext& ctx, BlockRead
     auto chunk = _chunk_builder();
     auto& columns = chunk->columns();
 
-    auto& serialize_buffer = ctx.serialize_buffer;
-    serialize_buffer.resize(attachment_size);
-
-    auto buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
-    const auto* end = buf + serialize_buffer.size();
-    {
-        auto st = reader->read_fully(buf, attachment_size);
-        RETURN_IF(st.is_end_of_file(), Status::InternalError("not found enough data in block"));
-        RETURN_IF_ERROR(st);
+    size_t encode_level_sizes = columns.size() * sizeof(uint32_t);
+    if (attachment_size < encode_level_sizes) {
+        return Status::InternalError(fmt::format("corrupted spill data, attachment size {} is less than {}",
+                                                 attachment_size, encode_level_sizes));
     }
 
-    const uint32_t* encode_levels = nullptr;
-    const uint8_t* read_cursor = buf;
-    encode_levels = reinterpret_cast<uint32_t*>(serialize_buffer.data());
+    // the view points either into the reader's internal buffer or into
+    // ctx.serialize_buffer; it stays valid until the next read on this reader
+    auto view_st = reader->read_view(&ctx.serialize_buffer, attachment_size);
+    RETURN_IF(view_st.status().is_end_of_file(), Status::InternalError("not found enough data in block"));
+    RETURN_IF_ERROR(view_st.status());
 
-    read_cursor += columns.size() * sizeof(uint32_t);
+    const auto* encode_level_cursor = reinterpret_cast<const uint8_t*>(view_st.value().data);
+    const auto* read_cursor = encode_level_cursor + encode_level_sizes;
+    const auto* end = encode_level_cursor + attachment_size;
+
     SCOPED_TIMER(_parent->metrics().deserialize_timer);
     for (size_t i = 0; i < columns.size(); i++) {
-        ASSIGN_OR_RETURN(read_cursor,
-                         serde::ColumnArraySerde::deserialize(read_cursor, end, columns[i]->as_mutable_raw_ptr(), false,
-                                                              encode_levels[i]));
+        uint32_t encode_level = UNALIGNED_LOAD32(encode_level_cursor + i * sizeof(uint32_t));
+        ASSIGN_OR_RETURN(read_cursor, serde::ColumnArraySerde::deserialize(
+                                              read_cursor, end, columns[i]->as_mutable_raw_ptr(), false, encode_level));
     }
 
     TRACE_SPILL_LOG << "deserialize chunk from block: " << reader->debug_string()

--- a/be/src/compute_env/spill/spill_components.cpp
+++ b/be/src/compute_env/spill/spill_components.cpp
@@ -211,9 +211,19 @@ Status RawSpillerWriter::acquire_stream(std::shared_ptr<SpillInputStream>* strea
 
     *stream = input_stream;
 
+    if (_mem_table != nullptr && _mem_table->consumed_by_exclusive_read()) {
+        // the in-memory rows were destructively handed over to a previously
+        // acquired stream; a second reader here means some multi-reader
+        // topology is missing read_shared and would silently lose those rows
+        return Status::InternalError(
+                fmt::format("spill mem table already consumed by an exclusive stream, spiller[{}] node[{}]", opts.name,
+                            opts.plan_node_id));
+    }
     if (_mem_table != nullptr && !_mem_table->is_empty()) {
         DCHECK(opts.is_unordered);
-        ASSIGN_OR_RETURN(auto mem_table_stream, _mem_table->as_input_stream(opts.read_shared));
+        ASSIGN_OR_RETURN(
+                auto mem_table_stream,
+                _mem_table->as_input_stream(opts.read_shared ? MemTableReadMode::SHARED : MemTableReadMode::EXCLUSIVE));
         *stream = SpillInputStream::union_all(mem_table_stream, *stream);
     }
 
@@ -475,8 +485,7 @@ void PartitionedSpillerWriter::shuffle(std::vector<uint32_t>& dst, const SpillHa
     }
 }
 
-Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_ctx, SerdeContext& ctx,
-                                                 SpilledPartition* partition) {
+Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_ctx, SpilledPartition* partition) {
     TRY_CATCH_ALLOC_SCOPE_START()
 
     auto mem_table = partition->spill_writer->mem_table();
@@ -506,7 +515,7 @@ Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_
     return Status::OK();
 }
 
-Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext& yield_ctx, SerdeContext& context,
+Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext& yield_ctx,
                                                          const std::vector<SpilledPartition*>& spilling_partitions) {
     SCOPED_TIMER(_spiller->metrics().flush_timer);
     auto io_task = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
@@ -518,7 +527,7 @@ Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext
                                        flush_ctx.processing_idx);
         {
             SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
-            RETURN_IF_ERROR(spill_partition(yield_ctx, context, partition));
+            RETURN_IF_ERROR(spill_partition(yield_ctx, partition));
             RETURN_IF_YIELD(yield_ctx.need_yield);
             ++flush_ctx.processing_idx;
             // check time
@@ -528,7 +537,7 @@ Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext
     return Status::OK();
 }
 
-Status PartitionedSpillerWriter::_split_input_partitions(workgroup::YieldContext& yield_ctx, SerdeContext& context,
+Status PartitionedSpillerWriter::_split_input_partitions(workgroup::YieldContext& yield_ctx,
                                                          const std::vector<SpilledPartition*>& splitting_partitions) {
     SCOPED_TIMER(_spiller->metrics().split_partition_timer);
     auto io_task = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
@@ -562,7 +571,7 @@ Status PartitionedSpillerWriter::_split_input_partitions(workgroup::YieldContext
             flush_ctx.right = std::move(right);
         }
 
-        auto st = _split_partition(yield_ctx, context, flush_ctx.reader.get(), partition, flush_ctx.left.get(),
+        auto st = _split_partition(yield_ctx, flush_ctx.reader.get(), partition, flush_ctx.left.get(),
                                    flush_ctx.right.get());
         RETURN_IF_YIELD(yield_ctx.need_yield);
         RETURN_IF(!st.is_ok_or_eof(), st);
@@ -725,9 +734,9 @@ Status PartitionedSpillerWriter::_compact_skew_chunks(size_t num_rows, std::vect
     return _spiller->options().skew_chunk_compactor(chunks, context);
 }
 
-Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield_ctx, SerdeContext& spill_ctx,
-                                                  SpillerReader* reader, SpilledPartition* partition,
-                                                  SpilledPartition* left_partition, SpilledPartition* right_partition) {
+Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield_ctx, SpillerReader* reader,
+                                                  SpilledPartition* partition, SpilledPartition* left_partition,
+                                                  SpilledPartition* right_partition) {
     size_t current_level = partition->level;
     auto left_mem_table = left_partition->spill_writer->mem_table();
     auto right_mem_table = right_partition->spill_writer->mem_table();
@@ -738,13 +747,13 @@ Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield
             left_mem_table->num_rows(), right_mem_table->num_rows());
     Status st;
     {
-        auto flush_partition = [this, &spill_ctx, &yield_ctx](SpilledPartition* partition) -> Status {
+        auto flush_partition = [this, &yield_ctx](SpilledPartition* partition) -> Status {
             auto mem_table = partition->spill_writer->mem_table();
             if (mem_table->is_empty()) {
                 return Status::OK();
             }
             RETURN_IF_ERROR(mem_table->done());
-            return this->spill_partition(yield_ctx, spill_ctx, partition);
+            return this->spill_partition(yield_ctx, partition);
         };
 
         auto defer = DeferOp([&]() {
@@ -832,17 +841,14 @@ Status PartitionedSpillerWriter::yieldable_flush_task(workgroup::YieldContext& c
     ctx.total_yield_point_cnt = FINISH;
     DCHECK(ctx.task_context_data.has_value()) << "spill flush context must be set";
 
-    // partition memory usage
-    // now we partitioned sorted spill
-    SerdeContext spill_ctx;
     switch (ctx.yield_point) {
     case SPILL:
-        RETURN_IF_ERROR(_spill_input_partitions(ctx, spill_ctx, spilling_partitions));
+        RETURN_IF_ERROR(_spill_input_partitions(ctx, spilling_partitions));
         RETURN_IF_YIELD(ctx.need_yield);
         TO_NEXT_STAGE(ctx.yield_point);
         [[fallthrough]];
     case SPLIT:
-        RETURN_IF_ERROR(_split_input_partitions(ctx, spill_ctx, splitting_partitions));
+        RETURN_IF_ERROR(_split_input_partitions(ctx, splitting_partitions));
         RETURN_IF_YIELD(ctx.need_yield);
         TO_NEXT_STAGE(ctx.yield_point);
         [[fallthrough]];

--- a/be/src/compute_env/spill/spill_components.h
+++ b/be/src/compute_env/spill/spill_components.h
@@ -301,7 +301,7 @@ public:
 
     const auto& level_to_partitions() { return _level_to_partitions; }
 
-    Status spill_partition(workgroup::YieldContext& ctx, SerdeContext& context, SpilledPartition* partition);
+    Status spill_partition(workgroup::YieldContext& ctx, SpilledPartition* partition);
 
     int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 
@@ -347,10 +347,10 @@ private:
     // prepare and acquire mem_table for each partition in _id_to_partitions
     void _prepare_partitions(RuntimeState* state);
 
-    Status _spill_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
+    Status _spill_input_partitions(workgroup::YieldContext& ctx,
                                    const std::vector<SpilledPartition*>& spilling_partitions);
 
-    Status _split_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
+    Status _split_input_partitions(workgroup::YieldContext& ctx,
                                    const std::vector<SpilledPartition*>& splitting_partitions);
 
     Status _pick_and_compact_skew_partitions(std::vector<SpilledPartition*>& partitions);
@@ -362,9 +362,8 @@ private:
     // 1. We can actually split partitions based on blocks (they all belong to the same partition, but
     // can be executed in splitting out more parallel tasks). Process all blocks that hit this partition while processing the task
     // 2. If our input is ordered, we can use some sorting-based algorithm to split the partition. This way the probe side can do full streaming of the data
-    Status _split_partition(workgroup::YieldContext& ctx, SerdeContext& context, SpillerReader* reader,
-                            SpilledPartition* partition, SpilledPartition* left_partition,
-                            SpilledPartition* right_partition);
+    Status _split_partition(workgroup::YieldContext& ctx, SpillerReader* reader, SpilledPartition* partition,
+                            SpilledPartition* left_partition, SpilledPartition* right_partition);
 
     void _add_partition(SpilledPartitionPtr&& partition);
     void _remove_partition(const SpilledPartition* partition);

--- a/be/src/compute_env/spill/spiller.cpp
+++ b/be/src/compute_env/spill/spiller.cpp
@@ -90,7 +90,7 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     shuffle_timer = ADD_CHILD_TIMER(profile, "ShuffleTime", parent);
     split_partition_timer = ADD_CHILD_TIMER(profile, "SplitPartitionTime", parent);
     restore_from_mem_table_rows = ADD_CHILD_COUNTER(profile, "RowsRestoreFromMemTable", TUnit::UNIT, parent);
-    restore_from_mem_table_bytes = ADD_CHILD_COUNTER(profile, "BytesRestoreFromMemTable", TUnit::UNIT, parent);
+    restore_from_mem_table_bytes = ADD_CHILD_COUNTER(profile, "BytesRestoreFromMemTable", TUnit::BYTES, parent);
     partition_writer_peak_memory_usage =
             profile->AddHighWaterMarkCounter("PartitionWriterPeakMemoryBytes", TUnit::BYTES,
                                              RuntimeProfile::Counter::create_strategy(TUnit::BYTES), parent);

--- a/be/src/compute_env/spill/spiller.hpp
+++ b/be/src/compute_env/spill/spiller.hpp
@@ -258,7 +258,6 @@ Status SpillerReader::trigger_restore(RuntimeState* state, MemGuard&& guard) {
                     return;
                 }
                 Status res;
-                SerdeContext serd_ctx;
                 if (!yield_ctx.task_context_data.has_value()) {
                     yield_ctx.task_context_data = std::make_shared<SpillIOTaskContext>();
                 }
@@ -270,7 +269,7 @@ Status SpillerReader::trigger_restore(RuntimeState* state, MemGuard&& guard) {
                 FAIL_POINT_TRIGGER_EXECUTE(spill_restore_sleep, { sleep(10); });
 
                 YieldableRestoreTask task(_stream);
-                res = task.do_read(yield_ctx, serd_ctx);
+                res = task.do_read(yield_ctx, ctx->serde_ctx);
 
                 FAIL_POINT_TRIGGER_EXECUTE(spill_restore_sleep, { sleep(10); });
                 // Simulate a non-EOF error coming out of the restore IO task

--- a/be/src/compute_env/spill/task_executor.h
+++ b/be/src/compute_env/spill/task_executor.h
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "common/status.h"
+#include "compute_env/spill/serde.h"
 #include "compute_env/workgroup/scan_task.h"
 #include "compute_env/workgroup/work_group_fwd.h"
 
@@ -25,6 +26,9 @@ namespace starrocks::spill {
 
 struct SpillIOTaskContext {
     bool use_local_io_executor = true;
+    // the serialize buffer survives yields and re-submissions of the task,
+    // so it is allocated once per IO task instead of once per resumption
+    SerdeContext serde_ctx;
 };
 using SpillIOTaskContextPtr = std::shared_ptr<SpillIOTaskContext>;
 

--- a/be/test/compute_env/spill/spill_test.cpp
+++ b/be/test/compute_env/spill/spill_test.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/container/raw_container.h"
 #include "base/testutil/assert.h"
 #include "base/uid_util.h"
 #include "base/utility/defer_op.h"
@@ -32,6 +33,7 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/column_visitor_adapter.h"
+#include "column/fixed_length_column.h"
 #include "column/map_column.h"
 #include "column/nullable_column.h"
 #include "column/struct_column.h"
@@ -832,5 +834,246 @@ TEST_F(SpillTest, file_group_test) {
     }
 }
 */
+
+namespace {
+
+spill::BlockReaderOptions make_block_read_options(RuntimeProfile* profile, bool enable_buffer_read,
+                                                  size_t max_buffer_bytes) {
+    spill::BlockReaderOptions opts;
+    opts.enable_buffer_read = enable_buffer_read;
+    opts.max_buffer_bytes = max_buffer_bytes;
+    opts.read_io_timer = ADD_TIMER(profile, "read_io_timer");
+    opts.read_io_count = ADD_COUNTER(profile, "read_io_count", TUnit::UNIT);
+    opts.read_io_bytes = ADD_COUNTER(profile, "read_io_bytes", TUnit::BYTES);
+    return opts;
+}
+
+ChunkPtr make_int_chunk(int32_t base, size_t rows) {
+    auto col = Int32Column::create();
+    for (size_t i = 0; i < rows; ++i) {
+        col->append(base + i);
+    }
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(std::move(col), 0);
+    return chunk;
+}
+
+} // namespace
+
+TEST_F(SpillTest, block_reader_read_view) {
+    spill::AcquireBlockOptions aopts;
+    aopts.query_id = generate_uuid();
+    aopts.fragment_instance_id = aopts.query_id;
+    aopts.plan_node_id = 1;
+    aopts.name = "read_view";
+    aopts.block_size = 1 << 20;
+    auto block_res = dummy_block_mgr->acquire_block(aopts);
+    ASSERT_OK(block_res.status());
+    auto block = block_res.value();
+
+    // records of [12-byte header][body]; body sizes chosen to exercise the
+    // buffered path (<= max_buffer_bytes, including the exact boundary), the
+    // fallback path (> max_buffer_bytes) and refills with a partial tail
+    constexpr size_t kMaxBuffer = 16384;
+    const std::vector<size_t> body_sizes = {100, kMaxBuffer, 40000, 5000, 1, 12345, kMaxBuffer - 1, 7000};
+    std::string master;
+    for (size_t len : body_sizes) {
+        for (size_t i = 0; i < 12 + len; ++i) {
+            master.push_back(static_cast<char>((master.size() * 131 + 7) % 251));
+        }
+    }
+    ASSERT_OK(block->append({Slice(master)}));
+    ASSERT_OK(block->flush());
+
+    auto verify = [&](bool enable_buffer_read) {
+        auto ropts = make_block_read_options(&dummy_profile, enable_buffer_read, kMaxBuffer);
+        auto reader = block->get_reader(ropts);
+        raw::RawString fallback;
+        size_t off = 0;
+        for (size_t len : body_sizes) {
+            char header[12];
+            ASSERT_OK(reader->read_fully(header, 12));
+            ASSERT_EQ(0, memcmp(header, master.data() + off, 12));
+            off += 12;
+            auto view = reader->read_view(&fallback, len);
+            ASSERT_OK(view.status());
+            ASSERT_EQ(len, view.value().size);
+            ASSERT_EQ(0, memcmp(view.value().data, master.data() + off, len));
+            off += len;
+        }
+        ASSERT_EQ(master.size(), off);
+        // the block is fully consumed
+        raw::RawString tail;
+        ASSERT_TRUE(reader->read_view(&tail, 1).status().is_end_of_file());
+        char dummy;
+        ASSERT_TRUE(reader->read_fully(&dummy, 1).is_end_of_file());
+    };
+    verify(true);
+    verify(false);
+
+    {
+        // a negative size (e.g. from a corrupted header) must fail instead of
+        // defeating the bounds checks
+        auto ropts = make_block_read_options(&dummy_profile, true, kMaxBuffer);
+        auto reader = block->get_reader(ropts);
+        raw::RawString fallback;
+        auto view = reader->read_view(&fallback, -8);
+        ASSERT_FALSE(view.ok());
+        ASSERT_FALSE(view.status().is_end_of_file());
+    }
+}
+
+TEST_F(SpillTest, raw_chunk_input_stream_move_or_clone) {
+    workgroup::YieldContext yield_ctx;
+    spill::SerdeContext serde_ctx;
+
+    {
+        // exclusively owned chunk: handed over without copying
+        auto chunk = make_int_chunk(0, 16);
+        const Column* raw_column = chunk->columns()[0].get();
+        std::vector<ChunkPtr> chunks;
+        chunks.emplace_back(std::move(chunk));
+        auto stream = spill::SpillInputStream::as_stream(std::move(chunks), nullptr);
+        auto res = stream->get_next(yield_ctx, serde_ctx);
+        ASSERT_OK(res.status());
+        ASSERT_EQ(raw_column, res.value()->columns()[0].get());
+        ASSERT_EQ(16, res.value()->num_rows());
+        ASSERT_TRUE(stream->get_next(yield_ctx, serde_ctx).status().is_end_of_file());
+    }
+
+    {
+        // the chunk itself is shared: served as a deep copy, the source stays
+        // intact
+        auto chunk = make_int_chunk(100, 8);
+        const Column* raw_column = chunk->columns()[0].get();
+        std::vector<ChunkPtr> chunks;
+        chunks.emplace_back(chunk);
+        auto stream = spill::SpillInputStream::as_stream(std::move(chunks), nullptr);
+        auto res = stream->get_next(yield_ctx, serde_ctx);
+        ASSERT_OK(res.status());
+        ASSERT_NE(raw_column, res.value()->columns()[0].get());
+        ASSERT_EQ(8, chunk->num_rows());
+        ASSERT_EQ(8, res.value()->num_rows());
+    }
+
+    {
+        // unique top-level column wrapping a shared child: the nested sharing
+        // must force a copy
+        auto data = Int64Column::create();
+        for (int i = 0; i < 4; ++i) {
+            data->append(i);
+        }
+        ColumnPtr shared_data = std::move(data);
+        auto nullable = NullableColumn::create(shared_data, NullColumn::create(4, 0));
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(std::move(nullable), 0);
+        const Column* raw_column = chunk->columns()[0].get();
+        std::vector<ChunkPtr> chunks;
+        chunks.emplace_back(std::move(chunk));
+        auto stream = spill::SpillInputStream::as_stream(std::move(chunks), nullptr);
+        auto res = stream->get_next(yield_ctx, serde_ctx);
+        ASSERT_OK(res.status());
+        ASSERT_NE(raw_column, res.value()->columns()[0].get());
+        ASSERT_EQ(4, shared_data->size());
+        ASSERT_EQ(4, res.value()->num_rows());
+    }
+}
+
+TEST_F(SpillTest, unordered_mem_table_read_modes) {
+    auto factory = spill::make_spilled_factory();
+    SpilledOptions spill_options;
+    spill_options.mem_table_pool_size = 2;
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
+    spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+    spill_options.block_manager = dummy_block_mgr.get();
+    auto spiller = factory->create(spill_options);
+    spiller->set_metrics(metrics);
+
+    auto mem_table = std::make_shared<spill::UnorderedMemTable>(&dummy_rt_st, 1L << 30, nullptr, spiller.get());
+    size_t input_rows = 0;
+    for (int i = 0; i < 10; ++i) {
+        auto chunk = make_int_chunk(i * 100, 64);
+        input_rows += chunk->num_rows();
+        ASSERT_OK(mem_table->append(std::move(chunk)));
+    }
+    size_t consumption = mem_table->mem_usage();
+    ASSERT_GT(consumption, 0);
+
+    workgroup::YieldContext yield_ctx;
+    spill::SerdeContext serde_ctx;
+    auto drain = [&](const std::shared_ptr<spill::SpillInputStream>& stream) {
+        size_t rows = 0;
+        while (true) {
+            auto res = stream->get_next(yield_ctx, serde_ctx);
+            if (res.status().is_end_of_file()) {
+                break;
+            }
+            EXPECT_OK(res.status());
+            rows += res.value()->num_rows();
+        }
+        return rows;
+    };
+
+    {
+        // shared read keeps the mem table intact
+        auto stream_st = mem_table->as_input_stream(spill::MemTableReadMode::SHARED);
+        ASSERT_OK(stream_st.status());
+        ASSERT_EQ(input_rows, drain(stream_st.value()));
+        ASSERT_FALSE(mem_table->is_empty());
+        ASSERT_FALSE(mem_table->consumed_by_exclusive_read());
+        ASSERT_EQ(consumption, mem_table->mem_usage());
+    }
+
+    {
+        // exclusive read consumes the mem table but keeps the accounting
+        // until reset
+        auto stream_st = mem_table->as_input_stream(spill::MemTableReadMode::EXCLUSIVE);
+        ASSERT_OK(stream_st.status());
+        ASSERT_TRUE(mem_table->is_empty());
+        ASSERT_TRUE(mem_table->consumed_by_exclusive_read());
+        ASSERT_EQ(consumption, mem_table->mem_usage());
+        ASSERT_EQ(input_rows, drain(stream_st.value()));
+    }
+
+    // both drains were served from in-memory chunks
+    ASSERT_EQ(2 * input_rows, metrics.restore_from_mem_table_rows->value());
+    ASSERT_GT(metrics.restore_from_mem_table_bytes->value(), 0);
+
+    // appending again makes the mem table reusable
+    ASSERT_OK(mem_table->append(make_int_chunk(0, 8)));
+    ASSERT_FALSE(mem_table->consumed_by_exclusive_read());
+
+    mem_table->reset();
+    ASSERT_FALSE(mem_table->consumed_by_exclusive_read());
+    ASSERT_EQ(0, mem_table->mem_usage());
+}
+
+TEST_F(SpillTest, mem_table_double_exclusive_acquire) {
+    auto factory = spill::make_spilled_factory();
+    SpilledOptions spill_options;
+    spill_options.mem_table_pool_size = 2;
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
+    spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+    spill_options.block_manager = dummy_block_mgr.get();
+    ASSERT_FALSE(spill_options.read_shared);
+
+    auto spiller = factory->create(spill_options);
+    spiller->set_metrics(metrics);
+    SpillerCaller<spill::RawSpillerWriter*, spill::SpillerReader*> caller(spiller.get());
+    ASSERT_OK(spiller->prepare(&dummy_rt_st));
+
+    // spill some data but do not flush, so the mem table stays in memory
+    ASSERT_OK(caller.spill<SyncExecutor>(&dummy_rt_st, make_int_chunk(0, 128), EmptyMemGuard{}));
+
+    auto writer = spiller->_writer->as<spill::RawSpillerWriter*>();
+    std::shared_ptr<spill::SpillInputStream> first;
+    ASSERT_OK(writer->acquire_stream(&first));
+
+    // the in-memory rows were handed over to the first stream; acquiring a
+    // second exclusive stream must fail loudly instead of losing them
+    std::shared_ptr<spill::SpillInputStream> second;
+    auto st = writer->acquire_stream(&second);
+    ASSERT_FALSE(st.ok());
+}
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## Why I'm doing:

Spill restore performs avoidable allocations and copies on every restored record:

1. Each record read from disk is copied twice before decoding: `ColumnarSerde::deserialize` does `serialize_buffer.resize(attachment_size)` (allocation) + `read_fully` (memcpy from the reader buffer) and only then decodes.
2. A fresh `SerdeContext` is created on every IO task submission and every yield re-submission, so its serialize buffer regrows from scratch each time.
3. In-memory mem-table chunks are deep-cloned (`clone_unique`) when served through `RawChunkInputStream`, even when the stream is the sole consumer. This path is hot: with default mem-table size, unflushed partition tails account for ~8% of restored rows on a spilled shuffle join, and it also serves the partition-split (recursive repartition) read.

## What I'm doing:

- `BlockReader::read_view(fallback, count)`: serve restore reads as zero-copy views into the internal read buffer when possible; fall back to copying into the caller's buffer otherwise. `ColumnarSerde::deserialize` consumes the view directly (encode levels via `UNALIGNED_LOAD32` since the view base can be unaligned, negative/short `attachment_size` rejected).
- Keep one `SerdeContext` in `SpillIOTaskContext` for the lifetime of an IO task (restore and flush sides), instead of recreating it per (re)submission. The buffer now lives as long as the IO task — bounded by `io_tasks_per_scan_operator` restore tasks plus one flush task per spiller.
- `MemTableReadMode::{SHARED, EXCLUSIVE}` for `UnorderedMemTable::as_input_stream`: a single-consumer read (`read_shared=false`) hands chunks over by move; `RawChunkInputStream` returns a chunk without cloning only when its whole column tree is exclusively owned (`ExclusiveOwnershipChecker`, conservative for unknown column types). Multi-reader topologies (broadcast, NL join) keep the copying SHARED mode. Mem tracker consumption is retained until reset/destruction so spill memory is never understated; a second exclusive acquire returns `InternalError` instead of silently losing rows.
- Wire up the `RowsRestoreFromMemTable` / `BytesRestoreFromMemTable` profile counters: they were registered but never incremented (always 0); `BytesRestoreFromMemTable` unit fixed from `UNIT` to `BYTES`. They now report the in-memory restore volume.
- Remove dead `SerdeContext&` parameters from the partition spill/split internals.

Measured (200M⋈200M spilled shuffle join, `spill_mode=force`, single-node A/B on one host, baseline = main + counters only):

| | baseline | patched | Δ |
|---|---|---|---|
| wall (5 runs) | 13.89 s | 13.76 s | within noise |
| query allocated memory | 325.8 GB | 310.3 GB | **−15.5 GB (−4.8%)** |
| with forced partition splits (4 MB mem tables) | 892.3 GB | 867.7 GB | **−24.6 GB (−2.8%)** |

Breakdown of the −15.5 GB: ~10.4 GB from `read_view` (= `BytesRestoreFromLocalDisk`, the volume previously copied into `serialize_buffer`), ~1 GB from the mem-table move (= `BytesRestoreFromMemTable`, the volume previously cloned), the remainder from `SerdeContext` reuse. The same volume of memcpy traffic is eliminated alongside the allocations. Wall time is unchanged on a single query (the bottleneck is flush/IO); the win is allocator and memory-bandwidth pressure. Query results are byte-identical with spill on/off and across all runs.

A moved chunk transfers `extra_data`/schema/slot maps verbatim, while `clone_unique` rebuilds them; both are correct for spill consumers.

Tests: 4 new cases in `be/test/compute_env/spill/spill_test.cpp`: `read_view` buffered/boundary/fallback/EOF/negative-count paths golden-checked against `read_fully`; move-vs-clone including a unique `NullableColumn` wrapping a shared child (must clone); SHARED/EXCLUSIVE read modes incl. tracker retention and counter values; double exclusive acquire returns an error. `compute_env_test`: 104/104 passed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
