### PR TITLE
[Enhancement] Route range-distribution OLAP tables by per-index distribution expressions

### DIFF
--- a/be/src/exec/data_sinks/range_router.cpp
+++ b/be/src/exec/data_sinks/range_router.cpp
@@ -27,7 +27,8 @@
 
 namespace starrocks {
 
-Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns) {
+Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, const std::vector<TypeDescriptor>& key_types) {
+    const size_t num_columns = key_types.size();
     const size_t num_ranges = tablet_ranges.size();
     if (num_ranges == 0) {
         return Status::InternalError("no tablet ranges for RangeRouter init");
@@ -38,6 +39,30 @@ Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, size_t 
     }
 
     RETURN_IF_ERROR(_validate_range(tablet_ranges, num_columns));
+
+    // Validate that the declared boundary type of each column is compatible with the
+    // expected routing-key type. The boundary type is taken from the first concrete
+    // lower/upper TVariant for that column.
+    for (size_t i = 0; i < num_columns; ++i) {
+        for (const auto& range : tablet_ranges) {
+            const TVariant* boundary = nullptr;
+            if (range.__isset.lower_bound) {
+                boundary = &range.lower_bound.values[i];
+            } else if (range.__isset.upper_bound) {
+                boundary = &range.upper_bound.values[i];
+            }
+            if (boundary == nullptr || !boundary->__isset.type) {
+                continue;
+            }
+            TypeDescriptor boundary_type = TypeDescriptor::from_thrift(boundary->type);
+            if (boundary_type.type != key_types[i].type) {
+                return Status::InternalError(fmt::format(
+                        "routing key type mismatch at column {}: key type {} incompatible with boundary type {}", i,
+                        key_types[i].debug_string(), boundary_type.debug_string()));
+            }
+            break;
+        }
+    }
 
     _upper_boundaries.resize(num_columns);
     for (size_t i = 0; i < num_ranges - 1; ++i) {
@@ -114,6 +139,25 @@ Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, size_t 
 Status RangeRouter::route_chunk_rows(Chunk* chunk, const std::vector<SlotDescriptor*>& slot_descs,
                                      const std::vector<uint16_t>& row_indices,
                                      const std::vector<int64_t>& candidate_dest, std::vector<int64_t>* target_dest) {
+    MutableColumns columns(slot_descs.size());
+    for (size_t i = 0; i < slot_descs.size(); ++i) {
+        columns[i] = chunk->get_column_by_slot_id(slot_descs[i]->id())->as_mutable_ptr();
+    }
+    return _route_rows(columns, row_indices, candidate_dest, target_dest);
+}
+
+Status RangeRouter::route_chunk_rows(const std::vector<ColumnPtr>& key_columns,
+                                     const std::vector<uint16_t>& row_indices,
+                                     const std::vector<int64_t>& candidate_dest, std::vector<int64_t>* target_dest) {
+    MutableColumns columns(key_columns.size());
+    for (size_t i = 0; i < key_columns.size(); ++i) {
+        columns[i] = key_columns[i]->as_mutable_ptr();
+    }
+    return _route_rows(columns, row_indices, candidate_dest, target_dest);
+}
+
+Status RangeRouter::_route_rows(const MutableColumns& key_columns, const std::vector<uint16_t>& row_indices,
+                                const std::vector<int64_t>& candidate_dest, std::vector<int64_t>* target_dest) {
     if (row_indices.empty()) {
         return Status::OK();
     }
@@ -134,12 +178,7 @@ Status RangeRouter::route_chunk_rows(Chunk* chunk, const std::vector<SlotDescrip
         return Status::OK();
     }
 
-    MutableColumns columns(slot_descs.size());
-    for (size_t i = 0; i < slot_descs.size(); ++i) {
-        columns[i] = chunk->get_column_by_slot_id(slot_descs[i]->id())->as_mutable_ptr();
-    }
-
-    ChunkRow cur_check_row(&columns, 0);
+    ChunkRow cur_check_row(&key_columns, 0);
     for (uint16_t row_idx : row_indices) {
         cur_check_row.index = row_idx;
         size_t t_idx = _find_tablet_index_for_row(cur_check_row);

--- a/be/src/exec/data_sinks/range_router.h
+++ b/be/src/exec/data_sinks/range_router.h
@@ -38,14 +38,28 @@ public:
 
     ~RangeRouter() = default;
 
-    Status init(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns);
+    // `key_types` carries the routing-key column types (one entry per range-distribution
+    // column). Its size replaces the previous `num_columns` argument, and each entry is
+    // validated against the type declared by the matching tablet-range boundary.
+    Status init(const std::vector<TTabletRange>& tablet_ranges, const std::vector<TypeDescriptor>& key_types);
 
+    // Route rows by gathering the routing-key columns from `chunk` via `slot_descs`.
     Status route_chunk_rows(Chunk* chunk, const std::vector<SlotDescriptor*>& slot_descs,
                             const std::vector<uint16_t>& row_indices, const std::vector<int64_t>& candidate_dest,
                             std::vector<int64_t>* target_dest);
 
+    // Route rows from already-evaluated routing-key columns. `key_columns` must have one
+    // entry per range-distribution column (matching the order/types passed to init()), and
+    // each column must outlive this call.
+    Status route_chunk_rows(const std::vector<ColumnPtr>& key_columns, const std::vector<uint16_t>& row_indices,
+                            const std::vector<int64_t>& candidate_dest, std::vector<int64_t>* target_dest);
+
 private:
     Status _validate_range(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns) const;
+
+    // Shared boundary-search routing over the row-wise view of the routing-key columns.
+    Status _route_rows(const MutableColumns& key_columns, const std::vector<uint16_t>& row_indices,
+                       const std::vector<int64_t>& candidate_dest, std::vector<int64_t>* target_dest);
 
     size_t _find_tablet_index_for_row(const ChunkRow& check_row) const;
 

--- a/be/src/exec/data_sinks/range_tablet_sink_sender.cpp
+++ b/be/src/exec/data_sinks/range_tablet_sink_sender.cpp
@@ -15,9 +15,33 @@
 #include "exec/data_sinks/range_tablet_sink_sender.h"
 
 #include "column/chunk.h"
+#include "column/column_helper.h"
 #include "common/statusor.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "fmt/format.h"
+#include "runtime/descriptors.h"
 
 namespace starrocks {
+
+std::vector<TypeDescriptor> RangeTabletSinkSender::routing_key_types(const OlapTableIndexSchema* index_schema) const {
+    std::vector<TypeDescriptor> key_types;
+    if (index_schema->has_distributed_exprs) {
+        // Per-index routing: key types come from the expr roots.
+        key_types.reserve(index_schema->distributed_expr_ctxs.size());
+        for (auto* ctx : index_schema->distributed_expr_ctxs) {
+            key_types.push_back(ctx->root()->type());
+        }
+    } else {
+        // Fallback: route by the shared partition distribution slots.
+        const auto& slot_descs = _partition_params->distribution_slot_descs();
+        key_types.reserve(slot_descs.size());
+        for (auto* slot_desc : slot_descs) {
+            key_types.push_back(slot_desc->type());
+        }
+    }
+    return key_types;
+}
 
 Status RangeTabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                                          const std::vector<OlapTablePartition*>& partitions,
@@ -55,9 +79,47 @@ Status RangeTabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
         DCHECK(_partition_params != nullptr && _partition_params->is_range_distribution());
         DCHECK(_partition_params->distribution_slot_descs().size() <= chunk->num_columns());
 
+        // NOTE: Per-index range routing is sender-only. The proto POlapTableIndexSchema
+        // intentionally has no `distributed_exprs` field, so remote add-chunks BEs (delta
+        // writer) cannot route by per-index keys; routing must be resolved here.
+        const bool has_distributed_exprs = index_schema->has_distributed_exprs;
+        const auto& distributed_expr_ctxs = index_schema->distributed_expr_ctxs;
+
+        // Evaluate this index's per-index distribution exprs ONCE per chunk (not per partition).
+        // The result key columns are reused for every partition's route_chunk_rows call below.
+        // Columns are owned here and kept alive past all routing for this index. Only the
+        // non-empty distributed_exprs path uses these; K=1 (empty) and the fallback path do not.
+        std::vector<ColumnPtr> key_columns;
+        if (has_distributed_exprs && !distributed_expr_ctxs.empty()) {
+            key_columns.reserve(distributed_expr_ctxs.size());
+            for (auto* ctx : distributed_expr_ctxs) {
+                ASSIGN_OR_RETURN(auto col, ctx->evaluate(chunk));
+                key_columns.push_back(
+                        ColumnHelper::unfold_const_column(ctx->root()->type(), chunk->num_rows(), std::move(col)));
+            }
+        }
+
         // Process each partition batch
         for (auto& [part_id, part] : partition_map) {
             const auto& row_indices = partition_row_indices_map[part_id];
+            const auto& candidate_tablet_ids = part->indexes[i].tablet_ids;
+
+            if (has_distributed_exprs && distributed_expr_ctxs.empty()) {
+                // K=1: empty routing key => single tablet. The router would error on empty
+                // boundaries, so fill the single candidate directly.
+                if (candidate_tablet_ids.size() != 1) {
+                    return Status::InternalError(
+                            fmt::format("index {} partition {} declares empty distributed_exprs (K=1) but has {} "
+                                        "candidate tablets",
+                                        index_schema->index_id, part_id, candidate_tablet_ids.size()));
+                }
+                for (uint16_t row_idx : row_indices) {
+                    _tablet_ids[row_idx] = candidate_tablet_ids[0];
+                }
+                index_id_partition_id[index_schema->index_id].emplace(part_id);
+                continue;
+            }
+
             // Get or create range router for this partition and index.
             // Use try_emplace to avoid double lookup
             auto [router_iter, inserted] = _range_routers[index_schema->index_id].try_emplace(part_id);
@@ -73,7 +135,7 @@ Status RangeTabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                     tablet_ranges.emplace_back(tablet.range);
                 }
                 auto router = std::make_unique<RangeRouter>();
-                RETURN_IF_ERROR(router->init(tablet_ranges, _partition_params->distribution_slot_descs().size()));
+                RETURN_IF_ERROR(router->init(tablet_ranges, routing_key_types(index_schema)));
                 router_ptr = router.get();
                 router_iter->second = std::move(router);
             } else {
@@ -82,10 +144,15 @@ Status RangeTabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
             }
 
             DCHECK(router_ptr != nullptr);
-            const auto& slot_descs = _partition_params->distribution_slot_descs();
-            const auto& candidate_tablet_ids = part->indexes[i].tablet_ids;
-            RETURN_IF_ERROR(router_ptr->route_chunk_rows(chunk, slot_descs, row_indices, candidate_tablet_ids,
-                                                         &_cur_result_tablet_ids));
+            if (has_distributed_exprs) {
+                // Route by the per-index key columns evaluated once above for this chunk.
+                RETURN_IF_ERROR(router_ptr->route_chunk_rows(key_columns, row_indices, candidate_tablet_ids,
+                                                             &_cur_result_tablet_ids));
+            } else {
+                const auto& slot_descs = _partition_params->distribution_slot_descs();
+                RETURN_IF_ERROR(router_ptr->route_chunk_rows(chunk, slot_descs, row_indices, candidate_tablet_ids,
+                                                             &_cur_result_tablet_ids));
+            }
             DCHECK(_cur_result_tablet_ids.size() == row_indices.size());
             for (size_t j = 0; j < row_indices.size(); ++j) {
                 _tablet_ids[row_indices[j]] = _cur_result_tablet_ids[j];

--- a/be/src/exec/data_sinks/range_tablet_sink_sender.h
+++ b/be/src/exec/data_sinks/range_tablet_sink_sender.h
@@ -39,6 +39,11 @@ public:
                       std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id, Chunk* chunk) override;
 
 private:
+    // Routing-key column types used to initialize a partition's RangeRouter. For an index with
+    // per-index distributed_exprs, the types come from the expr roots; otherwise we fall back to
+    // the shared partition distribution slots. Types are stable across chunks for a given index.
+    std::vector<TypeDescriptor> routing_key_types(const OlapTableIndexSchema* index_schema) const;
+
     // index_id -> partition_id -> range router
     std::unordered_map<int64_t, std::unordered_map<int64_t, std::unique_ptr<RangeRouter>>> _range_routers;
     std::vector<int64_t> _cur_result_tablet_ids;

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -215,6 +215,16 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
                 _shadow_indexes++;
             }
         }
+        if (t_index.__isset.distributed_exprs) {
+            index->has_distributed_exprs = true;
+            if (!t_index.distributed_exprs.empty()) {
+                if (state == nullptr) {
+                    return Status::InternalError("RuntimeState required to build per-index distributed_exprs");
+                }
+                RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_obj_pool, t_index.distributed_exprs,
+                                                               &index->distributed_expr_ctxs, state));
+            }
+        }
         _indexes.emplace_back(index);
     }
 
