### PR TITLE
[BugFix] Fix BE crash on compressed JSON stream load

### DIFF
--- a/be/src/exec/file_scanner/file_scanner.cpp
+++ b/be/src/exec/file_scanner/file_scanner.cpp
@@ -272,8 +272,7 @@ Status FileScanner::create_sequential_file(const TBrokerRangeDesc& range_desc, c
     // in JsonReader::_read_file_stream(). Wrapping the pipe in a CompressedInputStream here would
     // both double-decompress and break the down_cast<StreamLoadPipeInputStream*> in
     // _read_file_stream() (the stream becomes a CompressedInputStream), causing a crash.
-    if (range_desc.file_type == TFileType::FILE_STREAM &&
-        range_desc.format_type == TFileFormatType::FORMAT_JSON) {
+    if (range_desc.file_type == TFileType::FILE_STREAM && range_desc.format_type == TFileFormatType::FORMAT_JSON) {
         compression = CompressionTypePB::NO_COMPRESSION;
     } else if (range_desc.__isset.compression_type) {
         // Prefer explicit compression type if provided by FE

--- a/be/src/exec/file_scanner/file_scanner.cpp
+++ b/be/src/exec/file_scanner/file_scanner.cpp
@@ -268,8 +268,15 @@ Status FileScanner::create_sequential_file(const TBrokerRangeDesc& range_desc, c
                                            const TBrokerScanRangeParams& params,
                                            std::shared_ptr<SequentialFile>* file) {
     CompressionTypePB compression = CompressionTypePB::DEFAULT_COMPRESSION;
-    // Prefer explicit compression type if provided by FE
-    if (range_desc.__isset.compression_type) {
+    // JSON stream load (FILE_STREAM) decompresses internally via CompressedStreamLoadPipeReader
+    // in JsonReader::_read_file_stream(). Wrapping the pipe in a CompressedInputStream here would
+    // both double-decompress and break the down_cast<StreamLoadPipeInputStream*> in
+    // _read_file_stream() (the stream becomes a CompressedInputStream), causing a crash.
+    if (range_desc.file_type == TFileType::FILE_STREAM &&
+        range_desc.format_type == TFileFormatType::FORMAT_JSON) {
+        compression = CompressionTypePB::NO_COMPRESSION;
+    } else if (range_desc.__isset.compression_type) {
+        // Prefer explicit compression type if provided by FE
         compression = CompressionUtils::to_compression_pb(range_desc.compression_type);
     } else if (range_desc.format_type == TFileFormatType::FORMAT_CSV_PLAIN) {
         compression = CompressionTypePB::NO_COMPRESSION;

--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -678,12 +678,18 @@ Status JsonReader::_construct_row(simdjson::ondemand::object* row, Chunk* chunk)
 }
 
 Status JsonReader::_read_file_stream() {
-    // TODO: Remove the down_cast, should not rely on the specific implementation.
-    auto pipe = make_shared<StreamLoadPipeReader>(down_cast<StreamLoadPipeInputStream*>(_file->stream().get())->pipe());
+    // TODO: Remove the dynamic_cast, should not rely on the specific implementation.
+    // Use dynamic_cast (not down_cast) and check the result: the stream is expected to be a
+    // StreamLoadPipeInputStream here, but if it has been wrapped (e.g. in a CompressedInputStream),
+    // a blind down_cast would reinterpret the wrong type and crash on the bogus pipe pointer.
+    auto* stream = dynamic_cast<StreamLoadPipeInputStream*>(_file->stream().get());
+    if (stream == nullptr) {
+        return Status::InternalError("JSON stream load expects a StreamLoadPipeInputStream");
+    }
+    auto pipe = make_shared<StreamLoadPipeReader>(stream->pipe());
     if (_range_desc.compression_type != TCompressionType::NO_COMPRESSION &&
         _range_desc.compression_type != TCompressionType::UNKNOWN_COMPRESSION) {
-        pipe = std::make_shared<CompressedStreamLoadPipeReader>(
-                down_cast<StreamLoadPipeInputStream*>(_file->stream().get())->pipe(), _range_desc.compression_type);
+        pipe = std::make_shared<CompressedStreamLoadPipeReader>(stream->pipe(), _range_desc.compression_type);
     }
     ++_counter->file_read_count;
     SCOPED_RAW_TIMER(&_counter->file_read_ns);

--- a/be/test/exec/file_scanner/json_scanner_test.cpp
+++ b/be/test/exec/file_scanner/json_scanner_test.cpp
@@ -1749,6 +1749,56 @@ TEST_F(JsonScannerTest, file_stream) {
     EXPECT_EQ("[3, 4]", chunk->debug_row(1));
 }
 
+// Regression test for #11412: a gzip-compressed JSON stream load (FILE_STREAM + FORMAT_JSON
+// + compression_type) must be decompressed by CompressedStreamLoadPipeReader, NOT wrapped in a
+// CompressedInputStream by create_sequential_file. Wrapping it caused a double-decompress and a
+// type-confused down_cast<StreamLoadPipeInputStream*> in _read_file_stream(), crashing the BE.
+TEST_F(JsonScannerTest, file_stream_gzip_compressed) {
+    // 1. create StreamLoadPipe
+    auto load_id = UniqueId::gen_uid();
+    auto pipe = std::make_shared<StreamLoadPipe>(1024 * 1024, 64 * 1024);
+    DeferOp remove_pipe([&]() { _state->exec_env()->load_stream_mgr()->remove(load_id); });
+    ASSERT_OK(_state->exec_env()->load_stream_mgr()->put(load_id, pipe));
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TYPE_INT);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.file_type = TFileType::FILE_STREAM;
+    range.strip_outer_array = false;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = false;
+    range.__isset.json_root = false;
+    range.__set_load_id(load_id.to_thrift());
+    // The FE sets compression_type when the user requests a compressed stream load.
+    range.__set_compression_type(TCompressionType::GZIP);
+    ranges.emplace_back(range);
+
+    std::string data = R"({"key1": 1, "key2": 2 }{"key1": 3, "key2": 4 })";
+    std::string compressed = compress_gzip(data);
+    ASSERT_FALSE(compressed.empty());
+    EXPECT_OK(pipe->append(compressed.c_str(), compressed.size()));
+    EXPECT_OK(pipe->finish());
+
+    auto scanner = create_json_scanner(types, ranges, {"key1", "key2"});
+    Status st;
+    st = scanner->open();
+    EXPECT_OK(st);
+
+    auto res = scanner->get_next();
+    EXPECT_OK(res.status());
+
+    ChunkPtr chunk = res.value();
+    EXPECT_EQ(2, chunk->num_columns());
+    EXPECT_EQ(2, chunk->num_rows());
+
+    EXPECT_EQ("[1, 2]", chunk->debug_row(0));
+    EXPECT_EQ("[3, 4]", chunk->debug_row(1));
+}
+
 TEST_F(JsonScannerTest, test_duplicate_key) {
     std::vector<TypeDescriptor> types;
     types.emplace_back(TYPE_INT);


### PR DESCRIPTION
## Why I'm doing:

A gzip-compressed JSON **stream load** crashes the BE with a SIGSEGV in `starrocks::CompressedStreamLoadPipeReader::read()` (reported as StarRocksTest #11412).

Root cause: PR #61786 (`support load compressed json file`) changed `FileScanner::create_sequential_file()` to wrap the input stream in a `CompressedInputStream` whenever `range_desc.compression_type` is set:

```cpp
if (range_desc.__isset.compression_type) {
    compression = CompressionUtils::to_compression_pb(range_desc.compression_type);
}
```

For a JSON stream load (`file_type == FILE_STREAM`), the FE already sets `compression_type` when the user asks for a compressed stream load, but decompression for that path is handled separately by `CompressedStreamLoadPipeReader` inside `JsonReader::_read_file_stream()`. That method also does:

```cpp
down_cast<StreamLoadPipeInputStream*>(_file->stream().get())->pipe()
```

Once the stream is wrapped, `_file->stream()` is a `CompressedInputStream`, so this `down_cast` (a `static_cast` in release) is a type confusion: `pipe()` reads the `CompressedInputStream::_source_stream` and returns it typed as `shared_ptr<StreamLoadPipe>`. The later `_pipe->read()` then dispatches through the wrong vtable and returns an OK status with a **null** `ByteBufferPtr`, and `buf->meta()` dereferences null → crash.

Verified from the core dump (`core.3101`): the crashing instruction is `mov 0x28(%r14),%rdi` with `r14 = 0`; `this->_pipe` points at a `StreamLoadPipeInputStream` (whose inner `_pipe` is the real `StreamLoadPipe`), exactly matching `CompressedInputStream` layout.

## What I'm doing:

- `create_sequential_file()`: skip the `CompressedInputStream` wrapping for `FILE_STREAM + FORMAT_JSON`, so the JSON stream-load path decompresses via `CompressedStreamLoadPipeReader` as before. Compressed JSON **files** (`FILE_BROKER`/`FILE_LOCAL`, the feature added by #61786) are unaffected; CSV is unaffected.
- `_read_file_stream()`: use `dynamic_cast` and return an error instead of crashing if the stream is ever not a `StreamLoadPipeInputStream` (defensive, addresses the existing TODO).
- Add a regression unit test `JsonScannerTest.file_stream_gzip_compressed` covering gzip-compressed JSON stream load (the previously-crashing path; all pre-existing compression tests only cover `FILE_LOCAL`).

Related to #61786

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
