### PR TITLE
[Enhancement] Propagate flat_json config ALTER to BE via versioned task

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -983,9 +983,10 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
                 tablet->update_binlog_config(binlog_config);
                 break;
             case TTabletMetaType::FLAT_JSON_CONFIG: {
-                LOG(INFO) << "update tablet:" << tablet->tablet_id() << " flat_json_config";
                 FlatJsonConfig flat_json_config;
                 flat_json_config.update(tablet_meta_info.flat_json_config);
+                LOG(INFO) << "update tablet:" << tablet->tablet_id()
+                          << " flat_json_config, version: " << flat_json_config.get_flat_json_config_version();
                 tablet->update_flat_json_config(flat_json_config);
                 break;
             }

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -46,6 +46,7 @@
 #include "storage/tablet_manager.h"
 #include "storage/txn_manager.h"
 #include "storage/update_manager.h"
+#include "storage_primitive/flat_json_config.h"
 
 namespace starrocks {
 
@@ -981,6 +982,13 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
                 binlog_config.update(tablet_meta_info.binlog_config);
                 tablet->update_binlog_config(binlog_config);
                 break;
+            case TTabletMetaType::FLAT_JSON_CONFIG: {
+                LOG(INFO) << "update tablet:" << tablet->tablet_id() << " flat_json_config";
+                FlatJsonConfig flat_json_config;
+                flat_json_config.update(tablet_meta_info.flat_json_config);
+                tablet->update_flat_json_config(flat_json_config);
+                break;
+            }
             case TTabletMetaType::ENABLE_PERSISTENT_INDEX:
                 LOG(INFO) << "update tablet:" << tablet->tablet_id()
                           << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -42,6 +42,7 @@
 #include "storage/storage_metrics.h"
 #include "storage/tablet_index.h"
 #include "storage/tablet_reader_params.h"
+#include "storage_primitive/flat_json_config.h"
 
 namespace starrocks::lake {
 
@@ -573,6 +574,12 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
                                                            ? CompactionStrategyPB::DEFAULT
                                                            : CompactionStrategyPB::REAL_TIME;
         metadata_update_info->set_compaction_strategy(compaction_strategy);
+    }
+
+    if (tablet_meta_info.__isset.flat_json_config) {
+        FlatJsonConfig cfg;
+        cfg.update(tablet_meta_info.flat_json_config);
+        cfg.to_pb(metadata_update_info->mutable_flat_json_config());
     }
 
     RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -107,6 +107,13 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
                                      CompactionStrategyPB_Name(alter_meta.compaction_strategy()), metadata->id());
             metadata->set_compaction_strategy(alter_meta.compaction_strategy());
         }
+
+        if (alter_meta.has_flat_json_config()) {
+            LOG(INFO) << fmt::format("alter flat_json_config from version {} to version {} for tablet id: {}",
+                                     metadata->has_flat_json_config() ? metadata->flat_json_config().version() : 0,
+                                     alter_meta.flat_json_config().version(), metadata->id());
+            metadata->mutable_flat_json_config()->CopyFrom(alter_meta.flat_json_config());
+        }
     }
     return Status::OK();
 }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -69,6 +69,7 @@
 #include "storage/tablet_meta_manager.h"
 #include "storage/tablet_updates.h"
 #include "storage/update_manager.h"
+#include "storage_primitive/flat_json_config.h"
 #include "storage_primitive/tablet_basic_info.h"
 
 namespace starrocks {
@@ -492,6 +493,21 @@ void Tablet::update_binlog_config(const BinlogConfig& new_config) {
 
     LOG(INFO) << "set binlog config of tablet: " << tablet_id() << ", " << new_config.to_string()
               << ", minimum version: " << _tablet_meta->get_binlog_min_lsn();
+}
+
+void Tablet::update_flat_json_config(const FlatJsonConfig& new_config) {
+    std::shared_ptr<FlatJsonConfig> old_config = _tablet_meta->get_flat_json_config();
+    int64_t new_version = new_config.get_flat_json_config_version();
+    if (old_config != nullptr) {
+        int64_t old_version = old_config->get_flat_json_config_version();
+        if (old_version >= new_version) {
+            VLOG(3) << "skip to update flat_json_config of tablet: " << tablet_id()
+                    << ", current version: " << old_version << ", new version: " << new_version;
+            return;
+        }
+    }
+    _tablet_meta->set_flat_json_config(new_config);
+    LOG(INFO) << "set flat_json_config of tablet: " << tablet_id() << ", " << new_config.to_string();
 }
 
 StatusOr<bool> Tablet::_prepare_binlog_if_needed(const RowsetSharedPtr& rowset, int64_t version) {
@@ -1567,6 +1583,10 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
         tablet_info->__set_tablet_schema_version(_max_version_schema->schema_version());
         if (_tablet_meta->get_binlog_config() != nullptr) {
             tablet_info->__set_binlog_config_version(_tablet_meta->get_binlog_config()->version);
+        }
+        if (_tablet_meta->get_flat_json_config() != nullptr) {
+            tablet_info->__set_flat_json_config_version(
+                    _tablet_meta->get_flat_json_config()->get_flat_json_config_version());
         }
         if (_updates == nullptr) {
             int64_t max_version = _timestamped_version_tracker.get_max_continuous_version();

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -62,6 +62,7 @@
 namespace starrocks {
 
 class DataDir;
+class FlatJsonConfig;
 class RowsetReadOptions;
 class Tablet;
 class TabletMeta;
@@ -310,6 +311,8 @@ public:
     // This will modify the TabletMeta, and save_meta() will be called outside
     // to persist it. See run_update_meta_info_task() in agent_task.cpp
     void update_binlog_config(const BinlogConfig& binlog_config);
+
+    void update_flat_json_config(const FlatJsonConfig& flat_json_config);
 
     BinlogManager* binlog_manager() { return _binlog_manager == nullptr ? nullptr : _binlog_manager.get(); }
 

--- a/be/src/storage_primitive/flat_json_config.h
+++ b/be/src/storage_primitive/flat_json_config.h
@@ -46,27 +46,34 @@ public:
     int get_flat_json_max_column_max() const { return _flat_json_max_column_max; }
     void set_flat_json_max_column_max(int max) { _flat_json_max_column_max = max; }
 
-    void to_pb(FlatJsonConfigPB* binlog_config_pb) {
-        binlog_config_pb->set_flat_json_enable(_flat_json_enable);
-        binlog_config_pb->set_flat_json_null_factor(_flat_json_null_factor);
-        binlog_config_pb->set_flat_json_sparsity_factor(_flat_json_sparsity_factor);
-        binlog_config_pb->set_flat_json_max_column_max(_flat_json_max_column_max);
+    int64_t get_flat_json_config_version() const { return _flat_json_config_version; }
+    void set_flat_json_config_version(int64_t version) { _flat_json_config_version = version; }
+
+    void to_pb(FlatJsonConfigPB* flat_json_config_pb) {
+        flat_json_config_pb->set_flat_json_enable(_flat_json_enable);
+        flat_json_config_pb->set_flat_json_null_factor(_flat_json_null_factor);
+        flat_json_config_pb->set_flat_json_sparsity_factor(_flat_json_sparsity_factor);
+        flat_json_config_pb->set_flat_json_max_column_max(_flat_json_max_column_max);
+        flat_json_config_pb->set_version(_flat_json_config_version);
     }
 
     // Update function using another FlatJsonConfig
     void update(const FlatJsonConfig& config) {
         update(config.is_flat_json_enabled(), config.get_flat_json_null_factor(),
                config.get_flat_json_sparsity_factor(), config.get_flat_json_max_column_max());
+        _flat_json_config_version = config.get_flat_json_config_version();
     }
 
     void update(const TFlatJsonConfig& config) {
         update(config.flat_json_enable, config.flat_json_null_factor, config.flat_json_sparsity_factor,
                config.flat_json_column_max);
+        _flat_json_config_version = config.__isset.version ? config.version : 0;
     }
 
     void update(const FlatJsonConfigPB& flat_json_config_pb) {
         update(flat_json_config_pb.flat_json_enable(), flat_json_config_pb.flat_json_null_factor(),
                flat_json_config_pb.flat_json_sparsity_factor(), flat_json_config_pb.flat_json_max_column_max());
+        _flat_json_config_version = flat_json_config_pb.has_version() ? flat_json_config_pb.version() : 0;
     }
 
     // Copy Assignment
@@ -76,6 +83,7 @@ public:
             _flat_json_null_factor = other._flat_json_null_factor;
             _flat_json_sparsity_factor = other._flat_json_sparsity_factor;
             _flat_json_max_column_max = other._flat_json_max_column_max;
+            _flat_json_config_version = other._flat_json_config_version;
         }
         return *this;
     }
@@ -94,7 +102,8 @@ public:
         oss << "flat_json_enable=" << (_flat_json_enable ? "true" : "false") << ", ";
         oss << "flat_json_null_factor=" << _flat_json_null_factor << ", ";
         oss << "flat_json_sparsity_factor=" << _flat_json_sparsity_factor << ", ";
-        oss << "flat_json_max_column_max=" << _flat_json_max_column_max;
+        oss << "flat_json_max_column_max=" << _flat_json_max_column_max << ", ";
+        oss << "version=" << _flat_json_config_version;
         oss << "}";
         return oss.str();
     }
@@ -104,5 +113,6 @@ private:
     double _flat_json_null_factor = 0;
     double _flat_json_sparsity_factor = 0;
     int _flat_json_max_column_max = 0;
+    int64_t _flat_json_config_version = 0;
 };
 } // namespace starrocks

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -670,4 +670,37 @@ TEST_F(AlterTabletMetaTest, test_compaction_strategy) {
     ASSERT_EQ(CompactionStrategyPB::REAL_TIME, new_tablet_meta.value()->compaction_strategy());
 }
 
