### PR TITLE
[Enhancement] Bring public probe/observability HTTP endpoints into enable_http_auth as AuthN-only

### DIFF
--- a/be/src/exec/schema_scanner/schema_fe_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_fe_metrics_scanner.cpp
@@ -17,11 +17,10 @@
 #include <simdjson.h>
 
 #include "base/metrics.h"
-#include "common/system/master_info.h"
 #include "exec/schema_scanner/schema_helper.h"
-#include "gutil/strings/numbers.h"
+#include "gen_cpp/FrontendService.h"
 #include "gutil/strings/substitute.h"
-#include "http/core/http_client.h"
+#include "platform/thrift_rpc_helper.h"
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 
@@ -40,17 +39,31 @@ SchemaFeMetricsScanner::SchemaFeMetricsScanner()
 SchemaFeMetricsScanner::~SchemaFeMetricsScanner() = default;
 
 Status SchemaFeMetricsScanner::_get_fe_metrics(RuntimeState* state) {
+    int32_t timeout = state->query_options().query_timeout * 1000 / 2;
     for (const TFrontend& frontend : _param->frontends) {
-        std::string metrics;
-        std::string url = "http://" + frontend.ip + ":" + SimpleItoa(frontend.http_port) + "/metrics?type=json";
-        auto timeout = state->query_options().query_timeout * 1000 / 2;
-        auto mmetrics_cb = [&url, &metrics, &timeout](HttpClient* client) {
-            RETURN_IF_ERROR(client->init(url));
-            client->set_timeout_ms(timeout);
-            RETURN_IF_ERROR(client->execute(&metrics));
-            return Status::OK();
-        };
-        RETURN_IF_ERROR(HttpClient::execute_with_retry(2 /* retry times */, 1 /* sleep interval */, mmetrics_cb));
+        // Defensive guard: the FE planner always sets rpc_port (Config.rpc_port); a missing or
+        // non-positive port only happens under FE/BE version skew. Skip such a frontend with a
+        // warning rather than connecting to port 0 or failing the whole fe_metrics query.
+        if (!frontend.__isset.rpc_port || frontend.rpc_port <= 0) {
+            LOG(WARNING) << "skip fe_metrics for frontend " << frontend.id << " (" << frontend.ip
+                         << "): missing/invalid rpc_port";
+            continue;
+        }
+        // Fetch each FE's metrics over the FrontendService Thrift RPC. This replaces the
+        // previous HTTP scrape of /metrics?type=json, so fe_metrics works regardless of
+        // `enable_http_auth` (the RPC needs no HTTP Basic credentials). It takes no arguments —
+        // FE process metrics are global, with no per-object RBAC to authorize.
+        TFeMetricsResult result;
+        auto rpc_cb = [&result](FrontendServiceConnection& client) { client->getFeMetrics(result); };
+        RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(frontend.ip, frontend.rpc_port, rpc_cb, timeout,
+                                                                    2 /* retry times */));
+        if (result.__isset.status) {
+            RETURN_IF_ERROR(Status(result.status));
+        }
+        if (!result.__isset.json_metrics) {
+            return Status::InternalError("fe metrics response missing json_metrics from " + frontend.ip);
+        }
+        const std::string& metrics = result.json_metrics;
         VLOG(2) << "metrics: " << metrics;
 
         simdjson::ondemand::parser parser;

--- a/be/src/http/service/action/health_action.cpp
+++ b/be/src/http/service/action/health_action.cpp
@@ -49,6 +49,10 @@ const static std::string HEADER_JSON = "application/json";
 
 HealthAction::HealthAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
 
+bool HealthAction::need_auth() const {
+    return true;
+}
+
 void HealthAction::handle(HttpRequest* req) {
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_health"));
     std::stringstream ss;

--- a/be/src/http/service/action/health_action.h
+++ b/be/src/http/service/action/health_action.h
@@ -49,7 +49,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
-    bool need_auth() const override { return false; }
+    // AuthN-only: require Basic identity when `config::enable_http_auth` is on (the
+    // injected verifier short-circuits when it is off). No extra privilege required —
+    // `required_privilege()` stays NONE. Defined out-of-line in the .cpp so BE
+    // incremental-coverage attributes the line to a be/src translation unit; a
+    // header-inline override is inlined into callers and not counted.
+    bool need_auth() const override;
 
 private:
     [[maybe_unused]] ExecEnv* _exec_env;

--- a/be/src/http/service/action/memory_metrics_action.cpp
+++ b/be/src/http/service/action/memory_metrics_action.cpp
@@ -28,6 +28,10 @@
 
 namespace starrocks {
 
+bool MemoryMetricsAction::need_auth() const {
+    return true;
+}
+
 void MemoryMetricsAction::handle(HttpRequest* req) {
     LOG(INFO) << "Start collect memory metrics.";
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_memory_metrics"));

--- a/be/src/http/service/action/memory_metrics_action.h
+++ b/be/src/http/service/action/memory_metrics_action.h
@@ -54,7 +54,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
-    bool need_auth() const override { return false; }
+    // AuthN-only: require Basic identity when `config::enable_http_auth` is on (the
+    // injected verifier short-circuits when it is off). No extra privilege required —
+    // `required_privilege()` stays NONE. Defined out-of-line in the .cpp so BE
+    // incremental-coverage attributes the line to a be/src translation unit; a
+    // header-inline override is inlined into callers and not counted.
+    bool need_auth() const override;
 
 private:
     const GlobalEnv& _global_env;

--- a/be/src/http/service/action/metrics_action.cpp
+++ b/be/src/http/service/action/metrics_action.cpp
@@ -321,6 +321,10 @@ void JsonMetricsVisitor::visit(const std::string& prefix, const std::string& nam
     }
 }
 
+bool MetricsAction::need_auth() const {
+    return true;
+}
+
 void MetricsAction::handle(HttpRequest* req) {
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_metrics"));
     const std::string& type = req->param("type");

--- a/be/src/http/service/action/metrics_action.h
+++ b/be/src/http/service/action/metrics_action.h
@@ -60,7 +60,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
-    bool need_auth() const override { return false; }
+    // AuthN-only: require Basic identity when `config::enable_http_auth` is on (the
+    // injected verifier short-circuits when it is off). No extra privilege required —
+    // `required_privilege()` stays NONE. Defined out-of-line in the .cpp so BE
+    // incremental-coverage attributes the line to a be/src translation unit; a
+    // header-inline override is inlined into callers and not counted.
+    bool need_auth() const override;
 
 private:
     void _collect_table_metrics(starrocks::MetricsVisitor* visitor);

--- a/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
@@ -15,67 +15,157 @@
 #include "exec/schema_scanner/schema_fe_metrics_scanner.h"
 
 #include <gtest/gtest.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/server/TSimpleServer.h>
+#include <thrift/transport/TServerSocket.h>
+#include <unistd.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
 
 #include "base/testutil/assert.h"
-#include "http/core/ev_http_server.h"
-#include "http/core/http_channel.h"
-#include "http/core/http_client.h"
-#include "http/core/http_handler.h"
-#include "http/core/http_request.h"
+#include "common/object_pool.h"
+#include "common/util/thrift_client_cache.h"
+#include "gen_cpp/FrontendService.h"
+#include "platform/thrift_rpc_helper.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
 
-class SchemaFeMetricsScannerGetHandler : public HttpHandler {
+// Mock FrontendService that returns a canned `/metrics?type=json` payload over the
+// getFeMetrics RPC, so the scanner's new Thrift transport + JSON parsing can be exercised
+// without a live FE and without HTTP auth.
+class FeMetricsMockService : public FrontendServiceNull {
 public:
-    SchemaFeMetricsScannerGetHandler() = default;
-    void handle(HttpRequest* req) override {
-        std::string resp = R"([{"tags":{"metric":"jvm_young_gc","type":"count"},"unit":"nounit","value:741}])";
-        HttpChannel::send_reply(req, resp);
+    explicit FeMetricsMockService(std::string json, bool include_json = true)
+            : _json(std::move(json)), _include_json(include_json) {}
+    ~FeMetricsMockService() override = default;
+
+    void getFeMetrics(TFeMetricsResult& result) override {
+        TStatus status;
+        status.__set_status_code(TStatusCode::OK);
+        result.__set_status(status);
+        // When `_include_json` is false the reply carries an OK status but no json_metrics,
+        // mimicking a partial/older FE so the scanner's missing-field guard is exercised.
+        if (_include_json) {
+            result.__set_json_metrics(_json);
+        }
     }
+
+private:
+    std::string _json;
+    bool _include_json;
 };
 
 class SchemaFeMetricsScannerTest : public testing::Test {
 public:
-    SchemaFeMetricsScannerTest() {}
-    ~SchemaFeMetricsScannerTest() override = default;
+    void start_mock(const std::string& json, bool include_json = true) {
+        using namespace apache::thrift::transport;
+        using namespace apache::thrift::protocol;
+        using namespace apache::thrift::server;
 
-    void SetUp() override {
-        _server = std::make_unique<EvHttpServer>(0);
-        _server->register_handler(GET, "/metrics", &_handler);
-        ASSERT_OK(_server->start());
-        _port = _server->get_real_port();
-        ASSERT_NE(0, _port);
-        _hostname = "http://127.0.0.1:" + std::to_string(_port);
+        auto service = std::make_shared<FeMetricsMockService>(json, include_json);
+        _processor = std::make_shared<FrontendServiceProcessor>(service);
+        // Port 0 lets the OS assign an available port.
+        _server_transport = std::make_shared<TServerSocket>(0);
+        _server = std::make_unique<TSimpleServer>(_processor, _server_transport,
+                                                  std::make_shared<TBufferedTransportFactory>(),
+                                                  std::make_shared<TBinaryProtocolFactory>());
+        _thr = std::make_unique<std::thread>([this]() { _server->serve(); });
+        // TServerSocket binds and listens before getPort() returns a non-zero port, so once
+        // the port is assigned the server is ready to accept — poll for that instead of a
+        // fixed sleep, and fail fast (rather than proceeding with port 0) if it never binds.
+        for (int i = 0; i < 50 && _port <= 0; ++i) {
+            _port = _server_transport->getPort();
+            if (_port <= 0) {
+                usleep(100000); // 100ms
+            }
+        }
+        ASSERT_GT(_port, 0) << "mock FrontendService failed to bind an ephemeral port";
+
+        // The scanner reaches the FE via ThriftRpcHelper, which resolves its client cache from
+        // the static cache installed by setup() (done by ExecEnv in a real BE). Install a local
+        // cache here so the RPC works in the unit test; TearDown() clears it.
+        ThriftRpcHelper::setup(nullptr, &_fe_cache, nullptr);
     }
 
     void TearDown() override {
-        _server->stop();
-        _server->join();
+        ThriftRpcHelper::clear();
+        if (_server != nullptr) {
+            _server->stop();
+            _thr->join();
+        }
     }
 
 protected:
-    SchemaFeMetricsScannerGetHandler _handler;
-    std::unique_ptr<EvHttpServer> _server = nullptr;
+    std::unique_ptr<std::thread> _thr;
+    std::shared_ptr<FrontendServiceProcessor> _processor;
+    std::unique_ptr<apache::thrift::server::TSimpleServer> _server;
+    std::shared_ptr<apache::thrift::transport::TServerSocket> _server_transport;
+    FrontendServiceClientCache _fe_cache;
     int _port = 0;
-    std::string _hostname = "";
     ObjectPool _pool;
 };
 
-TEST_F(SchemaFeMetricsScannerTest, test_partial_json) {
-    RuntimeState state;
+static SchemaScannerParam make_param(int rpc_port) {
     TFrontend frontend;
     frontend.__set_ip("127.0.0.1");
     frontend.__set_id("1");
-    frontend.__set_http_port(_port);
+    frontend.__set_rpc_port(rpc_port);
 
     SchemaScannerParam param;
     param.frontends.push_back(std::move(frontend));
+    return param;
+}
 
+TEST_F(SchemaFeMetricsScannerTest, fetch_metrics_over_thrift_ok) {
+    start_mock(R"([{"tags":{"metric":"jvm_young_gc","type":"count"},"unit":"nounit","value":741}])");
+
+    RuntimeState state;
+    SchemaScannerParam param = make_param(_port);
+    SchemaFeMetricsScanner scanner;
+    ASSERT_OK(scanner.init(&param, &_pool));
+    ASSERT_OK(scanner.start(&state));
+}
+
+TEST_F(SchemaFeMetricsScannerTest, malformed_json_returns_error) {
+    // Missing quote after "value" makes the payload invalid JSON.
+    start_mock(R"([{"tags":{"metric":"jvm_young_gc","type":"count"},"unit":"nounit","value:741}])");
+
+    RuntimeState state;
+    SchemaScannerParam param = make_param(_port);
     SchemaFeMetricsScanner scanner;
     ASSERT_OK(scanner.init(&param, &_pool));
     auto st = scanner.start(&state);
     ASSERT_ERROR(st);
-    ASSERT_TRUE(st.message().find("A string is opened") != std::string::npos);
+    ASSERT_TRUE(st.message().find("Parse the result of fe metrics failed") != std::string::npos);
 }
+
+TEST_F(SchemaFeMetricsScannerTest, skip_frontend_with_invalid_rpc_port) {
+    // A frontend whose rpc_port is missing/invalid (e.g. FE/BE version skew) is skipped with
+    // a warning instead of connecting to port 0 — the query succeeds and yields no rows for it.
+    RuntimeState state;
+    SchemaScannerParam param = make_param(0);
+    SchemaFeMetricsScanner scanner;
+    ASSERT_OK(scanner.init(&param, &_pool));
+    ASSERT_OK(scanner.start(&state));
+}
+
+TEST_F(SchemaFeMetricsScannerTest, missing_json_metrics_returns_error) {
+    // FE replies with an OK status but no json_metrics field (e.g. a partial response or an
+    // older FE). The scanner must surface an InternalError instead of treating the missing
+    // payload as empty metrics — covers the `!result.__isset.json_metrics` guard.
+    start_mock(/*json=*/"", /*include_json=*/false);
+
+    RuntimeState state;
+    SchemaScannerParam param = make_param(_port);
+    SchemaFeMetricsScanner scanner;
+    ASSERT_OK(scanner.init(&param, &_pool));
+    auto st = scanner.start(&state);
+    ASSERT_ERROR(st);
+    ASSERT_TRUE(st.message().find("missing json_metrics") != std::string::npos);
+}
+
 } // namespace starrocks

--- a/be/test/http/handler_required_privilege_test.cpp
+++ b/be/test/http/handler_required_privilege_test.cpp
@@ -194,10 +194,16 @@ TEST(BeHandlerNeedAuthTest, download_action_error_log_requires_framework_auth) {
     EXPECT_TRUE(error_log.need_auth());
 }
 
-TEST(BeHandlerNeedAuthTest, probe_and_prometheus_endpoints_skip_framework_auth) {
-    EXPECT_FALSE(HealthAction(nullptr).need_auth());
-    EXPECT_FALSE(MetricsAction(nullptr).need_auth());
-    EXPECT_FALSE(MemoryMetricsAction(fake_global_env()).need_auth());
+// Probe / Prometheus endpoints (/api/health, /metrics, /metrics/memory) are AuthN-only:
+// historically anonymous, now gated by `config::enable_http_auth` -- need_auth() == true
+// (the injected verifier short-circuits when the flag is off) with no extra privilege.
+TEST(BeHandlerNeedAuthTest, probe_and_prometheus_endpoints_are_authn_only) {
+    EXPECT_TRUE(HealthAction(nullptr).need_auth());
+    EXPECT_EQ(Priv::NONE, HealthAction(nullptr).required_privilege());
+    EXPECT_TRUE(MetricsAction(nullptr).need_auth());
+    EXPECT_EQ(Priv::NONE, MetricsAction(nullptr).required_privilege());
+    EXPECT_TRUE(MemoryMetricsAction(fake_global_env()).need_auth());
+    EXPECT_EQ(Priv::NONE, MemoryMetricsAction(fake_global_env()).required_privilege());
 }
 
 TEST(BeHandlerNeedAuthTest, stream_load_uses_builtin_fe_auth_flow) {

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -204,7 +204,6 @@ This topic introduces the following types of BE configurations:
 - Is mutable: No
 - Introduced in: v4.2.0
 - Description: When true, most external BE HTTP endpoints require HTTP Basic Auth. Credentials are verified by RPC to the FE leader using the `checkAuth` Thrift method, so the user/password store on the FE side (including LDAP / security-integration) is the source of truth. The following are exempt:
-  - Public probes / observability: `/api/health`, `/metrics`, `/metrics/memory`.
   - Token-gated internal transport (used by FE/BE for tablet clone and load-error file fetch): `/api/_tablet/_download`, `/api/_download_load`. These remain protected by their own token check; setting `enable_http_auth=true` does **not** compensate for `enable_token_check=false`.
   - Stream Load and transaction endpoints that authenticate inside the handler using the load label + table grants: `/api/{db}/{table}/_stream_load`, `/api/transaction/{txn_op}`, `/api/transaction/load`.
 
@@ -636,7 +635,7 @@ This topic introduces the following types of BE configurations:
 - Type: Int
 - Unit: Percent
 - Is mutable: Yes
-- Description: Sets the metadata LRU cache size as a percentage of the process memory limit. At startup StarRocks computes cache bytes as (process_mem_limit * metadata_cache_memory_limit_percent / 100) and passes that to the metadata cache allocator. The cache is only used for non-PRIMARY_KEYS rowsets (PK tables are not supported) and is enabled only when metadata_cache_memory_limit_percent &gt; 0; set it &lt;= 0 to disable the metadata cache. Increasing this value raises metadata cache capacity but reduces memory available to other components; tune based on workload and system memory. Not active in BE_TEST builds.
+- Description: Sets the metadata LRU cache size as a percentage of the process memory limit. At startup StarRocks computes cache bytes as (process_mem_limit * metadata_cache_memory_limit_percent / 100) and passes that to the metadata cache allocator. The cache is only used for non-PRIMARY_KEYS rowsets (PK tables are not supported) and is enabled only when `metadata_cache_memory_limit_percent > 0`; set it to `<= 0` to disable the metadata cache. Increasing this value raises metadata cache capacity but reduces memory available to other components; tune based on workload and system memory. Not active in BE_TEST builds.
 - Introduced in: v3.2.10
 
 ### retry_apply_interval_second

--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -813,7 +813,7 @@ This topic introduces the following types of FE configurations:
 - Is mutable: No
 - Introduced in: v4.2.0
 - Description: When true, most external FE HTTP endpoints require HTTP Basic Auth. Credentials are validated against the user store via `AuthenticationHandler.authenticate()`, so LDAP / security-integration login works on the HTTP path the same way it does for the MySQL protocol. The following are exempt:
-  - Public probes / observability: `/api/health`, `/api/bootstrap`, `/api/idle_status`, `/api/v2/feature`, `/metrics`, `/api/oauth2`.
+  - Public probes / observability: `/api/bootstrap`, `/api/oauth2`.
   - Peer-FE / control-plane paths that are IP-whitelisted or token-gated inside the handler: `/image`, `/check`, `/journal_id`, `/info`, `/role`, `/dump`, `/dump_starmgr`, `/service_id`, `/static`, `/api/_meta_replay_state`, `/api/get_small_file`.
 
   Privileged endpoints additionally require a SYSTEM-level RBAC privilege (`OPERATE` or `NODE`) that is **active** in the caller's session. If the granting role is not the user's default, run `SET DEFAULT ROLE <roles> TO <user>;` or set the global variable `activate_all_roles_on_login=true` so the roles activate at login. LDAP / security-integration group → role mappings activate automatically.

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -177,7 +177,6 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 変更可能: いいえ
 - 導入時期: v4.2.0
 - 説明: true の場合、ほとんどの外部 BE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は Thrift `checkAuth` RPC で FE Leader に転送されて検証され、ユーザー名/パスワードは FE 側の認証システム（LDAP / security integration を含む）を正としています。次のエンドポイントは常に除外されます：
-  - 公開プローブ / 可観測性: `/api/health`、`/metrics`、`/metrics/memory`。
   - トークン認証の内部転送（FE/BE 間の tablet clone と load エラーファイル取得に使用）: `/api/_tablet/_download`、`/api/_download_load`。これらは各自の token チェックで保護されており、`enable_http_auth=true` を有効にしても `enable_token_check=false` の影響を補うことはできません。
   - ハンドラ内でロードラベル + テーブル権限から認証する Stream Load / transaction エンドポイント: `/api/{db}/{table}/_stream_load`、`/api/transaction/{txn_op}`、`/api/transaction/load`。
 

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -804,7 +804,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能：No
 - 導入時期：v4.2.0
 - 説明：true の場合、ほとんどの外部 FE HTTP エンドポイントで HTTP Basic 認証が必要になります。資格情報は `AuthenticationHandler.authenticate()` を介してユーザーストアと照合されるため、LDAP / security integration による認証も MySQL プロトコルと同様に HTTP 経路で機能します。次のエンドポイントは常に除外されます：
-  - 公開プローブ / 可観測性：`/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
+  - 公開プローブ / 可観測性：`/api/bootstrap`、`/api/oauth2`。
   - ハンドラ内で IP ホワイトリストまたはトークンで認証する FE 間 / コントロールプレーン経路：`/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。
 
   特権エンドポイントでは追加でセッション内に**有効化された** SYSTEM レベル RBAC 権限（`OPERATE` / `NODE`）が必要です。付与済みでデフォルトに設定されていないロールを使う場合は `SET DEFAULT ROLE <roles> TO <user>;` を実行するか、グローバル変数 `activate_all_roles_on_login=true` を設定してログイン時に有効化してください。LDAP / security integration のグループ → ロールマッピングは自動的に有効化されます。

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -192,7 +192,6 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 是否动态：否
 - 引入版本：v4.2.0
 - 描述：是否对大部分外部 BE HTTP 接口启用 Basic Auth。凭证通过 Thrift `checkAuth` RPC 转发到 FE Leader 校验，用户/密码以 FE 端的认证体系（含 LDAP / security integration）为准。以下接口始终豁免：
-  - 公开探针 / 可观测性：`/api/health`、`/metrics`、`/metrics/memory`。
   - Token 鉴权的内部传输（FE/BE 用于 tablet clone 和 load 错误文件拉取）：`/api/_tablet/_download`、`/api/_download_load`。这些接口仍由各自的 token 检查保护；开启 `enable_http_auth=true` **不**能弥补 `enable_token_check=false` 带来的安全损失。
   - Stream Load 及 transaction 接口，由 handler 内基于 load label + 表级授权识别身份：`/api/{db}/{table}/_stream_load`、`/api/transaction/{txn_op}`、`/api/transaction/load`。
 

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -812,7 +812,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否可变: No
 - 引入版本: v4.2.0
 - 描述: 是否对大部分外部 FE HTTP 接口启用 Basic Auth。凭证通过 `AuthenticationHandler.authenticate()` 校验，因此 LDAP / security integration 在 HTTP 路径上的工作方式与 MySQL 协议一致。以下接口始终豁免:
-  - 公开探针 / 可观测性: `/api/health`、`/api/bootstrap`、`/api/idle_status`、`/api/v2/feature`、`/metrics`、`/api/oauth2`。
+  - 公开探针 / 可观测性: `/api/bootstrap`、`/api/oauth2`。
   - 由 handler 自行通过 IP 白名单或 token 鉴权的对等 FE / 控制面端点: `/image`、`/check`、`/journal_id`、`/info`、`/role`、`/dump`、`/dump_starmgr`、`/service_id`、`/static`、`/api/_meta_replay_state`、`/api/get_small_file`。
 
   特权接口还要求会话中**当前激活**了 SYSTEM 级 RBAC 权限（`OPERATE` 或 `NODE`）。若用户已 GRANT 但未设为默认角色，需 `SET DEFAULT ROLE <roles> TO <user>;`，或将全局变量 `activate_all_roles_on_login` 设为 `true` 让角色登录时自动激活。LDAP / security integration 的组 → 角色映射会自动激活。

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
@@ -70,9 +70,9 @@ public class BootstrapFinishAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/bootstrap", new BootstrapFinishAction(controller));
     }
 
-    // FE bootstrap probe; intentionally unauthenticated. Caller can pass the cluster
-    // token to unlock additional fields (journal id / ports / version), but the endpoint
-    // itself accepts anonymous requests for readiness checks.
+    // Always anonymous, even under enable_http_auth: the FE-to-FE heartbeat (HeartbeatMgr)
+    // polls this with the cluster token, not HTTP Basic, so gating it would break peer-FE
+    // heartbeats.
     @Override
     public boolean needAuth() {
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.Version;
 import com.starrocks.feature.ProductFeature;
 import com.starrocks.http.ActionController;
@@ -32,10 +33,12 @@ public class FeatureAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/v2/feature", new FeatureAction(controller));
     }
 
-    // Public endpoint: returns server version + feature flag list, no sensitive data.
+    // Returns server version + feature flag list, no sensitive data. Historically
+    // anonymous; gated for backward compatibility so it requires Basic auth (AuthN-only,
+    // no privilege check) only when the operator opts in via `enable_http_auth`.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -53,10 +54,12 @@ public class HealthAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/health", new HealthAction(controller));
     }
 
-    // Liveness probe; intentionally unauthenticated.
+    // Liveness probe. Historically anonymous; gated for backward compatibility so it
+    // requires Basic auth (AuthN-only, no privilege check) only when the operator opts
+    // in via `enable_http_auth`.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
@@ -49,10 +49,12 @@ public class IdleAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/idle_status", new IdleAction(controller));
     }
 
-    // K8s idle probe; intentionally unauthenticated.
+    // K8s idle probe. Historically anonymous; gated for backward compatibility so it
+    // requires Basic auth (AuthN-only, no privilege check) only when the operator opts
+    // in via `enable_http_auth`.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -38,6 +38,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -123,12 +124,14 @@ public class MetricsAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, API_PATH, new MetricsAction(controller));
     }
 
