### PR TITLE
[Tool] Wire the module-risk briefing into the @codex review contract

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -10,13 +10,8 @@ on:
       - synchronize          # re-brief on every push so the comment tracks the live diff
       - ready_for_review     # brief when a draft is marked ready
 
-concurrency:
-  group: AI-SR-SKILLS-${{ github.event.number }}
-  cancel-in-progress: true
-
 permissions:
   pull-requests: write
-  issues: write          # the upsert step posts/edits via the Issues comments API (gh pr comment / /issues/{n}/comments)
 
 jobs:
   assign-reviewer:
@@ -246,6 +241,18 @@ jobs:
   # For an external PR a maintainer can still run /github-pr-module-risk:review manually.
   module-risk:
     runs-on: [self-hosted, normal]
+    # Dedup rapid pushes for THIS job only (a new event cancels the in-flight briefing run).
+    # Job-scoped — NOT workflow-wide — so a synchronize run never cancels the opened-only
+    # assign-reviewer job (which would otherwise miss reviewer assignment + Slack).
+    concurrency:
+      group: ai-sr-skills-module-risk-${{ github.event.number }}
+      cancel-in-progress: true
+    # Least privilege: only this job posts the sticky comment (Issues comments API), so issues:write
+    # lives here, not workflow-wide where it would also reach assign-reviewer's GITHUB_TOKEN.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     continue-on-error: true
     if: >
       (github.event.action == 'opened' || github.event.action == 'reopened' ||

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -7,6 +7,8 @@ on:
     types:
       - opened
       - reopened
+      - synchronize          # re-brief on every push so the comment tracks the live diff
+      - ready_for_review     # brief when a draft is marked ready
 
 concurrency:
   group: AI-SR-SKILLS-${{ github.event.number }}
@@ -14,6 +16,7 @@ concurrency:
 
 permissions:
   pull-requests: write
+  issues: write          # the upsert step posts/edits via the Issues comments API (gh pr comment / /issues/{n}/comments)
 
 jobs:
   assign-reviewer:
@@ -245,7 +248,8 @@ jobs:
     runs-on: [self-hosted, normal]
     continue-on-error: true
     if: >
-      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      (github.event.action == 'opened' || github.event.action == 'reopened' ||
+       github.event.action == 'synchronize' || github.event.action == 'ready_for_review') &&
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
@@ -253,6 +257,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Module-risk briefing (AI, read-only)
         run: |
@@ -282,7 +287,14 @@ jobs:
             echo "no high-confidence, diff-aligned module risk — not commenting"
             exit 0
           fi
-          printf '%s\n' "$body" > "${RUNNER_TEMP}/mr_body.md"
+          # Stamp the PR head SHA as line 2 (right after the marker, which sed guaranteed is line 1)
+          # so reviewers can detect a briefing that predates the latest push. awk avoids sed escaping
+          # pitfalls; the SHA is hex so it is injection-safe. Applies to both the real briefing and the
+          # incomplete-coverage caveat (both carry the marker as line 1).
+          sha_line="<!-- module-risk-head-sha: ${PR_HEAD_SHA} -->"
+          printf '%s\n' "$body" \
+            | awk -v s="$sha_line" 'NR==1{print; print s; next} {print}' \
+            > "${RUNNER_TEMP}/mr_body.md"
           # Sticky: edit our existing marked comment if present, else create one. Idempotent across
           # reopen / workflow rerun (the marker identifies our comment; gh is host-side, not in the
           # container). PATCH body is JSON-built with jq so markdown is escaped correctly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,23 @@ cd test && python3 run.py -v
 - Bug-fix PRs intended for branch backports must set the version checkboxes that drive auto-backporting.
 - When editing any file under `docs/`, read `docs/CLAUDE.md` for documentation-specific rules before making changes.
 
+## Codex PR Review Context
+
+When performing a PR review (including `@codex review`), first inspect the PR
+comments for one beginning with `<!-- module-risk-briefing -->`.
+
+If a current briefing exists, treat it as review focus, not a finding list:
+- check the listed modules/files first;
+- validate every risk against the actual diff before reporting;
+- do not report a finding solely because the briefing cites a historical risk;
+- if the embedded `<!-- module-risk-head-sha: X -->` differs from the PR's
+  current head commit, the briefing predates the latest push: use it only as
+  historical reference, NOT as the primary review focus for the current diff,
+  and flag this in the review summary;
+- if the briefing is stale or absent, say so briefly — never silently drop the
+  historical risks, and never report one as a current finding without checking
+  the diff.
+
 ## Nested Guides
 
 - [`handbook/index.md`](./handbook/index.md)


### PR DESCRIPTION
## Why I'm doing:

The `module-risk` CI job already mines a history-backed, diff-aligned review focus from merged-bugfix pathology cards and posts it as a sticky PR comment, but nothing tells a reviewer — in particular `@codex review` — that the comment exists or how to consume it, and the briefing can go stale after a push with no way to detect it. This PR gives `@codex review` a deterministic entry point to that briefing, keeps it fresh at review time, and makes staleness detectable.

## What I'm doing:

- `AGENTS.md`: add a `Codex PR Review Context` section telling a PR review to first read the `<!-- module-risk-briefing -->` sticky comment as review focus — validate every risk against the diff; if the embedded head-sha differs from the PR head, treat the briefing as historical reference only, not the primary focus; flag a stale or absent briefing.
- `.github/workflows/ai-sr-skills.yml`: re-run the briefing on `synchronize` and `ready_for_review` (not just open/reopen) so it tracks the live diff; grant `issues: write` for the comment upsert (Issues comments API); and stamp the PR head sha into the sticky comment (`<!-- module-risk-head-sha: ... -->`) so reviewers can detect a briefing that predates the latest push. The existing `author_association` trust gate and the mergify / sync-pr exclusions are unchanged, so external contributors still never reach the model.

This is the CI side of the contract; the briefing's fixed, Codex-parseable output structure (with PR-URL evidence) is a companion change to the `github-pr-module-risk` skill in the `CelerData/claude-marketplace` repo.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr
