### PR TITLE
[Doc] Fix Docusaurus sidebar file references

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,7 +28,7 @@ docs/
 ├── zh/                    # Chinese documentation (mirrors en/)
 ├── docusaurus/            # Docusaurus build config
 │   ├── docusaurus.config.js
-│   ├── sidebars.js
+│   ├── sidebars.json
 │   └── src/
 └── _assets/               # Shared images and assets
 ```

--- a/handbook/domains/docs-and-translation.md
+++ b/handbook/domains/docs-and-translation.md
@@ -24,7 +24,7 @@ Map the boundary between internal engineering knowledge in `handbook/` and publi
 
 ## Test and Validation
 
-- Add new public pages to `docs/docusaurus/sidebars.js`.
+- Add new public pages to `docs/docusaurus/sidebars.json`.
 - Keep cross-links relative and keep assets in `docs/_assets/`.
 - When docs describe code behavior, validate the code path before updating prose.
 


### PR DESCRIPTION
## What this PR does

Fixes documentation references from `docs/docusaurus/sidebars.js` to the actual `docs/docusaurus/sidebars.json` file.

## Checks

Not run. Documentation-only change.