### PR TITLE
[BugFix] Use scan.tag-name for Paimon tag time travel

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -136,8 +136,8 @@ public class PaimonMetadata implements ConnectorMetadata {
     private final ConnectorProperties properties;
     private final Map<Identifier, Map<String, Partition>> partitionInfos = new ConcurrentHashMap<>();
     private final ThreadLocal<String> branch = ThreadLocal.withInitial(() -> DEFAULT_MAIN_BRANCH);
-    // Carries the tag name from version parsing to getRemoteFiles, same pattern as `branch`.
-    private final ThreadLocal<String> scanTag = ThreadLocal.withInitial(() -> null);
+    // Resolved tag name, keyed by "tableName#snapshotId" (snapshot ids are per-table, not global).
+    private final Map<String, String> scanTags = new ConcurrentHashMap<>();
 
     public PaimonMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, Catalog paimonNativeCatalog,
                           ConnectorProperties properties) {
@@ -377,7 +377,12 @@ public class PaimonMetadata implements ConnectorMetadata {
         view.setComment(comment);
         return view;
     }
-
+    
+    @Override
+    public void clear() {
+        scanTags.clear();
+    }
+    
     @Override
     public TvrVersionRange getTableVersionRange(String dbName, Table table,
                                                 Optional<ConnectorTableVersion> startVersion,
@@ -482,12 +487,12 @@ public class PaimonMetadata implements ConnectorMetadata {
                         throw new StarRocksConnectorException("%s does not include tag: %s",
                                 table.fullName(), refNameParts[1]);
                     }
-                    scanTag.set(refNameParts[1]);
                     snapshotId = tagManager.tagObjects().stream()
                             .filter(p -> p.getValue().equals(refNameParts[1]))
                             .map(p -> p.getKey().id())
                             .findFirst()
                             .get();
+                    scanTags.put(table.fullName() + "#" + snapshotId, refNameParts[1]);
                 }
             } else {
                 throw new StarRocksConnectorException("Please input correct format like branch:branch_name or tag:tag_name");
@@ -623,8 +628,8 @@ public class PaimonMetadata implements ConnectorMetadata {
         snapshotId = tvrVersionRange.end().isPresent() ? tvrVersionRange.end().get() : -1L;
 
         Map<String, String> options = new HashMap<>();
-        String currentTag = scanTag.get();
-        scanTag.remove();
+        String currentTag = scanTags.get(
+                paimonTable.getCatalogDBName() + "." + paimonTable.getCatalogTableName() + "#" + snapshotId);
         boolean isDeltaScan = tvrVersionRange.start().isPresent() && tvrVersionRange.end().isPresent();
         if (currentTag != null && !isDeltaScan) {
             // Use scan.tag-name: tags survive snapshot expiration, scan.snapshot-id does not.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -136,6 +136,8 @@ public class PaimonMetadata implements ConnectorMetadata {
     private final ConnectorProperties properties;
     private final Map<Identifier, Map<String, Partition>> partitionInfos = new ConcurrentHashMap<>();
     private final ThreadLocal<String> branch = ThreadLocal.withInitial(() -> DEFAULT_MAIN_BRANCH);
+    // Carries the tag name from version parsing to getRemoteFiles, same pattern as `branch`.
+    private final ThreadLocal<String> scanTag = ThreadLocal.withInitial(() -> null);
 
     public PaimonMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, Catalog paimonNativeCatalog,
                           ConnectorProperties properties) {
@@ -480,6 +482,7 @@ public class PaimonMetadata implements ConnectorMetadata {
                         throw new StarRocksConnectorException("%s does not include tag: %s",
                                 table.fullName(), refNameParts[1]);
                     }
+                    scanTag.set(refNameParts[1]);
                     snapshotId = tagManager.tagObjects().stream()
                             .filter(p -> p.getValue().equals(refNameParts[1]))
                             .map(p -> p.getKey().id())
@@ -620,7 +623,15 @@ public class PaimonMetadata implements ConnectorMetadata {
         snapshotId = tvrVersionRange.end().isPresent() ? tvrVersionRange.end().get() : -1L;
 
         Map<String, String> options = new HashMap<>();
-        options.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshotId));
+        String currentTag = scanTag.get();
+        scanTag.remove();
+        boolean isDeltaScan = tvrVersionRange.start().isPresent() && tvrVersionRange.end().isPresent();
+        if (currentTag != null && !isDeltaScan) {
+            // Use scan.tag-name: tags survive snapshot expiration, scan.snapshot-id does not.
+            options.put(CoreOptions.SCAN_TAG_NAME.key(), currentTag);
+        } else {
+            options.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshotId));
+        }
 
         org.apache.paimon.table.Table paimonNativeTable = getNativeTable(paimonTable.getNativeTable(),
                 tvrVersionRange).copy(options);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -87,6 +87,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CachingCatalog;
 import org.apache.paimon.catalog.Catalog;
