### PR TITLE
[Refactor] Decouple FragmentContext from stream load cleanup

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -43,13 +43,11 @@
 #include "exec/pipeline/schedule/timeout_tasks.h"
 #include "exec/runtime/query_runtime_state.h"
 #include "platform/thrift_rpc_helper.h"
-#include "runtime/batch_write/batch_write_mgr.h"
 #include "runtime/exec_env.h"
+#include "runtime/fragment_attachment.h"
 #include "runtime/global_dict/fragment_dict_state.h"
 #include "runtime/logconfig.h"
 #include "runtime/runtime_state_helper.h"
-#include "runtime/stream_load/stream_load_context.h"
-#include "runtime/stream_load/transaction_mgr.h"
 
 namespace starrocks::pipeline {
 
@@ -91,7 +89,7 @@ private:
 FragmentContext::FragmentContext() : _data_sink(nullptr), _fragment_dict_state(std::make_unique<FragmentDictState>()) {}
 
 FragmentContext::~FragmentContext() {
-    _close_stream_load_contexts();
+    _close_fragment_attachments();
     _data_sink.reset();
     _fragment_runtime_state.runtime_filter_hub()->close_all_in_filters(_runtime_state.get());
     close_all_execution_groups();
@@ -319,9 +317,9 @@ void FragmentContext::set_final_status(const Status& status) {
             }
         });
 
