### PR TITLE
[Enhancement] Read DATE/DATETIME footer stats in tablet pre-split meta tier

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import java.time.LocalDate;
+
+/**
+ * The value window the meta tier accepts for DATE/DATETIME sort-key boundaries:
+ * {@code [1970-01-01, 9999-12-31]}. A value outside it falls back to data tier
+ * (it is not a load failure).
+ *
+ * <p>Why these bounds — render must be unambiguous and the FE-computed boundary must
+ * equal the value the BE load stores:
+ * <ul>
+ *   <li>Below 1970-01-01 the BE timestamp conversion uses signed C++ division whose
+ *       (seconds, nanos) split differs from {@code Math.floorDiv}/{@code floorMod},
+ *       and pre-1582 dates raise proleptic-vs-hybrid calendar parity questions.</li>
+ *   <li>Year 0 / BCE mis-renders through the {@code yyyy} (year-of-era) formatters.</li>
+ *   <li>Above year 9999 leaves the StarRocks DATE/DATETIME domain.</li>
+ * </ul>
+ *
+ * <p>This lives in one place — rather than being duplicated per reader like the
+ * integer-stat conversion — because the constraint is format-agnostic: it operates on
+ * an already-decoded {@link LocalDate}, identical whether the value came from a Parquet
+ * INT32/INT64 stat or an ORC day-of-epoch stat.
+ */
+final class MetaTierTemporalWindow {
+
+    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1970, 1, 1);
+    private static final LocalDate MAX_SUPPORTED_DATE = LocalDate.of(9999, 12, 31);
+
+    private MetaTierTemporalWindow() {
+    }
+
+    /**
+     * Throw {@link MetaTierUnavailableException} (the meta-tier-to-data-tier fallback signal)
+     * if {@code date} is outside {@code [1970-01-01, 9999-12-31]}.
+     */
+    static void rejectDateOutsideWindow(LocalDate date) throws MetaTierUnavailableException {
+        if (date.isBefore(MIN_SUPPORTED_DATE) || date.isAfter(MAX_SUPPORTED_DATE)) {
+            throw new MetaTierUnavailableException(
+                    "DATE/DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
+                            + date + " is outside that window");
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -18,10 +18,12 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.type.PrimitiveType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.orc.ColumnStatistics;
+import org.apache.orc.DateColumnStatistics;
 import org.apache.orc.IntegerColumnStatistics;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
@@ -30,6 +32,7 @@ import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -138,6 +141,8 @@ public final class OrcStripeStatisticsReader {
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (orcCategory) {
             case BYTE, SHORT, INT, LONG -> starRocksPrimitive.isIntegerType();
+            // ORC DATE is day-of-epoch (no timezone) → StarRocks DATE only.
+            case DATE -> starRocksPrimitive == PrimitiveType.DATE;
             default -> false;
         };
         if (!compatible) {
@@ -154,14 +159,22 @@ public final class OrcStripeStatisticsReader {
         ColumnStatistics[] columnStatistics = stripeStatistics.getColumnStatistics();
         ColumnStatistics sortKeyStatistics =
                 location.columnId < columnStatistics.length ? columnStatistics[location.columnId] : null;
-        // ORC integer stats expose no presence flag (getMinimum() returns a default
-        // when the stripe has no values), so we must treat absent / all-null stats
-        // as missing explicitly rather than emit a bogus min/max. The instanceof
-        // pattern also absorbs the out-of-bounds (null) case above.
-        if (!(sortKeyStatistics instanceof IntegerColumnStatistics integerStatistics)
-                || integerStatistics.getNumberOfValues() == 0) {
-            return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
+        if (sortKeyStatistics instanceof IntegerColumnStatistics integerStatistics
+                && integerStatistics.getNumberOfValues() > 0) {
+            return integerStripe(integerStatistics, rowCount, location);
         }
+        if (sortKeyStatistics instanceof DateColumnStatistics dateStatistics
+                && dateStatistics.getNumberOfValues() > 0) {
+            return dateStripe(dateStatistics, rowCount, location);
+        }
+        // Absent / all-null stats (no presence flag on ORC numeric/date stats, so an
+        // empty stripe is detected via getNumberOfValues() == 0) → missing min/max.
+        return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
+    }
+
+    private static RowGroupStatistics integerStripe(
+            IntegerColumnStatistics integerStatistics, long rowCount, SortKeyLocation location)
+            throws MetaTierUnavailableException {
         Variant minVariant;
         Variant maxVariant;
         try {
@@ -178,10 +191,47 @@ public final class OrcStripeStatisticsReader {
         }
         // ORC integer statistics are always exact (no truncation like Parquet binary).
         return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)),
-                new Tuple(List.of(maxVariant)),
-                rowCount,
-                /*truncated=*/ false);
+                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+    }
+
+    // v1 safe window — identical rationale to the Parquet reader: year 0/BCE mis-renders, pre-1970
+    // (negative epoch) has unverified BE parity, and pre-1582 raises calendar parity questions.
+    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1970, 1, 1);
+    private static final int MAX_SUPPORTED_YEAR = 9999;
+
+    private static RowGroupStatistics dateStripe(
+            DateColumnStatistics dateStatistics, long rowCount, SortKeyLocation location)
+            throws MetaTierUnavailableException {
+        LocalDate minDate;
+        LocalDate maxDate;
+        try {
+            // getMinimumDayOfEpoch() is day-of-epoch (timezone-free).
+            minDate = LocalDate.ofEpochDay(dateStatistics.getMinimumDayOfEpoch());
+            maxDate = LocalDate.ofEpochDay(dateStatistics.getMaximumDayOfEpoch());
+        } catch (RuntimeException conversionFailure) {
+            // Mirror integerStripe: an absurd ORC day-count (DateTimeException from ofEpochDay)
+            // becomes a meta-tier fallback signal, not a hard sampling error that skips pre-split.
+            throw new MetaTierUnavailableException(String.format(
+                    "ORC date stats value not representable for sort-key column \"%s\": %s",
+                    location.starRocksColumn.getName(), conversionFailure.getMessage()));
+        }
+        // Throws MetaTierUnavailableException (checked) directly — propagates past the catch above.
+        rejectUnsafeTemporalDate(minDate);
+        rejectUnsafeTemporalDate(maxDate);
+        return new RowGroupStatistics(
+                new Tuple(List.of(Variant.of(location.starRocksColumn.getType(),
+                        minDate.format(DateUtils.DATE_FORMATTER)))),
+                new Tuple(List.of(Variant.of(location.starRocksColumn.getType(),
+                        maxDate.format(DateUtils.DATE_FORMATTER)))),
+                rowCount, /*truncated=*/ false);
+    }
+
+    private static void rejectUnsafeTemporalDate(LocalDate date) throws MetaTierUnavailableException {
+        if (date.isBefore(MIN_SUPPORTED_DATE) || date.getYear() > MAX_SUPPORTED_YEAR) {
+            throw new MetaTierUnavailableException(
+                    "DATE meta tier supports [1970-01-01, 9999-12-31] only; value "
+                            + date + " is outside that window");
+        }
     }
 
     private record SortKeyLocation(int columnId, Column starRocksColumn) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -134,9 +134,10 @@ public final class OrcStripeStatisticsReader {
     /**
      * Reject ORC/StarRocks type pairings outside meta tier's supported window
      * eagerly, before iterating stripes. Anything outside the window means "fall
-     * back to data tier", not "fail the load". Only the unannotated integer
-     * categories are admitted in v1; string, boolean, floating-point, and the
-     * logical date/decimal/timestamp categories are deferred.
+     * back to data tier", not "fail the load". The supported window is the unannotated
+     * integer categories plus ORC DATE → StarRocks DATE. String, boolean, floating-point,
+     * TIMESTAMP/TIMESTAMP_INSTANT, decimal, and complex types are deferred (fall back to
+     * data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             TypeDescription.Category orcCategory, Column sortKeyColumn) throws MetaTierUnavailableException {
@@ -155,26 +156,26 @@ public final class OrcStripeStatisticsReader {
     }
 
     private static RowGroupStatistics convertStripe(
-            StripeStatistics stripeStatistics, StripeInformation stripeInfo, SortKeyLocation location)
+            StripeStatistics stripeStatistics, StripeInformation stripeInformation, SortKeyLocation location)
             throws MetaTierUnavailableException {
-        long rowCount = stripeInfo.getNumberOfRows();
+        long rowCount = stripeInformation.getNumberOfRows();
         ColumnStatistics[] columnStatistics = stripeStatistics.getColumnStatistics();
         ColumnStatistics sortKeyStatistics =
                 location.columnId < columnStatistics.length ? columnStatistics[location.columnId] : null;
         if (sortKeyStatistics instanceof IntegerColumnStatistics integerStatistics
                 && integerStatistics.getNumberOfValues() > 0) {
-            return integerStripe(integerStatistics, rowCount, location);
+            return convertIntegerStripe(integerStatistics, rowCount, location);
         }
         if (sortKeyStatistics instanceof DateColumnStatistics dateStatistics
                 && dateStatistics.getNumberOfValues() > 0) {
-            return dateStripe(dateStatistics, rowCount, location);
+            return convertDateStripe(dateStatistics, rowCount, location);
         }
         // Absent / all-null stats (no presence flag on ORC numeric/date stats, so an
         // empty stripe is detected via getNumberOfValues() == 0) → missing min/max.
         return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
     }
 
-    private static RowGroupStatistics integerStripe(
+    private static RowGroupStatistics convertIntegerStripe(
             IntegerColumnStatistics integerStatistics, long rowCount, SortKeyLocation location)
             throws MetaTierUnavailableException {
         Variant minVariant;
@@ -196,44 +197,32 @@ public final class OrcStripeStatisticsReader {
                 new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
     }
 
-    // v1 safe window — identical rationale to the Parquet reader: year 0/BCE mis-renders, pre-1970
-    // (negative epoch) has unverified BE parity, and pre-1582 raises calendar parity questions.
-    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1970, 1, 1);
-    private static final int MAX_SUPPORTED_YEAR = 9999;
-
-    private static RowGroupStatistics dateStripe(
+    private static RowGroupStatistics convertDateStripe(
             DateColumnStatistics dateStatistics, long rowCount, SortKeyLocation location)
             throws MetaTierUnavailableException {
-        LocalDate minDate;
-        LocalDate maxDate;
+        Variant minVariant;
+        Variant maxVariant;
         try {
             // getMinimumDayOfEpoch() is day-of-epoch (timezone-free).
-            minDate = LocalDate.ofEpochDay(dateStatistics.getMinimumDayOfEpoch());
-            maxDate = LocalDate.ofEpochDay(dateStatistics.getMaximumDayOfEpoch());
+            LocalDate minDate = LocalDate.ofEpochDay(dateStatistics.getMinimumDayOfEpoch());
+            LocalDate maxDate = LocalDate.ofEpochDay(dateStatistics.getMaximumDayOfEpoch());
+            // rejectDateOutsideWindow throws a checked MetaTierUnavailableException (not a
+            // RuntimeException), so a window rejection propagates past the catch below keeping its
+            // own message. ofEpochDay and Variant.of RuntimeExceptions are wrapped as a meta-tier
+            // fallback signal — mirroring convertIntegerStripe — so any unrepresentable value falls
+            // back to data tier instead of escaping read() (which only catches IOException) as an
+            // uncaught exception that would skip pre-split entirely.
+            MetaTierTemporalWindow.rejectDateOutsideWindow(minDate);
+            MetaTierTemporalWindow.rejectDateOutsideWindow(maxDate);
+            minVariant = Variant.of(location.starRocksColumn.getType(), minDate.format(DateUtils.DATE_FORMATTER));
+            maxVariant = Variant.of(location.starRocksColumn.getType(), maxDate.format(DateUtils.DATE_FORMATTER));
         } catch (RuntimeException conversionFailure) {
-            // Mirror integerStripe: an absurd ORC day-count (DateTimeException from ofEpochDay)
-            // becomes a meta-tier fallback signal, not a hard sampling error that skips pre-split.
             throw new MetaTierUnavailableException(String.format(
                     "ORC date stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
-        // Throws MetaTierUnavailableException (checked) directly — propagates past the catch above.
-        rejectUnsafeTemporalDate(minDate);
-        rejectUnsafeTemporalDate(maxDate);
         return new RowGroupStatistics(
-                new Tuple(List.of(Variant.of(location.starRocksColumn.getType(),
-                        minDate.format(DateUtils.DATE_FORMATTER)))),
-                new Tuple(List.of(Variant.of(location.starRocksColumn.getType(),
-                        maxDate.format(DateUtils.DATE_FORMATTER)))),
-                rowCount, /*truncated=*/ false);
-    }
-
-    private static void rejectUnsafeTemporalDate(LocalDate date) throws MetaTierUnavailableException {
-        if (date.isBefore(MIN_SUPPORTED_DATE) || date.getYear() > MAX_SUPPORTED_YEAR) {
-            throw new MetaTierUnavailableException(
-                    "DATE meta tier supports [1970-01-01, 9999-12-31] only; value "
-                            + date + " is outside that window");
-        }
+                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
     }
 
     private record SortKeyLocation(int columnId, Column starRocksColumn) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -44,16 +44,18 @@ import java.util.Objects;
  * tuples already carry the StarRocks-side primitive type and feed the same
  * format-agnostic {@link ParquetMetadataSampler}.
  *
- * <p>Supported type window (intentionally conservative, matching the Parquet
- * reader's integer subset):
+ * <p>Supported type window:
  * <ul>
  *   <li>ORC BYTE/SHORT/INT/LONG → StarRocks TINYINT/SMALLINT/INT/BIGINT</li>
+ *   <li>ORC DATE → StarRocks DATE (day-of-epoch, timezone-free), gated to
+ *       {@code [1970-01-01, 9999-12-31]} — values outside that window (year &le; 0
+ *       rendering, pre-1582 proleptic/hybrid calendar ambiguity) fall back to data tier</li>
  * </ul>
- * Everything else — STRING/CHAR/VARCHAR (whose stats would always need data-tier
- * fallback anyway), BOOLEAN, FLOAT/DOUBLE, DATE, TIMESTAMP, DECIMAL, and any
- * complex type — makes the reader throw {@link MetaTierUnavailableException} so
- * the pipeline falls back to data tier. That is NOT a load failure. Pure I/O
- * failures surface as {@link StarRocksException}.
+ * Everything else — STRING/CHAR/VARCHAR (data-tier fallback anyway), BOOLEAN,
+ * FLOAT/DOUBLE, TIMESTAMP/TIMESTAMP_INSTANT (reader-local-tz stats, deferred),
+ * DECIMAL, and any complex type — makes the reader throw
+ * {@link MetaTierUnavailableException} so the pipeline falls back to data tier. That is
+ * NOT a load failure. Pure I/O failures surface as {@link StarRocksException}.
  */
 public final class OrcStripeStatisticsReader {
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -143,8 +143,9 @@ public final class ParquetRowGroupStatisticsReader {
      * "fall back to data tier", not "fail the load". The supported window here is
      * the unannotated integer/boolean subset, the UTF8 string annotation for
      * character columns, and INT32 with the DATE annotation → StarRocks DATE.
-     * Other logical annotations (DECIMAL, UINT_*, TIMESTAMP, JSON, BSON, UUID, ...)
-     * change the value's meaning and ordering and are deferred to a future commit.
+     * Other logical annotations (DECIMAL, UINT_*, UTC-adjusted TIMESTAMP, JSON, BSON,
+     * UUID, ...) change the value's meaning and ordering and are deferred (fall back to
+     * data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             PrimitiveTypeName parquetTypeName,
@@ -152,32 +153,22 @@ public final class ParquetRowGroupStatisticsReader {
             Column sortKeyColumn) throws MetaTierUnavailableException {
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (parquetTypeName) {
-            case INT32 -> {
-                if (logicalAnnotation == null) {
-                    yield starRocksPrimitive == PrimitiveType.TINYINT
-                            || starRocksPrimitive == PrimitiveType.SMALLINT
-                            || starRocksPrimitive == PrimitiveType.INT
-                            || starRocksPrimitive == PrimitiveType.BIGINT;
-                }
-                // INT32+DATE is days-since-epoch; only a StarRocks DATE sort key
-                // gives those day counts their intended calendar meaning.
-                yield logicalAnnotation instanceof DateLogicalTypeAnnotation
-                        && starRocksPrimitive == PrimitiveType.DATE;
-            }
-            case INT64 -> {
-                if (logicalAnnotation == null) {
-                    yield starRocksPrimitive == PrimitiveType.TINYINT
-                            || starRocksPrimitive == PrimitiveType.SMALLINT
-                            || starRocksPrimitive == PrimitiveType.INT
-                            || starRocksPrimitive == PrimitiveType.BIGINT;
-                }
-                // Only local (non-UTC-adjusted) timestamps: the load stores those ticks
-                // verbatim as the DATETIME wall clock, so the FE-rendered boundary matches.
-                // UTC-adjusted timestamps get a session-tz offset at load time → data tier.
-                yield logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation
-                        && !timestampAnnotation.isAdjustedToUTC()
-                        && starRocksPrimitive == PrimitiveType.DATETIME;
-            }
+            // isIntegerType() is exactly {TINYINT, SMALLINT, INT, BIGINT} — the unannotated
+            // integer window; LARGEINT is intentionally excluded.
+            case INT32 -> logicalAnnotation == null
+                    ? starRocksPrimitive.isIntegerType()
+                    // INT32+DATE is days-since-epoch; only a StarRocks DATE sort key
+                    // gives those day counts their intended calendar meaning.
+                    : logicalAnnotation instanceof DateLogicalTypeAnnotation
+                            && starRocksPrimitive == PrimitiveType.DATE;
+            case INT64 -> logicalAnnotation == null
+                    ? starRocksPrimitive.isIntegerType()
+                    // Only local (non-UTC-adjusted) timestamps: the load stores those ticks
+                    // verbatim as the DATETIME wall clock, so the FE-rendered boundary matches.
+                    // UTC-adjusted timestamps get a session-tz offset at load time → data tier.
+                    : logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation
+                            && !timestampAnnotation.isAdjustedToUTC()
+                            && starRocksPrimitive == PrimitiveType.DATETIME;
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
             case BINARY -> logicalAnnotation instanceof StringLogicalTypeAnnotation
                     && (starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR);
@@ -214,7 +205,10 @@ public final class ParquetRowGroupStatisticsReader {
             // (e.g. unsupported type) or RuntimeException (e.g. BoolVariant on a
             // malformed literal) when a stat value cannot be represented. Translate
             // to a meta-tier fallback signal so the pipeline retries with data tier rather
-            // than aborting the load.
+            // than aborting the load. NOTE: toVariant's date/datetime path also throws the
+            // checked MetaTierUnavailableException (out-of-window rejection); that is not a
+            // RuntimeException and intentionally propagates past this catch with its own
+            // message — do not widen this to catch (Exception).
             throw new MetaTierUnavailableException(String.format(
                     "Parquet stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
@@ -234,43 +228,27 @@ public final class ParquetRowGroupStatisticsReader {
                 truncated);
     }
 
-    // v1 safe window: render is unambiguous and FE/BE agree on the value. Below 1970-01-01 the BE
-    // timestamp conversion uses signed C++ division whose (seconds, nanos) split differs from
-    // floorDiv/floorMod, and pre-1582 dates raise proleptic-vs-hybrid calendar parity questions;
-    // year 0/BCE mis-renders through the yyyy formatters; above year 9999 leaves the DATE/DATETIME
-    // domain. Everything outside the window falls back to data tier.
-    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1970, 1, 1);
-    private static final int MAX_SUPPORTED_YEAR = 9999;
-
     private static Variant toVariant(Object parquetValue, SortKeyLocation location)
             throws MetaTierUnavailableException {
         if (location.logicalAnnotation instanceof DateLogicalTypeAnnotation) {
             // INT32 days since 1970-01-01 → canonical "yyyy-MM-dd".
             LocalDate date = LocalDate.ofEpochDay(((Number) parquetValue).longValue());
-            rejectUnsafeTemporalDate(date);
+            MetaTierTemporalWindow.rejectDateOutsideWindow(date);
             return Variant.of(location.starRocksColumn.getType(), date.format(DateUtils.DATE_FORMATTER));
         }
         if (location.logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
             long ticks = ((Number) parquetValue).longValue();
             LocalDateTime dateTime = epochTicksToUtcDateTime(ticks, timestampAnnotation.getUnit());
-            // Same safe window as DATE. A negative (pre-1970) tick lands on a date before
-            // MIN_SUPPORTED_DATE and is rejected here, which also keeps the floorDiv/floorMod
-            // conversion above in the range where it is provably identical to BE's signed division.
-            rejectUnsafeTemporalDate(dateTime.toLocalDate());
+            // A negative (pre-1970) tick lands on a date before the window's lower bound and is
+            // rejected here, which also keeps the floorDiv/floorMod conversion above in the range
+            // where it is provably identical to BE's signed division.
+            MetaTierTemporalWindow.rejectDateOutsideWindow(dateTime.toLocalDate());
             return Variant.of(location.starRocksColumn.getType(), renderDateTime(dateTime));
         }
         String rendered = location.parquetTypeName == PrimitiveTypeName.BINARY
                 ? ((Binary) parquetValue).toStringUsingUTF8()
                 : parquetValue.toString();
         return Variant.of(location.starRocksColumn.getType(), rendered);
-    }
-
-    private static void rejectUnsafeTemporalDate(LocalDate date) throws MetaTierUnavailableException {
-        if (date.isBefore(MIN_SUPPORTED_DATE) || date.getYear() > MAX_SUPPORTED_YEAR) {
-            throw new MetaTierUnavailableException(
-                    "DATE/DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
-                            + date + " is outside that window");
-        }
     }
 
     private static LocalDateTime epochTicksToUtcDateTime(long ticks, LogicalTypeAnnotation.TimeUnit unit) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.type.PrimitiveType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -30,11 +31,13 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -119,17 +122,18 @@ public final class ParquetRowGroupStatisticsReader {
         LogicalTypeAnnotation logicalAnnotation = fieldType.getLogicalTypeAnnotation();
         rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, sortKeyColumn);
         return new SortKeyLocation(
-                ColumnPath.get(schema.getFieldName(fieldIndex)), parquetTypeName, sortKeyColumn);
+                ColumnPath.get(schema.getFieldName(fieldIndex)),
+                parquetTypeName, logicalAnnotation, sortKeyColumn);
     }
 
     /**
      * Reject Parquet/StarRocks type pairings outside meta tier's supported window
      * eagerly, before iterating row groups. Anything outside the window means
-     * "fall back to data tier", not "fail the load". Logical annotations
-     * (DATE, DECIMAL, UINT_*, TIMESTAMP, JSON, BSON, UUID, ...) change the
-     * value's meaning and ordering and are deferred to a future commit; the
-     * supported window here is the unannotated subset plus the UTF8 string
-     * annotation for character columns.
+     * "fall back to data tier", not "fail the load". The supported window here is
+     * the unannotated integer/boolean subset, the UTF8 string annotation for
+     * character columns, and INT32 with the DATE annotation → StarRocks DATE.
+     * Other logical annotations (DECIMAL, UINT_*, TIMESTAMP, JSON, BSON, UUID, ...)
+     * change the value's meaning and ordering and are deferred to a future commit.
      */
     private static void rejectIncompatibleTypeMapping(
             PrimitiveTypeName parquetTypeName,
@@ -137,7 +141,19 @@ public final class ParquetRowGroupStatisticsReader {
             Column sortKeyColumn) throws MetaTierUnavailableException {
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (parquetTypeName) {
-            case INT32, INT64 -> logicalAnnotation == null
+            case INT32 -> {
+                if (logicalAnnotation == null) {
+                    yield starRocksPrimitive == PrimitiveType.TINYINT
+                            || starRocksPrimitive == PrimitiveType.SMALLINT
+                            || starRocksPrimitive == PrimitiveType.INT
+                            || starRocksPrimitive == PrimitiveType.BIGINT;
+                }
+                // INT32+DATE is days-since-epoch; only a StarRocks DATE sort key
+                // gives those day counts their intended calendar meaning.
+                yield logicalAnnotation instanceof DateLogicalTypeAnnotation
+                        && starRocksPrimitive == PrimitiveType.DATE;
+            }
+            case INT64 -> logicalAnnotation == null
                     && (starRocksPrimitive == PrimitiveType.TINYINT
                         || starRocksPrimitive == PrimitiveType.SMALLINT
                         || starRocksPrimitive == PrimitiveType.INT
@@ -198,11 +214,34 @@ public final class ParquetRowGroupStatisticsReader {
                 truncated);
     }
 
-    private static Variant toVariant(Object parquetValue, SortKeyLocation location) {
+    // v1 safe window: render is unambiguous and FE/BE agree on the value. Below 1970-01-01 the BE
+    // timestamp conversion uses signed C++ division whose (seconds, nanos) split differs from
+    // floorDiv/floorMod, and pre-1582 dates raise proleptic-vs-hybrid calendar parity questions;
+    // year 0/BCE mis-renders through the yyyy formatters; above year 9999 leaves the DATE/DATETIME
+    // domain. Everything outside the window falls back to data tier.
+    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1970, 1, 1);
+    private static final int MAX_SUPPORTED_YEAR = 9999;
+
+    private static Variant toVariant(Object parquetValue, SortKeyLocation location)
+            throws MetaTierUnavailableException {
+        if (location.logicalAnnotation instanceof DateLogicalTypeAnnotation) {
+            // INT32 days since 1970-01-01 → canonical "yyyy-MM-dd".
+            LocalDate date = LocalDate.ofEpochDay(((Number) parquetValue).longValue());
+            rejectUnsafeTemporalDate(date);
+            return Variant.of(location.starRocksColumn.getType(), date.format(DateUtils.DATE_FORMATTER));
+        }
         String rendered = location.parquetTypeName == PrimitiveTypeName.BINARY
                 ? ((Binary) parquetValue).toStringUsingUTF8()
                 : parquetValue.toString();
         return Variant.of(location.starRocksColumn.getType(), rendered);
+    }
+
+    private static void rejectUnsafeTemporalDate(LocalDate date) throws MetaTierUnavailableException {
+        if (date.isBefore(MIN_SUPPORTED_DATE) || date.getYear() > MAX_SUPPORTED_YEAR) {
+            throw new MetaTierUnavailableException(
+                    "DATE/DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
+                            + date + " is outside that window");
+        }
     }
 
     private static ColumnChunkMetaData findColumnChunk(BlockMetaData block, ColumnPath path) {
@@ -214,6 +253,8 @@ public final class ParquetRowGroupStatisticsReader {
         return null;
     }
 
-    private record SortKeyLocation(ColumnPath path, PrimitiveTypeName parquetTypeName, Column starRocksColumn) {
+    private record SortKeyLocation(
+            ColumnPath path, PrimitiveTypeName parquetTypeName,
+            LogicalTypeAnnotation logicalAnnotation, Column starRocksColumn) {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -53,15 +53,23 @@ import java.util.Objects;
  * {@link BoundaryPlanner#validateTupleAgainstSchema} — the caller (a
  * {@link RowGroupStatisticsProvider}) just aggregates results across files.
  *
- * <p>Supported type window (intentionally conservative for P1):
+ * <p>Supported type window:
  * <ul>
  *   <li>Unannotated Parquet INT32/INT64 → StarRocks TINYINT/SMALLINT/INT/BIGINT</li>
  *   <li>Unannotated Parquet BOOLEAN → StarRocks BOOLEAN</li>
- *   <li>Parquet BINARY with UTF8 (string) logical annotation → StarRocks CHAR/VARCHAR
+ *   <li>Parquet INT32 with DATE annotation → StarRocks DATE</li>
+ *   <li>Parquet INT64 with TIMESTAMP annotation, {@code isAdjustedToUTC=false}
+ *       (MILLIS/MICROS/NANOS) → StarRocks DATETIME. UTC-adjusted timestamps are
+ *       deferred (the load applies a session-tz offset this reader cannot reproduce).</li>
+ *   <li>Parquet BINARY with UTF8 (string) annotation → StarRocks CHAR/VARCHAR
  *       (always marked truncated → forces data-tier fallback for string sort keys)</li>
  * </ul>
- * Anything else (DATE, DECIMAL, UINT_*, TIMESTAMP, JSON, BSON, UUID, FLOAT, DOUBLE,
- * INT96, FIXED_LEN_BYTE_ARRAY, raw BINARY for VARBINARY) makes the reader throw
+ * <p>DATE/DATETIME values are additionally gated to {@code [1970-01-01, 9999-12-31]}; values
+ * outside that window (year &le; 0 mis-renders through the {@code yyyy} formatters, pre-1970
+ * has unverified FE/BE timestamp-division parity, pre-1582 has calendar-parity questions)
+ * fall back to data tier.
+ * Anything else (DECIMAL, UINT_*, UTC-adjusted/INT96 timestamps, JSON, BSON, UUID,
+ * FLOAT, DOUBLE, FIXED_LEN_BYTE_ARRAY, raw BINARY for VARBINARY) makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier — not a
  * load failure. Pure I/O failures surface as {@link StarRocksException}.
  */

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -33,11 +33,14 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -153,11 +156,20 @@ public final class ParquetRowGroupStatisticsReader {
                 yield logicalAnnotation instanceof DateLogicalTypeAnnotation
                         && starRocksPrimitive == PrimitiveType.DATE;
             }
-            case INT64 -> logicalAnnotation == null
-                    && (starRocksPrimitive == PrimitiveType.TINYINT
-                        || starRocksPrimitive == PrimitiveType.SMALLINT
-                        || starRocksPrimitive == PrimitiveType.INT
-                        || starRocksPrimitive == PrimitiveType.BIGINT);
+            case INT64 -> {
+                if (logicalAnnotation == null) {
+                    yield starRocksPrimitive == PrimitiveType.TINYINT
+                            || starRocksPrimitive == PrimitiveType.SMALLINT
+                            || starRocksPrimitive == PrimitiveType.INT
+                            || starRocksPrimitive == PrimitiveType.BIGINT;
+                }
+                // Only local (non-UTC-adjusted) timestamps: the load stores those ticks
+                // verbatim as the DATETIME wall clock, so the FE-rendered boundary matches.
+                // UTC-adjusted timestamps get a session-tz offset at load time → data tier.
+                yield logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation
+                        && !timestampAnnotation.isAdjustedToUTC()
+                        && starRocksPrimitive == PrimitiveType.DATETIME;
+            }
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
             case BINARY -> logicalAnnotation instanceof StringLogicalTypeAnnotation
                     && (starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR);
@@ -230,6 +242,15 @@ public final class ParquetRowGroupStatisticsReader {
             rejectUnsafeTemporalDate(date);
             return Variant.of(location.starRocksColumn.getType(), date.format(DateUtils.DATE_FORMATTER));
         }
+        if (location.logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
+            long ticks = ((Number) parquetValue).longValue();
+            LocalDateTime dateTime = epochTicksToUtcDateTime(ticks, timestampAnnotation.getUnit());
+            // Same safe window as DATE. A negative (pre-1970) tick lands on a date before
+            // MIN_SUPPORTED_DATE and is rejected here, which also keeps the floorDiv/floorMod
+            // conversion above in the range where it is provably identical to BE's signed division.
+            rejectUnsafeTemporalDate(dateTime.toLocalDate());
+            return Variant.of(location.starRocksColumn.getType(), renderDateTime(dateTime));
+        }
         String rendered = location.parquetTypeName == PrimitiveTypeName.BINARY
                 ? ((Binary) parquetValue).toStringUsingUTF8()
                 : parquetValue.toString();
@@ -242,6 +263,40 @@ public final class ParquetRowGroupStatisticsReader {
                     "DATE/DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
                             + date + " is outside that window");
         }
+    }
+
+    private static LocalDateTime epochTicksToUtcDateTime(long ticks, LogicalTypeAnnotation.TimeUnit unit) {
+        long ticksPerSecond;
+        long nanosPerTick;
+        switch (unit) {
+            case MILLIS -> {
+                ticksPerSecond = 1_000L;
+                nanosPerTick = 1_000_000L;
+            }
+            case MICROS -> {
+                ticksPerSecond = 1_000_000L;
+                nanosPerTick = 1_000L;
+            }
+            case NANOS -> {
+                ticksPerSecond = 1_000_000_000L;
+                nanosPerTick = 1L;
+            }
+            default -> throw new IllegalArgumentException("unsupported Parquet timestamp unit " + unit);
+        }
+        // floorDiv/floorMod keep pre-1970 (negative) ticks correct.
+        long epochSecond = Math.floorDiv(ticks, ticksPerSecond);
+        long nanoOfSecond = Math.floorMod(ticks, ticksPerSecond) * nanosPerTick;
+        return LocalDateTime.ofEpochSecond(epochSecond, (int) nanoOfSecond, ZoneOffset.UTC);
+    }
+
+    private static String renderDateTime(LocalDateTime dateTime) {
+        // Mirrors DateVariant.getStringValue: second precision unless there is a
+        // sub-second part, then 6-digit microseconds. parseStrictDateTime round-trips both.
+        if (dateTime.getNano() == 0) {
+            return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
+        }
+        return dateTime.format(DateUtils.DATE_TIME_FORMATTER)
+                + "." + String.format("%06d", dateTime.getNano() / 1000);
     }
 
     private static ColumnChunkMetaData findColumnChunk(BlockMetaData block, ColumnPath path) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -19,8 +19,6 @@ import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
@@ -51,7 +49,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -82,7 +80,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex + 100);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("region_id", IntegerType.INT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("region_id", IntegerType.INT));
 
         long globalMin = Long.MAX_VALUE;
         long globalMax = Long.MIN_VALUE;
@@ -105,7 +103,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         Assertions.assertNotNull(stripeStatistics.get(0).getMinTuple());
@@ -123,7 +121,7 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR)));
     }
 
     @Test
@@ -137,7 +135,7 @@ class OrcStripeStatisticsReaderTest {
         // DOUBLE is outside the meta-tier mapping window even for a numeric sort key.
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(), new Column("payload", IntegerType.BIGINT)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("payload", IntegerType.BIGINT)));
     }
 
     @Test
@@ -151,7 +149,8 @@ class OrcStripeStatisticsReaderTest {
         // ORC integer stats cannot route into a VARCHAR sort-key column.
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(), new Column("region_id", VarcharType.VARCHAR)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("region_id", VarcharType.VARCHAR)));
     }
 
     @Test
