### PR TITLE
[BugFix] Support table-level override for first load statistics collection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2214,10 +2214,15 @@ public class OlapTable extends Table {
         return tableProperty.enableStatisticCollectOnFirstLoad();
     }
 
+    public boolean isSetEnableStatisticCollectOnFirstLoad() {
+        return tableProperty != null && tableProperty.isSetEnableStatisticCollectOnFirstLoad();
+    }
+
     public void setEnableStatisticCollectOnFirstLoad(boolean enable) {
         tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD,
                 Boolean.valueOf(enable).toString());
         tableProperty.buildEnableStatisticCollectOnFirstLoad();
+        tableProperty.setEnableStatisticCollectOnFirstLoad(enable);
     }
 
     public int getTableQueryTimeout() {
@@ -3001,9 +3006,9 @@ public class OlapTable extends Table {
             properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_LOAD_PROFILE, "true");
         }
 
-        Boolean enableStatisticCollectOnFirstLoad = enableStatisticCollectOnFirstLoad();
-        if (!enableStatisticCollectOnFirstLoad) {
-            properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, "false");
+        if (isSetEnableStatisticCollectOnFirstLoad()) {
+            properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD,
+                    Boolean.toString(enableStatisticCollectOnFirstLoad()));
         }
 
         // base compaction forbidden time ranges

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -345,6 +345,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     @SerializedName(value = "enableStatisticCollectOnFirstLoad")
     private boolean enableStatisticCollectOnFirstLoad = true;
 
+    @SerializedName(value = "enableStatisticCollectOnFirstLoadSet")
+    private boolean enableStatisticCollectOnFirstLoadSet = false;
+
     // table level query timeout in seconds
     // default value -1 means use cluster query_timeout
     @SerializedName(value = "tableQueryTimeout")
@@ -424,6 +427,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.compactionStrategy = other.compactionStrategy;
         this.lakeCompactionMaxParallel = other.lakeCompactionMaxParallel;
         this.enableStatisticCollectOnFirstLoad = other.enableStatisticCollectOnFirstLoad;
+        this.enableStatisticCollectOnFirstLoadSet = other.enableStatisticCollectOnFirstLoadSet;
         this.tableQueryTimeout = other.tableQueryTimeout;
         this.cloudNativeFastSchemaEvolutionV2 = other.cloudNativeFastSchemaEvolutionV2;
     }
@@ -1283,8 +1287,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return enableStatisticCollectOnFirstLoad;
     }
 
