### PR TITLE
[Doc] Add Vale rule to detect duplicate frontmatter keys

### DIFF
--- a/.github/workflows/ci-vale.yml
+++ b/.github/workflows/ci-vale.yml
@@ -58,6 +58,9 @@ jobs:
             docs/en/**/*.md
             docs/ja/**/*.md
             docs/zh/**/*.md
+            docs/en/**/*.mdx
+            docs/ja/**/*.mdx
+            docs/zh/**/*.mdx
 
       - name: Install Vale
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,6 +1,11 @@
 StylesPath = styles
 MinAlertLevel = error
 
+# Parse .mdx as Markdown so Vale can lint it without the external mdx2vast
+# binary. Our frontmatter checks use scope:raw, so reading the file is enough.
+[formats]
+mdx = md
+
 # FrontmatterDescription and FrontmatterDescriptionFluff are opt-in: disabled
 # by default, enabled only for the three language directories, and explicitly
 # off for _assets sub-directories.
@@ -22,6 +27,11 @@ local.FrontmatterDuplicateKey = NO
 [**/{en,zh,ja}/**/*.md]
 local.FrontmatterDescription = YES
 local.FrontmatterDescriptionFluff = YES
+local.FrontmatterDuplicateKey = YES
+
+# MDX pages use the same YAML frontmatter and can hit the same Docusaurus/js-yaml
+# duplicated mapping key build failure, so enable the duplicate-key check there too.
+[**/{en,zh,ja}/**/*.mdx]
 local.FrontmatterDuplicateKey = YES
 
 [**/{en,zh,ja}/_assets/**]

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -9,18 +9,22 @@ BasedOnStyles = local
 local.BareAngleBrackets = NO
 local.FrontmatterDescription = NO
 local.FrontmatterDescriptionFluff = NO
+local.FrontmatterDuplicateKey = NO
 
 [*.mdx]
 BasedOnStyles = local
 local.BareAngleBrackets = NO
 local.FrontmatterDescription = NO
 local.FrontmatterDescriptionFluff = NO
+local.FrontmatterDuplicateKey = NO
 
 # **/ prefix makes these match from any working directory (repo root or docs/).
 [**/{en,zh,ja}/**/*.md]
 local.FrontmatterDescription = YES
 local.FrontmatterDescriptionFluff = YES
+local.FrontmatterDuplicateKey = YES
 
 [**/{en,zh,ja}/_assets/**]
 local.FrontmatterDescription = NO
 local.FrontmatterDescriptionFluff = NO
+local.FrontmatterDuplicateKey = NO

--- a/docs/styles/config/scripts/FrontmatterDuplicateKey.tengo
+++ b/docs/styles/config/scripts/FrontmatterDuplicateKey.tengo
@@ -1,0 +1,40 @@
+// FrontmatterDuplicateKey.tengo
+//
+// Flag duplicate top-level keys in the YAML frontmatter of a documentation
+// page.  Docusaurus (js-yaml) fails the build with "duplicated mapping key"
+// when the same key appears twice in frontmatter, e.g. two `description:`
+// lines after a translation merge.  Each duplicate occurrence is flagged.
+//
+// NOTE: text.re_find returns `undefined` (not []) on no match, so `len()` on
+// its result is unsafe.  All result consumption uses `for` loops, which
+// Tengo iterates zero times over undefined.  A sentinel variable (fm_end=-1)
+// distinguishes "no frontmatter found" from "frontmatter found".
+
+text := import("text")
+
+matches := []
+
+// Locate the frontmatter block boundary.  (?s) lets .* cross newlines.
+fm_end := -1
+for m in text.re_find("(?s)^---\r?\n.*?\n---", scope, -1) {
+    fm_end = m[0].end
+    break   // there is only one frontmatter block
+}
+
+if fm_end >= 0 {
+    // Walk every top-level key line (column 0, no indentation) inside the
+    // frontmatter block.  Indented keys and list items are nested values, not
+    // top-level mapping keys, so they are intentionally ignored.
+    seen := {}
+    for m in text.re_find("(?m)^([A-Za-z0-9_.-]+)[ \t]*:", scope, -1) {
+        if m[0].begin >= fm_end {
+            break   // re_find returns matches in order; past frontmatter
+        }
+        key := m[1].text
+        if seen[key] {
+            matches = append(matches, {begin: m[0].begin, end: m[0].end})
+        } else {
+            seen[key] = true
+        }
+    }
+}

--- a/docs/styles/local/FrontmatterDuplicateKey.yml
+++ b/docs/styles/local/FrontmatterDuplicateKey.yml
@@ -1,0 +1,5 @@
+extends: script
+message: "Duplicate frontmatter key. Each key may appear only once; a repeated key (e.g. two 'description:' lines) breaks the Docusaurus build with 'duplicated mapping key'."
+level: error
+scope: raw
+script: FrontmatterDuplicateKey.tengo


### PR DESCRIPTION
## Why I'm doing:

A recent PR build failed with a js-yaml `duplicated mapping key` error: a Chinese doc page had two `description:` lines in its frontmatter (one left over from a translation merge). Docusaurus rejects duplicate top-level keys, so this breaks the build instead of being caught in review.

```
reason: 'duplicated mapping key',
buffer: 'displayed_sidebar: docs\n'
      + 'description: "定义远端存储中的数据文件，用于数据导入和导出。"\n'
      + 'toc_max_heading_level: 5\n'
      + 'description: "定义远程存储中的数据文件，用于导入和导出数据。"\n'
```

## What I'm doing:

Adds a Vale rule (`local.FrontmatterDuplicateKey`) that flags repeated **top-level** keys in a page's YAML frontmatter, so the problem is caught by the docs lint step rather than at build time.

- `docs/styles/config/scripts/FrontmatterDuplicateKey.tengo` — locates the frontmatter block, walks every column-0 key, and flags any key seen more than once. Indented keys (e.g. `description:` nested under `metadata:`) and list items are intentionally ignored.
- `docs/styles/local/FrontmatterDuplicateKey.yml` — `level: error`, `scope: raw`, with a message naming the `duplicated mapping key` build failure.
- `docs/.vale.ini` — wired in with the same opt-in scoping as the existing frontmatter rules: default `NO` for `[*.md]`/`[*.mdx]`, `YES` for `[**/{en,zh,ja}/**/*.md]`, `NO` under `_assets/`.

Verified with Vale 3.13.1: the exact failing fixture is flagged at the second `description:` line; clean files, nested/list keys, and files without frontmatter produce no errors.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)