### PR TITLE
[Tool] Add Rocky Linux 9 build toolchain and bump Ubuntu to 24.04

### DIFF
--- a/docker/dockerfiles/toolchains/README.md
+++ b/docker/dockerfiles/toolchains/README.md
@@ -32,3 +32,18 @@ DOCKER_BUILDKIT=1 docker buildx build -f toolchains-ubuntu.Dockerfile --platform
 ```
 DOCKER_BUILDKIT=1 docker build -f toolchains-ubuntu.Dockerfile -t starrocks/toolchains-ubuntu:20230306 .
 ```
+
+## 3 Build Toolchains for Rocky Linux 9
+### 3.1 Build multiarch toolchains on Rocky Linux 9 and publish to docker hub
+```
+DOCKER_BUILDKIT=1 docker buildx build -f toolchains-rocky9.Dockerfile --platform <platform_list> -t starrocks/toolchains-rocky9:<tag> --push .
+```
+E.g.:
+```shell
+DOCKER_BUILDKIT=1 docker buildx build -f toolchains-rocky9.Dockerfile --platform linux/amd64,linux/arm64 -t starrocks/toolchains-rocky9:20230306 --push .
+```
+
+### 3.2 Build a single platform toolchain for Rocky Linux 9
+```
+DOCKER_BUILDKIT=1 docker build -f toolchains-rocky9.Dockerfile -t starrocks/toolchains-rocky9:20230306 .
+```

--- a/docker/dockerfiles/toolchains/toolchains-rocky9.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-rocky9.Dockerfile
@@ -1,0 +1,75 @@
+# Build toolchains on rockylinux9, dev-env image can be built based on this image for rocky9
+# NOTE: build context MUST be set to `docker/dockerfiles/toolchains/`
+#  DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/toolchains/toolchains-rocky9.Dockerfile -t toolchains-rocky9:latest docker/dockerfiles/toolchains/
+
+ARG GCC_INSTALL_HOME=/opt/gcc-toolset-14
+ARG GCC_DOWNLOAD_URL=https://ftp.gnu.org/gnu/gcc/gcc-14.3.0/gcc-14.3.0.tar.gz
+ARG CMAKE_INSTALL_HOME=/opt/cmake
+ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_INSTALL_HOME=/opt/maven
+ARG COMMIT_ID=unset
+
+
+FROM rockylinux:9 AS base-builder
+# Rocky9 ships a recent gcc and binutils, enough to build gcc-14 directly.
+# curl is intentionally omitted: the base image already ships curl-minimal, and installing the
+# full curl package conflicts with it. Downloads here use wget.
+RUN dnf install -y gcc gcc-c++ make automake wget gzip zip bzip2 file bison flex diffutils && \
+    dnf clean all
+
+
+FROM base-builder AS gcc-builder
+ARG GCC_INSTALL_HOME
+ARG GCC_DOWNLOAD_URL
+# build gcc-14 with the distro gcc
+RUN mkdir -p /workspace/gcc && \
+    cd /workspace/gcc &&    \
+    wget --progress=dot:mega --no-check-certificate $GCC_DOWNLOAD_URL -O ../gcc.tar.gz && \
+    tar -xzf ../gcc.tar.gz --strip-components=1 && \
+    ./contrib/download_prerequisites && \
+    ./configure --disable-multilib --enable-languages=c,c++ --prefix=${GCC_INSTALL_HOME}
+RUN cd /workspace/gcc && make -j`nproc`
+RUN cd /workspace/gcc && mkdir -p /workspace/installed && make DESTDIR=/workspace/installed install && \
+    strip /workspace/installed/${GCC_INSTALL_HOME}/bin/* /workspace/installed/${GCC_INSTALL_HOME}/libexec/gcc/*/*/{cc1,cc1plus,collect2,lto1}
+
+
+FROM rockylinux:9
+
+ARG GCC_INSTALL_HOME
+ARG CMAKE_INSTALL_HOME
+ARG MAVEN_VERSION
+ARG MAVEN_INSTALL_HOME
+ARG COMMIT_ID
+
+LABEL org.opencontainers.image.source="https://github.com/StarRocks/starrocks"
+LABEL com.starrocks.commit=${COMMIT_ID}
+
+# Note: these packages are not part of rocky9's minimal base image, but are required to build
+# StarRocks: xz for .tar.xz extraction, gettext for autotools, perl (FindBin and friends) for
+# OpenSSL's Configure script, and binutils-devel for libiberty.a needed when linking the backend.
+RUN dnf install -y 'dnf-command(config-manager)' && \
+        dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+        dnf install -y epel-release && \
+        dnf install -y gh wget unzip bzip2 xz patch bison byacc flex autoconf automake make \
+        gettext perl binutils-devel libtool which git ccache python3 java-17-openjdk-devel file less psmisc clang-tools-extra glibc-langpack-en && \
+        dnf clean all && rm -rf /var/cache/dnf
+
+# install gcc
+COPY --from=gcc-builder /workspace/installed/ /
+# install cmake
+RUN ARCH=`uname -m` && mkdir -p $CMAKE_INSTALL_HOME && cd $CMAKE_INSTALL_HOME && \
+    curl -s -k https://cmake.org/files/v3.31/cmake-3.31.9-linux-${ARCH}.tar.gz | tar -xzf - --strip-components=1 && \
+    ln -s $CMAKE_INSTALL_HOME/bin/cmake /usr/bin/cmake
+
+# jdk17 is provided by the distro `java-17-openjdk-devel` package (installed above), no external download needed
+
+# install maven
+RUN mkdir -p ${MAVEN_INSTALL_HOME} && cd ${MAVEN_INSTALL_HOME} && \
+    curl -s -k https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | tar -xzf - --strip-components=1 && \
+    ln -s ${MAVEN_INSTALL_HOME}/bin/mvn /usr/bin/mvn
+# clang-format is provided by the distro `clang-tools-extra` package (installed above), no external download needed
+
+ENV STARROCKS_GCC_HOME=${GCC_INSTALL_HOME}
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV MAVEN_HOME=${MAVEN_INSTALL_HOME}
+ENV LANG=en_US.utf8

