### PR TITLE
[BugFix] Fix Tracers corruption when a shared tracer is used from parallel threads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -264,6 +264,10 @@ public class Tracers {
         tracers.tracer(module, Mode.VARS).count(name, count);
     }
 
+    public static void count(Tracers tracers, Module module, String name, long count) {
+        tracers.tracer(module, Mode.VARS).count(name, count);
+    }
+
     public static List<Var<?>> getAllVars() {
         Tracers tracers = THREAD_LOCAL.get();
         return tracers.allTracer[1].getAllVars();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -33,6 +33,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.profile.RawScopedTimer;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrDeltaStats;
@@ -1027,9 +1028,18 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                  Tracers tracers, ConnectContext connectContext) {
         if (!scannedTables.contains(key)) {
             tracers = tracers == null ? Tracers.get() : tracers;
-            try (Timer ignored = Tracers.watchScope(tracers, EXTERNAL, "ICEBERG.processSplit." + key)) {
+            // This may run in parallel for multiple tables on a shared query-level Tracers
+            // (see PrepareCollectMetaTask). The Tracers/TimeWatcher scope stack is single-threaded
+            // and unsafe for scopes that overlap across threads, so measure this table's split
+            // collection with an independent RawScopedTimer. Surface the time via count(), which
+            // accumulates the cumulative split-collection time across all parallel tables under
+            // TracerImpl's monitor (a shared accumulating stopwatch can't be used here - concurrent
+            // start() would throw "stopwatch already running").
+            RawScopedTimer timer = new RawScopedTimer();
+            try (RawScopedTimer.Guard ignored = timer.start()) {
                 collectTableStatisticsAndCacheIcebergSplit(key, table, tracers, connectContext);
             }
+            Tracers.count(tracers, EXTERNAL, "ICEBERG.processSplitMs", timer.getTotalTime());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -15,7 +15,7 @@
 package com.starrocks.qe.scheduler.dag;
 
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.RawScopedTimer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.qe.ConnectContext;
@@ -40,15 +40,15 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
     private volatile boolean cancelled = false;
     private DeployScanRangesTask deployScanRangesTask = null;
 
-    class TracerContext implements AutoCloseable {
-        Tracers savedTracers;
+    // Restores the query's ConnectContext on the shared background executor thread for one deploy
+    // round. The query Tracers is intentionally NOT installed here: its TimeWatcher scope stack is
+    // single-threaded and must not be driven from this background thread concurrently with the main
+    // thread (that caused ConcurrentModificationException / "stopwatch already running"). Deploy
+    // timing is measured with an independent RawScopedTimer instead (see runOnce).
+    static class ConnectContextScope implements AutoCloseable {
         ConnectContext savedConnectContext;
 
-        TracerContext(Tracers currentTracers, ConnectContext connectContext) {
-            if (currentTracers != null) {
-                savedTracers = Tracers.get();
-                Tracers.set(currentTracers);
-            }
+        ConnectContextScope(ConnectContext connectContext) {
             if (connectContext != null) {
                 savedConnectContext = ConnectContext.get();
                 ConnectContext.set(connectContext);
@@ -57,9 +57,6 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
 
         @Override
         public void close() {
-            if (savedTracers != null) {
-                Tracers.set(savedTracers);
-            }
             if (savedConnectContext != null) {
                 ConnectContext.set(savedConnectContext);
             }
@@ -71,6 +68,10 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         ExecutorService executorService;
         Tracers currentTracers;
         ConnectContext currentConnectContext;
+        // Accumulates total deploy time across all rounds of this task. Rounds run sequentially
+        // (each re-submits the next only after the previous returns), so this single timer/stopwatch
+        // is never started concurrently.
+        final RawScopedTimer deployScanRangesTimer = new RawScopedTimer();
 
         DeployScanRangesTask(List<DeployState> states) {
             this.states = states;
@@ -81,7 +82,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
             if (cancelled || states.isEmpty()) {
                 return;
             }
-            try (TracerContext tracerContext = new TracerContext(currentTracers, currentConnectContext)) {
+            try (ConnectContextScope ignored = new ConnectContextScope(currentConnectContext)) {
                 runOnce();
             }
             // If run in the executor service, we need to start the next turn.
@@ -90,7 +91,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         }
 
         public void runOnce() {
-            try (Timer timer = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeployScanRanges")) {
+            try (RawScopedTimer.Guard ignored = deployScanRangesTimer.start()) {
                 states = coordinator.assignIncrementalScanRangesToDeployStates(deployer, states);
                 if (states.isEmpty()) {
                     return;
@@ -103,6 +104,14 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
                 LOG.warn("Failed to assign incremental scan ranges to deploy states", e);
                 coordinator.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, e.getMessage());
                 throw new RuntimeException(e);
+            } finally {
+                // Surface the cumulative deploy time on the query's tracer. record() only appends to
+                // VarTracer under TracerImpl's monitor (no single-threaded scope stack), and the deploy
+                // completes before the query profile is assembled, so this is safe from this thread.
+                if (currentTracers != null) {
+                    Tracers.record(currentTracers, Tracers.Module.SCHEDULER, "DeployScanRanges",
+                            deployScanRangesTimer.getTotalTime() + "ms");
+                }
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/profile/TracersConcurrentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/profile/TracersConcurrentTest.java
@@ -1,0 +1,136 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.profile;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the parallel iceberg prepare / background scan-range deploy crash.
+ *
+ * <p>Those paths surface metrics onto a single query-level {@link Tracers} from multiple threads
+ * at the same time. The {@code TimeWatcher} scope stack used by {@code watchScope} is
+ * single-threaded, so driving it concurrently corrupted shared state
+ * ({@code ConcurrentModificationException}) and leaked the shared overhead stopwatch
+ * ({@code "This stopwatch is already running"}). The fix switched those sites to {@code count}/
+ * {@code record}, which mutate only {@code VarTracer} under {@code TracerImpl}'s monitor. These
+ * tests lock in that those two paths are safe and correct under concurrent use of a shared tracer.
+ */
+public class TracersConcurrentTest {
+
+    @BeforeEach
+    public void setUp() {
+        Tracers.register();
+        Tracers.enableTraceModule(Tracers.Module.EXTERNAL);
+        Tracers.enableTraceMode(Tracers.Mode.VARS);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Tracers.close();
+    }
+
+    @Test
+    public void testConcurrentCountIsSafeAndAccumulates() throws Exception {
+        final Tracers shared = Tracers.get();
+        final int threads = 16;
+        final int perThread = 10000;
+
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        List<Future<?>> futures = new ArrayList<>();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        for (int t = 0; t < threads; t++) {
+            futures.add(pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < perThread; i++) {
+                        Tracers.count(shared, Tracers.Module.EXTERNAL, "concurrent.count", 1);
+                    }
+                } catch (Throwable e) {
+                    errors.add(e);
+                }
+            }));
+        }
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS));
+        for (Future<?> f : futures) {
+            f.get();
+        }
+
+        assertTrue(errors.isEmpty(), "concurrent count threw: " + errors);
+        // synchronized add => no lost updates
+        assertEquals((long) threads * perThread, findVar("concurrent.count"));
+    }
+
+    @Test
+    public void testConcurrentRecordIsSafe() throws Exception {
+        final Tracers shared = Tracers.get();
+        final int threads = 16;
+        final int perThread = 2000;
+
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        List<Future<?>> futures = new ArrayList<>();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        for (int t = 0; t < threads; t++) {
+            final int tid = t;
+            futures.add(pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < perThread; i++) {
+                        Tracers.record(shared, Tracers.Module.EXTERNAL, "rec." + tid + "." + i, "v");
+                    }
+                } catch (Throwable e) {
+                    errors.add(e);
+                }
+            }));
+        }
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS));
+        for (Future<?> f : futures) {
+            f.get();
+        }
+
+        assertTrue(errors.isEmpty(), "concurrent record threw: " + errors);
+        // every distinct name must be present, none lost or corrupted
+        assertEquals(threads * perThread, Tracers.getAllVars().size());
+    }
+
+    private long findVar(String name) {
+        // getAllVars() reads the tracer registered on this (test) thread, i.e. the shared instance.
+        for (Var<?> var : Tracers.getAllVars()) {
+            if (name.equals(var.getName())) {
+                return ((Number) var.getValue()).longValue();
+            }
+        }
+        throw new IllegalStateException("var not found: " + name);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Two paths surface metrics onto a single query-level Tracers from multiple threads at once: parallel iceberg metadata prepare (PrepareCollectMetaTask) and the background scan-range deploy (AllAtOnceExecutionSchedule.DeployScanRangesTask). The Tracers/TimeWatcher scope stack used by watchScope is single-threaded, so driving it concurrently corrupted the shared 'levels' list (ConcurrentModificationException) and, because the thrown exception left the shared tracerCost stopwatch running, cascaded into 'This stopwatch is already running'.

- IcebergMetadata.triggerIcebergPlanFilesIfNeeded: measure per-table split collection with an independent RawScopedTimer and surface it via a new Tracers.count(Tracers, ...) overload as ICEBERG.processSplitMs, accumulating the cumulative split-collection time (ms) across all parallel tables under TracerImpl's monitor. A shared accumulating stopwatch can't be used here because its concurrent start() would throw 'stopwatch already running'.
- AllAtOnceExecutionSchedule.DeployScanRangesTask: stop installing the query Tracers into the background thread (Tracers.set); measure each round with an independent RawScopedTimer field that accumulates across the sequential rounds, and surface it via thread-safe Tracers.record.
- Add TracersConcurrentTest covering concurrent count/record on a shared tracer (no corruption, and count accumulates without lost updates).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