@@ -362,16 +372,25 @@ Status OlapTablePartitionParam::init(RuntimeState* state) {
 
 Status OlapTablePartitionParam::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExprExecutor::prepare(_partitions_expr_ctxs, state));
+    for (auto* index : _schema->indexes()) {
+        RETURN_IF_ERROR(ExprExecutor::prepare(index->distributed_expr_ctxs, state));
+    }
     return Status::OK();
 }
 
 Status OlapTablePartitionParam::open(RuntimeState* state) {
     RETURN_IF_ERROR(ExprExecutor::open(_partitions_expr_ctxs, state));
+    for (auto* index : _schema->indexes()) {
+        RETURN_IF_ERROR(ExprExecutor::open(index->distributed_expr_ctxs, state));
+    }
     return Status::OK();
 }
 
 void OlapTablePartitionParam::close(RuntimeState* state) {
     ExprExecutor::close(_partitions_expr_ctxs, state);
+    for (auto* index : _schema->indexes()) {
+        ExprExecutor::close(index->distributed_expr_ctxs, state);
+    }
 }
 
 Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNode>& t_exprs, ChunkRow* part_key) {

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -54,6 +54,14 @@ struct OlapTableIndexSchema {
     std::map<std::string, std::string> column_to_expr_value;
     bool is_shadow = false;
 
+    // Per-index distribution expressions for range tables. `has_distributed_exprs`
+    // distinguishes "unset" (fall back to partition-level routing) from "set but empty"
+    // (K=1, no per-index route). When set and non-empty, `distributed_expr_ctxs` holds
+    // the parsed ExprContexts; their prepare/open/close lifecycle is driven by
+    // OlapTablePartitionParam.
+    bool has_distributed_exprs = false;
+    std::vector<ExprContext*> distributed_expr_ctxs;
+
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };
 

--- a/be/test/exec/data_sinks/range_router_test.cpp
+++ b/be/test/exec/data_sinks/range_router_test.cpp
@@ -113,6 +113,15 @@ protected:
         return Chunk(std::move(cols), std::move(schema));
     }
 
+    // ---- Routing-key type helpers ----
+
+    static std::vector<TypeDescriptor> int_types(size_t n) {
+        return std::vector<TypeDescriptor>(n, TypeDescriptor::from_logical_type(TYPE_INT));
+    }
+    static std::vector<TypeDescriptor> varchar_types(size_t n) {
+        return std::vector<TypeDescriptor>(n, TypeDescriptor::from_logical_type(TYPE_VARCHAR));
+    }
+
     // ---- Single-column TTabletRange helpers ----
 
     // Helper to build a TTabletRange on a single INT column using long_value.
