### PR TITLE
[Enhancement] Implementing dictification for array functions with additional constant arguments (backend changes)

### DIFF
--- a/be/src/compute_env/global_dict/parser.cpp
+++ b/be/src/compute_env/global_dict/parser.cpp
@@ -14,6 +14,8 @@
 
 #include "compute_env/global_dict/parser.h"
 
+#include <limits>
+
 #include "base/simd/gather.h"
 #include "column/array_column.h"
 #include "column/chunk.h"
@@ -539,6 +541,25 @@ Status rewrite_global_dict_mapping_expr(RuntimeState* state, ExprContext* contex
         return Status::InternalError("fragment dict state is not set");
     }
     return fragment_dict_state->mutable_dict_optimize_parser()->rewrite_expr(state, context, expr, output_id);
+}
+
+StatusOr<DictId> DictOptimizeParser::lookup_dict_code(RuntimeState* runtime_state, SlotId slot_id, const Slice& value) {
+    std::lock_guard<std::recursive_mutex> guard(_dict_maps_mutex);
+
+    auto it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    if (it == _mutable_dict_maps->end()) {
+        RETURN_IF_ERROR(eval_dict_expr(runtime_state, slot_id));
+        it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    }
+    if (it == _mutable_dict_maps->end()) {
+        return Status::InternalError(fmt::format("dict_encode: global dictionary not found for slot {}", slot_id));
+    }
+
+    const GlobalDictMap& forward = it->second.first;
+    if (auto f = forward.find(value); f != forward.end()) {
+        return f->second;
+    }
+    return std::numeric_limits<DictId>::max();
 }
 
 } // namespace starrocks

