### PR TITLE
[BugFix] Keep the first segment of a rootless simple json path

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -74,9 +74,15 @@ Status JsonFunctions::_get_parsed_paths(const std::vector<std::string>& path_exp
         auto& current = path_exprs[i];
 
         if (i == 0) {
-            if (current.size() == 0 || current[0] != '$') {
+            if (current.empty()) {
                 parsed_paths->emplace_back("", -1, true);
                 continue;
+            }
+            if (current[0] != '$') {
+                // Simple syntax (no leading "$"): insert the implicit root segment, then fall
+                // through to parse this token as the first real segment. Every consumer iterates
+                // from segment 1, so dropping the token here would silently resolve "a.b" as "$.b".
+                parsed_paths->emplace_back("", -1, true);
             }
         }
 

--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -1362,6 +1362,28 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
     EXPECT_STATUS(Status::NotFound(""), test_extract_from_object(R"({"key1": null})", "$.key1[1].key4", &output));
 }
 
+TEST_F(JsonFunctionsTest, parse_json_paths_simple_syntax_keeps_first_segment) {
+    // "order.id" must mean "$.order.id": the implicit-root rewrite must not drop the first token,
+    // or the path silently resolves to "$.id" and extracts the wrong field.
+    std::vector<SimpleJsonPath> paths;
+    ASSERT_TRUE(JsonFunctions::parse_json_paths("order.id", &paths).ok());
+    ASSERT_EQ(3u, paths.size());
+    EXPECT_EQ("order", paths[1].key);
+    EXPECT_EQ("id", paths[2].key);
+
+    std::string output;
+    EXPECT_OK(test_extract_from_object(R"({"order": {"id": 42}, "id": 7})", "order.id", &output));
+    EXPECT_STREQ(output.data(), "42");
+
+    // A single-token simple path used to parse into the root placeholder alone and fail as an
+    // "empty json path"; it must select the field.
+    EXPECT_OK(test_extract_from_object(R"({"k1": 1, "k2": 2})", "k2", &output));
+    EXPECT_STREQ(output.data(), "2");
+
+    EXPECT_OK(test_extract_from_object(R"({"arr": [1, 2]})", "arr[1]", &output));
+    EXPECT_STREQ(output.data(), "2");
+}
+
 class JsonLengthTestFixture : public ::testing::TestWithParam<std::tuple<std::string, std::string, int>> {};
 
 TEST_P(JsonLengthTestFixture, json_length_test) {


### PR DESCRIPTION
## Why I'm doing:

`JsonFunctions::_get_parsed_paths` accepts two path syntaxes: strict (`$.a.b[x]`) and "simple" (`a.b`). For the simple syntax it inserts the implicit root segment — but `continue`s over the first token while doing so, so that token never makes it into the parsed path. Since every consumer iterates from segment 1, `"order.id"` silently resolves as `$.id`:

```sql
SELECT get_json_string('{"order": {"id": 42}, "id": 7}', 'order.id');
-- returns 7, expected 42
```

The same mis-resolution applies to `jsonpaths` in stream load / routine load (JSON): a rootless path loads a different field than requested into the target column, with no error and no filtered row. A single-token path (`'k2'`) parses into the root placeholder alone and fails as an "empty json path" instead of selecting the field.

Fixes #74700

## What I'm doing:

Insert the implicit root and still parse the first token, so `order.id` means `$.order.id` and `k2` means `$.k2`. An empty path keeps its previous behavior. Added UTs for the multi-segment, single-token and indexed (`arr[1]`) simple paths.

Note for operators: existing jobs using rootless paths were loading a different field than requested; after this fix they load the requested one.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