@@ -179,7 +188,7 @@ TEST_F(RangeRouterTest, SingleInfiniteRangeSelectAll) {
     std::vector<int64_t> tablet_ids{42};
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
 
     std::vector<int32_t> values{-100, -1, 0, 5, 10, 100};
     Chunk chunk = make_int_chunk("c1", values);
@@ -215,7 +224,7 @@ TEST_F(RangeRouterTest, IntThreeRangesFullCoverage) {
     std::vector<int64_t> tablet_ids{100, 200, 300};
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
 
     std::vector<int32_t> values{-5, 0, 5, 10, 11, 19, 20, 21, 100};
     Chunk chunk = make_int_chunk("c1", values);
@@ -267,7 +276,7 @@ TEST_F(RangeRouterTest, ManyRangesBinarySearchFullCoverage) {
     tablet_ids.emplace_back(108);
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
 
     // For each range, pick two sample points.
     std::vector<int32_t> values = {
@@ -350,7 +359,7 @@ TEST_F(RangeRouterTest, MultiColumnTwoRangesFullCoverage) {
     std::vector<int64_t> tablet_ids{100, 200};
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 2).ok());
+    ASSERT_TRUE(router.init(ranges, int_types(2)).ok());
 
     // (c1, c2) tuples:
     // 0: (1,10)   -> R0
@@ -426,7 +435,9 @@ TEST_F(RangeRouterTest, MultiColumnNullBoundaries) {
     std::vector<int64_t> tablet_ids{100, 200};
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 2).ok());
+    std::vector<TypeDescriptor> key_types{TypeDescriptor::from_logical_type(TYPE_INT),
+                                          TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    ASSERT_TRUE(router.init(ranges, key_types).ok());
 
     // Test data: (c1, c2, expected_tablet_id)
     std::vector<std::tuple<int32_t, std::string, int64_t>> test_data = {
@@ -495,7 +506,7 @@ TEST_F(RangeRouterTest, VarcharThreeRangesFullCoverage) {
     std::vector<int64_t> tablet_ids{10, 20, 30};
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, varchar_types(1)).ok());
 
     std::vector<std::string> values = {"apple", "banana", "cherry", "date", "fig"};
     Chunk chunk = make_varchar_chunk("s1", values);
@@ -567,7 +578,7 @@ TEST_F(RangeRouterTest, NullTypeBoundaryRouting) {
     std::vector<int64_t> tablet_ids{10, 20, 30};
 
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
 
     auto data = FixedLengthColumn<int32_t>::create();
     auto nulls = NullColumn::create();
@@ -628,7 +639,7 @@ TEST_F(RangeRouterTest, InitRejectsInvalidBoundVariantType) {
 
     std::vector<TTabletRange> ranges{r0, r1};
     RangeRouter router;
-    auto status = router.init(ranges, 1);
+    auto status = router.init(ranges, int_types(1));
     ASSERT_FALSE(status.ok());
     ASSERT_TRUE(status.is_invalid_argument());
     ASSERT_NE(std::string::npos, status.message().find("MINIMUM/MAXIMUM variant is not supported in range bound"));
@@ -657,7 +668,7 @@ TEST_F(RangeRouterTest, ValidateRangeRejectsInvalidVariantValue) {
 
     std::vector<TTabletRange> ranges{r0, r1};
     RangeRouter router;
-    auto status = router.init(ranges, 1);
+    auto status = router.init(ranges, int_types(1));
     ASSERT_FALSE(status.ok());
     ASSERT_TRUE(status.is_internal_error());
     ASSERT_EQ("Invalid variant for range validation", status.message());
@@ -674,7 +685,7 @@ TEST_F(RangeRouterTest, ValidateRangeRejectsOverlappingInclusiveBounds) {
     ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false));
 
     RangeRouter router;
-    Status st = router.init(ranges, 1);
+    Status st = router.init(ranges, int_types(1));
     ASSERT_FALSE(st.ok());
     assert_status_message_contains(
             st, "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
@@ -712,7 +723,7 @@ TEST_F(RangeRouterTest, ValidateRangeRejectsTypeMismatchOnBoundary) {
     }
 
     RangeRouter router;
-    Status st = router.init(ranges, 1);
+    Status st = router.init(ranges, int_types(1));
     ASSERT_FALSE(st.ok());
     assert_status_message_contains(st, "Type mismatch at column 0 between range[0] and range[1]");
 }
@@ -747,7 +758,7 @@ TEST_F(RangeRouterTest, ValidateRangeRejectsUpperLowerValueMismatch) {
     }
 
     RangeRouter router;
-    Status st = router.init(ranges, 1);
+    Status st = router.init(ranges, int_types(1));
     ASSERT_FALSE(st.ok());
     assert_status_message_contains(st, "Range[0] != range[1] at column 0");
 }
@@ -770,7 +781,7 @@ TEST_F(RangeRouterTest, RangeRouterSingleIntRangesRouting) {
     // The RangeRouter should be able to initialize and route correctly.
     std::vector<int64_t> tablet_ids{100, 200, 300, 400};
     RangeRouter router;
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
 
     std::vector<int32_t> values{5, 10, 15, 20, 25, 30, 35};
     Chunk chunk = make_int_chunk("c1", values);
@@ -808,7 +819,7 @@ TEST_F(RangeRouterTest, ValidateRangeMissingInfiniteBounds) {
         ranges.emplace_back(make_single_long_range(10, false, 20, true)); // (10,20]
 
         RangeRouter router;
-        auto st = router.init(ranges, 1);
+        auto st = router.init(ranges, int_types(1));
         ASSERT_FALSE(st.ok());
         assert_status_message_contains(st, "lower_inf_count and upper_inf_count must be 1");
     }
@@ -820,7 +831,7 @@ TEST_F(RangeRouterTest, ValidateRangeMissingInfiniteBounds) {
         ranges.emplace_back(make_single_long_range(std::nullopt, false, 20, true)); // another -inf range
 
         RangeRouter router;
-        auto st = router.init(ranges, 1);
+        auto st = router.init(ranges, int_types(1));
         ASSERT_FALSE(st.ok());
         assert_status_message_contains(st, "lower_inf_count and upper_inf_count must be 1");
     }
@@ -852,7 +863,7 @@ TEST_F(RangeRouterTest, ValidateRangeInfiniteNotAtEdges) {
         ranges.push_back(r2);
 
         RangeRouter router;
-        auto st = router.init(ranges, 1);
+        auto st = router.init(ranges, int_types(1));
         ASSERT_FALSE(st.ok());
         assert_status_message_contains(st, "-inf/inf range must be set for the first and last tablet range");
     }
@@ -876,7 +887,7 @@ TEST_F(RangeRouterTest, ValidateRangeInfiniteNotAtEdges) {
         ranges.push_back(r2);
 
         RangeRouter router;
-        auto st = router.init(ranges, 1);
+        auto st = router.init(ranges, int_types(1));
         ASSERT_FALSE(st.ok());
         assert_status_message_contains(st, "-inf/inf range must be set for the first and last tablet range");
     }
@@ -893,7 +904,7 @@ TEST_F(RangeRouterTest, ValidateRangeAdjacentInclusiveExclusiveOverlap) {
         ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false)); // [10,+inf)
 
         RangeRouter router;
-        auto st = router.init(ranges, 1);
+        auto st = router.init(ranges, int_types(1));
         ASSERT_FALSE(st.ok());
         assert_status_message_contains(
                 st, "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
@@ -906,7 +917,7 @@ TEST_F(RangeRouterTest, ValidateRangeAdjacentInclusiveExclusiveOverlap) {
         ranges.emplace_back(make_single_long_range(10, false, std::nullopt, false)); // (10,+inf)
 
         RangeRouter router;
-        auto st = router.init(ranges, 1);
+        auto st = router.init(ranges, int_types(1));
         ASSERT_FALSE(st.ok());
         assert_status_message_contains(
                 st, "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
@@ -942,7 +953,7 @@ TEST_F(RangeRouterTest, ValidateRangeTypeMismatchAtBoundary) {
     ranges.push_back(r1);
 
     RangeRouter router;
-    auto st = router.init(ranges, 1);
+    auto st = router.init(ranges, int_types(1));
     ASSERT_FALSE(st.ok());
     assert_status_message_contains(st, "Type mismatch at column 0 between range[0] and range[1]");
 }
@@ -962,7 +973,7 @@ TEST_F(RangeRouterTest, ValidateRangeEndpointsNotEqual) {
     ranges.push_back(r1);
 
     RangeRouter router;
-    auto st = router.init(ranges, 1);
+    auto st = router.init(ranges, int_types(1));
     ASSERT_FALSE(st.ok());
     assert_status_message_contains(st, "Range[0] != range[1] at column 0");
 }
@@ -1002,7 +1013,8 @@ TEST_F(RangeRouterTest, HllVariantInitNotSupported) {
     }
 
     RangeRouter router;
-    Status st = router.init(ranges, 1);
+    std::vector<TypeDescriptor> key_types{TypeDescriptor::create_hll_type()};
+    Status st = router.init(ranges, key_types);
     // The exact error code is implementation-defined, but we at least
     // expect a NotSupported error rather than a crash.
     ASSERT_TRUE(st.is_not_supported()) << st.to_string();
@@ -1046,9 +1058,124 @@ TEST_F(RangeRouterTest, DateTimeIsoWithNanosInitOk) {
     ranges.push_back(r1);
 
     RangeRouter router;
+    std::vector<TypeDescriptor> key_types{TypeDescriptor::from_logical_type(TYPE_DATETIME)};
     // If the FE-style ISO-8601 datetime with nanos cannot be parsed, init()
     // would return an error here. We only care that initialization succeeds.
-    ASSERT_TRUE(router.init(ranges, 1).ok());
+    ASSERT_TRUE(router.init(ranges, key_types).ok());
+}
+
+// ----------------------------------------------------------------------
+// init() routing-key type validation (key_types vs declared boundary type)
+// ----------------------------------------------------------------------
+
+// init() must reject a routing-key type that is incompatible with the type
+// declared by the tablet-range boundary (here: VARCHAR key vs INT boundary).
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, InitRejectsKeyTypeIncompatibleWithBoundary) {
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false)); // (-inf, 10) on INT
+    ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false));  // [10, +inf) on INT
+
+    RangeRouter router;
+    Status st = router.init(ranges, varchar_types(1)); // key type VARCHAR != boundary INT
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_internal_error());
+    assert_status_message_contains(st, "routing key type mismatch at column 0");
+}
+
+// init() succeeds when key types match the boundary types and the arity matches.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, InitAcceptsMatchingKeyTypesAndArity) {
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false));
+    ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false));
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
+}
+
+// init() must reject a key_types arity that does not match the boundary arity.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, InitRejectsArityMismatch) {
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false)); // single-column boundary
+    ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false));
+
+    RangeRouter router;
+    Status st = router.init(ranges, int_types(2)); // arity 2 vs boundary arity 1
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_internal_error());
+    assert_status_message_contains(st, "value size is not equal to column size");
+}
+
+// ----------------------------------------------------------------------
+// Pre-evaluated key-columns overload
+// ----------------------------------------------------------------------
+
+// route_chunk_rows(key_columns, ...) routes rows to the correct tablets based
+// solely on the supplied key columns (no Chunk / slot lookup).
+// Ranges (INT, left-closed/right-open):
+//   R0: (-inf, 10)  -> 100
+//   R1: [10, 20)    -> 200
+//   R2: [20, +inf)  -> 300
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, RouteByPreEvaluatedColumns) {
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false));
+    ranges.emplace_back(make_single_long_range(10, true, 20, false));
+    ranges.emplace_back(make_single_long_range(20, true, std::nullopt, false));
+
+    std::vector<int64_t> tablet_ids{100, 200, 300};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
+
+    std::vector<int32_t> values{-5, 0, 5, 10, 11, 19, 20, 21, 100};
+    auto col = FixedLengthColumn<int32_t>::create();
+    for (int32_t v : values) {
+        col->append(v);
+    }
+    std::vector<ColumnPtr> key_columns{col};
+
+    std::vector<uint16_t> row_indices;
+    for (size_t i = 0; i < values.size(); ++i) {
+        row_indices.emplace_back(static_cast<uint16_t>(i));
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(key_columns, row_indices, tablet_ids, &routed_ids).ok());
+
+    std::vector<int64_t> expected = {100, 100, 100, 200, 200, 200, 300, 300, 300};
+    ASSERT_EQ(expected.size(), routed_ids.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " value " << values[i] << " mismatch";
+    }
+}
+
+// The pre-evaluated overload also honors the single (-inf, +inf) fast path:
+// every row should be routed to the single candidate destination.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, RouteByPreEvaluatedColumnsSingleRange) {
+    std::vector<TTabletRange> ranges(1); // (-inf, +inf)
+    std::vector<int64_t> tablet_ids{42};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, int_types(1)).ok());
+
+    auto col = FixedLengthColumn<int32_t>::create();
+    for (int32_t v : {-100, -1, 0, 5, 10, 100}) {
+        col->append(v);
+    }
+    std::vector<ColumnPtr> key_columns{col};
+
+    std::vector<uint16_t> row_indices{0, 1, 2, 3, 4, 5};
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(key_columns, row_indices, tablet_ids, &routed_ids).ok());
+    ASSERT_EQ(row_indices.size(), routed_ids.size());
+    for (int64_t id : routed_ids) {
+        ASSERT_EQ(42, id);
+    }
 }
 
 } // namespace starrocks