+TEST_F(AlterTabletMetaTest, test_alter_flat_json_config) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+    TUpdateTabletMetaInfoReq update_tablet_meta_req;
+    int64_t txn_id = next_id();
+    update_tablet_meta_req.__set_txn_id(txn_id);
+
+    TTabletMetaInfo tablet_meta_info;
+    auto tablet_id = _tablet_metadata->id();
+    tablet_meta_info.__set_tablet_id(tablet_id);
+    TFlatJsonConfig flat_json_config;
+    flat_json_config.__set_flat_json_enable(true);
+    flat_json_config.__set_flat_json_null_factor(0.25);
+    flat_json_config.__set_flat_json_sparsity_factor(0.75);
+    flat_json_config.__set_flat_json_column_max(12);
+    flat_json_config.__set_version(3);
+    tablet_meta_info.__set_flat_json_config(flat_json_config);
+
+    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
+
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_TRUE(txn_log->has_op_alter_metadata());
+    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
+    ASSERT_OK(new_tablet_meta.status());
+    ASSERT_TRUE(new_tablet_meta.value()->has_flat_json_config());
+    const auto& flat_json_config_pb = new_tablet_meta.value()->flat_json_config();
+    ASSERT_TRUE(flat_json_config_pb.flat_json_enable());
+    ASSERT_DOUBLE_EQ(0.25, flat_json_config_pb.flat_json_null_factor());
+    ASSERT_DOUBLE_EQ(0.75, flat_json_config_pb.flat_json_sparsity_factor());
+    ASSERT_EQ(12, flat_json_config_pb.flat_json_max_column_max());
+    ASSERT_EQ(3, flat_json_config_pb.version());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/tablet_test.cpp
+++ b/be/test/storage/tablet_test.cpp
@@ -24,6 +24,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/tablet_manager.h"
+#include "storage_primitive/flat_json_config.h"
 #include "storage_primitive/tablet_basic_info.h"
 
 namespace starrocks {
@@ -122,5 +123,35 @@ TEST_F(TabletTest, test_get_basic_info_uses_tablet_footprint) {
     ASSERT_EQ(54321 + 999, info.data_size);
     ASSERT_EQ(321, info.num_row);
     ASSERT_EQ(1, info.num_segment);
+}
+
+TEST_F(TabletTest, test_update_flat_json_config_version_gate) {
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->set_tablet_id(1026);
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    schema_pb.set_id(1027);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+    tablet_meta->set_tablet_schema(schema);
+    DataDir data_dir("./data_dir");
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, &data_dir);
+
+    // a higher version installs the config
+    FlatJsonConfig config_v2(true, 0.25, 0.75, 12);
+    config_v2.set_flat_json_config_version(2);
+    tablet->update_flat_json_config(config_v2);
+    auto installed = tablet->tablet_meta()->get_flat_json_config();
+    ASSERT_TRUE(installed != nullptr);
+    ASSERT_EQ(2, installed->get_flat_json_config_version());
+    ASSERT_DOUBLE_EQ(0.25, installed->get_flat_json_null_factor());
+
+    // a stale (lower or equal) version is skipped, keeping the current config
+    FlatJsonConfig config_v1(false, 0.5, 0.5, 8);
+    config_v1.set_flat_json_config_version(1);
+    tablet->update_flat_json_config(config_v1);
+    installed = tablet->tablet_meta()->get_flat_json_config();
+    ASSERT_EQ(2, installed->get_flat_json_config_version());
+    ASSERT_TRUE(installed->is_flat_json_enabled());
+    ASSERT_DOUBLE_EQ(0.25, installed->get_flat_json_null_factor());
 }
 } // namespace starrocks

--- a/be/test/storage_primitive/storage_value_types_test.cpp
+++ b/be/test/storage_primitive/storage_value_types_test.cpp
@@ -181,7 +181,7 @@ TEST(StorageValueTypesTest, FlatJsonConfigUpdateAndSerializationSemantics) {
     EXPECT_EQ(12, config.get_flat_json_max_column_max());
     EXPECT_EQ(
             "FlatJsonConfig{flat_json_enable=true, flat_json_null_factor=0.25, "
-            "flat_json_sparsity_factor=0.75, flat_json_max_column_max=12}",
+            "flat_json_sparsity_factor=0.75, flat_json_max_column_max=12, version=0}",
             config.to_string());
 
     FlatJsonConfigPB pb;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -607,11 +607,11 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();
-                    locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
+                    locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
                     try {
                         schemaChangeHandler.processLakeTableAlterMeta(clause, db, (OlapTable) table);
                     } finally {
-                        locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
+                        locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
                     }
                     isSynchronous = false;
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -605,11 +605,21 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR) ||
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
-                boolean isSuccess = schemaChangeHandler.updateFlatJsonConfigMeta(db, table.getId(),
-                        properties, TTabletMetaType.FLAT_JSON_CONFIG);
-                if (!isSuccess) {
-                    throw new DdlException("modify flat json config of FEMeta failed");
-
+                if (table.isCloudNativeTable()) {
+                    Locker locker = new Locker();
+                    locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
+                    try {
+                        schemaChangeHandler.processLakeTableAlterMeta(clause, db, (OlapTable) table);
+                    } finally {
+                        locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
+                    }
+                    isSynchronous = false;
+                } else {
+                    boolean isSuccess = schemaChangeHandler.updateFlatJsonConfigMeta(db, table.getId(),
+                            properties, TTabletMetaType.FLAT_JSON_CONFIG);
+                    if (!isSuccess) {
+                        throw new DdlException("modify flat json config of FEMeta failed");
+                    }
                 }
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -16,6 +16,7 @@ package com.starrocks.alter;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
@@ -42,6 +43,9 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     @SerializedName(value = "compactionStrategy")
     private String compactionStrategy;
 
+    @SerializedName(value = "flatJsonConfig")
+    private FlatJsonConfig flatJsonConfig;
+
     // for deserialization
     public LakeTableAlterMetaJob() {
         super(JobType.SCHEMA_CHANGE);
@@ -67,6 +71,13 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         this.compactionStrategy = compactionStrategy;
     }
 
+    public LakeTableAlterMetaJob(long jobId, long dbId, long tableId, String tableName,
+                                 long timeoutMs, FlatJsonConfig flatJsonConfig) {
+        super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
+        this.metaType = TTabletMetaType.FLAT_JSON_CONFIG;
+        this.flatJsonConfig = flatJsonConfig;
+    }
+
     protected LakeTableAlterMetaJob(LakeTableAlterMetaJob job) {
         super(job);
         this.metaType = job.metaType;
@@ -74,6 +85,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         this.persistentIndexType = job.persistentIndexType;
         this.enableFileBundling = job.enableFileBundling;
         this.compactionStrategy = job.compactionStrategy;
+        this.flatJsonConfig = job.flatJsonConfig == null ? null : new FlatJsonConfig(job.flatJsonConfig);
     }
 
     @Override
@@ -90,6 +102,10 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         if (metaType == TTabletMetaType.COMPACTION_STRATEGY) {
             return TabletMetadataUpdateAgentTaskFactory.createUpdateCompactionStrategyTask(nodeId, tablets,
                         compactionStrategy);
+        }
+        if (metaType == TTabletMetaType.FLAT_JSON_CONFIG) {
+            return TabletMetadataUpdateAgentTaskFactory.createFlatJsonConfigUpdateTask(nodeId, tablets,
+                        flatJsonConfig);
         }
         return null;
     }
@@ -123,6 +139,9 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
                     String.valueOf(compactionStrategy));
             table.getTableProperty().buildCompactionStrategy();
         }
+        if (metaType == TTabletMetaType.FLAT_JSON_CONFIG && flatJsonConfig != null) {
+            table.setFlatJsonConfig(flatJsonConfig);
+        }
     }
 
     @Override
@@ -133,6 +152,9 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         this.persistentIndexType = other.persistentIndexType;
         this.enableFileBundling = other.enableFileBundling;
         this.compactionStrategy = other.compactionStrategy;
+        this.flatJsonConfig = other.flatJsonConfig == null
+                ? null
+                : new FlatJsonConfig(other.flatJsonConfig);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3074,33 +3074,41 @@ public class SchemaChangeHandler extends AlterHandler {
             AgentTaskExecutor.submit(batchTask);
             LOG.info("send update flat_json_config tablet meta task for table {}, partition {}, number: {}",
                     tableName, partitionName, batchTask.getTaskNum());
+            waitForTabletMetaBatchTask(batchTask, countDownLatch, totalTaskNum,
+                    "Failed to update partition[" + partitionName + "] flat_json_config tablet meta.");
+        }
+    }
 
-            long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
-            timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000L);
-            boolean ok = false;
-            try {
-                ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                LOG.warn("InterruptedException: ", e);
-            }
+    // Wait for a dispatched tablet-meta batch task and turn a timeout/error into a DdlException.
+    private static void waitForTabletMetaBatchTask(AgentBatchTask batchTask,
+                                                   MarkedCountDownLatch<Long, Set<Long>> countDownLatch,
+                                                   int totalTaskNum, String errMsgPrefix) throws DdlException {
+        long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
+        timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000L);
+        boolean ok = false;
+        try {
+            ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("InterruptedException: ", e);
+        }
 