-        for (const auto& stream_load_context : _stream_load_contexts) {
-            if (stream_load_context->body_sink) {
-                stream_load_context->body_sink->cancel(s_status);
+        for (const auto& attachment : _fragment_attachments) {
+            if (attachment != nullptr) {
+                attachment->cancel(s_status);
             }
         }
     }
@@ -348,8 +346,8 @@ void FragmentContext::_set_default_workgroup() {
     set_workgroup(ExecEnv::GetInstance()->workgroup_manager()->get_default_workgroup());
 }
 
-void FragmentContext::set_stream_load_contexts(const std::vector<StreamLoadContext*>& contexts) {
-    _stream_load_contexts = contexts;
+void FragmentContext::set_fragment_attachments(std::vector<std::unique_ptr<FragmentAttachment>>&& attachments) {
+    _fragment_attachments = std::move(attachments);
 }
 
 // Note: this function should be thread safe
@@ -514,15 +512,14 @@ void FragmentContext::acquire_runtime_filters() {
     iterate_pipeline([this](Pipeline* pipeline) { pipeline->acquire_runtime_filter(this->runtime_state()); });
 }
 
-void FragmentContext::_close_stream_load_contexts() {
-    for (const auto& context : _stream_load_contexts) {
-        context->body_sink->cancel(Status::Cancelled("Close the stream load pipe"));
-        if (context->enable_batch_write) {
-            runtime_services(_runtime_state.get()).batch_write_mgr->unregister_stream_load_pipe(context);
-        } else {
-            runtime_services(_runtime_state.get()).stream_context_mgr->remove_channel_context(context);
+void FragmentContext::_close_fragment_attachments() {
+    const auto status = Status::Cancelled("Close the stream load pipe");
+    for (const auto& attachment : _fragment_attachments) {
+        if (attachment != nullptr) {
+            attachment->close(status);
         }
     }
+    _fragment_attachments.clear();
 }
 
 void FragmentContext::init_event_scheduler() {

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -50,7 +50,7 @@
 
 namespace starrocks {
 
-class StreamLoadContext;
+class FragmentAttachment;
 class FragmentDictState;
 
 namespace pipeline {
@@ -143,7 +143,7 @@ public:
 
     bool enable_cache() const { return _fragment_runtime_state.enable_cache(); }
 
-    void set_stream_load_contexts(const std::vector<StreamLoadContext*>& contexts);
+    void set_fragment_attachments(std::vector<std::unique_ptr<FragmentAttachment>>&& attachments);
 
     void set_enable_adaptive_dop(bool val) { _fragment_runtime_state.set_enable_adaptive_dop(val); }
     bool enable_adaptive_dop() const { return _fragment_runtime_state.enable_adaptive_dop(); }
@@ -189,7 +189,7 @@ public:
 
 private:
     void _set_default_workgroup();
-    void _close_stream_load_contexts();
+    void _close_fragment_attachments();
 
     bool _enable_group_execution = false;
     // Id of this query
@@ -228,7 +228,7 @@ private:
     std::unique_ptr<PassThroughChunkBufferGuard> _pass_through_chunk_buffer_guard;
 
     query_cache::CacheParam _cache_param;
-    std::vector<StreamLoadContext*> _stream_load_contexts;
+    std::vector<std::unique_ptr<FragmentAttachment>> _fragment_attachments;
 
     AdaptiveDopParam _adaptive_dop_param;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -66,6 +66,7 @@
 #include "runtime/global_dict/fragment_dict_state.h"
 #include "runtime/runtime_state_helper.h"
 #include "runtime/stream_load/stream_load_context.h"
+#include "runtime/stream_load/stream_load_context_handle.h"
 #include "runtime/stream_load/transaction_mgr.h"
 
 namespace starrocks::pipeline {
@@ -658,17 +659,15 @@ Status FragmentExecutor::_prepare_stream_load_pipe(ExecEnv* exec_env, const Unif
     if (!iter2->second[0].scan_range.broker_scan_range.__isset.channel_id) {
         return Status::OK();
     }
-    std::vector<StreamLoadContext*> stream_load_contexts;
+    std::vector<std::unique_ptr<FragmentAttachment>> fragment_attachments;
 
     bool success = false;
     DeferOp defer_op([&] {
         if (!success) {
-            for (auto& ctx : stream_load_contexts) {
-                ctx->body_sink->cancel(Status::Cancelled("Failed to prepare stream load pipe"));
-                if (ctx->enable_batch_write) {
-                    exec_env->batch_write_mgr()->unregister_stream_load_pipe(ctx);
-                } else {
-                    exec_env->stream_context_mgr()->remove_channel_context(ctx);
+            const auto status = Status::Cancelled("Failed to prepare stream load pipe");
+            for (const auto& attachment : fragment_attachments) {
+                if (attachment != nullptr) {
+                    attachment->close(status);
                 }
             }
         }
@@ -693,6 +692,8 @@ Status FragmentExecutor::_prepare_stream_load_pipe(ExecEnv* exec_env, const Unif
                                                   exec_env, exec_env->batch_write_mgr(), db_name, table_name,
                                                   broker_scan_range.batch_write_parameters, label, txn_id, load_id,
                                                   broker_scan_range.batch_write_interval_ms));
+                    fragment_attachments.emplace_back(
+                            std::make_unique<StreamLoadContextHandle>(ctx, exec_env->batch_write_mgr()));
                 } else {
                     RETURN_IF_ERROR(exec_env->stream_context_mgr()->create_channel_context(
                             exec_env, label, channel_id, db_name, table_name, format, ctx, load_id, txn_id));
@@ -703,14 +704,15 @@ Status FragmentExecutor::_prepare_stream_load_pipe(ExecEnv* exec_env, const Unif
                     });
                     RETURN_IF_ERROR(
                             exec_env->stream_context_mgr()->put_channel_context(label, table_name, channel_id, ctx));
+                    fragment_attachments.emplace_back(
+                            std::make_unique<StreamLoadContextHandle>(ctx, exec_env->stream_context_mgr()));
                 }
-                stream_load_contexts.push_back(ctx);
             }
         }
     }
 
     success = true;
-    _fragment_ctx->set_stream_load_contexts(stream_load_contexts);
+    _fragment_ctx->set_fragment_attachments(std::move(fragment_attachments));
     return Status::OK();
 }
 

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -100,6 +100,7 @@ set(RUNTIME_FILES
     local_tablets_channel.cpp
     snapshot_loader.cpp
     message_body_sink.cpp
+    stream_load/stream_load_context_handle.cpp
     stream_load/transaction_mgr.cpp
     stream_load/stream_load_context.cpp
     stream_load/stream_load_executor.cpp

--- a/be/src/runtime/fragment_attachment.h
+++ b/be/src/runtime/fragment_attachment.h
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/status.h"
+
+namespace starrocks {
+
+class FragmentAttachment {
+public:
+    virtual ~FragmentAttachment() = default;
+
+    virtual void cancel(const Status& status) = 0;
+    virtual void close(const Status& status) = 0;
+};
+
+} // namespace starrocks

--- a/be/src/runtime/stream_load/stream_load_context_handle.cpp
+++ b/be/src/runtime/stream_load/stream_load_context_handle.cpp
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/stream_load/stream_load_context_handle.h"
+
+#include "runtime/batch_write/batch_write_mgr.h"
+#include "runtime/message_body_sink.h"
+#include "runtime/stream_load/stream_load_context.h"
+#include "runtime/stream_load/transaction_mgr.h"
+
+namespace starrocks {
+
+StreamLoadContextHandle::StreamLoadContextHandle(StreamLoadContext* context, BatchWriteMgr* batch_write_mgr)
+        : _context(context), _batch_write_mgr(batch_write_mgr) {}
+
+StreamLoadContextHandle::StreamLoadContextHandle(StreamLoadContext* context, StreamContextMgr* stream_context_mgr)
+        : _context(context), _stream_context_mgr(stream_context_mgr) {}
+
+StreamLoadContextHandle::~StreamLoadContextHandle() {
+    close(Status::Cancelled("Close the stream load pipe"));
+}
+
+void StreamLoadContextHandle::cancel(const Status& status) {
+    if (_context == nullptr || _context->body_sink == nullptr) {
+        return;
+    }
+    _context->body_sink->cancel(status);
+}
+
+void StreamLoadContextHandle::close(const Status& status) {
+    if (_closed) {
+        return;
+    }
+    _closed = true;
+
+    if (_context == nullptr) {
+        return;
+    }
+
+    cancel(status);
+    if (_batch_write_mgr != nullptr) {
+        _batch_write_mgr->unregister_stream_load_pipe(_context);
+    } else if (_stream_context_mgr != nullptr) {
+        _stream_context_mgr->remove_channel_context(_context);
+    }
+    _context = nullptr;
+}
+
+} // namespace starrocks

--- a/be/src/runtime/stream_load/stream_load_context_handle.h
+++ b/be/src/runtime/stream_load/stream_load_context_handle.h
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "runtime/fragment_attachment.h"
+
+namespace starrocks {
+
+class BatchWriteMgr;
+class StreamContextMgr;
+class StreamLoadContext;
+
+class StreamLoadContextHandle final : public FragmentAttachment {
+public:
+    StreamLoadContextHandle(StreamLoadContext* context, BatchWriteMgr* batch_write_mgr);
+    StreamLoadContextHandle(StreamLoadContext* context, StreamContextMgr* stream_context_mgr);
+    ~StreamLoadContextHandle() override;
+
+    StreamLoadContextHandle(const StreamLoadContextHandle&) = delete;
+    StreamLoadContextHandle& operator=(const StreamLoadContextHandle&) = delete;
+    StreamLoadContextHandle(StreamLoadContextHandle&&) = delete;
+    StreamLoadContextHandle& operator=(StreamLoadContextHandle&&) = delete;
+
+    void cancel(const Status& status) override;
+    void close(const Status& status) override;
+
+private:
+    StreamLoadContext* _context = nullptr;
+    BatchWriteMgr* _batch_write_mgr = nullptr;
+    StreamContextMgr* _stream_context_mgr = nullptr;
+    bool _closed = false;
+};
+
+} // namespace starrocks

--- a/be/test/runtime/batch_write/batch_write_mgr_test.cpp
+++ b/be/test/runtime/batch_write/batch_write_mgr_test.cpp
@@ -29,6 +29,7 @@
 #include "http/http_headers.h"
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/stream_load_context.h"
+#include "runtime/stream_load/stream_load_context_handle.h"
 #include "runtime/stream_load/time_bounded_stream_load_pipe.h"
 
 namespace starrocks {
@@ -129,6 +130,30 @@ TEST_F(BatchWriteMgrTest, register_and_unregister_pipe) {
         auto batch_write = status_or_batch_write.value();
         ASSERT_FALSE(batch_write->contain_pipe(ctx));
     }
+}
+
+TEST_F(BatchWriteMgrTest, stream_load_context_handle_cancel_and_close_batch_write_pipe) {
+    BatchWriteId batch_write_id{.db = "db", .table = "table", .load_params = {{"k", "v"}}};
+    auto status_or_ctx = BatchWriteMgr::create_and_register_pipe(_exec_env, _batch_write_mgr.get(), batch_write_id.db,
+                                                                 batch_write_id.table, batch_write_id.load_params,
+                                                                 "label", 1, generate_uuid(), 10000);
+    ASSERT_OK(status_or_ctx.status());
+    StreamLoadContext* ctx = status_or_ctx.value();
+
+    auto status_or_batch_write = _batch_write_mgr->get_batch_write(batch_write_id);
+    ASSERT_OK(status_or_batch_write.status());
+    auto batch_write = status_or_batch_write.value();
+    ASSERT_TRUE(batch_write->contain_pipe(ctx));
+
+    StreamLoadContextHandle handle(ctx, _batch_write_mgr.get());
+    handle.cancel(Status::Cancelled("cancel only"));
+    ASSERT_TRUE(batch_write->contain_pipe(ctx));
+
+    handle.close(Status::Cancelled("close"));
+    ASSERT_FALSE(batch_write->contain_pipe(ctx));
+
+    handle.close(Status::Cancelled("close again"));
+    ASSERT_FALSE(batch_write->contain_pipe(ctx));
 }
 
 TEST_F(BatchWriteMgrTest, append_data) {

--- a/be/test/runtime/stream_load/stream_load_context_test.cpp
+++ b/be/test/runtime/stream_load/stream_load_context_test.cpp
@@ -16,9 +16,31 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
+#include "base/testutil/assert.h"
+#include "base/uid_util.h"
+#include "base/utility/defer_op.h"
 #include "runtime/exec_env.h"
+#include "runtime/message_body_sink.h"
+#include "runtime/stream_load/stream_load_context_handle.h"
+#include "runtime/stream_load/transaction_mgr.h"
 
 namespace starrocks {
+
+class CountingBodySink final : public MessageBodySink {
+public:
+    Status append(const char* /*data*/, size_t /*size*/) override { return Status::OK(); }
+    Status append(ByteBufferPtr&& /*buf*/) override { return Status::OK(); }
+
+    void cancel(const Status& status) override {
+        ++cancel_count;
+        last_status = status;
+    }
+
+    int cancel_count = 0;
+    Status last_status;
+};
 
 class StreamLoadContextTest : public testing::Test {
 public:
@@ -79,6 +101,39 @@ TEST_F(StreamLoadContextTest, calc_put_and_commit_rpc_timeout_ms) {
         EXPECT_EQ(tc.expected_rpc_timeout_ms, result) << "Failed for timeout_second=" << tc.timeout_second;
         EXPECT_EQ(original_timeout_second, ctx.timeout_second) << "Method should not modify timeout_second";
     }
+}
+
+TEST_F(StreamLoadContextTest, stream_load_context_handle_cancel_and_close_channel_context) {
+    StreamContextMgr stream_context_mgr;
+    StreamLoadContext* ctx = nullptr;
+    const std::string label = "stream_load_context_handle_label";
+    const std::string db = "db";
+    const std::string table = "table";
+    const int channel_id = 7;
+    const TUniqueId load_id = UniqueId::gen_uid().to_thrift();
+
+    ASSERT_OK(stream_context_mgr.create_channel_context(_exec_env, label, channel_id, db, table,
+                                                        TFileFormatType::FORMAT_CSV_PLAIN, ctx, load_id, 123));
+    DeferOp release_ctx([&] { StreamLoadContext::release(ctx); });
+
+    auto sink = std::make_shared<CountingBodySink>();
+    ctx->body_sink = sink;
+    ASSERT_OK(stream_context_mgr.put_channel_context(label, table, channel_id, ctx));
+
+    StreamLoadContextHandle handle(ctx, &stream_context_mgr);
+    handle.cancel(Status::Cancelled("cancel only"));
+    EXPECT_EQ(1, sink->cancel_count);
+
+    auto* fetched = stream_context_mgr.get_channel_context(label, table, channel_id);
+    ASSERT_NE(nullptr, fetched);
+    StreamLoadContext::release(fetched);
+
+    handle.close(Status::Cancelled("close"));
+    EXPECT_EQ(2, sink->cancel_count);
+    EXPECT_EQ(nullptr, stream_context_mgr.get_channel_context(label, table, channel_id));
+
+    handle.close(Status::Cancelled("close again"));
+    EXPECT_EQ(2, sink->cancel_count);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