--- a/be/test/exec/data_sinks/tablet_sink_sender_range_test.cpp
+++ b/be/test/exec/data_sinks/tablet_sink_sender_range_test.cpp
@@ -39,8 +39,8 @@ namespace starrocks {
 template <typename T, typename = void>
 struct HasDistributedExprsField : std::false_type {};
 template <typename T>
-struct HasDistributedExprsField<T, std::void_t<decltype(std::declval<T>().distributed_exprs_size())>>
-        : std::true_type {};
+struct HasDistributedExprsField<T, std::void_t<decltype(std::declval<T>().distributed_exprs_size())>> : std::true_type {
+};
 static_assert(!HasDistributedExprsField<POlapTableIndexSchema>::value,
               "proto POlapTableIndexSchema must not carry distributed_exprs: per-index range routing is sender-only");
 
@@ -1338,8 +1338,7 @@ TEST_F(TabletSinkSenderRangeTest, PerIndexDistributedExprsRouting) {
     tschema.slot_descs.push_back(make_bigint_slot(0, "c1"));
     tschema.slot_descs.push_back(make_bigint_slot(1, "c2"));
 
-    auto make_index = [](int64_t index_id, const std::vector<std::string>& cols,
-                         const std::vector<int>& uids) {
+    auto make_index = [](int64_t index_id, const std::vector<std::string>& cols, const std::vector<int>& uids) {
         TOlapTableIndexSchema index_schema;
         index_schema.id = index_id;
         index_schema.columns = cols;

--- a/be/test/exec/data_sinks/tablet_sink_sender_range_test.cpp
+++ b/be/test/exec/data_sinks/tablet_sink_sender_range_test.cpp
@@ -23,10 +23,26 @@
 #include "column/schema.h"
 #include "exec/data_sinks/range_tablet_sink_sender.h"
 #include "exec/tablet_info.h"
+#include "gen_cpp/descriptors.pb.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
 #include "types/datum.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks {
+
+// Sender-only invariant: per-index distributed_exprs routing must happen at the sink
+// sender, never on a remote add-chunks BE. The proto POlapTableIndexSchema therefore must
+// NOT carry a distributed_exprs field, so a remote delta-writer BE has no way to route by
+// per-index keys. This is a compile-time guard against accidentally adding such a field.
+template <typename T, typename = void>
+struct HasDistributedExprsField : std::false_type {};
+template <typename T>
+struct HasDistributedExprsField<T, std::void_t<decltype(std::declval<T>().distributed_exprs_size())>>
+        : std::true_type {};
+static_assert(!HasDistributedExprsField<POlapTableIndexSchema>::value,
+              "proto POlapTableIndexSchema must not carry distributed_exprs: per-index range routing is sender-only");
 
 class TestRangeTabletSinkSender : public RangeTabletSinkSender {
 public:
@@ -333,6 +349,34 @@ protected:
         chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
         chunk->set_slot_id_to_index(1, 1); // slot_id 1 -> column index 1
         return chunk;
+    }
+
+    // Build a BIGINT slot-ref TExpr referencing the given slot of tuple 0.
+    static TExpr _make_slot_ref_texpr(int slot_id) {
+        TExpr texpr;
+        TExprNode node;
+        node.node_type = TExprNodeType::SLOT_REF;
+        node.type = gen_type_desc(TPrimitiveType::BIGINT);
+        node.num_children = 0;
+        TSlotRef t_slot_ref;
+        t_slot_ref.slot_id = slot_id;
+        t_slot_ref.tuple_id = 0;
+        node.__set_slot_ref(t_slot_ref);
+        node.is_nullable = false;
+        texpr.nodes.emplace_back(node);
+        return texpr;
+    }
+
+    RuntimeState* _make_runtime_state() {
+        TUniqueId query_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        TUniqueId fragment_id;
+        auto* exec_env = ExecEnv::GetInstance();
+        auto* state = _object_pool->add(new RuntimeState(query_id, fragment_id, query_options, query_globals,
+                                                         &exec_env->query_execution_services(), exec_env));
+        state->init_mem_trackers(query_id);
+        return state;
     }
 
     std::unique_ptr<ObjectPool> _object_pool;
@@ -1259,6 +1303,243 @@ TEST_F(TabletSinkSenderRangeTest, EmptyInput) {
     Status st = sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, &chunk);
     ASSERT_OK(st);
     ASSERT_TRUE(sender.sent_batches().empty());
+}
+
+// Two indexes route independently: index A carries per-index distributed_exprs over
+// column c2 and routes by c2 boundaries, while index B (no exprs) routes by the shared
+// partition distribution slot c1. With rows whose c1 and c2 orderings disagree, the two
+// indexes must route the same row to different tablets.
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, PerIndexDistributedExprsRouting) {
+    // ---- Schema: two columns (c1, c2) BIGINT, two indexes ----
+    TOlapTableSchemaParam tschema;
+    tschema.db_id = _db_id;
+    tschema.table_id = _table_id;
+    tschema.version = 0;
+
+    TTupleDescriptor tuple_desc;
+    tuple_desc.id = 0;
+    tuple_desc.byteSize = 32;
+    tuple_desc.numNullBytes = 0;
+    tuple_desc.tableId = _table_id;
+    tschema.tuple_desc = tuple_desc;
+
+    auto make_bigint_slot = [](int id, const std::string& name) {
+        TSlotDescriptor slot;
+        slot.id = id;
+        slot.parent = 0;
+        slot.colName = name;
+        slot.slotType.types.emplace_back();
+        slot.slotType.types.back().__set_type(TTypeNodeType::SCALAR);
+        slot.slotType.types.back().__set_scalar_type(TScalarType());
+        slot.slotType.types.back().scalar_type.__set_type(TPrimitiveType::BIGINT);
+        return slot;
+    };
+    tschema.slot_descs.push_back(make_bigint_slot(0, "c1"));
+    tschema.slot_descs.push_back(make_bigint_slot(1, "c2"));
+
+    auto make_index = [](int64_t index_id, const std::vector<std::string>& cols,
+                         const std::vector<int>& uids) {
+        TOlapTableIndexSchema index_schema;
+        index_schema.id = index_id;
+        index_schema.columns = cols;
+        index_schema.schema_hash = 0;
+        TOlapTableColumnParam column_param;
+        for (size_t k = 0; k < cols.size(); ++k) {
+            TColumn tcol;
+            tcol.column_name = cols[k];
+            tcol.column_type.type = TPrimitiveType::BIGINT;
+            tcol.is_key = true;
+            tcol.is_allow_null = false;
+            tcol.col_unique_id = uids[k];
+            column_param.columns.push_back(tcol);
+            column_param.sort_key_uid.push_back(uids[k]);
+        }
+        index_schema.__set_column_param(column_param);
+        return index_schema;
+    };
+
+    // Index A (100): carries distributed_exprs over c2 (slot 1).
+    TOlapTableIndexSchema index_a = make_index(_index_id, {"c1", "c2"}, {0, 1});
+    index_a.__set_distributed_exprs({_make_slot_ref_texpr(1)});
+    tschema.indexes.push_back(index_a);
+    // Index B (101): no distributed_exprs => falls back to partition slot c1.
+    tschema.indexes.push_back(make_index(_index_id + 1, {"c1", "c2"}, {0, 1}));
+
+    auto* state = _make_runtime_state();
+    ASSERT_OK(_schema_param->init(tschema, state));
+
+    // ---- Partition param: distribute by c1; per-index ranges below. ----
+    auto make_single_bigint_range = [](std::optional<int64_t> lower, bool lower_incl, std::optional<int64_t> upper,
+                                       bool upper_incl) {
+        TTabletRange range;
+        if (lower.has_value()) {
+            TVariant v;
+            v.__set_type(TYPE_BIGINT_DESC.to_thrift());
+            v.__set_value(std::to_string(lower.value()));
+            TTuple t;
+            t.__set_values({v});
+            range.__set_lower_bound(t);
+            range.__set_lower_bound_included(lower_incl);
+        }
+        if (upper.has_value()) {
+            TVariant v;
+            v.__set_type(TYPE_BIGINT_DESC.to_thrift());
+            v.__set_value(std::to_string(upper.value()));
+            TTuple t;
+            t.__set_values({v});
+            range.__set_upper_bound(t);
+            range.__set_upper_bound_included(upper_incl);
+        }
+        return range;
+    };
+
+    // Index A boundaries (interpreted over c2): (-inf,10)->10000, [10,+inf)->10001
+    std::vector<TTabletRange> ranges_a;
+    ranges_a.push_back(make_single_bigint_range(std::nullopt, false, 10, false));
+    ranges_a.push_back(make_single_bigint_range(10, true, std::nullopt, false));
+    // Index B boundaries (over c1): (-inf,5)->10100, [5,+inf)->10101
+    std::vector<TTabletRange> ranges_b;
+    ranges_b.push_back(make_single_bigint_range(std::nullopt, false, 5, false));
+    ranges_b.push_back(make_single_bigint_range(5, true, std::nullopt, false));
+
+    auto* partition_param = _create_partition_param({ranges_a, ranges_b});
+    ASSERT_OK(partition_param->init(state));
+    ASSERT_OK(partition_param->prepare(state));
+    ASSERT_OK(partition_param->open(state));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    index_id_to_tablet_be_map[_index_id + 1] = {};
+
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id + 1, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Rows: (c1, c2)
+    //   row 0: (2, 50)  -> A by c2=50 => 10001 ; B by c1=2 => 10100
+    //   row 1: (7,  3)  -> A by c2=3  => 10000 ; B by c1=7 => 10101
+    auto chunk = _create_two_column_chunk({2, 7}, {50, 3});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(2, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+    partition_param->close(state);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(2, batches.size());
+
+    // Index A routes by c2.
+    EXPECT_EQ(_index_id, batches[0].index_id);
+    ASSERT_EQ(2, batches[0].tablet_ids.size());
+    EXPECT_EQ(10001, batches[0].tablet_ids[0]); // c2=50 -> [10,+inf)
+    EXPECT_EQ(10000, batches[0].tablet_ids[1]); // c2=3  -> (-inf,10)
+
+    // Index B routes by c1 (shared partition slot).
+    EXPECT_EQ(_index_id + 1, batches[1].index_id);
+    ASSERT_EQ(2, batches[1].tablet_ids.size());
+    EXPECT_EQ(10100, batches[1].tablet_ids[0]); // c1=2 -> (-inf,5)
+    EXPECT_EQ(10101, batches[1].tablet_ids[1]); // c1=7 -> [5,+inf)
+}
+
+// K=1: an index whose distributed_exprs is set but empty has a single tablet per
+// partition. The sender must fill that single candidate directly without initializing or
+// invoking the RangeRouter (the router would error on empty boundaries).
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, EmptyDistributedExprsSingleTablet) {
+    TOlapTableSchemaParam tschema;
+    tschema.db_id = _db_id;
+    tschema.table_id = _table_id;
+    tschema.version = 0;
+
+    TTupleDescriptor tuple_desc;
+    tuple_desc.id = 0;
+    tuple_desc.byteSize = 16;
+    tuple_desc.numNullBytes = 0;
+    tuple_desc.tableId = _table_id;
+    tschema.tuple_desc = tuple_desc;
+
+    TSlotDescriptor slot1;
+    slot1.id = 0;
+    slot1.parent = 0;
+    slot1.colName = "c1";
+    slot1.slotType.types.emplace_back();
+    slot1.slotType.types.back().__set_type(TTypeNodeType::SCALAR);
+    slot1.slotType.types.back().__set_scalar_type(TScalarType());
+    slot1.slotType.types.back().scalar_type.__set_type(TPrimitiveType::BIGINT);
+    tschema.slot_descs.push_back(slot1);
+
+    TOlapTableIndexSchema index_schema;
+    index_schema.id = _index_id;
+    index_schema.columns = {"c1"};
+    index_schema.schema_hash = 0;
+    TOlapTableColumnParam column_param;
+    TColumn tcol;
+    tcol.column_name = "c1";
+    tcol.column_type.type = TPrimitiveType::BIGINT;
+    tcol.is_key = true;
+    tcol.is_allow_null = false;
+    tcol.col_unique_id = 0;
+    column_param.columns.push_back(tcol);
+    column_param.sort_key_uid.push_back(0);
+    index_schema.__set_column_param(column_param);
+    // K=1: distributed_exprs set but empty (no per-index routing key).
+    index_schema.__set_distributed_exprs(std::vector<TExpr>{});
+    tschema.indexes.push_back(index_schema);
+
+    // distributed_exprs is set but empty => no RuntimeState required for parsing.
+    ASSERT_OK(_schema_param->init(tschema, nullptr));
+    ASSERT_TRUE(_schema_param->indexes()[0]->has_distributed_exprs);
+    ASSERT_TRUE(_schema_param->indexes()[0]->distributed_expr_ctxs.empty());
+
+    // Single (-inf, +inf) tablet for the partition.
+    std::vector<TTabletRange> ranges(1);
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    auto chunk = _create_chunk({5, 15, 0, 19});
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(4, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2, 3};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    const auto& tablet_ids = batches[0].tablet_ids;
+    ASSERT_EQ(4, tablet_ids.size());
+    // All rows go to the single tablet, regardless of value.
+    for (int64_t id : tablet_ids) {
+        EXPECT_EQ(10000, id);
+    }
+    ASSERT_EQ(1, index_id_partition_id[_index_id].size());
 }
 
 } // namespace starrocks

--- a/be/test/exec/tablet_info_test.cpp
+++ b/be/test/exec/tablet_info_test.cpp
@@ -37,6 +37,9 @@
 #include <gtest/gtest.h>
 
 #include "runtime/descriptor_helper.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -193,6 +196,81 @@ TEST_F(OlapTablePartitionParamTest, NodesInfo) {
         auto node = nodes.find_node(2);
         ASSERT_TRUE(node == nullptr);
     }
