### PR TITLE
[Tool] AI CI: bugfix-version-index workflow + module-risk PR-comment job

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -224,13 +224,24 @@ jobs:
   # `context-base` MCP with `code_kb` USAGE (read). gh is absent in the container → the skill uses
   # the GitHub REST API (GITHUB_TOKEN injected). --comment applies a strict confidence gate and emits
   # either a sticky-marked briefing or the sentinel "MODULE-RISK: none" (then we post nothing).
+  #
+  # SECURITY (pull_request_target): this job injects secrets (GITHUB_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)
+  # into `claude --dangerously-skip-permissions`, which reads attacker-influenceable PR body/diff and
+  # whose output is posted back to the PR. An untrusted author could prompt-inject the model to run
+  # bash / emit secrets (e.g. after the marker) and have them published. So it is GATED to TRUSTED
+  # authors only (author_association OWNER/MEMBER/COLLABORATOR = write access); external / first-time
+  # contributors never reach the model. (assign-reviewer tolerates all authors because its host step
+  # extracts only login-shaped tokens — a strict whitelist; module-risk's output is free-form, so it
+  # needs the author gate. The marker-bounded extraction below is defense-in-depth, not the control.)
+  # For an external PR a maintainer can still run /github-pr-module-risk:review manually.
   module-risk:
     runs-on: [self-hosted, normal]
     continue-on-error: true
     if: >
       (github.event.action == 'opened' || github.event.action == 'reopened') &&
       !startsWith(github.head_ref, 'mergify/') &&
-      !contains(github.head_ref, '-sync-pr-')
+      !contains(github.head_ref, '-sync-pr-') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -215,3 +215,68 @@ jobs:
             --token "$SLACK_BOT_TOKEN" \
             --channel "$CHANNEL_ID" \
             --text "$text"