--- a/be/src/compute_env/global_dict/parser.cpp
+++ b/be/src/compute_env/global_dict/parser.cpp
@@ -546,6 +546,9 @@ Status rewrite_global_dict_mapping_expr(RuntimeState* state, ExprContext* contex
 StatusOr<DictId> DictOptimizeParser::lookup_dict_code(RuntimeState* runtime_state, SlotId slot_id, const Slice& value) {
     std::lock_guard<std::recursive_mutex> guard(_dict_maps_mutex);
 
+    if (_mutable_dict_maps == nullptr) {
+        return Status::InternalError("dict_encode: dict maps not initialized");
+    }
     auto it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
     if (it == _mutable_dict_maps->end()) {
         RETURN_IF_ERROR(eval_dict_expr(runtime_state, slot_id));

--- a/be/src/compute_env/global_dict/parser.h
+++ b/be/src/compute_env/global_dict/parser.h
@@ -26,6 +26,7 @@
 #include "common/global_types.h"
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "common/statusor.h"
 
 namespace starrocks {
 
@@ -67,6 +68,11 @@ public:
     void close(RuntimeState* runtime_state) noexcept;
 
     void check_could_apply_dict_optimize(ExprContext* expr_ctx, DictOptimizeContext* dict_opt_ctx);
+
+    // Look up `value`'s global-dict code for `slot_id`.
+    // Returns std::numeric_limits<DictId>::max() when `value` is not present,
+    // valid for equality/membership only.
+    StatusOr<DictId> lookup_dict_code(RuntimeState* runtime_state, SlotId slot_id, const Slice& value);
 
     // For global dictionary optimized columns,
     // the type at the execution level is INT but at the storage level is TYPE_STRING/TYPE_CHAR,

--- a/be/src/exprs_ext/CMakeLists.txt
+++ b/be/src/exprs_ext/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXPR_DICT_FILES
   dict/dictmapping_expr.cpp
   dict/dict_query_expr.cpp
   dict/dictionary_get_expr.cpp
+  dict/dict_functions.cpp
 )
 
 ADD_BE_LIB(ExprDict ${EXPR_DICT_FILES})

--- a/be/src/exprs_ext/dict/dict_functions.cpp
+++ b/be/src/exprs_ext/dict/dict_functions.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs_ext/dict/dict_functions.h"
+
+#include <cstdint>
+#include <string>
+
+#include "column/column_helper.h"
+#include "column/global_dict/config.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+namespace {
+struct EncodeDictState {
+    bool is_null = false;
+    DictId code = 0;
+};
+} // namespace
+
+Status DictFunctions::dict_encode_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
+    }
+    auto* state = new EncodeDictState();
+    context->set_function_state(scope, state);
+
+    if (!context->is_notnull_constant_column(1)) {
+        return Status::InternalError("dict_encode: dict_slot_id must be a non-null constant");
+    }
+    const int32_t slot_id = ColumnHelper::get_const_value<TYPE_INT>(context->get_constant_column(1));
+
+    if (!context->is_constant_column(0)) {
+        return Status::InternalError("dict_encode: value must be a constant");
+    }
+    if (!context->is_notnull_constant_column(0)) {
+        state->is_null = true;
+        return Status::OK();
+    }
+
+    RuntimeState* runtime_state = context->state();
+    if (runtime_state == nullptr) {
+        return Status::InternalError("dict_encode: null runtime state for slot " + std::to_string(slot_id));
+    }
+    FragmentDictState* dict_state = runtime_state->fragment_dict_state();
+    if (dict_state == nullptr) {
+        return Status::InternalError("dict_encode: missing dict state for slot " + std::to_string(slot_id));
+    }
+
+    const Slice value = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(0));
+    ASSIGN_OR_RETURN(state->code,
+                     dict_state->mutable_dict_optimize_parser()->lookup_dict_code(runtime_state, slot_id, value));
+    return Status::OK();
+}
+
+Status DictFunctions::dict_encode_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        delete reinterpret_cast<EncodeDictState*>(context->get_function_state(scope));
+    }
+    return Status::OK();
+}
+
+StatusOr<ColumnPtr> DictFunctions::dict_encode(FunctionContext* context, const Columns& columns) {
+    auto* state = reinterpret_cast<EncodeDictState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (state == nullptr) {
+        return Status::InternalError("dict_encode: function state not initialized");
+    }
+    const size_t num_rows = columns[0]->size();
+    if (state->is_null) {
+        return ColumnHelper::create_const_null_column(num_rows);
+    }
+    return ColumnHelper::create_const_column<TYPE_INT>(state->code, num_rows);
+}
+
+} // namespace starrocks
+
+#include "gen_cpp/opcode/DictFunctions.inc"

--- a/be/src/exprs_ext/dict/dict_functions.h
+++ b/be/src/exprs_ext/dict/dict_functions.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exprs/function_context.h"
+#include "exprs/function_helper.h"
+
+namespace starrocks {
+
+class DictFunctions {
+public:
+    // dict_encode(value, dict_slot_id): translate a constant VARCHAR to its global-dictionary code
+    // for the column identified by dict_slot_id, resolved once from BE runtime state. Lets the
+    // low-cardinality rewrite pre-encode a constant operand so a dict-aware comparison runs directly
+    // on integer codes (e.g. array_contains(dict_array, dict_encode('foo', slot))).
+    //
+    //   value         VARCHAR constant.
+    //   dict_slot_id  INT constant: the global-dict column id whose dictionary to use.
+    //
+    // A value absent from the dictionary encodes to a guaranteed-absent "no match" code (size + 1).
+    // This makes equality comparisons against it behave correctly, but it should not be used for order
+    // comparison. A NULL input value encodes to NULL.
+    DEFINE_VECTORIZED_FN(dict_encode);
+
+    static Status dict_encode_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status dict_encode_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+};
+
+} // namespace starrocks

--- a/be/src/exprs_ext/dict/dict_functions.h
+++ b/be/src/exprs_ext/dict/dict_functions.h
@@ -29,9 +29,9 @@ public:
     //   value         VARCHAR constant.
     //   dict_slot_id  INT constant: the global-dict column id whose dictionary to use.
     //
