### PR TITLE
[BugFix] Make Tracers fork-aware to prevent `IllegalStateException` in parallel profile collection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
@@ -81,6 +81,8 @@ public class TimeWatcher {
             ScopedTimer mine = this.scopedTimers.get(name, prefix);
             if (mine == null) {
                 mine = new ScopedTimer(otherTimer.firstTimePointNanoSecond, name);
+                // scopeLevel from levels.size() is wrong at merge time — use prefix depth
+                mine.scopeLevel = (int) prefix.chars().filter(c -> c == '/').count();
                 this.scopedTimers.put(name, prefix, mine);
             }
             mine.accumulateFrom(otherTimer);
@@ -89,7 +91,7 @@ public class TimeWatcher {
 
     private class ScopedTimer extends Timer {
         private final String name;
-        private final int scopeLevel;
+        private int scopeLevel;
         private final long firstTimePointNanoSecond;
         private final Stopwatch stopWatch = Stopwatch.createUnstarted();
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
@@ -34,7 +34,7 @@ public class TimeWatcher {
     private final List<String> levels = Lists.newArrayList();
     private final Table<String, String, ScopedTimer> scopedTimers = HashBasedTable.create();
 
-    public Timer scope(long time, String name) {
+    public synchronized Timer scope(long time, String name) {
         ScopedTimer t;
         String prefix = String.join("/", levels);
         if (scopedTimers.row(name).containsKey(prefix)) {
@@ -81,8 +81,11 @@ public class TimeWatcher {
             ScopedTimer mine = this.scopedTimers.get(name, prefix);
             if (mine == null) {
                 mine = new ScopedTimer(otherTimer.firstTimePointNanoSecond, name);
-                // scopeLevel from levels.size() is wrong at merge time — use prefix depth
-                mine.scopeLevel = (int) prefix.chars().filter(c -> c == '/').count();
+                // scopeLevel from levels.size() is wrong at merge time.
+                // Prefix "A/B" has 1 '/' → scopeLevel 2 (= levels.size() when prefix was built).
+                mine.scopeLevel = prefix.isEmpty()
+                        ? 0
+                        : (int) prefix.chars().filter(c -> c == '/').count() + 1;
                 this.scopedTimers.put(name, prefix, mine);
             }
             mine.accumulateFrom(otherTimer);

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class TimeWatcher {
@@ -64,6 +66,27 @@ public class TimeWatcher {
                 .collect(Collectors.toList());
     }
 
+    public TimeWatcher fork() {
+        TimeWatcher f = new TimeWatcher();
+        f.levels.addAll(this.levels);
+        return f;
+    }
+
+    public synchronized void mergeFrom(TimeWatcher other) {
+        for (Table.Cell<String, String, ScopedTimer> cell : other.scopedTimers.cellSet()) {
+            String name = cell.getRowKey();
+            String prefix = cell.getColumnKey();
+            ScopedTimer otherTimer = cell.getValue();
+
+            ScopedTimer mine = this.scopedTimers.get(name, prefix);
+            if (mine == null) {
+                mine = new ScopedTimer(otherTimer.firstTimePointNanoSecond, name);
+                this.scopedTimers.put(name, prefix, mine);
+            }
+            mine.accumulateFrom(otherTimer);
+        }
+    }
+
     private class ScopedTimer extends Timer {
         private final String name;
         private final int scopeLevel;
@@ -72,6 +95,10 @@ public class TimeWatcher {
 
         private int count = 0;
         private int reentrantCount = 0;
+
+        // Accumulated from detached forks merged into this timer
+        private final AtomicLong accumulatedNanos = new AtomicLong(0);
+        private final AtomicInteger accumulatedCount = new AtomicInteger(0);
 
         public ScopedTimer(long time, String name) {
             // The reason why here we want nanosecond is to make sure
@@ -103,6 +130,13 @@ public class TimeWatcher {
             }
         }
 
+        void accumulateFrom(ScopedTimer other) {
+            long otherNanos = other.stopWatch.elapsed(TimeUnit.NANOSECONDS) + other.accumulatedNanos.get();
+            int otherCount = other.count + other.accumulatedCount.get();
+            this.accumulatedNanos.addAndGet(otherNanos);
+            this.accumulatedCount.addAndGet(otherCount);
+        }
+
         @Override
         public long getFirstTimePoint() {
             return firstTimePointNanoSecond / 1000000;
@@ -110,13 +144,15 @@ public class TimeWatcher {
 
         @Override
         public String toString() {
-            return StringUtils.repeat("    ", scopeLevel) + "-- " + name + "[" + count + "] " +
+            int totalCount = count + accumulatedCount.get();
+            return StringUtils.repeat("    ", scopeLevel) + "-- " + name + "[" + totalCount + "] " +
                     DebugUtil.getPrettyStringMs(getTotalTime());
         }
 
         @Override
         public long getTotalTime() {
-            return stopWatch.elapsed(TimeUnit.MILLISECONDS);
+            return stopWatch.elapsed(TimeUnit.MILLISECONDS)
+                    + TimeUnit.NANOSECONDS.toMillis(accumulatedNanos.get());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
@@ -66,9 +66,11 @@ public class TimeWatcher {
                 .collect(Collectors.toList());
     }
 
-    public TimeWatcher fork() {
+    public TimeWatcher fork(boolean retainScope) {
         TimeWatcher f = new TimeWatcher();
-        f.levels.addAll(this.levels);
+        if (retainScope) {
+            f.levels.addAll(this.levels);
+        }
         return f;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracer.java
@@ -76,4 +76,20 @@ public abstract class Tracer {
     public Optional<Timer> getSpecifiedTimer(String name) {
         return Optional.empty();
     }
+
+    /**
+     * Create a lightweight fork of this Tracer for parallel worker threads.
+     * The default implementation returns {@code this} (identity — used by the empty tracer).
+     * Real tracers override to return an independent copy.
+     */
+    public Tracer fork() {
+        return this;
+    }
+
+    /**
+     * Merge timer and variable data from a forked Tracer back into this one.
+     * The default implementation is a no-op (used by the empty tracer).
+     */
+    public void mergeFrom(Tracer other) {
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracer.java
@@ -82,7 +82,7 @@ public abstract class Tracer {
      * The default implementation returns {@code this} (identity — used by the empty tracer).
      * Real tracers override to return an independent copy.
      */
-    public Tracer fork() {
+    public Tracer fork(boolean retainScope) {
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
@@ -43,13 +43,13 @@ class TracerImpl extends Tracer {
     }
 
     @Override
-    public Tracer fork() {
+    public Tracer fork(boolean retainScope) {
         return new TracerImpl(
-                this.timing,           // shared — unified time base
-                this.watcher.fork(),   // forked — independent scope stack
-                this.varTracer,        // shared — no record/count calls in parallel paths
-                this.logTracer,        // shared — already sync-safe
-                this.reasonTracer      // shared — already sync-safe
+                this.timing,                     // shared — unified time base
+                this.watcher.fork(retainScope),  // forked — retainScope copies levels
+                this.varTracer,                  // shared — no record/count calls in parallel paths
+                this.logTracer,                  // shared — already sync-safe
+                this.reasonTracer                // shared — already sync-safe
         );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
@@ -42,6 +42,25 @@ class TracerImpl extends Tracer {
         this.reasonTracer = reasonTracer;
     }
 
+    @Override
+    public Tracer fork() {
+        return new TracerImpl(
+                this.timing,           // shared — unified time base
+                this.watcher.fork(),   // forked — independent scope stack
+                this.varTracer,        // shared — no record/count calls in parallel paths
+                this.logTracer,        // shared — already sync-safe
+                this.reasonTracer      // shared — already sync-safe
+        );
+    }
+
+    @Override
+    public void mergeFrom(Tracer other) {
+        if (other instanceof TracerImpl) {
+            TracerImpl o = (TracerImpl) other;
+            this.watcher.mergeFrom(o.watcher);
+        }
+    }
+
     private long timePoint() {
         return timing.elapsed(TimeUnit.MILLISECONDS);
     }
@@ -52,9 +71,11 @@ class TracerImpl extends Tracer {
 
     public synchronized Timer watchScope(String name) {
         tracerCost.start();
-        Timer t = watcher.scope(timePointNanoSecond(), name);
-        tracerCost.stop();
-        return t;
+        try {
+            return watcher.scope(timePointNanoSecond(), name);
+        } finally {
+            tracerCost.stop();
+        }
     }
 
     public synchronized void log(String event) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -86,8 +86,8 @@ public class Tracers {
 
     /**
      * Create a lightweight fork of this Tracers for use in a parallel worker thread.
-     * The fork shares the timing stopwatch, logTracer, and reasonTracer with the owner
-     * but gets its own TimeWatcher and VarTracer (to be merged back via {@link #mergeFrom}).
+     * The fork shares the timing stopwatch, VarTracer, logTracer, and reasonTracer with
+     * the owner but gets its own TimeWatcher (to be merged back via {@link #mergeFrom}).
      */
     public Tracers fork() {
         Tracers f = new Tracers();
@@ -99,7 +99,7 @@ public class Tracers {
     }
 
     /**
-     * Merge timer and var data from a forked Tracers back into this (owner) Tracers.
+     * Merge timer data from a forked Tracers back into this (owner) Tracers.
      * Must be called from the owner thread or externally synchronized.
      */
     public void mergeFrom(Tracers other) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -85,6 +85,28 @@ public class Tracers {
     }
 
     /**
+     * Create a lightweight fork of this Tracers for use in a parallel worker thread.
+     * The fork shares the timing stopwatch, logTracer, and reasonTracer with the owner
+     * but gets its own TimeWatcher and VarTracer (to be merged back via {@link #mergeFrom}).
+     */
+    public Tracers fork() {
+        Tracers f = new Tracers();
+        f.moduleMask = this.moduleMask;
+        f.modeMask = this.modeMask;
+        f.allTracer[0] = EMPTY_TRACER;
+        f.allTracer[1] = this.allTracer[1].fork();
+        return f;
+    }
+
+    /**
+     * Merge timer and var data from a forked Tracers back into this (owner) Tracers.
+     * Must be called from the owner thread or externally synchronized.
+     */
+    public void mergeFrom(Tracers other) {
+        this.allTracer[1].mergeFrom(other.allTracer[1]);
+    }
+
+    /**
      * Init tracer with context and mode.
      * @param context connect context
      * @param modeStr tracer mode

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -89,12 +89,12 @@ public class Tracers {
      * The fork shares the timing stopwatch, VarTracer, logTracer, and reasonTracer with
      * the owner but gets its own TimeWatcher (to be merged back via {@link #mergeFrom}).
      */
-    public Tracers fork() {
+    public Tracers fork(boolean retainScope) {
         Tracers f = new Tracers();
         f.moduleMask = this.moduleMask;
         f.modeMask = this.modeMask;
         f.allTracer[0] = EMPTY_TRACER;
-        f.allTracer[1] = this.allTracer[1].fork();
+        f.allTracer[1] = this.allTracer[1].fork(retainScope);
         return f;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -100,7 +100,7 @@ public class Tracers {
 
     /**
      * Merge timer data from a forked Tracers back into this (owner) Tracers.
-     * Must be called from the owner thread or externally synchronized.
+     * Thread-safe — may be called from a worker thread after fork completes.
      */
     public void mergeFrom(Tracers other) {
         this.allTracer[1].mergeFrom(other.allTracer[1]);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -143,7 +143,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         if (option.useQueryDeployExecutor) {
             deployScanRangesTask.executorService = GlobalStateMgr.getCurrentState().getQueryDeployExecutor();
             deployScanRangesTask.ownerTracers = Tracers.get();
-            deployScanRangesTask.forkedTracers = deployScanRangesTask.ownerTracers.fork();
+            deployScanRangesTask.forkedTracers = deployScanRangesTask.ownerTracers.fork(false);
             deployScanRangesTask.currentConnectContext = ConnectContext.get();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -40,26 +40,27 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
     private volatile boolean cancelled = false;
     private DeployScanRangesTask deployScanRangesTask = null;
 
+    /**
+     * Sets the worker thread's ThreadLocal Tracers to a pre-forked instance
+     * and cleans up on close. Does NOT fork or merge — those happen at the
+     * task level (see {@link DeployScanRangesTask}).
+     */
     class TracerContext implements AutoCloseable {
-        Tracers savedTracers;
-        ConnectContext savedConnectContext;
+        private final ConnectContext savedConnectContext;
 
-        TracerContext(Tracers currentTracers, ConnectContext connectContext) {
-            if (currentTracers != null) {
-                savedTracers = Tracers.get();
-                Tracers.set(currentTracers);
-            }
+        TracerContext(Tracers forkedTracers, ConnectContext connectContext) {
+            Tracers.set(forkedTracers);
             if (connectContext != null) {
                 savedConnectContext = ConnectContext.get();
                 ConnectContext.set(connectContext);
+            } else {
+                savedConnectContext = null;
             }
         }
 
         @Override
         public void close() {
-            if (savedTracers != null) {
-                Tracers.set(savedTracers);
-            }
+            Tracers.close();
             if (savedConnectContext != null) {
                 ConnectContext.set(savedConnectContext);
             }
@@ -69,7 +70,8 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
     class DeployScanRangesTask implements Runnable {
         List<DeployState> states;
         ExecutorService executorService;
-        Tracers currentTracers;
+        Tracers ownerTracers;          // merge target, captured from the main thread
+        Tracers forkedTracers;         // fork of ownerTracers, used by worker threads
         ConnectContext currentConnectContext;
 
         DeployScanRangesTask(List<DeployState> states) {
@@ -79,9 +81,11 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         @Override
         public void run() {
             if (cancelled || states.isEmpty()) {
+                // Task complete — merge forked profiling data back into the owner
+                ownerTracers.mergeFrom(forkedTracers);
                 return;
             }
-            try (TracerContext tracerContext = new TracerContext(currentTracers, currentConnectContext)) {
+            try (TracerContext ignored = new TracerContext(forkedTracers, currentConnectContext)) {
                 runOnce();
             }
             // If run in the executor service, we need to start the next turn.
@@ -138,7 +142,8 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
         deployScanRangesTask = new DeployScanRangesTask(states);
         if (option.useQueryDeployExecutor) {
             deployScanRangesTask.executorService = GlobalStateMgr.getCurrentState().getQueryDeployExecutor();
-            deployScanRangesTask.currentTracers = Tracers.get();
+            deployScanRangesTask.ownerTracers = Tracers.get();
+            deployScanRangesTask.forkedTracers = deployScanRangesTask.ownerTracers.fork();
             deployScanRangesTask.currentConnectContext = ConnectContext.get();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -65,17 +65,29 @@ public class PrepareCollectMetaTask extends OptimizerTask {
                 new ThreadFactoryBuilder().setNameFormat(String.format("prepare-metadata-%s", queryId)).build());
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Tracers tracers = Tracers.get();
+        Tracers ownerTracers = Tracers.get();
         ConnectContext connectContext = ConnectContext.get();
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "EXTERNAL.parallel_prepare_metadata")) {
-            CompletableFuture<Void> allFutures = CompletableFuture.allOf(scanOperators.stream()
-                    .map(op -> CompletableFuture.supplyAsync(() ->
-                                    metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
-                                            new MetaPreparationItem(op.getTable(), op.getPredicate(),
-                                                    op.getLimit(), op.getTvrVersionRange()),
-                                            tracers, connectContext),
-                            executorService)).toArray(CompletableFuture[]::new));
-            allFutures.join();
+            // Fork tracers for each parallel task on the owner thread
+            int numTasks = scanOperators.size();
+            List<Tracers> forks = new ArrayList<>(numTasks);
+            CompletableFuture<?>[] futures = new CompletableFuture[numTasks];
+            for (int i = 0; i < numTasks; i++) {
+                LogicalScanOperator op = scanOperators.get(i);
+                Tracers forked = ownerTracers.fork();
+                forks.add(forked);
+                futures[i] = CompletableFuture.supplyAsync(() ->
+                                metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
+                                        new MetaPreparationItem(op.getTable(), op.getPredicate(),
+                                                op.getLimit(), op.getTvrVersionRange()),
+                                        forked, connectContext),
+                        executorService);
+            }
+            CompletableFuture.allOf(futures).join();
+            // Merge all forks back on the owner thread (single-threaded, no race)
+            for (Tracers f : forks) {
+                ownerTracers.mergeFrom(f);
+            }
         }
         executorService.shutdown();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -67,29 +67,32 @@ public class PrepareCollectMetaTask extends OptimizerTask {
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         Tracers ownerTracers = Tracers.get();
         ConnectContext connectContext = ConnectContext.get();
-        try (Timer ignored = Tracers.watchScope(EXTERNAL, "EXTERNAL.parallel_prepare_metadata")) {
-            // Fork tracers for each parallel task on the owner thread
-            int numTasks = scanOperators.size();
-            List<Tracers> forks = new ArrayList<>(numTasks);
-            CompletableFuture<?>[] futures = new CompletableFuture[numTasks];
-            for (int i = 0; i < numTasks; i++) {
-                LogicalScanOperator op = scanOperators.get(i);
-                Tracers forked = ownerTracers.fork();
-                forks.add(forked);
-                futures[i] = CompletableFuture.supplyAsync(() ->
-                                metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
-                                        new MetaPreparationItem(op.getTable(), op.getPredicate(),
-                                                op.getLimit(), op.getTvrVersionRange()),
-                                        forked, connectContext),
-                        executorService);
+        try {
+            try (Timer ignored = Tracers.watchScope(EXTERNAL, "EXTERNAL.parallel_prepare_metadata")) {
+                // Fork tracers for each parallel task on the owner thread
+                int numTasks = scanOperators.size();
+                List<Tracers> forks = new ArrayList<>(numTasks);
+                CompletableFuture<?>[] futures = new CompletableFuture[numTasks];
+                for (int i = 0; i < numTasks; i++) {
+                    LogicalScanOperator op = scanOperators.get(i);
+                    Tracers forked = ownerTracers.fork();
+                    forks.add(forked);
+                    futures[i] = CompletableFuture.supplyAsync(() ->
+                                    metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
+                                            new MetaPreparationItem(op.getTable(), op.getPredicate(),
+                                                    op.getLimit(), op.getTvrVersionRange()),
+                                            forked, connectContext),
+                            executorService);
+                }
+                CompletableFuture.allOf(futures).join();
+                // Merge all forks back on the owner thread (single-threaded, no race)
+                for (Tracers f : forks) {
+                    ownerTracers.mergeFrom(f);
+                }
             }
-            CompletableFuture.allOf(futures).join();
-            // Merge all forks back on the owner thread (single-threaded, no race)
-            for (Tracers f : forks) {
-                ownerTracers.mergeFrom(f);
-            }
+        } finally {
+            executorService.shutdown();
         }
-        executorService.shutdown();
     }
 
     private List<LogicalScanOperator> collectScanOperators(OptExpression tree) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -75,7 +75,7 @@ public class PrepareCollectMetaTask extends OptimizerTask {
                 CompletableFuture<?>[] futures = new CompletableFuture[numTasks];
                 for (int i = 0; i < numTasks; i++) {
                     LogicalScanOperator op = scanOperators.get(i);
-                    Tracers forked = ownerTracers.fork();
+                    Tracers forked = ownerTracers.fork(true);
                     forks.add(forked);
                     futures[i] = CompletableFuture.supplyAsync(() ->
                                     metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/PrepareCollectMetaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/PrepareCollectMetaTaskTest.java
@@ -1,0 +1,123 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.connector.MetaPreparationItem;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.task.PrepareCollectMetaTask;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import com.starrocks.type.IntegerType;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+public class PrepareCollectMetaTaskTest {
+
+    @BeforeEach
+    public void setUp() {
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setSessionVariable(new SessionVariable());
+        connectContext.getSessionVariable().setEnableProfile(true);
+        ConnectContext.set(connectContext);
+        Tracers.register(connectContext);
+        Tracers.init(Tracers.Mode.TIMER, Tracers.Module.ALL, true, false);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Tracers.close();
+        ConnectContext.remove();
+    }
+
+    @Test
+    public void testForkJoinMergeEndToEnd() throws Exception {
+
+        List<Column> columns = Lists.newArrayList(new Column("c1", IntegerType.INT));
+        IcebergTable tbl1 = new IcebergTable(1L, "t1", "default_catalog", "default_catalog",
+                "db", "t1", "", columns, null, Maps.newHashMap());
+        IcebergTable tbl2 = new IcebergTable(2L, "t2", "default_catalog", "default_catalog",
+                "db", "t2", "", columns, null, Maps.newHashMap());
+
+        LogicalIcebergScanOperator scan1 = new LogicalIcebergScanOperator.Builder()
+                .setTable(tbl1).setColRefToColumnMetaMap(Maps.newHashMap()).build();
+        LogicalIcebergScanOperator scan2 = new LogicalIcebergScanOperator.Builder()
+                .setTable(tbl2).setColRefToColumnMetaMap(Maps.newHashMap()).build();
+
+        OptExpression planTree = OptExpression.create(new LogicalJoinOperator(),
+                OptExpression.create(scan1),
+                OptExpression.create(scan2));
+
+        // Mock MetadataMgr.prepareMetadata to return true (no actual connector work)
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public boolean prepareMetadata(String queryId, String catalogName,
+                                           MetaPreparationItem item, Tracers tracers,
+                                           ConnectContext connectContext) {
+                return true;
+            }
+        };
+
+        ConnectContext ctx = ConnectContext.get();
+        ctx.getSessionVariable().setPrepareMetadataPoolSize(4);
+
+        // Create a real OptimizerContext via mock — constructor is package-private
+        // in com.starrocks.sql.optimizer, not accessible from .task subpackage
+        new MockUp<OptimizerContext>() {
+            @Mock
+            public void $init(ConnectContext cc) {}
+
+            @Mock
+            public SessionVariable getSessionVariable() {
+                return ctx.getSessionVariable();
+            }
+
+            @Mock
+            public UUID getQueryId() {
+                return UUID.randomUUID();
+            }
+        };
+
+        OptimizerContext optimizerCtx = new OptimizerContext(ctx);
+        TaskContext taskCtx = new TaskContext(optimizerCtx,
+                new PhysicalPropertySet(), new ColumnRefSet(), 0);
+
+        // Execute — this covers the fork/merge/join/shutdown path
+        new PrepareCollectMetaTask(taskCtx, planTree).execute();
+
+        // Verify profiling shows the outer scope
+        String output = Tracers.printScopeTimer();
+        Assertions.assertTrue(output.contains("EXTERNAL.parallel_prepare_metadata"),
+                "Expected outer scope in output:\n" + output);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
@@ -166,36 +166,39 @@ public class TracerTest extends PlanTestBase {
 
         int numThreads = 4;
         ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-
-        // Run multiple iterations to expose any potential race conditions
-        for (int iter = 0; iter < 100; iter++) {
-            List<Tracers> forks = new ArrayList<>();
-            List<Future<?>> futures = new ArrayList<>();
-            for (int i = 0; i < numThreads; i++) {
-                Tracers forked = owner.fork();
-                forks.add(forked);
-                futures.add(executor.submit(() -> {
-                    try (Timer ignored = Tracers.watchScope(forked, Tracers.Module.BASE,
-                            "forkedParallelWork")) {
-                        // Simulate work
-                    }
-                    return null;
-                }));
+        try {
+            // Run multiple iterations to expose any potential race conditions
+            for (int iter = 0; iter < 100; iter++) {
+                List<Tracers> forks = new ArrayList<>();
+                List<Future<?>> futures = new ArrayList<>();
+                for (int i = 0; i < numThreads; i++) {
+                    Tracers forked = owner.fork();
+                    forks.add(forked);
+                    futures.add(executor.submit(() -> {
+                        try (Timer ignored = Tracers.watchScope(forked, Tracers.Module.BASE,
+                                "forkedParallelWork")) {
+                            // Simulate work
+                        }
+                        return null;
+                    }));
+                }
+                for (Future<?> f : futures) {
+                    f.get();
+                }
+                // Merge forks back on the owner thread after all tasks complete
+                for (Tracers f : forks) {
+                    owner.mergeFrom(f);
+                }
             }
-            for (Future<?> f : futures) {
-                f.get();
-            }
-            // Merge forks back on the owner thread after all tasks complete
-            for (Tracers f : forks) {
-                owner.mergeFrom(f);
-            }
+        } finally {
+            executor.shutdown();
         }
 
-        executor.shutdown();
         String output = Tracers.printScopeTimer();
         // Each iteration creates 4 scopes, 100 iterations = 400 total
-        int count = StringUtils.countMatches(output, "forkedParallelWork");
-        Assertions.assertTrue(count > 0, "Expected forkedParallelWork in output but got: " + output);
+        // The toString() format includes [count], e.g. "forkedParallelWork[400]"
+        Assertions.assertTrue(output.contains("forkedParallelWork[400]"),
+                "Expected forkedParallelWork[400] in output but got: " + output);
         Tracers.close();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
@@ -20,6 +20,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 public class TracerTest extends PlanTestBase {
     @Test
     public void testTracerDefault() throws Exception {
@@ -150,5 +156,46 @@ public class TracerTest extends PlanTestBase {
         System.out.println(ss);
         Assertions.assertEquals(2, StringUtils.countMatches(ss, "Parser"));
         Assertions.assertEquals(2, StringUtils.countMatches(ss, "Planner"));
+    }
+
+    @Test
+    public void testTracerForkConcurrency() throws Exception {
+        Tracers.register(connectContext);
+        Tracers.init(Tracers.Mode.TIMER, Tracers.Module.BASE, false, false);
+        Tracers owner = Tracers.get();
+
+        int numThreads = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+        // Run multiple iterations to expose any potential race conditions
+        for (int iter = 0; iter < 100; iter++) {
+            List<Tracers> forks = new ArrayList<>();
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < numThreads; i++) {
+                Tracers forked = owner.fork();
+                forks.add(forked);
+                futures.add(executor.submit(() -> {
+                    try (Timer ignored = Tracers.watchScope(forked, Tracers.Module.BASE,
+                            "forkedParallelWork")) {
+                        // Simulate work
+                    }
+                    return null;
+                }));
+            }
+            for (Future<?> f : futures) {
+                f.get();
+            }
+            // Merge forks back on the owner thread after all tasks complete
+            for (Tracers f : forks) {
+                owner.mergeFrom(f);
+            }
+        }
+
+        executor.shutdown();
+        String output = Tracers.printScopeTimer();
+        // Each iteration creates 4 scopes, 100 iterations = 400 total
+        int count = StringUtils.countMatches(output, "forkedParallelWork");
+        Assertions.assertTrue(count > 0, "Expected forkedParallelWork in output but got: " + output);
+        Tracers.close();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
@@ -201,4 +201,58 @@ public class TracerTest extends PlanTestBase {
                 "Expected forkedParallelWork[400] in output but got: " + output);
         Tracers.close();
     }
+
+    @Test
+    public void testTracerForkPrepareCollectMetaPattern() throws Exception {
+        // Replicates the exact fork/merge orchestration used by PrepareCollectMetaTask.execute():
+        // 1. outer scope on owner thread ("EXTERNAL.parallel_prepare_metadata")
+        // 2. fork per parallel task → submit to executor
+        // 3. join all futures
+        // 4. merge all forks back
+        // 5. shutdown executor in finally
+        Tracers.register(connectContext);
+        Tracers.init(Tracers.Mode.TIMER, Tracers.Module.BASE, false, false);
+        Tracers owner = Tracers.get();
+
+        int numTasks = 4;
+        ExecutorService executor = Executors.newFixedThreadPool(numTasks);
+        try {
+            try (Timer ignored = Tracers.watchScope(Tracers.Module.BASE,
+                    "BASE.parallel_prepare_metadata")) {
+                List<Tracers> forks = new ArrayList<>(numTasks);
+                Future<?>[] futures = new Future[numTasks];
+                for (int i = 0; i < numTasks; i++) {
+                    Tracers forked = owner.fork();
+                    forks.add(forked);
+                    String scopeName = "BASE.processSplit.table" + i;
+                    futures[i] = executor.submit(() -> {
+                        try (Timer t = Tracers.watchScope(forked, Tracers.Module.BASE,
+                                scopeName)) {
+                            // simulate metadata preparation work
+                        }
+                        return null;
+                    });
+                }
+                for (Future<?> f : futures) {
+                    f.get();
+                }
+                for (Tracers f : forks) {
+                    owner.mergeFrom(f);
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+
+        String output = Tracers.printScopeTimer();
+        // Outer scope present and wrapping the parallel work
+        Assertions.assertTrue(output.contains("BASE.parallel_prepare_metadata"),
+                "Expected outer scope in output but got: " + output);
+        // Each of the 4 forks has its own per-table scope in the merged output
+        for (int i = 0; i < numTasks; i++) {
+            Assertions.assertTrue(output.contains("BASE.processSplit.table" + i),
+                    "Expected per-table scope table" + i + " in output but got: " + output);
+        }
+        Tracers.close();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerTest.java
@@ -172,7 +172,7 @@ public class TracerTest extends PlanTestBase {
                 List<Tracers> forks = new ArrayList<>();
                 List<Future<?>> futures = new ArrayList<>();
                 for (int i = 0; i < numThreads; i++) {
-                    Tracers forked = owner.fork();
+                    Tracers forked = owner.fork(true);
                     forks.add(forked);
                     futures.add(executor.submit(() -> {
                         try (Timer ignored = Tracers.watchScope(forked, Tracers.Module.BASE,
@@ -222,7 +222,7 @@ public class TracerTest extends PlanTestBase {
                 List<Tracers> forks = new ArrayList<>(numTasks);
                 Future<?>[] futures = new Future[numTasks];
                 for (int i = 0; i < numTasks; i++) {
-                    Tracers forked = owner.fork();
+                    Tracers forked = owner.fork(true);
                     forks.add(forked);
                     String scopeName = "BASE.processSplit.table" + i;
                     futures[i] = executor.submit(() -> {


### PR DESCRIPTION
## Why I'm doing:

When `enable_profile=true` (cluster default), queries joining many Iceberg/Hive external tables fan metadata preparation out to parallel threads via `PrepareCollectMetaTask`. A single `Tracers` object (and its `TimeWatcher`) was shared across all worker threads. Since `TimeWatcher.ScopedTimer` instances are cached and reused by scope name, concurrent `start()` (inside `synchronized TracerImpl.watchScope`) and `close()` (from try-with-resources, **outside any lock**) race on `reentrantCount`, `stopWatch`, and the shared `levels` ArrayList, producing:

```
java.lang.IllegalStateException: This stopwatch is already running.
  at com.google.common.base.Stopwatch.start(Stopwatch.java:166)
  at com.starrocks.common.profile.TracerImpl.watchScope(TracerImpl.java:54)
```

The failure is intermittent — when metadata is warm-cached, `prepareMetadata` short-circuits without spawning parallel work, so no collision occurs. The JDBC client sees a misleading `SQLSyntaxErrorException`.

`AllAtOnceExecutionSchedule` has the same sharing pattern via `Tracers.set()`, where the owner keeps working while a deploy-executor worker touches the same `TimeWatcher`.

## What I'm doing:

Add a **fork/merge** pattern to `Tracers` so each parallel thread gets an independent copy, then merges profiling data back:

```
Owner thread                       Worker thread(s)
─────────                          ──────────────
Tracers owner = Tracers.get()
                                   ┌──────────────────┐
Tracers f = owner.fork() ────────▶ │ Tracers.set(f)   │
                                   │ watchScope(...)   │  ← isolated TimeWatcher
                                   │ close() / cleanup │
                                   └──────────────────┘
owner.mergeFrom(f)   ◀────────────  accumulated timers merged back
```

- **`Tracer`**: new `fork()` / `mergeFrom()` interface methods (default identity/no-op for the empty tracer)
- **`TracerImpl.fork()`**: creates a fork that shares the read-only timing `Stopwatch` and `logTracer`/`reasonTracer` (already sync-safe), but gets an independent `TimeWatcher` (own `levels` stack, own `scopedTimers` cache)
- **`TimeWatcher.fork()`**: snapshots current `levels` as prefix context; `mergeFrom()` (synchronized) iterates the fork's `ScopedTimer` table and accumulates elapsed time + count into the owner's timers via `AtomicLong`/`AtomicInteger`
- **`PrepareCollectMetaTask`**: forks on the owner thread → passes fork to each `CompletableFuture` → merges all forks after `join()`
- **`AllAtOnceExecutionSchedule`**: fork at `schedule()` time → worker uses the fork → merge at task completion in `run()`. `TracerContext` simplified to pure ThreadLocal set/clear (no fork/merge inside)
- **`VarTracer`**: intentionally shared (not forked) — no `record()`/`count()` calls use the explicit-tracers parameter in parallel code paths
- **Defensive**: `TracerImpl.watchScope()` now uses try-finally so `tracerCost` always stops

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
