### PR TITLE
[Tool] include repo in Slack reviewer notification link text

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -211,7 +211,11 @@ jobs:
             fi
           done <<< "$reviewers"
 
-          text="${mentions}You were assigned as reviewer for <${PR_URL}|#${PR} ${TITLE}>"
+          # Include `${REPO}` so the link text shows e.g. `StarRocks/starrocks#74725 ...`
+          # — this file is synced to both StarRocks/starrocks and
+          # CelerData/celerdata-enterprise, both notify the same Slack channel,
+          # so the repo prefix lets reviewers tell which repo the PR is in.
+          text="${mentions}You were assigned as reviewer for <${PR_URL}|${REPO}#${PR} ${TITLE}>"
 
           python3 lib/slack_notify.py \
             --mode channel \


### PR DESCRIPTION
## Why I'm doing:

\`ai-sr-skills.yml\` is synced to both \`StarRocks/starrocks\` and \`the downstream fork\`, and the Slack notification step fires into a single shared channel \`C0B4GU36HJN\` (hardcoded). The current message shows only \`#74725 [Feature] ...\` — reviewers can't tell from the message whether the PR is in the open-source repo or the downstream repo without hovering/clicking the link.

## What I'm doing:

Add \`\${REPO}\` to the link text. Before/after:

Before:
\`\`\`
@Youngwb @stdpain You were assigned as reviewer for #74725 [Feature] Add MERGE INTO planner...
\`\`\`

After:
\`\`\`
@Youngwb @stdpain You were assigned as reviewer for StarRocks/starrocks#74725 [Feature] Add MERGE INTO planner...
\`\`\`

The \`org/repo#N\` form matches GitHub's canonical cross-repo reference syntax. \`${REPO}\` is already in the step's env (\`github.repository\`), so this is a one-line change.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Files changed
- \`.github/workflows/ai-sr-skills.yml\` — 1 substantive line (line 214); also adds a short comment explaining the rationale.

## Not included
- Did not touch the channel ID — both repos still notify the same channel, which is the situation that necessitates this fix.
- Did not add the \`global-reviewer\` team mention (separate concern — team→Slack user-group mapping isn't yet wired up in \`member_slack.json\`).
