### PR TITLE
[BugFix] Fix MV refresh for joins of same-named base tables across databases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -554,30 +555,36 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     private InsertStmt buildInsertPlan(InsertStmt insertStmt) throws AnalysisException {
         QueryStatement queryStatement = insertStmt.getQueryStatement();
         Multimap<String, TableRelation> tableRelations = AnalyzerUtils.collectAllTableRelation(queryStatement);
-        Map<String, TvrVersionRange> baseTableNameToTvrVersionRangeMap = snapshotBaseTables.values()
-                .stream()
-                .map(snapshotInfo -> (TvrTableSnapshotInfo) snapshotInfo)
-                .map(snapshotInfo -> {
-                    BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
-                    TvrVersionRange tvrVersionRange = snapshotInfo.getTvrSnapshot();
-                    if (tvrVersionRange == null) {
-                        throw new SemanticException("Base table %s.%s does not have a valid tvr version range",
-                                baseTableInfo.getDbName(), baseTableInfo.getTableName());
-                    }
-                    return Maps.immutableEntry(baseTableInfo.getTableName(), tvrVersionRange);
-                })
-                .collect(Collectors.toMap(entry -> entry.getKey(), Map.Entry::getValue));
+        bindBaseTableTvrVersionRanges(snapshotBaseTables.values(), tableRelations);
+        return insertStmt;
+    }
+
+    @VisibleForTesting
+    static void bindBaseTableTvrVersionRanges(Collection<BaseTableSnapshotInfo> snapshotInfos,
+                                              Multimap<String, TableRelation> tableRelations) {
+        // Key by the base-table object, not its unqualified name: two same-named tables from different
+        // databases have distinct table identity, while a self-join collapses to one entry.
+        Map<Table, TvrVersionRange> tvrRangeByTable = Maps.newHashMap();
+        for (BaseTableSnapshotInfo snapshotInfo : snapshotInfos) {
+            TvrTableSnapshotInfo tvrInfo = (TvrTableSnapshotInfo) snapshotInfo;
+            TvrVersionRange tvrVersionRange = tvrInfo.getTvrSnapshot();
+            if (tvrVersionRange == null) {
+                BaseTableInfo baseTableInfo = tvrInfo.getBaseTableInfo();
+                throw new SemanticException("Base table %s.%s does not have a valid tvr version range",
+                        baseTableInfo.getDbName(), baseTableInfo.getTableName());
+            }
+            tvrRangeByTable.put(tvrInfo.getBaseTable(), tvrVersionRange);
+        }
         for (Map.Entry<String, TableRelation> entry : tableRelations.entries()) {
             TableRelation tableRelation = entry.getValue();
             Table table = tableRelation.getTable();
-            if (!baseTableNameToTvrVersionRangeMap.containsKey(table.getName())) {
+            TvrVersionRange tvrVersionRange = tvrRangeByTable.get(table);
+            if (tvrVersionRange == null) {
                 throw new SemanticException("Base table %s.%s is not found in the changed version ranges",
                         tableRelation.getName().getDb(), tableRelation.getName().getTbl());
             }
-            TvrVersionRange tvrVersionRange = baseTableNameToTvrVersionRangeMap.get(table.getName());
             tableRelation.setTvrVersionRange(tvrVersionRange);
         }
-        return insertStmt;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
@@ -14,6 +14,7 @@
 package com.starrocks.scheduler.mv.pct;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -52,7 +53,6 @@ import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
-import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellUtils;
 import com.starrocks.sql.parser.NodePosition;
@@ -63,7 +63,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class MVPCTRefreshPlanBuilder {
@@ -78,18 +77,20 @@ public class MVPCTRefreshPlanBuilder {
     // record mv's plan builder message to trace push-downed partition names and predicates
     private final Map<String, String> mvPlanBuildMessage = Maps.newLinkedHashMap();
 
-    private void tracePartitionNames(Table table, PCellSortedSet partitionNames) {
-        if (table == null || PCellUtils.isEmpty(partitionNames)) {
+    private void tracePartitionNames(TableRelation tableRelation, PCellSortedSet partitionNames) {
+        if (tableRelation == null || PCellUtils.isEmpty(partitionNames)) {
             return;
         }
-        mvPlanBuildMessage.put(table.getName(), partitionNames.toString());
+        // Key by the qualified relation name so two same-named base tables across databases keep separate
+        // trace entries instead of overwriting each other.
+        mvPlanBuildMessage.put(tableRelation.getName().toString(), partitionNames.toString());
     }
 
-    private void tracePartitionPredicate(Table table, Expr partitionPredicate) {
-        if (table == null || partitionPredicate == null) {
+    private void tracePartitionPredicate(TableRelation tableRelation, Expr partitionPredicate) {
+        if (tableRelation == null || partitionPredicate == null) {
             return;
         }
-        mvPlanBuildMessage.put(table.getName(), ExprToSql.toSql(partitionPredicate));
+        mvPlanBuildMessage.put(tableRelation.getName().toString(), ExprToSql.toSql(partitionPredicate));
     }
 
     private void tracePartitionPredicates(Expr partitionPredicate) {
@@ -116,7 +117,7 @@ public class MVPCTRefreshPlanBuilder {
 
     public InsertStmt analyzeAndBuildInsertPlan(InsertStmt insertStmt,
                                                 PCellSortedSet mvToRefreshedPartitions,
-                                                PCellSetMapping refTableRefreshPartitions,
+                                                Map<Table, PCellSortedSet> refTableRefreshPartitions,
                                                 ConnectContext ctx) throws AnalysisException {
         Analyzer.analyze(insertStmt, ctx);
         return buildInsertPlan(insertStmt, mvToRefreshedPartitions, refTableRefreshPartitions, ctx);
@@ -124,7 +125,7 @@ public class MVPCTRefreshPlanBuilder {
 
     private InsertStmt buildInsertPlan(InsertStmt insertStmt,
                                        PCellSortedSet mvToRefreshedPartitions,
-                                       PCellSetMapping refTableRefreshPartitions,
+                                       Map<Table, PCellSortedSet> refTableRefreshPartitions,
                                        ConnectContext ctx) throws AnalysisException {
         // Collect table relations once — used by pinned-TVR injection (all pinned batches) and by
         // partition-predicate push-down (partitioned MVs only).
@@ -141,8 +142,8 @@ public class MVPCTRefreshPlanBuilder {
         for (Map.Entry<String, TableRelation> entry : tableRelations.entries()) {
             TableRelation relation = entry.getValue();
             Table table = relation.getTable();
-            // An unresolved/dropped base table is handled as a controlled AnalysisException later
-            // in the ref-base-table path; skip here to preserve that error surface (and avoid NPE).
+            // Skip null here to avoid NPE on getTableIdentifier(); the relation-grouping loop below
+            // throws a controlled AnalysisException for any base table that resolved to null.
             if (table == null) {
                 continue;
             }
@@ -174,30 +175,35 @@ public class MVPCTRefreshPlanBuilder {
                     mvDb.getFullName(), mv.getName()));
         }
 
-        Set<String> uniqueTableNames = tableRelations.keySet().stream().collect(Collectors.toSet());
-        int numOfPushDownIntoTables = 0;
-        boolean hasGenerateNonPushDownPredicates = false;
-        SessionVariable sessionVariable = mvContext.getCtx().getSessionVariable();
-        boolean isEnableMVRefreshQueryRewrite = sessionVariable.isEnableMaterializedViewRewriteForInsert();
-        for (String tblName : uniqueTableNames) {
-            // skip to generate partition predicate for non-ref base tables
-            if (!refTableRefreshPartitions.containsKey(tblName)) {
-                logger.warn("Skip to generate partition predicate to refresh because it's not ref " +
-                                "base table, table: {}, mv:{}, refTableRefreshPartitions:{}", tblName, mv.getName(),
-                        refTableRefreshPartitions);
-                continue;
-            }
-            // set partition names for ref base table
-            PCellSortedSet tablePartitionNames = refTableRefreshPartitions.get(tblName);
-            Collection<TableRelation> relations = tableRelations.get(tblName);
-            TableRelation tableRelation = relations.iterator().next();
-            Table table = tableRelation.getTable();
+        // Group relations by the base-table object: two same-named tables from different databases have
+        // distinct identities (pushed down independently), while a self-join shares one identity.
+        Multimap<Table, TableRelation> relationsByTable = ArrayListMultimap.create();
+        for (TableRelation relation : tableRelations.values()) {
+            Table table = relation.getTable();
             if (table == null) {
                 throw new AnalysisException(String.format("Materialized view %s.%s refresh failed: " +
                         "table relation '%s' resolved to null when building refresh plan. " +
                         "The base table may have been dropped or is inaccessible.",
-                        mvDb.getFullName(), mv.getName(), tableRelation.getName()));
+                        mvDb.getFullName(), mv.getName(), relation.getName()));
             }
+            relationsByTable.put(table, relation);
+        }
+        int numOfPushDownIntoTables = 0;
+        boolean hasGenerateNonPushDownPredicates = false;
+        SessionVariable sessionVariable = mvContext.getCtx().getSessionVariable();
+        boolean isEnableMVRefreshQueryRewrite = sessionVariable.isEnableMaterializedViewRewriteForInsert();
+        for (Table table : relationsByTable.keySet()) {
+            // skip to generate partition predicate for non-ref base tables
+            if (!refTableRefreshPartitions.containsKey(table)) {
+                logger.warn("Skip to generate partition predicate to refresh because it's not ref " +
+                                "base table, table: {}, mv:{}, refTableRefreshPartitions:{}", table.getName(), mv.getName(),
+                        refTableRefreshPartitions);
+                continue;
+            }
+            // set partition names for ref base table
+            PCellSortedSet tablePartitionNames = refTableRefreshPartitions.get(table);
+            Collection<TableRelation> relations = relationsByTable.get(table);
+            TableRelation tableRelation = relations.iterator().next();
             // skip it table is not ref base table.
             if (!refBaseTablePartitionSlots.containsKey(table)) {
                 logger.warn("Skip to generate partition predicate because it's mv direct ref base table:{}, mv:{}, " +
@@ -263,7 +269,7 @@ public class MVPCTRefreshPlanBuilder {
             logger.info("Generate partition extra predicates empty, mv:{}, numOfPushDownIntoTables:{}",
                     mv.getName(), numOfPushDownIntoTables);
             return insertStmt;
-        } else if (numOfPushDownIntoTables != uniqueTableNames.size() || extraPartitionPredicates.isEmpty()) {
+        } else if (numOfPushDownIntoTables != relationsByTable.keySet().size() || extraPartitionPredicates.isEmpty()) {
             // Only generate partition predicates by mv's target partitions when ref base tables'
             // predicates cannot be pushed down
             return generateMVPartitionPredicate(mvToRefreshedPartitions, queryStatement, insertStmt);
@@ -373,7 +379,7 @@ public class MVPCTRefreshPlanBuilder {
                 mv.getName(), tableRelation.getName(), tablePartitionNames);
         tableRelation.setPartitionNames(
                 new PartitionRef(new ArrayList<>(tablePartitionNames.getPartitionNames()), false, NodePosition.ZERO));
-        tracePartitionNames(table, tablePartitionNames);
+        tracePartitionNames(tableRelation, tablePartitionNames);
         return true;
     }
 
@@ -417,7 +423,7 @@ public class MVPCTRefreshPlanBuilder {
                         "relation {},  partition predicate:{} ",
                 mv.getName(), tableRelation.getName(), ExprToSql.toSql(partitionPredicate));
         tableRelation.setPartitionPredicate(partitionPredicate);
-        tracePartitionPredicate(table, partitionPredicate);
+        tracePartitionPredicate(tableRelation, partitionPredicate);
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -52,7 +52,6 @@ import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -161,7 +160,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         try (Timer ignored = Tracers.watchScope("MVRefreshPrepareRefreshPlan")) {
             PCTRefreshScope refreshScope = mvContext.getRefreshScope();
             insertStmt = prepareRefreshPlan(refreshScope.getMvPartitionsToRefresh(),
-                    refreshScope.getRefTablePartitionNames());
+                    toTableKeyedRefreshPartitions(refreshScope.getRefTableRefreshPartitions()));
         }
         return new ProcessExecPlan(Constants.TaskRunState.SUCCESS, mvContext.getExecPlan(), insertStmt);
     }
@@ -182,11 +181,23 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         return Constants.TaskRunState.SUCCESS;
     }
 
+    private static Map<Table, PCellSortedSet> toTableKeyedRefreshPartitions(
+            Map<BaseTableSnapshotInfo, PCellSortedSet> snapshotKeyed) {
+        Map<Table, PCellSortedSet> result = Maps.newLinkedHashMap();
+        snapshotKeyed.forEach((snapshotInfo, partitions) -> {
+            Table table = snapshotInfo.getBaseTable();
+            if (table != null) {
+                result.put(table, partitions);
+            }
+        });
+        return result;
+    }
+
     /**
      * Prepare the statement and plan for mv refreshing, considering the partitions of ref table
      */
     private InsertStmt prepareRefreshPlan(PCellSortedSet mvToRefreshedPartitions,
-                                          PCellSetMapping refTablePartitionNames)
+                                          Map<Table, PCellSortedSet> refTableRefreshPartitions)
             throws AnalysisException, LockTimeoutException {
         // Prepare refresh connect context
         ConnectContext ctx = mvContext.getCtx();
@@ -228,7 +239,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
             // considering to-refresh partitions of ref tables/ mv
             try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {
                 insertStmt = planBuilder.analyzeAndBuildInsertPlan(insertStmt,
-                        mvToRefreshedPartitions, refTablePartitionNames, ctx);
+                        mvToRefreshedPartitions, refTableRefreshPartitions, ctx);
                 // Must set execution id before StatementPlanner.plan
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
             }
@@ -272,11 +283,11 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         if (logger.isDebugEnabled() || debugOptions.isEnableQueryTraceLog()) {
             logger.info("MV Refresh Final Plan\nMV PartitionsToRefresh: {}\nBase PartitionsToScan: {}\n" +
                             "Insert Plan:\n{}",
-                    mvToRefreshedPartitions, refTablePartitionNames,
+                    mvToRefreshedPartitions, refTableRefreshPartitions,
                     execPlan != null ? execPlan.getExplainString(StatementBase.ExplainLevel.VERBOSE) : "");
         } else {
             logger.info("MV Refresh Final Plan, MV PartitionsToRefresh: {}, Base PartitionsToScan: {}",
-                    mvToRefreshedPartitions, refTablePartitionNames);
+                    mvToRefreshedPartitions, refTableRefreshPartitions);
         }
 
         mvContext.setExecPlan(execPlan);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculator.java
@@ -70,10 +70,17 @@ public class PCTRefreshScopeCalculator {
                                       boolean hasPotentialPartitions) {
         Map<BaseTableSnapshotInfo, PCellSortedSet> refTableRefreshPartitions = projectRefTableRefreshPartitions(
                 topology, snapshotBaseTables, mvPartitionsToRefresh);
+        // Diagnostic-only map (the executor pushes partitions down by table object, see MVPCTRefreshPlanBuilder).
+        // Two base tables sharing an unqualified name across databases collide on this name key, so merge their
+        // partitions rather than let Collectors.toMap throw on the duplicate key.
         PCellSetMapping refTablePartitionNames = PCellSetMapping.of(refTableRefreshPartitions.entrySet().stream()
                 .collect(Collectors.toMap(
                         entry -> entry.getKey().getName(),
-                        entry -> PCellSortedSet.of(entry.getValue()))));
+                        entry -> PCellSortedSet.of(entry.getValue()),
+                        (left, right) -> {
+                            left.addAll(right);
+                            return left;
+                        })));
         return new PCTRefreshScope(
                 mvPartitionsToRefresh,
                 refTableRefreshPartitions,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1098,7 +1098,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                         Assertions.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
                         Assertions.assertEquals("p2", message.getMvPartitionsToRefreshString());
-                        Assertions.assertEquals(Map.of("s2", "p2"), message.getPlanBuilderMessage());
+                        Assertions.assertEquals(Map.of("test.s2", "p2"), message.getPlanBuilderMessage());
                         assertRefreshScopeMatchesExtraMessage(mvTaskRunContext, message);
                         ExecPlan execPlan = mvTaskRunContext.getExecPlan();
                         Assertions.assertNotEquals(null, execPlan);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -1287,7 +1287,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
             Assertions.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableSpill());
             Assertions.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableProfile());
-            Assertions.assertEquals(Map.of("tbl1", "(k1 >= '2022-03-01') AND (k1 < '2022-04-01')"),
+            Assertions.assertEquals(Map.of("test.tbl1", "(k1 >= '2022-03-01') AND (k1 < '2022-04-01')"),
                     extraMessage.getPlanBuilderMessage());
 
             Config.enable_materialized_view_spill = true;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessorTest.java
@@ -14,11 +14,18 @@
 
 package com.starrocks.scheduler.mv.ivm;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
 import com.starrocks.common.tvr.TvrDeltaStats;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
+import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.TableRelation;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -123,5 +130,71 @@ public class MVIVMRefreshProcessorTest {
         List<TvrTableDeltaTrait> traits = List.of(TvrTableDeltaTrait.ofRetractable(TvrTableDelta.of(11L, 12L)));
         assertThrows(SemanticException.class,
                 () -> MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 12L), 2, MAX_BYTES));
+    }
+
+    // Same-named base tables across databases used to collide under a name key.
+    @Test
+    public void joinOfSameNamedBaseTablesAcrossDatabasesBindsEachByTableObject() {
+        TvrTableDelta rangeA = TvrTableDelta.of(0L, 1L);
+        TvrTableDelta rangeB = TvrTableDelta.of(0L, 2L);
+        Table tableA = mockTable("tj");
+        Table tableB = mockTable("tj");
+        List<BaseTableSnapshotInfo> snapshotInfos = List.of(
+                mockSnapshotInfo(tableA, "db_a", rangeA),
+                mockSnapshotInfo(tableB, "db_b", rangeB));
+
+        TableRelation relationA = mockRelation(tableA);
+        TableRelation relationB = mockRelation(tableB);
+        Multimap<String, TableRelation> tableRelations = ArrayListMultimap.create();
+        tableRelations.put("tj", relationA);
+        tableRelations.put("tj", relationB);
+
+        MVIVMRefreshProcessor.bindBaseTableTvrVersionRanges(snapshotInfos, tableRelations);
+
+        Mockito.verify(relationA).setTvrVersionRange(rangeA);
+        Mockito.verify(relationB).setTvrVersionRange(rangeB);
+    }
+
+    @Test
+    public void relationWithoutMatchingChangedRangeThrows() {
+        List<BaseTableSnapshotInfo> snapshotInfos =
+                List.of(mockSnapshotInfo(mockTable("tj"), "db_a", TvrTableDelta.of(0L, 1L)));
+        Multimap<String, TableRelation> tableRelations = ArrayListMultimap.create();
+        tableRelations.put("tj", mockRelation(mockTable("tj")));
+        assertThrows(SemanticException.class,
+                () -> MVIVMRefreshProcessor.bindBaseTableTvrVersionRanges(snapshotInfos, tableRelations));
+    }
+
+    @Test
+    public void baseTableWithoutTvrRangeThrows() {
+        List<BaseTableSnapshotInfo> snapshotInfos = List.of(mockSnapshotInfo(mockTable("tj"), "db_a", null));
+        assertThrows(SemanticException.class, () ->
+                MVIVMRefreshProcessor.bindBaseTableTvrVersionRanges(snapshotInfos, ArrayListMultimap.create()));
+    }
+
+    private static Table mockTable(String tableName) {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.getName()).thenReturn(tableName);
+        return table;
+    }
+
+    private static BaseTableSnapshotInfo mockSnapshotInfo(Table baseTable, String dbName, TvrVersionRange tvrSnapshot) {
+        String tableName = baseTable.getName();
+        BaseTableInfo baseTableInfo = Mockito.mock(BaseTableInfo.class);
+        Mockito.when(baseTableInfo.getTableName()).thenReturn(tableName);
+        Mockito.when(baseTableInfo.getDbName()).thenReturn(dbName);
+        TvrTableSnapshotInfo snapshotInfo = Mockito.mock(TvrTableSnapshotInfo.class);
+        Mockito.when(snapshotInfo.getBaseTable()).thenReturn(baseTable);
+        Mockito.when(snapshotInfo.getBaseTableInfo()).thenReturn(baseTableInfo);
+        Mockito.when(snapshotInfo.getTvrSnapshot()).thenReturn(tvrSnapshot);
+        return snapshotInfo;
+    }
+
+    private static TableRelation mockRelation(Table table) {
+        String tableName = table.getName();
+        TableRelation relation = Mockito.mock(TableRelation.class);
+        Mockito.when(relation.getTable()).thenReturn(table);
+        Mockito.when(relation.getName()).thenReturn(new TableName("db", tableName));
+        return relation;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculatorTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class PCTRefreshScopeCalculatorTest {
 
@@ -130,17 +131,19 @@ public class PCTRefreshScopeCalculatorTest {
     }
 
     @Test
-    public void testBuildScopeFailsWhenSnapshotTablesShareTheSameName() {
+    public void testBuildScopeMergesSameNameTablesWithoutCrashing() {
+        // Two base tables sharing an unqualified name across databases resolve to the same diagnostic name
+        // key. The snapshot-keyed map (used by the executor) keeps them distinct, while the diagnostic name
+        // map merges their partitions rather than throw on the duplicate key.
         Table tableA = Mockito.mock(Table.class);
         Table tableB = Mockito.mock(Table.class);
 
         BaseTableSnapshotInfo snapshotInfoA = Mockito.mock(BaseTableSnapshotInfo.class);
         Mockito.when(snapshotInfoA.getBaseTable()).thenReturn(tableA);
-        Mockito.when(snapshotInfoA.getName()).thenReturn("dup_table");
-
+        Mockito.when(snapshotInfoA.getName()).thenReturn("tj");
         BaseTableSnapshotInfo snapshotInfoB = Mockito.mock(BaseTableSnapshotInfo.class);
         Mockito.when(snapshotInfoB.getBaseTable()).thenReturn(tableB);
-        Mockito.when(snapshotInfoB.getName()).thenReturn("dup_table");
+        Mockito.when(snapshotInfoB.getName()).thenReturn("tj");
 
         PCellSortedSet mvPartitionsToRefresh = PCellSortedSet.of();
         mvPartitionsToRefresh.add(PCellWithName.of("mv_p1", new PCellNone()));
@@ -166,7 +169,11 @@ public class PCTRefreshScopeCalculatorTest {
         snapshotBaseTables.put(1L, snapshotInfoA);
         snapshotBaseTables.put(2L, snapshotInfoB);
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> calculator.buildScope(topology, snapshotBaseTables, mvPartitionsToRefresh, false, false));
+        PCTRefreshScope scope = calculator.buildScope(topology, snapshotBaseTables, mvPartitionsToRefresh, false, false);
+
+        Assertions.assertEquals(2, scope.getRefTableRefreshPartitions().size());
+        Map<String, Set<String>> byName = scope.getRefTablePartitionNames().getRefTablePartitionNames();
+        Assertions.assertEquals(1, byName.size());
+        Assertions.assertEquals(Set.of("base_a_p1", "base_b_p1"), byName.get("tj"));
     }
 }

--- a/test/sql/test_materialized_view_ivm/R/test_mv_with_same_name_join
+++ b/test/sql/test_materialized_view_ivm/R/test_mv_with_same_name_join
@@ -1,0 +1,462 @@
+-- name: test_ivm_with_iceberg_same_name_join
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_a_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_b_${uuid0};
+-- result:
+-- !result
+create table mv_ice_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+create table mv_ice_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_ice_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj a
+JOIN mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj b ON a.dt = b.dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+2023-12-03	3	30	300
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0} force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0} force;
+-- result:
+-- !result
+-- name: test_pct_mv_with_iceberg_same_name_join
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_a_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_b_${uuid0};
+-- result:
+-- !result
+create table mv_ice_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+create table mv_ice_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_ice_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj a
+JOIN mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj b ON a.dt = b.dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+2023-12-03	3	30	300
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0} force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0} force;
+-- result:
+-- !result
+-- name: test_mv_with_iceberg_self_join
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_db_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_db_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.k AS k2
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj a
+JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj b ON a.dt = b.dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT dt, k, v, k2 FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	1
+2023-12-02	2	20	2
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj values (3, 30, '2023-12-03');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT dt, k, v, k2 FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	1
+2023-12-02	2	20	2
+2023-12-03	3	30	3
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_pct_mv_with_olap_same_name_join
+create database mv_olap_db_a_${uuid0};
+-- result:
+-- !result
+create database mv_olap_db_b_${uuid0};
+-- result:
+-- !result
+create table mv_olap_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+)
+duplicate key(k)
+partition by (dt)
+distributed by hash(k) buckets 2;
+-- result:
+-- !result
+create table mv_olap_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date
+)
+duplicate key(k)
+partition by (dt)
+distributed by hash(k) buckets 2;
+-- result:
+-- !result
+insert into mv_olap_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_olap_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_olap_db_a_${uuid0}.tj a
+JOIN mv_olap_db_b_${uuid0}.tj b ON a.dt = b.dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+-- !result
+insert into mv_olap_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+-- result:
+-- !result
+insert into mv_olap_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+2023-12-03	3	30	300
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_olap_db_a_${uuid0}.tj force;
+-- result:
+-- !result
+drop table mv_olap_db_b_${uuid0}.tj force;
+-- result:
+-- !result
+drop database mv_olap_db_a_${uuid0} force;
+-- result:
+-- !result
+drop database mv_olap_db_b_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_pct_mv_with_hive_same_name_join
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_hive_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_a_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_b_${uuid0};
+-- result:
+-- !result
+create table mv_hive_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date not null
+)
+partition by (dt);
+-- result:
+-- !result
+create table mv_hive_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date not null
+)
+partition by (dt);
+-- result:
+-- !result
+insert into mv_hive_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+-- result:
+-- !result
+insert into mv_hive_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_hive_${uuid0}.mv_hive_db_a_${uuid0}.tj a
+JOIN mv_hive_${uuid0}.mv_hive_db_b_${uuid0}.tj b ON a.dt = b.dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+-- !result
+insert into mv_hive_${uuid0}.mv_hive_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+-- result:
+-- !result
+insert into mv_hive_${uuid0}.mv_hive_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+-- result:
+2023-12-01	1	10	100
+2023-12-02	2	20	200
+2023-12-03	3	30	300
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_a_${uuid0}.tj force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_b_${uuid0}.tj force;
+-- result:
+-- !result
+drop database mv_hive_${uuid0}.mv_hive_db_a_${uuid0};
+-- result:
+-- !result
+drop database mv_hive_${uuid0}.mv_hive_db_b_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_mv_with_same_name_join
+++ b/test/sql/test_materialized_view_ivm/T/test_mv_with_same_name_join
@@ -1,0 +1,282 @@
+-- name: test_ivm_with_iceberg_same_name_join
+-- Regression: an incremental MV joining two base tables that share the same unqualified name
+-- across databases used to fail every incremental refresh with a "Duplicate key" error.
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+
+create database mv_ice_db_a_${uuid0};
+create database mv_ice_db_b_${uuid0};
+
+create table mv_ice_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+) partition by(dt);
+
+create table mv_ice_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date
+) partition by(dt);
+
+insert into mv_ice_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+insert into mv_ice_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj a
+JOIN mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj b ON a.dt = b.dt;
+
+-- initial (PCT) refresh
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+-- append to both same-named bases; the first INCREMENTAL refresh used to throw "Duplicate key tj"
+insert into mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+insert into mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0} force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0} force;
+
+-- name: test_pct_mv_with_iceberg_same_name_join
+-- Regression: a partitioned, NON-incremental (PCT) MV joining two base tables that share the same
+-- unqualified name across databases used to fail refresh with a "Duplicate key" error in the PCT
+-- refresh-scope calculator. Mirrors the IVM case but exercises the pure PCT refresh path.
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+
+create database mv_ice_db_a_${uuid0};
+create database mv_ice_db_b_${uuid0};
+
+create table mv_ice_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+) partition by(dt);
+
+create table mv_ice_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date
+) partition by(dt);
+
+insert into mv_ice_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+insert into mv_ice_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj a
+JOIN mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj b ON a.dt = b.dt;
+
+-- full PCT refresh
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+-- append a new partition to both same-named bases; the PCT refresh used to throw "Duplicate key"
+insert into mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+insert into mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0}.tj force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0}.tj force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_a_${uuid0} force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_b_${uuid0} force;
+
+-- name: test_mv_with_iceberg_self_join
+-- Guards self-join after the same-name-join fix re-keyed relations by table identifier: the two
+-- aliases of a self-join share one identifier, so they must still be treated as one base table
+-- (one refresh-scope entry / a self-join), not mistaken for two distinct tables.
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+
+create database mv_ice_db_${uuid0};
+create table mv_ice_db_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+) partition by(dt);
+
+insert into mv_ice_db_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.k AS k2
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj a
+JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj b ON a.dt = b.dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, k2 FROM test_mv1 ORDER BY dt, k;
+
+-- append a new partition; partial PCT refresh of a self-join must still work
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj values (3, 30, '2023-12-03');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, k2 FROM test_mv1 ORDER BY dt, k;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.tj force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+
+-- name: test_pct_mv_with_olap_same_name_join
+-- Regression: a partitioned native MV joining two OLAP base tables that share an unqualified name
+-- across databases used to crash PCT refresh-scope calculation on a duplicate name key. OLAP tables
+-- are now keyed by table id (external tables by catalog+uuid), so each is tracked independently.
+create database mv_olap_db_a_${uuid0};
+create database mv_olap_db_b_${uuid0};
+
+create table mv_olap_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date
+)
+duplicate key(k)
+partition by (dt)
+distributed by hash(k) buckets 2;
+
+create table mv_olap_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date
+)
+duplicate key(k)
+partition by (dt)
+distributed by hash(k) buckets 2;
+
+insert into mv_olap_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+insert into mv_olap_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_olap_db_a_${uuid0}.tj a
+JOIN mv_olap_db_b_${uuid0}.tj b ON a.dt = b.dt;
+
+-- full PCT refresh
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+-- append a new partition to both same-named bases; the PCT refresh used to throw "Duplicate key"
+insert into mv_olap_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+insert into mv_olap_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_olap_db_a_${uuid0}.tj force;
+drop table mv_olap_db_b_${uuid0}.tj force;
+drop database mv_olap_db_a_${uuid0} force;
+drop database mv_olap_db_b_${uuid0} force;
+
+-- name: test_pct_mv_with_hive_same_name_join
+-- Regression: a partitioned MV joining two Hive external base tables that share an unqualified name
+-- across databases. Hive tables are keyed by (catalog, db, name:createTime), so each is tracked
+-- independently and PCT refresh no longer collides on the duplicate name.
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+set catalog mv_hive_${uuid0};
+
+create database mv_hive_db_a_${uuid0};
+create database mv_hive_db_b_${uuid0};
+
+create table mv_hive_db_a_${uuid0}.tj (
+  k int,
+  v bigint,
+  dt date not null
+)
+partition by (dt);
+
+create table mv_hive_db_b_${uuid0}.tj (
+  k int,
+  w bigint,
+  dt date not null
+)
+partition by (dt);
+
+insert into mv_hive_db_a_${uuid0}.tj values (1, 10, '2023-12-01'), (2, 20, '2023-12-02');
+insert into mv_hive_db_b_${uuid0}.tj values (1, 100, '2023-12-01'), (2, 200, '2023-12-02');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT a.dt, a.k, a.v, b.w
+FROM mv_hive_${uuid0}.mv_hive_db_a_${uuid0}.tj a
+JOIN mv_hive_${uuid0}.mv_hive_db_b_${uuid0}.tj b ON a.dt = b.dt;
+
+-- full PCT refresh
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+-- append a new partition to both same-named bases; the PCT refresh used to throw "Duplicate key"
+insert into mv_hive_${uuid0}.mv_hive_db_a_${uuid0}.tj values (3, 30, '2023-12-03');
+insert into mv_hive_${uuid0}.mv_hive_db_b_${uuid0}.tj values (3, 300, '2023-12-03');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(*) FROM test_mv1;
+SELECT dt, k, v, w FROM test_mv1 ORDER BY dt, k;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_hive_${uuid0}.mv_hive_db_a_${uuid0}.tj force;
+drop table mv_hive_${uuid0}.mv_hive_db_b_${uuid0}.tj force;
+drop database mv_hive_${uuid0}.mv_hive_db_a_${uuid0};
+drop database mv_hive_${uuid0}.mv_hive_db_b_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