-    // Prometheus-style metrics; intentionally unauthenticated by default. Per-table /
-    // per-MV / per-user-connection breakdowns do their own admin check inside
-    // parseRequestParams() and gracefully fall back when unauthenticated.
+    // Prometheus-style metrics. Historically anonymous; gated for backward compatibility
+    // so it requires Basic auth (AuthN-only, no privilege check) only when the operator
+    // opts in via `enable_http_auth`. The per-table / per-MV / per-user-connection
+    // breakdowns still do their own admin check inside parseRequestParams() and
+    // gracefully fall back when the caller lacks admin.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -334,6 +334,12 @@ public class SchemaScanNode extends ScanNode {
             feInfo.setId(fe.getNodeName());
             feInfo.setIp(fe.getHost());
             feInfo.setHttp_port(Config.http_port);
+            // Thrift (FrontendService) port, used by the BE fe_metrics scanner to fetch
+            // metrics over RPC instead of scraping the HTTP /metrics endpoint. Prefer the
+            // per-FE port reported via heartbeat (Frontend.getRpcPort()); fall back to the
+            // local Config.rpc_port only when it is not yet known (e.g. before the first
+            // heartbeat of the local node).
+            feInfo.setRpc_port(fe.getRpcPort() > 0 ? fe.getRpcPort() : Config.rpc_port);
             frontends.add(feInfo);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -120,6 +120,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.failpoint.FailPoint;
 import com.starrocks.failpoint.TriggerPolicy;
 import com.starrocks.http.BaseAction;
