### PR TITLE
[Enhancement] Derive guard predicates from multi-branch OR to enable expression short-circuit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ArithmeticCommutativeRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ConsolidateLikesRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.DeriveGuardPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ExtractCommonPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
@@ -54,6 +55,7 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
+            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );
@@ -84,6 +86,7 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
+            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -22,7 +22,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ArithmeticCommutativeRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ConsolidateLikesRule;
-import com.starrocks.sql.optimizer.rewrite.scalar.DeriveGuardPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ExtractCommonPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
@@ -55,7 +54,6 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
-            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );
@@ -86,7 +84,6 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
-            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -34,8 +34,8 @@ import java.util.Set;
 /**
  * Derive guard predicates from OR expressions where every branch contains
  * a comparison on a common pivot column.  The guard is a single-slot predicate
- * that enters conjunct_ctxs_by_slot in the BE, making the pivot column ACTIVE
- * while branch-local columns remain LAZY.
+ * that enters conjunct_ctxs_by_slot in the BE, enabling early evaluation and
+ * expression short-circuit on the pivot column before the full OR is evaluated.
  * <p>
  * This is a one-pass transformation (like ScalarRangePredicateExtractor),
  * NOT a ScalarOperatorRewriteRule.  It is called directly from
@@ -299,6 +299,12 @@ public class DeriveGuardPredicateRule {
      * </ul>
      */
     private static boolean isGuardCandidatePredicate(ScalarOperator op) {
+        // Nondeterministic predicates (e.g. rand(), uuid()) must not be
+        // duplicated — the guard and original expression would evaluate
+        // different values, potentially filtering rows incorrectly.
+        if (Utils.hasNonDeterministicFunc(op)) {
+            return false;
+        }
         if (op instanceof BinaryPredicateOperator) {
             return isGuardCandidateBinaryPredicate((BinaryPredicateOperator) op);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -21,7 +22,6 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.type.Type;
 
 import java.util.ArrayList;
@@ -33,9 +33,13 @@ import java.util.Set;
 
 /**
  * Derive guard predicates from OR expressions where every branch contains
- * a comparison on a common pivot column. The guard is a single-slot predicate
+ * a comparison on a common pivot column.  The guard is a single-slot predicate
  * that enters conjunct_ctxs_by_slot in the BE, making the pivot column ACTIVE
  * while branch-local columns remain LAZY.
+ * <p>
+ * This is a one-pass transformation (like ScalarRangePredicateExtractor),
+ * NOT a ScalarOperatorRewriteRule.  It is called directly from
+ * PushDownPredicateScanRule after the scalar rewriter completes.
  * <p>
  * Example:
  * <pre>
@@ -50,60 +54,30 @@ import java.util.Set;
  *     OR (l_shipdate BETWEEN '1998-06-15' AND '1998-06-15' AND l_returnflag = 'A'))
  * </pre>
  * <p>
- * This is V1: only handles top-level OR conjuncts (children of the root AND).
- * The guard is purely additive (AND with the original), so correctness is
- * preserved even if guard logic has gaps.
+ * V1: processes top-level OR conjuncts (children of the root AND). The guard
+ * is purely additive (AND with the original), so correctness is preserved.
  */
-public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
+public class DeriveGuardPredicateRule {
 
     /**
-     * Track OR nodes that have already been wrapped with a guard,
-     * to prevent infinite rewrite loops across fixpoint iterations.
-     * After wrapping, the original OR remains in the tree as a child
-     * of AND(guard, OR) and would be re-processed on the next iteration.
-     * Keyed by System.identityHashCode.
-     * <p>
-     * Cleared at the start of each ScalarOperatorRewriter.rewrite() call
-     * (when context.changeNum() == 0, indicating context.reset() was just called).
+     * Apply guard derivation to the predicate tree.  Called once per query,
+     * outside any fixpoint rewrite loop.
      */
-    private final Set<Integer> wrappedOrIdentities = new HashSet<>();
-    private int clearEpoch = 0;
-
-    @Override
-    public boolean isOnlyOnce() {
-        return true;
-    }
-
-    @Override
-    public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
-        // Clear the seen set at the start of a new rewrite pass
-        if (context.changeNum() == 0 && clearEpoch != 0) {
-            wrappedOrIdentities.clear();
-            clearEpoch = 0;
-        }
-        clearEpoch = context.changeNum();
-
-        // Flatten the root AND to find all top-level OR conjuncts.
-        List<ScalarOperator> conjuncts = Utils.extractConjuncts(root);
+    public static ScalarOperator apply(ScalarOperator predicate) {
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
         boolean changed = false;
         for (int i = 0; i < conjuncts.size(); i++) {
             ScalarOperator conjunct = conjuncts.get(i);
             if (conjunct instanceof CompoundPredicateOperator
                     && ((CompoundPredicateOperator) conjunct).isOr()) {
-                // Skip ORs already wrapped in a previous iteration
-                if (wrappedOrIdentities.contains(System.identityHashCode(conjunct))) {
-                    continue;
-                }
                 ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
                 if (wrapped != conjunct) {
                     conjuncts.set(i, wrapped);
-                    wrappedOrIdentities.add(System.identityHashCode(conjunct));
-                    context.change();
                     changed = true;
                 }
             }
         }
-        return changed ? Utils.compoundAnd(conjuncts) : root;
+        return changed ? Utils.compoundAnd(conjuncts) : predicate;
     }
 
     /**
@@ -111,6 +85,7 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
      * Returns the wrapped expression AND(guard, orExpr) if guards can be derived,
      * or the original orExpr unchanged.
      */
+    @VisibleForTesting
     static ScalarOperator tryDeriveGuard(CompoundPredicateOperator orExpr) {
         List<ScalarOperator> disjuncts = Utils.extractDisjunctive(orExpr);
         if (disjuncts.size() <= 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -1,0 +1,217 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Derive guard predicates from OR expressions where every branch contains
+ * a comparison on a common pivot column. The guard is a single-slot predicate
+ * that enters conjunct_ctxs_by_slot in the BE, making the pivot column ACTIVE
+ * while branch-local columns remain LAZY.
+ * <p>
+ * Example:
+ * <pre>
+ *   (l_shipdate BETWEEN '1998-01-01' AND '1998-01-01' AND l_returnflag = 'R')
+ *   OR (l_shipdate BETWEEN '1998-06-15' AND '1998-06-15' AND l_returnflag = 'A')
+ *
+ *   becomes:
+ *
+ *   (l_shipdate BETWEEN '1998-01-01' AND '1998-01-01'
+ *    OR l_shipdate BETWEEN '1998-06-15' AND '1998-06-15')  -- guard (single-slot)
+ *   AND ((l_shipdate BETWEEN '1998-01-01' AND '1998-01-01' AND l_returnflag = 'R')
+ *     OR (l_shipdate BETWEEN '1998-06-15' AND '1998-06-15' AND l_returnflag = 'A'))
+ * </pre>
+ * <p>
+ * This is V1: only handles top-level OR conjuncts (children of the root AND).
+ * The guard is purely additive (AND with the original), so correctness is
+ * preserved even if guard logic has gaps.
+ */
+public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
+
+    @Override
+    public boolean isOnlyOnce() {
+        return true;
+    }
+
+    @Override
+    public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
+        // Flatten the root AND to find all top-level OR conjuncts.
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(root);
+        boolean changed = false;
+        for (int i = 0; i < conjuncts.size(); i++) {
+            ScalarOperator conjunct = conjuncts.get(i);
+            if (conjunct instanceof CompoundPredicateOperator
+                    && ((CompoundPredicateOperator) conjunct).isOr()) {
+                ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
+                if (wrapped != conjunct) {
+                    conjuncts.set(i, wrapped);
+                    context.change();
+                    changed = true;
+                }
+            }
+        }
+        return changed ? Utils.compoundAnd(conjuncts) : root;
+    }
+
+    /**
+     * Try to derive a guard predicate for the given OR expression.
+     * Returns the wrapped expression AND(guard, orExpr) if guards can be derived,
+     * or the original orExpr unchanged.
+     */
+    static ScalarOperator tryDeriveGuard(CompoundPredicateOperator orExpr) {
+        List<ScalarOperator> disjuncts = Utils.extractDisjunctive(orExpr);
+        if (disjuncts.size() <= 1) {
+            return orExpr;
+        }
+
+        // For each disjunct, extract its AND conjuncts
+        List<List<ScalarOperator>> disjunctConjuncts = new ArrayList<>();
+        for (ScalarOperator disjunct : disjuncts) {
+            disjunctConjuncts.add(Utils.extractConjuncts(disjunct));
+        }
+
+        // Step 1: For each disjunct, collect range column predicates by column id.
+        // Also track the total number of real (non-AND) leaves in each disjunct tree.
+        List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds = new ArrayList<>();
+        List<Integer> disjunctLeafCounts = new ArrayList<>();
+        for (int di = 0; di < disjuncts.size(); di++) {
+            Map<Integer, List<ScalarOperator>> colPreds = new HashMap<>();
+            List<ScalarOperator> conjuncts = disjunctConjuncts.get(di);
+            for (ScalarOperator conjunct : conjuncts) {
+                if (isRangeColumnPredicate(conjunct)) {
+                    ColumnRefSet usedCols = conjunct.getUsedColumns();
+                    if (usedCols.cardinality() == 1) {
+                        int colId = usedCols.getFirstId();
+                        colPreds.computeIfAbsent(colId, k -> new ArrayList<>()).add(conjunct);
+                    }
+                }
+            }
+            perDisjunctColPreds.add(colPreds);
+            // Count all leaves in this disjunct's AND tree, not just those from extractConjuncts
+            disjunctLeafCounts.add(countFlatConjuncts(disjuncts.get(di)));
+        }
+
+        // Step 2: Find columns that appear in ALL disjuncts (intersection)
+        Set<Integer> commonColIds = new HashSet<>(perDisjunctColPreds.get(0).keySet());
+        if (commonColIds.isEmpty()) {
+            return orExpr;
+        }
+        for (int i = 1; i < perDisjunctColPreds.size(); i++) {
+            commonColIds.retainAll(perDisjunctColPreds.get(i).keySet());
+        }
+
+        if (commonColIds.isEmpty()) {
+            return orExpr;
+        }
+
+        // Step 3: Build guard predicate for each common column.
+        List<ScalarOperator> guards = new ArrayList<>();
+        for (int colId : commonColIds) {
+            if (allDisjunctsAreOnlyColumnPreds(disjunctLeafCounts, perDisjunctColPreds, colId)) {
+                continue;
+            }
+
+            List<ScalarOperator> perDisjunctGuardParts = new ArrayList<>();
+            for (Map<Integer, List<ScalarOperator>> disjunctPreds : perDisjunctColPreds) {
+                List<ScalarOperator> colPreds = disjunctPreds.get(colId);
+                perDisjunctGuardParts.add(Utils.compoundAnd(colPreds));
+            }
+            guards.add(Utils.compoundOr(perDisjunctGuardParts));
+        }
+
+        if (guards.isEmpty()) {
+            return orExpr;
+        }
+
+        // Step 4: Wrap original OR with guard: AND(guard1, ..., guardN, original_OR)
+        List<ScalarOperator> andArgs = new ArrayList<>(guards);
+        andArgs.add(orExpr);
+        return Utils.compoundAnd(andArgs);
+    }
+
+    /**
+     * Check if all leaves across all disjuncts for a given column consist only of
+     * column predicates for that column. If so, the guard would be redundant.
+     */
+    private static boolean allDisjunctsAreOnlyColumnPreds(
+            List<Integer> disjunctLeafCounts,
+            List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds,
+            int colId) {
+        int totalLeaves = 0;
+        int totalColPreds = 0;
+        for (int i = 0; i < disjunctLeafCounts.size(); i++) {
+            totalLeaves += disjunctLeafCounts.get(i);
+            List<ScalarOperator> colPreds = perDisjunctColPreds.get(i).get(colId);
+            totalColPreds += (colPreds != null ? colPreds.size() : 0);
+        }
+        return totalLeaves == totalColPreds;
+    }
+
+    /**
+     * Count the total number of leaf (non-compound) children in the AND tree
+     * rooted at the given scalar operator, without being limited to
+     * getChild(0)/getChild(1) like extractConjuncts.
+     */
+    private static int countFlatConjuncts(ScalarOperator node) {
+        if (!(node instanceof CompoundPredicateOperator)) {
+            return 1;
+        }
+        CompoundPredicateOperator cpo = (CompoundPredicateOperator) node;
+        if (!cpo.isAnd()) {
+            return 1;
+        }
+        int count = 0;
+        for (ScalarOperator child : cpo.getChildren()) {
+            count += countFlatConjuncts(child);
+        }
+        return count;
+    }
+
+    /**
+     * Check if this is a single-column predicate that provides a range constraint
+     * (GE, LE, GT, LT, IN). Equality-only predicates are excluded to avoid creating
+     * non-selective guards for low-cardinality payload columns.
+     */
+    private static boolean isRangeColumnPredicate(ScalarOperator op) {
+        if (op instanceof BinaryPredicateOperator) {
+            if (op.getUsedColumns().cardinality() != 1) {
+                return false;
+            }
+            BinaryPredicateOperator bop = (BinaryPredicateOperator) op;
+            BinaryType type = bop.getBinaryType();
+            return type == BinaryType.GE || type == BinaryType.LE
+                    || type == BinaryType.GT || type == BinaryType.LT;
+        }
+        if (op instanceof InPredicateOperator) {
+            return op.getUsedColumns().cardinality() == 1;
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.type.Type;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -105,7 +106,7 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
             Map<Integer, List<ScalarOperator>> colPreds = new HashMap<>();
             List<ScalarOperator> conjuncts = disjunctConjuncts.get(di);
             for (ScalarOperator conjunct : conjuncts) {
-                if (isRangeColumnPredicate(conjunct)) {
+                if (isGuardCandidatePredicate(conjunct)) {
                     ColumnRefSet usedCols = conjunct.getUsedColumns();
                     if (usedCols.cardinality() == 1) {
                         int colId = usedCols.getFirstId();
@@ -195,23 +196,70 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
     }
 
     /**
-     * Check if this is a single-column predicate that provides a range constraint
-     * (GE, LE, GT, LT, IN). Equality-only predicates are excluded to avoid creating
-     * non-selective guards for low-cardinality payload columns.
+     * Check if this predicate should contribute to a guard.
+     * <p>
+     * Guard derivation strategy:
+     * <ul>
+     *   <li><b>Range predicates (GE, LE, GT, LT)</b>: always collected. These are the primary
+     *       target — they form contiguous intervals that are inherently selective.</li>
+     *   <li><b>IN predicates</b>: always collected. IN lists on date/numeric columns are
+     *       selective and commonly used as pivot columns in OR branches.</li>
+     *   <li><b>EQ on DATE / DATETIME / TIMESTAMP / numeric types</b>: collected.
+     *       EQ on a high-cardinality date or numeric column (e.g. {@code l_shipdate = '1998-12-01'})
+     *       is as selective as a range predicate and should contribute to the guard.
+     *       <p>
+     *       <b>EQ on VARCHAR / CHAR / BOOLEAN is intentionally excluded.</b>
+     *       These columns are typically low-cardinality payload columns (e.g.
+     *       {@code l_returnflag = 'R'}). Adding a guard for them would:
+     *       <ol>
+     *         <li>Produce a non-selective guard (e.g. {@code returnflag = 'R' OR returnflag = 'A'})</li>
+     *         <li>Put the column into {@code conjunct_ctxs_by_slot} → ACTIVE →
+     *             decoded for all rows instead of LAZY (decoded only for survivor rows)</li>
+     *         <li>Negate the benefit of the real guard on the pivot column</li>
+     *       </ol>
+     *       This is the key difference from Trino's TupleDomain: Trino's TupleDomain is
+     *       only used for page-level pruning and does NOT force column decoding order.
+     *       Our guard flows through {@code conjunct_ctxs_by_slot} which DOES control the
+     *       ACTIVE vs LAZY column split, so we must be more selective.</li>
+     * </ul>
      */
-    private static boolean isRangeColumnPredicate(ScalarOperator op) {
+    private static boolean isGuardCandidatePredicate(ScalarOperator op) {
         if (op instanceof BinaryPredicateOperator) {
-            if (op.getUsedColumns().cardinality() != 1) {
-                return false;
-            }
-            BinaryPredicateOperator bop = (BinaryPredicateOperator) op;
-            BinaryType type = bop.getBinaryType();
-            return type == BinaryType.GE || type == BinaryType.LE
-                    || type == BinaryType.GT || type == BinaryType.LT;
+            return isGuardCandidateBinaryPredicate((BinaryPredicateOperator) op);
         }
         if (op instanceof InPredicateOperator) {
             return op.getUsedColumns().cardinality() == 1;
         }
+        return false;
+    }
+
+    /**
+     * Check if a BinaryPredicateOperator is a guard candidate.
+     * Range predicates (GE, LE, GT, LT) are always candidates.
+     * EQ is only a candidate on high-cardinality types (date/datetime/numeric).
+     */
+    private static boolean isGuardCandidateBinaryPredicate(BinaryPredicateOperator bop) {
+        ColumnRefSet usedCols = bop.getUsedColumns();
+        if (usedCols.cardinality() != 1) {
+            return false;
+        }
+        BinaryType type = bop.getBinaryType();
+
+        // Range predicates: always candidates
+        if (type == BinaryType.GE || type == BinaryType.LE
+                || type == BinaryType.GT || type == BinaryType.LT) {
+            return true;
+        }
+
+        // EQ: only for high-cardinality column types
+        // Skip VARCHAR/CHAR/BOOLEAN to avoid creating non-selective guards
+        // that would make low-cardinality payload columns ACTIVE unnecessarily
+        if (type == BinaryType.EQ) {
+            // After NormalizePredicateRule, the column reference is child(0)
+            Type colType = bop.getChild(0).getType();
+            return colType.isNumericType() || colType.isDateType() || colType.isDatetime();
+        }
+
         return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -25,8 +25,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.Type;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +70,14 @@ public class DeriveGuardPredicateRule {
             ScalarOperator conjunct = conjuncts.get(i);
             if (conjunct instanceof CompoundPredicateOperator
                     && ((CompoundPredicateOperator) conjunct).isOr()) {
+                List<ScalarOperator> disjuncts = Utils.extractDisjunctive(conjunct);
+                // Skip when the OR involves too few columns — with <= 2 columns both
+                // are already ACTIVE, so the guard's short-circuit benefit is minimal.
+                // Additionally, guard predicates added during MV refresh break MV
+                // matching because the stored plan's predicate structure changes.
+                if (countDistinctColumns(disjuncts) < MIN_DISTINCT_COLUMNS_FOR_GUARD) {
+                    continue;
+                }
                 ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
                 if (wrapped != conjunct) {
                     conjuncts.set(i, wrapped);
@@ -103,7 +111,7 @@ public class DeriveGuardPredicateRule {
         List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds = new ArrayList<>();
         List<Integer> disjunctLeafCounts = new ArrayList<>();
         for (int di = 0; di < disjuncts.size(); di++) {
-            Map<Integer, List<ScalarOperator>> colPreds = new HashMap<>();
+            Map<Integer, List<ScalarOperator>> colPreds = new LinkedHashMap<>();
             List<ScalarOperator> conjuncts = disjunctConjuncts.get(di);
             for (ScalarOperator conjunct : conjuncts) {
                 if (isGuardCandidatePredicate(conjunct)) {
@@ -120,7 +128,7 @@ public class DeriveGuardPredicateRule {
         }
 
         // Step 2: Find columns that appear in ALL disjuncts (intersection)
-        Set<Integer> commonColIds = new HashSet<>(perDisjunctColPreds.get(0).keySet());
+        Set<Integer> commonColIds = new LinkedHashSet<>(perDisjunctColPreds.get(0).keySet());
         if (commonColIds.isEmpty()) {
             return orExpr;
         }
@@ -136,6 +144,15 @@ public class DeriveGuardPredicateRule {
         List<ScalarOperator> guards = new ArrayList<>();
         for (int colId : commonColIds) {
             if (allDisjunctsAreOnlyColumnPreds(disjunctLeafCounts, perDisjunctColPreds, colId)) {
+                continue;
+            }
+
+            // Skip if the guard for this column is purely EQ/IN predicates.
+            // The ScalarRangePredicateExtractor already handles EQ-only columns
+            // via IN lists, so a pure-EQ guard would be redundant and would
+            // unnecessarily change the plan text (breaking MV matching, test
+            // assertions, etc.).
+            if (isOnlyEqualityGuard(perDisjunctColPreds, colId)) {
                 continue;
             }
 
@@ -158,6 +175,45 @@ public class DeriveGuardPredicateRule {
     }
 
     /**
+     * Check whether every guard predicate for the given column across all disjuncts
+     * is an equality (EQ or IN) — no range predicates (GE, LE, GT, LT).
+     * <p>
+     * An EQ-only guard like {@code col = 1 OR col = 2 OR col = 3} is redundant with
+     * what {@code ScalarRangePredicateExtractor} already produces (an IN list).
+     * Skipping it avoids unnecessary plan-text changes that can break MV matching
+     * and test assertions.
+     */
+    private static boolean isOnlyEqualityGuard(
+            List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds,
+            int colId) {
+        for (Map<Integer, List<ScalarOperator>> disjunctPreds : perDisjunctColPreds) {
+            List<ScalarOperator> colPreds = disjunctPreds.get(colId);
+            if (colPreds == null) {
+                continue;
+            }
+            for (ScalarOperator pred : colPreds) {
+                if (isRangePredicate(pred)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check whether a scalar operator is a range predicate (not EQ or IN).
+     */
+    private static boolean isRangePredicate(ScalarOperator op) {
+        if (op instanceof BinaryPredicateOperator) {
+            BinaryType type = ((BinaryPredicateOperator) op).getBinaryType();
+            return type == BinaryType.GE || type == BinaryType.LE
+                    || type == BinaryType.GT || type == BinaryType.LT;
+        }
+        // IN predicates are treated as equality (not range)
+        return false;
+    }
+
+    /**
      * Check if all leaves across all disjuncts for a given column consist only of
      * column predicates for that column. If so, the guard would be redundant.
      */
@@ -173,6 +229,25 @@ public class DeriveGuardPredicateRule {
             totalColPreds += (colPreds != null ? colPreds.size() : 0);
         }
         return totalLeaves == totalColPreds;
+    }
+
+    // Minimum number of distinct columns across OR branches required to
+    // trigger guard generation.  With <= 2 columns both are already ACTIVE,
+    // so the guard's short-circuit benefit is minimal.  Additionally, guards
+    // added during MV refresh break MV matching because the stored plan's
+    // predicate structure changes (MV matching is not guard-aware yet).
+    @VisibleForTesting
+    static final int MIN_DISTINCT_COLUMNS_FOR_GUARD = 3;
+
+    /**
+     * Count the total number of distinct columns referenced by all disjuncts.
+     */
+    private static int countDistinctColumns(List<ScalarOperator> disjuncts) {
+        ColumnRefSet allCols = new ColumnRefSet();
+        for (ScalarOperator disjunct : disjuncts) {
+            allCols.union(disjunct.getUsedColumns());
+        }
+        return allCols.cardinality();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -56,6 +56,19 @@ import java.util.Set;
  */
 public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
 
+    /**
+     * Track OR nodes that have already been wrapped with a guard,
+     * to prevent infinite rewrite loops across fixpoint iterations.
+     * After wrapping, the original OR remains in the tree as a child
+     * of AND(guard, OR) and would be re-processed on the next iteration.
+     * Keyed by System.identityHashCode.
+     * <p>
+     * Cleared at the start of each ScalarOperatorRewriter.rewrite() call
+     * (when context.changeNum() == 0, indicating context.reset() was just called).
+     */
+    private final Set<Integer> wrappedOrIdentities = new HashSet<>();
+    private int clearEpoch = 0;
+
     @Override
     public boolean isOnlyOnce() {
         return true;
@@ -63,6 +76,13 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
+        // Clear the seen set at the start of a new rewrite pass
+        if (context.changeNum() == 0 && clearEpoch != 0) {
+            wrappedOrIdentities.clear();
+            clearEpoch = 0;
+        }
+        clearEpoch = context.changeNum();
+
         // Flatten the root AND to find all top-level OR conjuncts.
         List<ScalarOperator> conjuncts = Utils.extractConjuncts(root);
         boolean changed = false;
@@ -70,9 +90,14 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
             ScalarOperator conjunct = conjuncts.get(i);
             if (conjunct instanceof CompoundPredicateOperator
                     && ((CompoundPredicateOperator) conjunct).isOr()) {
+                // Skip ORs already wrapped in a previous iteration
+                if (wrappedOrIdentities.contains(System.identityHashCode(conjunct))) {
+                    continue;
+                }
                 ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
                 if (wrapped != conjunct) {
                     conjuncts.set(i, wrapped);
+                    wrappedOrIdentities.add(System.identityHashCode(conjunct));
                     context.change();
                     changed = true;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
 import com.starrocks.sql.optimizer.rewrite.TimeDriftConstraint;
+import com.starrocks.sql.optimizer.rewrite.scalar.DeriveGuardPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -89,6 +90,11 @@ public class PushDownPredicateScanRule extends TransformationRule {
 
         predicates = TimeDriftConstraint.tryAddDerivedPredicates(predicates, logicalScanOperator.getTable(),
                 logicalScanOperator.getColumnNameToColRefMap());
+
+        // Derive guard predicates from OR branches to help BE column loading.
+        // Called once here (not in the scalar rewrite fixpoint loop) to avoid
+        // redundant re-processing.
+        predicates = DeriveGuardPredicateRule.apply(predicates);
 
         // clone a new scan operator and rewrite predicate.
         Operator.Builder builder = OperatorBuilderFactory.build(logicalScanOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -17,13 +17,17 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -212,5 +216,85 @@ public class DeriveGuardPredicateRuleTest {
                 (CompoundPredicateOperator) orExpr);
         // No guard expected: EQ on VARCHAR is skipped
         assertEquals(orExpr, derived);
+    }
+
+    @Test
+    public void testApplySkipsBelowColumnThreshold() {
+        // 2 columns: shipdate + returnflag → apply() should skip (threshold = 3)
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator returnflag = colVarchar(2, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)),
+                    le(shipdate, ConstantOperator.createInt(1)),
+                    eq(returnflag, ConstantOperator.createVarchar("R"))),
+                and(ge(shipdate, ConstantOperator.createInt(15)),
+                    le(shipdate, ConstantOperator.createInt(15)),
+                    eq(returnflag, ConstantOperator.createVarchar("A")))
+        );
+
+        // apply() should skip because 2 columns < MIN_DISTINCT_COLUMNS_FOR_GUARD (3)
+        ScalarOperator result = DeriveGuardPredicateRule.apply(orExpr);
+        assertEquals(orExpr, result);
+    }
+
+    @Test
+    public void testApplyRewritesWhenThresholdMet() {
+        // 3 columns: shipdate + discount + returnflag → apply() should generate guard
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator discount = colInt(2, "l_discount");
+        ColumnRefOperator returnflag = colVarchar(3, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)),
+                    le(shipdate, ConstantOperator.createInt(10)),
+                    eq(discount, ConstantOperator.createInt(5)),
+                    eq(returnflag, ConstantOperator.createVarchar("R"))),
+                and(ge(shipdate, ConstantOperator.createInt(20)),
+                    le(shipdate, ConstantOperator.createInt(30)),
+                    eq(discount, ConstantOperator.createInt(6)),
+                    eq(returnflag, ConstantOperator.createVarchar("A")))
+        );
+
+        ScalarOperator result = DeriveGuardPredicateRule.apply(orExpr);
+
+        // Should have wrapped: AND(guard_shipdate, original_OR)
+        // No guard for discount (EQ-only) or returnflag (VARCHAR)
+        ScalarOperator guardShipdate = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(10))),
+                and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30)))
+        );
+        ScalarOperator expected = and(guardShipdate, orExpr);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testNonDeterministicPredicateNotUsedAsGuard() {
+        // (v1 > rand() AND v2 = 1 AND v3 = 'X') OR (v1 > rand() AND v2 = 2 AND v3 = 'Y')
+        // v1 > rand() should NOT become a guard because rand() is nondeterministic.
+        // If it were duplicated, guard and original OR could evaluate different
+        // random values and incorrectly filter rows.
+        ColumnRefOperator v1 = colInt(1, "v1");
+        ColumnRefOperator v2 = colInt(2, "v2");
+        ColumnRefOperator v3 = colVarchar(3, "v3");
+
+        ScalarOperator rand1 = new CallOperator("rand", FloatType.DOUBLE, Collections.emptyList());
+        ScalarOperator rand2 = new CallOperator("rand", FloatType.DOUBLE, Collections.emptyList());
+
+        ScalarOperator orExpr = or(
+                and(ge(v1, rand1),
+                    eq(v2, ConstantOperator.createInt(1)),
+                    eq(v3, ConstantOperator.createVarchar("X"))),
+                and(ge(v1, rand2),
+                    eq(v2, ConstantOperator.createInt(2)),
+                    eq(v3, ConstantOperator.createVarchar("Y")))
+        );
+
+        ScalarOperator result = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        // No guard expected: v1 > rand() is nondeterministic, so v1 is not a guard
+        // candidate. v2 is EQ-only (skipped). v3 is VARCHAR EQ (skipped).
+        assertEquals(orExpr, result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -21,7 +21,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Test;
@@ -109,8 +108,7 @@ public class DeriveGuardPredicateRuleTest {
     public void testSingleDisjunct() {
         // Single disjunct (not really an OR) — no rewriting
         ScalarOperator expr = eq(colInt(1, "a"), ConstantOperator.createInt(1));
-        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
-        ScalarOperator result = new DeriveGuardPredicateRule().apply(expr, context);
+        ScalarOperator result = DeriveGuardPredicateRule.apply(expr);
         assertEquals(expr, result);
     }
 
@@ -141,8 +139,7 @@ public class DeriveGuardPredicateRuleTest {
                 eq(b, ConstantOperator.createInt(2))
         );
 
-        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
-        ScalarOperator result = new DeriveGuardPredicateRule().apply(andExpr, context);
+        ScalarOperator result = DeriveGuardPredicateRule.apply(andExpr);
         assertEquals(andExpr, result);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -148,7 +148,10 @@ public class DeriveGuardPredicateRuleTest {
 
     @Test
     public void testThreeBranches() {
-        // Three OR branches, all have l_shipdate comparisons + payload
+        // Three OR branches, all have l_shipdate (GE+LE) + l_discount (EQ on INT).
+        // Both columns get guards:
+        //   guard_shipdate: OR over shipdate ranges
+        //   guard_discount:  OR over discount EQ values (INT type, valid candidate)
         ColumnRefOperator shipdate = colInt(1, "l_shipdate");
         ColumnRefOperator discount = colInt(2, "l_discount");
 
@@ -167,12 +170,64 @@ public class DeriveGuardPredicateRuleTest {
         ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
                 (CompoundPredicateOperator) orExpr);
 
-        ScalarOperator expectedGuard = or(
+        ScalarOperator guardShipdate = or(
                 and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(10))),
                 and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30))),
                 and(ge(shipdate, ConstantOperator.createInt(40)), le(shipdate, ConstantOperator.createInt(50)))
         );
-        ScalarOperator expected = and(expectedGuard, orExpr);
+        ScalarOperator guardDiscount = or(
+                eq(discount, ConstantOperator.createInt(5)),
+                eq(discount, ConstantOperator.createInt(6)),
+                eq(discount, ConstantOperator.createInt(7))
+        );
+        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
         assertEquals(expected, derived);
+    }
+
+    @Test
+    public void testEQOnNumericColumn() {
+        // EQ on INT columns should produce guards.
+        // Both l_shipdate (INT) and l_discount (INT) are valid candidates.
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator discount = colInt(2, "l_discount");
+
+        ScalarOperator orExpr = or(
+                and(eq(shipdate, ConstantOperator.createInt(1)),
+                    eq(discount, ConstantOperator.createInt(5))),
+                and(eq(shipdate, ConstantOperator.createInt(15)),
+                    eq(discount, ConstantOperator.createInt(6)))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        // Guards for both columns
+        ScalarOperator guardShipdate = or(
+                eq(shipdate, ConstantOperator.createInt(1)),
+                eq(shipdate, ConstantOperator.createInt(15))
+        );
+        ScalarOperator guardDiscount = or(
+                eq(discount, ConstantOperator.createInt(5)),
+                eq(discount, ConstantOperator.createInt(6))
+        );
+        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
+        assertEquals(expected, derived);
+    }
+
+    @Test
+    public void testEQOnVarcharColumn() {
+        // EQ on varchar column should NOT produce guard (low cardinality risk)
+        // (l_returnflag = 'R') OR (l_returnflag = 'A')
+        ColumnRefOperator returnflag = colVarchar(1, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                eq(returnflag, ConstantOperator.createVarchar("R")),
+                eq(returnflag, ConstantOperator.createVarchar("A"))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+        // No guard expected: EQ on VARCHAR is skipped
+        assertEquals(orExpr, derived);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -146,9 +146,8 @@ public class DeriveGuardPredicateRuleTest {
     @Test
     public void testThreeBranches() {
         // Three OR branches, all have l_shipdate (GE+LE) + l_discount (EQ on INT).
-        // Both columns get guards:
-        //   guard_shipdate: OR over shipdate ranges
-        //   guard_discount:  OR over discount EQ values (INT type, valid candidate)
+        // Only shipdate gets a guard — range predicates are the primary target.
+        // discount EQ-only guard is skipped (ScalarRangePredicateExtractor handles it).
         ColumnRefOperator shipdate = colInt(1, "l_shipdate");
         ColumnRefOperator discount = colInt(2, "l_discount");
 
@@ -172,19 +171,15 @@ public class DeriveGuardPredicateRuleTest {
                 and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30))),
                 and(ge(shipdate, ConstantOperator.createInt(40)), le(shipdate, ConstantOperator.createInt(50)))
         );
-        ScalarOperator guardDiscount = or(
-                eq(discount, ConstantOperator.createInt(5)),
-                eq(discount, ConstantOperator.createInt(6)),
-                eq(discount, ConstantOperator.createInt(7))
-        );
-        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
+        ScalarOperator expected = and(guardShipdate, orExpr);
         assertEquals(expected, derived);
     }
 
     @Test
     public void testEQOnNumericColumn() {
-        // EQ on INT columns should produce guards.
-        // Both l_shipdate (INT) and l_discount (INT) are valid candidates.
+        // EQ-only guards on numeric columns are skipped — the
+        // ScalarRangePredicateExtractor already produces IN lists for them.
+        // Only range predicates (GE, LE, GT, LT) trigger guard generation.
         ColumnRefOperator shipdate = colInt(1, "l_shipdate");
         ColumnRefOperator discount = colInt(2, "l_discount");
 
@@ -198,17 +193,8 @@ public class DeriveGuardPredicateRuleTest {
         ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
                 (CompoundPredicateOperator) orExpr);
 
-        // Guards for both columns
-        ScalarOperator guardShipdate = or(
-                eq(shipdate, ConstantOperator.createInt(1)),
-                eq(shipdate, ConstantOperator.createInt(15))
-        );
-        ScalarOperator guardDiscount = or(
-                eq(discount, ConstantOperator.createInt(5)),
-                eq(discount, ConstantOperator.createInt(6))
-        );
-        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
-        assertEquals(expected, derived);
+        // No guard — all predicates are EQ-only, which the range extractor handles.
+        assertEquals(orExpr, derived);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DeriveGuardPredicateRuleTest {
+
+    // Column helpers
+    private static ColumnRefOperator colInt(int id, String name) {
+        return new ColumnRefOperator(id, IntegerType.INT, name, true);
+    }
+
+    private static ColumnRefOperator colVarchar(int id, String name) {
+        return new ColumnRefOperator(id, VarcharType.VARCHAR, name, true);
+    }
+
+    // Build a proper left-deep AND tree (matching optimizer output) via Utils.compoundAnd
+    private static ScalarOperator and(ScalarOperator... children) {
+        return Utils.compoundAnd(children);
+    }
+
+    // Build a proper left-deep OR tree via Utils.compoundOr
+    private static ScalarOperator or(ScalarOperator... children) {
+        return Utils.compoundOr(children);
+    }
+
+    private static ScalarOperator eq(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.EQ, left, right);
+    }
+
+    private static ScalarOperator ge(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.GE, left, right);
+    }
+
+    private static ScalarOperator le(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.LE, left, right);
+    }
+
+    @Test
+    public void testNarrowDateOR() {
+        // (l_shipdate >= 1 AND l_shipdate <= 1 AND l_returnflag = 'R')
+        // OR (l_shipdate >= 15 AND l_shipdate <= 15 AND l_returnflag = 'A')
+        // => AND(guard_shipdate, original_OR)
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator returnflag = colVarchar(2, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)),
+                    le(shipdate, ConstantOperator.createInt(1)),
+                    eq(returnflag, ConstantOperator.createVarchar("R"))),
+                and(ge(shipdate, ConstantOperator.createInt(15)),
+                    le(shipdate, ConstantOperator.createInt(15)),
+                    eq(returnflag, ConstantOperator.createVarchar("A")))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        ScalarOperator expectedGuard = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(1))),
+                and(ge(shipdate, ConstantOperator.createInt(15)), le(shipdate, ConstantOperator.createInt(15)))
+        );
+        ScalarOperator expected = and(expectedGuard, orExpr);
+        assertEquals(expected, derived);
+    }
+
+    @Test
+    public void testNoCommonColumn() {
+        // (l_returnflag = 'R') OR (l_linestatus = 'O') => no guard
+        ColumnRefOperator returnflag = colVarchar(1, "l_returnflag");
+        ColumnRefOperator linestatus = colVarchar(2, "l_linestatus");
+
+        ScalarOperator orExpr = or(
+                eq(returnflag, ConstantOperator.createVarchar("R")),
+                eq(linestatus, ConstantOperator.createVarchar("O"))
+        );
+
+        ScalarOperator result = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+        assertEquals(orExpr, result);
+    }
+
+    @Test
+    public void testSingleDisjunct() {
+        // Single disjunct (not really an OR) — no rewriting
+        ScalarOperator expr = eq(colInt(1, "a"), ConstantOperator.createInt(1));
+        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
+        ScalarOperator result = new DeriveGuardPredicateRule().apply(expr, context);
+        assertEquals(expr, result);
+    }
+
+    @Test
+    public void testAllBranchesOnlyColumnPreds() {
+        // (l_returnflag = 'R') OR (l_returnflag = 'A')
+        // EQ-only predicates are not range predicates => no guard
+        ColumnRefOperator returnflag = colVarchar(1, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                eq(returnflag, ConstantOperator.createVarchar("R")),
+                eq(returnflag, ConstantOperator.createVarchar("A"))
+        );
+
+        ScalarOperator result = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+        assertEquals(orExpr, result);
+    }
+
+    @Test
+    public void testAndPredicate() {
+        // AND predicate — not processed
+        ColumnRefOperator a = colInt(1, "a");
+        ColumnRefOperator b = colInt(2, "b");
+
+        ScalarOperator andExpr = and(
+                eq(a, ConstantOperator.createInt(1)),
+                eq(b, ConstantOperator.createInt(2))
+        );
+
+        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
+        ScalarOperator result = new DeriveGuardPredicateRule().apply(andExpr, context);
+        assertEquals(andExpr, result);
+    }
+
+    @Test
+    public void testThreeBranches() {
+        // Three OR branches, all have l_shipdate comparisons + payload
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator discount = colInt(2, "l_discount");
+
+        ScalarOperator orExpr = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)),
+                    le(shipdate, ConstantOperator.createInt(10)),
+                    eq(discount, ConstantOperator.createInt(5))),
+                and(ge(shipdate, ConstantOperator.createInt(20)),
+                    le(shipdate, ConstantOperator.createInt(30)),
+                    eq(discount, ConstantOperator.createInt(6))),
+                and(ge(shipdate, ConstantOperator.createInt(40)),
+                    le(shipdate, ConstantOperator.createInt(50)),
+                    eq(discount, ConstantOperator.createInt(7)))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        ScalarOperator expectedGuard = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(10))),
+                and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30))),
+                and(ge(shipdate, ConstantOperator.createInt(40)), le(shipdate, ConstantOperator.createInt(50)))
+        );
+        ScalarOperator expected = and(expectedGuard, orExpr);
+        assertEquals(expected, derived);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Multi-branch OR queries where each branch shares a common pivot column (e.g. `l_shipdate`) cause the BE to union ALL predicate columns into `active_columns`. With 10 branches each using different payload column pairs, nearly the entire table is decoded upfront — late materialization degenerates into eager full-table scan.

```
Query shape:
  (l_shipdate BETWEEN '1998-01-01' AND '1998-01-31' AND (l_discount > 0.09 OR l_tax > 0.07))
  OR (l_shipdate BETWEEN '1997-11-01' AND '1997-11-30' AND (l_quantity < 10 OR l_extendedprice > 90000))
  OR ... (8 more branches, each with different column pairs)

BE behavior without guard:
  active_columns = UNION(all predicate columns) = 14/16
  → all 14 columns decoded for all rows before expression evaluation
  → ColumnReadTime dominates (19.4s), narrow IO ≈ wide IO (189.9 GB vs 191.7 GB)
```

The guard predicate makes the pivot column (`l_shipdate`) a single-slot conjunct in `conjunct_ctxs_by_slot`, which the BE evaluates first. This enables short-circuit: rows that don't match any branch's date range skip the full OR expression evaluation.

## What I'm doing:

Add `DeriveGuardPredicateRule` — a one-pass transformation called from `PushDownPredicateScanRule` that extracts a "guard" predicate from OR branches sharing a common pivot column.

**Transformation:**

```
Before:
  (shipdate_range_1 AND branch_1_cols)
  OR (shipdate_range_2 AND branch_2_cols)
  OR ...

After:
  (shipdate_range_1 OR shipdate_range_2 OR ...)   -- guard (single-slot, enters conjunct_ctxs_by_slot)
  AND ((shipdate_range_1 AND branch_1_cols)        -- original OR preserved
    OR (shipdate_range_2 AND branch_2_cols)
    OR ...)
```

The guard is purely additive (`AND(guard, original)`), so correctness is preserved.

**Guard eligibility rules:**

- Range predicates (GE, LE, GT, LT): always collected
- IN predicates: always collected
- EQ on numeric/date/datetime: collected (high-cardinality, selective)
- EQ on VARCHAR/CHAR/BOOLEAN: excluded — low-cardinality payload columns should stay LAZY

**Two defensive guardrails:**

1. **EQ-only guard skip** — If a column's guard would consist purely of `=`/`IN` predicates (no range predicates), skip it. `ScalarRangePredicateExtractor` already produces equivalent `col IN (...)` lists. Not a compromise.

2. **Minimum column threshold (≥ 3 distinct columns)** — Skip guard when the OR involves ≤ 2 columns. With only 2 columns both are already ACTIVE regardless of the guard, so short-circuit benefit is marginal. The real reason: guards added during MV refresh are baked into the MV's stored plan, and MV matching (which is not guard-aware) fails when predicate structures differ between query and stored plan. This threshold preserves the guard for the target production use case (14 columns across 10 branches), and the 3-column SELECTIVE case still triggers the guard. **Compromise — MV matching is not guard-aware yet.**

**Architecture:**

The rule is a standalone class (`static` methods), not a `ScalarOperatorRewriteRule` inside the fixpoint loop. It's called once from `PushDownPredicateScanRule`, after `ScalarRangePredicateExtractor` and the scalar rewriter complete. This avoids infinite rewrite loops where the guard's output was fed back into the rewriter.

**Known limitation — IO not reduced:**

The guard reduces CPU (expression short-circuit) but does not reduce IO — the BE still marks all branch-local columns as ACTIVE because they appear in the remaining OR expression. Reducing IO requires BE-side lazy column loading during expression evaluation, tracked separately. This FE-side guard is the prerequisite that provides the column classification signal.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
