### PR TITLE
[BugFix] Preserve SQL line comment markers inside string literals

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -5,6 +5,7 @@ Version history
 
 **1.3.4**
 
+- Preserve SQL line comment markers inside quoted string literals during SQL normalization (#74750)
 - Add `to_diff_tuple` for Alembic alter operations (#70146 by @arvindKandpal-ksolves)
 - Fix parsing of reflected nested `STRUCT` / `ARRAY` / `MAP` column types when inline field comments are present (#69817)
 - Deserialize complex types to matching Python list, dict types (#70480 by @chris-celerdata)

--- a/contrib/starrocks-python-client/pyproject.toml
+++ b/contrib/starrocks-python-client/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "lark>=1.3.1",
     "alembic>=1.14.0",
     "asyncmy2>=0.2.20",
+    "sqlparse>=0.5.0",
 ]
 dynamic = ["readme", "version"]
 

--- a/contrib/starrocks-python-client/requirements-dev.txt
+++ b/contrib/starrocks-python-client/requirements-dev.txt
@@ -2,6 +2,7 @@ sqlalchemy==2.0.25
 alembic==1.14.1
 pymysql==1.1.1
 lark>=1.3.1
+sqlparse>=0.5.0
 pytest>=8.0
 sqlacodegen>=3.0
 asyncmy2>=0.2.20

--- a/contrib/starrocks-python-client/starrocks/common/utils.py
+++ b/contrib/starrocks-python-client/starrocks/common/utils.py
@@ -15,6 +15,7 @@
 import re
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
+import sqlparse
 from sqlalchemy import schema as sa_schema
 from sqlalchemy.exc import StatementError
 
@@ -264,7 +265,7 @@ class TableAttributeNormalizer:
         # MySQL-style escaping: 'O\'Brien' -> 'O''Brien'
         sql = sql.replace("\\'", "''")
 
-        sql = TableAttributeNormalizer._strip_line_comments(sql)
+        sql = sqlparse.format(sql, strip_comments=True)
         if lowercase:
             sql = sql.lower().strip()
 

--- a/contrib/starrocks-python-client/test/unit/test_sql_normalization.py
+++ b/contrib/starrocks-python-client/test/unit/test_sql_normalization.py
@@ -171,6 +171,54 @@ class TestNormalizeSQL:
         result = TableAttributeNormalizer.normalize_sql("")
         assert result == ""
 
+    def test_include_comment_string_normalization(self):
+        cases = [
+            (
+                """
+                SELECT '--not a comment' AS marker -- real comment
+                FROM users
+                """,
+                "select '--not a comment' as marker from users",
+            ),
+            (
+                '''
+                SELECT "--not a comment" AS marker -- real comment
+                FROM users
+                ''',
+                'select "--not a comment" as marker from users',
+            ),
+            (
+                """
+                SELECT 'don\\'t -- not a comment' AS marker -- real comment
+                FROM users
+                """,
+                "select 'don''t -- not a comment' as marker from users",
+            ),
+            (
+                '''
+                SELECT "say \\"--not a comment\\"" AS marker -- real comment
+                FROM users
+                ''',
+                'select "say \\"--not a comment\\"" as marker from users',
+            ),
+            (
+                """
+                SELECT 'path\\\\--not a comment' AS marker -- real comment
+                FROM users
+                """,
+                "select 'path\\\\--not a comment' as marker from users",
+            ),
+        ]
+        for sql, expected in cases:
+            result = TableAttributeNormalizer.normalize_sql(sql)
+            assert result == expected
+
+    def test_line_comment_at_end_of_sql_normalization(self):
+        sql = "SELECT `id` FROM `users` -- trailing comment"
+        expected = "select id from users"
+        result = TableAttributeNormalizer.normalize_sql(sql)
+        assert result == expected
+
     def test_case_conversion(self):
         """Test case conversion to lowercase."""
         sql = "SELECT `ID`, `NAME` FROM `USERS` WHERE `STATUS` = 'ACTIVE'"


### PR DESCRIPTION
## Why I'm doing:

`normalize_sql()` treats `--` inside string literals as a line comment and truncates valid SQL text.

## What I'm doing:

Preserve `--` inside quoted strings while still removing real line comments. Add a regression test.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
