### PR TITLE
[Enhancement] Support FE constant folding for xx_hash3_64 (backport #58714)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -932,6 +932,13 @@ under the License.
             <groupId>tools.profiler</groupId>
             <artifactId>async-profiler</artifactId>
         </dependency>
+
+        <!-- for xx_hash3_64 -->
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>zero-allocation-hashing</artifactId>
+            <version>0.16</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -55,6 +55,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import net.openhft.hashing.LongHashFunction;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -236,6 +237,29 @@ public class ScalarOperatorFunctions {
             Pair<Long, Long> value = computeYearWeekValue(year, month, day, weekBehaviour | 2);
             return value.first * 100 + value.second;
         }
+    }
+
+    public static class HashFunctions {
+        private static final long XX_HASH3_64_SEED = 0;
+
+        public static long hash64(String value, long seed) {
+            byte[] data = value.getBytes();
+            LongHashFunction hasher = LongHashFunction.xx3(seed);
+            return hasher.hashBytes(data, 0, data.length);
+        }
+    }
+
+    @ConstantFunction(name = "xx_hash3_64", argTypes = {VARCHAR}, returnType = BIGINT)
+    public static ConstantOperator xxHash64(ConstantOperator... input) {
+        Preconditions.checkArgument(input.length > 0);
+        long hashValue = HashFunctions.XX_HASH3_64_SEED;
+        for (ConstantOperator constantOperator : input) {
+            if (constantOperator.isNull()) {
+                return ConstantOperator.createNull(Type.BIGINT);
+            }
+            hashValue = HashFunctions.hash64(constantOperator.getVarchar(), hashValue);
+        }
+        return ConstantOperator.createBigint(hashValue);
     }
 
     /**
@@ -1616,4 +1640,3 @@ public class ScalarOperatorFunctions {
     }
 
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -1154,6 +1154,17 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void xxHash64() {
+        assertEquals(-7685981735718036227L,
+                ScalarOperatorFunctions.xxHash64(ConstantOperator.createVarchar("hello")).getBigint());
+        assertEquals(7001965798170371843L,
+                ScalarOperatorFunctions.xxHash64(
+                        ConstantOperator.createVarchar("hello"),
+                        ConstantOperator.createVarchar("world")).getBigint());
+        assertTrue(ScalarOperatorFunctions.xxHash64(ConstantOperator.createNull(Type.VARCHAR)).isNull());
+    }
+
+    @Test
     public void bitandTinyInt() {
         assertEquals(10, ScalarOperatorFunctions.bitandTinyInt(O_TI_10, O_TI_10).getTinyInt());
     }


### PR DESCRIPTION
## Why I'm doing:

`xx_hash3_64` is supported as a SQL hash function, but in the 3.5 branch it is not registered as an FE constant-foldable scalar function.

This prevents the FE optimizer from evaluating constant `xx_hash3_64(...)` expressions during planning. It also blocks planner paths that require deterministic FE-foldable expressions, such as generated partition expression pruning.

This PR backports the existing 4.x FE constant folding support for `xx_hash3_64` to the 3.5 branch.

## What I'm doing:

Add FE constant folding for `xx_hash3_64(VARCHAR) -> BIGINT` in `ScalarOperatorFunctions`.

The implementation uses `LongHashFunction.xx3` with seed `0`, matching the existing 4.x implementation and the documented SQL behavior.

Also add unit tests covering:
- `xx_hash3_64('hello')`
- `xx_hash3_64('hello', 'world')`
- `xx_hash3_64(NULL)`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
