### PR TITLE
[BugFix] Stop vector index rewrite from polluting the shared table schema

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteToVectorPlanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteToVectorPlanRule.java
@@ -169,10 +169,15 @@ public class RewriteToVectorPlanRule extends TransformationRule {
                                                      ScalarOperator newPredicate,
                                                      VectorFuncInfo info,
                                                      VectorSearchOptions opts) {
-        // Add index distanceColumn to the scan operator, including table, colRefToColumnMetaMap, and columnMetaToColRefMap.
+        // The distance column is per-query synthetic state: it only needs to live in the scan operator's
+        // colRef maps below (PlanFragmentBuilder builds the scan slot's Column from colRefToColumnMetaMap).
+        // It must NOT be added to the shared catalog table's fullSchema. Table.addColumn appends to
+        // fullSchema (a List that does not dedup) while only nameToColumn dedups, so adding it here
+        // appended a duplicate "__vector_*" column on every vector query that planned on the live table
+        // (the whole-phase-lock path). Once two duplicates accumulated, building the Column-keyed map in
+        // RelationTransformer threw "Multiple entries with same key" for any later statement on the table.
         String distanceColumnName = scanOp.getVectorSearchOptions().getDistanceColumnName();
         Column distanceColumn = new Column(distanceColumnName, FloatType.FLOAT);
-        scanOp.getTable().addColumn(distanceColumn);
 
         ColumnRefOperator distanceColRef = context.getColumnRefFactory().create(distanceColumnName, FloatType.FLOAT, false);
         Map<ColumnRefOperator, Column> newColRefToColumnMetaMap = new HashMap<>(scanOp.getColRefToColumnMetaMap());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/VectorIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/VectorIndexTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VectorIndexTest extends PlanTestBase {
 
@@ -894,6 +896,58 @@ public class VectorIndexTest extends PlanTestBase {
             connectContext.getSessionVariable().setEnableGlobalLateMaterialization(originalLazyMat);
             connectContext.getSessionVariable().setEnableVectorIndexRefine(false);
         }
+    }
+
+    // Regression guard for the vector distance-column schema pollution bug.
+    //
+    // RewriteToVectorPlanRule used to call scanOp.getTable().addColumn(distanceColumn) on the scan's
+    // table. On the whole-phase-lock planning path that table is the shared catalog OlapTable, and
+    // Table.addColumn appends to fullSchema (a List that does not dedup). So every vector ANN query
+    // that planned on the live table appended another "__vector_*" column; once two accumulated, the
+    // Column-keyed ImmutableMap in RelationTransformer.visitTable threw "Multiple entries with same
+    // key" for any later statement touching the table (and the failure was intermittent because
+    // analyze-phase column pruning sometimes dropped the synthetic columns).
+    //
+    // The fix keeps the synthetic column only in the scan operator's colRef maps and never mutates
+    // the table schema. This test forces the lock path (cbo_use_lock_db) and plans the same vector
+    // query repeatedly; the shared schema must stay clean and planning must keep succeeding.
+    @Test
+    public void testRewriteDoesNotPolluteSharedCatalogSchema() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.test_vi_no_pollution ("
+                + " c0 INT,"
+                + " c1 array<float> NOT NULL,"
+                + " INDEX index_vector1 (c1) USING VECTOR ('metric_type' = 'cosine_similarity', "
+                + "'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim'='5') "
+                + ") DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 "
+                + "PROPERTIES ('replication_num'='1');");
+
+        OlapTable table = (OlapTable) starRocksAssert.getTable("test", "test_vi_no_pollution");
+        String distanceColumn = "__vector_approx_cosine_similarity";
+        // No WHERE clause so the rewrite reaches the distance-column code path (a scalar predicate
+        // would disable the vector index and never get there).
+        String vectorSql = "select c1 from test.test_vi_no_pollution "
+                + "order by approx_cosine_similarity([1.1,2.2,3.3,4.4,5.5], c1) desc limit 10";
+
+        boolean originalLock = connectContext.getSessionVariable().isCboUseDBLock();
+        // Force the whole-phase-lock path so the rewrite plans on the live shared table, not a copy.
+        connectContext.getSessionVariable().setCboUseDBLock(true);
+        try {
+            assertEquals(0, countColumns(table, distanceColumn));
+            for (int i = 0; i < 5; i++) {
+                String plan = getVerboseExplain(vectorSql);
+                assertContains(plan, "VECTORINDEX: ON");
+                assertEquals(0, countColumns(table, distanceColumn),
+                        "the rewrite must not add the distance column to the shared catalog schema");
+            }
+        } finally {
+            connectContext.getSessionVariable().setCboUseDBLock(originalLock);
+        }
+    }
+
+    private static long countColumns(OlapTable table, String columnName) {
+        return table.getFullSchema().stream()
+                .filter(c -> c.getName().equalsIgnoreCase(columnName))
+                .count();
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

A vector ANN query (`ORDER BY approx_*_distance(v, [...]) LIMIT k`) can intermittently break unrelated statements on the same table with:

```
java.lang.IllegalArgumentException: Multiple entries with same key:
  `__vector_approx_cosine_similarity` float NOT NULL COMMENT ""=N: __vector_approx_cosine_similarity and
  `__vector_approx_cosine_similarity` float NOT NULL COMMENT ""=M: __vector_approx_cosine_similarity
```

Root cause: `RewriteToVectorPlanRule.rewriteOptByDistanceColumn` registers the synthetic distance column by calling `scanOp.getTable().addColumn(...)`. On the whole-phase-lock planning path the scan references the shared catalog `OlapTable`, and `Table.addColumn` appends to `fullSchema` (a `List` with no dedup) while only `nameToColumn` dedups. So every vector query that plans on the live table appends another duplicate `__vector_*` column. Once two duplicates accumulate, building the `Column`-keyed `ImmutableMap` in `RelationTransformer.visitTable` throws `Multiple entries with same key` for any later statement on that table (SELECT/DELETE/INSERT). It is intermittent because analyze-phase column pruning sometimes drops the synthetic columns. The default lock-free path was unaffected because it plans on a per-query `copyOnlyForQuery` snapshot whose `fullSchema` is a private list.

## What I'm doing:

The distance column is per-query synthetic state; it only needs to live in the scan operator's `colRefToColumnMetaMap`/`columnMetaToColRefMap` (`PlanFragmentBuilder` builds the scan slot's `Column` from `colRefToColumnMetaMap`, never from the table schema). The fix creates the column locally and stops adding it to the shared table schema entirely, so no planning path mutates the catalog `OlapTable`. Only `RewriteToVectorPlanRule` changes; a regression test in `VectorIndexTest` forces the lock path and verifies that repeated vector queries leave the shared schema clean and keep planning successfully.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5