### PR TITLE
[BugFix] Prevent zero row counts from corrupting partition statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -47,7 +47,7 @@ public class StatisticSQLBuilder {
     private static final String QUERY_TABLE_STATISTIC_TEMPLATE =
             "select cast(" + STATISTIC_TABLE_VERSION + " as INT), partition_id, any_value(row_count)"
                     + " FROM " + FULL_STATISTICS_TABLE_NAME
-                    + " WHERE $predicate"
+                    + " WHERE $predicate AND row_count > 0"
                     + " GROUP BY partition_id";
 
     private static final String QUERY_PARTITION_STATISTIC_TEMPLATE =

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/ConstQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/ConstQueryJob.java
@@ -44,7 +44,11 @@ public class ConstQueryJob extends HyperQueryJob {
             if (partition == null || !partition.hasData()) {
                 continue;
             }
-            partitionRowCounts.put(pid, partition.getRowCount());
+            long rowCount = partition.getRowCount();
+            if (rowCount <= 0) {
+                continue;
+            }
+            partitionRowCounts.put(pid, rowCount);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -385,6 +385,18 @@ public class StatisticsSQLTest extends PlanTestBase {
     }
 
     @Test
+    public void testQueryTableStatisticsFiltersZeroRowCount() {
+        String sql = StatisticSQLBuilder.buildQueryTableStatisticsSQL(2L, Lists.newArrayList());
+        assertContains(sql, "WHERE table_id = 2 AND row_count > 0");
+
+        sql = StatisticSQLBuilder.buildQueryTableStatisticsSQL(2L, Lists.newArrayList(10L, 20L));
+        assertContains(sql, "WHERE table_id = 2 and partition_id in (10, 20) AND row_count > 0");
+
+        sql = StatisticSQLBuilder.buildQueryTableStatisticsSQL(2L, 10L);
+        assertContains(sql, "WHERE table_id = 2 and partition_id = 10 AND row_count > 0");
+    }
+
+    @Test
     public void testCacheExternalQueryColumnStatics() {
         String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a", Lists.newArrayList("col1", "col2"),
                 Lists.newArrayList(IntegerType.INT, IntegerType.INT));

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
@@ -235,6 +235,31 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
+    public void testConstQueryJobSkipsPartitionWithZeroRowCount() {
+        Pair<List<String>, List<Type>> pair = initColumn(List.of("c4", "c5", "c6"));
+        for (Partition partition : ((OlapTable) table).getAllPartitions()) {
+            partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(0);
+        }
+        try {
+            List<HyperQueryJob> jobs = HyperQueryJob.createFullQueryJobs(1L, connectContext, db, table, pair.first,
+                    pair.second, List.of(pid), 1, false);
+            ConstQueryJob constQueryJob = jobs.stream()
+                    .filter(ConstQueryJob.class::isInstance)
+                    .map(ConstQueryJob.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("missing ConstQueryJob"));
+
+            constQueryJob.queryStatistics();
+            Assertions.assertTrue(constQueryJob.getStatisticsValueSQL().isEmpty());
+            Assertions.assertTrue(constQueryJob.getStatisticsData().isEmpty());
+        } finally {
+            for (Partition partition : ((OlapTable) table).getAllPartitions()) {
+                partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(10000);
+            }
+        }
+    }
+
+    @Test
     public void testFullJobs() {
         Pair<List<String>, List<Type>> pair = initColumn(List.of("c1", "c2", "c3"));
 


### PR DESCRIPTION
## Why I'm doing:

After INSERT OVERWRITE, partition row counts in FE metadata may still be 0 before tablet stats are refreshed. For unsupported statistics columns such as JSON/complex types, `ConstQueryJob` uses `partition.getRowCount()` directly and may write `row_count=0` into `_statistics_.column_statistics`.

This can make `row_count` inconsistent across columns in the same partition. Later, table row count estimation queries use `any_value(row_count)` grouped by partition. If `any_value` picks the zero row count, the partition cardinality may collapse to 1, leading to bad plans such as broadcasting a large table.

## What I'm doing:

Prevent zero row counts from entering or affecting partition-level statistics:

- Skip `ConstQueryJob` output when `partition.getRowCount() <= 0`.
- Add `row_count > 0` to table statistics row-count query SQL, so historical zero row counts are ignored.
- Keep `any_value(row_count)` instead of changing it to `max(row_count)`, so partitions with only zero row counts return no cache-hit row and can fall back to safer row-count estimation.
- Add FE unit tests for both:
  - `ConstQueryJob` does not emit statistics rows for zero-row-count partitions.
  - table statistics query SQL filters out `row_count <= 0`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