@@ -164,7 +163,8 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(), new Column("missing_sort_key", IntegerType.BIGINT)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("missing_sort_key", IntegerType.BIGINT)));
     }
 
     @Test
@@ -181,7 +181,7 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT)));
     }
 
     @Test
@@ -196,7 +196,8 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(), new Column("wide_value", IntegerType.TINYINT)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("wide_value", IntegerType.TINYINT)));
     }
 
     @Test
@@ -215,7 +216,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         long totalRowCount = 0L;
         for (RowGroupStatistics stripe : stripeStatistics) {
@@ -234,7 +235,7 @@ class OrcStripeStatisticsReaderTest {
                 (batch, batchRow, rowIndex) -> { });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         Assertions.assertTrue(stripeStatistics.isEmpty());
     }
@@ -249,7 +250,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -279,7 +280,7 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(),
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
                         new Column("event_day", IntegerType.BIGINT)));
     }
 
@@ -296,7 +297,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -319,7 +320,7 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(),
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
                         new Column("event_day", DateType.DATE)));
     }
 
@@ -338,18 +339,12 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        statusOf(orcPath), new Configuration(),
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME)));
     }
 
     private Path writeOrc(
             String schemaText, int rowCount, PresplitTestSupport.OrcRowFiller rowFiller) throws IOException {
         return PresplitTestSupport.writeOrcFixture(tempDirectory, schemaText, rowCount, rowFiller);
-    }
-
-    private static FileStatus statusOf(Path path) throws IOException {
-        LocalFileSystem fs = new LocalFileSystem();
-        fs.initialize(path.toUri(), new Configuration());
-        return fs.getFileStatus(path);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
@@ -24,6 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -235,6 +237,109 @@ class OrcStripeStatisticsReaderTest {
                 statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         Assertions.assertTrue(stripeStatistics.isEmpty());
+    }
+
+    @Test
+    void readsDateStatistics() throws Exception {
+        // ORC DATE is stored in a LongColumnVector as day-of-epoch. Day 0 = 1970-01-01.
+        Path orcPath = writeOrc(
+                "struct<event_day:date>",
+                /*rowCount=*/ 5,
+                (batch, batchRow, rowIndex) ->
+                        ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
+
+        List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
+                statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertFalse(stripeStatistics.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        long totalRowCount = 0L;
+        for (RowGroupStatistics stripe : stripeStatistics) {
+            Assertions.assertFalse(stripe.isTruncated());
+            String minValue = stripe.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = stripe.getMaxTuple().getValues().get(0).getStringValue();
+            Assertions.assertTrue(minValue.compareTo(maxValue) <= 0);
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+            totalRowCount += stripe.getRowCount();
+        }
+        Assertions.assertEquals(5L, totalRowCount);
+        Assertions.assertEquals("1970-01-01", globalMin);
+        Assertions.assertEquals("1970-01-05", globalMax);
+    }
+
+    @Test
+    void dateColumnIntoNonDateSortKeyFallsBackToDataTier() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<event_day:date>",
+                /*rowCount=*/ 3,
+                (batch, batchRow, rowIndex) ->
+                        ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        statusOf(orcPath), new Configuration(),
+                        new Column("event_day", IntegerType.BIGINT)));
+    }
+
+    @Test
+    void allNullDateStripeReportsAbsentStatistics() throws Exception {
+        // ORC DATE column written with only nulls → DateColumnStatistics.getNumberOfValues() == 0,
+        // so the stripe reports absent min/max (same contract as the integer all-null path).
+        Path orcPath = writeOrc(
+                "struct<event_day:date>",
+                /*rowCount=*/ 3,
+                (batch, batchRow, rowIndex) -> {
+                    batch.cols[0].noNulls = false;
+                    batch.cols[0].isNull[batchRow] = true;
+                });
+
+        List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
+                statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertFalse(stripeStatistics.isEmpty());
+        long totalRowCount = 0L;
+        for (RowGroupStatistics stripe : stripeStatistics) {
+            Assertions.assertNull(stripe.getMinTuple());
+            Assertions.assertNull(stripe.getMaxTuple());
+            totalRowCount += stripe.getRowCount();
+        }
+        Assertions.assertEquals(3L, totalRowCount);
+    }
+
+    @Test
+    void pre1970DateStripeFallsBackToDataTier() throws Exception {
+        // day-of-epoch -1 = 1969-12-31 < 1970-01-01: outside the safe window → data tier.
+        Path orcPath = writeOrc(
+                "struct<event_day:date>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) ->
+                        ((LongColumnVector) batch.cols[0]).vector[batchRow] = -1 - rowIndex);
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        statusOf(orcPath), new Configuration(),
+                        new Column("event_day", DateType.DATE)));
+    }
+
+    @Test
+    void timestampColumnStillFallsBackToDataTier() throws Exception {
+        // ORC TIMESTAMP stats carry reader-local-tz semantics that need separate
+        // alignment work; deferred. Falls back to data tier (NOT a load failure).
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.time[batchRow] = rowIndex * 1000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME)));
     }
 
     private Path writeOrc(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSamplerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSamplerTest.java
@@ -14,10 +14,12 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.NullVariant;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -300,6 +302,43 @@ public class ParquetMetadataSamplerTest {
         Assertions.assertFalse(exception instanceof MetaTierUnavailableException);
         Assertions.assertTrue(exception.getMessage().contains("null"),
                 "expected null in message, got: " + exception.getMessage());
+    }
+
+    // --- DATE integration test ---
+
+    private static SampleRequest dateSampleRequest() {
+        return new SampleRequest(
+                DUMMY_CONTEXT,
+                List.of(new Column("event_day", DateType.DATE)),
+                1024L, 0L);
+    }
+
+    private static RowGroupStatistics dateRowGroup(String minDate, String maxDate, long rowCount) {
+        return new RowGroupStatistics(
+                new Tuple(List.of(Variant.of(DateType.DATE, minDate))),
+                new Tuple(List.of(Variant.of(DateType.DATE, maxDate))),
+                rowCount, /*truncated=*/ false);
+    }
+
+    @Test
+    public void placesDateQuantileBoundaries() throws Exception {
+        // Three non-overlapping row groups, 100 rows each, covering Jan/Feb/Mar 2024.
+        // Requesting 3 tablets (= 2 boundaries) should land at 2024-02-01 and 2024-03-01.
+        // This test proves the sampler pipeline is type-agnostic: DateVariant.compareTo
+        // drives correct quantile placement with zero sampler changes.
+        List<RowGroupStatistics> rowGroups = List.of(
+                dateRowGroup("2024-01-01", "2024-01-31", 100L),
+                dateRowGroup("2024-02-01", "2024-02-29", 100L),
+                dateRowGroup("2024-03-01", "2024-03-31", 100L));
+        ParquetMetadataSampler sampler = new ParquetMetadataSampler(new FakeProvider(rowGroups));
+
+        BoundaryPlannerResult result = sampler.tryPlan(dateSampleRequest(), /*requestedTabletCount=*/ 3);
+
+        Assertions.assertFalse(result.isNoSplit());
+        List<Tuple> boundaries = result.getBoundaries();
+        Assertions.assertEquals(2, boundaries.size());
+        Assertions.assertEquals("2024-02-01", boundaries.get(0).getValues().get(0).getStringValue());
+        Assertions.assertEquals("2024-03-01", boundaries.get(1).getValues().get(0).getStringValue());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.type.BooleanType;
+import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
@@ -251,6 +252,87 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertEquals(3L, only.getRowCount());
         Assertions.assertNull(only.getMinTuple());
         Assertions.assertNull(only.getMaxTuple());
+    }
+
+    @Test
+    void readsDateStatisticsForInt32DateColumn() throws Exception {
+        // INT32+DATE is days-since-epoch. Day 0 = 1970-01-01 (canonical anchor,
+        // hand-verifiable). With a StarRocks DATE sort key the reader renders
+        // canonical "yyyy-MM-dd" boundary text.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 5,
+                (group, rowIndex) -> group.append("event_day", rowIndex));
+
+        List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
+                statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertEquals(1, rowGroupStatistics.size());
+        Assertions.assertFalse(rowGroupStatistics.get(0).isTruncated());
+        Assertions.assertEquals("1970-01-01",
+                rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("1970-01-05",
+                rowGroupStatistics.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void dateAnnotatedColumnIntoNonDateSortKeyFallsBackToDataTier() throws Exception {
+        // INT32+DATE only maps to a StarRocks DATE column; routing it into a BIGINT
+        // sort key would publish day-counts as integer boundaries — reject.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 3,
+                (group, rowIndex) -> group.append("event_day", rowIndex));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        statusOf(parquetPath), new Configuration(),
+                        new Column("event_day", IntegerType.BIGINT)));
+    }
+
+    @Test
+    void pre1970DateFallsBackToDataTier() throws Exception {
+        // epochDay -1 = 1969-12-31 < 1970-01-01: outside the safe window (pre-1970 +
+        // pre-1582 + year-0 parity traps). Meta tier must defer to data tier.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("event_day", -1 - rowIndex));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        statusOf(parquetPath), new Configuration(),
+                        new Column("event_day", DateType.DATE)));
+    }
+
+    @Test
+    void maxSupportedDateIsAccepted() throws Exception {
+        // epochDay 2932896 = 9999-12-31, the upper edge of the safe window — accepted.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_day", 2932896));
+
+        List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
+                statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertEquals(1, rowGroupStatistics.size());
+        Assertions.assertEquals("9999-12-31",
+                rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void postYear9999DateFallsBackToDataTier() throws Exception {
+        // epochDay 2932897 = 10000-01-01, year > 9999: above the safe window → data tier.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_day", 2932897));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        statusOf(parquetPath), new Configuration(),
+                        new Column("event_day", DateType.DATE)));
     }
 
     private Path writeParquet(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -20,8 +20,6 @@ import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -50,7 +48,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("sort_key", (long) rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -81,7 +79,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("tenant", String.format("tenant-%02d", rowIndex)));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         String globalMin = null;
@@ -101,22 +99,6 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
-    void dateAnnotatedColumnFallsBackToDataTier() throws Exception {
-        // INT32+DATE is days-since-epoch; mapping its raw int32 stats into a BIGINT
-        // sort-key column would produce nonsensical boundaries. Logical annotations
-        // are deferred to a follow-up commit.
-        Path parquetPath = writeParquet(
-                "message schema { required int32 event_day (DATE); }",
-                /*rowCount=*/ 3,
-                (group, rowIndex) -> group.append("event_day", rowIndex + 19000));
-
-        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
-                ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", IntegerType.BIGINT)));
-    }
-
-    @Test
     void unannotatedBinaryColumnFallsBackToDataTier() throws Exception {
         // Parquet BINARY without a UTF8/string annotation could hold arbitrary bytes;
         // toStringUsingUTF8 would corrupt non-UTF8 data and change ordering. Meta tier
@@ -128,7 +110,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("opaque_bytes", VarcharType.VARCHAR)));
     }
 