-            if (!ok || !countDownLatch.getStatus().ok()) {
-                String errMsg = "Failed to update partition[" + partitionName + "] flat_json_config tablet meta.";
-                AgentTaskQueue.removeBatchTask(batchTask, TTaskType.UPDATE_TABLET_META_INFO);
-                if (!countDownLatch.getStatus().ok()) {
-                    errMsg += " Error: " + countDownLatch.getStatus().getErrorMsg();
-                } else {
-                    List<Map.Entry<Long, Set<Long>>> unfinishedMarks = countDownLatch.getLeftMarks();
-                    List<Map.Entry<Long, Set<Long>>> subList =
-                            unfinishedMarks.subList(0, Math.min(unfinishedMarks.size(), 3));
-                    if (!subList.isEmpty()) {
-                        errMsg += " Unfinished mark: " + Joiner.on(", ").join(subList);
-                    }
+        if (!ok || !countDownLatch.getStatus().ok()) {
+            String errMsg = errMsgPrefix;
+            AgentTaskQueue.removeBatchTask(batchTask, TTaskType.UPDATE_TABLET_META_INFO);
+            if (!countDownLatch.getStatus().ok()) {
+                errMsg += " Error: " + countDownLatch.getStatus().getErrorMsg();
+            } else {
+                List<Map.Entry<Long, Set<Long>>> unfinishedMarks = countDownLatch.getLeftMarks();
+                List<Map.Entry<Long, Set<Long>>> subList =
+                        unfinishedMarks.subList(0, Math.min(unfinishedMarks.size(), 3));
+                if (!subList.isEmpty()) {
+                    errMsg += " Unfinished mark: " + Joiner.on(", ").join(subList);
                 }
-                errMsg += ". This operation maybe partial successfully, You should retry until success.";
-                LOG.warn(errMsg);
-                throw new DdlException(errMsg);
             }
+            errMsg += ". This operation maybe partial successfully, You should retry until success.";
+            LOG.warn(errMsg);
+            throw new DdlException(errMsg);
         }
     }
 
@@ -3364,6 +3372,7 @@ public class SchemaChangeHandler extends AlterHandler {
             try {
                 ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 LOG.warn("InterruptedException: ", e);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2750,6 +2750,15 @@ public class SchemaChangeHandler extends AlterHandler {
                         ? new FlatJsonConfig(olapTable.getFlatJsonConfig())
                         : new FlatJsonConfig();
                 newConfig.buildFromProperties(properties);
+                // The analyzer's enabled-check ran without the table lock, so a concurrent ALTER
+                // may have disabled flat_json since; re-validate against the locked state so a
+                // factor change cannot land on a disabled config (mirrors updateFlatJsonConfigMeta).
+                if (!newConfig.getFlatJsonEnable()
+                        && (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX))) {
+                    throw new DdlException("flat JSON configuration must be set after enabling flat JSON.");
+                }
                 newConfig.incVersion();
                 metaType = TTabletMetaType.FLAT_JSON_CONFIG;
                 flatJsonConfig = newConfig;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2641,6 +2641,7 @@ public class SchemaChangeHandler extends AlterHandler {
             boolean enableFileBundling = false;
             TTabletMetaType metaType = TTabletMetaType.ENABLE_PERSISTENT_INDEX;
             String compactionStrategy = "";
+            FlatJsonConfig flatJsonConfig = null;
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                 enablePersistentIndex = PropertyAnalyzer.analyzeBooleanProp(properties,
                         PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, false);
@@ -2741,16 +2742,34 @@ public class SchemaChangeHandler extends AlterHandler {
                 return null;
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
                 return processAlterCloudNativeFastSchemaEvolutionV2Property(db, olapTable, properties).orElse(null);
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+                FlatJsonConfig newConfig = olapTable.containsFlatJsonConfig()
+                        ? new FlatJsonConfig(olapTable.getFlatJsonConfig())
+                        : new FlatJsonConfig();
+                newConfig.buildFromProperties(properties);
+                newConfig.incVersion();
+                metaType = TTabletMetaType.FLAT_JSON_CONFIG;
+                flatJsonConfig = newConfig;
             } else {
                 throw new DdlException("does not support alter " + properties.entrySet().iterator().next().getKey() +
                         " in shared_data mode");
             }
 
             long timeoutSecond = PropertyAnalyzer.analyzeTimeout(properties, Config.alter_table_timeout_second);
-            alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
-                    db.getId(),
-                    olapTable.getId(), olapTable.getName(), timeoutSecond * 1000 /* should be ms*/,
-                    metaType, enablePersistentIndex, persistentIndexType, enableFileBundling, compactionStrategy);
+            if (metaType == TTabletMetaType.FLAT_JSON_CONFIG) {
+                alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
+                        db.getId(),
+                        olapTable.getId(), olapTable.getName(), timeoutSecond * 1000 /* should be ms*/,
+                        flatJsonConfig);
+            } else {
+                alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
+                        db.getId(),
+                        olapTable.getId(), olapTable.getName(), timeoutSecond * 1000 /* should be ms*/,
+                        metaType, enablePersistentIndex, persistentIndexType, enableFileBundling, compactionStrategy);
+            }
         } else {
             // shouldn't happen
             throw new DdlException("only support alter enable_persistent_index in shared_data mode");
@@ -2901,6 +2920,7 @@ public class SchemaChangeHandler extends AlterHandler {
         if (olapTable == null) {
             return false;
         }
+        List<Partition> partitions = Lists.newArrayList();
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
         try {
@@ -2910,6 +2930,7 @@ public class SchemaChangeHandler extends AlterHandler {
             } else {
                 newFlatJsonConfig = new FlatJsonConfig(olapTable.getFlatJsonConfig());
             }
+            partitions.addAll(olapTable.getPartitions());
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
         }
@@ -2958,6 +2979,25 @@ public class SchemaChangeHandler extends AlterHandler {
 
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.WRITE);
         try {
+            // check for concurrent modifications by version
+            if (olapTable.containsFlatJsonConfig()
+                    && olapTable.getFlatJsonConfig().getVersion() != newFlatJsonConfig.getVersion()) {
+                Map<String, String> newProperties = olapTable.getFlatJsonConfig().toProperties();
+                newProperties.putAll(properties);
+                newFlatJsonConfig.buildFromProperties(newProperties);
+                newFlatJsonConfig.setVersion(olapTable.getFlatJsonConfig().getVersion());
+                // Re-validate after rebasing onto the (possibly concurrently-modified) current
+                // config: a factor change must not be silently merged onto a now-disabled config,
+                // which would persist an invalid disabled-with-factor state (the factor is dropped
+                // by toProperties() while disabled, diverging in-memory vs replay/failover).
+                if (!newFlatJsonConfig.getFlatJsonEnable()
+                        && (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX))) {
+                    throw new RuntimeException("flat JSON configuration must be set after enabling flat JSON.");
+                }
+            }
+            newFlatJsonConfig.incVersion();
             GlobalStateMgr.getCurrentState().getLocalMetastore().modifyFlatJsonMeta(db, olapTable, newFlatJsonConfig);
         } catch (Exception e) {
             isModifiedSuccess = false;
@@ -2965,7 +3005,103 @@ public class SchemaChangeHandler extends AlterHandler {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.WRITE);
         }
 
+        if (isModifiedSuccess) {
+            try {
+                for (Partition partition : partitions) {
+                    updateFlatJsonPartitionTabletMeta(db, olapTable.getName(), partition.getName(),
+                            olapTable.getFlatJsonConfig());
+                }
+            } catch (DdlException e) {
+                LOG.warn("Failed to execute updateFlatJsonPartitionTabletMeta", e);
+            }
+        }
+
         return isModifiedSuccess;
+    }
+
+    /**
+     * Update one specified partition's flat_json_config by partition name of table
+     */
+    public void updateFlatJsonPartitionTabletMeta(Database db,
+                                                  String tableName,
+                                                  String partitionName,
+                                                  FlatJsonConfig flatJsonConfig) throws DdlException {
+        // be id -> Set<tablet id>
+        Map<Long, Set<Long>> beIdToTabletId = Maps.newHashMap();
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        if (olapTable == null) {
+            throw new DdlException("Table[" + tableName + "] does not exist");
+        }
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        try {
+            Partition partition = olapTable.getPartition(partitionName);
+            if (partition == null) {
+                throw new DdlException(
+                        "Partition[" + partitionName + "] does not exist in table[" + olapTable.getName() + "]");
+            }
+
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                MaterializedIndex baseIndex = physicalPartition.getLatestBaseIndex();
+                for (Tablet tablet : baseIndex.getTablets()) {
+                    for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
+                        Set<Long> tabletSet = beIdToTabletId.computeIfAbsent(replica.getBackendId(), k -> Sets.newHashSet());
+                        tabletSet.add(tablet.getId());
+                    }
+                }
+            }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+        }
+
+        int totalTaskNum = beIdToTabletId.keySet().size();
+        if (totalTaskNum == 0) {
+            return;
+        }
+        MarkedCountDownLatch<Long, Set<Long>> countDownLatch = new MarkedCountDownLatch<>(totalTaskNum);
+        AgentBatchTask batchTask = new AgentBatchTask();
+        for (Map.Entry<Long, Set<Long>> kv : beIdToTabletId.entrySet()) {
+            countDownLatch.addMark(kv.getKey(), kv.getValue());
+            TabletMetadataUpdateAgentTask task = TabletMetadataUpdateAgentTaskFactory
+                    .createFlatJsonConfigUpdateTask(kv.getKey(), kv.getValue(), flatJsonConfig);
+            task.setLatch(countDownLatch);
+            batchTask.addTask(task);
+        }
+        if (!FeConstants.runningUnitTest) {
+            AgentTaskQueue.addBatchTask(batchTask);
+            AgentTaskExecutor.submit(batchTask);
+            LOG.info("send update flat_json_config tablet meta task for table {}, partition {}, number: {}",
+                    tableName, partitionName, batchTask.getTaskNum());
+
+            long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
+            timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000L);
+            boolean ok = false;
+            try {
+                ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                LOG.warn("InterruptedException: ", e);
+            }
+
+            if (!ok || !countDownLatch.getStatus().ok()) {
+                String errMsg = "Failed to update partition[" + partitionName + "] flat_json_config tablet meta.";
+                AgentTaskQueue.removeBatchTask(batchTask, TTaskType.UPDATE_TABLET_META_INFO);
+                if (!countDownLatch.getStatus().ok()) {
+                    errMsg += " Error: " + countDownLatch.getStatus().getErrorMsg();
+                } else {
+                    List<Map.Entry<Long, Set<Long>>> unfinishedMarks = countDownLatch.getLeftMarks();
+                    List<Map.Entry<Long, Set<Long>>> subList =
+                            unfinishedMarks.subList(0, Math.min(unfinishedMarks.size(), 3));
+                    if (!subList.isEmpty()) {
+                        errMsg += " Unfinished mark: " + Joiner.on(", ").join(subList);
+                    }
+                }
+                errMsg += ". This operation maybe partial successfully, You should retry until success.";
+                LOG.warn(errMsg);
+                throw new DdlException(errMsg);
+            }
+        }
     }
 
     // return true means that the modification of FEMeta is successful,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FlatJsonConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FlatJsonConfig.java
@@ -36,11 +36,15 @@ public class FlatJsonConfig implements Writable {
     @SerializedName("flatJsonColumnMax")
     private int flatJsonColumnMax;
 
+    @SerializedName("configVersion")
+    private long configVersion;
+
     public FlatJsonConfig(boolean enabled, double nullFactor, double sparsityFactor, int columnMax) {
         this.flatJsonEnable = enabled;
         this.flatJsonNullFactor = nullFactor;
         this.flatJsonSparsityFactor = sparsityFactor;
         this.flatJsonColumnMax = columnMax;
+        this.configVersion = 0;
     }
 
     public FlatJsonConfig(FlatJsonConfig config) {
@@ -48,6 +52,7 @@ public class FlatJsonConfig implements Writable {
         this.flatJsonNullFactor = config.getFlatJsonNullFactor();
         this.flatJsonSparsityFactor = config.getFlatJsonSparsityFactor();
         this.flatJsonColumnMax = config.getFlatJsonColumnMax();
+        this.configVersion = config.getVersion();
     }
 
     public FlatJsonConfig() {
@@ -56,6 +61,10 @@ public class FlatJsonConfig implements Writable {
     }
 
     public void buildFromProperties(Map<String, String> properties) {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION)) {
+            configVersion = Long.parseLong(properties.get(
+                    PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION));
+        }
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE)) {
             flatJsonEnable = Boolean.parseBoolean(properties.get(
                     PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
@@ -106,8 +115,21 @@ public class FlatJsonConfig implements Writable {
         this.flatJsonColumnMax = flatJsonColumnMax;
     }
 
+    public long getVersion() {
+        return configVersion;
+    }
+
+    public void setVersion(long version) {
+        this.configVersion = version;
+    }
+
+    public void incVersion() {
+        this.configVersion++;
+    }
+
     public Map<String, String> toProperties() {
         Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION, String.valueOf(configVersion));
         properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, String.valueOf(flatJsonEnable));
 
         // Only include other flat JSON properties if flat JSON is enabled
@@ -122,6 +144,7 @@ public class FlatJsonConfig implements Writable {
 
     public TFlatJsonConfig toTFlatJsonConfig() {
         TFlatJsonConfig tFlatJsonConfig = new TFlatJsonConfig();
+        tFlatJsonConfig.setVersion(configVersion);
         tFlatJsonConfig.setFlat_json_enable(flatJsonEnable);
         tFlatJsonConfig.setFlat_json_null_factor(flatJsonNullFactor);
         tFlatJsonConfig.setFlat_json_sparsity_factor(flatJsonSparsityFactor);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3179,35 +3179,40 @@ public class OlapTable extends Table {
             properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE, storageType());
         }
 
-        // flat json enable
-        String flatJsonEnable = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE);
-        if (!Strings.isNullOrEmpty(flatJsonEnable)) {
-            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, flatJsonEnable);
-
-            // Only include other flat JSON properties if flat_json.enable is true
-            if (Boolean.parseBoolean(flatJsonEnable)) {
-                // flat json null factor
-                String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
-                if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
-                }
-
-                // flat json sparsity factor
-                String flatJsonSparsityFactor =
-                        tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
-                if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
-                }
-
-                // flat json column max
-                String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
-                if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
-                }
-            }
-        }
+        // flat json
+        appendFlatJsonProperties(properties, tableProperties);
 
         return properties;
