### PR TITLE
[BugFix] Reject non-sortable (JSON) columns as rollup key columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -592,7 +592,9 @@ public class MaterializedViewHandler extends AlterHandler {
                         }
                         break;
                     }
-                    if (column.getType().isFloatingPointType() || column.getType().isComplexType()) {
+                    if (!column.getType().canDistributedBy()) {
+                        // JSON and other non-sortable types must not become rollup sort-key
+                        // columns (mirrors base-table key derivation in CreateTableAnalyzer).
                         break;
                     }
                     if (column.getType().isVarchar()) {
@@ -656,6 +658,12 @@ public class MaterializedViewHandler extends AlterHandler {
 
                     Column oneColumn = new Column(baseColumn);
                     if (isKey) {
+                        if (!baseColumn.getType().canDistributedBy()) {
+                            // JSON and other non-sortable types cannot be rollup key columns
+                            // (mirrors base-table key validation in ColumnDefAnalyzer).
+                            throw new DdlException(String.format(
+                                    "Invalid data type of key column '%s': '%s'", rollupColName, baseColumn.getType()));
+                        }
                         hasKey = true;
                         oneColumn.setIsKey(true);
                         oneColumn.setAggregationType(null, false);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerTest.java
@@ -42,11 +42,13 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.MVColumnItem;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.JsonType;
 import com.starrocks.type.VarcharType;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -282,6 +284,72 @@ public class MaterializedViewHandlerTest {
             Assertions.assertEquals(null, newMVColumn.getAggregationType());
             Assertions.assertEquals(false, newMVColumn.isAggregationTypeImplicit());
             Assertions.assertTrue(newMVColumn.getType().isVarchar());
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRollupRejectsJsonKeyColumn(@Injectable OlapTable olapTable, @Injectable Database db) {
+        // Explicit DUPLICATE KEY listing a JSON column must be rejected, mirroring
+        // base-table key validation. Otherwise the JSON column becomes a rollup sort
+        // key and the BE crashes while building the sort-key tuple.
+        final long baseIndexMetaId = 1L;
+        final String rollupName = "r_json_key";
+        Column idColumn = new Column("id", IntegerType.BIGINT, true, AggregateType.NONE, "", "");
+        Column jsonColumn = new Column("j", JsonType.JSON, false, AggregateType.NONE, "", "");
+        AddRollupClause addRollupClause = new AddRollupClause(rollupName,
+                Lists.newArrayList("id", "j"), Lists.newArrayList("id", "j"), null, null);
+        new Expectations() {
+            {
+                olapTable.hasMaterializedIndex(rollupName);
+                result = false;
+                olapTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                olapTable.getSchemaByIndexMetaId(baseIndexMetaId);
+                result = Lists.newArrayList(idColumn, jsonColumn);
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
+                    addRollupClause, olapTable, baseIndexMetaId);
+            Assertions.fail("expected DdlException for JSON key column");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("Invalid data type of key column 'j'"),
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRollupDemotesJsonToValueColumn(@Injectable OlapTable olapTable, @Injectable Database db) {
+        // Auto key derivation (no explicit DUPLICATE KEY) must stop promoting keys at a
+        // non-sortable type, so the JSON column is added as a value column rather than a key.
+        final long baseIndexMetaId = 1L;
+        final String rollupName = "r_json_value";
+        Column idColumn = new Column("id", IntegerType.BIGINT, true, AggregateType.NONE, "", "");
+        Column jsonColumn = new Column("j", JsonType.JSON, false, AggregateType.NONE, "", "");
+        AddRollupClause addRollupClause = new AddRollupClause(rollupName,
+                Lists.newArrayList("id", "j"), null, null, null);
+        new Expectations() {
+            {
+                olapTable.hasMaterializedIndex(rollupName);
+                result = false;
+                olapTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                olapTable.getSchemaByIndexMetaId(baseIndexMetaId);
+                result = Lists.newArrayList(idColumn, jsonColumn);
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        try {
+            List<Column> rollupSchema = Deencapsulation.invoke(materializedViewHandler,
+                    "checkAndPrepareMaterializedView", addRollupClause, olapTable, baseIndexMetaId);
+            Assertions.assertEquals(2, rollupSchema.size());
+            Column idResult = rollupSchema.stream().filter(c -> c.getName().equals("id")).findFirst().orElseThrow();
+            Column jsonResult = rollupSchema.stream().filter(c -> c.getName().equals("j")).findFirst().orElseThrow();
+            Assertions.assertTrue(idResult.isKey());
+            Assertions.assertFalse(jsonResult.isKey(), "JSON column must not be a rollup key");
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }


### PR DESCRIPTION
DUP_KEYS rollup key derivation in MaterializedViewHandler used an ad-hoc
guard (isFloatingPointType || isComplexType) that missed JSON, metric,
variant, and function types. When a JSON column became a rollup sort-key,
BE SchemaChangeWithSorting::process crashed with SIGSEGV @0x20 in
build_variant_tuple_from_chunk_row, which cannot construct a sort-key
datum from a JSON value.

Fix two paths in checkAndPrepareMaterializedView:
- Path 1 (auto key derivation): replace the ad-hoc guard with !canDistributedBy(), mirroring CreateTableAnalyzer key derivation. Non-sortable columns are silently demoted to value columns.
- Path 2 (explicit DUPLICATE KEY): reject non-sortable key columns with the same error message as base-table validation (ColumnDefAnalyzer), so rollup can never produce a key schema the base table itself rejects.

Verified: before fix — SIGSEGV on ADD ROLLUP r(id,j); after fix — FINISHED, BE alive. Both DUP/AGG/UNIQUE table models, inline ROLLUP, explicit DUPLICATE KEY, large datasets (20k rows × 8 buckets), and JSON-as-first-column edge cases tested. 110+ FE unit tests pass, checkstyle clean.

Fixes #74757

## Why I'm doing:

JSON columns cannot be sort/key columns in StarRocks, but the DUP_KEYS
rollup key derivation path silently promoted JSON to a sort key, causing
BE SIGSEGV. The failed alter task is also persisted in the edit log, so
every BE restart re-dispatches the same task and crashes the BE again —
a permanent crash loop until the job is manually cancelled. Tracked in #74757.

## What I'm doing:

Fixes #74757

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
