### PR TITLE
[BugFix] Decouple aggregate rewrite and output dictification logic to fix multi-input aggregate bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -166,6 +166,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     private final Map<Integer, List<CallOperator>> stringAggregateExpressions = Maps.newHashMap();
 
+    private final Map<CallOperator, ColumnRefSet> aggFnToSupportColumns = Maps.newIdentityHashMap();
+
     private final Map<Integer, Integer> tableFunctionDependencies = Maps.newHashMap();
 
     private final Map<Integer, ScalarOperator> stringRefToDefineExprMap = Maps.newHashMap();
@@ -404,7 +406,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 if (agg.getColumnRefs().stream().map(ColumnRefOperator::getId)
                         .anyMatch(context.allStringColumns::contains)) {
                     context.stringAggregateExprs.put(aggregateId, aggregateExprs);
-                    context.allStringColumns.add(aggregateId);
                     break;
                 }
             }
@@ -419,26 +420,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             info.inputStringColumns.intersect(alls);
             if (!info.isEmpty()) {
                 context.operatorDecodeInfo.put(operator, info);
-                if (operator instanceof PhysicalHashAggregateOperator hashAgg) {
-                    hashAgg.getAggregations().keySet().forEach(agg -> {
-                        context.aggIdToSupportColumns.computeIfAbsent(agg.getId(), k -> new ColumnRefSet())
-                                .union(info.inputStringColumns);
-                    });
-                }
-                if (operator instanceof PhysicalWindowOperator window) {
-                    window.getAnalyticCall().keySet().forEach(agg -> {
-                        context.aggIdToSupportColumns.computeIfAbsent(agg.getId(), k -> new ColumnRefSet())
-                                .union(info.inputStringColumns);
-                    });
-                }
-                if (operator instanceof PhysicalTopNOperator topN && topN.getPreAggCall() != null) {
-                    topN.getPreAggCall().keySet().forEach(agg -> {
-                        context.aggIdToSupportColumns.computeIfAbsent(agg.getId(), k -> new ColumnRefSet())
-                                .union(info.inputStringColumns);
-                    });
-                }
             }
         }
+        context.aggFnToSupportColumns = aggFnToSupportColumns;
         // Filling context's structOpToFieldUseStringRefMap and structRefToFieldUseStringRefMap with fields in
         // context.allStringColumns.
         context.structOpToFieldUseStringRefMap = structOpToFieldUseStringRef.entrySet().stream()
@@ -681,6 +665,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 }
                 // aggregate ref -> aggregate expr
                 stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
+                aggFnToSupportColumns.put(value, info.inputStringColumns);
                 // min/max should replace to dict column, count/count distinct don't need
                 if (FunctionSet.MAX.equals(value.getFnName()) || FunctionSet.MIN.equals(value.getFnName())) {
                     info.outputStringColumns.union(key.getId());
@@ -944,6 +929,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             }
 
             stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
+            aggFnToSupportColumns.put(value, info.inputStringColumns);
             // if the function return type is not string or array<string>, then its output column can not be
             // encoded, however the function evaluation can adopt encoded columns, for examples:
             // 1. select v1, count(t.a1) over(partition by v1) select t0, unnest(t0.a1) t(a1);
@@ -986,7 +972,11 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return info;
     }
 
