### PR TITLE
[Refactor] Separate selected-id computation from operator rebuild in the OLAP partition/distribution pruners

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
@@ -32,6 +32,7 @@ import com.starrocks.planner.RangeDistributionPruner;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,15 +45,27 @@ public class OptDistributionPruner {
 
     public static List<Long> pruneTabletIds(LogicalOlapScanOperator olapScanOperator,
                                             List<Long> selectedPartitionIds) {
-        OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
+        return computeSelectedTabletIds(olapScanOperator, selectedPartitionIds,
+                olapScanOperator.getSelectedIndexMetaId());
+    }
+
+    /**
+     * Computes the selected tablet ids within {@code selectedPartitionIds} from the scan's
+     * distribution-column predicates. Typed against the base LogicalScanOperator because it reads
+     * only generic scan state (table, predicate, column filters), nothing OLAP-scan specific.
+     * {@code selectedIndexMetaId} picks the materialized index per physical partition.
+     */
+    private static List<Long> computeSelectedTabletIds(LogicalScanOperator scan,
+                                                      List<Long> selectedPartitionIds, long selectedIndexMetaId) {
+        OlapTable olapTable = (OlapTable) scan.getTable();
 
         List<Long> result = Lists.newArrayList();
         for (Long partitionId : selectedPartitionIds) {
             Partition partition = olapTable.getPartition(partitionId);
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                MaterializedIndex table = physicalPartition.getLatestIndex(olapScanOperator.getSelectedIndexMetaId());
-                Collection<Long> tabletIds = distributionPrune(table, partition.getDistributionInfo(),
-                        olapScanOperator, olapTable.getIdToColumn());
+                MaterializedIndex index = physicalPartition.getLatestIndex(selectedIndexMetaId);
+                Collection<Long> tabletIds = distributionPrune(index, partition.getDistributionInfo(),
+                        scan, olapTable.getIdToColumn());
                 result.addAll(tabletIds);
             }
         }
@@ -60,7 +73,7 @@ public class OptDistributionPruner {
     }
 
     private static Collection<Long> distributionPrune(MaterializedIndex index, DistributionInfo distributionInfo,
-                                                      LogicalOlapScanOperator operator, Map<ColumnId, Column> idToColumn) {
+                                                      LogicalScanOperator operator, Map<ColumnId, Column> idToColumn) {
         if (distributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH ||
                 distributionInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
             Map<String, PartitionColumnFilter> filters = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PartitionNames;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.common.AnalysisException;
@@ -49,6 +50,7 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -71,16 +73,22 @@ import static com.starrocks.sql.optimizer.rule.transformation.ListPartitionPrune
 public class OptOlapPartitionPruner {
     private static final Logger LOG = LogManager.getLogger(OptOlapPartitionPruner.class);
 
-    public static LogicalOlapScanOperator prunePartitions(LogicalOlapScanOperator logicalOlapScanOperator) {
-        List<Long> selectedPartitionIds = null;
-        OlapTable table = (OlapTable) logicalOlapScanOperator.getTable();
-
+    /**
+     * Computes the selected logical partition ids from the scan's partition-column predicates.
+     * Typed against the base LogicalScanOperator because it reads only generic scan state (table,
+     * predicate, column-ref map, column filters), nothing OLAP-scan specific. {@code partitionNames}
+     * carries an explicit PARTITION hint, or null when the scan supplies none. Returns the surviving
+     * logical partition ids (never null).
+     */
+    private static List<Long> computeSelectedPartitionIds(LogicalScanOperator scan, PartitionNames partitionNames) {
+        OlapTable table = (OlapTable) scan.getTable();
         PartitionInfo partitionInfo = table.getPartitionInfo();
 
+        List<Long> selectedPartitionIds = null;
         if (partitionInfo.isRangePartition()) {
-            selectedPartitionIds = rangePartitionPrune(table, (RangePartitionInfo) partitionInfo, logicalOlapScanOperator);
+            selectedPartitionIds = rangePartitionPrune(table, (RangePartitionInfo) partitionInfo, scan, partitionNames);
         } else if (partitionInfo.getType() == PartitionType.LIST) {
-            selectedPartitionIds = listPartitionPrune(table, (ListPartitionInfo) partitionInfo, logicalOlapScanOperator);
+            selectedPartitionIds = listPartitionPrune(table, (ListPartitionInfo) partitionInfo, scan, partitionNames);
         }
 
         if (selectedPartitionIds == null) {
@@ -94,10 +102,16 @@ public class OptOlapPartitionPruner {
         }
 
         // Do further partition prune if needed
-        if (isNeedFurtherPrune(selectedPartitionIds, logicalOlapScanOperator, partitionInfo)) {
-            selectedPartitionIds = doFurtherPartitionPrune(table, logicalOlapScanOperator.getPredicate(),
-                    logicalOlapScanOperator.getColumnMetaToColRefMap(), selectedPartitionIds);
+        if (isNeedFurtherPrune(table, selectedPartitionIds, scan.getPredicate(), partitionInfo)) {
+            selectedPartitionIds = doFurtherPartitionPrune(table, scan.getPredicate(),
+                    scan.getColumnMetaToColRefMap(), selectedPartitionIds);
         }
+        return selectedPartitionIds;
+    }
+
+    public static LogicalOlapScanOperator prunePartitions(LogicalOlapScanOperator logicalOlapScanOperator) {
+        List<Long> selectedPartitionIds =
+                computeSelectedPartitionIds(logicalOlapScanOperator, logicalOlapScanOperator.getPartitionNames());
 
         try {
             checkScanPartitionLimit(selectedPartitionIds.size());
@@ -294,7 +308,7 @@ public class OptOlapPartitionPruner {
     }
 
     private static List<Long> listPartitionPrune(OlapTable olapTable, ListPartitionInfo listPartitionInfo,
-                                                 LogicalOlapScanOperator operator) {
+                                                 LogicalScanOperator operator, PartitionNames partitionNames) {
 
         Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap =
                 Maps.newConcurrentMap();
@@ -305,9 +319,9 @@ public class OptOlapPartitionPruner {
         boolean isTemporaryPartitionPrune = false;
         List<Long> specifyPartitionIds = null;
         Set<Long> partitionIds = Sets.newHashSet();
-        if (operator.getPartitionNames() != null) {
-            for (String partName : operator.getPartitionNames().getPartitionNames()) {
-                boolean isTemp = operator.getPartitionNames().isTemp();
+        if (partitionNames != null) {
+            for (String partName : partitionNames.getPartitionNames()) {
+                boolean isTemp = partitionNames.isTemp();
                 if (isTemp) {
                     isTemporaryPartitionPrune = true;
                 }
@@ -345,12 +359,12 @@ public class OptOlapPartitionPruner {
     }
 
     private static List<Long> rangePartitionPrune(OlapTable olapTable, RangePartitionInfo partitionInfo,
-                                                  LogicalOlapScanOperator operator) {
+                                                  LogicalScanOperator operator, PartitionNames partitionNames) {
         Map<Long, Range<PartitionKey>> keyRangeById;
-        if (operator.getPartitionNames() != null && operator.getPartitionNames().getPartitionNames() != null) {
+        if (partitionNames != null && partitionNames.getPartitionNames() != null) {
             keyRangeById = Maps.newHashMap();
-            for (String partName : operator.getPartitionNames().getPartitionNames()) {
-                Partition part = olapTable.getPartition(partName, operator.getPartitionNames().isTemp());
+            for (String partName : partitionNames.getPartitionNames()) {
+                Partition part = olapTable.getPartition(partName, partitionNames.isTemp());
                 if (part == null) {
                     continue;
                 }
@@ -368,13 +382,6 @@ public class OptOlapPartitionPruner {
             LOG.warn("PartitionPrune Failed. ", e);
         }
         return Lists.newArrayList(keyRangeById.keySet());
-    }
-
-    private static boolean isNeedFurtherPrune(List<Long> candidatePartitions,
-                                              LogicalOlapScanOperator olapScanOperator,
-                                             PartitionInfo partitionInfo) {
-        return isNeedFurtherPrune((OlapTable) olapScanOperator.getTable(), candidatePartitions,
-                olapScanOperator.getPredicate(), partitionInfo);
     }
 
     public static List<Long> doFurtherPartitionPrune(OlapTable table,


### PR DESCRIPTION
## Why I'm doing:

`OptOlapPartitionPruner.prunePartitions` and `OptDistributionPruner.pruneTabletIds` interleave two
distinct concerns: computing the set of selected partition / tablet ids from the scan's predicates,
and the `LogicalOlapScanOperator`-specific work around it (rebuilding the operator, enforcing
`scan_olap_partition_num_limit`, stripping always-true partition predicates). The id-computation
itself reads only generic scan state — table, predicate, column-ref map, column filters — but was
tangled into `LogicalOlapScanOperator`-typed methods and private helpers, so it could not be read or
exercised in isolation.

## What I'm doing:

Extract the id-computation core in both classes and type it to the base `LogicalScanOperator`:

- **`OptOlapPartitionPruner`** — new private
  `computeSelectedPartitionIds(LogicalScanOperator, PartitionNames)` holds the range/list prune plus
  the further-prune step. `prunePartitions(LogicalOlapScanOperator)` delegates to it and keeps the
  OLAP-only tail unchanged (scan-partition-limit check, `prunePartitionPredicates`, operator
  rebuild). The `PARTITION`-hint list — previously read off the operator inside the helpers — is
  lifted to an explicit `partitionNames` parameter, and `rangePartitionPrune` / `listPartitionPrune`
  are retyped to the base operator. Drops a redundant
  `isNeedFurtherPrune(List, LogicalOlapScanOperator, PartitionInfo)` overload that only unpacked the
  operator into the existing `(OlapTable, List, ScalarOperator, PartitionInfo)` overload.

- **`OptDistributionPruner`** — new private
  `computeSelectedTabletIds(LogicalScanOperator, List<Long>, long)` holds the per-partition tablet
  pruning. `pruneTabletIds(LogicalOlapScanOperator, List<Long>)` delegates with
  `getSelectedIndexMetaId()`. `distributionPrune` is retyped to the base operator.

The core is typed to `LogicalScanOperator` because it consumes only that base state, drawing a clean
line between "compute selected ids from generic scan state" and "OLAP operator rebuild," and keeps
reading the operator's already-cached `columnFilters` map rather than recomputing it. No call sites
outside these two classes change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4