@@ -140,7 +122,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("region_id", rowIndex + 100));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("region_id", IntegerType.INT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("region_id", IntegerType.INT));
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("100", rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -155,7 +137,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("flag", rowIndex % 2 == 0));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("flag", BooleanType.BOOLEAN));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("flag", BooleanType.BOOLEAN));
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals(2L, rowGroupStatistics.get(0).getRowCount());
@@ -170,7 +152,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("missing_sort_key", IntegerType.BIGINT)));
     }
 
@@ -185,7 +167,7 @@ class ParquetRowGroupStatisticsReaderTest {
         // mapping window — caller should fall through to reservoir sampling.
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("payload", IntegerType.BIGINT)));
     }
 
@@ -199,7 +181,7 @@ class ParquetRowGroupStatisticsReaderTest {
         // Parquet INT32 cannot route into a VARCHAR sort-key column.
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("region_id", VarcharType.VARCHAR)));
     }
 
@@ -218,7 +200,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("sort_key", IntegerType.BIGINT)));
     }
 
@@ -234,7 +216,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("wide_value", IntegerType.TINYINT)));
     }
 
@@ -249,7 +231,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("keepalive", (long) rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         RowGroupStatistics only = rowGroupStatistics.get(0);
@@ -269,7 +251,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertFalse(rowGroupStatistics.get(0).isTruncated());
@@ -290,7 +272,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_day", IntegerType.BIGINT)));
     }
 