-    private boolean shouldProcessAggFunction(CallOperator agg, ColumnRefSet supportColumns, boolean isFirstStage) {
+    private boolean shouldProcessAggFunction(CallOperator agg, DecodeInfo info, boolean isFirstStage) {
+        ColumnRefSet supportColumns = new ColumnRefSet();
+        supportColumns.union(info.getInputStringColumns());
+        supportColumns.union(info.getInProgressStringAggregations());
+        supportColumns.union(info.getFinalizingStringAggregations());
         final boolean enableArrayAgg = sessionVariable.isEnableArrayAggLowCardinalityOptimize()
                 && sessionVariable.isEnableArrayLowCardinalityOptimize()
                 && sessionVariable.isEnableStructLowCardinalityOptimize();
@@ -1012,18 +1002,21 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     @Override
     public DecodeInfo visitPhysicalHashAggregate(OptExpression optExpression, DecodeInfo context) {
-        if (context.outputStringColumns.isEmpty()) {
+        if (context.outputStringColumns.isEmpty() && context.inProgressStringAggregations.isEmpty()) {
             return DecodeInfo.empty();
         }
         PhysicalHashAggregateOperator aggregate = optExpression.getOp().cast();
         DecodeInfo info = context.createOutputInfo();
+        if (aggregate.getType().isGlobal()) {
+            info.inProgressStringAggregations.clear();
+        }
 
         ColumnRefSet disableColumns = new ColumnRefSet();
         for (ColumnRefOperator key : aggregate.getAggregations().keySet()) {
             CallOperator agg = aggregate.getAggregations().get(key);
             final boolean isFirstStage = !agg.getArguments().isEmpty() &&
                     (!(agg.getArguments().get(0) instanceof ColumnRefOperator ref) || ref.getId() != key.getId());
-            if (!shouldProcessAggFunction(agg, info.inputStringColumns, isFirstStage)) {
+            if (!shouldProcessAggFunction(agg, info, isFirstStage)) {
                 disableColumns.union(agg.getUsedColumns());
                 disableColumns.union(key);
             } else if (isFirstStage && FunctionSet.ARRAY_AGG.equals(agg.getFnName()) &&
@@ -1046,6 +1039,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             CallOperator value = aggregate.getAggregations().get(key);
             // aggregate ref -> aggregate expr
             stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
+            aggFnToSupportColumns.put(value, info.inputStringColumns);
             AggregateFunction aggFn = (AggregateFunction) value.getFunction();
             if (aggFn.getIntermediateTypeOrReturnType().isStructType()
                     && !structRefToFieldUseStringRef.containsKey(key.getId())) {
@@ -1070,11 +1064,16 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 structOpToFieldUseStringRef.put(value, fieldsData);
             }
             if (supportLowCardinality(value.getType())) {
-                info.outputStringColumns.union(key.getId());
+                if (aggregate.getType().isGlobal() || !aggregate.isSplit()) {
+                    info.outputStringColumns.union(key.getId());
+                    info.finalizingStringAggregations.union(key.getId());
+                } else {
+                    info.inProgressStringAggregations.union(key.getId());
+                }
                 setDefineExpr(key, value, 1);
             } else if (aggregate.getType().isLocal() || aggregate.getType().isDistinct()) {
                 // count/count distinct, need output dict-set in 1st stage
-                info.outputStringColumns.union(key.getId());
+                info.inProgressStringAggregations.union(key.getId());
             }
         }
 
@@ -1134,7 +1133,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     @Override
     public DecodeInfo visitPhysicalDistribution(OptExpression optExpression, DecodeInfo context) {
-        if (context.outputStringColumns.isEmpty()) {
+        if (context.outputStringColumns.isEmpty() && context.inProgressStringAggregations.isEmpty()) {
             return DecodeInfo.empty();
         }
         return context.createOutputInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -91,7 +91,7 @@ class DecodeContext {
     // all string aggregate expressions
     Map<Integer, List<CallOperator>> stringAggregateExprs = Maps.newHashMap();
 
-    Map<Integer, ColumnRefSet> aggIdToSupportColumns = Maps.newHashMap();
+    Map<CallOperator, ColumnRefSet> aggFnToSupportColumns;
 
     // The string columns used by the operator
     // IdentityHashMap: use object == object, operator equals is not enough
@@ -243,10 +243,11 @@ class DecodeContext {
         // rewrite string aggregate expression
         AggregateRewriter rewriter = new AggregateRewriter();
         stringAggregateExprs.forEach((aggId, aggFns) -> {
-            ColumnRefSet supportColumns = aggIdToSupportColumns.get(aggId);
-            Preconditions.checkNotNull(supportColumns);
-            rewriter.setSupportColumns(supportColumns);
+            rewriter.setAggId(aggId);
             for (CallOperator aggFn : aggFns) {
+                ColumnRefSet supportColumns = aggFnToSupportColumns.get(aggFn);
+                Preconditions.checkNotNull(supportColumns);
+                rewriter.setSupportColumns(supportColumns);
                 CallOperator new1stAggFn = (CallOperator) (aggFn.accept(rewriter, null));
                 stringExprToDictExprMap.put(aggFn, new1stAggFn);
             }
@@ -497,10 +498,11 @@ class DecodeContext {
 
     private class AggregateRewriter extends BaseScalarOperatorShuttle {
         private ColumnRefSet supportColumns;
+        private int aggId;
 
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void ignore) {
-            return supportColumns.contains(variable) ?
+            return (variable.getId() == aggId || supportColumns.contains(variable)) ?
                     stringRefToDictRefMap.getOrDefault(variable, variable) : variable;
         }
 
@@ -517,7 +519,9 @@ class DecodeContext {
                     Map<String, ColumnRefOperator> fieldMapping = getFieldUseStringRefMap(originalChildren.get(0));
                     Preconditions.checkNotNull(fieldMapping);
                     for (int i = 0; i < fn.getNumArgs(); ++i) {
-                        argTypes.add(fieldMapping.containsKey("col" + (i + 1)) ? getDictifiedType(fn.getArgs()[i])
+                        ColumnRefOperator fieldStringRef = fieldMapping.get("col" + (i + 1));
+                        argTypes.add(fieldStringRef != null && supportColumns.contains(fieldStringRef) ?
+                                getDictifiedType(fn.getArgs()[i])
                                 : fn.getArgs()[i]);
                     }
                 } else {
@@ -553,15 +557,18 @@ class DecodeContext {
 
             if (call.getFunction() instanceof AggregateFunction origFn) {
                 AggregateFunction fn = buildAggregateFunction(origFn, newChildren, call.getArguments());
-                ColumnRefOperator firstChild = newChildren.get(0).isColumnRef() ? newChildren.get(0).cast() : null;
-                if (firstChild != null && firstChild != call.getArguments().get(0)) {
-                    if (firstChild.getType().matchesType(fn.getReturnType())) {
-                        newChildren.set(0, new ColumnRefOperator(firstChild.getId(), fn.getReturnType(),
+                ColumnRefOperator firstChild =
+                        call.getChild(0).isColumnRef() ? call.getChild(0).cast() : null;
+                if (firstChild != null && firstChild.getId() == aggId) {
+                    Preconditions.checkState(newChildren.get(0).isColumnRef());
+                    int newAggId = ((ColumnRefOperator) newChildren.get(0)).getId();
+                    if (firstChild.getType().matchesType(origFn.getReturnType())) {
+                        newChildren.set(0, new ColumnRefOperator(newAggId, fn.getReturnType(),
                                 firstChild.getName(), firstChild.isNullable()));
                     }
-                    if (fn.getIntermediateType() != null
-                            && firstChild.getType().matchesType(fn.getIntermediateType())) {
-                        newChildren.set(0, new ColumnRefOperator(firstChild.getId(), fn.getIntermediateType(),
+                    if (origFn.getIntermediateType() != null
+                            && firstChild.getType().matchesType(origFn.getIntermediateType())) {
+                        newChildren.set(0, new ColumnRefOperator(newAggId, fn.getIntermediateType(),
                                 firstChild.getName(), firstChild.isNullable()));
                     }
                 }
@@ -584,6 +591,10 @@ class DecodeContext {
 
         void setSupportColumns(ColumnRefSet supportColumns) {
             this.supportColumns = supportColumns;
+        }
+
+        void setAggId(int aggId) {
+            this.aggId = aggId;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
@@ -46,6 +46,12 @@ public class DecodeInfo {
     // operator used string column but not output to downstream operator
     ColumnRefSet usedStringColumns = new ColumnRefSet();
 
+    // Low cardinality aggregations that have been started but are not finalized yet
+    ColumnRefSet inProgressStringAggregations = new ColumnRefSet();
+
+    // Low cardinality aggregations that are being finalized in this operator
+    ColumnRefSet finalizingStringAggregations = new ColumnRefSet();
+
     public ColumnRefSet getInputStringColumns() {
         return inputStringColumns;
     }
@@ -58,14 +64,23 @@ public class DecodeInfo {
         return outputStringColumns;
     }
 
+    public ColumnRefSet getInProgressStringAggregations() {
+        return inProgressStringAggregations;
+    }
+
+    public ColumnRefSet getFinalizingStringAggregations() {
+        return finalizingStringAggregations;
+    }
+
     public DecodeInfo createOutputInfo() {
-        if (this.outputStringColumns.isEmpty()) {
+        if (this.outputStringColumns.isEmpty() && this.inProgressStringAggregations.isEmpty()) {
             return DecodeInfo.empty();
         }
 
         DecodeInfo info = DecodeInfo.create();
         info.inputStringColumns.union(this.outputStringColumns);
         info.outputStringColumns.union(this.outputStringColumns);
+        info.inProgressStringAggregations.union(this.inProgressStringAggregations);
         return info;
     }
 
@@ -81,16 +96,19 @@ public class DecodeInfo {
 
     public boolean isEmpty() {
         return this.outputStringColumns.isEmpty() && this.inputStringColumns.isEmpty() &&
-                this.decodeStringColumns.isEmpty();
+                this.decodeStringColumns.isEmpty() && this.inProgressStringAggregations.isEmpty() &&
+                this.finalizingStringAggregations.isEmpty();
     }
 
     public void addChildInfo(DecodeInfo other) {
         this.outputStringColumns.union(other.outputStringColumns);
+        this.inProgressStringAggregations.union(other.inProgressStringAggregations);
     }
 
     @Override
     public String toString() {
         return "input[" + inputStringColumns + "], " + "decode[" + decodeStringColumns + "], " + "output[" +
-                outputStringColumns + ']';
+                outputStringColumns + "]," + " inProgressAgreegations[" + inProgressStringAggregations + "]" +
+                " finalizingAgreegations[" + finalizingStringAggregations + "]";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -134,6 +134,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
 
         fragmentUsedDictExprs.union(decodeInfo.outputStringColumns);
         fragmentUsedDictExprs.union(decodeInfo.usedStringColumns);
+        fragmentUsedDictExprs.union(decodeInfo.inProgressStringAggregations);
+        fragmentUsedDictExprs.union(decodeInfo.finalizingStringAggregations);
         ColumnRefSet childFragmentUsedDictExpr = optExpression.getOp() instanceof PhysicalDistributionOperator ?
                 new ColumnRefSet() : fragmentUsedDictExprs;
 
@@ -152,7 +154,9 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             optExpression.setChild(i, child);
         }
         // some string column need rewrite
-        boolean hasDictInput = !decodeInfo.inputStringColumns.isEmpty();
+        boolean hasDictInput = !decodeInfo.inputStringColumns.isEmpty()
+                || !decodeInfo.inProgressStringAggregations.isEmpty()
+                || !decodeInfo.finalizingStringAggregations.isEmpty();
         boolean hasDictOutput = !decodeInfo.outputStringColumns.isEmpty();
 
         if (hasDictInput || hasDictOutput) {
@@ -488,6 +492,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         Map<Integer, ColumnDict> dictMap = Maps.newHashMap();
         ColumnRefSet inputColumns = new ColumnRefSet();
         inputColumns.union(info.inputStringColumns);
+        inputColumns.union(info.inProgressStringAggregations);
+        inputColumns.union(info.finalizingStringAggregations);
         info.inputStringColumns.getStream()
                 .map(factory::getColumnRef)
                 .filter(c -> c.getType().isStructType())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -14,8 +14,11 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.utframe.StarRocksAssert;
+import mockit.Expectations;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -650,5 +653,58 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  aggregate: array_agg[([3: ARRAY_VARCHAR_COL, ARRAY<VARCHAR(40)>, true]); args: INVALID_TYPE; " +
                 "result: struct<`col1` array<array<varchar(40)>>>; args nullable: true; result nullable: true]\n" +
                 "  |  cardinality: 1"), plan);
+    }
+
+    @Test
+    public void testArrayAggNonLowCardStringInput() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='2') */
+                ARRAY_AGG(VARCHAR_COL ORDER BY VARCHAR_COL2)
+                FROM T JOIN T2 ON (KEY_COL = KEY_COL2)
+                """;
+
+        IDictManager dictManager = IDictManager.getInstance();
+        new Expectations(dictManager) {
+            {
+                dictManager.hasGlobalDict(anyLong, ColumnId.create("VARCHAR_COL"), anyLong);
+                result = false;
+            }
+        };
+
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("7:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([9: array_agg, struct<`col1` array<varchar(25)>, `col2` array<int(11)>>, " +
+                "true]); args: VARCHAR,INT; result: ARRAY<VARCHAR(25)>; args nullable: true; result nullable: " +
+                "true]"), plan);
+    }
+
+    @Test
+    public void testDecodeInMiddle() throws Exception {
+        String sql = """ 
+                SELECT
+                GROUP_CONCAT(DISTINCT VARCHAR_COL), ARRAY_AGG(KEY_COL ORDER BY VARCHAR_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  aggregate: array_agg[([1: KEY_COL, INT, false], [2: VARCHAR_COL, VARCHAR, true]); " +
+                "args: INT,VARCHAR; result: struct<`col1` array<int(11)>, `col2` array<varchar(25)>>; " +
+                "args nullable: true; result nullable: true]\n" +
+                "  |  group by: [2: VARCHAR_COL, VARCHAR, true]"), plan);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge serialize)\n" +
+                "  |  aggregate: array_agg[([6: array_agg, struct<`col1` array<int(11)>, `col2` array<varchar(25)>>, " +
+                "true]); args: INT,VARCHAR; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  group by: [2: VARCHAR_COL, VARCHAR, true]"), plan);
+        Assertions.assertTrue(plan.contains("4:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: group_concat[([2: VARCHAR_COL, VARCHAR, true], ','); args: VARCHAR,VARCHAR; result: " +
+                "struct<`col1` array<varchar>, `col2` array<varchar>>; args nullable: true; result nullable: true], " +
+                "array_agg[([6: array_agg, ARRAY<INT>, true]); args: INT,VARCHAR; result: struct<`col1` array<int(11)>," +
+                " `col2` array<varchar(25)>>; args nullable: true; result nullable: true]\n"), plan);
+        Assertions.assertTrue(plan.contains("6:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: group_concat[([5: group_concat, struct<`col1` array<varchar>, `col2` array<varchar>>, " +
+                "true], ','); args: VARCHAR,VARCHAR; result: VARCHAR; args nullable: true; result nullable: true], " +
+                "array_agg[([6: array_agg, struct<`col1` array<int(11)>, `col2` array<varchar(25)>>, true]); args: " +
+                "INT,VARCHAR; result: ARRAY<INT>; args nullable: true; result nullable: true]\n"), plan);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, the dictification framework uses the same logic to decide both whether an aggregate should be rewritten and whether its output should be dictified. This overlapping logic can cause bugs in aggregates with multiple inputs, such as `ARRAY_AGG(NON_LOW_CARD_COLUMN ORDER BY LOW_CARD_COLUMN)`. This PR decouples these two pieces of logic.

## What I'm doing:
* Added new fields to `DecodeInfo` to distinguish between string output columns and the specific aggregations being processed.
* Centralized the decision logic for whether an aggregate output is low-cardinality into `checkDependsOnExpr()`, making it the single source of truth for this behavior across the entire framework.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
