### PR TITLE
[Tool] gate global-review on GLOBAL-REVIEW label assigned by AI

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -113,26 +113,29 @@ jobs:
               || echo "WARN: add-reviewer $r failed (permissions, already a reviewer, or transient API error)"
           }
 
-          assign_team() {
+          # Route team request through a label instead of calling
+          # gh pr edit --add-reviewer directly. label-action.yml has a
+          # `global-review:` job that watches the GLOBAL-REVIEW label and
+          # POSTs the requested_reviewers API. Keeping this on the label
+          # path means manual label toggling and AI assignment funnel
+          # through one code path; approve-checker.yml's global-review
+          # gate also keys off the same label.
+          assign_global_team() {
             local t="$1"
             if [ -z "$t" ] || [ "$t" = "none" ]; then
               return
             fi
-            # gh expects team form `org/team-slug`. If the skill already emits
-            # a qualified form, use it as-is; otherwise scope to the current
-            # repo's org. This file is synced to both StarRocks/starrocks and
-            # CelerData/celerdata-enterprise, and each org has its own
-            # `global-reviewer` team -- StarRocks/global-reviewer vs
-            # CelerData/global-reviewer. Hardcoding one org would route the
-            # wrong team in the other repo, so derive org from $REPO
-            # (`<owner>/<repo>`) at runtime.
+            # Strip optional org prefix the skill may emit
             case "$t" in
-              */*) ;;
-              *)   t="${REPO%%/*}/${t}" ;;
+              */*) t="${t#*/}" ;;
             esac
-            echo "Assigning team: $t"
-            gh pr edit "$PR" -R "$REPO" --add-reviewer "$t" \
-              || echo "WARN: add-reviewer $t failed (permissions, already a reviewer, or transient API error)"
+            if [ "$t" != "global-reviewer" ]; then
+              echo "WARN: unsupported team slug from AI: $t (only global-reviewer is supported via GLOBAL-REVIEW label routing)"
+              return
+            fi
+            echo "Adding GLOBAL-REVIEW label (label-action.yml will request the team)"
+            gh pr edit "$PR" -R "$REPO" --add-label GLOBAL-REVIEW \
+              || echo "WARN: add-label GLOBAL-REVIEW failed (permissions or transient API error)"
           }
 
           assign_user "$owner"
@@ -142,7 +145,7 @@ jobs:
             affinity=""
           fi
           assign_user "$affinity"
-          assign_team "$global"
+          assign_global_team "$global"
 
       - name: Notify Slack
         env:

--- a/.github/workflows/approve-checker.yml
+++ b/.github/workflows/approve-checker.yml
@@ -38,8 +38,6 @@ jobs:
       TITLE: ${{ steps.pr_info.outputs.title }}
       LABELS: ${{ steps.pr_info.outputs.labels }}
       DIFF_LINES: ${{ steps.pr_info.outputs.diff_lines }}
-      SKIP_GLOBAL_REVIEW: ${{ steps.skip_rule.outputs.skip }}
-      SKIP_GLOBAL_REVIEW_REASON: ${{ steps.skip_rule.outputs.reason }}
 
 
     steps:
