### PR TITLE
[BugFix] Honor the targeted snapshot's schema and partition spec for Iceberg reads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -129,6 +129,7 @@ public class IcebergTable extends Table {
 
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
     private transient Schema readSchema;
+    private transient Map<Integer, PartitionSpec> readSpecsById;
     private List<Column> partitionColumns;
     private Optional<Boolean> hasBucketProperties = Optional.empty();
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
@@ -212,7 +213,7 @@ public class IcebergTable extends Table {
     public boolean isAllPartitionColumnsAlwaysIdentity() {
         // now we are sure we have never applied transformation,
         // we check if all partition columns are identity.
-        for (PartitionField field : getNativeTable().spec().fields()) {
+        for (PartitionField field : getReadSpec().fields()) {
             if (!field.transform().isIdentity()) {
                 return false;
             }
@@ -221,7 +222,7 @@ public class IcebergTable extends Table {
     }
 
     public PartitionField getPartitionField(String partitionColumnName) {
-        List<PartitionField> allPartitionFields = getNativeTable().spec().fields();
+        List<PartitionField> allPartitionFields = getReadSpec().fields();
         Schema schema = getReadSchema();
         for (PartitionField field : allPartitionFields) {
             if (getPartitionSourceName(schema, field).equalsIgnoreCase(partitionColumnName)) {
@@ -272,8 +273,8 @@ public class IcebergTable extends Table {
     //  in the same partition column.
     // day(dt) -> identity dt
     public boolean hasPartitionTransformedEvolution() {
-        return (!isV2Format() && getNativeTable().spec().fields().stream().anyMatch(field -> field.transform().isVoid())) ||
-                (isV2Format() && getNativeTable().spec().specId() > 0);
+        return (!isV2Format() && getReadSpec().fields().stream().anyMatch(field -> field.transform().isVoid())) ||
+                (isV2Format() && getReadSpec().specId() > 0);
     }
 
     public boolean isV2Format() {
@@ -319,7 +320,7 @@ public class IcebergTable extends Table {
 
     @Override
     public boolean isUnPartitioned() {
-        return ((BaseTable) getNativeTable()).operations().current().spec().isUnpartitioned();
+        return getReadSpec().isUnpartitioned();
     }
 
     public boolean isPartitioned() {
@@ -332,7 +333,7 @@ public class IcebergTable extends Table {
     }
 
     public List<String> getPartitionColumnNamesWithTransform() {
-        PartitionSpec partitionSpec = getNativeTable().spec();
+        PartitionSpec partitionSpec = getReadSpec();
         return IcebergApiConverter.toPartitionFields(partitionSpec, false);
     }
 
@@ -441,35 +442,54 @@ public class IcebergTable extends Table {
         return nativeTable;
     }
 
-    // Return a per-query copy bound to the given read schema (a targeted snapshot's schema for
-    // time travel), with the StarRocks full schema rebuilt from it.
-    public IcebergTable withReadSchema(Schema schema) {
+    // Return a per-query copy bound to the given read metadata (a targeted snapshot's schema and the
+    // partition specs its manifests reference, for time travel), with the StarRocks full schema
+    // rebuilt from the read schema.
+    public IcebergTable withReadMetadata(Schema readSchema, Map<Integer, PartitionSpec> readSpecsById) {
         IcebergTable table = new IcebergTable(id, name, catalogName, resourceName, catalogDBName, catalogTableName,
-                comment, IcebergApiConverter.toFullSchemas(schema, getNativeTable()), getNativeTable(), icebergProperties);
-        table.readSchema = schema;
+                comment, IcebergApiConverter.toFullSchemas(readSchema, getNativeTable()), getNativeTable(),
+                icebergProperties);
+        table.readSchema = readSchema;
+        table.readSpecsById = readSpecsById;
         table.setUniqueConstraints(getUniqueConstraints());
         table.setForeignKeyConstraints(getForeignKeyConstraints());
         table.metricsReporter = metricsReporter;
         return table;
     }
 
-    // Current-spec partition fields whose source column exists in the read schema. Time travel
-    // drops fields added by later spec evolution; non-time-travel keeps the full spec.
+    // Read-spec partition fields whose source column exists in the read schema. Time travel uses the
+    // targeted snapshot's spec (see getReadSpec), so partition fields added by later spec evolution
+    // are not exposed; ordinary reads keep the current spec.
     private List<PartitionField> readSchemaPartitionFields() {
         Schema schema = getReadSchema();
-        return getNativeTable().spec().fields().stream()
+        return getReadSpec().fields().stream()
                 .filter(field -> schema.findColumnName(field.sourceId()) != null)
                 .collect(Collectors.toList());
     }
 
     // The Iceberg schema this table instance is read with: the targeted snapshot's schema for a
-    // time-travel read (bound via withReadSchema), otherwise the current table schema.
+    // time-travel read (bound via withReadMetadata), otherwise the current table schema.
     public Schema getReadSchema() {
         return readSchema != null ? readSchema : getNativeTable().schema();
     }
 
-    // True when a time-travel read has pinned an explicit snapshot schema via withReadSchema. Lets
-    // callers tell a time-travel read (keep the snapshot schema) from an ordinary read.
+    // The partition spec this table instance is read with. For a time-travel read this is derived
+    // from the target snapshot's manifests: a single spec is the snapshot's partitioning; multiple
+    // specs (mixed partitioning within the snapshot) are treated as unpartitioned so table-level
+    // partition-metadata optimizations are disabled and correctness is preserved (scan planning still
+    // uses each file's own spec). Ordinary reads use the current table spec.
+    public PartitionSpec getReadSpec() {
+        if (readSpecsById == null) {
+            return getNativeTable().spec();
+        }
+        if (readSpecsById.size() == 1) {
+            return readSpecsById.values().iterator().next();
+        }
+        return PartitionSpec.unpartitioned();
+    }
+
+    // True when a time-travel read has pinned explicit read metadata via withReadMetadata. Lets
+    // callers tell a time-travel read (keep the snapshot schema/spec) from an ordinary read.
     public boolean hasReadSchema() {
         return readSchema != null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -468,6 +468,12 @@ public class IcebergTable extends Table {
         return readSchema != null ? readSchema : getNativeTable().schema();
     }
 
+    // True when a time-travel read has pinned an explicit snapshot schema via withReadSchema. Lets
+    // callers tell a time-travel read (keep the snapshot schema) from an ordinary read.
+    public boolean hasReadSchema() {
+        return readSchema != null;
+    }
+
     @Override
     public TTableDescriptor toThrift(List<DescriptorTable.ReferencedPartitionInfo> partitions) {
         Preconditions.checkNotNull(partitions);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -128,6 +128,7 @@ public class IcebergTable extends Table {
     private Map<String, String> icebergProperties = Maps.newHashMap();
 
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
+    private transient Schema readSchema;
     private List<Column> partitionColumns;
     private Optional<Boolean> hasBucketProperties = Optional.empty();
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
@@ -184,9 +185,8 @@ public class IcebergTable extends Table {
     @Override
     public List<Column> getPartitionColumns() {
         if (partitionColumns == null) {
-            List<PartitionField> partitionFields = this.getNativeTable().spec().fields();
-            Schema schema = this.getNativeTable().schema();
-            partitionColumns = partitionFields.stream().map(partitionField ->
+            Schema schema = getReadSchema();
+            partitionColumns = readSchemaPartitionFields().stream().map(partitionField ->
                     getColumn(getPartitionSourceName(schema, partitionField))).collect(Collectors.toList());
         }
         return partitionColumns;
@@ -198,13 +198,13 @@ public class IcebergTable extends Table {
 
     public List<Column> getPartitionColumnsIncludeTransformed() {
         List<Column> allPartitionColumns = new ArrayList<>();
-        for (PartitionField field : getNativeTable().spec().fields()) {
+        Schema schema = getReadSchema();
+        // readSchemaPartitionFields() guarantees the source column resolves, so no null check.
+        for (PartitionField field : readSchemaPartitionFields()) {
             if (!field.transform().isIdentity() && hasPartitionTransformedEvolution()) {
                 continue;
             }
-            String baseColumnName = nativeTable.schema().findColumnName(field.sourceId());
-            Column partitionCol = getColumn(baseColumnName);
-            allPartitionColumns.add(partitionCol);
+            allPartitionColumns.add(getColumn(schema.findColumnName(field.sourceId())));
         }
         return allPartitionColumns;
     }
@@ -222,7 +222,7 @@ public class IcebergTable extends Table {
 
     public PartitionField getPartitionField(String partitionColumnName) {
         List<PartitionField> allPartitionFields = getNativeTable().spec().fields();
-        Schema schema = this.getNativeTable().schema();
+        Schema schema = getReadSchema();
         for (PartitionField field : allPartitionFields) {
             if (getPartitionSourceName(schema, field).equalsIgnoreCase(partitionColumnName)) {
                 return field;
@@ -392,8 +392,9 @@ public class IcebergTable extends Table {
         List<BucketProperty> bucketProperties = new ArrayList<>();
         List<Pair<Integer, Integer>> bucketSourceIdWithBucketNums = getBucketSourceIdWithBucketNum(getNativeTable().spec());
 
+        Schema schema = getReadSchema();
         for (Pair<Integer, Integer> bucket : bucketSourceIdWithBucketNums) {
-            Column column = getColumn(nativeTable.schema().findColumnName(bucket.first));
+            Column column = getColumn(schema.findColumnName(bucket.first));
             if (!bucketPropertySupported(column.getType())) {
                 continue;
             }
@@ -440,6 +441,33 @@ public class IcebergTable extends Table {
         return nativeTable;
     }
 
+    // Return a per-query copy bound to the given read schema (a targeted snapshot's schema for
+    // time travel), with the StarRocks full schema rebuilt from it.
+    public IcebergTable withReadSchema(Schema schema) {
+        IcebergTable table = new IcebergTable(id, name, catalogName, resourceName, catalogDBName, catalogTableName,
+                comment, IcebergApiConverter.toFullSchemas(schema, getNativeTable()), getNativeTable(), icebergProperties);
+        table.readSchema = schema;
+        table.setUniqueConstraints(getUniqueConstraints());
+        table.setForeignKeyConstraints(getForeignKeyConstraints());
+        table.metricsReporter = metricsReporter;
+        return table;
+    }
+
+    // Current-spec partition fields whose source column exists in the read schema. Time travel
+    // drops fields added by later spec evolution; non-time-travel keeps the full spec.
+    private List<PartitionField> readSchemaPartitionFields() {
+        Schema schema = getReadSchema();
+        return getNativeTable().spec().fields().stream()
+                .filter(field -> schema.findColumnName(field.sourceId()) != null)
+                .collect(Collectors.toList());
+    }
+
+    // The Iceberg schema this table instance is read with: the targeted snapshot's schema for a
+    // time-travel read (bound via withReadSchema), otherwise the current table schema.
+    public Schema getReadSchema() {
+        return readSchema != null ? readSchema : getNativeTable().schema();
+    }
+
     @Override
     public TTableDescriptor toThrift(List<DescriptorTable.ReferencedPartitionInfo> partitions) {
         Preconditions.checkNotNull(partitions);
@@ -448,7 +476,7 @@ public class IcebergTable extends Table {
         tIcebergTable.setLocation(getNativeTable().location());
 
         List<TColumn> tColumns = Lists.newArrayList();
-        Schema iceSchema = nativeTable.schema();
+        Schema iceSchema = getReadSchema();
         for (Column column : getBaseSchema()) {
             TColumn tc = column.toThrift();
             // Per Iceberg spec, the read path should ONLY use initial-default to backfill
@@ -468,10 +496,15 @@ public class IcebergTable extends Table {
         }
         tIcebergTable.setColumns(tColumns);
 
-        tIcebergTable.setIceberg_schema(IcebergApiConverter.getTIcebergSchema(nativeTable.schema()));
+        tIcebergTable.setIceberg_schema(IcebergApiConverter.getTIcebergSchema(iceSchema));
         tIcebergTable.setPartition_column_names(getPartitionColumnNames());
         if (comment == null || !comment.equals(EQUALITY_DELETE_TABLE_COMMENT)) {
-            List<String> exprStr = IcebergApiConverter.toPartitionFields(nativeTable.spec(), true);
+            // Resolve partition source names against the read schema so the generated
+            // expressions match the column names in fullSchema.
+            List<PartitionField> partitionFields = readSchemaPartitionFields();
+            List<String> exprStr = partitionFields.stream()
+                    .map(field -> IcebergApiConverter.toPartitionField(iceSchema, field, true))
+                    .collect(Collectors.toList());
             List<Expr> partitionExprs = exprStr.stream()
                     .map(expr -> {
                         if (expr.startsWith(FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "void")) {
@@ -525,11 +558,11 @@ public class IcebergTable extends Table {
             }
             List<TIcebergPartitionInfo> partitionInfos = Lists.newArrayList();
             for (int i = 0; i < partitionExprs.size(); i++) {
+                PartitionField field = partitionFields.get(i);
                 TIcebergPartitionInfo partInfo = new TIcebergPartitionInfo();
-                partInfo.setSource_column_name(nativeTable.schema()
-                        .findColumnName(nativeTable.spec().fields().get(i).sourceId()));
-                partInfo.setPartition_column_name(nativeTable.spec().fields().get(i).name());
-                partInfo.setTransform_expr(nativeTable.spec().fields().get(i).transform().toString());
+                partInfo.setSource_column_name(iceSchema.findColumnName(field.sourceId()));
+                partInfo.setPartition_column_name(field.name());
+                partInfo.setTransform_expr(field.transform().toString());
                 partInfo.setPartition_expr(ExprToThrift.treeToThrift(partitionExprs.get(i)));
                 partitionInfos.add(partInfo);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -128,8 +128,10 @@ public class IcebergTable extends Table {
     private Map<String, String> icebergProperties = Maps.newHashMap();
 
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
-    private transient Schema readSchema;
-    private transient Map<Integer, PartitionSpec> readSpecsById;
+    // Per-query read view of a targeted snapshot for time travel; null means an ordinary read of the
+    // current table state. Bundles the snapshot schema and the partition specs its manifests reference
+    // so the two are always pinned and dropped together.
+    private transient SnapshotReadView readView;
     private List<Column> partitionColumns;
     private Optional<Boolean> hasBucketProperties = Optional.empty();
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
@@ -442,6 +444,18 @@ public class IcebergTable extends Table {
         return nativeTable;
     }
 
+    // Immutable read view a time-travel query pins on its per-query IcebergTable copy: the targeted
+    // snapshot's schema and the partition specs its manifests reference, keyed by spec id.
+    private static class SnapshotReadView {
+        private final Schema schema;
+        private final Map<Integer, PartitionSpec> specsById;
+
+        SnapshotReadView(Schema schema, Map<Integer, PartitionSpec> specsById) {
+            this.schema = schema;
+            this.specsById = specsById;
+        }
+    }
+
     // Return a per-query copy bound to the given read metadata (a targeted snapshot's schema and the
     // partition specs its manifests reference, for time travel), with the StarRocks full schema
     // rebuilt from the read schema.
@@ -449,8 +463,7 @@ public class IcebergTable extends Table {
         IcebergTable table = new IcebergTable(id, name, catalogName, resourceName, catalogDBName, catalogTableName,
                 comment, IcebergApiConverter.toFullSchemas(readSchema, getNativeTable()), getNativeTable(),
                 icebergProperties);
-        table.readSchema = readSchema;
-        table.readSpecsById = readSpecsById;
+        table.readView = new SnapshotReadView(readSchema, readSpecsById);
         table.setUniqueConstraints(getUniqueConstraints());
         table.setForeignKeyConstraints(getForeignKeyConstraints());
         table.metricsReporter = metricsReporter;
@@ -470,7 +483,7 @@ public class IcebergTable extends Table {
     // The Iceberg schema this table instance is read with: the targeted snapshot's schema for a
     // time-travel read (bound via withReadMetadata), otherwise the current table schema.
     public Schema getReadSchema() {
-        return readSchema != null ? readSchema : getNativeTable().schema();
+        return readView != null ? readView.schema : getNativeTable().schema();
     }
 
     // The partition spec this table instance is read with. For a time-travel read this is derived
@@ -479,19 +492,21 @@ public class IcebergTable extends Table {
     // partition-metadata optimizations are disabled and correctness is preserved (scan planning still
     // uses each file's own spec). Ordinary reads use the current table spec.
     public PartitionSpec getReadSpec() {
-        if (readSpecsById == null) {
+        Map<Integer, PartitionSpec> specsById = readView != null ? readView.specsById : null;
+        if (specsById == null) {
             return getNativeTable().spec();
         }
-        if (readSpecsById.size() == 1) {
-            return readSpecsById.values().iterator().next();
+        if (specsById.size() == 1) {
+            return specsById.values().iterator().next();
         }
         return PartitionSpec.unpartitioned();
     }
 
-    // True when a time-travel read has pinned explicit read metadata via withReadMetadata. Lets
-    // callers tell a time-travel read (keep the snapshot schema/spec) from an ordinary read.
-    public boolean hasReadSchema() {
-        return readSchema != null;
+    // True when this is a time-travel read that pinned an explicit snapshot read view via
+    // withReadMetadata. Lets callers tell a time-travel read (keep the snapshot schema/spec) from an
+    // ordinary read of the current table state.
+    public boolean isTimeTravelRead() {
+        return readView != null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -65,7 +65,9 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.Projections;
@@ -686,7 +688,12 @@ public class IcebergApiConverter {
 
     public static List<ManifestFile> filterManifests(List<ManifestFile> manifests,
                                                org.apache.iceberg.Table table, Expression filter) {
-        Map<Integer, ManifestEvaluator> evalCache = specCache(table, filter);
+        return filterManifests(manifests, table.specs(), filter);
+    }
+
+    public static List<ManifestFile> filterManifests(List<ManifestFile> manifests,
+                                               Map<Integer, PartitionSpec> specsById, Expression filter) {
+        Map<Integer, ManifestEvaluator> evalCache = specCache(specsById, filter);
 
         return manifests.stream()
                 .filter(manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles())
@@ -694,15 +701,21 @@ public class IcebergApiConverter {
                 .collect(Collectors.toList());
     }
 
-    private static Map<Integer, ManifestEvaluator> specCache(org.apache.iceberg.Table table, Expression filter) {
+    private static Map<Integer, ManifestEvaluator> specCache(Map<Integer, PartitionSpec> specsById, Expression filter) {
         Map<Integer, ManifestEvaluator> cache = new ConcurrentHashMap<>();
 
-        for (Map.Entry<Integer, PartitionSpec> entry : table.specs().entrySet()) {
+        for (Map.Entry<Integer, PartitionSpec> entry : specsById.entrySet()) {
             Integer spedId = entry.getKey();
             PartitionSpec spec = entry.getValue();
 
-            Expression projection = Projections.inclusive(spec, false).project(filter);
-            ManifestEvaluator evaluator = ManifestEvaluator.forPartitionFilter(projection, spec, false);
+            ManifestEvaluator evaluator;
+            try {
+                Expression projection = Projections.inclusive(spec, false).project(filter);
+                evaluator = ManifestEvaluator.forPartitionFilter(projection, spec, false);
+            } catch (ValidationException e) {
+                // Cannot evaluate the filter against this spec's schema; skip manifest pruning for it.
+                evaluator = ManifestEvaluator.forPartitionFilter(Expressions.alwaysTrue(), spec, false);
+            }
 
             cache.put(spedId, evaluator);
         }
@@ -730,8 +743,14 @@ public class IcebergApiConverter {
     }
 
     public static List<String> toPartitionFields(PartitionSpec spec, Boolean withTransfomPrefix) {
+        return toPartitionFields(spec, spec.schema(), withTransfomPrefix);
+    }
+
+    // Resolve partition source column names against the given schema instead of the spec's own
+    // (current) schema, so time-travel reads can pass a snapshot schema.
+    public static List<String> toPartitionFields(PartitionSpec spec, Schema schema, Boolean withTransfomPrefix) {
         return spec.fields().stream()
-                .map(field -> toPartitionField(spec, field, withTransfomPrefix))
+                .map(field -> toPartitionField(schema, field, withTransfomPrefix))
                 .collect(toImmutableList());
     }
 
@@ -793,7 +812,11 @@ public class IcebergApiConverter {
     }
 
     public static String toPartitionField(PartitionSpec spec, PartitionField field, Boolean withTransfomPrefix) {
-        String name = spec.schema().findColumnName(field.sourceId());
+        return toPartitionField(spec.schema(), field, withTransfomPrefix);
+    }
+
+    public static String toPartitionField(Schema schema, PartitionField field, Boolean withTransfomPrefix) {
+        String name = schema.findColumnName(field.sourceId());
         String escapedName =  "`" + name + "`";
         String transform = field.transform().toString();
         String prefix = withTransfomPrefix ? FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX : "";

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1553,7 +1553,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         //    snapshot) is visible instead of the stale schema recorded on the current snapshot.
         // Other reads (e.g. an internal read pinned to an older snapshot) keep Iceberg's per-snapshot schema.
         Snapshot currentSnapshot = nativeTbl.currentSnapshot();
-        if (icebergTable.hasReadSchema()) {
+        if (icebergTable.isTimeTravelRead()) {
             scanContext.setReadSchema(icebergTable.getReadSchema());
         } else if (currentSnapshot != null && snapshotId == currentSnapshot.snapshotId()) {
             scanContext.setReadSchema(nativeTbl.schema());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -842,6 +842,17 @@ public class IcebergMetadata implements ConnectorMetadata {
         return snapshotId;
     }
 
+    // Schema bound to the given snapshot. Returns null when it cannot be resolved (e.g. legacy
+    // metadata without a per-snapshot schema id), in which case callers keep the current schema.
+    public static Schema getSnapshotSchema(org.apache.iceberg.Table table, long snapshotId) {
+        Snapshot snapshot = table.snapshot(snapshotId);
+        if (snapshot == null || snapshot.schemaId() == null) {
+            return null;
+        }
+        return table.schemas().get(snapshot.schemaId());
+    }
+
+
     private static long getSnapshotIdFromTemporalVersion(org.apache.iceberg.Table table, ConstantOperator version) {
         try {
             if (version.getType() != DateType.DATETIME &&
@@ -1217,8 +1228,6 @@ public class IcebergMetadata implements ConnectorMetadata {
         boolean enableCollectColumnStatistics = params.isEnableColumnStats();
 
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
-        Types.StructType schema = nativeTbl.schema().asStruct();
-
         List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
         // Cast-on-string-partition-column conjuncts (e.g. CAST(c AS DATETIME) = <ts>) are pruned unsoundly
         // by Iceberg's native string comparison, so keep them out of the pushed predicate and evaluate them
@@ -1226,8 +1235,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
                 scalarOperators, identityStringPartitionColumns(icebergTable));
         boolean existPartitionTransformedEvolution = icebergTable.hasPartitionTransformedEvolution();
-        ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(schema);
-        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
+        Expression icebergPredicate = convertPredicate(icebergTable, residual.pushable);
 
         List<FileScanTask> icebergScanTasks = Lists.newArrayList();
         try (CloseableIterator<FileScanTask> iterator =
@@ -1297,9 +1305,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             // pushed predicate and evaluate them here so pruning stays consistent with the backend filter.
             PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
                     scalarOperators, identityStringPartitionColumns(icebergTable));
-            ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(
-                    icebergTable.getNativeTable().schema().asStruct());
-            Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
+            Expression icebergPredicate = convertPredicate(icebergTable, residual.pushable);
             baseSource = buildRemoteInfoSource(icebergTable, icebergPredicate, tvrVersionRange, params);
             if (residual.hasResidual()) {
                 baseSource = filterByPartitionResidual(baseSource, residual.residual, icebergTable,
@@ -1794,9 +1800,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         // filter the returned delete files against their partition values StarRocks-side.
         PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
                 scalarOperators, identityStringPartitionColumns(icebergTable));
-        ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(
-                table.schema().asStruct());
-        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
+        Expression icebergPredicate = convertPredicate(icebergTable, residual.pushable);
 
         StarRocksIcebergTableScanContext scanContext = new StarRocksIcebergTableScanContext(
                 catalogName, dbName, tableName, PlanMode.LOCAL, ConnectContext.get());
@@ -1865,6 +1869,16 @@ public class IcebergMetadata implements ConnectorMetadata {
             LOG.debug("failed to decode delete file partition values, keep file: {}", file.path(), e);
             return Collections.emptyMap();
         }
+    }
+
+    private Expression convertPredicate(IcebergTable icebergTable, ScalarOperator predicate) {
+        return convertPredicate(icebergTable, Utils.extractConjuncts(predicate));
+    }
+
+    private Expression convertPredicate(IcebergTable icebergTable, List<ScalarOperator> conjuncts) {
+        ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(
+                icebergTable.getReadSchema().asStruct());
+        return new ScalarOperatorToIcebergExpr().convert(conjuncts, icebergContext);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1848,6 +1848,17 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         StarRocksIcebergTableScanContext scanContext = new StarRocksIcebergTableScanContext(
                 catalogName, dbName, tableName, PlanMode.LOCAL, ConnectContext.get());
+        // Bind the delete-file scan to the query's read schema, mirroring buildFileScanTaskIterator, so the
+        // pushed predicate (already converted against getReadSchema) and the file specs resolve against the
+        // same schema instead of the snapshot schema useSnapshot would otherwise fall back to:
+        //  - time-travel read: the targeted snapshot's schema;
+        //  - ordinary current read: the current table schema, so a metadata-only ADD COLUMN is visible.
+        Snapshot currentSnapshot = table.currentSnapshot();
+        if (icebergTable.isTimeTravelRead()) {
+            scanContext.setReadSchema(icebergTable.getReadSchema());
+        } else if (currentSnapshot != null && snapshotId == currentSnapshot.snapshotId()) {
+            scanContext.setReadSchema(table.schema());
+        }
 
         TableScan scan = icebergCatalog.getTableScan(table, scanContext)
                 .useSnapshot(snapshotId)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1540,8 +1540,14 @@ public class IcebergMetadata implements ConnectorMetadata {
         checkUnsupportedEncryption(nativeTbl);
         traceIcebergMetricsConfig(nativeTbl);
 
+        // Force local planning for time-travel reads: the remote metadata-collection scanner
+        // (IcebergMetadataScanner) binds the pushed-down predicate against the current table specs, so a
+        // predicate on a column renamed after the target snapshot fails to bind. Local planning rebinds
+        // the specs to the snapshot's read schema and evaluates correctly. Remove once the remote
+        // metadata reader honors the snapshot schema/specs.
+        PlanMode planMode = icebergTable.isTimeTravelRead() ? PlanMode.LOCAL : planMode(connectContext);
         StarRocksIcebergTableScanContext scanContext = new StarRocksIcebergTableScanContext(
-                catalogName, dbName, tableName, planMode(connectContext), connectContext);
+                catalogName, dbName, tableName, planMode, connectContext);
         scanContext.setLocalParallelism(catalogProperties.getIcebergJobPlanningThreadNum());
         scanContext.setLocalPlanningMaxSlotSize(catalogProperties.getLocalPlanningMaxSlotBytes());
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -852,6 +852,31 @@ public class IcebergMetadata implements ConnectorMetadata {
         return table.schemas().get(snapshot.schemaId());
     }
 
+    // Partition specs actually referenced by the snapshot's data manifests, keyed by spec id. This is
+    // the snapshot's partitioning view (Iceberg plans a snapshot from the specs attached to its
+    // manifests), which can differ from the current table spec after partition evolution. Returns null
+    // when the snapshot is unresolved. Reads only the manifest list, and only for time-travel reads.
+    public static Map<Integer, PartitionSpec> getSnapshotSpecs(org.apache.iceberg.Table table, long snapshotId) {
+        Snapshot snapshot = table.snapshot(snapshotId);
+        if (snapshot == null) {
+            return null;
+        }
+        // The spec never evolved: the only spec is the snapshot's spec; skip the manifest-list read.
+        if (table.specs().size() == 1) {
+            return table.specs();
+        }
+        Map<Integer, PartitionSpec> specsById = new HashMap<>();
+        for (ManifestFile manifest : snapshot.dataManifests(table.io())) {
+            PartitionSpec spec = table.specs().get(manifest.partitionSpecId());
+            if (spec == null) {
+                // A referenced spec is missing from the table metadata: treat the snapshot's
+                // partitioning as unknown (empty map reads as unpartitioned, the conservative view).
+                return Map.of();
+            }
+            specsById.put(manifest.partitionSpecId(), spec);
+        }
+        return specsById;
+    }
 
     private static long getSnapshotIdFromTemporalVersion(org.apache.iceberg.Table table, ConstantOperator version) {
         try {
@@ -1159,7 +1184,9 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         Set<List<String>> scannedPartitions = new HashSet<>();
-        PartitionSpec spec = icebergTable.getNativeTable().spec();
+        // Use the read spec so the extracted values, the partition columns, and the evolution check
+        // below all derive from the same partitioning view (the snapshot's for time travel).
+        PartitionSpec spec = icebergTable.getReadSpec();
         List<Column> partitionColumns = icebergTable.getPartitionColumnsIncludeTransformed();
         boolean existPartitionTransformedEvolution = ((IcebergTable) table).hasPartitionTransformedEvolution();
         for (FileScanTask fileScanTask : icebergSplitTasks) {
@@ -1521,7 +1548,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         final long snapshotId = tvrVersionRange.end().orElseThrow(() -> new StarRocksConnectorException(
                 "Snapshot ID is not present in tvrVersionRange: " + tvrVersionRange));
         // Bind the scan to the query's read schema so scan planning matches the predicate/descriptor:
-        //  - time-travel read: the targeted snapshot's schema (pinned via IcebergTable#withReadSchema);
+        //  - time-travel read: the targeted snapshot's schema (pinned via IcebergTable#withReadMetadata);
         //  - ordinary current read: the current table schema, so a metadata-only ADD COLUMN (no new
         //    snapshot) is visible instead of the stale schema recorded on the current snapshot.
         // Other reads (e.g. an internal read pinned to an older snapshot) keep Iceberg's per-snapshot schema.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1520,6 +1520,17 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         final long snapshotId = tvrVersionRange.end().orElseThrow(() -> new StarRocksConnectorException(
                 "Snapshot ID is not present in tvrVersionRange: " + tvrVersionRange));
+        // Bind the scan to the query's read schema so scan planning matches the predicate/descriptor:
+        //  - time-travel read: the targeted snapshot's schema (pinned via IcebergTable#withReadSchema);
+        //  - ordinary current read: the current table schema, so a metadata-only ADD COLUMN (no new
+        //    snapshot) is visible instead of the stale schema recorded on the current snapshot.
+        // Other reads (e.g. an internal read pinned to an older snapshot) keep Iceberg's per-snapshot schema.
+        Snapshot currentSnapshot = nativeTbl.currentSnapshot();
+        if (icebergTable.hasReadSchema()) {
+            scanContext.setReadSchema(icebergTable.getReadSchema());
+        } else if (currentSnapshot != null && snapshotId == currentSnapshot.snapshotId()) {
+            scanContext.setReadSchema(nativeTbl.schema());
+        }
         Scan scan;
         IcebergMetricsReporter metricsReporter = icebergTable.getIcebergMetricsReporter();
         if (metricsReporter == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -20,6 +20,7 @@ import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
 import com.starrocks.qe.ConnectContext;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Schema;
 
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +40,10 @@ public class StarRocksIcebergTableScanContext {
     private boolean enableCacheDataFileIdentifierColumnMetrics;
     private long fileSplitSize;
     private ConnectContext connectContext;
+    // The schema the scan reads with: the targeted snapshot's schema for a time-travel read, or the
+    // current table schema for an ordinary read (so a metadata-only ADD COLUMN, which advances the
+    // schema without a new snapshot, is visible). Null means keep Iceberg's default per-snapshot schema.
+    private Schema readSchema;
 
     public StarRocksIcebergTableScanContext(String catalogName, String dbName, String tableName, PlanMode planMode) {
         this(catalogName, dbName, tableName, planMode, null);
@@ -142,5 +147,13 @@ public class StarRocksIcebergTableScanContext {
 
     public long getFileSplitSize() {
         return fileSplitSize;
+    }
+
+    public Schema getReadSchema() {
+        return readSchema;
+    }
+
+    public void setReadSchema(Schema readSchema) {
+        this.readSchema = readSchema;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -175,12 +175,15 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
 
-        Set<String> nativeColumnNames = icebergTable.getNativeTable().schema().columns().stream()
+        // Filter against the read schema (the targeted snapshot's schema for time travel), not the
+        // current native schema, so snapshot-only column names (e.g. a column before a later rename)
+        // are not dropped before IcebergMetadata calls scan.select(fieldNames).
+        Set<String> readSchemaColumnNames = icebergTable.getReadSchema().columns().stream()
                 .map(Types.NestedField::name)
                 .collect(Collectors.toSet());
         List<String> requiredColumnNames = desc.getSlots().stream()
                 .map(slot -> slot.getColumn().getName())
-                .filter(nativeColumnNames::contains)
+                .filter(readSchemaColumnNames::contains)
                 .distinct()
                 .collect(Collectors.toList());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -114,6 +114,7 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 
 import java.util.ArrayDeque;
@@ -2509,12 +2510,18 @@ public class QueryAnalyzer {
         }
         org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
         Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(nativeTable, snapshotId.get());
-        if (snapshotSchema != null && snapshotSchema.schemaId() != nativeTable.schema().schemaId()) {
-            IcebergTable snapshotTable = icebergTable.withReadSchema(snapshotSchema);
-            tableRelation.setTable(snapshotTable);
-            return snapshotTable;
+        if (snapshotSchema == null) {
+            // Legacy metadata without a per-snapshot schema id: keep the current table state.
+            return icebergTable;
         }
-        return icebergTable;
+        // Pin the snapshot's read metadata (schema + partition specs). Bind it whenever time travel
+        // resolves a snapshot, not only when the schema id differs: partition evolution can change the
+        // spec while leaving the schema id unchanged, and the descriptor/partition metadata must then
+        // still reflect the snapshot rather than the current spec.
+        Map<Integer, PartitionSpec> snapshotSpecs = IcebergMetadata.getSnapshotSpecs(nativeTable, snapshotId.get());
+        IcebergTable snapshotTable = icebergTable.withReadMetadata(snapshotSchema, snapshotSpecs);
+        tableRelation.setTable(snapshotTable);
+        return snapshotTable;
     }
 
     private Table resolveTableFunctionTable(Map<String, String> properties, Consumer<TableFunctionTable> pushDownSchemaFunc) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -28,7 +28,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
@@ -47,10 +46,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadata;
-import com.starrocks.connector.ConnectorTableVersion;
-import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -73,7 +69,6 @@ import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.PivotAggregation;
 import com.starrocks.sql.ast.PivotRelation;
 import com.starrocks.sql.ast.PivotValue;
-import com.starrocks.sql.ast.QueryPeriod;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -114,8 +109,6 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -832,7 +825,7 @@ public class QueryAnalyzer {
                 if (table == null || catalogName == null || CatalogMgr.isInternalCatalog(catalogName)) {
                     table = resolveTable(tableRelation);
                 }
-                table = applyIcebergTimeTravelIfNeeded(table, tableRelation);
+                table = QueryPeriodResolver.resolveAndBindTable(tableRelation, table, session, metadataMgr);
 
                 Relation r;
                 if (table instanceof View) {
@@ -2480,48 +2473,6 @@ public class QueryAnalyzer {
         } catch (AnalysisException e) {
             throw new SemanticException(e.getMessage());
         }
-    }
-
-    private Table applyIcebergTimeTravelIfNeeded(Table table, TableRelation tableRelation) {
-        if (table instanceof IcebergTable && tableRelation.getQueryPeriod() != null
-                && tableRelation.getTvrVersionRange() == null) {
-            return applyIcebergTimeTravel((IcebergTable) table, tableRelation);
-        }
-        return table;
-    }
-
-    // Resolve the query period to a version range once, pin it on the relation (so
-    // RelationTransformer reuses it), and rebind the table to the targeted snapshot's schema
-    // when it differs, so column resolution and the BE descriptor honor that snapshot.
-    private IcebergTable applyIcebergTimeTravel(IcebergTable icebergTable, TableRelation tableRelation) {
-        QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
-        QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
-        Optional<ConnectorTableVersion> startVersion =
-                QueryPeriodResolver.resolve(queryPeriod.getStart(), periodType, session);
-        Optional<ConnectorTableVersion> endVersion =
-                QueryPeriodResolver.resolve(queryPeriod.getEnd(), periodType, session);
-        TvrVersionRange versionRange = metadataMgr.getTableVersionRange(
-                tableRelation.getName().getDb(), icebergTable, startVersion, endVersion);
-        tableRelation.setTvrVersionRange(versionRange);
-
-        Optional<Long> snapshotId = versionRange.end();
-        if (snapshotId.isEmpty()) {
-            return icebergTable;
-        }
-        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
-        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(nativeTable, snapshotId.get());
-        if (snapshotSchema == null) {
-            // Legacy metadata without a per-snapshot schema id: keep the current table state.
-            return icebergTable;
-        }
-        // Pin the snapshot's read metadata (schema + partition specs). Bind it whenever time travel
-        // resolves a snapshot, not only when the schema id differs: partition evolution can change the
-        // spec while leaving the schema id unchanged, and the descriptor/partition metadata must then
-        // still reflect the snapshot rather than the current spec.
-        Map<Integer, PartitionSpec> snapshotSpecs = IcebergMetadata.getSnapshotSpecs(nativeTable, snapshotId.get());
-        IcebergTable snapshotTable = icebergTable.withReadMetadata(snapshotSchema, snapshotSpecs);
-        tableRelation.setTable(snapshotTable);
-        return snapshotTable;
     }
 
     private Table resolveTableFunctionTable(Map<String, String> properties, Consumer<TableFunctionTable> pushDownSchemaFunc) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
@@ -46,7 +47,10 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorTableVersion;
+import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -69,6 +73,7 @@ import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.PivotAggregation;
 import com.starrocks.sql.ast.PivotRelation;
 import com.starrocks.sql.ast.PivotValue;
+import com.starrocks.sql.ast.QueryPeriod;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -109,6 +114,7 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.iceberg.Schema;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -825,6 +831,7 @@ public class QueryAnalyzer {
                 if (table == null || catalogName == null || CatalogMgr.isInternalCatalog(catalogName)) {
                     table = resolveTable(tableRelation);
                 }
+                table = applyIcebergTimeTravelIfNeeded(table, tableRelation);
 
                 Relation r;
                 if (table instanceof View) {
@@ -2472,6 +2479,42 @@ public class QueryAnalyzer {
         } catch (AnalysisException e) {
             throw new SemanticException(e.getMessage());
         }
+    }
+
+    private Table applyIcebergTimeTravelIfNeeded(Table table, TableRelation tableRelation) {
+        if (table instanceof IcebergTable && tableRelation.getQueryPeriod() != null
+                && tableRelation.getTvrVersionRange() == null) {
+            return applyIcebergTimeTravel((IcebergTable) table, tableRelation);
+        }
+        return table;
+    }
+
+    // Resolve the query period to a version range once, pin it on the relation (so
+    // RelationTransformer reuses it), and rebind the table to the targeted snapshot's schema
+    // when it differs, so column resolution and the BE descriptor honor that snapshot.
+    private IcebergTable applyIcebergTimeTravel(IcebergTable icebergTable, TableRelation tableRelation) {
+        QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
+        QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
+        Optional<ConnectorTableVersion> startVersion =
+                QueryPeriodResolver.resolve(queryPeriod.getStart(), periodType, session);
+        Optional<ConnectorTableVersion> endVersion =
+                QueryPeriodResolver.resolve(queryPeriod.getEnd(), periodType, session);
+        TvrVersionRange versionRange = metadataMgr.getTableVersionRange(
+                tableRelation.getName().getDb(), icebergTable, startVersion, endVersion);
+        tableRelation.setTvrVersionRange(versionRange);
+
+        Optional<Long> snapshotId = versionRange.end();
+        if (snapshotId.isEmpty()) {
+            return icebergTable;
+        }
+        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(nativeTable, snapshotId.get());
+        if (snapshotSchema != null && snapshotSchema.schemaId() != nativeTable.schema().schemaId()) {
+            IcebergTable snapshotTable = icebergTable.withReadSchema(snapshotSchema);
+            tableRelation.setTable(snapshotTable);
+            return snapshotTable;
+        }
+        return icebergTable;
     }
 
     private Table resolveTableFunctionTable(Map<String, String> properties, Consumer<TableFunctionTable> pushDownSchemaFunc) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryPeriodResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryPeriodResolver.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.connector.ConnectorTableVersion;
+import com.starrocks.connector.PointerType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.QueryPeriod;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+
+import java.util.Optional;
+
+public class QueryPeriodResolver {
+    private QueryPeriodResolver() {
+    }
+
+    public static Optional<ConnectorTableVersion> resolve(Optional<Expr> version,
+                                                          QueryPeriod.PeriodType type,
+                                                          ConnectContext session) {
+        if (version.isEmpty()) {
+            return Optional.empty();
+        }
+        ScalarOperator result;
+        try {
+            Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+            ExpressionAnalyzer.analyzeExpression(version.get(), new AnalyzeState(), scope, session);
+            ExpressionMapping expressionMapping = new ExpressionMapping(scope);
+            result = SqlToScalarOperatorTranslator.translate(version.get(), expressionMapping, new ColumnRefFactory());
+        } catch (Exception e) {
+            throw new SemanticException("Failed to resolve query period [type: %s, value: %s]. msg: %s",
+                    type.toString(), version.get().toString(), e.getMessage());
+        }
+
+        if (!(result instanceof ConstantOperator)) {
+            if (version.get() instanceof FunctionCallExpr) {
+                throw new SemanticException("Invalid datetime function: [type: %s, value: %s]. " +
+                        "The function requirement must be inferred in frontend.", type.toString(),
+                        version.get().toString());
+            } else {
+                throw new SemanticException("Invalid version value. [type: %s, value: %s]",
+                        type.toString(), version.get().toString());
+            }
+        }
+        PointerType pointerType = type == QueryPeriod.PeriodType.TIMESTAMP ? PointerType.TEMPORAL : PointerType.VERSION;
+        return Optional.of(new ConnectorTableVersion(pointerType, (ConstantOperator) result));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryPeriodResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryPeriodResolver.java
@@ -14,10 +14,16 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.PointerType;
+import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.QueryPeriod;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -25,7 +31,10 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class QueryPeriodResolver {
@@ -61,5 +70,57 @@ public class QueryPeriodResolver {
         }
         PointerType pointerType = type == QueryPeriod.PeriodType.TIMESTAMP ? PointerType.TEMPORAL : PointerType.VERSION;
         return Optional.of(new ConnectorTableVersion(pointerType, (ConstantOperator) result));
+    }
+
+    /**
+     * Relation-level entry for the analyzer: resolve the relation's query period to a version range
+     * once, pin it on the relation (so RelationTransformer reuses it), and rebind the table to the
+     * targeted snapshot's read metadata, so column resolution and the BE descriptor honor that snapshot.
+     * Returns the (possibly rebound) table; the caller owns writing it back to the relation. No-op when
+     * the relation has no query period or its version range is already pinned (e.g. pre-resolved in the
+     * unlocked phase).
+     */
+    public static Table resolveAndBindTable(TableRelation tableRelation, Table table,
+                                            ConnectContext session, MetadataMgr metadataMgr) {
+        if (tableRelation.getQueryPeriod() == null || tableRelation.getTvrVersionRange() != null) {
+            return table;
+        }
+        // Only Iceberg resolves its version range and binds a per-query read view during analysis today;
+        // other temporal tables (Paimon, MySQL) keep resolving at transform time, so gate here to avoid
+        // adding any analysis-time overhead for them.
+        if (!(table instanceof IcebergTable)) {
+            return table;
+        }
+
+        QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
+        QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
+        Optional<ConnectorTableVersion> startVersion = resolve(queryPeriod.getStart(), periodType, session);
+        Optional<ConnectorTableVersion> endVersion = resolve(queryPeriod.getEnd(), periodType, session);
+        TvrVersionRange versionRange = metadataMgr.getTableVersionRange(
+                tableRelation.getName().getDb(), table, startVersion, endVersion);
+        tableRelation.setTvrVersionRange(versionRange);
+
+        return bindIcebergSnapshotReadView((IcebergTable) table, versionRange);
+    }
+
+    // Rebind the Iceberg table to the resolved snapshot's read metadata (schema + partition specs),
+    // returning an immutable per-query copy.
+    private static Table bindIcebergSnapshotReadView(IcebergTable icebergTable, TvrVersionRange versionRange) {
+        Optional<Long> snapshotId = versionRange.end();
+        if (snapshotId.isEmpty()) {
+            return icebergTable;
+        }
+        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(nativeTable, snapshotId.get());
+        if (snapshotSchema == null) {
+            // Legacy metadata without a per-snapshot schema id: keep the current table state.
+            return icebergTable;
+        }
+        // Pin the snapshot's read metadata (schema + partition specs). Bind it whenever time travel
+        // resolves a snapshot, not only when the schema id differs: partition evolution can change the
+        // spec while leaving the schema id unchanged, and the descriptor/partition metadata must then
+        // still reflect the snapshot rather than the current spec.
+        Map<Integer, PartitionSpec> snapshotSpecs = IcebergMetadata.getSnapshotSpecs(nativeTable, snapshotId.get());
+        return icebergTable.withReadMetadata(snapshotSchema, snapshotSpecs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -36,17 +36,15 @@ import com.starrocks.catalog.View;
 import com.starrocks.common.Pair;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorTableVersion;
-import com.starrocks.connector.PointerType;
 import com.starrocks.connector.elasticsearch.EsTablePartitions;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
-import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.FieldId;
+import com.starrocks.sql.analyzer.QueryPeriodResolver;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
@@ -813,31 +811,7 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
     }
 
     private Optional<ConnectorTableVersion> resolveQueryPeriod(Optional<Expr> version, QueryPeriod.PeriodType type) {
-        if (version.isEmpty()) {
-            return Optional.empty();
-        }
-        ScalarOperator result;
-        try {
-            Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
-            ExpressionAnalyzer.analyzeExpression(version.get(), new AnalyzeState(), scope, session);
-            ExpressionMapping expressionMapping = new ExpressionMapping(scope);
-            result = SqlToScalarOperatorTranslator.translate(version.get(), expressionMapping, new ColumnRefFactory());
-        } catch (Exception e) {
-            throw new SemanticException("Failed to resolve query period [type: %s, value: %s]. msg: %s",
-                    type.toString(), version.get().toString(), e.getMessage());
-        }
-
-        if (!(result instanceof ConstantOperator)) {
-            if (version.get() instanceof FunctionCallExpr) {
-                throw new SemanticException("Invalid datetime function: [type: %s, value: %s]. " +
-                        "The function requirement must be inferred in frontend.", type.toString(), version.get().toString());
-            } else {
-                throw new SemanticException("Invalid version value. [type: %s, value: %s]",
-                        type.toString(), version.get().toString());
-            }
-        }
-        PointerType pointerType = type == QueryPeriod.PeriodType.TIMESTAMP ? PointerType.TEMPORAL : PointerType.VERSION;
-        return Optional.of(new ConnectorTableVersion(pointerType, (ConstantOperator) result));
+        return QueryPeriodResolver.resolve(version, type, session);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -77,6 +77,7 @@ public class MetadataParser {
     });
 
     public MetadataParser(Table table,
+                          String schemaString,
                           Map<Integer, String> specStringCache,
                           Map<Integer, ResidualEvaluator> residualCache,
                           ExecutorService executorService,
@@ -91,7 +92,9 @@ public class MetadataParser {
         this.isPartitionedTable = table.spec().isPartitioned();
         this.specStringCache = specStringCache;
         this.residualCache = residualCache;
-        this.schemaString = SchemaParser.toJson(table.schema());
+        // Use the scan's read schema (the targeted snapshot's schema for a time-travel read), not the
+        // current table schema, so remote-planned tasks carry the same schema as locally-planned ones.
+        this.schemaString = schemaString;
         this.executorService = executorService;
         this.liveFilesCount = liveFilesCount;
     }

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -216,7 +216,7 @@ public class StarRocksIcebergTableScan
         executeInNewThread(threadNamePrefix + "-fetch_result", metadataCollectJob::asyncCollectMetadata);
 
         MetadataParser parser = new MetadataParser(
-                table(), specStringCache, residualCache, planExecutor(), scanMetrics(),
+                table(), schemaString, specStringCache, residualCache, planExecutor(), scanMetrics(),
                 deleteFileIndex, metadataCollectJob, liveFilesCount);
         executeInNewThread(threadNamePrefix + "-parallel_parser", parser::parse);
 

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -144,6 +144,21 @@ public class StarRocksIcebergTableScan
     }
 
     @Override
+    public TableScan useSnapshot(long scanSnapshotId) {
+        // Delegate to the parent (inheriting its validation and context assembly), which binds the scan
+        // to the target snapshot's recorded schema (DataScan#useSnapshotSchema). When a read schema was
+        // resolved for this query, rebind to it so the scan uses the same schema the query bound its
+        // predicates and descriptor against: the current table schema for an ordinary read (making a
+        // metadata-only ADD COLUMN visible), or the targeted snapshot's schema for a time-travel read.
+        TableScan scan = super.useSnapshot(scanSnapshotId);
+        Schema readSchema = scanContext.getReadSchema();
+        if (readSchema != null && useSnapshotSchema()) {
+            return newRefinedScan(table(), readSchema, ((StarRocksIcebergTableScan) scan).context());
+        }
+        return scan;
+    }
+
+    @Override
     protected ManifestGroup newManifestGroup(List<ManifestFile> dataManifests,
                                              List<ManifestFile> deleteManifests,
                                              boolean withColumnStats) {

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -32,6 +32,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TResultSinkType;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -72,6 +73,7 @@ public class StarRocksIcebergTableScan
     private final Cache<String, Set<DataFile>> dataFileCache;
     private final Cache<String, Set<DeleteFile>> deleteFileCache;
     private final Map<IcebergTableName, Set<String>> metaFileCacheMap;
+    private final Map<Integer, PartitionSpec> scanSpecsById;
     private final Map<Integer, String> specStringCache;
     private final Map<Integer, ResidualEvaluator> residualCache;
     private final Map<Integer, Evaluator> partitionEvaluatorCache;
@@ -115,10 +117,14 @@ public class StarRocksIcebergTableScan
         this.planMode = scanContext.getPlanMode();
         this.connectContext = scanContext.getConnectContext();
         this.scanContext = scanContext;
-        this.specStringCache = specCache(PartitionSpecParser::toJson);
-        this.residualCache = specCache(this::newResidualEvaluator);
-        this.partitionEvaluatorCache = specCache(this::newPartitionEvaluator);
-        this.inclusiveMetricsEvaluatorCache = specCache(this::newInclusiveMetricsEvaluator);
+        // The scan schema is the snapshot schema for time travel (DataScan#useSnapshotSchema), but
+        // partition specs stay bound to the current schema. Rebind them so evaluators bind against
+        // the same schema as the filter; spec strings sent to scan tasks keep the original specs.
+        this.scanSpecsById = specsForScanSchema(table.specs());
+        this.specStringCache = specCache(table.specs(), PartitionSpecParser::toJson);
+        this.residualCache = specCache(scanSpecsById, this::newResidualEvaluator);
+        this.partitionEvaluatorCache = specCache(scanSpecsById, this::newPartitionEvaluator);
+        this.inclusiveMetricsEvaluatorCache = specCache(scanSpecsById, this::newInclusiveMetricsEvaluator);
         this.schemaString = SchemaParser.toJson(tableSchema());
         this.dataFileCache = scanContext.getDataFileCache();
         this.deleteFileCache = scanContext.getDeleteFileCache();
@@ -135,6 +141,16 @@ public class StarRocksIcebergTableScan
         StarRocksIcebergTableScan scan = new StarRocksIcebergTableScan(newTable, newSchema, newContext, scanContext);
         scan.metricsReporter = this.metricsReporter;
         return scan;
+    }
+
+    @Override
+    protected ManifestGroup newManifestGroup(List<ManifestFile> dataManifests,
+                                             List<ManifestFile> deleteManifests,
+                                             boolean withColumnStats) {
+        // Use the specs rebound to the scan schema so that the manifest evaluators bind the
+        // filter consistently for time-travel reads.
+        return super.newManifestGroup(dataManifests, deleteManifests, withColumnStats)
+                .specsById(scanSpecsById);
     }
 
     @Override
@@ -203,7 +219,7 @@ public class StarRocksIcebergTableScan
         }
 
         return builder
-                .specsById(table().specs())
+                .specsById(scanSpecsById)
                 .filterData(filter())
                 .caseSensitive(isCaseSensitive())
                 .scanMetrics(scanMetrics())
@@ -215,7 +231,8 @@ public class StarRocksIcebergTableScan
         List<ManifestFile> dataManifests = snapshot.dataManifests(io());
         scanMetrics().totalDataManifests().increment(dataManifests.size());
 
-        List<ManifestFile> matchingDataManifests = IcebergApiConverter.filterManifests(dataManifests, table(), filter());
+        List<ManifestFile> matchingDataManifests =
+                IcebergApiConverter.filterManifests(dataManifests, scanSpecsById, filter());
         int skippedDataManifestsCount = dataManifests.size() - matchingDataManifests.size();
         scanMetrics().skippedDataManifests().increment(skippedDataManifestsCount);
 
@@ -224,7 +241,8 @@ public class StarRocksIcebergTableScan
 
     private List<ManifestFile> findMatchingDeleteManifests(Snapshot snapshot) {
         List<ManifestFile> deleteManifests = snapshot.deleteManifests(io());
-        List<ManifestFile> matchingDeleteManifests = IcebergApiConverter.filterManifests(deleteManifests, table(), filter());
+        List<ManifestFile> matchingDeleteManifests =
+                IcebergApiConverter.filterManifests(deleteManifests, scanSpecsById, filter());
 
         scanMetrics().totalDeleteManifests().increment(deleteManifests.size());
         scanMetrics().skippedDeleteManifests().increment(deleteManifests.size() - matchingDeleteManifests.size());
@@ -347,7 +365,7 @@ public class StarRocksIcebergTableScan
                         .caseSensitive(isCaseSensitive())
                         .select(shouldReturnColumnStats() ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
                         .filterData(filter())
-                        .specsById(table().specs())
+                        .specsById(scanSpecsById)
                         .scanMetrics(scanMetrics())
                         .ignoreDeleted()
                         .withDataFileCache(dataFileCache)
@@ -464,7 +482,7 @@ public class StarRocksIcebergTableScan
             if (shouldPlanWithExecutor() && deleteManifests.size() > 1) {
                 builder.planWith(planExecutor());
             }
-            builder.specsById(table().specs())
+            builder.specsById(scanSpecsById)
                     .filterData(filter())
                     .caseSensitive(isCaseSensitive())
                     .scanMetrics(scanMetrics())
@@ -532,25 +550,62 @@ public class StarRocksIcebergTableScan
     }
 
     private ResidualEvaluator newResidualEvaluator(PartitionSpec spec) {
-        return ResidualEvaluator.of(spec, residualFilter(), isCaseSensitive());
+        try {
+            return ResidualEvaluator.of(spec, residualFilter(), isCaseSensitive());
+        } catch (ValidationException e) {
+            // The filter references a column this spec's schema doesn't have (the spec couldn't
+            // be rebound to the scan schema). Keep the whole filter as the residual so the rows
+            // are still filtered after scanning.
+            return ResidualEvaluator.unpartitioned(residualFilter());
+        }
     }
 
     private Evaluator newPartitionEvaluator(PartitionSpec spec) {
-        Expression projected = Projections.inclusive(spec, false).project(filter());
-        return new Evaluator(spec.partitionType(), projected, false);
+        try {
+            Expression projected = Projections.inclusive(spec, false).project(filter());
+            return new Evaluator(spec.partitionType(), projected, false);
+        } catch (ValidationException e) {
+            // Cannot evaluate the filter against this spec; skip partition pruning for it.
+            return new Evaluator(spec.partitionType(), Expressions.alwaysTrue(), false);
+        }
     }
 
     private InclusiveMetricsEvaluator newInclusiveMetricsEvaluator(PartitionSpec spec) {
-        if (filter() != null) {
-            return new InclusiveMetricsEvaluator(spec.schema(), filter(), false);
-        } else {
+        try {
+            if (filter() != null) {
+                return new InclusiveMetricsEvaluator(spec.schema(), filter(), false);
+            } else {
+                return new InclusiveMetricsEvaluator(spec.schema(), Expressions.alwaysTrue(), false);
+            }
+        } catch (ValidationException e) {
+            // Cannot evaluate the filter against this spec's schema; skip metrics pruning for it.
             return new InclusiveMetricsEvaluator(spec.schema(), Expressions.alwaysTrue(), false);
         }
     }
 
-    private <R> Map<Integer, R> specCache(Function<PartitionSpec, R> load) {
+    // Rebind the given specs to the scan schema, which is the snapshot schema for time-travel
+    // reads. A spec referencing a column the scan schema doesn't have is kept as-is; the
+    // evaluators above fall back to no pruning for it.
+    private Map<Integer, PartitionSpec> specsForScanSchema(Map<Integer, PartitionSpec> specs) {
+        Schema scanSchema = tableSchema();
+        Map<Integer, PartitionSpec> result = new ConcurrentHashMap<>();
+        specs.forEach((specId, spec) -> {
+            PartitionSpec boundSpec = spec;
+            if (spec.schema().schemaId() != scanSchema.schemaId()) {
+                try {
+                    boundSpec = spec.toUnbound().bind(scanSchema);
+                } catch (RuntimeException e) {
+                    boundSpec = spec;
+                }
+            }
+            result.put(specId, boundSpec);
+        });
+        return result;
+    }
+
+    private <R> Map<Integer, R> specCache(Map<Integer, PartitionSpec> specs, Function<PartitionSpec, R> load) {
         Map<Integer, R> cache = new ConcurrentHashMap<>();
-        table().specs().forEach((specId, spec) -> cache.put(specId, load.apply(spec)));
+        specs.forEach((specId, spec) -> cache.put(specId, load.apply(spec)));
         return cache;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4443,7 +4443,7 @@ public class IcebergMetadataTest extends TableTestBase {
         // old column name must plan files of the targeted snapshot instead of failing.
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
         ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
                 new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
         List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
@@ -4474,7 +4474,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
         ScalarOperator predicate = new IsNullPredicateOperator(false,
                 new ColumnRefOperator(3, INT, "k3", true));
         List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
@@ -4525,7 +4525,7 @@ public class IcebergMetadataTest extends TableTestBase {
         // A scan of the pre-evolution snapshot plans its files (which use the old spec).
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
         List<RemoteFileInfo> res = metadata.getRemoteFiles(snapshotTable,
                 GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(s1)))
                         .setFieldNames(Lists.newArrayList()).setLimit(10).build());
@@ -4572,32 +4572,39 @@ public class IcebergMetadataTest extends TableTestBase {
         // column renamed after the snapshot. Local planning rebinds to the snapshot spec, so a predicate
         // on the old column name plans the snapshot's files instead of routing to the remote scanner.
         StarRocksAssert starRocksAssert = new StarRocksAssert();
+        // Restore the plan mode afterwards: this test shares the thread-local ConnectContext, so leaking
+        // DISTRIBUTED would push later tests (e.g. testGetRemoteFileStringDatePartitionPrune) onto the remote
+        // metadata-planning path and make them fail.
+        String previousPlanMode = starRocksAssert.getCtx().getSessionVariable().getPlanMode();
         starRocksAssert.getCtx().getSessionVariable().setPlanMode(PlanMode.DISTRIBUTED.modeName());
+        try {
+            mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+            mockedNativeTableB.refresh();
+            long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+            mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
+            mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+            mockedNativeTableB.refresh();
 
-        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
-        mockedNativeTableB.refresh();
-        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
-        mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
-        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
-        mockedNativeTableB.refresh();
+            IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+            IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                    Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+            IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                    "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
+                    mockedNativeTableB, Maps.newHashMap());
+            icebergTable = icebergTable.withReadMetadata(IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1),
+                    IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
 
-        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
-        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
-                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
-                mockedNativeTableB, Maps.newHashMap());
-        icebergTable = icebergTable.withReadMetadata(IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1),
-                IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
-
-        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
-                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
-        List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
-                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(s1)))
-                        .setPredicate(predicate).setFieldNames(Lists.newArrayList()).setLimit(10).build());
-        Assertions.assertEquals(3, res.stream()
-                .map(f -> (IcebergRemoteFileInfo) f)
-                .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+            ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
+                    new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
+            List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
+                    GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(s1)))
+                            .setPredicate(predicate).setFieldNames(Lists.newArrayList()).setLimit(10).build());
+            Assertions.assertEquals(3, res.stream()
+                    .map(f -> (IcebergRemoteFileInfo) f)
+                    .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+        } finally {
+            starRocksAssert.getCtx().getSessionVariable().setPlanMode(previousPlanMode);
+        }
     }
 
     @Test
@@ -4619,7 +4626,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
                 "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
                 mockedNativeTableB, Maps.newHashMap());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -75,6 +75,7 @@ import com.starrocks.server.NodeMgr;
 import com.starrocks.server.TemporaryTableMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
+import com.starrocks.sql.analyzer.QueryAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -92,8 +93,12 @@ import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.ReplacePartitionColumnClause;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
@@ -4376,5 +4381,229 @@ public class IcebergMetadataTest extends TableTestBase {
         assertTrue(exception.getMessage().contains("Starting snapshot (exclusive)"));
         assertTrue(exception.getMessage().contains(String.valueOf(snap1.snapshotId())));
         assertTrue(exception.getMessage().contains(String.valueOf(snap3.snapshotId())));
+    }
+
+    @Test
+    public void testTimeTravelHonorsSnapshotSchema() {
+        // S1 committed under the original schema (k1, k2); then k2 is renamed; then S2 is
+        // committed under the new schema (k1, k2_renamed). A time-travel read of S1 must honor
+        // S1's schema (k2), not the latest table schema (k2_renamed). See POST-1557.
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+        int s1SchemaId = mockedNativeTableB.currentSnapshot().schemaId();
+
+        mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
+        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+
+        // The current (latest) schema carries the renamed column.
+        Assertions.assertNotEquals(s1SchemaId, mockedNativeTableB.schema().schemaId());
+        Assertions.assertNotNull(mockedNativeTableB.schema().findField("k2_renamed"));
+        Assertions.assertNull(mockedNativeTableB.schema().findField("k2"));
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
+                mockedNativeTableB, Maps.newHashMap());
+        Assertions.assertNotNull(icebergTable.getColumn("k2_renamed"));
+        Assertions.assertNull(icebergTable.getColumn("k2"));
+
+        // getSnapshotSchema resolves the schema bound to the targeted snapshot.
+        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1);
+        Assertions.assertNotNull(snapshotSchema);
+        Assertions.assertEquals(s1SchemaId, snapshotSchema.schemaId());
+        Assertions.assertNotNull(snapshotSchema.findField("k2"));
+        Assertions.assertNull(snapshotSchema.findField("k2_renamed"));
+
+        // Rebinding the table to the snapshot schema must flip both the StarRocks-side full
+        // schema (column resolution / result-set metadata) and the schema fed to the BE.
+        icebergTable = icebergTable.withReadSchema(snapshotSchema);
+        Assertions.assertNotNull(icebergTable.getColumn("k2"));
+        Assertions.assertNull(icebergTable.getColumn("k2_renamed"));
+        Assertions.assertNotNull(icebergTable.getReadSchema().findField("k2"));
+        Assertions.assertNull(icebergTable.getReadSchema().findField("k2_renamed"));
+
+        // The table is partitioned by identity(k2): partition columns must resolve through the
+        // snapshot schema (old name) instead of going null on the renamed current name.
+        List<Column> partitionColumns = icebergTable.getPartitionColumns();
+        Assertions.assertEquals(1, partitionColumns.size());
+        Assertions.assertNotNull(partitionColumns.get(0));
+        Assertions.assertEquals("k2", partitionColumns.get(0).getName());
+
+        // The BE descriptor must also build its partition info from the snapshot schema:
+        // expressions and source column names reference the old name, matching fullSchema.
+        TTableDescriptor tableDescriptor = icebergTable.toThrift(Lists.newArrayList());
+        TIcebergTable tIcebergTable = tableDescriptor.getIcebergTable();
+        Assertions.assertEquals("k2", tIcebergTable.getPartition_info().get(0).getSource_column_name());
+        Assertions.assertEquals("k2", tIcebergTable.getIceberg_schema().getFields().get(1).getName());
+
+        // Scan planning converts predicates against the snapshot schema, so filtering on the
+        // old column name must plan files of the targeted snapshot instead of failing.
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
+        List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(s1)))
+                        .setPredicate(predicate).setFieldNames(Lists.newArrayList()).setLimit(10).build());
+        Assertions.assertEquals(3, res.stream()
+                .map(f -> (IcebergRemoteFileInfo) f)
+                .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+    }
+
+    @Test
+    public void testTimeTravelSnapshotBeforePartitionEvolution() {
+        // S1 committed when the table was partitioned only by k2. Later a new column `k3` is
+        // added and the partition spec evolves to also partition by k3. Time travel to S1 must
+        // still be readable: the partition column added after S1 is dropped from the snapshot's
+        // partitioning rather than rejecting the query or failing to resolve column `k3`.
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+
+        mockedNativeTableB.updateSchema().addColumn("k3", Types.IntegerType.get()).commit();
+        mockedNativeTableB.updateSpec().addField("k3").commit();
+        mockedNativeTableB.refresh();
+
+        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1);
+        Assertions.assertNotNull(snapshotSchema);
+        Assertions.assertNull(snapshotSchema.findField("k3"));
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
+                mockedNativeTableB, Maps.newHashMap());
+        // Latest table is partitioned by both k2 and k3.
+        Assertions.assertEquals(List.of("k2", "k3"), icebergTable.getPartitionColumnNames());
+
+        // Binding the snapshot schema must not throw, and must drop the k3 partition column.
+        IcebergTable snapshotTable = icebergTable.withReadSchema(snapshotSchema);
+        Assertions.assertEquals(List.of("k2"), snapshotTable.getPartitionColumnNames());
+        Assertions.assertTrue(snapshotTable.getPartitionColumns().stream().allMatch(java.util.Objects::nonNull));
+
+        // The BE descriptor must build without referencing the evolved partition column.
+        TTableDescriptor tableDescriptor = snapshotTable.toThrift(Lists.newArrayList());
+        TIcebergTable tIcebergTable = tableDescriptor.getIcebergTable();
+        Assertions.assertEquals(1, tIcebergTable.getPartition_info().size());
+        Assertions.assertEquals("k2", tIcebergTable.getPartition_info().get(0).getSource_column_name());
+        Assertions.assertNull(tIcebergTable.getIceberg_schema().getFields().stream()
+                .filter(f -> f.getName().equals("k3")).findAny().orElse(null));
+
+        // A scan of the pre-evolution snapshot plans its files (which use the old spec).
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        List<RemoteFileInfo> res = metadata.getRemoteFiles(snapshotTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(s1)))
+                        .setFieldNames(Lists.newArrayList()).setLimit(10).build());
+        Assertions.assertEquals(3, res.stream()
+                .map(f -> (IcebergRemoteFileInfo) f)
+                .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+    }
+
+    @Test
+    public void testTimeTravelSnapshotSchemaThroughAnalyzer() throws Exception {
+        // End-to-end through QueryAnalyzer: SELECT * VERSION AS OF <old snapshot> must expose the
+        // old column name, and the analyzer must pin the resolved version range on the relation
+        // so the transformer does not resolve the query period a second time.
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        String createCatalog = "CREATE EXTERNAL CATALOG iceberg_tt_catalog PROPERTIES(\"type\"=\"iceberg\", " +
+                "\"iceberg.catalog.hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"iceberg.catalog.type\"=\"hive\")";
+        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withCatalog(createCatalog);
+
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+        // TestTables snapshot ids are small integers whose SQL literals don't parse as BIGINT,
+        // so target the snapshot through a tag (the VARCHAR version path).
+        mockedNativeTableB.manageSnapshots().createTag("tag_s1", s1).commit();
+        mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
+        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+
+        new MockUp<IcebergMetadata>() {
+            @Mock
+            public Database getDb(ConnectContext context, String dbName) {
+                return new Database(1, "db");
+            }
+        };
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
+                return mockedNativeTableB;
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tableName) {
+                return true;
+            }
+        };
+
+        String sql = "SELECT * FROM iceberg_tt_catalog.db.tb VERSION AS OF 'tag_s1'";
+        QueryStatement stmt = (QueryStatement) AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertEquals(List.of("k1", "k2"), stmt.getQueryRelation().getColumnOutputNames());
+
+        TableRelation tableRelation =
+                (TableRelation) ((SelectRelation) stmt.getQueryRelation()).getRelation();
+        Assertions.assertNotNull(tableRelation.getTvrVersionRange());
+        Assertions.assertEquals(Optional.of(s1), tableRelation.getTvrVersionRange().end());
+
+        // The latest schema keeps working without a query period.
+        QueryStatement latestStmt =
+                (QueryStatement) AnalyzeTestUtil.analyzeSuccess("SELECT * FROM iceberg_tt_catalog.db.tb");
+        Assertions.assertEquals(List.of("k1", "k2_renamed"), latestStmt.getQueryRelation().getColumnOutputNames());
+    }
+
+    @Test
+    public void testTimeTravelSnapshotSchemaThroughExternalTablePreparse() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        String createCatalog = "CREATE EXTERNAL CATALOG iceberg_tt_catalog_preparse PROPERTIES(\"type\"=\"iceberg\", " +
+                "\"iceberg.catalog.hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"iceberg.catalog.type\"=\"hive\")";
+        new StarRocksAssert().withCatalog(createCatalog);
+
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+        mockedNativeTableB.manageSnapshots().createTag("tag_s1", s1).commit();
+        mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
+        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+
+        new MockUp<IcebergMetadata>() {
+            @Mock
+            public Database getDb(ConnectContext context, String dbName) {
+                return new Database(1, "db");
+            }
+        };
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
+                return mockedNativeTableB;
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tableName) {
+                return true;
+            }
+        };
+
+        StatementBase statement =
+                AnalyzeTestUtil.parseSql("SELECT * FROM iceberg_tt_catalog_preparse.db.tb VERSION AS OF 'tag_s1'");
+        QueryAnalyzer queryAnalyzer = new QueryAnalyzer(AnalyzeTestUtil.getConnectContext());
+        queryAnalyzer.analyzeExternalTablesOnly(statement);
+        queryAnalyzer.analyze(statement);
+
+        QueryStatement stmt = (QueryStatement) statement;
+        Assertions.assertEquals(List.of("k1", "k2"), stmt.getQueryRelation().getColumnOutputNames());
+
+        TableRelation tableRelation =
+                (TableRelation) ((SelectRelation) stmt.getQueryRelation()).getRelation();
+        Assertions.assertNotNull(tableRelation.getTvrVersionRange());
+        Assertions.assertEquals(Optional.of(s1), tableRelation.getTvrVersionRange().end());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4601,6 +4601,57 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testGetDeleteFilesBindsReadSchemaForTimeTravel() {
+        // The equality-delete rewrite path (getDeleteFiles) converts its predicate against getReadSchema(),
+        // so it must also pin that read schema on the scan context -- mirroring buildFileScanTaskIterator --
+        // otherwise useSnapshot falls back to the snapshot's per-snapshot schema and the pushed predicate /
+        // file specs bind against the wrong schema. Capture the context handed to getTableScan and assert the
+        // targeted snapshot schema is set on it.
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+        mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
+        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+
+        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1);
+        Assertions.assertNotNull(snapshotSchema);
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
+                mockedNativeTableB, Maps.newHashMap());
+        IcebergTable snapshotTable = icebergTable.withReadMetadata(snapshotSchema,
+                IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
+        Assertions.assertTrue(snapshotTable.isTimeTravelRead());
+
+        // Capture the read schema bound onto the scan context. Intercept setReadSchema directly (a regular
+        // instance method) rather than the inherited default getTableScan, which MockUp cannot fake:
+        // getDeleteFiles must call setReadSchema with the targeted snapshot schema (it never did before the fix).
+        Schema[] boundReadSchema = new Schema[1];
+        new MockUp<StarRocksIcebergTableScanContext>() {
+            @Mock
+            public void setReadSchema(Schema schema) {
+                boundReadSchema[0] = schema;
+            }
+        };
+
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
+        try {
+            metadata.getDeleteFiles(snapshotTable, s1, predicate, FileContent.EQUALITY_DELETES);
+        } catch (Exception ignore) {
+            // The mock table carries no equality deletes; we assert only the read-schema binding, which happens
+            // before the scan runs.
+        }
+
+        Assertions.assertSame(snapshotSchema, boundReadSchema[0],
+                "getDeleteFiles must bind the targeted snapshot schema on the scan context for time travel");
+    }
+
+    @Test
     public void testTimeTravelSnapshotSchemaThroughAnalyzer() throws Exception {
         // End-to-end through QueryAnalyzer: SELECT * VERSION AS OF <old snapshot> must expose the
         // old column name, and the analyzer must pin the resolved version range on the relation

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4418,7 +4418,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         // Rebinding the table to the snapshot schema must flip both the StarRocks-side full
         // schema (column resolution / result-set metadata) and the schema fed to the BE.
-        icebergTable = icebergTable.withReadSchema(snapshotSchema);
+        icebergTable = icebergTable.withReadMetadata(snapshotSchema,
+                IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
         Assertions.assertNotNull(icebergTable.getColumn("k2"));
         Assertions.assertNull(icebergTable.getColumn("k2_renamed"));
         Assertions.assertNotNull(icebergTable.getReadSchema().findField("k2"));
@@ -4507,8 +4508,9 @@ public class IcebergMetadataTest extends TableTestBase {
         // Latest table is partitioned by both k2 and k3.
         Assertions.assertEquals(List.of("k2", "k3"), icebergTable.getPartitionColumnNames());
 
-        // Binding the snapshot schema must not throw, and must drop the k3 partition column.
-        IcebergTable snapshotTable = icebergTable.withReadSchema(snapshotSchema);
+        // Binding the snapshot read metadata must not throw, and must drop the k3 partition column.
+        IcebergTable snapshotTable = icebergTable.withReadMetadata(snapshotSchema,
+                IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
         Assertions.assertEquals(List.of("k2"), snapshotTable.getPartitionColumnNames());
         Assertions.assertTrue(snapshotTable.getPartitionColumns().stream().allMatch(java.util.Objects::nonNull));
 
@@ -4530,6 +4532,37 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(3, res.stream()
                 .map(f -> (IcebergRemoteFileInfo) f)
                 .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+    }
+
+    @Test
+    public void testTimeTravelDropsPartitionFieldAddedOnPreexistingColumn() {
+        // S1 committed when the table was partitioned only by k2. Later the spec evolves to also
+        // partition by k1 -- a column that ALREADY existed at S1. Filtering the current spec by
+        // schema membership would wrongly keep k1 (its source column is in the snapshot schema), so
+        // the snapshot must be read with its own spec: at S1 only k2 is a partition column.
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+
+        mockedNativeTableB.updateSpec().addField("k1").commit();
+        mockedNativeTableB.refresh();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
+                mockedNativeTableB, Maps.newHashMap());
+        // Latest table is partitioned by both k2 and the newly added k1.
+        Assertions.assertTrue(icebergTable.getPartitionColumnNames().contains("k1"));
+
+        Schema snapshotSchema = IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1);
+        IcebergTable snapshotTable = icebergTable.withReadMetadata(snapshotSchema,
+                IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
+        // The k1 partition field was added after S1, so S1 is partitioned only by k2.
+        Assertions.assertEquals(List.of("k2"), snapshotTable.getPartitionColumnNames());
+        Assertions.assertFalse(snapshotTable.isUnPartitioned());
+        TTableDescriptor tableDescriptor = snapshotTable.toThrift(Lists.newArrayList());
+        Assertions.assertEquals(1, tableDescriptor.getIcebergTable().getPartition_info().size());
+        Assertions.assertEquals("k2",
+                tableDescriptor.getIcebergTable().getPartition_info().get(0).getSource_column_name());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4468,8 +4468,8 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
                 "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableC.schema(), mockedNativeTableC),
                 mockedNativeTableC, Maps.newHashMap());
-        // Ordinary read: no time-travel read schema, so getReadSchema() is the current schema (has k3).
-        Assertions.assertFalse(icebergTable.hasReadSchema());
+        // Ordinary read: no time-travel read view, so getReadSchema() is the current schema (has k3).
+        Assertions.assertFalse(icebergTable.isTimeTravelRead());
         Assertions.assertNotNull(icebergTable.getReadSchema().findField("k3"));
 
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -115,6 +115,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
@@ -4450,6 +4451,36 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(3, res.stream()
                 .map(f -> (IcebergRemoteFileInfo) f)
                 .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+    }
+
+    @Test
+    public void testCurrentReadHonorsSchemaAfterMetadataOnlyAddColumn() {
+        // ADD COLUMN is a metadata-only commit: it advances the schema without a new snapshot, so the
+        // current snapshot still references the pre-evolution schema (no k3). An ordinary current read
+        // must resolve the new column against the current table schema (backfilled NULL) instead of the
+        // stale snapshot schema, so a filter on k3 binds instead of failing with "Cannot find field".
+        mockedNativeTableC.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableC.updateSchema().addColumn("k3", Types.IntegerType.get()).commit();
+        mockedNativeTableC.refresh();
+        long currentSnapshotId = mockedNativeTableC.currentSnapshot().snapshotId();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableC.schema(), mockedNativeTableC),
+                mockedNativeTableC, Maps.newHashMap());
+        // Ordinary read: no time-travel read schema, so getReadSchema() is the current schema (has k3).
+        Assertions.assertFalse(icebergTable.hasReadSchema());
+        Assertions.assertNotNull(icebergTable.getReadSchema().findField("k3"));
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        ScalarOperator predicate = new IsNullPredicateOperator(false,
+                new ColumnRefOperator(3, INT, "k3", true));
+        List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(currentSnapshotId)))
+                        .setPredicate(predicate).setFieldNames(Lists.newArrayList("k1", "k3")).setLimit(10).build());
+        Assertions.assertEquals(1, res.size());
+        Assertions.assertEquals(3, ((IcebergRemoteFileInfo) res.get(0)).getFileScanTask().file().recordCount());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4566,6 +4566,41 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testTimeTravelForcesLocalPlanning() throws Exception {
+        // Time travel must plan locally even when the session requests distributed planning: the remote
+        // metadata scanner binds pushed-down predicates against the current specs, which fails for a
+        // column renamed after the snapshot. Local planning rebinds to the snapshot spec, so a predicate
+        // on the old column name plans the snapshot's files instead of routing to the remote scanner.
+        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert.getCtx().getSessionVariable().setPlanMode(PlanMode.DISTRIBUTED.modeName());
+
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        long s1 = mockedNativeTableB.currentSnapshot().snapshotId();
+        mockedNativeTableB.updateSchema().renameColumn("k2", "k2_renamed").commit();
+        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", IcebergApiConverter.toFullSchemas(mockedNativeTableB.schema(), mockedNativeTableB),
+                mockedNativeTableB, Maps.newHashMap());
+        icebergTable = icebergTable.withReadMetadata(IcebergMetadata.getSnapshotSchema(mockedNativeTableB, s1),
+                IcebergMetadata.getSnapshotSpecs(mockedNativeTableB, s1));
+
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
+        List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(s1)))
+                        .setPredicate(predicate).setFieldNames(Lists.newArrayList()).setLimit(10).build());
+        Assertions.assertEquals(3, res.stream()
+                .map(f -> (IcebergRemoteFileInfo) f)
+                .map(fileInfo -> fileInfo.getFileScanTask().file().recordCount()).reduce(0L, Long::sum), 0.001);
+    }
+
+    @Test
     public void testTimeTravelSnapshotSchemaThroughAnalyzer() throws Exception {
         // End-to-end through QueryAnalyzer: SELECT * VERSION AS OF <old snapshot> must expose the
         // old column name, and the analyzer must pin the resolved version range on the relation

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -1766,6 +1766,9 @@ public class IcebergScanNodeTest {
             table.getCatalogTableName(); result = "test_tbl"; minTimes = 0;
             table.getNativeTable(); result = nativeTable; minTimes = 0;
             nativeTable.schema(); result = nativeSchema; minTimes = 0;
+            // setupScanRangeLocations filters required column names against the read schema (the
+            // targeted snapshot's schema for time travel, the current schema otherwise).
+            table.getReadSchema(); result = nativeSchema; minTimes = 0;
             globalStateMgr.getMetadataMgr(); result = metadataMgr; minTimes = 0;
             metadataMgr.getRemoteFiles((com.starrocks.catalog.Table) any, (GetRemoteFilesParams) any);
             result = new mockit.Delegate() {

--- a/test/sql/test_iceberg/R/test_timetravel_snapshot_schema.sql
+++ b/test/sql/test_iceberg/R/test_timetravel_snapshot_schema.sql
@@ -121,6 +121,31 @@ select p from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0}
 -- result:
 E: (1064, "Getting analyzing error. Detail message: Column 'p' cannot be resolved.")
 -- !result
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} (id int, c int)", False, 5, 1000)
+-- result:
+{'status': True, 'result': '', 'msg': b''}
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} values (1, 100), (2, 200);
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} add column extra int;
+-- result:
+-- !result
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0};
+-- result:
+-- !result
+select id, extra from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} order by id;
+-- result:
+1	None
+2	None
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} where extra is null;
+-- result:
+2
+-- !result
+select id from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} where extra = 1 order by id;
+-- result:
+-- !result
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
 -- result:
 -- !result
@@ -128,6 +153,9 @@ drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} f
 -- result:
 -- !result
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} force;
+-- result:
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} force;
 -- result:
 -- !result
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};

--- a/test/sql/test_iceberg/R/test_timetravel_snapshot_schema.sql
+++ b/test/sql/test_iceberg/R/test_timetravel_snapshot_schema.sql
@@ -1,0 +1,143 @@
+-- name: test_timetravel_snapshot_schema @sequential @no_arrow_flight_sql
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}", "enable_iceberg_metadata_cache"="false");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_tt_schema_${uuid0}/iceberg_db/${uuid0}"
+);
+-- result:
+-- !result
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (id int, c int)", False, 5, 1000)
+-- result:
+{'status': True, 'result': '', 'msg': b''}
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (1, 100);
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create tag tag_before_rename;
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create branch branch_before_rename;
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} rename column c to c_renamed;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (2, 200);
+-- result:
+-- !result
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+-- !result
+select id, c_renamed from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by id;
+-- result:
+1	100
+2	200
+-- !result
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by id;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'c' cannot be resolved.")
+-- !result
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "tag_before_rename" order by id;
+-- result:
+1	100
+-- !result
+select id, c_renamed from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "tag_before_rename" order by id;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'c_renamed' cannot be resolved.")
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "tag_before_rename" where c = 100;
+-- result:
+1	100
+-- !result
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "branch_before_rename" where c >= 100 order by id;
+-- result:
+1	100
+-- !result
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} (id int, c int) partition by c", False, 5, 1000)
+-- result:
+{'status': True, 'result': '', 'msg': b''}
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} values (1, 100);
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} create tag tag_part_before_rename;
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} rename column c to c_renamed;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} values (2, 200);
+-- result:
+-- !result
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0};
+-- result:
+-- !result
+select id, c_renamed from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} order by id;
+-- result:
+1	100
+2	200
+-- !result
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} version as of "tag_part_before_rename" order by id;
+-- result:
+1	100
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} version as of "tag_part_before_rename" where c = 100;
+-- result:
+1	100
+-- !result
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} (id int, c int) partition by c", False, 5, 1000)
+-- result:
+{'status': True, 'result': '', 'msg': b''}
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} values (1, 100);
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} create tag tag_evo_before;
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} add column p int;
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} add partition column p;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} values (2, 200, 20);
+-- result:
+-- !result
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0};
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} order by id;
+-- result:
+1	100	None
+2	200	20
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} version as of "tag_evo_before" order by id;
+-- result:
+1	100
+-- !result
+select p from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} version as of "tag_evo_before" order by id;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'p' cannot be resolved.")
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} force;
+-- result:
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_tt_schema_${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_timetravel_snapshot_schema.sql
+++ b/test/sql/test_iceberg/T/test_timetravel_snapshot_schema.sql
@@ -4,6 +4,8 @@
 --      snapshot schema: the old column name resolves, the renamed name does not exist yet.
 --   2. Predicates on the snapshot-schema column name are planned and evaluated correctly.
 --   3. The same holds for a partitioned table whose partition source column was renamed.
+--   4. An ordinary current read after a metadata-only ADD COLUMN (no new snapshot) resolves the
+--      new column against the current schema, including predicates on it.
 -- Method: rename a column between two snapshots anchored by a tag and a branch; assert
 --         column resolution (positive and negative) and row results for time-travel reads
 --         vs latest-schema reads, with and without predicates.
@@ -75,9 +77,25 @@ select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0}
 -- the column added after the snapshot does not exist in the snapshot schema
 select p from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} version as of "tag_evo_before" order by id;
 
+-- 4) ordinary current read after a metadata-only ADD COLUMN (no new snapshot yet): the current
+-- snapshot still references the pre-evolution schema, but a normal read must resolve the new column
+-- against the current table schema (backfilled NULL), including predicates on it.
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} (id int, c int)", False, 5, 1000)
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} values (1, 100), (2, 200);
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} add column extra int;
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0};
+
+-- projection of the newly added column: old rows backfill NULL
+select id, extra from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} order by id;
+-- predicate on the newly added column must bind against the current schema (was "Cannot find field")
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} where extra is null;
+select id from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} where extra = 1 order by id;
+
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} force;
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} force;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_add_tbl_${uuid0} force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 drop catalog iceberg_sql_test_${uuid0};
 