+import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.http.rest.WarehouseInfosBuilder;
 import com.starrocks.journal.CheckpointException;
@@ -146,6 +147,7 @@ import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.load.streamload.StreamLoadTask;
+import com.starrocks.metric.JsonMetricVisitor;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.SlotDescriptor;
@@ -238,6 +240,7 @@ import com.starrocks.thrift.TFeLocksReq;
 import com.starrocks.thrift.TFeLocksRes;
 import com.starrocks.thrift.TFeMemoryReq;
 import com.starrocks.thrift.TFeMemoryRes;
+import com.starrocks.thrift.TFeMetricsResult;
 import com.starrocks.thrift.TFeResult;
 import com.starrocks.thrift.TFetchResourceResult;
 import com.starrocks.thrift.TFinishCheckpointRequest;
@@ -711,6 +714,30 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TFeMemoryRes listFeMemoryUsage(TFeMemoryReq request) throws TException {
         return SysFeMemoryUsage.listFeMemoryUsage(request);
+    }
+
+    // information_schema.fe_metrics: return this FE's metrics as the JSON payload that the
+    // HTTP `/metrics?type=json` endpoint produces. Serving it over this Thrift RPC (instead of
+    // the BE scanner scraping the HTTP endpoint) keeps fe_metrics working regardless of
+    // `enable_http_auth` — the internal RPC needs no HTTP Basic credentials. FE process metrics
+    // have no per-object RBAC, so the RPC takes no arguments and there is nothing to authorize
+    // here.
+    @Override
+    public TFeMetricsResult getFeMetrics() throws TException {
+        TFeMetricsResult result = new TFeMetricsResult();
+        try {
+            JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
+            String json = MetricRepo.getMetric(visitor,
+                    new MetricsAction.RequestParams(false, false, false, false, false));
+            result.setJson_metrics(json);
+            result.setStatus(new TStatus(TStatusCode.OK));
+        } catch (Exception e) {
+            LOG.warn("get fe metrics failed", e);
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            result.setStatus(status);
+        }
+        return result;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -333,14 +333,16 @@ public class RestBaseActionTest {
 
     @Test
     public void testAlwaysAnonymousRestActionsBypassBasicAuth() {
+        // These endpoints can never require Basic auth, even when the operator opts into
+        // `enable_http_auth`:
+        //  - GetSmallFile is internal token-protected.
+        //  - The OAuth2 callback is itself the auth handshake.
+        //  - /api/bootstrap is polled by the FE-to-FE heartbeat (HeartbeatMgr) using the
+        //    cluster token rather than HTTP Basic; gating it would break peer-FE heartbeats.
         Config.enable_http_auth = true;
-        Assertions.assertFalse(new BootstrapFinishAction(null).needAuth());
-        Assertions.assertFalse(new FeatureAction(null).needAuth());
-        Assertions.assertFalse(new HealthAction(null).needAuth());
         Assertions.assertFalse(new GetSmallFileAction(null).needAuth());
         Assertions.assertFalse(new OAuth2Action(null).needAuth());
-        Assertions.assertFalse(new IdleAction(null).needAuth());
-        Assertions.assertFalse(new MetricsAction(null).needAuth());
+        Assertions.assertFalse(new BootstrapFinishAction(null).needAuth());
     }
 
     @Test
@@ -362,6 +364,36 @@ public class RestBaseActionTest {
         Assertions.assertTrue(new QueryProgressAction(null).needAuth());
         Assertions.assertTrue(new ShowMetaInfoAction(null).needAuth());
         Assertions.assertTrue(new ShowRuntimeInfoAction(null).needAuth());
+    }
+
+    @Test
+    public void testPublicProbeActionsAreAuthNOnlyGatedByHttpAuthFlag() {
+        // Health / observability probes were historically anonymous. They are now brought
+        // into the `enable_http_auth` scope at AuthN-only level: Basic identity required
+        // when the flag is on, anonymous (backward compatible) when off. None of them
+        // declare a privilege requirement, so identity alone is sufficient.
+        Config.enable_http_auth = false;
+        Assertions.assertFalse(new HealthAction(null).needAuth());
+        Assertions.assertFalse(new IdleAction(null).needAuth());
+        Assertions.assertFalse(new FeatureAction(null).needAuth());
+        Assertions.assertFalse(new MetricsAction(null).needAuth());
+
+        Config.enable_http_auth = true;
+        Assertions.assertTrue(new HealthAction(null).needAuth());
+        Assertions.assertTrue(new IdleAction(null).needAuth());
+        Assertions.assertTrue(new FeatureAction(null).needAuth());
+        Assertions.assertTrue(new MetricsAction(null).needAuth());
+    }
+
+    @Test
+    public void testOAuth2ActionNeverRequiresBasicAuth() {
+        // Guard: the OAuth2 callback must never be pulled into `enable_http_auth`, since
+        // the callback itself is the authentication handshake. It stays anonymous
+        // regardless of the flag.
+        Config.enable_http_auth = false;
+        Assertions.assertFalse(new OAuth2Action(null).needAuth());
+        Config.enable_http_auth = true;
+        Assertions.assertFalse(new OAuth2Action(null).needAuth());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -39,11 +39,14 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestLoadResult;
 import com.starrocks.load.batchwrite.TableId;
 import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.load.streamload.StreamLoadTask;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.MetricVisitor;
 import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -67,6 +70,7 @@ import com.starrocks.thrift.TCreatePartitionResult;
 import com.starrocks.thrift.TDescribeTableParams;
 import com.starrocks.thrift.TDescribeTableResult;
 import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TFeMetricsResult;
 import com.starrocks.thrift.TFeResult;
 import com.starrocks.thrift.TFileType;
 import com.starrocks.thrift.TGetDictQueryParamRequest;
@@ -210,6 +214,33 @@ public class FrontendServiceImplTest {
 
         TMVReportEpochResponse response = impl.mvReport(request);
         Assertions.assertNotNull(response);
+    }
+
+    @Test
+    public void testGetFeMetrics() throws TException {
+        // information_schema.fe_metrics is served over this RPC instead of scraping HTTP /metrics.
+        // It returns the same JSON payload as /metrics?type=json with an OK status.
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TFeMetricsResult result = impl.getFeMetrics();
+        Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
+        Assertions.assertNotNull(result.getJson_metrics());
+    }
+
+    @Test
+    public void testGetFeMetricsReturnsErrorStatusOnException() throws TException {
+        // When metric collection throws, getFeMetrics must return an INTERNAL_ERROR status
+        // (with an error message) instead of propagating the exception.
+        new MockUp<MetricRepo>() {
+            @Mock
+            public String getMetric(MetricVisitor visitor, MetricsAction.RequestParams requestParams) {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TFeMetricsResult result = impl.getFeMetrics();
+        Assertions.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
+        Assertions.assertFalse(result.getStatus().getError_msgs().isEmpty());
     }
 
     @Test

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2439,6 +2439,16 @@ struct TBatchGetTabletMetadataResponse {
     2: optional list<TGetTabletMetadataResponse> responses;
 }
 
+// information_schema.fe_metrics: the BE scanner fetches each FE's metrics over the getFeMetrics
+// RPC (instead of scraping the HTTP /metrics endpoint), so fe_metrics works regardless of
+// `enable_http_auth` and no longer depends on HTTP Basic auth. The RPC takes no arguments —
+// FE process metrics are global with no per-object RBAC to authorize.
+struct TFeMetricsResult {
+    1: optional Status.TStatus status
+    // JSON payload identical to the FE `/metrics?type=json` output, parsed by the BE scanner.
+    2: optional string json_metrics
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -2539,6 +2549,9 @@ service FrontendService {
 
     // sys.fe_memory_usage
     TFeMemoryRes listFeMemoryUsage(1: TFeMemoryReq request)
+
+    // information_schema.fe_metrics
+    TFeMetricsResult getFeMetrics()
 
     // information_schema.column_stats_uage
     TColumnStatsUsageRes getColumnStatsUsage(1: TColumnStatsUsageReq request)

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -565,6 +565,7 @@ struct TFrontend {
   1: optional string id
   2: optional string ip
   3: optional i32 http_port
+  4: optional i32 rpc_port
 }
 
 struct TSchemaScanNode {


### PR DESCRIPTION


> Previously the FE/BE health and observability probe endpoints were fully exempt from the enable_http_auth framework. This change brings them into scope at an authentication-only (AuthN-only) level: when enable_http_auth=true they require valid HTTP Basic credentials but no RBAC privilege; when enable_http_auth=false they remain anonymous (fully backward compatible).

When enable_http_auth=true, most external FE/BE HTTP endpoints require HTTP Basic Auth (verified against the FE user store; BE delegates to the FE via the checkAuth RPC). The public probe / observability endpoints are authentication-only (AuthN-only): they require valid Basic credentials when the flag is on, require no RBAC privilege (any authenticated user may call them), and stay anonymous when the flag is off:

- FE: /api/health, /api/idle_status, /api/v2/feature, /metrics
- BE: /api/health, /metrics, /metrics/memory

The following stay fully anonymous regardless of the flag:

- /api/oauth2 (FE) — the OAuth2 callback is itself the authentication handshake, so it can never require Basic Auth.
- /api/bootstrap (FE) — polled by the FE-to-FE heartbeat (HeartbeatMgr) using the cluster token, not HTTP Basic; gating it would break peer-FE heartbeats. (It still accepts the cluster token to unlock extra fields.)
- Token-gated internal transport (tablet clone, load-error file download, Stream Load / transaction endpoints) — protected by their own token checks.

▎ Note: /api/bootstrap is intentionally excluded from the AuthN-only set (an earlier revision listed it; corrected here).

information_schema.fe_metrics no longer depends on HTTP auth

The BE fe_metrics scanner previously scraped each FE's HTTP /metrics?type=json, which would 401 once enable_http_auth=true. It now fetches metrics over a new FrontendService.getFeMetrics Thrift RPC. The FE returns the identical JSON payload, so the table's columns are unchanged, and the view works regardless of enable_http_auth. information_schema.be_metrics is unaffected (it reads BE process metrics in-process, never over HTTP).

Impact:
- No behavior change when enable_http_auth=false (the default).
- When enabled, the listed probes require Basic auth, so Prometheus scrapers, k8s liveness/readiness probes, and bootstrap pollers must supply credentials.
- The /metrics per-table / per-MV / per-user-connection breakdowns keep their existing admin authorization check.

Tests:
- FE RestBaseActionTest: probes gated by the flag; OAuth2 never gated.
- BE metrics_action_test: probes are need_auth()=true with NONE privilege.

Docs: updated the enable_http_auth description in the en/zh/ja FE and BE parameter docs to describe the AuthN-only behavior and the OAuth2 exemption.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