@@ -75,69 +73,6 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           cat $GITHUB_OUTPUT
-
-      - name: Compute skip rule
-        id: skip_rule
-        env:
-          PR: ${{ steps.pr.outputs.PR_NUMBER }}
-          TITLE: ${{ steps.pr_info.outputs.title }}
-        run: |
-          set -x
-          # Skip GLOBAL REVIEW gate for small/test-only PRs to reduce noise.
-          # Adjust BUGFIX_LINE_THRESHOLD as needed (non-test add+del lines).
-          BUGFIX_LINE_THRESHOLD=30
-          TEST_PATTERN='(Test\.(java|kt)$|_test\.(cpp|cc|h)$|/test/|^test/|^fe-test/|^regression-test/|/__test__/)'
-
-          skip=false
-          reason=""
-
-          # Rule 1: [UT] / [Doc] title prefix
-          if echo "$TITLE" | grep -qE '^\[(UT|Doc)\]'; then
-            skip=true
-            reason="title prefix [UT] or [Doc]"
-          fi
-
-          # Rule 2: all changed files match test pattern
-          # Fail-closed: if the metadata query errors out, do NOT apply skip —
-          # a transient API failure must not bypass the GLOBAL REVIEW gate.
-          if [ "$skip" = "false" ]; then
-            files=$(gh pr diff "$PR" -R "$REPO" --name-only 2>/dev/null)
-            query_status=$?
-            if [ "$query_status" -ne 0 ]; then
-              echo "WARN: 'gh pr diff' failed (exit=$query_status); not applying test-only rule"
-            else
-              total=$(echo "$files" | grep -cv '^$' || true)
-              non_test=$(echo "$files" | grep -v '^$' | grep -cvE "$TEST_PATTERN" || true)
-              if [ "$total" -gt 0 ] && [ "$non_test" -eq 0 ]; then
-                skip=true
-                reason="all $total changed files are tests"
-              fi
-            fi
-          fi
-
-          # Rule 3: [BugFix] with non-test add+del < threshold
-          # NOTE: jq's regex needs \\. for a literal dot (the pattern must match TEST_PATTERN above).
-          # Fail-closed: if the metadata query errors out or returns empty, do NOT apply skip —
-          # otherwise a transient gh API failure would silently bypass the GLOBAL REVIEW gate.
-          if [ "$skip" = "false" ] && echo "$TITLE" | grep -qE '^\[BugFix\]'; then
-            non_test_lines=$(gh pr view "$PR" -R "$REPO" --json files --jq '
-              [.files[]
-               | select(.path | test("(Test\\.(java|kt)$|_test\\.(cpp|cc|h)$|/test/|^test/|^fe-test/|^regression-test/|/__test__/)") | not)
-               | (.additions + .deletions)]
-              | add // 0
-            ' 2>/dev/null)
-            query_status=$?
-            if [ "$query_status" -ne 0 ] || [ -z "$non_test_lines" ]; then
-              echo "WARN: 'gh pr view --json files' failed (exit=$query_status, output='$non_test_lines'); not applying [BugFix] rule"
-            elif [ "$non_test_lines" -lt "$BUGFIX_LINE_THRESHOLD" ]; then
-              skip=true
-              reason="[BugFix] non-test lines=$non_test_lines < $BUGFIX_LINE_THRESHOLD"
-            fi
-          fi
-
-          echo "skip=$skip"     >> "$GITHUB_OUTPUT"
-          echo "reason=$reason" >> "$GITHUB_OUTPUT"
-          echo "=== gate result: skip=$skip, reason='$reason' ==="
 
   meta-review:
     needs: info
@@ -189,6 +124,7 @@ jobs:
     if: >
       github.event_name == 'pull_request_review' &&
       needs.info.outputs.BASE_REF == 'main' &&
+      contains(needs.info.outputs.LABELS, 'GLOBAL-REVIEW') &&
       !contains(needs.info.outputs.LABELS, 'sync') &&
       !startsWith(needs.info.outputs.HEAD_REF, 'mergify/')
     name: GLOBAL REVIEW
@@ -201,13 +137,6 @@ jobs:
 
     steps:
       - name: GLOBAL REVIEW
-        env:
-          SKIP_GLOBAL_REVIEW: ${{ needs.info.outputs.SKIP_GLOBAL_REVIEW }}
-          SKIP_GLOBAL_REVIEW_REASON: ${{ needs.info.outputs.SKIP_GLOBAL_REVIEW_REASON }}
         run: |
-          if [[ "$SKIP_GLOBAL_REVIEW" == "true" ]]; then
-            echo "::notice::GLOBAL REVIEW skipped: $SKIP_GLOBAL_REVIEW_REASON"
-            exit 0
-          fi
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
           ./scripts/check-approve.sh

--- a/.github/workflows/label-action.yml
+++ b/.github/workflows/label-action.yml
@@ -80,3 +80,33 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
             -f "reviewers[]=" -f "team_reviewers[]=${PROTO_TEAM}" 1>/dev/null
+
+  global-review:
+    name: GLOBAL REVIEW LABEL
+    if: github.event.label.name == 'GLOBAL-REVIEW'
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      GLOBAL_TEAM: global-reviewer
+      GH_TOKEN: ${{ secrets.PAT }}
+
+    steps:
+      - name: ADD REVIEWER
+        if: github.event.action == 'labeled'
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${GLOBAL_TEAM}" 1>/dev/null
+
+      - name: REMOVE REVIEWER
+        if: github.event.action == 'unlabeled'
+        run: |
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${GLOBAL_TEAM}" 1>/dev/null


### PR DESCRIPTION
## Why I'm doing:

The current \`global-review\` gate in \`approve-checker.yml\` fires on every Approve event on \`main\` and tries to skip noisy cases with a hardcoded multi-rule block (\`[UT]/[Doc]\` title prefix, all-test-files, small \`[BugFix]\` line count). That keeps drifting from what actually matters — AI in \`ai-sr-skills.yml\` already decides per-PR whether the \`global-reviewer\` team should be requested. We should treat that decision as the source of truth.

## What I'm doing:

Mirror the existing \`PROTO-REVIEW\` / \`META-REVIEW\` pattern: one label drives both the team review request and the approval gate.

**1. \`ai-sr-skills.yml\`** — stop calling \`gh pr edit --add-reviewer <team>\` directly. Add the \`GLOBAL-REVIEW\` label instead; \`label-action.yml\` translates it into a team review request. Only \`global-reviewer\` is supported via this path (matching the skill's current output template).

**2. \`label-action.yml\`** — add a \`global-review:\` job mirroring \`proto-review:\`:
- \`labeled\` → POST \`/requested_reviewers\` with \`global-reviewer\` team
- \`unlabeled\` → DELETE the same

**3. \`approve-checker.yml\`** — \`global-review:\` job gates on \`contains(LABELS, 'GLOBAL-REVIEW')\`. Delete the entire \`SKIP_GLOBAL_REVIEW\` block (output + Compute-skip-rule step + the skip-checking block in the job step). Those rules become redundant: the label is the gate. If AI didn't decide global review is needed, the label isn't there, and the job is skipped at the \`if:\` level (visible as Skipped in the Actions UI, no log noise).

Net: \`approve-checker.yml\` shrinks 213 → 142 lines.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous

The CI-side policy for who triggers the global-review gate moves from hardcoded heuristics (title prefix / file types / line count) to AI-driven label assignment.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Trade-offs / caveats

- Old PRs that already have \`global-reviewer\` requested as a team but no \`GLOBAL-REVIEW\` label will see the gate go from "requires global-reviewer approval" to "skipped" on next Approve event. Acceptable because AI was the assigner anyway; if you want to keep an in-flight PR gated, manually add the \`GLOBAL-REVIEW\` label.
- \`ai-sr-skills.yml\` is synced to both \`StarRocks/starrocks\` and \`the downstream fork\`. The label-routed path no longer needs the org-prefix derivation logic (since label-action.yml requests \`global-reviewer\` within the current repo's org automatically); the old org-derivation comment is removed in this PR.