--- a/test/sql/test_iceberg/T/test_timetravel_snapshot_schema.sql
+++ b/test/sql/test_iceberg/T/test_timetravel_snapshot_schema.sql
@@ -1,0 +1,84 @@
+-- name: test_timetravel_snapshot_schema @sequential @no_arrow_flight_sql
+-- Test Point:
+--   1. VERSION AS OF a tag/branch created before a column rename resolves columns by the
+--      snapshot schema: the old column name resolves, the renamed name does not exist yet.
+--   2. Predicates on the snapshot-schema column name are planned and evaluated correctly.
+--   3. The same holds for a partitioned table whose partition source column was renamed.
+-- Method: rename a column between two snapshots anchored by a tag and a branch; assert
+--         column resolution (positive and negative) and row results for time-travel reads
+--         vs latest-schema reads, with and without predicates.
+-- Scope: Iceberg time travel per-snapshot schema (analyzer read schema / BE descriptor / scan planning)
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}", "enable_iceberg_metadata_cache"="false");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_tt_schema_${uuid0}/iceberg_db/${uuid0}"
+);
+
+-- 1) unpartitioned table: rename column between snapshots
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (id int, c int)", False, 5, 1000)
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (1, 100);
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create tag tag_before_rename;
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create branch branch_before_rename;
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} rename column c to c_renamed;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (2, 200);
+
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+
+-- latest read uses the renamed column
+select id, c_renamed from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by id;
+-- the old name no longer exists in the latest schema
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by id;
+
+-- time travel to the tag resolves the snapshot schema: old name works
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "tag_before_rename" order by id;
+-- the renamed name does not exist in the snapshot schema
+select id, c_renamed from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "tag_before_rename" order by id;
+-- predicate on the snapshot-schema column name
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "tag_before_rename" where c = 100;
+-- branch reference behaves the same as the tag
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "branch_before_rename" where c >= 100 order by id;
+
+-- 2) partitioned table: partition source column renamed between snapshots
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} (id int, c int) partition by c", False, 5, 1000)
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} values (1, 100);
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} create tag tag_part_before_rename;
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} rename column c to c_renamed;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} values (2, 200);
+
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0};
+
+select id, c_renamed from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} order by id;
+-- time travel on the partitioned table resolves the snapshot schema and plans the scan
+select id, c from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} version as of "tag_part_before_rename" order by id;
+-- predicate on the renamed partition source column under time travel
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} version as of "tag_part_before_rename" where c = 100;
+
+-- 3) partition evolution: a partition column is added after the targeted snapshot
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} (id int, c int) partition by c", False, 5, 1000)
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} values (1, 100);
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} create tag tag_evo_before;
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} add column p int;
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} add partition column p;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} values (2, 200, 20);
+
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0};
+
+-- latest schema has the added partition column p
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} order by id;
+-- time travel to before the partition evolution must stay readable: the snapshot schema has
+-- no column p, so its partitioning is dropped and the pre-evolution rows are returned
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} version as of "tag_evo_before" order by id;
+-- the column added after the snapshot does not exist in the snapshot schema
+select p from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} version as of "tag_evo_before" order by id;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_part_tbl_${uuid0} force;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_evo_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_tt_schema_${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

Iceberg time travel queries (`VERSION AS OF` / `TIMESTAMP AS OF`, tag/branch) resolved the target snapshot only to select data files, while column resolution, the result-set metadata, the descriptor sent to BE, scan planning, and the partition view all used the **latest** table schema/spec. After a schema or partition-spec change the time-travel read diverged from the targeted snapshot:

```sql
CREATE TABLE t (id INT, c INT);            -- snapshot S1 committed with schema (id, c)
ALTER TABLE t RENAME COLUMN c TO c_renamed;
INSERT INTO t VALUES (...);                -- snapshot S2 with schema (id, c_renamed)

SELECT * FROM t VERSION AS OF <S1>;        -- returned column `c_renamed` instead of `c`
SELECT * FROM t VERSION AS OF <S1> WHERE c = 1;  -- failed: `c` could not be resolved
```

The same divergence affected partitioning: a partition field added by later spec evolution was advertised for a snapshot whose files were written under the previous spec. This is contrary to Iceberg semantics — the snapshot's `schema-id` is defined by the spec as "ID of the table's current schema when the snapshot was created", and a snapshot is planned with the specs attached to its manifests (matching `SnapshotUtil.schemaFor` / `DataScan#useSnapshotSchema` and other engines).

## What I'm doing:

Resolve the query period once during analysis and bind the targeted snapshot's metadata — schema and partition specs — through the whole read path:

- `QueryAnalyzer`: after table resolution, resolve the query period to a version range (via the new `QueryPeriodResolver`, extracted from `RelationTransformer` so both layers share one implementation), pin the resolved range on the `TableRelation` so the transformer does not resolve it again, and — whenever time travel resolves a snapshot — replace the table with an immutable per-query copy created by `IcebergTable#withReadMetadata`. It is bound whenever a snapshot is resolved, not only when the schema id changes, because partition evolution can change the spec while leaving the schema id unchanged.
- `IcebergTable`: `withReadMetadata` pins a `SnapshotReadView` (the snapshot schema plus the partition specs its manifests reference, via `IcebergMetadata#getSnapshotSpecs`) and rebuilds the StarRocks-side full schema from it. `getReadSchema()` / `getReadSpec()` feed column/partition resolution and `toThrift` (columns, `iceberg_schema`, partition info) so FE and BE see one consistent view: a single snapshot spec is used directly, multiple specs collapse to unpartitioned so table-level partition-metadata optimizations are disabled (scan planning still uses each file's own spec), and partition fields added after the snapshot are not advertised.
- `IcebergMetadata`: convert pushdown predicates against the read schema, matching the schema the scan binds expressions against. `IcebergScanNode#setupScanRangeLocations` filters required column names against the read schema so snapshot-only names are not dropped.
- `StarRocksIcebergTableScan`: the scan schema is the read schema; rebind specs to it (`scanSpecsById`) for the residual/partition/metrics evaluators, `DeleteFileIndex`, `ManifestGroup`, and manifest filtering, so filter expressions bind consistently, and carry the read schema into remote metadata planning (`MetadataParser`) too. A spec that cannot be rebound degrades to no pruning with the full filter kept as residual. Time-travel reads force local planning as a temporary workaround, since the remote metadata scanner binds predicates against the current specs (removed once it honors the snapshot schema/specs).

Fixing this the same way — resolving a read against the schema the query targets rather than the latest schema — also fixes StarRocksTest#11432: a metadata-only `ALTER TABLE ... ADD COLUMN` advances the current schema without producing a snapshot, and an ordinary current read now resolves the newly added column against the current schema instead of failing with `Cannot find field` until the next write.

Verification:
- New UTs cover schema rebinding, the analyzer path (including the pre-resolved external-table path), the BE descriptor, scan planning with predicates on renamed columns, partition-evolution snapshots (fields added on new and preexisting columns), forced local planning for time travel, and the metadata-only `ADD COLUMN` current read.
- New SQL tests (`test_timetravel_snapshot_schema`) cover tag/branch reads, old/new column-name resolution, predicates on renamed columns, a partitioned table whose partition source column was renamed, partition evolution, and reading a column added after the current snapshot.
- Verified end to end on a real Hive-catalog Iceberg cluster.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