@@ -305,7 +287,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_day", DateType.DATE)));
     }
 
@@ -318,7 +300,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", 2932896));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("9999-12-31",
@@ -335,7 +317,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_day", DateType.DATE)));
     }
 
@@ -363,7 +345,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -382,7 +364,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 1_500_000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("1970-01-01 00:00:01.500000",
@@ -400,7 +382,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 1_500_000_500L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
 
         Assertions.assertEquals("1970-01-01 00:00:01.500000",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -417,7 +399,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME)));
     }
 
@@ -432,7 +414,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME)));
     }
 
@@ -445,7 +427,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
-                        statusOf(parquetPath), new Configuration(),
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_ts", IntegerType.BIGINT)));
     }
 
@@ -454,11 +436,5 @@ class ParquetRowGroupStatisticsReaderTest {
             java.util.function.BiConsumer<org.apache.parquet.example.data.Group, Integer> rowFiller)
             throws IOException {
         return PresplitTestSupport.writeParquetFixture(tempDirectory, schemaText, rowCount, rowFiller);
-    }
-
-    private static FileStatus statusOf(Path path) throws IOException {
-        LocalFileSystem fs = new LocalFileSystem();
-        fs.initialize(path.toUri(), new Configuration());
-        return fs.getFileStatus(path);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -23,6 +23,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -333,6 +337,116 @@ class ParquetRowGroupStatisticsReaderTest {
                 ParquetRowGroupStatisticsReader.read(
                         statusOf(parquetPath), new Configuration(),
                         new Column("event_day", DateType.DATE)));
+    }
+
+    private static MessageType timestampSchema(LogicalTypeAnnotation.TimeUnit unit, boolean isAdjustedToUTC) {
+        return Types.buildMessage()
+                .required(PrimitiveTypeName.INT64)
+                .as(LogicalTypeAnnotation.timestampType(isAdjustedToUTC, unit))
+                .named("event_ts")
+                .named("schema");
+    }
+
+    private Path writeParquet(MessageType schema, int rowCount,
+            java.util.function.BiConsumer<org.apache.parquet.example.data.Group, Integer> rowFiller)
+            throws IOException {
+        return PresplitTestSupport.writeParquetFixture(tempDirectory, schema, rowCount, rowFiller);
+    }
+
+    @Test
+    void readsDatetimeStatisticsForNonUtcMillisTimestamp() throws Exception {
+        // epoch milli 0 = 1970-01-01 00:00:00 UTC; +1000ms per row. isAdjustedToUTC=false
+        // means the stored ticks ARE the wall clock, so no tz math is needed.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 3,
+                (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
+        Assertions.assertEquals("1970-01-01 00:00:00",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("1970-01-01 00:00:02",
+                stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void readsDatetimeStatisticsForNonUtcMicrosTimestampWithFraction() throws Exception {
+        // 1_500_000 micros = 1.5s → sub-second boundary text exercises the micros render path.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MICROS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", 1_500_000L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertEquals("1970-01-01 00:00:01.500000",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void readsDatetimeStatisticsForNonUtcNanosTruncatedToMicros() throws Exception {
+        // 1_500_000_500 ns = 1.5000005 s. StarRocks DATETIME is microsecond-precision and BE
+        // truncates nanos→micros at storage (of_epoch_second divides nanos by 1000), so the
+        // boundary must render ".500000" (the trailing 500 ns dropped), matching the loaded value.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.NANOS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", 1_500_000_500L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals("1970-01-01 00:00:01.500000",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void pre1970TimestampFallsBackToDataTier() throws Exception {
+        // -1000 ms = 1969-12-31 23:59:59 < 1970-01-01: outside the safe window, where the FE
+        // floorDiv/floorMod split is not proven equal to BE's signed C++ division. Defer to data tier.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("event_ts", -1000L - rowIndex));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        statusOf(parquetPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME)));
+    }
+
+    @Test
+    void utcAdjustedTimestampFallsBackToDataTier() throws Exception {
+        // isAdjustedToUTC=true: the load applies a session-tz offset the FE reader cannot
+        // reproduce here, so meta tier must defer to data tier rather than risk an offset boundary.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        statusOf(parquetPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME)));
+    }
+
+    @Test
+    void timestampIntoNonDatetimeSortKeyFallsBackToDataTier() throws Exception {
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        statusOf(parquetPath), new Configuration(),
+                        new Column("event_ts", IntegerType.BIGINT)));
     }
 
     private Path writeParquet(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
@@ -179,9 +179,22 @@ final class PresplitTestSupport {
             String schemaText,
             int rowCount,
             BiConsumer<Group, Integer> rowFiller) throws IOException {
+        return writeParquetFixture(tempDirectory, MessageTypeParser.parseMessageType(schemaText), rowCount, rowFiller);
+    }
+
+    /**
+     * Variant of {@link #writeParquetFixture(java.nio.file.Path, String, int, BiConsumer)} that
+     * takes a prebuilt {@link MessageType}. Tests that need a precise logical-type flag the schema
+     * text cannot express (e.g. TIMESTAMP {@code isAdjustedToUTC}) build the schema with the
+     * {@code org.apache.parquet.schema.Types} API and call this overload.
+     */
+    static Path writeParquetFixture(
+            java.nio.file.Path tempDirectory,
+            MessageType schema,
+            int rowCount,
+            BiConsumer<Group, Integer> rowFiller) throws IOException {
         java.nio.file.Path file = Files.createTempFile(tempDirectory, "presplit-fixture-", ".parquet");
         Path outputPath = new Path(file.toUri());
-        MessageType schema = MessageTypeParser.parseMessageType(schemaText);
         SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
         Configuration configuration = new Configuration();
         configuration.setLong("parquet.block.size", 256);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
@@ -25,6 +25,8 @@ import com.starrocks.thrift.TResultBatch;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
@@ -212,6 +214,17 @@ final class PresplitTestSupport {
             }
         }
         return outputPath;
+    }
+
+    /**
+     * Resolve a local-filesystem {@link FileStatus} for a fixture {@link Path}. The footer readers
+     * take a {@code FileStatus} (the load snapshots one), so reader tests pass their written fixture
+     * through here.
+     */
+    static FileStatus statusOf(Path path) throws IOException {
+        LocalFileSystem fileSystem = new LocalFileSystem();
+        fileSystem.initialize(path.toUri(), new Configuration());
+        return fileSystem.getFileStatus(path);
     }
 
     /** Fills column values for one row into an ORC {@link VectorizedRowBatch}. */


### PR DESCRIPTION
## Why I'm doing:

The Sample-Based Tablet Pre-Split *meta tier* reads Parquet/ORC footer column statistics to plan tablet split boundaries cheaply, avoiding a full data-tier `SELECT` sub-query. Until now it only accepted integer/boolean stats, so temporal range/partition sort keys — the dominant bulk-load case — always fell through to the data tier. This extends the meta tier to DATE/DATETIME so those loads get the cheap footer-based split.

## What I'm doing:

Only the two footer readers change; the pipeline below them (`ParquetMetadataSampler`, `BoundaryPlanner`, `Variant`/`DateVariant`, the providers, `MetaTierFormat`) is type-agnostic and untouched.

- **Parquet** (`ParquetRowGroupStatisticsReader`): `INT32 + DATE` → StarRocks `DATE`; `INT64 + TIMESTAMP` with `isAdjustedToUTC=false` (MILLIS/MICROS/NANOS) → `DATETIME`.
- **ORC** (`OrcStripeStatisticsReader`): `DATE` category → StarRocks `DATE`.
- All gated to the value window `[1970-01-01, 9999-12-31]` via the new `MetaTierTemporalWindow`. Anything outside it — plus UTC-adjusted/INT96 Parquet timestamps, ORC `TIMESTAMP`/`TIMESTAMP_INSTANT`, `DECIMAL`, and `FLOAT/DOUBLE` — throws `MetaTierUnavailableException` and falls back to the data tier (never a wrong boundary, never a load failure).

Why the window: for non-negative ticks the FE `Math.floorDiv`/`floorMod` conversion is bit-identical to the BE load's signed division (`Int64ToDateTimeConverter`), so the FE-computed boundary equals the value the load stores; the window also avoids the `yyyy`-formatter year-0 mis-render and the pre-1582 proleptic/hybrid-calendar parity question. Boundary strings round-trip through `DateVariant.getStringValue` (canonical `yyyy-MM-dd` / `yyyy-MM-dd HH:mm:ss[.ffffff]`).

Tests: per-reader DATE/DATETIME success (incl. window edges and NANOS→micros truncation), UTC-adjusted / out-of-window / type-mismatch / all-null fallbacks, ORC `TIMESTAMP` deferral, and a `ParquetMetadataSampler` date-quantile integration test that pins the type-agnostic-pipeline claim.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