+    }
+
+    // Render flat_json.* for SHOW CREATE TABLE; shared with LakeTable.getUniqueProperties()
+    // so both modes stay in sync.
+    protected static void appendFlatJsonProperties(Map<String, String> properties,
+                                                   Map<String, String> tableProperties) {
+        String flatJsonEnable = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE);
+        if (Strings.isNullOrEmpty(flatJsonEnable)) {
+            return;
+        }
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, flatJsonEnable);
+
+        // Only include other flat JSON properties if flat_json.enable is true
+        if (Boolean.parseBoolean(flatJsonEnable)) {
+            String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
+            if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
+                properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
+            }
+
+            String flatJsonSparsityFactor =
+                    tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
+            if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
+                properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
+            }
+
+            String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
+            if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
+                properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -45,7 +45,6 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
@@ -576,25 +575,38 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
                 properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
             boolean enableFlatJson = PropertyAnalyzer.analyzeFlatJsonEnabled(properties);
-            
-            // In gsonPostProcess, we should be tolerant of existing properties even when flat_json.enable is false.
-            // The validation should be done at ALTER TABLE time, not during deserialization/copy.
-            // If flat_json.enable is false, ignore other flat JSON properties and use default values.
+            // Read with get(), not analyzerDoubleProp/analyzeIntProp: those remove() the keys, and this
+            // runs on every image load (gsonPostProcess), so the factors would be lost on the next
+            // checkpoint. On a malformed value, warn and keep defaults instead of failing the image
+            // load, matching buildLakeCompactionMaxParallel().
             try {
-                double flatJsonNullFactor = PropertyAnalyzer.analyzerDoubleProp(properties,
-                        PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, Config.flat_json_null_factor);
-                double flatJsonSparsityFactory = PropertyAnalyzer.analyzerDoubleProp(properties,
-                        PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, Config.flat_json_sparsity_factory);
-                int flatJsonColumnMax = PropertyAnalyzer.analyzeIntProp(properties,
-                        PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, Config.flat_json_column_max);
+                double flatJsonNullFactor = Config.flat_json_null_factor;
+                double flatJsonSparsityFactory = Config.flat_json_sparsity_factory;
+                int flatJsonColumnMax = Config.flat_json_column_max;
+                if (enableFlatJson) {
+                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)) {
+                        flatJsonNullFactor = Double.parseDouble(
+                                properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+                    }
+                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)) {
+                        flatJsonSparsityFactory = Double.parseDouble(
+                                properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+                    }
+                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+                        flatJsonColumnMax = Integer.parseInt(
+                                properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+                    }
+                }
                 flatJsonConfig = new FlatJsonConfig(enableFlatJson, flatJsonNullFactor,
                         flatJsonSparsityFactory, flatJsonColumnMax);
                 if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION)) {
                     flatJsonConfig.setVersion(Long.parseLong(properties.get(
                             PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION)));
                 }
-            } catch (AnalysisException e) {
-                throw new RuntimeException("Failed to analyze flat JSON properties: " + e.getMessage(), e);
+            } catch (NumberFormatException e) {
+                LOG.warn("Invalid flat_json property value, using defaults: {}", e.getMessage());
+                flatJsonConfig = new FlatJsonConfig(enableFlatJson, Config.flat_json_null_factor,
+                        Config.flat_json_sparsity_factory, Config.flat_json_column_max);
             }
         }
         return this;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -589,6 +589,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
                         PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, Config.flat_json_column_max);
                 flatJsonConfig = new FlatJsonConfig(enableFlatJson, flatJsonNullFactor,
                         flatJsonSparsityFactory, flatJsonColumnMax);
+                if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION)) {
+                    flatJsonConfig.setVersion(Long.parseLong(properties.get(
+                            PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION)));
+                }
             } catch (AnalysisException e) {
                 throw new RuntimeException("Failed to analyze flat JSON properties: " + e.getMessage(), e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -177,6 +177,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_FLAT_JSON_COLUMN_MAX = "flat_json.column.max";
 
+    public static final String PROPERTIES_FLAT_JSON_VERSION = "flat_json.version";
+
     public static final String PROPERTIES_STORAGE_TYPE_COLUMN = "column";
     public static final String PROPERTIES_STORAGE_TYPE_COLUMN_WITH_ROW = "column_with_row";
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -160,6 +160,33 @@ public class LakeTable extends OlapTable {
         properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
                 String.valueOf(isFastSchemaEvolutionV2()));
 
+        // flat_json: render it like OlapTable.getUniqueProperties() so SHOW CREATE TABLE reflects
+        // the table-level flat_json config for cloud-native tables too.
+        Map<String, String> tableProperties = tableProperty.getProperties();
+        String flatJsonEnable = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE);
+        if (!Strings.isNullOrEmpty(flatJsonEnable)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, flatJsonEnable);
+
+            // Only include the other flat JSON properties when flat_json.enable is true.
+            if (Boolean.parseBoolean(flatJsonEnable)) {
+                String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
+                if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
+                }
+
+                String flatJsonSparsityFactor =
+                        tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
+                if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
+                }
+
+                String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
+                if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
+                }
+            }
+        }
+
         return properties;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -162,30 +162,7 @@ public class LakeTable extends OlapTable {
 
         // flat_json: render it like OlapTable.getUniqueProperties() so SHOW CREATE TABLE reflects
         // the table-level flat_json config for cloud-native tables too.
-        Map<String, String> tableProperties = tableProperty.getProperties();
-        String flatJsonEnable = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE);
-        if (!Strings.isNullOrEmpty(flatJsonEnable)) {
-            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, flatJsonEnable);
-
-            // Only include the other flat JSON properties when flat_json.enable is true.
-            if (Boolean.parseBoolean(flatJsonEnable)) {
-                String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
-                if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
-                }
-
-                String flatJsonSparsityFactor =
-                        tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
-                if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
-                }
-
-                String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
-                if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
-                    properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
-                }
-            }
-        }
+        appendFlatJsonProperties(properties, tableProperty.getProperties());
 
         return properties;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -51,6 +51,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.LocalTablet.TabletHealthStatus;
 import com.starrocks.catalog.MaterializedIndex;
@@ -559,6 +560,9 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
 
         // 11. send set table binlog config to be
         handleSetTabletBinlogConfig(backendId, backendTablets);
+
+        // 11.5. flat_json_config reconciliation — re-push when BE-reported version is behind.
+        handleSetTabletFlatJsonConfig(backendId, backendTablets);
 
         // 12. send primary index cache expire sec to be
         handleSetPrimaryIndexCacheExpireSec(backendId, backendTablets);
@@ -1879,6 +1883,10 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         handleSetTabletBinlogConfig(backendId, backendTablets);
     }
 
