### PR TITLE
[BugFix] CI test: module-risk e2e probe (no-op, will close)

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -51,6 +51,7 @@ public:
 
     Status open();
 
+    // CI test (module-risk e2e) — no-op comment line, will be reverted; see PR description.
     void write(const Chunk* chunk, const uint32_t* indexes, uint32_t indexes_size, Callback cb);
 
     void flush(Callback cb);


### PR DESCRIPTION
**⚠️ Throwaway CI test PR — do not review/merge. Will be closed shortly.**

Purpose: exercise the new `module-risk` job in `ai-sr-skills.yml` end-to-end (PR-open → `/github-pr-module-risk:review --comment` in the claude-cli container → sticky review-focus comment).

- No behavior change: a single comment line in `be/src/storage/lake/async_delta_writer.cpp` (the `storage/lake` module has a rich pathology card, 20 source bugfixes).
- Opened by a trusted author to satisfy the workflow's author gate.
- Closing without merging.