+
+  # Module-risk briefing: a read-only, history-backed review focus for the PR's changed modules,
+  # mined from merged-bugfix pathology cards in code_kb, posted as a sticky PR comment. Sibling to
+  # assign-reviewer (same PR-open trigger / container / mergify+sync exclusion). Read-only: it never
+  # writes code_kb, so per-PR concurrency (cancel-in-progress) is fine — no origin-write race here.
+  # PREREQUISITES (container, one-time): the `github-pr-module-risk` plugin installed + the
+  # `context-base` MCP with `code_kb` USAGE (read). gh is absent in the container → the skill uses
+  # the GitHub REST API (GITHUB_TOKEN injected). --comment applies a strict confidence gate and emits
+  # either a sticky-marked briefing or the sentinel "MODULE-RISK: none" (then we post nothing).
+  module-risk:
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    if: >
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      !startsWith(github.head_ref, 'mergify/') &&
+      !contains(github.head_ref, '-sync-pr-')
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Module-risk briefing (AI, read-only)
+        run: |
+          # Namespaced plugin command (a bare /review would NOT resolve in headless -p — it would be
+          # treated as prompt text and silently no-op). tee captures stdout for the upsert step.
+          docker exec -i -u claudeuser \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+            claude-cli claude --dangerously-skip-permissions \
+            -p "/github-pr-module-risk:review ${PR_URL} --comment" 2>&1 | tee "${RUNNER_TEMP}/module_risk.txt" || true
+
+      - name: Upsert sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          out="${RUNNER_TEMP}/module_risk.txt"
+          marker="<!-- module-risk-briefing -->"
+          [ -f "$out" ] || { echo "no skill output, skip"; exit 0; }
+          # The skill emits the briefing starting at the marker line, or "MODULE-RISK: none" (no
+          # marker) when nothing clears the confidence gate. Take from the marker to EOF as the body;
+          # empty (no marker / sentinel / error) => post nothing. sed from the marker also strips any
+          # claude preamble before it.
+          body="$(sed -n "/$marker/,\$p" "$out" 2>/dev/null || true)"
+          if [ -z "$body" ]; then
+            echo "no high-confidence, diff-aligned module risk — not commenting"
+            exit 0
+          fi
+          printf '%s\n' "$body" > "${RUNNER_TEMP}/mr_body.md"
+          # Sticky: edit our existing marked comment if present, else create one. Idempotent across
+          # reopen / workflow rerun (the marker identifies our comment; gh is host-side, not in the
+          # container). PATCH body is JSON-built with jq so markdown is escaped correctly.
+          existing="$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+                        --jq ".[] | select(.body | contains(\"$marker\")) | .id" 2>/dev/null | head -1 || true)"
+          if [ -n "$existing" ]; then
+            jq -n --rawfile b "${RUNNER_TEMP}/mr_body.md" '{body:$b}' \
+              | gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input - >/dev/null \
+              && echo "updated sticky comment $existing" \
+              || echo "WARN: patch comment $existing failed (permissions or transient API error)"
+          else
+            gh pr comment "$PR" -R "$REPO" --body-file "${RUNNER_TEMP}/mr_body.md" \
+              && echo "created sticky comment" \
+              || echo "WARN: create comment failed (permissions or transient API error)"
+          fi

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -31,8 +31,11 @@ on:
   pull_request_target:
     branches:
       - main
-      - 'branch-[0-9].[0-9]'
-      - 'branch-[0-9].[0-9].[0-9]'
+      # release lines. Use [0-9]+ (one-or-more), NOT bare [0-9] (single digit) — else multi-digit
+      # versions like branch-3.12, branch-3.5.20, branch-3.12.20 silently never match the filter
+      # and their backport merges never trigger this workflow. (Mirrors the push-tag pattern below.)
+      - 'branch-[0-9]+.[0-9]+'
+      - 'branch-[0-9]+.[0-9]+.[0-9]+'
     types:
       - closed
   push:

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -1,0 +1,129 @@
+name: Bugfix Version Index
+run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.number || github.ref_name }}
+
+# Maintains the deterministic code_kb.versions index (fix side) + the heuristic
+# code_kb.task_summaries cause cache, via the github-bugfix-versions skill running in
+# the claude-cli container (same runner/container pattern as ai-sr-skills.yml). Three events:
+#
+#   ① origin bugfix PR merges to main      → /index-fix (seed versions) + /affected-versions (cache cause)
+#   ② a backport PR merges to branch-X.Y*  → /index-fix (rebuild the origin's versions record)
+#   ③ a release tag X.Y.Z is pushed        → /index-fix <tag> (resolve pending-<line> → concrete tag)
+#
+# The skill computes everything (gh PR/backport data, git tag --contains / blame, the rung
+# firewall) and writes via the context-base MCP. RC stores/serves only; CI never POSTs to RC.
+# See: plugins/github-bugfix-versions (cd-claude-marketplace) and the version-index design doc.
+#
+# PREREQUISITES on the self-hosted runner's claude-cli container (one-time, infra):
+#   - the `github-bugfix-versions` plugin installed (provides /index-fix, /affected-versions);
+#   - the `context-base` MCP configured with `code_kb` USAGE (read+write data) for the
+#     container's identity — USAGE alone is enough to context_upsert (no ALTER needed);
+#   - the `code_kb.versions` and `code_kb.task_summaries` collections pre-created by an admin
+#     (CREATE CONTEXT COLLECTION ...; the emitter cannot create shared-base collections).
+# gh is NOT installed in the container, but GITHUB_TOKEN is passed in — the skill uses the
+# GitHub REST/compare API for PR/backport/tag-contains when no local clone is present.
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - 'branch-[0-9].[0-9]'
+      - 'branch-[0-9].[0-9].[0-9]'
+    types:
+      - closed
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+concurrency:
+  # Per origin PR / backport PR / tag. Do NOT cancel in progress: each emit rebuilds from the
+  # GitHub source of truth and is idempotent, but a half-finished run is wasted, not harmful.
+  group: BUGFIX-VERSION-INDEX-${{ github.event.number || github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # ① origin bugfix PR merged to main → seed versions (fix side) + cache cause (task_summaries).
+  # Gated to [BugFix]-titled PRs (StarRocks convention) to avoid an LLM cause analysis on every
+  # merge; broaden the title/label gate if your bugfixes are titled differently.
+  origin-merge:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.base_ref == 'main' &&
+      contains(github.event.pull_request.title, '[BugFix]') &&
+      !startsWith(github.head_ref, 'mergify/') &&
+      !contains(github.head_ref, '-sync-pr-')
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: index-fix (deterministic fix side → code_kb.versions)
+        run: |
+          echo "origin-merge PR #${{ github.event.number }} → ${PR_URL}"
+          docker exec -i -u claudeuser \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+            claude-cli claude --dangerously-skip-permissions \
+            -p "/index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+
+      - name: affected-versions (heuristic cause → code_kb.task_summaries)
+        run: |
+          # Cause is stable at origin-merge (blame over immutable pre-fix history); cache it now
+          # so the pre-release report is a fast bulk query, not dozens of live analyses. The
+          # firewall (version_emit_check / firewall_check) runs inside the skill before any write.
+          docker exec -i -u claudeuser \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+            claude-cli claude --dangerously-skip-permissions \
+            -p "/affected-versions ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/affected_versions.txt" || true
+
+  # ② a backport PR merged to a release branch → rebuild the origin's versions record (the
+  # backport_set + per-line earliest_fix_tag accrete as backports land). Idempotent rebuild.
+  backport-merge:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.base_ref, 'branch-') &&
+      contains(github.event.pull_request.title, 'backport')
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: index-fix (rebuild origin N from "(backport #N)")
+        run: |
+          echo "backport-merge PR #${{ github.event.number }} (${{ github.base_ref }}) → ${PR_URL}"
+          docker exec -i -u claudeuser \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+            claude-cli claude --dangerously-skip-permissions \
+            -p "/index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+
+  # ③ release tag cut → resolve pending-<line> records on that line to the concrete tag.
+  tag-cut:
+    if: github.event_name == 'push'
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - name: "index-fix (tag-cut → concrete tag for this line)"
+        run: |
+          echo "tag-cut ${TAG}"
+          docker exec -i -u claudeuser \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+            claude-cli claude --dangerously-skip-permissions \
+            -p "/index-fix ${TAG}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -5,16 +5,21 @@ run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.numbe
 # code_kb.task_summaries cause cache, via the github-bugfix-versions skill running in
 # the claude-cli container (same runner/container pattern as ai-sr-skills.yml). Three events:
 #
-#   ① origin bugfix PR merges to main      → /index-fix (seed versions) + /affected-versions (cache cause)
-#   ② a backport PR merges to branch-X.Y*  → /index-fix (rebuild the origin's versions record)
-#   ③ a release tag X.Y.Z is pushed        → /index-fix <tag> (resolve pending-<line> → concrete tag)
+#   ① origin bugfix PR merges to main      → /github-bugfix-versions:index-fix (seed versions) + :affected-versions (cache cause)
+#   ② a backport PR merges to branch-X.Y*  → /github-bugfix-versions:index-fix (rebuild the origin's versions record)
+#   ③ a release tag X.Y.Z is pushed        → /github-bugfix-versions:index-fix <tag> (resolve pending-<line> → concrete tag)
+#
+# NOTE: plugin commands MUST be namespaced (/github-bugfix-versions:<cmd>). A bare /index-fix
+# in headless `-p` does NOT resolve — it is silently treated as prompt text (no error, no write),
+# which combined with continue-on-error would look green while doing nothing.
 #
 # The skill computes everything (gh PR/backport data, git tag --contains / blame, the rung
 # firewall) and writes via the context-base MCP. RC stores/serves only; CI never POSTs to RC.
 # See: plugins/github-bugfix-versions (cd-claude-marketplace) and the version-index design doc.
 #
 # PREREQUISITES on the self-hosted runner's claude-cli container (one-time, infra):
-#   - the `github-bugfix-versions` plugin installed (provides /index-fix, /affected-versions);
+#   - the `github-bugfix-versions` plugin installed (provides :index-fix, :affected-versions,
+#     :release-report — invoked namespaced as /github-bugfix-versions:<cmd>, see NOTE above);
 #   - the `context-base` MCP configured with `code_kb` USAGE (read+write data) for the
 #     container's identity — USAGE alone is enough to context_upsert (no ALTER needed);
 #   - the `code_kb.versions` and `code_kb.task_summaries` collections pre-created by an admin
@@ -71,7 +76,7 @@ jobs:
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
-            -p "/index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+            -p "/github-bugfix-versions:index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
 
       - name: affected-versions (heuristic cause → code_kb.task_summaries)
         run: |
@@ -82,7 +87,7 @@ jobs:
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
-            -p "/affected-versions ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/affected_versions.txt" || true
+            -p "/github-bugfix-versions:affected-versions ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/affected_versions.txt" || true
 
   # ② a backport PR merged to a release branch → rebuild the origin's versions record (the
   # backport_set + per-line earliest_fix_tag accrete as backports land). Idempotent rebuild.
@@ -107,7 +112,7 @@ jobs:
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
-            -p "/index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+            -p "/github-bugfix-versions:index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
 
   # ③ release tag cut → resolve pending-<line> records on that line to the concrete tag.
   tag-cut:
@@ -126,4 +131,4 @@ jobs:
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
-            -p "/index-fix ${TAG}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+            -p "/github-bugfix-versions:index-fix ${TAG}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -94,13 +94,18 @@ jobs:
 
   # ② a backport PR merged to a release branch → rebuild the origin's versions record (the
   # backport_set + per-line earliest_fix_tag accrete as backports land). Idempotent rebuild.
+  # Exclude branch-sync PRs (head like `branch-4.1-sync-pr-74722` → branch-4.1): a sync of a
+  # backport carries 'backport' in its title but is NOT a real (backport #N) landing — it would
+  # misattribute the origin. Do NOT exclude `mergify/` here (unlike origin-merge): mergify IS the
+  # backport mechanism (head `mergify/bp/branch-X.Y/pr-N`) — excluding it would drop real backports.
   backport-merge:
     if: >
       github.event_name == 'pull_request_target' &&
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       startsWith(github.base_ref, 'branch-') &&
-      contains(github.event.pull_request.title, 'backport')
+      contains(github.event.pull_request.title, 'backport') &&
+      !contains(github.head_ref, '-sync-pr-')
     runs-on: [self-hosted, normal]
     continue-on-error: true
     env:

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -166,12 +166,13 @@ jobs:
             -p "/github-bugfix-versions:index-fix ${{ github.repository }}#${{ matrix.origin }}" 2>&1 | tee "${RUNNER_TEMP}/index_fix_${{ matrix.origin }}.txt" || true
 
   # ③ release tag cut → resolve pending-<line> records on that line to the concrete tag.
-  # RESIDUAL (accepted): a tag-cut run touches MANY origins (every record pending on the line), so
-  # it cannot share the per-origin groups above — it can still race a concurrent backport-write of
-  # one of those origins. Severity is bounded: `pending-<line>` already counts as "fixed (tag TBD)"
-  # in the gap query, so a delayed/lost resolution under-states the concrete tag, not the fix's
-  # existence; and a clobber self-heals on that origin's next event. Tags are infrequent. A fully
-  # race-free version would fan tag-cut out per pending origin (a code_kb query → matrix) — deferred.
+  # A tag-cut touches MANY origins (every record pending on the line), so it can't share the
+  # per-origin groups above and CAN start concurrently with a same-origin backport-write. The
+  # pending->concrete clobber that would cause (a late backport-write reverting this resolution) is
+  # prevented at the WRITE layer, not here: /index-fix's monotonic guard refuses to overwrite a
+  # stored concrete earliest_fix_tag with pending-* (github-bugfix-versions plugin). So a per-origin
+  # group for tag-cut is not needed for correctness; a full fan-out (per pending origin, reusing
+  # BVI-...-origin-<N>) remains an option if stricter serialization is ever wanted.
   tag-cut:
     if: github.event_name == 'push'
     concurrency:

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -42,11 +42,14 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
-concurrency:
-  # Per origin PR / backport PR / tag. Do NOT cancel in progress: each emit rebuilds from the
-  # GitHub source of truth and is idempotent, but a half-finished run is wasted, not harmful.
-  group: BUGFIX-VERSION-INDEX-${{ github.event.number || github.ref_name }}
-  cancel-in-progress: false
+# Concurrency is per-ORIGIN, set at the JOB level (not here) — see each job's `concurrency:`.
+# A workflow-level group keyed on the triggering event (PR #/tag) would be WRONG: the entity
+# written is the *origin* PR's cumulative record (version/<repo>/<origin>), and two backports of
+# the same origin merging on different release branches fire as different events → different
+# groups → concurrent runs. The earlier run can read the backport set before the later backport
+# merged, then write AFTER the later run, clobbering the just-accreted backport_set/earliest_fix_tag
+# (lost update). With continue-on-error that loss is silent. Grouping by origin serializes all
+# writers of the same record; rebuild-from-source makes a superseded pending run harmless.
 
 permissions:
   contents: read
@@ -65,6 +68,11 @@ jobs:
       contains(github.event.pull_request.title, '[BugFix]') &&
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-')
+    # Serialize on the origin = this PR's own number (it writes version/<repo>/<number> +
+    # task/pr/<repo>/<number>). Shares the group with any backport-write of the same origin.
+    concurrency:
+      group: BVI-${{ github.repository }}-origin-${{ github.event.number }}
+      cancel-in-progress: false
     runs-on: [self-hosted, normal]
     continue-on-error: true
     env:
@@ -92,13 +100,17 @@ jobs:
             claude-cli claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:affected-versions ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/affected_versions.txt" || true
 
-  # ② a backport PR merged to a release branch → rebuild the origin's versions record (the
-  # backport_set + per-line earliest_fix_tag accrete as backports land). Idempotent rebuild.
+  # ② a backport PR merged to a release branch → rebuild EACH origin it backports. A title can
+  # bundle several origins ((backport #a)(backport #b)...), so one event may touch multiple
+  # version/<repo>/<origin> records. FAN OUT: resolve every marker, then one matrix instance per
+  # origin, each serialized on that origin via `concurrency`. That is the P1 fix — two backports of
+  # the SAME origin landing on different branches (separate events) no longer write concurrently and
+  # clobber each other's accreted backport_set/earliest_fix_tag.
   # Exclude branch-sync PRs (head like `branch-4.1-sync-pr-74722` → branch-4.1): a sync of a
   # backport carries 'backport' in its title but is NOT a real (backport #N) landing — it would
   # misattribute the origin. Do NOT exclude `mergify/` here (unlike origin-merge): mergify IS the
   # backport mechanism (head `mergify/bp/branch-X.Y/pr-N`) — excluding it would drop real backports.
-  backport-merge:
+  backport-resolve:
     if: >
       github.event_name == 'pull_request_target' &&
       github.event.action == 'closed' &&
@@ -107,24 +119,64 @@ jobs:
       contains(github.event.pull_request.title, 'backport') &&
       !contains(github.head_ref, '-sync-pr-')
     runs-on: [self-hosted, normal]
+    outputs:
+      origins: ${{ steps.parse.outputs.origins }}
+    steps:
+      - name: parse all (backport #N) markers → origin list
+        id: parse
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # ALL markers (mirrors the skill's backport_markers), not just the last — bundled/chained
+          # titles backport several origins. Looser than \(backport #N\) (no parens required): an
+          # extra non-origin number only yields a harmless no-op /index-fix (exits 0 on a non-origin).
+          # Build the JSON array with awk (not a shell for-loop) so it is shell-agnostic — unquoted
+          # word-splitting differs between bash and sh/zsh; awk handles the line stream itself.
+          json="$(printf '%s' "$TITLE" | grep -oiE 'backport #[0-9]+' | grep -oE '[0-9]+' | sort -un \
+                 | awk 'BEGIN{printf "["} {printf "%s\"%s\"",(NR>1?",":""),$0} END{printf "]"}')"
+          echo "origins=$json" >> "$GITHUB_OUTPUT"
+          echo "backport PR #${{ github.event.number }} (${{ github.base_ref }}) → origins: $json"
+
+  backport-write:
+    needs: backport-resolve
+    if: ${{ needs.backport-resolve.outputs.origins != '[]' && needs.backport-resolve.outputs.origins != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        origin: ${{ fromJSON(needs.backport-resolve.outputs.origins) }}
+    # Serialize per origin: same-origin runs queue (1 running + at most 1 pending; a superseded
+    # pending run is harmless — /index-fix rebuilds the full set from GitHub). Different origins run
+    # in parallel (distinct groups). Shares the group with the origin-merge job of the same origin.
+    concurrency:
+      group: BVI-${{ github.repository }}-origin-${{ matrix.origin }}
+      cancel-in-progress: false
+    runs-on: [self-hosted, normal]
     continue-on-error: true
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: index-fix (rebuild origin N from "(backport #N)")
+      - name: index-fix (rebuild origin ${{ matrix.origin }} from its merged backports)
         run: |
-          echo "backport-merge PR #${{ github.event.number }} (${{ github.base_ref }}) → ${PR_URL}"
+          echo "rebuild origin ${{ github.repository }}#${{ matrix.origin }} (triggered by backport PR #${{ github.event.number }})"
           docker exec -i -u claudeuser \
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
-            -p "/github-bugfix-versions:index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+            -p "/github-bugfix-versions:index-fix ${{ github.repository }}#${{ matrix.origin }}" 2>&1 | tee "${RUNNER_TEMP}/index_fix_${{ matrix.origin }}.txt" || true
 
   # ③ release tag cut → resolve pending-<line> records on that line to the concrete tag.
+  # RESIDUAL (accepted): a tag-cut run touches MANY origins (every record pending on the line), so
+  # it cannot share the per-origin groups above — it can still race a concurrent backport-write of
+  # one of those origins. Severity is bounded: `pending-<line>` already counts as "fixed (tag TBD)"
+  # in the gap query, so a delayed/lost resolution under-states the concrete tag, not the fix's
+  # existence; and a clobber self-heals on that origin's next event. Tags are infrequent. A fully
+  # race-free version would fan tag-cut out per pending origin (a code_kb query → matrix) — deferred.
   tag-cut:
     if: github.event_name == 'push'
+    concurrency:
+      group: BVI-${{ github.repository }}-tagcut-${{ github.ref_name }}
+      cancel-in-progress: false
     runs-on: [self-hosted, normal]
     continue-on-error: true
     env:

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -22,8 +22,10 @@ run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.numbe
 #     :release-report — invoked namespaced as /github-bugfix-versions:<cmd>, see NOTE above);
 #   - the `context-base` MCP configured with `code_kb` USAGE (read+write data) for the
 #     container's identity — USAGE alone is enough to context_upsert (no ALTER needed);
-#   - the `code_kb.versions` and `code_kb.task_summaries` collections pre-created by an admin
-#     (CREATE CONTEXT COLLECTION ...; the emitter cannot create shared-base collections).
+#   - the `code_kb.versions` (collection_type=knowledge) and `code_kb.task_summaries`
+#     (collection_type=task_summary — NOT knowledge; the task_summary family, shared with the
+#     release-bug write-back) collections pre-created by an admin (the emitter cannot create
+#     shared-base collections; MCP create_collection only targets the caller's personal base).
 # gh is NOT installed in the container, but GITHUB_TOKEN is passed in — the skill uses the
 # GitHub REST/compare API for PR/backport/tag-contains when no local clone is present.
 


### PR DESCRIPTION
## Why I'm doing:

Release planning needs a fast, bulk answer to "for release tag T, which merged bugfixes is it missing, what versions are affected, and what should clusters upgrade to" — computing this per-PR on demand is too slow (dozens of PRs per release). This adds a CI step that incrementally maintains a deterministic version/backport index in the team knowledge base as PRs merge, so the question becomes one query instead of many live analyses.

## What I'm doing:

Add `.github/workflows/bugfix-version-index.yml`, which invokes the `github-bugfix-versions` skill in the `claude-cli` container (same runner/container pattern as `ai-sr-skills.yml`) on three events: an origin `[BugFix]` PR merging to main (`/index-fix` records where the fix lives + `/affected-versions` caches its cause), a `(backport #N)` PR merging to a `branch-X.Y*` (`/index-fix` rebuilds that origin's record as backports accrete), and a release tag `X.Y.Z` being pushed (`/index-fix <tag>` resolves a pending line to the concrete tag). The skill does all git/GitHub computation and writes to the `code_kb` knowledge base via the context-base MCP. The workflow does not build, test, clone, or modify the repo and posts nothing back to GitHub; every job is `continue-on-error` and a no-op for non-bugfix / non-backport PRs, so it cannot affect merge gating. It is inert until the runner's `claude-cli` container is provisioned with the plugin, the context-base MCP, and the pre-created collections (tracked separately). Pushed as a temporary development branch for review.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

## Also in this PR — module-risk briefing (`ai-sr-skills.yml`)

Adds a `module-risk` job to the existing AI-SR-Skills workflow (sibling to the reviewer-assignment job, same PR-open trigger / container). On PR open/reopen it runs the read-only `github-pr-module-risk` skill over `code_kb` merged-bugfix pathology cards and **upserts a sticky review-focus comment** (`<!-- module-risk-briefing -->`). It is gated to **high-confidence, diff-aligned** pitfalls (card built from ≥2 bugfixes AND a pitfall mapping to an actual changed hunk); when nothing clears the gate it posts nothing. Read-only — never writes `code_kb` — so the existing per-PR `cancel-in-progress` concurrency is correct. Reuses the `mergify/` + `-sync-pr-` exclusion.

Companion marketplace PR (the `--comment` strict-gate mode + no-`gh` REST fallback the skill needs): CelerData/claude-marketplace#6. Inert until the runner's `claude-cli` container has the `github-pr-module-risk` plugin + `context-base` MCP with `code_kb` USAGE (read).