+    public static void testHandleSetTabletFlatJsonConfig(long backendId, Map<Long, TTablet> backendTablets) {
+        handleSetTabletFlatJsonConfig(backendId, backendTablets);
+    }
+
     private static void handleSetTabletEnablePersistentIndex(long backendId, Map<Long, TTablet> backendTablets) {
         List<Pair<Long, Boolean>> tabletToEnablePersistentIndex = Lists.newArrayList();
 
@@ -2203,6 +2211,63 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
             AgentBatchTask batchTask = new AgentBatchTask();
             TabletMetadataUpdateAgentTask task = TabletMetadataUpdateAgentTaskFactory.createBinlogConfigUpdateTask(
                     backendId, tabletToBinlogConfig);
+            batchTask.addTask(task);
+            AgentTaskExecutor.submit(batchTask);
+        }
+    }
+
+    private static void handleSetTabletFlatJsonConfig(long backendId, Map<Long, TTablet> backendTablets) {
+        List<Pair<Long, FlatJsonConfig>> tabletToFlatJsonConfig = Lists.newArrayList();
+
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        for (TTablet backendTablet : backendTablets.values()) {
+            for (TTabletInfo tabletInfo : backendTablet.tablet_infos) {
+                long tabletId = tabletInfo.getTablet_id();
+                // Treat unset version as stale so orphan tablets get reconciled.
+                long beFlatJsonConfigVersion =
+                        tabletInfo.isSetFlat_json_config_version() ? tabletInfo.flat_json_config_version : 0;
+                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
+                long dbId = tabletMeta != null ? tabletMeta.getDbId() : TabletInvertedIndex.NOT_EXIST_VALUE;
+                long tableId = tabletMeta != null ? tabletMeta.getTableId() : TabletInvertedIndex.NOT_EXIST_VALUE;
+
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+                if (db == null) {
+                    continue;
+                }
+
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), tableId);
+                if (olapTable == null) {
+                    continue;
+                }
+                Locker locker = new Locker();
+                locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
+                try {
+                    if (!olapTable.containsFlatJsonConfig()) {
+                        continue;
+                    }
+                    FlatJsonConfig flatJsonConfig = olapTable.getFlatJsonConfig();
+                    long feFlatJsonConfigVersion = flatJsonConfig.getVersion();
+                    if (beFlatJsonConfigVersion < feFlatJsonConfigVersion) {
+                        tabletToFlatJsonConfig.add(new Pair<>(tabletId, flatJsonConfig));
+                    } else if (beFlatJsonConfigVersion > feFlatJsonConfigVersion) {
+                        LOG.warn("table {} flat_json_config version of tabletId: {}, BeId: {}, is {} " +
+                                        "greater than version of FE, which is {}",
+                                olapTable.getName(), tabletId, backendId,
+                                beFlatJsonConfigVersion, feFlatJsonConfigVersion);
+                    }
+                } finally {
+                    locker.unLockTablesWithIntensiveDbLock(db.getId(),
+                            Lists.newArrayList(olapTable.getId()), LockType.READ);
+                }
+            }
+        }
+
+        LOG.debug("find [{}] tablets need set flat_json_config", tabletToFlatJsonConfig.size());
+        if (!tabletToFlatJsonConfig.isEmpty()) {
+            AgentBatchTask batchTask = new AgentBatchTask();
+            TabletMetadataUpdateAgentTask task = TabletMetadataUpdateAgentTaskFactory
+                    .createFlatJsonConfigUpdateTask(backendId, tabletToFlatJsonConfig);
             batchTask.addTask(task);
             AgentTaskExecutor.submit(batchTask);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -2240,13 +2240,19 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                 if (olapTable == null) {
                     continue;
                 }
+                // Skip non-flat_json tables before locking so the report hot path avoids a per-tablet
+                // lock for them (cf. handleSetTabletBinlogConfig); the version compare stays under the lock.
+                if (!olapTable.containsFlatJsonConfig()) {
+                    continue;
+                }
                 Locker locker = new Locker();
                 locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
                 try {
-                    if (!olapTable.containsFlatJsonConfig()) {
+                    FlatJsonConfig flatJsonConfig = olapTable.getFlatJsonConfig();
+                    if (flatJsonConfig == null) {
+                        // flat_json could have been removed between the lock-free check and the lock.
                         continue;
                     }
-                    FlatJsonConfig flatJsonConfig = olapTable.getFlatJsonConfig();
                     long feFlatJsonConfigVersion = flatJsonConfig.getVersion();
                     if (beFlatJsonConfigVersion < feFlatJsonConfigVersion) {
                         tabletToFlatJsonConfig.add(new Pair<>(tabletId, flatJsonConfig));

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -2223,9 +2223,12 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         for (TTablet backendTablet : backendTablets.values()) {
             for (TTabletInfo tabletInfo : backendTablet.tablet_infos) {
                 long tabletId = tabletInfo.getTablet_id();
-                // Treat unset version as stale so orphan tablets get reconciled.
+                // A missing version means the tablet has no flat_json config at all (the BE only
+                // reports the field when a config exists). Map it below any real version — real
+                // versions start at 0 for CREATE-time configs — so such tablets get reconciled
+                // even when the FE-side config was never bumped by an ALTER.
                 long beFlatJsonConfigVersion =
-                        tabletInfo.isSetFlat_json_config_version() ? tabletInfo.flat_json_config_version : 0;
+                        tabletInfo.isSetFlat_json_config_version() ? tabletInfo.flat_json_config_version : -1;
                 TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
                 long dbId = tabletMeta != null ? tabletMeta.getDbId() : TabletInvertedIndex.NOT_EXIST_VALUE;
                 long tableId = tabletMeta != null ? tabletMeta.getTableId() : TabletInvertedIndex.NOT_EXIST_VALUE;

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -16,6 +16,7 @@ package com.starrocks.task;
 
 import com.google.common.collect.Lists;
 import com.starrocks.binlog.BinlogConfig;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Pair;
@@ -98,6 +99,21 @@ public class TabletMetadataUpdateAgentTaskFactory {
     public static TabletMetadataUpdateAgentTask createBinlogConfigUpdateTask(long backendId,
                                                                              List<Pair<Long, BinlogConfig>> configs) {
         return new UpdateBinlogConfigTask(backendId, requireNonNull(configs, "configs is null"));
+    }
+
+    public static TabletMetadataUpdateAgentTask createFlatJsonConfigUpdateTask(long backendId,
+                                                                               Set<Long> tablets,
+                                                                               FlatJsonConfig flatJsonConfig) {
+        requireNonNull(tablets, "tablets is null");
+        requireNonNull(flatJsonConfig, "flatJsonConfig is null");
+        List<Pair<Long, FlatJsonConfig>> configList = tablets.stream()
+                .map(id -> new Pair<>(id, flatJsonConfig)).collect(Collectors.toList());
+        return createFlatJsonConfigUpdateTask(backendId, configList);
+    }
+
+    public static TabletMetadataUpdateAgentTask createFlatJsonConfigUpdateTask(long backendId,
+                                                                               List<Pair<Long, FlatJsonConfig>> configs) {
+        return new UpdateFlatJsonConfigTask(backendId, requireNonNull(configs, "configs is null"));
     }
 
     public static TabletMetadataUpdateAgentTask createPrimaryIndexCacheExpireTimeUpdateTask(long backendId,
@@ -309,6 +325,33 @@ public class TabletMetadataUpdateAgentTaskFactory {
                 metaInfo.setTablet_id(pair.first);
                 metaInfo.setBinlog_config(pair.second.toTBinlogConfig());
                 metaInfo.setMeta_type(TTabletMetaType.BINLOG_CONFIG);
+                metaInfos.add(metaInfo);
+            }
+            return metaInfos;
+        }
+    }
+
+    private static class UpdateFlatJsonConfigTask extends TabletMetadataUpdateAgentTask {
+        private final List<Pair<Long, FlatJsonConfig>> flatJsonConfigList;
+
+        private UpdateFlatJsonConfigTask(long backendId, List<Pair<Long, FlatJsonConfig>> flatJsonConfigList) {
+            super(backendId, flatJsonConfigList.hashCode());
+            this.flatJsonConfigList = flatJsonConfigList;
+        }
+
+        @Override
+        public Set<Long> getTablets() {
+            return flatJsonConfigList.stream().map(p -> p.first).collect(Collectors.toSet());
+        }
+
+        @Override
+        public List<TTabletMetaInfo> getTTabletMetaInfoList() {
+            List<TTabletMetaInfo> metaInfos = Lists.newArrayList();
+            for (Pair<Long, FlatJsonConfig> pair : flatJsonConfigList) {
+                TTabletMetaInfo metaInfo = new TTabletMetaInfo();
+                metaInfo.setTablet_id(pair.first);
+                metaInfo.setFlat_json_config(pair.second.toTFlatJsonConfig());
+                metaInfo.setMeta_type(TTabletMetaType.FLAT_JSON_CONFIG);
                 metaInfos.add(metaInfo);
             }
             return metaInfos;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterFlatJsonConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterFlatJsonConfigTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.FlatJsonConfig;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Durability of the cloud-native (lake) flat_json ALTER applied by
+ * {@link LakeTableAlterMetaJob#updateCatalog}.
+ *
+ * The config applied to a cloud-native table by the alter-meta job must be written into the
+ * GSON-serialized {@code properties} map. {@code TableProperty.flatJsonConfig} carries no
+ * {@code @SerializedName} and is rebuilt from {@code properties} via {@code buildFlatJsonConfig()}
+ * in {@code gsonPostProcess()}; if the job only set the transient field, the config (enable /
+ * factors / version) would be silently lost once the async job is GC'd and a new FE image is
+ * written. These tests reconstruct a {@link TableProperty} from only the serialized properties to
+ * simulate an FE restart and assert the config — including its version — is recovered.
+ */
+public class LakeTableAlterFlatJsonConfigTest {
+
+    private LakeTable newLakeTable(long tableId) {
+        Column c0 = new Column("c0", IntegerType.INT, true);
+        DistributionInfo dist = new HashDistributionInfo(1, Collections.singletonList(c0));
+        PartitionInfo partitionInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        LakeTable table = new LakeTable(tableId, "t_flat_json", Collections.singletonList(c0),
+                KeysType.DUP_KEYS, partitionInfo, dist);
+        table.setTableProperty(new TableProperty(new HashMap<>()));
+        return table;
+    }
+
+    private FlatJsonConfig newConfig(boolean enable, long version) {
+        FlatJsonConfig cfg = new FlatJsonConfig();
+        cfg.setFlatJsonEnable(enable);
+        cfg.setFlatJsonNullFactor(0.1);
+        cfg.setFlatJsonSparsityFactor(0.8);
+        cfg.setFlatJsonColumnMax(90);
+        cfg.setVersion(version);
+        return cfg;
+    }
+
+    private static FlatJsonConfig reloadFromImage(TableProperty source) throws Exception {
+        // Rebuild a TableProperty from only the serialized `properties` map, the way an FE image
+        // reload would, and let gsonPostProcess() reconstruct the transient flat_json config.
+        TableProperty reloaded = new TableProperty(new HashMap<>(source.getProperties()));
+        reloaded.gsonPostProcess();
+        return reloaded.getFlatJsonConfig();
+    }
+
+    @Test
+    public void testFlatJsonConfigSurvivesFeImageReload() throws Exception {
+        Database db = new Database(1L, "db_flat_json");
+        LakeTable table = newLakeTable(1001L);
+        FlatJsonConfig cfg = newConfig(true, 1L);
+
+        LakeTableAlterMetaJob job = new LakeTableAlterMetaJob(
+                10L, db.getId(), table.getId(), table.getName(), 3600000L, cfg);
+        // updateCatalog runs both on the leader at job finish and on journal replay.
+        job.updateCatalog(db, table, false);
+
+        // In-memory transient field is set.
+        Assertions.assertNotNull(table.getFlatJsonConfig());
+        Assertions.assertTrue(table.getFlatJsonConfig().getFlatJsonEnable());
+
+        // Durability: the config must be in the serialized `properties` map so it survives a restart.
+        Map<String, String> persisted = table.getTableProperty().getProperties();
+        Assertions.assertTrue(persisted.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE),
+                "flat_json config must be persisted into the table properties map to survive FE restart");
+        Assertions.assertTrue(persisted.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION));
+
+        // Simulate an FE restart and verify the config (incl. version) is recovered.
+        FlatJsonConfig recovered = reloadFromImage(table.getTableProperty());
+        Assertions.assertNotNull(recovered, "flat_json config must survive an FE image reload");
+        Assertions.assertEquals(cfg.getVersion(), recovered.getVersion());
+        Assertions.assertTrue(recovered.getFlatJsonEnable());
+        Assertions.assertEquals(0.8, recovered.getFlatJsonSparsityFactor(), 1e-9);
+        Assertions.assertEquals(90, recovered.getFlatJsonColumnMax());
+    }
+
+    @Test
+    public void testFlatJsonConfigReplayPersistsToProperties() throws Exception {
+        Database db = new Database(2L, "db_flat_json_replay");
+        LakeTable table = newLakeTable(2001L);
+        FlatJsonConfig cfg = newConfig(true, 3L);
+
+        LakeTableAlterMetaJob job = new LakeTableAlterMetaJob(
+                11L, db.getId(), table.getId(), table.getName(), 3600000L, cfg);
+        job.updateCatalog(db, table, true);
+
+        Map<String, String> persisted = table.getTableProperty().getProperties();
+        Assertions.assertEquals("3", persisted.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION),
+                "replayed flat_json config must persist its version into the properties map");
+
+        FlatJsonConfig recovered = reloadFromImage(table.getTableProperty());
+        Assertions.assertNotNull(recovered);
+        Assertions.assertEquals(3L, recovered.getVersion());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterFlatJsonConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterFlatJsonConfigTest.java
@@ -22,10 +22,15 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.type.IntegerType;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -122,5 +127,61 @@ public class LakeTableAlterFlatJsonConfigTest {
         FlatJsonConfig recovered = reloadFromImage(table.getTableProperty());
         Assertions.assertNotNull(recovered);
         Assertions.assertEquals(3L, recovered.getVersion());
+    }
+
+    /**
+     * The analyzer's "factors require flat_json.enable=true" check runs without the table lock,
+     * so a concurrent ALTER can disable flat_json between analysis and execution. The lake
+     * branch of createAlterMetaJob must re-validate under the lock, or it would persist and
+     * propagate a disabled config carrying factor changes (which toProperties() then drops on
+     * image save, diverging in-memory state from replay/failover).
+     */
+    @Test
+    public void testCreateAlterMetaJobRejectsFactorOnDisabledConfig() {
+        Map<String, String> factorValues = new HashMap<>();
+        factorValues.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.2");
+        factorValues.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "0.5");
+        factorValues.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, "50");
+
+        long tableId = 3001L;
+        for (Map.Entry<String, String> factor : factorValues.entrySet()) {
+            Database db = new Database(3L, "db_flat_json_revalidate");
+            LakeTable table = newLakeTable(tableId++);
+            // The table's config was disabled after the (unlocked) analyzer check passed.
+            table.getTableProperty().setFlatJsonConfig(newConfig(false, 2L));
+
+            Map<String, String> properties = new HashMap<>();
+            properties.put(factor.getKey(), factor.getValue());
+            ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+
+            DdlException e = Assertions.assertThrows(DdlException.class,
+                    () -> new SchemaChangeHandler().createAlterMetaJob(clause, db, table),
+                    factor.getKey() + " must be rejected on a disabled config");
+            Assertions.assertTrue(e.getMessage().contains("must be set after enabling flat JSON"),
+                    "unexpected message: " + e.getMessage());
+            // The stale config must remain untouched: no factor applied, no version bump.
+            Assertions.assertEquals(2L, table.getFlatJsonConfig().getVersion());
+            Assertions.assertEquals(0.1, table.getFlatJsonConfig().getFlatJsonNullFactor(), 1e-9);
+        }
+    }
+
+    @Test
+    public void testCreateAlterMetaJobAcceptsFactorOnEnabledConfig() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public long getNextId() {
+                return 12345L;
+            }
+        };
+        Database db = new Database(4L, "db_flat_json_enabled");
+        LakeTable table = newLakeTable(4001L);
+        table.getTableProperty().setFlatJsonConfig(newConfig(true, 2L));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.2");
+        ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+
+        AlterJobV2 job = new SchemaChangeHandler().createAlterMetaJob(clause, db, table);
+        Assertions.assertNotNull(job);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
@@ -65,10 +65,10 @@ public class FlatJsonConfigValidationTest {
         FlatJsonConfig config2 = tableProperty2.getFlatJsonConfig();
         Assertions.assertNotNull(config2);
         Assertions.assertFalse(config2.getFlatJsonEnable());
-        // Should use default values, ignoring the residual properties
-        Assertions.assertEquals(0.1, config2.getFlatJsonNullFactor(), 0.001);
-        Assertions.assertEquals(0.8, config2.getFlatJsonSparsityFactor(), 0.001);
-        Assertions.assertEquals(50, config2.getFlatJsonColumnMax());
+        // Should use default values, ignoring the residual properties (flat_json is disabled)
+        Assertions.assertEquals(Config.flat_json_null_factor, config2.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_sparsity_factory, config2.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_column_max, config2.getFlatJsonColumnMax());
 
         // Test 3: flat_json.enable = true with other properties (should work)
         Map<String, String> properties3 = new HashMap<>();
@@ -100,6 +100,73 @@ public class FlatJsonConfigValidationTest {
         Assertions.assertEquals(Config.flat_json_null_factor, config4.getFlatJsonNullFactor(), 0.001);
         Assertions.assertEquals(Config.flat_json_sparsity_factory, config4.getFlatJsonSparsityFactor(), 0.001);
         Assertions.assertEquals(Config.flat_json_column_max, config4.getFlatJsonColumnMax());
+    }
+
+    @Test
+    public void testBuildFlatJsonConfigPreservesPropertiesAcrossReload() {
+        // Regression test for the durability bug: buildFlatJsonConfig() runs on every FE image load
+        // (gsonPostProcess). The previous implementation read the factors via
+        // analyzerDoubleProp/analyzeIntProp, which call properties.remove(), so each reload stripped the
+        // factor keys from the serialized properties map. The config looked correct on the first load,
+        // but after the next checkpoint only flat_json.enable survived and the factors reverted to
+        // defaults. The fix reads the factors non-destructively (get()), so the keys must remain in the
+        // map and the values must survive repeated buildFlatJsonConfig() calls.
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, "0.13");
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "0.71");
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, "29");
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION, "7");
+
+        TableProperty tableProperty = new TableProperty(properties);
+
+        // First load (e.g. the image that recorded the ALTER).
+        tableProperty.buildFlatJsonConfig();
+
+        // The factor keys MUST still be present in the underlying map; this is exactly what the
+        // remove-on-read implementation broke and what is lost on the next checkpoint.
+        Map<String, String> afterFirstLoad = tableProperty.getProperties();
+        Assertions.assertEquals("0.13", afterFirstLoad.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertEquals("0.71", afterFirstLoad.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertEquals("29", afterFirstLoad.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+        Assertions.assertEquals("7", afterFirstLoad.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_VERSION));
+
+        // Second load simulates the next FE restart reloading the checkpointed image. The factors must
+        // still resolve to the configured values, not the Config defaults.
+        tableProperty.buildFlatJsonConfig();
+        FlatJsonConfig config = tableProperty.getFlatJsonConfig();
+        Assertions.assertNotNull(config);
+        Assertions.assertTrue(config.getFlatJsonEnable());
+        Assertions.assertEquals(0.13, config.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(0.71, config.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(29, config.getFlatJsonColumnMax());
+        Assertions.assertEquals(7, config.getVersion());
+
+        // toProperties() (what gets written into the next image) must still carry the factors.
+        Map<String, String> serialized = config.toProperties();
+        Assertions.assertEquals("0.13", serialized.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        Assertions.assertEquals("0.71", serialized.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        Assertions.assertEquals("29", serialized.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+    }
+
+    @Test
+    public void testBuildFlatJsonConfigToleratesMalformedValueOnImageLoad() {
+        // buildFlatJsonConfig() runs in gsonPostProcess on every image load. A malformed value must not
+        // throw (which would fail image load / FE startup); it should warn and fall back to defaults,
+        // matching buildLakeCompactionMaxParallel().
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, "true");
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, "not-a-number");
+
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildFlatJsonConfig();
+
+        FlatJsonConfig config = tableProperty.getFlatJsonConfig();
+        Assertions.assertNotNull(config);
+        Assertions.assertTrue(config.getFlatJsonEnable());
+        Assertions.assertEquals(Config.flat_json_null_factor, config.getFlatJsonNullFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_sparsity_factory, config.getFlatJsonSparsityFactor(), 0.001);
+        Assertions.assertEquals(Config.flat_json_column_max, config.getFlatJsonColumnMax());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -303,6 +303,38 @@ public class CreateLakeTableTest {
     }
 
     @Test
+    public void testCreateLakeTableWithFlatJson() throws Exception {
+        // enabled: flat_json.enable and the factors are rendered
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.lake_flat_json_on (k int, j json)\n" +
+                        "duplicate key(k) distributed by hash(k) buckets 1\n" +
+                        "properties('flat_json.enable' = 'true', 'flat_json.null.factor' = '0.15',\n" +
+                        "'flat_json.sparsity.factor' = '0.6', 'flat_json.column.max' = '30');"));
+        {
+            LakeTable lakeTable = getLakeTable("lake_test", "lake_flat_json_on");
+            Map<String, String> properties = lakeTable.getProperties();
+            Assertions.assertEquals("true", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+            Assertions.assertNotNull(properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+            Assertions.assertNotNull(properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+            Assertions.assertNotNull(properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+        }
+
+        // disabled: only flat_json.enable is rendered, factors omitted
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.lake_flat_json_off (k int, j json)\n" +
+                        "duplicate key(k) distributed by hash(k) buckets 1\n" +
+                        "properties('flat_json.enable' = 'false');"));
+        {
+            LakeTable lakeTable = getLakeTable("lake_test", "lake_flat_json_off");
+            Map<String, String> properties = lakeTable.getProperties();
+            Assertions.assertEquals("false", properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+            Assertions.assertNull(properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+            Assertions.assertNull(properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+            Assertions.assertNull(properties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+        }
+    }
+
+    @Test
     public void testCreateLakeTableException() {
         // storage_cache disabled but enable_async_write_back = true
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -20,10 +20,12 @@ import com.google.common.collect.Lists;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
@@ -32,6 +34,7 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -54,6 +57,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -72,6 +76,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public class ReportHandlerTest {
     private static ConnectContext connectContext;
@@ -99,7 +104,10 @@ public class ReportHandlerTest {
                                 "'primary_index_cache_expire_sec' = '3600');")
                     .withTable("CREATE TABLE test.update_schema(k1 int, v1 int) " +
                                 "primary key(k1) distributed by hash(k1) buckets 5 properties('replication_num' = '1', " +
-                                "'primary_index_cache_expire_sec' = '3600');");
+                                "'primary_index_cache_expire_sec' = '3600');")
+                    .withTable("CREATE TABLE test.flat_json_report_handler_test(k1 int, v1 int) " +
+                                "duplicate key(k1) distributed by hash(k1) buckets 5 properties('replication_num' = '1', " +
+                                "'flat_json.enable' = 'true');");
     }
 
     @Test
@@ -556,6 +564,193 @@ public class ReportHandlerTest {
                 "exception message should mention stop reason, got: " + ex.getMessage());
         Assertions.assertEquals(0, reportHandler.getPendingTabletReportTaskCnt());
         Assertions.assertEquals(0, reportHandler.getReportQueueSize());
+    }
+
+    private static OlapTable getFlatJsonTable() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "flat_json_report_handler_test");
+    }
+
+    private static List<Long> getTableTabletIds(OlapTable table) {
+        List<Long> ids = new ArrayList<>();
+        for (Partition partition : table.getPartitions()) {
+            PhysicalPartition physPartition = partition.getDefaultPhysicalPartition();
+            for (MaterializedIndex index :
+                    physPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                for (Tablet tablet : index.getTablets()) {
+                    ids.add(tablet.getId());
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static Map<Long, TTablet> buildBackendTablets(long backendId, List<Long> tabletIds,
+                                                          Consumer<TTabletInfo> setup) {
+        List<TTabletInfo> infos = Lists.newArrayList();
+        TTablet tablet = new TTablet(infos);
+        for (Long id : tabletIds) {
+            TTabletInfo info = new TTabletInfo();
+            info.setTablet_id(id);
+            info.setSchema_hash(60000);
+            setup.accept(info);
+            tablet.tablet_infos.add(info);
+        }
+        Map<Long, TTablet> backendTablets = new HashMap<>();
+        backendTablets.put(backendId, tablet);
+        return backendTablets;
+    }
+
+    private static List<AgentBatchTask> mockSubmitCapture() {
+        List<AgentBatchTask> submitted = new ArrayList<>();
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+                submitted.add(task);
+            }
+        };
+        return submitted;
+    }
+
+    @Test
+    public void testHandleSetTabletFlatJsonConfigStaleBe() {
+        List<AgentBatchTask> submitted = mockSubmitCapture();
+        List<Long> tabletIds = getTableTabletIds(getFlatJsonTable());
+        Assertions.assertFalse(tabletIds.isEmpty());
+
+        Map<Long, TTablet> backendTablets = buildBackendTablets(
+                10001L, tabletIds, info -> info.setFlat_json_config_version(-1));
+
+        ReportHandler handler = new ReportHandler();
+        handler.testHandleSetTabletFlatJsonConfig(10001L, backendTablets);
+
+        Assertions.assertFalse(submitted.isEmpty());
+        Assertions.assertTrue(submitted.get(0).getTaskNum() > 0);
+    }
+
+    @Test
+    public void testHandleSetTabletFlatJsonConfigOrphanBe() {
+        // flat_json_config_version not reported by BE (isSet=false) is treated as 0,
+        // so a BE that never received the config is reconciled on the next heartbeat.
+        FlatJsonConfig config = getFlatJsonTable().getFlatJsonConfig();
+        config.incVersion();
+        try {
+            List<AgentBatchTask> submitted = mockSubmitCapture();
+            List<Long> tabletIds = getTableTabletIds(getFlatJsonTable());
+            Assertions.assertFalse(tabletIds.isEmpty());
+
+            Map<Long, TTablet> backendTablets = buildBackendTablets(10001L, tabletIds, info -> {});
+
+            ReportHandler handler = new ReportHandler();
+            handler.testHandleSetTabletFlatJsonConfig(10001L, backendTablets);
+
+            Assertions.assertFalse(submitted.isEmpty());
+        } finally {
+            config.setVersion(0);
+        }
+    }
+
+    @Test
+    public void testHandleSetTabletFlatJsonConfigUpToDateBe() {
+        List<AgentBatchTask> submitted = mockSubmitCapture();
+        List<Long> tabletIds = getTableTabletIds(getFlatJsonTable());
+        Assertions.assertFalse(tabletIds.isEmpty());
+
+        Map<Long, TTablet> backendTablets = buildBackendTablets(
+                10001L, tabletIds, info -> info.setFlat_json_config_version(0));
+
+        ReportHandler handler = new ReportHandler();
+        handler.testHandleSetTabletFlatJsonConfig(10001L, backendTablets);
+
+        Assertions.assertTrue(submitted.isEmpty());
+    }
+
+    @Test
+    public void testHandleSetTabletFlatJsonConfigAheadBe() {
+        List<AgentBatchTask> submitted = mockSubmitCapture();
+        List<Long> tabletIds = getTableTabletIds(getFlatJsonTable());
+        Assertions.assertFalse(tabletIds.isEmpty());
+
+        Map<Long, TTablet> backendTablets = buildBackendTablets(
+                10001L, tabletIds, info -> info.setFlat_json_config_version(1));
+
+        ReportHandler handler = new ReportHandler();
+        handler.testHandleSetTabletFlatJsonConfig(10001L, backendTablets);
+
+        Assertions.assertTrue(submitted.isEmpty());
+    }
+
+    @Test
+    public void testHandleSetTabletFlatJsonConfigTableWithoutFlatJson() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable nonFlatJsonTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "properties_change_test");
+        List<Long> tabletIds = getTableTabletIds(nonFlatJsonTable);
+        Assertions.assertFalse(tabletIds.isEmpty());
+
+        List<AgentBatchTask> submitted = mockSubmitCapture();
+        Map<Long, TTablet> backendTablets = buildBackendTablets(
+                10001L, tabletIds, info -> info.setFlat_json_config_version(-1));
+
+        ReportHandler handler = new ReportHandler();
+        handler.testHandleSetTabletFlatJsonConfig(10001L, backendTablets);
+
+        Assertions.assertTrue(submitted.isEmpty());
+    }
+
+    // Concurrent ALTER race: session-2 changes a factor (validated while enabled) while session-1
+    // disables flat_json. Under the write lock the change is rebased onto the now-disabled config,
+    // and the re-validation there must reject it so no disabled-with-factor state is persisted.
+    @Test
+    public void testConcurrentDisableRacesFactorChangeViaRebase() {
+        SchemaChangeHandler sch = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = getFlatJsonTable();
+
+        // Restore the shared fixture's config afterwards.
+        long origVersion = table.getFlatJsonConfig().getVersion();
+        boolean origEnable = table.getFlatJsonConfig().getFlatJsonEnable();
+        try {
+            table.getFlatJsonConfig().setFlatJsonEnable(true);
+            double racingFactor = 0.6;
+            double defaultNullFactor = new FlatJsonConfig().getFlatJsonNullFactor();
+            Assertions.assertNotEquals(racingFactor, defaultNullFactor);
+
+            mockSubmitCapture();
+
+            // session-1 disables flat_json (and bumps the version) when session-2 takes the write lock.
+            final boolean[] injected = {false};
+            new MockUp<Locker>() {
+                @Mock
+                public void lockTablesWithIntensiveDbLock(Long dbId, List<Long> tableList, LockType lockType) {
+                    if (lockType == LockType.WRITE && !injected[0]) {
+                        injected[0] = true;
+                        FlatJsonConfig live = table.getFlatJsonConfig();
+                        live.setFlatJsonEnable(false);
+                        live.incVersion();
+                    }
+                }
+
+                @Mock
+                public void unLockTablesWithIntensiveDbLock(Long dbId, List<Long> tableList, LockType lockType) {
+                }
+            };
+
+            // session-2 changes null.factor, validated while flat_json was still enabled.
+            Map<String, String> props = new HashMap<>();
+            props.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, String.valueOf(racingFactor));
+            boolean ok = sch.updateFlatJsonConfigMeta(db, table.getId(), props, TTabletMetaType.FLAT_JSON_CONFIG);
+
+            Assertions.assertTrue(injected[0]);
+            FlatJsonConfig result = table.getFlatJsonConfig();
+            Assertions.assertFalse(ok, "factor change rebased onto a disabled config must be rejected");
+            Assertions.assertFalse(result.getFlatJsonEnable());
+            Assertions.assertNotEquals(racingFactor, result.getFlatJsonNullFactor());
+        } finally {
+            table.getFlatJsonConfig().setFlatJsonEnable(origEnable);
+            table.getFlatJsonConfig().setVersion(origVersion);
+        }
     }
 
     private static final long VERSION_MISS_VISIBLE = 100L;

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -630,9 +630,27 @@ public class ReportHandlerTest {
     }
 
     @Test
+    public void testHandleSetTabletFlatJsonConfigCreateTimeConfigOrphanBe() {
+        // A config that comes from CREATE TABLE keeps version 0 on the FE. A tablet that
+        // reports no flat_json_config_version (isSet=false) has no config at all, so it must
+        // still be reconciled: the unset report maps below any real version (-1 < 0).
+        List<AgentBatchTask> submitted = mockSubmitCapture();
+        List<Long> tabletIds = getTableTabletIds(getFlatJsonTable());
+        Assertions.assertFalse(tabletIds.isEmpty());
+        Assertions.assertEquals(0, getFlatJsonTable().getFlatJsonConfig().getVersion());
+
+        Map<Long, TTablet> backendTablets = buildBackendTablets(10001L, tabletIds, info -> {});
+
+        ReportHandler handler = new ReportHandler();
+        handler.testHandleSetTabletFlatJsonConfig(10001L, backendTablets);
+
+        Assertions.assertFalse(submitted.isEmpty());
+    }
+
+    @Test
     public void testHandleSetTabletFlatJsonConfigOrphanBe() {
-        // flat_json_config_version not reported by BE (isSet=false) is treated as 0,
-        // so a BE that never received the config is reconciled on the next heartbeat.
+        // flat_json_config_version not reported by BE (isSet=false) maps below any real
+        // version, so a BE that never received the config is reconciled on the next heartbeat.
         FlatJsonConfig config = getFlatJsonTable().getFlatJsonConfig();
         config.incVersion();
         try {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -285,6 +285,7 @@ message FlatJsonConfigPB {
     optional double flat_json_null_factor = 2;
     optional double flat_json_sparsity_factor = 3;
     optional int64 flat_json_max_column_max = 4;
+    optional int64 version = 5;
 }
 
 message TabletMetaPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -90,6 +90,7 @@ struct TFlatJsonConfig {
     2: optional double flat_json_null_factor;
     3: optional double flat_json_sparsity_factor;
     4: optional i64 flat_json_column_max;
+    5: optional i64 version;
 }
 
 // If you want to add types,

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -66,6 +66,7 @@ struct TTabletInfo {
     20: optional i64 max_rowset_creation_time
     21: optional i32 primary_index_cache_expire_sec
     22: optional i32 tablet_schema_version
+    23: optional i64 flat_json_config_version
 }
 
 struct TTabletVersionPair {


### PR DESCRIPTION
> **Squashed, single-history re-submission of #73514** (2 clean commits — the fix + its UT), opened separately per maintainer request so it can be fast-tracked and backported independently of the long review/CI history on #73514.
>
> The change set is **identical to #73514** (17/18 touched files are byte-identical; `ReportHandler.java` differs only in surrounding context after rebasing onto the latest `main`). Re-verified on the latest `main`: FE compiles, `mvn checkstyle:check` clean, `ReportHandlerTest` 20/0, and the touched BE files (`tablet.cpp`, `agent_task.cpp`, `lake/schema_change.cpp`, `lake/txn_log_applier.cpp`) recompile cleanly.

---

Fixes #73846

## Why I'm doing:

`ALTER TABLE ... SET ("flat_json.*" = ...)` is documented as a way to retune flat_json behaviour on an existing table (`flat_json.enable`, `flat_json.sparsity.factor`, `flat_json.null.factor`, `flat_json.column.max`). The FE accepts the ALTER and `SHOW CREATE TABLE` reflects the new values, but the BE never receives the change: subsequent INSERTs, flushes, and compactions keep using the CREATE-time `FlatJsonConfig` indefinitely.

`SchemaChangeHandler.updateFlatJsonConfigMeta(..., TTabletMetaType metaType)` already takes a `metaType` parameter but never uses it. There is no `TabletMetadataUpdateAgentTask` dispatch, no version field on `FlatJsonConfig` or `TTabletInfo`, and no `ReportHandler` reconciliation. The dangling `metaType` parameter and the unused `TTabletMetaType.FLAT_JSON_CONFIG` enum value look like surface remnants of an unfinished implementation that the existing tests do not exercise — no SQL fixture under `test/sql/test_semi/` covers ALTER property changes for flat_json.

### Decision point (where the bug surfaces in the BE)

`be/src/util/json_flattener.cpp:688` is the single decision branch that decides whether a JSON path becomes a sub-column:

```cpp
if (type_check && node->multi_times <= 0
    && node->hits >= _total_rows * _min_json_sparsity_factory) {
    hit_leaf->emplace_back(node, absolute_path);   // → columnize
    node->remain = false;
    return 1;
} else {
    node->remain = true;                            // → SKIPPED (raw remain)
    return 0;
}
```

`_min_json_sparsity_factory` is the BE's runtime view of `flat_json.sparsity.factor`. Before this fix, ALTERing the table-level property never changes that field on any BE; the comparison silently uses the CREATE-time value forever.

## What I'm doing:

Mirror the binlog config pattern, which already solves this exact problem in production for `BinlogConfig`. Two flows close the gap together; neither alone is sufficient.

**Flow 1 — Immediate FE → BE push.** On `ALTER`, the FE
- snapshots partitions under the table read lock,
- bumps `FlatJsonConfig.configVersion` (`incVersion()`),
- persists via `EditLog` (existing `LocalMetastore.modifyFlatJsonMeta`),
- then drops the lock and pushes the new config to every BE that holds a replica, via `createFlatJsonConfigUpdateTask` → `UpdateFlatJsonConfigTask` → `AgentBatchTask` → BE's `agent_task.cpp` new `case TTabletMetaType::FLAT_JSON_CONFIG` → `Tablet::update_flat_json_config` (version-gated, so replays or out-of-order pushes are idempotent).

**Flow 2 — Heartbeat reconciliation.** Every tablet report now carries `TTabletInfo.flat_json_config_version`. On the leader, `ReportHandler.handleSetTabletFlatJsonConfig` compares it against `olapTable.getFlatJsonConfig().getVersion()` and re-pushes via the same task factory when a BE has fallen behind. So a BE that was down (or briefly unreachable) at ALTER time automatically catches up on its next report cycle, without operator intervention.

Both flows are mechanical mirrors of `BinlogConfig`'s `updateBinlogPartitionTabletMeta` + `handleSetTabletBinlogConfig` — same call shape, same locking pattern (intensive table read lock + lock acquired outside the `try` block), same agent task / countdown latch / timeout / error-handling structure.

### Thrift / proto additions (all optional, append-only)

- `TFlatJsonConfig.version`
- `TTabletInfo.flat_json_config_version`
- `FlatJsonConfigPB.version`

Old peers that omit these fields are treated as `version=0` on the receiving side (`__isset.version ? config.version : 0` on BE, `has_version() ? ... : 0` on proto). Mixed-version clusters stay correct: an old BE/FE keeps the pre-fix behaviour (no propagation) but cannot crash a new peer; a new BE seeing legacy on-disk meta initialises at `version=0` and accepts the first push normally.

### Files changed

```
gensrc/thrift/AgentService.thrift                                     (+TFlatJsonConfig.version)
gensrc/thrift/MasterService.thrift                                    (+TTabletInfo.flat_json_config_version)
gensrc/proto/olap_file.proto                                          (+FlatJsonConfigPB.version)

be/src/storage/flat_json_config.h                                     (version field + serde)
be/src/storage/tablet.h                                               (update_flat_json_config decl + fwd)
be/src/storage/tablet.cpp                                             (update_flat_json_config impl, version-gated)
be/src/agent/agent_task.cpp                                           (case FLAT_JSON_CONFIG)

fe/.../catalog/FlatJsonConfig.java                                    (configVersion + incVersion + thrift carry)
fe/.../task/TabletMetadataUpdateAgentTaskFactory.java                 (factory + UpdateFlatJsonConfigTask)
fe/.../alter/SchemaChangeHandler.java                                 (incVersion + updateFlatJsonPartitionTabletMeta)
fe/.../leader/ReportHandler.java                                      (handleSetTabletFlatJsonConfig)
```

## Verification

End-to-end on a single-FE / single-BE local cluster, rebased onto current upstream `main` HEAD + this commit, with `thirdparty` rebuilt from scratch (fmt 10.2.1 / staros v4.2-rc1 / tenann updated). Same scenario run before and after applying the fix; outcomes are opposite at the decision line above.

### Scenario

```sql
CREATE TABLE t (id BIGINT, j JSON)
DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES (
    'replication_num'           = '1',
    'flat_json.enable'          = 'true',
    'flat_json.sparsity.factor' = '0.5',
    'flat_json.null.factor'     = '0.99',
    'flat_json.column.max'      = '100'
);

ALTER TABLE t SET ('flat_json.sparsity.factor' = '1');

INSERT INTO t
SELECT n,
       CASE WHEN n % 100 < 60
            THEN parse_json('{"a":"v","p":"hit"}')
            ELSE parse_json('{"a":"v"}')
       END
FROM TABLE(generate_series(1, 1000)) AS t(n);
```

Path `.p` ends up in 600/1000 rows = 60%. With `sparsity.factor = 1.0`, the FE-configured policy requires that path to be SKIPPED (`600 >= 1000 × 1.0` → false). Path `.a` at 100% must still be columnized.

### Before the fix

`SHOW CREATE TABLE` reflects `flat_json.sparsity.factor = 1.0`, but the BE-side decision uses the stale CREATE-time `0.5`:

```
JsonPathDeriver: path '.p' columnized: hits=600/1000,  sparsity_factor=0.5   ← !!! must be SKIPPED
JsonPathDeriver: path '.a' columnized: hits=1000/1000, sparsity_factor=0.5
```

Same arithmetic at `json_flattener.cpp:688` then runs `600 >= 1000 × 0.5 = 500` → TRUE → columnize, contradicting the FE-configured policy. The ALTER produced **zero** BE-side log activity:

```
$ tail -f be.INFO | grep flat_json_config
# (nothing during ALTER)
```

### After the fix

`ALTER` immediately produces BE-side activity through Flow 1:

```
agent_server.cpp Submit task success. type=UPDATE_TABLET_META_INFO, signatures=…
agent_task.cpp   update tablet:N flat_json_config
tablet.cpp       set flat_json_config of tablet: N,
                  FlatJsonConfig{flat_json_enable=true,
                                 flat_json_null_factor=0.99,
                                 flat_json_sparsity_factor=1,         ← now matches FE
                                 flat_json_max_column_max=100,
                                 version=1}                           ← version bumped
```

Next INSERT uses the new threshold at the same decision line:

```
JsonPathDeriver: path '.p' SKIPPED:    hits=600/1000,  sparsity_factor=1   ← !!! policy honoured
JsonPathDeriver: path '.a' columnized: hits=1000/1000, sparsity_factor=1
```

`600 >= 1000 × 1.0 = 1000` → FALSE → SKIPPED. Path `.a` still columnizes (100% ≥ 100%). Both branches are exercised; both print `sparsity_factor=1` from `_min_json_sparsity_factory`.

The two `VLOG(2)` lines used to dump `sparsity_factor` are local diagnostic patches only and are **not** part of this PR — verification was done with them enabled, the PR ships without them.

### Backward compatibility check (logical)

- **Old FE + new BE**: old FE never dispatches → new BE's `case FLAT_JSON_CONFIG` never fires → matches pre-fix behaviour. No crash.
- **New FE + old BE**: new FE dispatches `meta_type=FLAT_JSON_CONFIG`, old BE's switch falls through default → silent skip. Pre-fix behaviour preserved.
- **Old on-disk `FlatJsonConfigPB` (no `version`)**: `has_version()` → false → `_flat_json_config_version = 0`. First ALTER then has `BE_version=0 < FE_version=1` → push proceeds normally.
- **FE leader failover mid-ALTER**: `incVersion()` + `EditLog` happen under the table write lock, so the new leader sees the bumped version. Any BE that missed Flow 1 catches up via Flow 2 on its next tablet report.
- **BE reports `version > FE_version`** (shouldn't happen): handler emits a WARN log and does not re-push; never regresses to a stale value.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Rationale for the boxes:
- **Policy changes**: `ALTER TABLE SET ("flat_json.*" = ...)` now actually takes effect on the BE for new writes and compactions, instead of being silently a no-op against existing tablets.
- **Miscellaneous (compatibility)**: new optional `version` fields on `TFlatJsonConfig`, `TTabletInfo`, `FlatJsonConfigPB`. Behaviour for both directions of mixed-version clusters is described under "Backward compatibility check" above.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Notes on the boxes:
- **Tests**: end-to-end behavioural verification at the decision line is recorded in the "Verification" section above. Happy to add a SQL fixture under `test/sql/test_semi/` if reviewers want a check that runs in CI.
- **Docs**: the user-facing page at [`docs/en/using_starrocks/Flat_json/`](https://docs.starrocks.io/docs/using_starrocks/Flat_json/) describes the `flat_json.*` table properties and `ALTER` flow without flagging that the BE silently keeps stale values, so the docs already describe the intended (and now actual) behaviour — no doc change required to *describe* this fix.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