--- a/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
@@ -1,11 +1,11 @@
-# Build toolchains on ubuntu22.04, dev-env image can be built based on this image for ubuntu22
+# Build toolchains on ubuntu24.04, dev-env image can be built based on this image for ubuntu24
 #  DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile -t toolchains-ubuntu:latest docker/dockerfiles/toolchains/
 
 ARG GCC_INSTALL_HOME=/opt/gcc-toolset-14
 ARG GCC_WORK_DIR=/workspace/gcc-14
 ARG GCC_DOWNLOAD_URL=https://ftp.gnu.org/gnu/gcc/gcc-14.3.0/gcc-14.3.0.tar.gz
 
-FROM ubuntu:22.04 AS build-gcc
+FROM ubuntu:24.04 AS build-gcc
 
 ARG GCC_INSTALL_HOME
 ARG GCC_DOWNLOAD_URL
@@ -24,7 +24,7 @@ RUN mkdir -p $GCC_WORK_DIR && \
     make -j$(nproc) && \
     make install-strip
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG GCC_INSTALL_HOME
 ARG CMAKE_INSTALL_HOME=/opt/cmake
@@ -44,7 +44,12 @@ RUN apt-get update -y && \
 
 COPY --from=build-gcc $GCC_INSTALL_HOME $GCC_INSTALL_HOME
 
-RUN for bin in cpp gcc g++ gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do \
+# Make the freshly built gcc-14 the default toolchain via update-alternatives.
+# On ubuntu 24.04 the distro pre-registers a `cpp` alternative whose /etc/alternatives/cpp points
+# back to /usr/bin/cpp; reusing the `cpp` name with a /usr/bin/cpp link would create a
+# self-referential symlink loop ("Too many levels of symbolic links"), so drop it first.
+RUN update-alternatives --remove-all cpp 2>/dev/null || true; \
+    for bin in cpp gcc g++ gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do \
         update-alternatives --install /usr/bin/$bin $bin ${GCC_INSTALL_HOME}/bin/$bin 200; \
     done && \
     update-alternatives --set gcc ${GCC_INSTALL_HOME}/bin/gcc && \
@@ -56,7 +61,7 @@ RUN ARCH=`uname -m` && mkdir -p $CMAKE_INSTALL_HOME && cd $CMAKE_INSTALL_HOME &&
     curl -s -k https://cmake.org/files/v3.31/cmake-3.31.9-linux-${ARCH}.tar.gz | tar -xzf - --strip-components=1 && \
     ln -s $CMAKE_INSTALL_HOME/bin/cmake /usr/bin/cmake
 
-# Set the soft link to jvm
+# Set the soft link to jvm; the build uses JAVA_HOME (set below) which points at JDK 17.
 RUN ARCH=`uname -m` && \
     cd /lib/jvm && \
     if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;


### PR DESCRIPTION
Add toolchains-rocky9.Dockerfile building gcc-14, cmake, maven, and JDK 17 on rockylinux:9, and document its build commands in the README.

Update toolchains-ubuntu.Dockerfile from 22.04 to 24.04, dropping the distro-registered cpp alternative first to avoid a self-referential symlink loop in update-alternatives.

## Why I'm doing:

## What I'm doing:

Refs #74517

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