+}
+
+// Build a single slot-ref TExpr referencing slot 0 of tuple 0, typed INT.
+static TExpr make_slot_ref_texpr() {
+    TExpr texpr;
+    TExprNode node;
+    node.node_type = TExprNodeType::SLOT_REF;
+    node.type = gen_type_desc(TPrimitiveType::INT);
+    node.num_children = 0;
+    TSlotRef t_slot_ref = TSlotRef();
+    t_slot_ref.slot_id = 0;
+    t_slot_ref.tuple_id = 0;
+    node.__set_slot_ref(t_slot_ref);
+    node.is_nullable = true;
+    texpr.nodes.emplace_back(node);
+    return texpr;
+}
+
+static RuntimeState* make_runtime_state(ObjectPool* pool) {
+    TUniqueId query_id;
+    TQueryOptions query_options;
+    TQueryGlobals query_globals;
+    TUniqueId fragment_id;
+    auto* exec_env = ExecEnv::GetInstance();
+    auto* state = pool->add(new RuntimeState(query_id, fragment_id, query_options, query_globals,
+                                             &exec_env->query_execution_services(), exec_env));
+    state->init_mem_trackers(query_id);
+    return state;
+}
+
+TEST_F(OlapTablePartitionParamTest, per_index_distributed_exprs_parsed) {
+    ObjectPool pool;
+    TDescriptorTable t_desc_tbl;
+    auto t_schema = get_schema(&t_desc_tbl);
+    t_schema.indexes[0].__set_distributed_exprs({make_slot_ref_texpr()});
+
+    auto* state = make_runtime_state(&pool);
+    std::shared_ptr<OlapTableSchemaParam> schema(new OlapTableSchemaParam());
+    auto st = schema->init(t_schema, state);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // index_id 4 == indexes[0]
+    const OlapTableIndexSchema* idx = nullptr;
+    for (auto* i : schema->indexes()) {
+        if (i->index_id == 4) {
+            idx = i;
+        }
+    }
+    ASSERT_TRUE(idx != nullptr);
+    ASSERT_TRUE(idx->has_distributed_exprs);
+    ASSERT_EQ(1u, idx->distributed_expr_ctxs.size());
+}
+
+TEST_F(OlapTablePartitionParamTest, per_index_distributed_exprs_unset_falls_back) {
+    TDescriptorTable t_desc_tbl;
+    auto t_schema = get_schema(&t_desc_tbl);
+    // no distributed_exprs set on any index
+    std::shared_ptr<OlapTableSchemaParam> schema(new OlapTableSchemaParam());
+    auto st = schema->init(t_schema, nullptr);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    for (auto* idx : schema->indexes()) {
+        ASSERT_FALSE(idx->has_distributed_exprs);
+        ASSERT_TRUE(idx->distributed_expr_ctxs.empty());
+    }
+}
+
+TEST_F(OlapTablePartitionParamTest, per_index_distributed_exprs_nonempty_requires_state) {
+    TDescriptorTable t_desc_tbl;
+    auto t_schema = get_schema(&t_desc_tbl);
+    t_schema.indexes[0].__set_distributed_exprs({make_slot_ref_texpr()});
+
+    std::shared_ptr<OlapTableSchemaParam> schema(new OlapTableSchemaParam());
+    auto st = schema->init(t_schema, nullptr);
+    ASSERT_FALSE(st.ok());
 }
 
 TEST_F(OlapTablePartitionParamTest, removePartition) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -93,7 +93,7 @@ public class DictionaryCacheSink extends DataSink {
 
     private TOlapTableSchemaParam createSchema(long dbId, Table table, TupleDescriptor tupleDescriptor) {
         if (table instanceof OlapTable) {
-            return OlapTableSink.createSchema(dbId, (OlapTable) table, tupleDescriptor);
+            return OlapTableSink.createSchema(dbId, (OlapTable) table, tupleDescriptor, null);
         }
 
         // For the non-olaptable queryable object, construct the fake TOlapTableSchemaParam manually

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -164,6 +164,9 @@ public class OlapTableSink extends DataSink {
     private boolean isFromOverwrite = false;
     private boolean isMultiStatementTxn = false;
     private boolean isStreamingLoad = false;
+    // When set, only the index with this id is written (schema + partitions + loaded-index state).
+    // null (default) means write all indexes, i.e. today's behavior.
+    private Long targetWriteIndexId = null;
 
     // Conservative default for RANGE-partitioned tables under stream / routine load.
     // Both planner paths flag streaming ingest via setIsStreamingLoad(true): StreamLoadPlanner
@@ -280,6 +283,10 @@ public class OlapTableSink extends DataSink {
 
     public void setIsStreamingLoad(boolean isStreamingLoad) {
         this.isStreamingLoad = isStreamingLoad;
+    }
+
+    public void setTargetWriteIndexId(Long targetWriteIndexId) {
+        this.targetWriteIndexId = targetWriteIndexId;
     }
 
     public void complete(String mergeCondition) throws StarRocksException {
@@ -411,12 +418,12 @@ public class OlapTableSink extends DataSink {
             }
             tSink.setNum_replicas(numReplicas);
             tSink.setNeed_gen_rollup(dstTable.shouldLoadToNewRollup());
-            tSink.setSchema(createSchema(tSink.getDb_id(), dstTable, tupleDescriptor));
+            tSink.setSchema(createSchema(tSink.getDb_id(), dstTable, tupleDescriptor, targetWriteIndexId, true));
 
             TransactionState txnState = getTransactionState(tSink, dstTable.isOlapExternalTable());
 
             TOlapTablePartitionParam partitionParam = createPartition(tSink.getDb_id(), dstTable, tupleDescriptor,
-                    enableAutomaticPartition, automaticBucketSize, getOpenPartitions(), txnState);
+                    enableAutomaticPartition, automaticBucketSize, getOpenPartitions(), txnState, targetWriteIndexId);
             tSink.setPartition(partitionParam);
             tSink.setLocation(createLocation(dstTable, partitionParam, enableReplicatedStorage, computeResource, txnState));
             tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(computeResource, getSystemInfoService(dstTable)));
@@ -440,7 +447,7 @@ public class OlapTableSink extends DataSink {
                     tSink2.unsetPartition();
                     tSink2.unsetLocation();
                     TOlapTablePartitionParam partitionParam2 = createPartition(tSink2.getDb_id(), dstTable, tupleDescriptor,
-                            false, automaticBucketSize, doubleWritePartitionIds, txnState);
+                            false, automaticBucketSize, doubleWritePartitionIds, txnState, targetWriteIndexId);
                     tSink2.setPartition(partitionParam2);
                     tSink2.setLocation(createLocation(dstTable, partitionParam2, enableReplicatedStorage, computeResource, txnState));
                     tSink2.setIgnore_out_of_partition(true);
@@ -489,7 +496,18 @@ public class OlapTableSink extends DataSink {
         return tDataSink;
     }
 
-    public static TOlapTableSchemaParam createSchema(long dbId, OlapTable table, TupleDescriptor tupleDescriptor) {
+    public static TOlapTableSchemaParam createSchema(long dbId, OlapTable table, TupleDescriptor tupleDescriptor,
+                                                     @Nullable Long targetWriteIndexId) {
+        return createSchema(dbId, table, tupleDescriptor, targetWriteIndexId, false);
+    }
+
+    // emitDistributedExprs gates the per-index range routing exprs to the OLAP write-sink path only.
+    // Non-write callers (e.g. dictionary cache schema building) pass false: their BE consumers init
+    // OlapTableSchemaParam without a RuntimeState, and distributed_exprs requires one to build the
+    // expr contexts (see be/src/exec/tablet_info.cpp). Only the write sink (OlapTableSink.complete())
+    // passes true.
+    public static TOlapTableSchemaParam createSchema(long dbId, OlapTable table, TupleDescriptor tupleDescriptor,
+                                                     @Nullable Long targetWriteIndexId, boolean emitDistributedExprs) {
         TOlapTableSchemaParam schemaParam = new TOlapTableSchemaParam();
         schemaParam.setDb_id(dbId);
         schemaParam.setTable_id(table.getId());
@@ -501,6 +519,11 @@ public class OlapTableSink extends DataSink {
         }
 
         for (Map.Entry<Long, MaterializedIndexMeta> pair : table.getIndexMetaIdToMeta().entrySet()) {
+            // Keep the schema index list 1:1 with the partition index list: when a target index is
+            // specified, only emit that index here (createPartition applies the same filter).
+            if (targetWriteIndexId != null && pair.getKey() != targetWriteIndexId.longValue()) {
+                continue;
+            }
             MaterializedIndexMeta indexMeta = pair.getValue();
             List<String> columns = Lists.newArrayList();
             List<TColumn> columnsDesc = Lists.newArrayList();
@@ -537,6 +560,10 @@ public class OlapTableSink extends DataSink {
             indexSchema.setSchema_id(indexMeta.getSchemaId());
             indexSchema.setColumn_to_expr_value(columnToExprValue);
             indexSchema.setIs_shadow(isShadow);
+            if (emitDistributedExprs && table.isRangeDistribution()) {
+                indexSchema.setDistributed_exprs(ExprToThrift.treesToThrift(
+                        buildRangeIndexDistributionExprs(table, pair.getKey(), tupleDescriptor)));
+            }
             schemaParam.addToIndexes(indexSchema);
             if (indexMeta.getWhereClause() != null) {
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
@@ -600,6 +627,38 @@ public class OlapTableSink extends DataSink {
         return schemaParam;
     }
 
+    /**
+     * Builds per-index routing exprs for a range-distribution index: one slot-ref over each of the
+     * index's range distribution (sort-key) columns, resolved against the sink's output tuple.
+     *
+     * <p>P1a only handles routing keys that are direct columns in the output tuple (base index).
+     * Added-key literals and retyped casts are deferred.
+     */
+    private static List<Expr> buildRangeIndexDistributionExprs(
+            OlapTable table, long indexMetaId, TupleDescriptor tupleDesc) {
+        // Key the output-tuple slots by the same column->slot name convention this file uses for
+        // the column list (:512) and SlotDescriptor.toThrift (:267): isShadowColumn ? name : columnId.
+        Map<String, SlotDescriptor> slotByColName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (SlotDescriptor slot : tupleDesc.getSlots()) {
+            Column col = slot.getColumn();
+            if (col == null) {
+                continue;
+            }
+            slotByColName.put(col.isShadowColumn() ? col.getName() : col.getColumnId().getId(), slot);
+        }
+
+        List<Column> routingColumns = MetaUtils.getRangeDistributionColumns(table, indexMetaId);
+        List<Expr> exprs = Lists.newArrayListWithCapacity(routingColumns.size());
+        for (Column col : routingColumns) {
+            String colName = col.isShadowColumn() ? col.getName() : col.getColumnId().getId();
+            SlotDescriptor slot = slotByColName.get(colName);
+            Preconditions.checkNotNull(slot,
+                    "no output-tuple slot for range distribution column %s", colName);
+            exprs.add(new SlotRef(slot));
+        }
+        return exprs;
+    }
+
     private static List<String> getDistColumns(DistributionInfo distInfo, OlapTable table) throws StarRocksException {
         List<String> distColumns = Lists.newArrayList();
         switch (distInfo.getType()) {
@@ -633,12 +692,38 @@ public class OlapTableSink extends DataSink {
         return false;
     }
 
+    // Restricts the partition's materialized index list to a single target index when requested.
+    // Returns the full list unchanged when targetWriteIndexId is null (write-all, today's behavior).
+    // Throws when the target index is not present in this partition, so the schema and partition
+    // index lists stay consistent with the BE 1:1 invariant.
+    private static List<MaterializedIndex> filterTargetWriteIndexes(List<MaterializedIndex> indexes,
+                                                                    PhysicalPartition physicalPartition,
+                                                                    @Nullable Long targetWriteIndexId)
+            throws StarRocksException {
+        if (targetWriteIndexId == null) {
+            return indexes;
+        }
+        // Key on the index META id: createSchema filters on the meta id, the thrift outputs
+        // (TOlapTableIndexSchema / TOlapTableIndexTablets) carry the meta id, and the BE 1:1 check
+        // compares meta ids. getId() != getMetaId() for split/merge-rewritten indexes.
+        List<MaterializedIndex> filtered = indexes.stream()
+                .filter(idx -> idx.getMetaId() == targetWriteIndexId)
+                .collect(Collectors.toList());
+        if (filtered.isEmpty()) {
+            throw new StarRocksException("target write index " + targetWriteIndexId
+                    + " not found in partition " + physicalPartition.getId());
+        }
+        return filtered;
+    }
+
     public static TOlapTablePartitionParam createPartition(long dbId, OlapTable table,
                                                            TupleDescriptor tupleDescriptor,
                                                            boolean enableAutomaticPartition,
                                                            long automaticBucketSize,
                                                            List<Long> partitionIds,
-                                                           TransactionState txnState) throws StarRocksException {
+                                                           TransactionState txnState,
+                                                           @Nullable Long targetWriteIndexId)
+            throws StarRocksException {
         TOlapTablePartitionParam partitionParam = new TOlapTablePartitionParam();
         partitionParam.setDb_id(dbId);
         partitionParam.setTable_id(table.getId());
@@ -677,7 +762,9 @@ public class OlapTableSink extends DataSink {
                         TOlapTablePartition tPartition = new TOlapTablePartition();
                         tPartition.setId(physicalPartition.getId());
                         setRangeKeys(rangePartitionInfo, partition, tPartition);
-                        List<MaterializedIndex> indexes = physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+                        List<MaterializedIndex> indexes = filterTargetWriteIndexes(
+                                physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL),
+                                physicalPartition, targetWriteIndexId);
                         setMaterializedIndexes(tPartition, indexes);
                         partitionParam.addToPartitions(tPartition);
                         if (txnState != null) {
@@ -758,7 +845,9 @@ public class OlapTableSink extends DataSink {
                         TOlapTablePartition tPartition = new TOlapTablePartition();
                         tPartition.setId(physicalPartition.getId());
                         setListPartitionValues(listPartitionInfo, partition, tPartition);
-                        List<MaterializedIndex> indexes = physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+                        List<MaterializedIndex> indexes = filterTargetWriteIndexes(
+                                physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL),
+                                physicalPartition, targetWriteIndexId);
                         setMaterializedIndexes(tPartition, indexes);
                         partitionParam.addToPartitions(tPartition);
                         if (txnState != null) {
@@ -801,7 +890,9 @@ public class OlapTableSink extends DataSink {
                     TOlapTablePartition tPartition = new TOlapTablePartition();
                     tPartition.setId(physicalPartition.getId());
                     // No lowerBound and upperBound for this range
-                    List<MaterializedIndex> indexes = physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+                    List<MaterializedIndex> indexes = filterTargetWriteIndexes(
+                            physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL),
+                            physicalPartition, targetWriteIndexId);
                     setMaterializedIndexes(tPartition, indexes);
                     partitionParam.addToPartitions(tPartition);
                     if (txnState != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -3371,12 +3371,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         TGetDictQueryParamResponse response = new TGetDictQueryParamResponse();
-        response.setSchema(OlapTableSink.createSchema(db.getId(), dictTable, tupleDescriptor));
+        response.setSchema(OlapTableSink.createSchema(db.getId(), dictTable, tupleDescriptor, null));
         try {
             List<Long> allPartitions = dictTable.getAllPartitionIds();
             TOlapTablePartitionParam partitionParam = OlapTableSink.createPartition(
                     db.getId(), dictTable, tupleDescriptor, dictTable.supportedAutomaticPartition(),
-                    dictTable.getAutomaticBucketSize(), allPartitions, null);
+                    dictTable.getAutomaticBucketSize(), allPartitions, null, null);
             response.setPartition(partitionParam);
             response.setLocation(OlapTableSink.createLocation(
                     dictTable, partitionParam, dictTable.enableReplicatedStorage(), null));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -52,16 +53,24 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.system.Backend;
 import com.starrocks.system.BackendHbResponse;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TOlapTableIndexSchema;
+import com.starrocks.thrift.TOlapTableIndexTablets;
 import com.starrocks.thrift.TOlapTableLocationParam;
+import com.starrocks.thrift.TOlapTableSchemaParam;
 import com.starrocks.thrift.TOlapTableSink;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
+import com.starrocks.thrift.TSlotDescriptor;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
@@ -1077,5 +1086,410 @@ public class OlapTableSinkTest {
         } finally {
             Config.lake_enable_per_partition_coordinator_txn_log = original;
         }
+    }
+
+    // Build the sink output tuple from the table schema, mirroring how
+    // StreamLoadPlanner/InsertPlanner bind one materialized slot per column.
+    private static TupleDescriptor buildOutputTuple(List<Column> schema) {
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tuple = descTable.createTupleDescriptor("DstTable");
+        for (Column col : schema) {
+            SlotDescriptor slot = descTable.addSlotDescriptor(tuple);
+            slot.setIsMaterialized(true);
+            slot.setColumn(col);
+            slot.setIsNullable(col.isAllowNull());
+        }
+        descTable.computeMemLayout();
+        return tuple;
+    }
+
+    // A DUP-keys index over (k1, k2, v1) whose sort key is (k1, k2). createSchema reads only
+    // metadata off the table; it never touches the cluster/backends, so a mocked table suffices.
+    private MaterializedIndexMeta rangeIndexMeta(long indexMetaId, List<Column> schema) {
+        return new MaterializedIndexMeta(indexMetaId, schema, 0, 0, (short) 2,
+                TStorageType.COLUMN, KeysType.DUP_KEYS, null, Lists.newArrayList(0, 1));
+    }
+
+    @Test
+    public void testRangeTableEmitsPerIndexDistributedExprs() {
+        List<Column> schema = Lists.newArrayList(
+                new Column("k1", IntegerType.INT, true, null, false, null, ""),
+                new Column("k2", IntegerType.INT, true, null, false, null, ""),
+                new Column("v1", IntegerType.INT, false, null, true, null, ""));
+        long indexMetaId = 100L;
+        MaterializedIndexMeta indexMeta = rangeIndexMeta(indexMetaId, schema);
+        Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newLinkedHashMap();
+        indexMetaIdToMeta.put(indexMetaId, indexMeta);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = 1L;
+                dstTable.getBaseIndexMetaId();
+                result = indexMetaId;
+                dstTable.getIndexMetaByMetaId(indexMetaId);
+                result = indexMeta;
+                dstTable.getIndexMetaIdToMeta();
+                result = indexMetaIdToMeta;
+                dstTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                dstTable.getIndexes();
+                result = Lists.newArrayList();
+                dstTable.getBfColumnIds();
+                result = Sets.newHashSet();
+                dstTable.isRangeDistribution();
+                result = true;
+            }
+        };
+
+        TupleDescriptor tuple = buildOutputTuple(schema);
+        TOlapTableSchemaParam schemaParam = OlapTableSink.createSchema(1L, dstTable, tuple, null, true);
+
+        // Routing columns are the index sort key (k1, k2).
+        int expectedExprCount = MetaUtils.getRangeDistributionColumns(dstTable, indexMetaId).size();
+        Assertions.assertEquals(1, schemaParam.getIndexes().size());
+        TOlapTableIndexSchema baseIndex = schemaParam.getIndexes().get(0);
+        Assertions.assertTrue(baseIndex.isSetDistributed_exprs(),
+                "range-distribution base index must carry distributed_exprs");
+        List<TExpr> exprs = baseIndex.getDistributed_exprs();
+        Assertions.assertEquals(expectedExprCount, exprs.size(),
+                "one routing expr per range distribution column");
+        for (TExpr expr : exprs) {
+            Assertions.assertEquals(1, expr.getNodes().size(),
+                    "each routing expr is a single slot-ref node");
+            Assertions.assertEquals(TExprNodeType.SLOT_REF, expr.getNodes().get(0).getNode_type());
+        }
+    }
+
+    @Test
+    public void testRangeTableNonWritePathLeavesDistributedExprsUnset() {
+        // Non-write callers (dictionary cache schema building) use the createSchema overload that
+        // does not emit distributed_exprs (emitDistributedExprs = false). Their BE consumers init
+        // OlapTableSchemaParam without a RuntimeState, which cannot build the per-index expr
+        // contexts. Even on a range-distribution table the field must stay unset on this path.
+        List<Column> schema = Lists.newArrayList(
+                new Column("k1", IntegerType.INT, true, null, false, null, ""),
+                new Column("k2", IntegerType.INT, true, null, false, null, ""),
+                new Column("v1", IntegerType.INT, false, null, true, null, ""));
+        long indexMetaId = 100L;
+        MaterializedIndexMeta indexMeta = rangeIndexMeta(indexMetaId, schema);
+        Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newLinkedHashMap();
+        indexMetaIdToMeta.put(indexMetaId, indexMeta);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = 1L;
+                dstTable.getBaseIndexMetaId();
+                result = indexMetaId;
+                dstTable.getIndexMetaByMetaId(indexMetaId);
+                result = indexMeta;
+                dstTable.getIndexMetaIdToMeta();
+                result = indexMetaIdToMeta;
+                dstTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                dstTable.getIndexes();
+                result = Lists.newArrayList();
+                dstTable.getBfColumnIds();
+                result = Sets.newHashSet();
+                // isRangeDistribution() is gated out before it is reached on the non-write path,
+                // so it is allowed to be called zero times.
+                dstTable.isRangeDistribution();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        TupleDescriptor tuple = buildOutputTuple(schema);
+        // 4-arg overload == dictionary-style non-write call (emitDistributedExprs defaults to false).
+        TOlapTableSchemaParam schemaParam = OlapTableSink.createSchema(1L, dstTable, tuple, null);
+
+        Assertions.assertFalse(schemaParam.getIndexes().isEmpty());
+        for (TOlapTableIndexSchema indexSchema : schemaParam.getIndexes()) {
+            Assertions.assertFalse(indexSchema.isSetDistributed_exprs(),
+                    "non-write (dictionary) createSchema must leave distributed_exprs unset on a range table");
+        }
+    }
+
+    @Test
+    public void testRangeTablePerIndexExprsMatchPartitionLevelColumns() {
+        // Behavior-preservation guarantee: for a base-only range table the LIVE per-index routing
+        // path must select exactly the columns (and order) the old partition-level
+        // distributed_columns path used, i.e. MetaUtils.getRangeDistributionColumnIds(table).
+        List<Column> schema = Lists.newArrayList(
+                new Column("k1", IntegerType.INT, true, null, false, null, ""),
+                new Column("k2", IntegerType.INT, true, null, false, null, ""),
+                new Column("v1", IntegerType.INT, false, null, true, null, ""));
+        long indexMetaId = 100L;
+        MaterializedIndexMeta indexMeta = rangeIndexMeta(indexMetaId, schema);
+        Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newLinkedHashMap();
+        indexMetaIdToMeta.put(indexMetaId, indexMeta);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = 1L;
+                dstTable.getBaseIndexMetaId();
+                result = indexMetaId;
+                dstTable.getIndexMetaByMetaId(indexMetaId);
+                result = indexMeta;
+                dstTable.getIndexMetaIdToMeta();
+                result = indexMetaIdToMeta;
+                dstTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                dstTable.getIndexes();
+                result = Lists.newArrayList();
+                dstTable.getBfColumnIds();
+                result = Sets.newHashSet();
+                dstTable.isRangeDistribution();
+                result = true;
+            }
+        };
+
+        TupleDescriptor tuple = buildOutputTuple(schema);
+        TOlapTableSchemaParam schemaParam = OlapTableSink.createSchema(1L, dstTable, tuple, null, true);
+
+        // TSlotRef carries only slot_id (no column-name field); resolve slot_id -> colName via the
+        // schema param's slot descriptors.
+        Map<Integer, String> slotIdToColName = Maps.newHashMap();
+        for (TSlotDescriptor slotDesc : schemaParam.getSlot_descs()) {
+            slotIdToColName.put(slotDesc.getId(), slotDesc.getColName());
+        }
+
+        TOlapTableIndexSchema baseIndex = schemaParam.getIndexes().get(0);
+        List<String> perIndexColumnKeys = new ArrayList<>();
+        for (TExpr expr : baseIndex.getDistributed_exprs()) {
+            TExprNode root = expr.getNodes().get(0);
+            Assertions.assertEquals(TExprNodeType.SLOT_REF, root.getNode_type(),
+                    "each routing expr root must be a slot-ref");
+            int slotId = root.getSlot_ref().getSlot_id();
+            Assertions.assertTrue(slotIdToColName.containsKey(slotId),
+                    "routing slot_id must resolve to a schema slot descriptor");
+            perIndexColumnKeys.add(slotIdToColName.get(slotId));
+        }
+
+        // Per-index routing selects exactly the partition-level range distribution columns,
+        // same columns AND same order.
+        Assertions.assertEquals(MetaUtils.getRangeDistributionColumnIds(dstTable), perIndexColumnKeys,
+                "per-index routing must match partition-level distributed columns (same columns, same order)");
+    }
+
+    @Test
+    public void testNonRangeTableLeavesDistributedExprsUnset() {
+        List<Column> schema = Lists.newArrayList(
+                new Column("k1", IntegerType.INT, true, null, false, null, ""),
+                new Column("k2", IntegerType.INT, true, null, false, null, ""),
+                new Column("v1", IntegerType.INT, false, null, true, null, ""));
+        long indexMetaId = 200L;
+        MaterializedIndexMeta indexMeta = rangeIndexMeta(indexMetaId, schema);
+        Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newLinkedHashMap();
+        indexMetaIdToMeta.put(indexMetaId, indexMeta);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = 1L;
+                dstTable.getBaseIndexMetaId();
+                result = indexMetaId;
+                dstTable.getIndexMetaByMetaId(indexMetaId);
+                result = indexMeta;
+                dstTable.getIndexMetaIdToMeta();
+                result = indexMetaIdToMeta;
+                dstTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                dstTable.getIndexes();
+                result = Lists.newArrayList();
+                dstTable.getBfColumnIds();
+                result = Sets.newHashSet();
+                // The 4-arg createSchema overload does not emit distributed_exprs, so the
+                // emitDistributedExprs && isRangeDistribution() guard short-circuits before the
+                // distribution check; allow zero invocations.
+                dstTable.isRangeDistribution();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        TupleDescriptor tuple = buildOutputTuple(schema);
+        TOlapTableSchemaParam schemaParam = OlapTableSink.createSchema(1L, dstTable, tuple, null);
+
+        Assertions.assertFalse(schemaParam.getIndexes().isEmpty());
+        for (TOlapTableIndexSchema indexSchema : schemaParam.getIndexes()) {
+            Assertions.assertFalse(indexSchema.isSetDistributed_exprs(),
+                    "hash-distribution index must leave distributed_exprs unset");
+        }
+    }
+
+    // A single-partition (UNPARTITIONED) table with a base index plus one rollup index. The
+    // target-write id is the index META id: createSchema and createPartition both filter on the
+    // meta id, so the same index is selected on both sides regardless of MaterializedIndex.getId().
+    // (These constants happen to set getId()==getMetaId(), but that equality is NOT relied on.)
+    private static final long TARGET_BASE_INDEX_ID = 10L;
+    private static final long TARGET_ROLLUP_INDEX_ID = 20L;
+    private static final long TARGET_TABLE_ID = 1L;
+    private static final long TARGET_PHYSICAL_PARTITION_ID = 1100L;
+
+    private List<Column> targetIndexSchema() {
+        return Lists.newArrayList(
+                new Column("k1", IntegerType.INT, true, null, false, null, ""),
+                new Column("v1", IntegerType.INT, false, null, true, null, ""));
+    }
+
+    // Mock the schema-side metadata reads for a base + rollup table.
+    private void expectTargetWriteSchema(List<Column> schema) {
+        MaterializedIndexMeta baseMeta = rangeIndexMeta(TARGET_BASE_INDEX_ID, schema);
+        MaterializedIndexMeta rollupMeta = rangeIndexMeta(TARGET_ROLLUP_INDEX_ID, schema);
+        Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newLinkedHashMap();
+        indexMetaIdToMeta.put(TARGET_BASE_INDEX_ID, baseMeta);
+        indexMetaIdToMeta.put(TARGET_ROLLUP_INDEX_ID, rollupMeta);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = TARGET_TABLE_ID;
+                minTimes = 0;
+                dstTable.getBaseIndexMetaId();
+                result = TARGET_BASE_INDEX_ID;
+                dstTable.getIndexMetaByMetaId(TARGET_BASE_INDEX_ID);
+                result = baseMeta;
+                dstTable.getIndexMetaIdToMeta();
+                result = indexMetaIdToMeta;
+                dstTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                dstTable.getIndexes();
+                result = Lists.newArrayList();
+                dstTable.getBfColumnIds();
+                result = Sets.newHashSet();
+                // createSchema is invoked through the 4-arg (non-write) overload here, which short-
+                // circuits the emitDistributedExprs guard before the distribution check.
+                dstTable.isRangeDistribution();
+                result = false;
+                minTimes = 0;
+            }
+        };
+    }
+
+    // Build a real single-partition Partition whose physical partition carries the base index and
+    // one rollup index, and mock the partition-side metadata reads. createPartition then runs its
+    // genuine UNPARTITIONED path (filter + setMaterializedIndexes + loaded-index recording).
+    private Partition expectTargetWritePartition(List<Column> schema) {
+        Column k1 = schema.get(0);
+        HashDistributionInfo distInfo = new HashDistributionInfo(2, Lists.newArrayList(k1));
+        MaterializedIndex baseIndex =
+                new MaterializedIndex(TARGET_BASE_INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        MaterializedIndex rollupIndex =
+                new MaterializedIndex(TARGET_ROLLUP_INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(900, TARGET_PHYSICAL_PARTITION_ID, "p1", baseIndex, distInfo);
+        partition.getDefaultPhysicalPartition().createRollupIndex(rollupIndex);
+
+        SinglePartitionInfo partInfo = new SinglePartitionInfo();
+        partInfo.setReplicationNum(900, (short) 1);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = TARGET_TABLE_ID;
+                minTimes = 0;
+                dstTable.getPartitionInfo();
+                result = partInfo;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
+                dstTable.getPartitions();
+                result = Lists.newArrayList(partition);
+                dstTable.getPartition(900L);
+                result = partition;
+            }
+        };
+        return partition;
+    }
+
+    @Test
+    public void testTargetWriteIndexFilterRestrictsToOneIndex() throws StarRocksException {
+        List<Column> schema = targetIndexSchema();
+        expectTargetWriteSchema(schema);
+        TupleDescriptor tuple = buildOutputTuple(schema);
+
+        // Schema side: only the base index is emitted.
+        TOlapTableSchemaParam schemaParam =
+                OlapTableSink.createSchema(1L, dstTable, tuple, TARGET_BASE_INDEX_ID);
+        Assertions.assertEquals(1, schemaParam.getIndexes().size(),
+                "filter must restrict the schema to a single index");
+        Assertions.assertEquals(TARGET_BASE_INDEX_ID, schemaParam.getIndexes().get(0).getId());
+
+        // Partition side: every partition lists ONLY the base index, and the txn loaded-index
+        // record agrees (the 1:1 invariant the BE relies on).
+        Partition partition = expectTargetWritePartition(schema);
+        TransactionState txnState = new TransactionState();
+        TOlapTablePartitionParam partitionParam = OlapTableSink.createPartition(
+                1L, dstTable, tuple, false, 0, Lists.newArrayList(900L), txnState, TARGET_BASE_INDEX_ID);
+
+        Assertions.assertFalse(partitionParam.getPartitions().isEmpty());
+        for (TOlapTablePartition tPartition : partitionParam.getPartitions()) {
+            Assertions.assertEquals(1, tPartition.getIndexes().size(),
+                    "filter must restrict every partition to a single index");
+            Assertions.assertEquals(TARGET_BASE_INDEX_ID, tPartition.getIndexes().get(0).getIndex_id());
+        }
+
+        List<MaterializedIndex> loaded = txnState.getPartitionLoadedIndexes(
+                TARGET_TABLE_ID, partition.getDefaultPhysicalPartition());
+        Assertions.assertEquals(1, loaded.size(), "loaded-index state must record only the target index");
+        Assertions.assertEquals(TARGET_BASE_INDEX_ID, loaded.get(0).getId());
+
+        // Schema and partition must agree on the single index id.
+        Assertions.assertEquals(schemaParam.getIndexes().get(0).getId(),
+                partitionParam.getPartitions().get(0).getIndexes().get(0).getIndex_id(),
+                "schema and partition index lists must stay 1:1");
+    }
+
+    @Test
+    public void testTargetWriteIndexFilterUnsetWritesAllIndexes() throws StarRocksException {
+        List<Column> schema = targetIndexSchema();
+        expectTargetWriteSchema(schema);
+        TupleDescriptor tuple = buildOutputTuple(schema);
+
+        // Schema side: both indexes emitted when no target is set.
+        TOlapTableSchemaParam schemaParam =
+                OlapTableSink.createSchema(1L, dstTable, tuple, null);
+        Assertions.assertEquals(2, schemaParam.getIndexes().size(),
+                "unset filter must emit all indexes in the schema");
+        Set<Long> schemaIndexIds = Sets.newHashSet();
+        for (TOlapTableIndexSchema indexSchema : schemaParam.getIndexes()) {
+            schemaIndexIds.add(indexSchema.getId());
+        }
+        Assertions.assertEquals(Sets.newHashSet(TARGET_BASE_INDEX_ID, TARGET_ROLLUP_INDEX_ID), schemaIndexIds);
+
+        // Partition side: every partition lists ALL indexes when no target is set.
+        Partition partition = expectTargetWritePartition(schema);
+        TransactionState txnState = new TransactionState();
+        TOlapTablePartitionParam partitionParam = OlapTableSink.createPartition(
+                1L, dstTable, tuple, false, 0, Lists.newArrayList(900L), txnState, null);
+
+        Assertions.assertFalse(partitionParam.getPartitions().isEmpty());
+        for (TOlapTablePartition tPartition : partitionParam.getPartitions()) {
+            Set<Long> partitionIndexIds = Sets.newHashSet();
+            for (TOlapTableIndexTablets tIndex : tPartition.getIndexes()) {
+                partitionIndexIds.add(tIndex.getIndex_id());
+            }
+            Assertions.assertEquals(Sets.newHashSet(TARGET_BASE_INDEX_ID, TARGET_ROLLUP_INDEX_ID),
+                    partitionIndexIds, "unset filter must list all indexes per partition");
+        }
+
+        List<MaterializedIndex> loaded = txnState.getPartitionLoadedIndexes(
+                TARGET_TABLE_ID, partition.getDefaultPhysicalPartition());
+        Assertions.assertEquals(2, loaded.size(), "loaded-index state must record all indexes when unset");
+    }
+
+    @Test
+    public void testTargetWriteIndexFilterThrowsWhenIndexAbsent() {
+        List<Column> schema = targetIndexSchema();
+        TupleDescriptor tuple = buildOutputTuple(schema);
+        expectTargetWritePartition(schema);
+
+        long absentIndexId = 999L;
+        StarRocksException e = assertThrows(StarRocksException.class, () ->
+                OlapTableSink.createPartition(
+                        1L, dstTable, tuple, false, 0, Lists.newArrayList(900L), null, absentIndexId));
+        Assertions.assertTrue(e.getMessage().contains("not found in partition"),
+                "missing target index must fail with a 'not found in partition' message, got: " + e.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
@@ -130,7 +130,7 @@ public class OlapTableSinkTest2 {
 
             StarRocksException exception = Assertions.assertThrows(StarRocksException.class, () -> {
                 OlapTableSink.createPartition(db.getId(), olapTable, null,
-                        false, 0, partitionIds, null);
+                        false, 0, partitionIds, null, null);
             });
             Assertions.assertTrue(exception.getMessage().contains("different distribute columns"));
         } finally {
@@ -161,7 +161,7 @@ public class OlapTableSinkTest2 {
 
             StarRocksException exception = Assertions.assertThrows(StarRocksException.class, () -> {
                 OlapTableSink.createPartition(db.getId(), olapTable, null,
-                        false, 0, partitionIds, null);
+                        false, 0, partitionIds, null, null);
             });
             Assertions.assertTrue(exception.getMessage().contains("different distribute columns"));
         } finally {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -365,6 +365,12 @@ struct TOlapTableIndexSchema {
     6: optional i64 schema_id // schema id
     7: optional map<string, string> column_to_expr_value
     8: optional bool is_shadow
+    // Per-index distribution routing expressions (slot/cast/literal trees), evaluated
+    // at the sink SENDER to pick the destination tablet for this index. Mirrors
+    // TOlapTablePartitionParam.partition_exprs. When unset, the sink falls back to the
+    // partition-level `distributed_columns` routing (default for all existing loads).
+    // An explicitly EMPTY list means "single tablet, do not route" (degenerate K=1).
+    9: optional list<Exprs.TExpr> distributed_exprs
 }
 
 struct TOlapTableSchemaParam {


### PR DESCRIPTION
## Why I'm doing:

Range-distribution (shared-data) tables route rows to tablets by per-tablet boundaries stored in sort-key space, but the OLAP table sink could only carry a single partition-level distribution-column set. It therefore could not route different rows to materialized indexes that live in different key spaces. This is the missing sink piece for two future features — the K-tablet shadow-index rewrite job (key-column schema change) and range-distribution rollup — both of which need a base index and a new-key index to coexist in one partition and be routed independently.

## What I'm doing:

Add **per-index distribution routing** to the sink:

- **thrift:** new `TOlapTableIndexSchema.distributed_exprs` (field 9) carrying per-index routing expression trees, evaluated at the sink **sender**. Sender-only: `POlapTableIndexSchema` (proto) is unchanged, so remote write channels never route by it.
- **FE:** `OlapTableSink.createSchema` fills `distributed_exprs` for range-distribution tables with slot-refs over each index's range sort-key columns, gated to the OLAP write-sink path (dictionary / non-write callers do not emit it). For today's base-only range tables this resolves to exactly the columns the partition-level path already used, so routing is **behavior-preserving**. Also adds an optional `targetWriteIndexId` filter (write only one index; schema, partition and loaded-index lists stay 1:1 by meta id).
- **BE:** `OlapTableSchemaParam` parses `distributed_exprs` into per-index `ExprContext`s (prepare/open/close lifecycle); the range sink sender evaluates them once per chunk per index and routes via `RangeRouter`. `RangeRouter::init` validates routing-key types against the boundary types; a new `route_chunk_rows` overload routes from pre-evaluated columns; an empty `distributed_exprs` (K=1) routes to the single tablet. When an index has no `distributed_exprs`, routing falls back to the partition-level path unchanged.

No version gate is needed: StarRocks upgrades BE/CN before FE, so a newly-upgraded FE (the only one that emits the field) never runs against a BE that does not understand it, and an old FE never emits it. Non-range tables and any unset field are byte-for-byte unchanged. This is prerequisite-only: the new capability is dormant for existing tables and consumed by future work.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)