-    // A value absent from the dictionary encodes to a guaranteed-absent "no match" code (size + 1).
-    // This makes equality comparisons against it behave correctly, but it should not be used for order
-    // comparison. A NULL input value encodes to NULL.
+    // A value absent from the dictionary encodes to std::numeric_limits<DictId>::max() (a guaranteed-absent
+    // sentinel). This makes equality/membership comparisons against it behave correctly, but it must not be
+    // used for order comparison. A NULL input value encodes to NULL.
     DEFINE_VECTORIZED_FN(dict_encode);
 
     static Status dict_encode_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -119,6 +119,7 @@ set(EXEC_FILES
         ./exprs/table_function/test_list_rowsets.cpp
         ./exprs/table_function/java_udtf_factory_test.cpp
         ./exprs/dict_expr_test.cpp
+        ./exprs/dict_functions_test.cpp
         ./formats/json/binary_column_test.cpp
         ./formats/json/numeric_column_test.cpp
         ./formats/json/nullable_column_test.cpp

--- a/be/test/exprs/dict_functions_test.cpp
+++ b/be/test/exprs/dict_functions_test.cpp
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs_ext/dict/dict_functions.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/string/slice.h"
+#include "column/column_helper.h"
+#include "column/global_dict/types.h"
+#include "column/vectorized_fwd.h"
+#include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+class EncodeDictTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _dict_strings = {"a", "b", "c"};
+        GlobalDictMap forward;
+        RGlobalDictMap reverse;
+        for (size_t i = 0; i < _dict_strings.size(); ++i) {
+            auto code = static_cast<int32_t>(i + 1);
+            forward.emplace(Slice(_dict_strings[i]), code);
+            reverse.emplace(code, Slice(_dict_strings[i]));
+        }
+        _dict_state = std::make_unique<FragmentDictState>();
+        _dict_state->mutable_query_global_dicts()->emplace(kSlotId,
+                                                           std::make_pair(std::move(forward), std::move(reverse)));
+        _dict_state->mutable_dict_optimize_parser()->set_mutable_dict_maps(_dict_state->mutable_query_global_dicts());
+        _state.set_fragment_dict_state(_dict_state.get());
+    }
+
+protected:
+    static constexpr int32_t kSlotId = 1;
+    static constexpr DictId kNoMatch = std::numeric_limits<DictId>::max();
+
+    std::unique_ptr<FunctionContext> makeContext(const TypeDescriptor& arg0_type, RuntimeState* rs,
+                                                 const Columns& constant_columns) {
+        std::vector<TypeDescriptor> arg_types = {arg0_type, TypeDescriptor(TYPE_INT)};
+        std::unique_ptr<FunctionContext> ctx(
+                FunctionContext::create_test_context(std::move(arg_types), TypeDescriptor(TYPE_INT)));
+        ctx->set_runtime_state(rs);
+        ctx->set_constant_columns(constant_columns);
+        return ctx;
+    }
+
+    std::vector<std::string> _dict_strings;
+    std::unique_ptr<FragmentDictState> _dict_state;
+    RuntimeState _state;
+};
+
+TEST_F(EncodeDictTest, scalar_value_in_dict) {
+    Columns columns = {ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("b"), 1),
+                       ColumnHelper::create_const_column<TYPE_INT>(kSlotId, 1)};
+    auto ctx = makeContext(TypeDescriptor(TYPE_VARCHAR), &_state, columns);
+
+    ASSERT_TRUE(DictFunctions::dict_encode_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+    ColumnPtr result = DictFunctions::dict_encode(ctx.get(), columns).value();
+    EXPECT_EQ(2, ColumnHelper::get_const_value<TYPE_INT>(result));
+    ASSERT_TRUE(DictFunctions::dict_encode_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+}
+
+TEST_F(EncodeDictTest, scalar_value_absent_uses_no_match_code) {
+    Columns columns = {ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("z"), 1),
+                       ColumnHelper::create_const_column<TYPE_INT>(kSlotId, 1)};
+    auto ctx = makeContext(TypeDescriptor(TYPE_VARCHAR), &_state, columns);
+
+    ASSERT_TRUE(DictFunctions::dict_encode_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+    ColumnPtr result = DictFunctions::dict_encode(ctx.get(), columns).value();
+    EXPECT_EQ(kNoMatch, ColumnHelper::get_const_value<TYPE_INT>(result));
+    ASSERT_TRUE(DictFunctions::dict_encode_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+}
+
+TEST_F(EncodeDictTest, scalar_null_value_returns_null) {
+    Columns columns = {ColumnHelper::create_const_null_column(1),
+                       ColumnHelper::create_const_column<TYPE_INT>(kSlotId, 1)};
+    auto ctx = makeContext(TypeDescriptor(TYPE_VARCHAR), &_state, columns);
+
+    ASSERT_TRUE(DictFunctions::dict_encode_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+    ColumnPtr result = DictFunctions::dict_encode(ctx.get(), columns).value();
+    EXPECT_TRUE(result->only_null());
+    ASSERT_TRUE(DictFunctions::dict_encode_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+}
+
+} // namespace starrocks

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -489,6 +489,11 @@ vectorized_functions = [
     [30603, 'from_binary', True, True, 'VARCHAR', ['VARBINARY'], 'BinaryFunctions::from_binary',
      'BinaryFunctions::from_binary_prepare', 'BinaryFunctions::from_binary_close'],
 
+    # dict_encode(value, dict_slot_id): translate a constant to its global dictionary code (resolved
+    # once from BE runtime state), so a dict-aware comparison can run on codes. BE-only.
+    [30700, 'dict_encode', True, False, 'INT', ['VARCHAR', 'INT'], 'DictFunctions::dict_encode',
+     'DictFunctions::dict_encode_prepare', 'DictFunctions::dict_encode_close'],
+
     # 50xxx: timestamp functions
     [50008, 'year', True, False, 'SMALLINT', ['DATE'], 'TimeFunctions::yearV3'],
     [50009, 'year', True, False, 'SMALLINT', ['DATETIME'], 'TimeFunctions::yearV2'],

--- a/gensrc/script/gen_functions.py
+++ b/gensrc/script/gen_functions.py
@@ -135,6 +135,7 @@ void __attribute__((constructor)) {module}_initialize() {{
 function_list = list()
 function_set = set()
 function_signature_set = set()
+FE_HIDDEN_FUNCTIONS = {'dict_encode'}
 
 def add_function(fn_data):
     entry = dict()
@@ -263,7 +264,7 @@ ${default_values}
 
     value = dict()
     value["license"] = license_string
-    value["functions"] = "\n        ".join([gen_fe_fn(i) for i in function_list])
+    value["functions"] = "\n        ".join([gen_fe_fn(i) for i in function_list if i['name'] not in FE_HIDDEN_FUNCTIONS])
 
     content = java_template.substitute(value)
 
@@ -330,6 +331,7 @@ def generate_cpp(path):
         "GinFunctions",
         "AiFunctions",
         "HttpRequestFunctions",
+        "DictFunctions",
     ]
 
     modules_contents = dict()


### PR DESCRIPTION
## Why I'm doing:
Currently dictification framework cannot rewrite array functions with constant arguments (like `ARRAY_CONTAINS(arr, 'abc')`).  This is due to the fact that constant strings can't be translated into dictionary space.  This PR implements the be changes for this feature. 


## What I'm doing:
Implementing `dict_encode(value, dict_slot_id)` function which translates a constant to its global-dictionary code for the column identified by dict_slot_id, resolved once from BE runtime state. It lets the low-cardinality rewrite pre-encode a constant operand so a dict-aware comparison can run directly on integer codes.
NOTE: This function is hidden from fe and can be only added to the plan by low cardinality framework.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