A materialized view whose query joins two distinct base tables that share the same **unqualified name** across different databases/catalogs (e.g. `db_a.tj JOIN db_b.tj`) fails to refresh. `CREATE` and the initial baseline refresh are accepted, but every subsequent refresh aborts with `java.lang.IllegalStateException: Duplicate key tj`, leaving the MV stale. First observed on an INCREMENTAL (IVM) iceberg MV, but the same collision affects any partitioned MV with such a join — including native OLAP base tables.

## What I'm doing:

The refresh path identified base tables by their **unqualified name** in three places, which collide when two distinct base tables share a name:

- **IVM** (`MVIVMRefreshProcessor.bindBaseTableTvrVersionRanges`): the per-base-table TVR delta map was keyed by table name (`Collectors.toMap`, no merge) → crash, and the subsequent lookup mis-assigned the delta.
- **PCT pushdown** (`MVPCTRefreshPlanBuilder`): relations were grouped and the to-refresh partition map looked up by `Table.getTableIdentifier()`, which returns the **bare name for OLAP tables**, so two same-named tables were conflated and partition predicates pushed onto one relation only.
- **PCT scope** (`PCTRefreshScopeCalculator.buildScope`): the diagnostic `RefBasePartitionsToRefreshMap` was built with `Collectors.toMap` keyed by name → crash (hit first, by the IVM hybrid baseline refresh).

