### PR TITLE
[Enhancement] Read DECIMAL footer stats in tablet pre-split meta tier

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -266,6 +266,8 @@ public final class OrcStripeStatisticsReader {
             // RuntimeExceptions are wrapped as a meta-tier fallback signal — mirroring
             // convertIntegerStripe/convertDateStripe — so an unrepresentable value falls back
             // to data tier instead of escaping read() (which only catches IOException).
+            // Render via toPlainString() (not toString()) so large-exponent values never
+            // surface in scientific notation, which the BE datum_from_string would reject.
             BigDecimal minValue = decimalStatistics.getMinimum().bigDecimalValue();
             BigDecimal maxValue = decimalStatistics.getMaximum().bigDecimalValue();
             minVariant = Variant.of(location.starRocksColumn.getType(), minValue.toPlainString());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -35,7 +35,6 @@ import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -268,10 +267,10 @@ public final class OrcStripeStatisticsReader {
             // to data tier instead of escaping read() (which only catches IOException).
             // Render via toPlainString() (not toString()) so large-exponent values never
             // surface in scientific notation, which the BE datum_from_string would reject.
-            BigDecimal minValue = decimalStatistics.getMinimum().bigDecimalValue();
-            BigDecimal maxValue = decimalStatistics.getMaximum().bigDecimalValue();
-            minVariant = Variant.of(location.starRocksColumn.getType(), minValue.toPlainString());
-            maxVariant = Variant.of(location.starRocksColumn.getType(), maxValue.toPlainString());
+            minVariant = Variant.of(location.starRocksColumn.getType(),
+                    decimalStatistics.getMinimum().bigDecimalValue().toPlainString());
+            maxVariant = Variant.of(location.starRocksColumn.getType(),
+                    decimalStatistics.getMaximum().bigDecimalValue().toPlainString());
         } catch (RuntimeException conversionFailure) {
             throw new MetaTierUnavailableException(String.format(
                     "ORC decimal stats value not representable for sort-key column \"%s\": %s",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -20,10 +20,13 @@ import com.starrocks.catalog.Variant;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.DateColumnStatistics;
+import org.apache.orc.DecimalColumnStatistics;
 import org.apache.orc.IntegerColumnStatistics;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
@@ -32,6 +35,7 @@ import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,10 +54,12 @@ import java.util.Objects;
  *   <li>ORC DATE → StarRocks DATE (day-of-epoch, timezone-free), gated to
  *       {@code [1970-01-01, 9999-12-31]} — values outside that window (year &le; 0
  *       rendering, pre-1582 proleptic/hybrid calendar ambiguity) fall back to data tier</li>
+ *   <li>ORC DECIMAL → StarRocks DECIMAL of the SAME precision and scale (ORC orders decimal
+ *       stats correctly, so footer min/max are usable). Non-matching precision/scale → data tier</li>
  * </ul>
  * Everything else — STRING/CHAR/VARCHAR (data-tier fallback anyway), BOOLEAN,
  * FLOAT/DOUBLE, TIMESTAMP/TIMESTAMP_INSTANT (reader-local-tz stats, deferred),
- * DECIMAL, and any complex type — makes the reader throw
+ * non-matching-precision/scale DECIMAL, and any complex type — makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier. That is
  * NOT a load failure. Pure I/O failures surface as {@link StarRocksException}.
  */
@@ -125,7 +131,7 @@ public final class OrcStripeStatisticsReader {
                     "ORC schema does not contain sort-key column \"" + columnName + "\"");
         }
         TypeDescription fieldType = fieldTypes.get(fieldIndex);
-        rejectIncompatibleTypeMapping(fieldType.getCategory(), sortKeyColumn);
+        rejectIncompatibleTypeMapping(fieldType, sortKeyColumn);
         // ORC assigns column ids in schema pre-order; getColumnStatistics() is
         // indexed by that id (index 0 is the struct root).
         return new SortKeyLocation(fieldType.getId(), sortKeyColumn);
@@ -135,17 +141,21 @@ public final class OrcStripeStatisticsReader {
      * Reject ORC/StarRocks type pairings outside meta tier's supported window
      * eagerly, before iterating stripes. Anything outside the window means "fall
      * back to data tier", not "fail the load". The supported window is the unannotated
-     * integer categories plus ORC DATE → StarRocks DATE. String, boolean, floating-point,
-     * TIMESTAMP/TIMESTAMP_INSTANT, decimal, and complex types are deferred (fall back to
-     * data tier).
+     * integer categories, ORC DATE → StarRocks DATE, and ORC DECIMAL → a same-precision/scale
+     * StarRocks DECIMAL. String, boolean, floating-point, TIMESTAMP/TIMESTAMP_INSTANT,
+     * non-matching DECIMAL, and complex types are deferred (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
-            TypeDescription.Category orcCategory, Column sortKeyColumn) throws MetaTierUnavailableException {
+            TypeDescription fieldType, Column sortKeyColumn) throws MetaTierUnavailableException {
+        TypeDescription.Category orcCategory = fieldType.getCategory();
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (orcCategory) {
             case BYTE, SHORT, INT, LONG -> starRocksPrimitive.isIntegerType();
             // ORC DATE is day-of-epoch (no timezone) → StarRocks DATE only.
             case DATE -> starRocksPrimitive == PrimitiveType.DATE;
+            // ORC orders decimal stats correctly (no Parquet unsigned-byte trap), so footer
+            // min/max are usable; require an exact precision/scale match with the StarRocks column.
+            case DECIMAL -> decimalMatchesExactly(fieldType, sortKeyColumn);
             default -> false;
         };
         if (!compatible) {
@@ -153,6 +163,21 @@ public final class OrcStripeStatisticsReader {
                     "ORC %s cannot map to StarRocks %s for sort-key column \"%s\"",
                     orcCategory, starRocksPrimitive, sortKeyColumn.getName()));
         }
+    }
+
+    /**
+     * True only when the StarRocks sort-key column is a DECIMAL whose precision and scale
+     * exactly equal the ORC decimal field's. The BE split validator requires an exact match
+     * too; anything else falls back to data tier.
+     */
+    private static boolean decimalMatchesExactly(TypeDescription fieldType, Column sortKeyColumn) {
+        Type starRocksType = sortKeyColumn.getType();
+        if (!starRocksType.isDecimalOfAnyVersion()) {
+            return false;
+        }
+        ScalarType scalarType = (ScalarType) starRocksType;
+        return fieldType.getPrecision() == scalarType.getScalarPrecision()
+                && fieldType.getScale() == scalarType.getScalarScale();
     }
 
     private static RowGroupStatistics convertStripe(
@@ -169,6 +194,10 @@ public final class OrcStripeStatisticsReader {
         if (sortKeyStatistics instanceof DateColumnStatistics dateStatistics
                 && dateStatistics.getNumberOfValues() > 0) {
             return convertDateStripe(dateStatistics, rowCount, location);
+        }
+        if (sortKeyStatistics instanceof DecimalColumnStatistics decimalStatistics
+                && decimalStatistics.getNumberOfValues() > 0) {
+            return convertDecimalStripe(decimalStatistics, rowCount, location);
         }
         // Absent / all-null stats (no presence flag on ORC numeric/date stats, so an
         // empty stripe is detected via getNumberOfValues() == 0) → missing min/max.
@@ -219,6 +248,31 @@ public final class OrcStripeStatisticsReader {
         } catch (RuntimeException conversionFailure) {
             throw new MetaTierUnavailableException(String.format(
                     "ORC date stats value not representable for sort-key column \"%s\": %s",
+                    location.starRocksColumn.getName(), conversionFailure.getMessage()));
+        }
+        return new RowGroupStatistics(
+                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+    }
+
+    private static RowGroupStatistics convertDecimalStripe(
+            DecimalColumnStatistics decimalStatistics, long rowCount, SortKeyLocation location)
+            throws MetaTierUnavailableException {
+        Variant minVariant;
+        Variant maxVariant;
+        try {
+            // HiveDecimal min/max carry the source scale; ORC orders decimal stats correctly
+            // (no Parquet-style unsigned-byte trap), and the exact precision/scale gate
+            // guarantees the source scale equals the StarRocks column scale. Variant.of
+            // RuntimeExceptions are wrapped as a meta-tier fallback signal — mirroring
+            // convertIntegerStripe/convertDateStripe — so an unrepresentable value falls back
+            // to data tier instead of escaping read() (which only catches IOException).
+            BigDecimal minValue = decimalStatistics.getMinimum().bigDecimalValue();
+            BigDecimal maxValue = decimalStatistics.getMaximum().bigDecimalValue();
+            minVariant = Variant.of(location.starRocksColumn.getType(), minValue.toPlainString());
+            maxVariant = Variant.of(location.starRocksColumn.getType(), maxValue.toPlainString());
+        } catch (RuntimeException conversionFailure) {
+            throw new MetaTierUnavailableException(String.format(
+                    "ORC decimal stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
         return new RowGroupStatistics(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -67,13 +67,17 @@ import java.util.Objects;
  *       deferred (the load applies a session-tz offset this reader cannot reproduce).</li>
  *   <li>Parquet BINARY with UTF8 (string) annotation → StarRocks CHAR/VARCHAR
  *       (always marked truncated → forces data-tier fallback for string sort keys)</li>
+ *   <li>Parquet INT32/INT64 with DECIMAL annotation → StarRocks DECIMAL of the SAME
+ *       precision and scale (the unscaled integer's signed order equals the decimal
+ *       order). FIXED_LEN_BYTE_ARRAY/BINARY-backed decimals are deferred (their footer
+ *       min/max may use unsigned byte ordering, wrong for negatives) → data tier.</li>
  * </ul>
  * <p>DATE/DATETIME values are additionally gated to {@code [1970-01-01, 9999-12-31]}; values
  * outside that window (year &le; 0 mis-renders through the {@code yyyy} formatters, pre-1970
  * has unverified FE/BE timestamp-division parity, pre-1582 has calendar-parity questions)
  * fall back to data tier.
- * Anything else (DECIMAL, UINT_*, UTC-adjusted/INT96 timestamps, JSON, BSON, UUID,
- * FLOAT, DOUBLE, FIXED_LEN_BYTE_ARRAY, raw BINARY for VARBINARY) makes the reader throw
+ * Anything else (UINT_*, UTC-adjusted/INT96 timestamps, JSON, BSON, UUID, FLOAT, DOUBLE,
+ * FIXED_LEN_BYTE_ARRAY/BINARY-backed DECIMAL, raw BINARY for VARBINARY) makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier — not a
  * load failure. Pure I/O failures surface as {@link StarRocksException}.
  */
@@ -145,11 +149,12 @@ public final class ParquetRowGroupStatisticsReader {
      * Reject Parquet/StarRocks type pairings outside meta tier's supported window
      * eagerly, before iterating row groups. Anything outside the window means
      * "fall back to data tier", not "fail the load". The supported window here is
-     * the unannotated integer/boolean subset, the UTF8 string annotation for
-     * character columns, and INT32 with the DATE annotation → StarRocks DATE.
-     * Other logical annotations (DECIMAL, UINT_*, UTC-adjusted TIMESTAMP, JSON, BSON,
-     * UUID, ...) change the value's meaning and ordering and are deferred (fall back to
-     * data tier).
+     * the unannotated integer/boolean subset, the UTF8 string annotation for character
+     * columns, INT32 with the DATE annotation → StarRocks DATE, INT64 with a non-UTC
+     * TIMESTAMP annotation → StarRocks DATETIME, and INT32/INT64 with a DECIMAL annotation
+     * → a same-precision/scale StarRocks DECIMAL. FIXED_LEN_BYTE_ARRAY/BINARY-backed DECIMAL
+     * and other annotations (UINT_*, UTC-adjusted TIMESTAMP, JSON, BSON, UUID, ...) are
+     * deferred (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             PrimitiveTypeName parquetTypeName,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.Variant;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.parquet.column.statistics.Statistics;
@@ -32,12 +34,14 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -153,22 +157,38 @@ public final class ParquetRowGroupStatisticsReader {
             Column sortKeyColumn) throws MetaTierUnavailableException {
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (parquetTypeName) {
-            // isIntegerType() is exactly {TINYINT, SMALLINT, INT, BIGINT} — the unannotated
-            // integer window; LARGEINT is intentionally excluded.
-            case INT32 -> logicalAnnotation == null
-                    ? starRocksPrimitive.isIntegerType()
+            case INT32 -> {
+                if (logicalAnnotation == null) {
+                    // isIntegerType() is exactly {TINYINT, SMALLINT, INT, BIGINT} — the
+                    // unannotated integer window; LARGEINT is intentionally excluded.
+                    yield starRocksPrimitive.isIntegerType();
+                }
+                if (logicalAnnotation instanceof DateLogicalTypeAnnotation) {
                     // INT32+DATE is days-since-epoch; only a StarRocks DATE sort key
                     // gives those day counts their intended calendar meaning.
-                    : logicalAnnotation instanceof DateLogicalTypeAnnotation
-                            && starRocksPrimitive == PrimitiveType.DATE;
-            case INT64 -> logicalAnnotation == null
-                    ? starRocksPrimitive.isIntegerType()
+                    yield starRocksPrimitive == PrimitiveType.DATE;
+                }
+                // INT32-backed DECIMAL: the signed-integer order of the unscaled stat equals the
+                // decimal order, so footer min/max are safe. Require an exact precision/scale match
+                // with the StarRocks column (the BE split validator requires the same).
+                yield logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
+                        && decimalMatchesExactly(decimalAnnotation, sortKeyColumn);
+            }
+            case INT64 -> {
+                if (logicalAnnotation == null) {
+                    yield starRocksPrimitive.isIntegerType();
+                }
+                if (logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
                     // Only local (non-UTC-adjusted) timestamps: the load stores those ticks
                     // verbatim as the DATETIME wall clock, so the FE-rendered boundary matches.
                     // UTC-adjusted timestamps get a session-tz offset at load time → data tier.
-                    : logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation
-                            && !timestampAnnotation.isAdjustedToUTC()
+                    yield !timestampAnnotation.isAdjustedToUTC()
                             && starRocksPrimitive == PrimitiveType.DATETIME;
+                }
+                // INT64-backed DECIMAL: same signed-order safety as INT32. Exact precision/scale.
+                yield logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
+                        && decimalMatchesExactly(decimalAnnotation, sortKeyColumn);
+            }
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
             case BINARY -> logicalAnnotation instanceof StringLogicalTypeAnnotation
                     && (starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR);
@@ -245,6 +265,14 @@ public final class ParquetRowGroupStatisticsReader {
             MetaTierTemporalWindow.rejectDateOutsideWindow(dateTime.toLocalDate());
             return Variant.of(location.starRocksColumn.getType(), renderDateTime(dateTime));
         }
+        if (location.logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation) {
+            // Only INT32/INT64-backed decimals reach here — the gate rejects FIXED_LEN/BINARY —
+            // so the stat is the signed unscaled integer. Reconstruct at the source scale; the
+            // exact precision/scale gate guarantees it equals the StarRocks column scale.
+            long unscaled = ((Number) parquetValue).longValue();
+            BigDecimal decoded = BigDecimal.valueOf(unscaled, decimalAnnotation.getScale());
+            return Variant.of(location.starRocksColumn.getType(), decoded.toPlainString());
+        }
         String rendered = location.parquetTypeName == PrimitiveTypeName.BINARY
                 ? ((Binary) parquetValue).toStringUsingUTF8()
                 : parquetValue.toString();
@@ -292,6 +320,23 @@ public final class ParquetRowGroupStatisticsReader {
             }
         }
         return null;
+    }
+
+    /**
+     * True only when the StarRocks sort-key column is a DECIMAL whose precision and scale
+     * exactly equal the Parquet decimal annotation's. The BE split validator requires an
+     * exact match too; anything else falls back to data tier rather than risk a boundary the
+     * BE would reject or round differently.
+     */
+    private static boolean decimalMatchesExactly(
+            DecimalLogicalTypeAnnotation annotation, Column sortKeyColumn) {
+        Type starRocksType = sortKeyColumn.getType();
+        if (!starRocksType.isDecimalOfAnyVersion()) {
+            return false;
+        }
+        ScalarType scalarType = (ScalarType) starRocksType;
+        return annotation.getPrecision() == scalarType.getScalarPrecision()
+                && annotation.getScale() == scalarType.getScalarScale();
     }
 
     private record SortKeyLocation(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -330,8 +330,8 @@ public final class ParquetRowGroupStatisticsReader {
     /**
      * True only when the StarRocks sort-key column is a DECIMAL whose precision and scale
      * exactly equal the Parquet decimal annotation's. The BE split validator requires an
-     * exact match too; anything else falls back to data tier rather than risk a boundary the
-     * BE would reject or round differently.
+     * exact match too; anything else falls back to data tier rather than risk a boundary from
+     * the wrong type domain.
      */
     private static boolean decimalMatchesExactly(
             DecimalLogicalTypeAnnotation annotation, Column sortKeyColumn) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -17,10 +17,14 @@ package com.starrocks.alter.reshard.presplit;
 import com.starrocks.catalog.Column;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -29,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -341,6 +346,163 @@ class OrcStripeStatisticsReaderTest {
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME)));
+    }
+
+    @Test
+    void readsDecimalStatistics() throws Exception {
+        // ORC decimal(18,2): write 1.00, 2.00, ... 5.00. ORC orders decimal stats correctly.
+        Path orcPath = writeOrc(
+                "struct<d:decimal(18,2)>",
+                /*rowCount=*/ 5,
+                (batch, batchRow, rowIndex) -> ((DecimalColumnVector) batch.cols[0])
+                        .set(batchRow, HiveDecimal.create(BigDecimal.valueOf((rowIndex + 1) * 100L, 2))));
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+
+        // Assert on BigDecimal VALUE, not the exact string: ORC's decimal-stats round-trip may
+        // normalize trailing-zero scale ("1.00" vs "1"). Both are accepted downstream because the
+        // Variant carries the column's ScalarType precision/scale regardless of the rendered text.
+        Assertions.assertFalse(stats.isEmpty());
+        BigDecimal globalMin = null;
+        BigDecimal globalMax = null;
+        for (RowGroupStatistics stripe : stats) {
+            Assertions.assertFalse(stripe.isTruncated());
+            BigDecimal minValue = new BigDecimal(stripe.getMinTuple().getValues().get(0).getStringValue());
+            BigDecimal maxValue = new BigDecimal(stripe.getMaxTuple().getValues().get(0).getStringValue());
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals(0, globalMin.compareTo(new BigDecimal("1.00")));
+        Assertions.assertEquals(0, globalMax.compareTo(new BigDecimal("5.00")));
+    }
+
+    @Test
+    void readsNegativeDecimalStatistics() throws Exception {
+        // ORC decimal(18,2) spanning negative→positive: -2.00, -1.00, 0.00, 1.00. ORC orders by value.
+        Path orcPath = writeOrc(
+                "struct<d:decimal(18,2)>",
+                /*rowCount=*/ 4,
+                (batch, batchRow, rowIndex) -> ((DecimalColumnVector) batch.cols[0])
+                        .set(batchRow, HiveDecimal.create(BigDecimal.valueOf((rowIndex - 2) * 100L, 2))));
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+
+        // Value-based comparison (ORC may render scale as "1" vs "1.00"); proves signed order.
+        BigDecimal globalMin = null;
+        BigDecimal globalMax = null;
+        for (RowGroupStatistics stripe : stats) {
+            BigDecimal minValue = new BigDecimal(stripe.getMinTuple().getValues().get(0).getStringValue());
+            BigDecimal maxValue = new BigDecimal(stripe.getMaxTuple().getValues().get(0).getStringValue());
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals(0, globalMin.compareTo(new BigDecimal("-2.00")));
+        Assertions.assertEquals(0, globalMax.compareTo(new BigDecimal("1.00")));
+    }
+
+    @Test
+    void readsDecimal128Statistics() throws Exception {
+        // Accepted non-DECIMAL64 case: ORC decimal(20,2) → StarRocks DECIMAL128(20,2). The max
+        // value's unscaled form (20 digits) exceeds 64-bit range, so this genuinely exercises the
+        // 128-bit path through Type.isDecimalOfAnyVersion()/Variant.of/DecimalVariant.
+        BigDecimal[] values = {
+                new BigDecimal("1.00"),
+                new BigDecimal("2.00"),
+                new BigDecimal("999999999999999999.99"),
+        };
+        Path orcPath = writeOrc(
+                "struct<d:decimal(20,2)>",
+                /*rowCount=*/ values.length,
+                (batch, batchRow, rowIndex) -> ((DecimalColumnVector) batch.cols[0])
+                        .set(batchRow, HiveDecimal.create(values[rowIndex])));
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)));
+
+        Assertions.assertFalse(stats.isEmpty());
+        BigDecimal globalMin = null;
+        BigDecimal globalMax = null;
+        for (RowGroupStatistics stripe : stats) {
+            Assertions.assertFalse(stripe.isTruncated());
+            BigDecimal minValue = new BigDecimal(stripe.getMinTuple().getValues().get(0).getStringValue());
+            BigDecimal maxValue = new BigDecimal(stripe.getMaxTuple().getValues().get(0).getStringValue());
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals(0, globalMin.compareTo(new BigDecimal("1.00")));
+        Assertions.assertEquals(0, globalMax.compareTo(new BigDecimal("999999999999999999.99")));
+    }
+
+    @Test
+    void decimalScaleMismatchFallsBackToDataTier() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<d:decimal(18,2)>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> ((DecimalColumnVector) batch.cols[0])
+                        .set(batchRow, HiveDecimal.create(BigDecimal.valueOf((rowIndex + 1) * 100L, 2))));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))));
+    }
+
+    @Test
+    void decimalPrecisionMismatchFallsBackToDataTier() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<d:decimal(18,2)>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> ((DecimalColumnVector) batch.cols[0])
+                        .set(batchRow, HiveDecimal.create(BigDecimal.valueOf((rowIndex + 1) * 100L, 2))));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2))));
+    }
+
+    @Test
+    void decimalIntoNonDecimalSortKeyFallsBackToDataTier() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<d:decimal(18,2)>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> ((DecimalColumnVector) batch.cols[0])
+                        .set(batchRow, HiveDecimal.create(BigDecimal.valueOf((rowIndex + 1) * 100L, 2))));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("d", IntegerType.BIGINT)));
+    }
+
+    @Test
+    void allNullDecimalStripeReportsAbsentStatistics() throws Exception {
+        // All-null decimal column → DecimalColumnStatistics.getNumberOfValues() == 0 → absent min/max.
+        Path orcPath = writeOrc(
+                "struct<d:decimal(18,2)>",
+                /*rowCount=*/ 3,
+                (batch, batchRow, rowIndex) -> {
+                    batch.cols[0].noNulls = false;
+                    batch.cols[0].isNull[batchRow] = true;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+
+        Assertions.assertFalse(stats.isEmpty());
+        long totalRowCount = 0L;
+        for (RowGroupStatistics stripe : stats) {
+            Assertions.assertNull(stripe.getMinTuple());
+            Assertions.assertNull(stripe.getMaxTuple());
+            totalRowCount += stripe.getRowCount();
+        }
+        Assertions.assertEquals(3L, totalRowCount);
     }
 
     private Path writeOrc(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -395,6 +395,7 @@ class OrcStripeStatisticsReaderTest {
         BigDecimal globalMin = null;
         BigDecimal globalMax = null;
         for (RowGroupStatistics stripe : stats) {
+            Assertions.assertFalse(stripe.isTruncated());
             BigDecimal minValue = new BigDecimal(stripe.getMinTuple().getValues().get(0).getStringValue());
             BigDecimal maxValue = new BigDecimal(stripe.getMaxTuple().getValues().get(0).getStringValue());
             globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -18,9 +18,12 @@ import com.starrocks.catalog.Column;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -429,6 +432,42 @@ class ParquetRowGroupStatisticsReaderTest {
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_ts", IntegerType.BIGINT)));
+    }
+
+    @Test
+    void readsDecimalStatisticsForInt32Decimal() throws Exception {
+        // INT32-backed DECIMAL(9,2): precision 9 fits int32. Unscaled (rowIndex+1)*100 → 1.00..3.00.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 d (DECIMAL(9,2)); }",
+                /*rowCount=*/ 3,
+                (group, rowIndex) -> group.append("d", (rowIndex + 1) * 100));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertEquals("1.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("3.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void readsDecimalStatisticsForInt64Decimal() throws Exception {
+        // INT64-backed DECIMAL(18,2): unscaled (rowIndex+1)*100 → 1.00, 2.00, ... 5.00.
+        // Signed INT64 order == decimal order, so footer min/max are safe to use.
+        Path parquetPath = writeParquet(
+                "message schema { required int64 d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 5,
+                (group, rowIndex) -> group.append("d", (rowIndex + 1) * 100L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
+        Assertions.assertEquals("1.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("5.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
     }
 
     private Path writeParquet(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -447,6 +447,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)));
 
         Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
         Assertions.assertEquals("1.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
         Assertions.assertEquals("3.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
     }
@@ -483,6 +484,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                 new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
 
+        Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("-2.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
         Assertions.assertEquals("1.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -470,6 +470,98 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertEquals("5.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
     }
 
+    @Test
+    void readsNegativeDecimalPreservesSignedOrder() throws Exception {
+        // INT64-backed DECIMAL(18,2) spanning negative→positive: -2.00, -1.00, 0.00, 1.00.
+        // parquet-mr orders INT64 stats by SIGNED comparison, so min is the most negative.
+        Path parquetPath = writeParquet(
+                "message schema { required int64 d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 4,
+                (group, rowIndex) -> group.append("d", (rowIndex - 2) * 100L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+
+        Assertions.assertEquals("-2.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("1.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void decimalScaleMismatchFallsBackToDataTier() throws Exception {
+        // Source DECIMAL(18,2) into a StarRocks DECIMAL64(18,4): scales differ → reject.
+        Path parquetPath = writeParquet(
+                "message schema { required int64 d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("d", (rowIndex + 1) * 100L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))));
+    }
+
+    @Test
+    void decimalPrecisionMismatchFallsBackToDataTier() throws Exception {
+        // Source DECIMAL(18,2) into a StarRocks DECIMAL64(10,2): precisions differ → reject.
+        Path parquetPath = writeParquet(
+                "message schema { required int64 d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("d", (rowIndex + 1) * 100L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2))));
+    }
+
+    @Test
+    void decimalIntoNonDecimalSortKeyFallsBackToDataTier() throws Exception {
+        // Source DECIMAL into a BIGINT sort key → reject (publishing unscaled ints would be wrong).
+        Path parquetPath = writeParquet(
+                "message schema { required int64 d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("d", (rowIndex + 1) * 100L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("d", IntegerType.BIGINT)));
+    }
+
+    @Test
+    void fixedLenByteArrayDecimalFallsBackToDataTier() throws Exception {
+        // Even with an EXACT precision/scale match, a FIXED_LEN_BYTE_ARRAY-backed decimal is
+        // rejected: parquet-mr footer min/max for byte-array decimals can use unsigned byte
+        // ordering (wrong for negatives) unless a typed sort order was set — which we do not
+        // inspect. Conservative gate → data tier. (The gate rejects at schema inspection before
+        // any row group is read, so all-zero bytes are fine.)
+        Path parquetPath = writeParquet(
+                "message schema { required fixed_len_byte_array(8) d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("d", Binary.fromConstantByteArray(new byte[8])));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))));
+    }
+
+    @Test
+    void binaryBackedDecimalFallsBackToDataTier() throws Exception {
+        // BINARY-backed decimal: same unsigned-byte-order trap as FIXED_LEN → reject (the BINARY
+        // arm only admits the UTF8 string annotation). DECIMAL128(20,2) exactly matches precision/scale.
+        Path parquetPath = writeParquet(
+                "message schema { required binary d (DECIMAL(20,2)); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("d", Binary.fromConstantByteArray(new byte[] {0})));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2))));
+    }
+
     private Path writeParquet(
             String schemaText, int rowCount,
             java.util.function.BiConsumer<org.apache.parquet.example.data.Group, Integer> rowFiller)


### PR DESCRIPTION
## Why I'm doing:

Tablet pre-split can compute split boundaries cheaply from Parquet/ORC footer min/max stats (the "meta tier") instead of running a data-tier SELECT sample. After #74739, a DECIMAL sort key already pre-splits, but only via the **data tier** — the two footer readers rejected DECIMAL stats, so every decimal bulk load paid the data-tier sub-query. This closes that gap so a DECIMAL sort key pre-splits via the cheap meta tier, mirroring the DATE/DATETIME work in #74710.

## What I'm doing:

Teach the two meta-tier footer readers to decode DECIMAL min/max stats. The pipeline below the readers is type-agnostic and untouched; `DecimalVariant` / `Variant.of(decimalType, …)` already exist (#74739) and are unchanged. BE is unchanged.

- **`ParquetRowGroupStatisticsReader`**: accept `DecimalLogicalTypeAnnotation` only for INT32/INT64-backed decimals (the unscaled integer's signed order equals the decimal order) with an **exact precision/scale match** against the StarRocks column; decode via `BigDecimal.valueOf(unscaled, scale).toPlainString()` → `Variant.of`. FIXED_LEN_BYTE_ARRAY/BINARY-backed decimals are rejected → data tier, because parquet-mr footer min/max for byte-array decimals may use unsigned byte ordering (wrong for negatives) unless the writer set a typed sort order this reader does not inspect.
- **`OrcStripeStatisticsReader`**: accept ORC `DECIMAL` with an exact precision/scale match; `convertDecimalStripe` mirrors `convertDateStripe` (`HiveDecimal.bigDecimalValue().toPlainString()` → `Variant.of`, absent stats when `getNumberOfValues() == 0`, decode failures wrapped as `MetaTierUnavailableException` → data-tier fallback). ORC decimal stats are correctly ordered, so no byte-order gate is needed.

Anything outside this window (non-matching precision/scale, byte-array-backed Parquet decimals) falls back to the data tier — never a load failure. BE is unchanged: `datum_from_string` parses all decimal types and `tablet_splitter` requires an exact precision/scale match (else identical-fallback).

Tests: 8 Parquet + 7 ORC decimal cases (positive/negative signed ordering, INT32/INT64/DECIMAL128, scale/precision/non-decimal mismatch rejections, FIXED_LEN/BINARY rejection, all-null absent stats).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)