@@ -125,6 +126,7 @@ import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.ManifestsTable;
 import org.apache.paimon.table.system.SnapshotsTable;
+import org.apache.paimon.tag.Tag;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BooleanType;
 import org.apache.paimon.types.CharType;
@@ -137,7 +139,9 @@ import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.SerializationUtils;
+import org.apache.paimon.utils.TagManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -162,6 +166,7 @@ import static org.apache.paimon.io.DataFileMeta.EMPTY_MAX_KEY;
 import static org.apache.paimon.io.DataFileMeta.EMPTY_MIN_KEY;
 import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1916,5 +1921,57 @@ public class PaimonMetadataTest {
             }
         };
         org.junit.jupiter.api.Assertions.assertThrows(DdlException.class, () -> metadata.dropTable(connectContext, dropStmt));
+    }
+    
+    @Test
+    public void testGetRemoteFilesWithTag(@Mocked FileStoreTable paimonNativeTable,
+                                          @Mocked ReadBuilder readBuilder,
+                                          @Mocked InnerTableScan scan,
+                                          @Mocked TagManager tagManager,
+                                          @Mocked Tag tag) throws Catalog.TableNotExistException {
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable((Identifier) any);
+                result = paimonNativeTable;
+                paimonNativeTable.tagManager();
+                result = tagManager;
+                tagManager.tagExists("20260610");
+                result = true;
+                tagManager.tagObjects();
+                result = Lists.newArrayList(Pair.of(tag, "20260610"));
+                tag.id();
+                result = 100L;
+                paimonNativeTable.newReadBuilder();
+                result = readBuilder;
+                readBuilder.withFilter((List<Predicate>) any).withProjection((int[]) any).newScan().plan().splits();
+                result = splits;
+                readBuilder.newScan();
+                result = scan;
+            }
+        };
+        PaimonTable paimonTable = (PaimonTable) metadata.getTable(connectContext, "db1", "tbl1");
+        // Parsing the tag version records the tag name in a ThreadLocal that getRemoteFiles reads.
+        long snapshotId = metadata.getSnapshotIdFromVersion(paimonTable.getNativeTable(),
+                new ConnectorTableVersion(PointerType.VERSION, ConstantOperator.createVarchar("tag:20260610")));
+        assertEquals(100L, snapshotId);
+
+        List<String> requiredNames = Lists.newArrayList("f2", "dt");
+        metadata.getRemoteFiles(paimonTable, GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames)
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId))).build());
+
+        new Verifications() {
+            {
+                List<Map<String, String>> capturedOptions = new ArrayList<>();
+                paimonNativeTable.copy(withCapture(capturedOptions));
+                // A tag read must scan via scan.tag-name (reads the snapshot copy under tag/),
+                // never via scan.snapshot-id, which fails once the snapshot expires.
+                boolean usesTagName = capturedOptions.stream()
+                        .anyMatch(opts -> "20260610".equals(opts.get(CoreOptions.SCAN_TAG_NAME.key())));
+                assertTrue(usesTagName, "tag read must inject scan.tag-name");
+                boolean usesSnapshotId = capturedOptions.stream()
+                        .anyMatch(opts -> opts.containsKey(CoreOptions.SCAN_SNAPSHOT_ID.key()));
+                assertFalse(usesSnapshotId, "tag read must not inject scan.snapshot-id");
+            }
+        };
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -1933,6 +1933,8 @@ public class PaimonMetadataTest {
             {
                 paimonNativeCatalog.getTable((Identifier) any);
                 result = paimonNativeTable;
+                paimonNativeTable.fullName();
+                result = "db1.tbl1";
                 paimonNativeTable.tagManager();
                 result = tagManager;
                 tagManager.tagExists("20260610");
@@ -1950,7 +1952,7 @@ public class PaimonMetadataTest {
             }
         };
         PaimonTable paimonTable = (PaimonTable) metadata.getTable(connectContext, "db1", "tbl1");
-        // Parsing the tag version records the tag name in a ThreadLocal that getRemoteFiles reads.
+        // Parsing the tag version records the tag name in scanTags that getRemoteFiles reads back.
         long snapshotId = metadata.getSnapshotIdFromVersion(paimonTable.getNativeTable(),
                 new ConnectorTableVersion(PointerType.VERSION, ConstantOperator.createVarchar("tag:20260610")));
         assertEquals(100L, snapshotId);
@@ -1971,6 +1973,160 @@ public class PaimonMetadataTest {
                 boolean usesSnapshotId = capturedOptions.stream()
                         .anyMatch(opts -> opts.containsKey(CoreOptions.SCAN_SNAPSHOT_ID.key()));
                 assertFalse(usesSnapshotId, "tag read must not inject scan.snapshot-id");
+            }
+        };
+    }
+    
+    @Test
+    public void testGetRemoteFilesWithTagMultipleTables(@Mocked FileStoreTable tableA,
+                                                        @Mocked FileStoreTable tableB,
+                                                        @Mocked ReadBuilder readBuilder,
+                                                        @Mocked InnerTableScan scan,
+                                                        @Mocked TagManager tagManagerA,
+                                                        @Mocked TagManager tagManagerB,
+                                                        @Mocked Tag tagA,
+                                                        @Mocked Tag tagB) throws Catalog.TableNotExistException {
+        // Two different tables, each read at its own tag, resolve to different snapshot ids.
+        // The tag of one table must not leak into the scan of the other (regression for the case
+        // where a single shared slot was overwritten by the last parsed table).
+        new Expectations() {
+            {
+                tableA.fullName();
+                result = "db1.tblA";
+                tableA.tagManager();
+                result = tagManagerA;
+                tagManagerA.tagExists("taga");
+                result = true;
+                tagManagerA.tagObjects();
+                result = Lists.newArrayList(Pair.of(tagA, "taga"));
+                tagA.id();
+                result = 100L;
+
+                tableB.fullName();
+                result = "db1.tblB";
+                tableB.tagManager();
+                result = tagManagerB;
+                tagManagerB.tagExists("tagb");
+                result = true;
+                tagManagerB.tagObjects();
+                result = Lists.newArrayList(Pair.of(tagB, "tagb"));
+                tagB.id();
+                result = 200L;
+
+                paimonNativeCatalog.getTable((Identifier) any);
+                result = tableA;
+                tableA.newReadBuilder();
+                result = readBuilder;
+                readBuilder.withFilter((List<Predicate>) any).withProjection((int[]) any).newScan().plan().splits();
+                result = splits;
+                readBuilder.newScan();
+                result = scan;
+            }
+        };
+        PaimonTable paimonTableA = (PaimonTable) metadata.getTable(connectContext, "db1", "tblA");
+
+        // Parse both tag versions first (as the planner does for all scans before reading files),
+        // so the single-slot bug would have left only the last table's tag behind.
+        long snapshotA = metadata.getSnapshotIdFromVersion(tableA,
+                new ConnectorTableVersion(PointerType.VERSION, ConstantOperator.createVarchar("tag:taga")));
+        long snapshotB = metadata.getSnapshotIdFromVersion(tableB,
+                new ConnectorTableVersion(PointerType.VERSION, ConstantOperator.createVarchar("tag:tagb")));
+        assertEquals(100L, snapshotA);
+        assertEquals(200L, snapshotB);
+
+        List<String> requiredNames = Lists.newArrayList("f2", "dt");
+        metadata.getRemoteFiles(paimonTableA, GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames)
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotA))).build());
+
+        new Verifications() {
+            {
+                List<Map<String, String>> capturedOptions = new ArrayList<>();
+                tableA.copy(withCapture(capturedOptions));
+                // tableA scan (snapshot 100) must use tagA, never tagB or scan.snapshot-id.
+                boolean usesTagA = capturedOptions.stream()
+                        .anyMatch(opts -> "taga".equals(opts.get(CoreOptions.SCAN_TAG_NAME.key())));
+                assertTrue(usesTagA, "tableA scan must use its own tag (tagA)");
+                boolean leakedTagB = capturedOptions.stream()
+                        .anyMatch(opts -> "tagb".equals(opts.get(CoreOptions.SCAN_TAG_NAME.key())));
+                assertFalse(leakedTagB, "tableB's tag must not leak into tableA scan");
+            }
+        };
+    }
+
+    @Test
+    public void testGetRemoteFilesWithTagSameSnapshotId(@Mocked FileStoreTable tableA,
+                                                        @Mocked FileStoreTable tableB,
+                                                        @Mocked ReadBuilder readBuilder,
+                                                        @Mocked InnerTableScan scan,
+                                                        @Mocked TagManager tagManagerA,
+                                                        @Mocked TagManager tagManagerB,
+                                                        @Mocked Tag tagA,
+                                                        @Mocked Tag tagB) throws Catalog.TableNotExistException {
+        // Two different tables read at their own tags that BOTH resolve to the same snapshot id (1).
+        // Paimon snapshot ids restart from 1 per table, so distinct tables routinely share an id.
+        // Keying the remembered tag on the snapshot id alone would let tableB's tag overwrite tableA's
+        // (a cross-join "tableA FOR VERSION AS OF 'tag:taga'" join "tableB FOR VERSION AS OF 'tag:tagb'"
+        // would then scan tableA with tagb and fail). The key must combine the table full name.
+        new Expectations() {
+            {
+                tableA.fullName();
+                result = "db1.tblA";
+                tableA.tagManager();
+                result = tagManagerA;
+                tagManagerA.tagExists("taga");
+                result = true;
+                tagManagerA.tagObjects();
+                result = Lists.newArrayList(Pair.of(tagA, "taga"));
+                tagA.id();
+                result = 1L;
+
+                tableB.fullName();
+                result = "db1.tblB";
+                tableB.tagManager();
+                result = tagManagerB;
+                tagManagerB.tagExists("tagb");
+                result = true;
+                tagManagerB.tagObjects();
+                result = Lists.newArrayList(Pair.of(tagB, "tagb"));
+                tagB.id();
+                result = 1L;
+
+                paimonNativeCatalog.getTable((Identifier) any);
+                result = tableA;
+                tableA.newReadBuilder();
+                result = readBuilder;
+                readBuilder.withFilter((List<Predicate>) any).withProjection((int[]) any).newScan().plan().splits();
+                result = splits;
+                readBuilder.newScan();
+                result = scan;
+            }
+        };
+        PaimonTable paimonTableA = (PaimonTable) metadata.getTable(connectContext, "db1", "tblA");
+
+        // Parse both tag versions first; with the snapshot-id-only key the second parse (tableB)
+        // would clobber tableA's entry, since both resolve to snapshot 1.
+        long snapshotA = metadata.getSnapshotIdFromVersion(tableA,
+                new ConnectorTableVersion(PointerType.VERSION, ConstantOperator.createVarchar("tag:taga")));
+        long snapshotB = metadata.getSnapshotIdFromVersion(tableB,
+                new ConnectorTableVersion(PointerType.VERSION, ConstantOperator.createVarchar("tag:tagb")));
+        assertEquals(1L, snapshotA);
+        assertEquals(1L, snapshotB);
+
+        List<String> requiredNames = Lists.newArrayList("f2", "dt");
+        metadata.getRemoteFiles(paimonTableA, GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames)
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotA))).build());
+
+        new Verifications() {
+            {
+                List<Map<String, String>> capturedOptions = new ArrayList<>();
+                tableA.copy(withCapture(capturedOptions));
+                // tableA scan must use its own tag (taga), even though tableB shares snapshot id 1.
+                boolean usesTagA = capturedOptions.stream()
+                        .anyMatch(opts -> "taga".equals(opts.get(CoreOptions.SCAN_TAG_NAME.key())));
+                assertTrue(usesTagA, "tableA scan must use its own tag (taga)");
+                boolean leakedTagB = capturedOptions.stream()
+                        .anyMatch(opts -> "tagb".equals(opts.get(CoreOptions.SCAN_TAG_NAME.key())));
+                assertFalse(leakedTagB, "tableB's tag must not leak into tableA scan despite shared snapshot id");
             }
         };
     }