Fix: the execution paths (IVM delta bind, PCT partition pushdown) now key base tables by the **base-table object**. Object identity is unique per base table (OLAP by table id, external by catalog+uuid), stable across the snapshot/relation boundary, and matches the existing `mv.getRefBaseTablePartitionSlots()` keying right beside the old lookup. A self-join (one identity) is still correctly distinguished from two same-named tables (two identities). The `buildScope` diagnostic stays keyed by table name; same-named tables now **merge** in that map instead of throwing — it is diagnostic-only, so refresh correctness is unaffected and the existing name-keyed format is preserved.

The fix applies uniformly across base-table types: native OLAP (keyed by table id) and external iceberg/hive/hudi/delta (keyed by `catalog + db + stable identifier`, i.e. `name:uuid` for iceberg/delta, `name:createTime` for hive/hudi). Validated end-to-end on a dev cluster — the native-OLAP and Hive same-name-join PCT MVs refresh to 2 rows initially and 3 after appending to both base tables (previously aborted). Added FE unit tests for the IVM bind and the PCT scope (including the same-name merge), a native-OLAP PCT regression, and SQL-Tester e2e cases (iceberg IVM / iceberg PCT / iceberg self-join / native-OLAP PCT / Hive PCT) consolidated in one file. Commits are split by component (IVM / PCT / e2e).

Fixes #issue: N/A — reported via an internal tracker.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