+    public boolean isSetEnableStatisticCollectOnFirstLoad() {
+        // Older versions persisted "false" only when the user explicitly disabled this table property,
+        // but also wrote the default "true" on table creation. Preserve explicit false while avoiding
+        // treating old default true as a table-level override.
+        return enableStatisticCollectOnFirstLoadSet ||
+                (properties != null &&
+                        "false".equalsIgnoreCase(properties.get(
+                                PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)));
+    }
+
     public void setEnableStatisticCollectOnFirstLoad(boolean enableStatisticCollectOnFirstLoad) {
         this.enableStatisticCollectOnFirstLoad = enableStatisticCollectOnFirstLoad;
+        this.enableStatisticCollectOnFirstLoadSet = true;
     }
 
     public TWriteQuorumType writeQuorum() {

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
@@ -17,7 +17,6 @@ package com.starrocks.listener;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.Config;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.qe.DmlType;
 import com.starrocks.server.GlobalStateMgr;
@@ -81,9 +80,6 @@ public class LoadJobStatsListener implements LoadJobListener {
     }
 
     private void onTransactionFinish(TransactionState transactionState, boolean sync) {
-        if (!Config.enable_statistic_collect_on_first_load) {
-            return;
-        }
         if (!needTrigger()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4724,6 +4724,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 TableProperty tableProperty = olapTable.getTableProperty();
                 tableProperty.modifyTableProperties(properties);
                 tableProperty.buildProperty(opCode);
+                if (opCode == OperationType.OP_ALTER_TABLE_PROPERTIES &&
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+                    tableProperty.setEnableStatisticCollectOnFirstLoad(
+                            Boolean.parseBoolean(properties.get(
+                                    PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)));
+                }
 
                 if (StringUtils.isNotEmpty(comment)) {
                     olapTable.setComment(comment);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -499,11 +499,10 @@ public class OlapTableFactory implements AbstractTableFactory {
                 table.setEnableLoadProfile(true);
             }
 
-            if (PropertyAnalyzer.analyzeBooleanProp(properties,
-                    PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, true)) {
-                table.setEnableStatisticCollectOnFirstLoad(true);
-            } else {
-                table.setEnableStatisticCollectOnFirstLoad(false);
+            if (properties != null &&
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+                table.setEnableStatisticCollectOnFirstLoad(PropertyAnalyzer.analyzeBooleanProp(properties,
+                        PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, true));
             }
 
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -124,13 +124,7 @@ public class StatisticsCollectionTrigger {
     }
 
     private void process() {
-        if (table instanceof OlapTable) {
-            if (!((OlapTable) table).enableStatisticCollectOnFirstLoad()) {
-                return;
-            }
-        }
-
-        if (!Config.enable_statistic_collect_on_first_load) {
+        if (!enableStatisticCollectOnFirstLoad()) {
             return;
         }
         if (!Config.enable_statistic_collect_on_update && dmlType.equals(DmlType.UPDATE)) {
@@ -170,6 +164,13 @@ public class StatisticsCollectionTrigger {
             executeCollect();
             waitFinish();
         }
+    }
+
+    private boolean enableStatisticCollectOnFirstLoad() {
+        if (table instanceof OlapTable olapTable && olapTable.isSetEnableStatisticCollectOnFirstLoad()) {
+            return olapTable.enableStatisticCollectOnFirstLoad();
+        }
+        return Config.enable_statistic_collect_on_first_load;
     }
 
     private void executeOverWrite() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreTablePropertyEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreTablePropertyEditLogTest.java
@@ -1745,10 +1745,49 @@ public class LocalMetastoreTablePropertyEditLogTest {
         // Cover OlapTable setters/getters + getProperties export path.
         olapTable.setEnableStatisticCollectOnFirstLoad(false);
         Assertions.assertFalse(olapTable.enableStatisticCollectOnFirstLoad());
+        Assertions.assertTrue(olapTable.isSetEnableStatisticCollectOnFirstLoad());
         olapTable.setTableQueryTimeout(120);
         Assertions.assertEquals(120, olapTable.getTableQueryTimeout());
         Map<String, String> exported = olapTable.getProperties();
+        Assertions.assertEquals("false", exported.get(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD));
         Assertions.assertEquals("120", exported.get(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT));
+
+        OlapTable unsetFirstLoadTable = createHashOlapTable(TABLE_ID + 9202, TABLE_NAME + "_first_load_unset", 3);
+        Assertions.assertFalse(unsetFirstLoadTable.isSetEnableStatisticCollectOnFirstLoad());
+        Assertions.assertFalse(unsetFirstLoadTable.getProperties()
+                .containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD));
+
+        unsetFirstLoadTable.setEnableStatisticCollectOnFirstLoad(true);
+        Assertions.assertTrue(unsetFirstLoadTable.isSetEnableStatisticCollectOnFirstLoad());
+        Assertions.assertEquals("true", unsetFirstLoadTable.getProperties()
+                .get(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD));
+
+        Map<String, String> legacyDefaultTrueProperties = new HashMap<>();
+        legacyDefaultTrueProperties.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, "true");
+        TableProperty legacyDefaultTrueTableProperty = new TableProperty(legacyDefaultTrueProperties)
+                .buildEnableStatisticCollectOnFirstLoad();
+        Assertions.assertTrue(legacyDefaultTrueTableProperty.enableStatisticCollectOnFirstLoad());
+        Assertions.assertFalse(legacyDefaultTrueTableProperty.isSetEnableStatisticCollectOnFirstLoad());
+
+        Map<String, String> legacyExplicitFalseProperties = new HashMap<>();
+        legacyExplicitFalseProperties.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, "false");
+        TableProperty legacyExplicitFalseTableProperty = new TableProperty(legacyExplicitFalseProperties)
+                .buildEnableStatisticCollectOnFirstLoad();
+        Assertions.assertFalse(legacyExplicitFalseTableProperty.enableStatisticCollectOnFirstLoad());
+        Assertions.assertTrue(legacyExplicitFalseTableProperty.isSetEnableStatisticCollectOnFirstLoad());
+
+        Database replayDb = new Database(DB_ID + 9202, DB_NAME + "_first_load_replay");
+        metastore.unprotectCreateDb(replayDb);
+        OlapTable replayTable = createHashOlapTable(TABLE_ID + 9203, TABLE_NAME + "_first_load_replay", 3);
+        replayDb.registerTableUnlocked(replayTable);
+
+        Map<String, String> replayProperties = new HashMap<>();
+        replayProperties.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, "true");
+        ModifyTablePropertyOperationLog replayLog = new ModifyTablePropertyOperationLog(
+                replayDb.getId(), replayTable.getId(), replayProperties);
+        metastore.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, replayLog);
+        Assertions.assertTrue(replayTable.enableStatisticCollectOnFirstLoad());
+        Assertions.assertTrue(replayTable.isSetEnableStatisticCollectOnFirstLoad());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.DmlType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.InMemoryStatisticStorage;
@@ -201,5 +202,58 @@ public class StatisticsCollectionTriggerTest extends PlanTestBase {
         trigger = StatisticsCollectionTrigger.triggerOnFirstLoad(transactionState, db, table, true, true,
                 DmlType.UPDATE);
         Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, trigger.getAnalyzeType());
+    }
+
+    @Test
+    public void testTableLevelFirstLoadConfigOverridesGlobalWhenExplicitlySet() throws Exception {
+        boolean oldEnableStatisticCollectOnFirstLoad = Config.enable_statistic_collect_on_first_load;
+        try {
+            final String dbName = "test_statistics_first_load_override";
+            starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+            createPartitionedTable("t_follow_global", "");
+            createPartitionedTable("t_disable_table",
+                    ", 'enable_statistic_collect_on_first_load' = 'false'");
+            createPartitionedTable("t_enable_table",
+                    ", 'enable_statistic_collect_on_first_load' = 'true'");
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+
+            Config.enable_statistic_collect_on_first_load = false;
+            StatisticsCollectionTrigger trigger = triggerFirstLoad(db, "t_follow_global");
+            Assertions.assertNull(trigger.getAnalyzeType());
+
+            Config.enable_statistic_collect_on_first_load = true;
+            trigger = triggerFirstLoad(db, "t_disable_table");
+            Assertions.assertNull(trigger.getAnalyzeType());
+
+            Config.enable_statistic_collect_on_first_load = false;
+            trigger = triggerFirstLoad(db, "t_enable_table");
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, trigger.getAnalyzeType());
+        } finally {
+            Config.enable_statistic_collect_on_first_load = oldEnableStatisticCollectOnFirstLoad;
+        }
+    }
+
+    private void createPartitionedTable(String tableName, String extraProperties) throws Exception {
+        starRocksAssert.withTable("create table " + tableName + " (" +
+                "c1 int not null," +
+                "c2 int not null" +
+                ") " +
+                "partition by (c1)\n" +
+                "properties('replication_num'='1'" + extraProperties + ")");
+        starRocksAssert.ddl("alter table " + tableName + " add partition p1 values in ('1')");
+    }
+
+    private StatisticsCollectionTrigger triggerFirstLoad(Database db, String tableName) {
+        Table table = db.getTable(tableName);
+        Partition partition = table.getPartition("p1");
+        TransactionState transactionState = new TransactionState();
+        TableCommitInfo commitInfo = new TableCommitInfo(table.getId());
+        commitInfo.addPartitionCommitInfo(new PartitionCommitInfo(partition.getDefaultPhysicalPartition().getId(), 2, 1));
+        transactionState.putIdToTableCommitInfo(table.getId(), commitInfo);
+        transactionState.setTxnCommitAttachment(new InsertTxnCommitAttachment(1000, 5));
+        setPartitionStatistics((OlapTable) table, "p1", 1000);
+        return StatisticsCollectionTrigger.triggerOnFirstLoad(transactionState, db, table, true, true,
+                DmlType.INSERT_INTO);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`enable_statistic_collect_on_first_load` currently behaves like an AND between the table property and the global config. This makes it impossible to disable first-load statistics collection globally while enabling it for selected tables.

Also, the old create-table flow always persisted `enable_statistic_collect_on_first_load=true` into table properties by default, even when users did not explicitly set this property. So we cannot simply use the existence of this key to determine whether the table property was explicitly configured.

The expected behavior is:
- If the table property is explicitly set, use the table-level value.
- If the table property is not explicitly set, fall back to the global config.

## What I'm doing:

Change the first-load statistics collection decision from:

```text
table_value && global_value
```

to:

```text
table property explicitly set ? table_value : global_value
```

Behavior before this change:

```text
table default true + global true  => collect
table default true + global false => skip
table false        + global true  => skip
table false        + global false => skip
table true         + global false => skip
```

Behavior after this change:

```text
table unset        + global true  => collect
table unset        + global false => skip
table false        + global true  => skip
table false        + global false => skip
table true         + global true  => collect
table true         + global false => collect
```

Compatibility handling:
- Add an explicit-set marker in `TableProperty` for new metadata.
- Only persist `enable_statistic_collect_on_first_load` during create table when users explicitly specify it.
- For old metadata:
  - Old `enable_statistic_collect_on_first_load=true` is treated as unset, because it may have been written by the old default create-table flow.
  - Old `enable_statistic_collect_on_first_load=false` is treated as explicitly set, because old default creation would not write `false`.
- This preserves existing behavior for most upgraded tables: if users never configured the table property, the table still follows the global config.

Other changes:
- Remove the global config short-circuit in `LoadJobStatsListener`, so the final decision can be made per table in `StatisticsCollectionTrigger`.
- Add FE unit tests for runtime trigger behavior and metadata compatibility.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