### PR DESCRIPTION
## Why I'm doing:

`FOR VERSION AS OF 'tag:<name>'` on a Paimon catalog fails once the tagged snapshot has expired, even though the tag still exists and its data files are retained:

```
ERROR 1064 (HY000): The specified scan snapshotId 208205 is out of available snapshotId range [210257, 210562].
```

`PaimonMetadata` resolves the tag to a snapshot id and scans through `CoreOptions.SCAN_SNAPSHOT_ID`. When snapshot expiration removes that snapshot from the `snapshot/` directory, the scan can no longer find it — but Paimon keeps a copy of the snapshot metadata under `tag/<name>` and keeps the tagged data files alive. Paimon's own engines read a tag via `CoreOptions.SCAN_TAG_NAME` (`StaticFromTagStartingScanner`), which has no snapshot-range check and therefore keeps working after expiration. Flattening the tag to a snapshot id defeats the purpose of the tag and makes daily tags effectively unreadable, since their snapshots expire well before the tag is queried.

## What I'm doing:

Fixes #74777 

Carry the tag name from version parsing to `getRemoteFiles` using a  `ThreadLocal<String>` (the same pattern already used for `branch`), and inject `scan.tag-name` instead of `scan.snapshot-id` for single-snapshot tag reads. Delta (`incremental-between`) scans and all non-tag reads keep using `scan.snapshot-id`, so existing behavior is unchanged.

Verified against a Kerberized HDFS Paimon warehouse: a tag whose snapshot had already expired now reads correctly, and reads of different daily tags return distinct, monotonically increasing row counts (each tag resolves to its own snapshot). Added a unit test asserting that a tag read injects `scan.tag-name` and never `scan.snapshot-id`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: `FOR VERSION AS OF 'tag:<name>'` now reads tags whose snapshots have expired, instead of failing.
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
