### PR TITLE
[BugFix] Stop double-counting vector index cache memory on the process tracker

### DIFF
--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -83,9 +83,20 @@ Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::str
     auto meta_copy = meta;
     apply_index_reader_cache_options(&meta_copy);
 
-    // Loader runs under vector_index mem tracker and opens the remote file
-    // lazily, so warm-path cache hits skip the OSS/S3 round-trip entirely.
-    auto* tracker = GlobalEnv::GetInstance()->vector_index_mem_tracker();
+    // Loader opens the remote file lazily, so warm-path cache hits skip the OSS/S3
+    // round-trip entirely.
+    //
+    // Charge the load to the process tracker (not the vector_index tracker): the
+    // index lives in the heap, so the allocator hook already accounts these bytes
+    // to process exactly once here. The VectorIndexCache then labels the same bytes
+    // on the vector_index tracker via consume_without_root (see its ctor), which
+    // does NOT re-add to process. Pointing the hook at the vector_index tracker
+    // instead would double the vector_index label (hook + cache) and leak it on
+    // eviction (the eventual tenann free runs on whatever thread drops the last
+    // IndexRef, not necessarily under this tracker). Routing through process keeps
+    // the load off the originating query's mem limit while leaving the deterministic
+    // cache consume/release as the sole source of the vector_index label.
+    auto* tracker = GlobalEnv::GetInstance()->process_mem_tracker();
 
     // Loader catches its own failures (incl. tenann::Error, which inherits
     // privately from std::exception and would otherwise escape GetOrCreate)

--- a/be/src/storage/index/vector/vector_index_cache.cpp
+++ b/be/src/storage/index/vector/vector_index_cache.cpp
@@ -22,7 +22,13 @@
 namespace starrocks {
 
 VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker) : _cache(capacity) {
-    _cache.set_mem_tracker(tracker);
+    // The HNSW/tenann index lives in the normal heap, so the global allocator hook
+    // already charges its bytes to the process tracker once during load. Accounting
+    // them additively on the vector_index tracker (a child of process) would count
+    // the same bytes a second time on process and spuriously trip the process
+    // mem_limit. Use the excluding-root variant so the vector_index tracker labels
+    // the usage without re-adding it to process.
+    _cache.set_mem_tracker_excluding_root(tracker);
 }
 
 // Drain IndexRefs outside _cache._lock before ~DynamicCache acquires it.

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -91,9 +91,25 @@ public:
         _list.clear();
     }
 
+    // Additive accounting: cached bytes are consumed on `mem_tracker` and propagate
+    // up to all ancestors including the root (process) tracker.
     void set_mem_tracker(MemTracker* mem_tracker) {
         DCHECK(_mem_tracker == nullptr);
         _mem_tracker = mem_tracker;
+    }
+
+    // Like set_mem_tracker, but accounts cached bytes via
+    // consume_without_root/release_without_root: the cache tracker labels the usage
+    // WITHOUT re-adding it to the root (process) tracker. Use this for caches whose
+    // objects live in the normal heap -- the global allocator hook already charges
+    // those bytes to process once, so plain additive accounting would count them a
+    // second time on process and can spuriously trip the process mem_limit. The cache
+    // tracker then acts as a non-additive label/view of process. Same idiom as
+    // segment_replicate_executor's brpc send buffer. See MemTracker::consume_without_root.
+    void set_mem_tracker_excluding_root(MemTracker* mem_tracker) {
+        DCHECK(_mem_tracker == nullptr);
+        _mem_tracker = mem_tracker;
+        _tracker_exclude_root = true;
     }
 
     // get or return null
@@ -127,7 +143,7 @@ public:
             _object_size++;
             if (insert->_size > 0) {
                 _size += insert->_size;
-                if (_mem_tracker) _mem_tracker->consume(insert->_size);
+                _tracker_consume(insert->_size);
                 _evict();
             }
             return *ret;
@@ -153,7 +169,7 @@ public:
             _list.erase(entry->_handle);
             _object_size--;
             _size -= entry->_size;
-            if (_mem_tracker) _mem_tracker->release(entry->_size);
+            _tracker_release(entry->_size);
             delete entry;
         }
     }
@@ -169,7 +185,7 @@ public:
             _list.erase(entry->_handle);
             _object_size--;
             _size -= entry->_size;
-            if (_mem_tracker) _mem_tracker->release(entry->_size);
+            _tracker_release(entry->_size);
             delete entry;
             return true;
         }
@@ -195,7 +211,7 @@ public:
             _list.erase(v);
             _object_size--;
             _size -= entry->_size;
-            if (_mem_tracker) _mem_tracker->release(entry->_size);
+            _tracker_release(entry->_size);
             delete entry;
         }
         return true;
@@ -219,7 +235,7 @@ public:
             _list.erase(v);
             _object_size--;
             _size -= entry->_size;
-            if (_mem_tracker) _mem_tracker->release(entry->_size);
+            _tracker_release(entry->_size);
             delete entry;
         }
         return true;
@@ -238,7 +254,7 @@ public:
         {
             std::lock_guard<Lock> lg(_lock);
             _size += new_size - entry->_size;
-            if (_mem_tracker) _mem_tracker->consume(new_size - entry->_size);
+            _tracker_consume(new_size - entry->_size);
             entry->_size = new_size;
             ret = _evict(_capacity, &entry_list);
         }
@@ -263,7 +279,7 @@ public:
                     itr = _list.erase(itr);
                     _object_size--;
                     _size -= entry->_size;
-                    if (_mem_tracker) _mem_tracker->release(entry->_size);
+                    _tracker_release(entry->_size);
                     entry_list.push_back(entry);
                 } else {
                     itr++;
@@ -289,7 +305,7 @@ public:
                     itr = _list.erase(itr);
                     _object_size--;
                     _size -= entry->_size;
-                    if (_mem_tracker) _mem_tracker->release(entry->_size);
+                    _tracker_release(entry->_size);
                     entry_list.push_back(entry);
                 } else {
                     itr++;
@@ -383,7 +399,7 @@ private:
                 itr = _list.erase(itr);
                 _object_size--;
                 _size -= entry->_size;
-                if (_mem_tracker) _mem_tracker->release(entry->_size);
+                _tracker_release(entry->_size);
                 entry_list->push_back(entry);
             } else {
                 itr++;
@@ -401,6 +417,26 @@ private:
         return ret;
     }
 
+    // Route tracker accounting through consume_without_root when _tracker_exclude_root
+    // is set, so heap-resident cache bytes already charged to process by the allocator
+    // hook are not counted a second time on process.
+    void _tracker_consume(int64_t bytes) {
+        if (_mem_tracker == nullptr) return;
+        if (_tracker_exclude_root) {
+            _mem_tracker->consume_without_root(bytes);
+        } else {
+            _mem_tracker->consume(bytes);
+        }
+    }
+    void _tracker_release(int64_t bytes) {
+        if (_mem_tracker == nullptr) return;
+        if (_tracker_exclude_root) {
+            _mem_tracker->release_without_root(bytes);
+        } else {
+            _mem_tracker->release(bytes);
+        }
+    }
+
     mutable Lock _lock;
     List _list;
     Map _map;
@@ -409,6 +445,7 @@ private:
     size_t _capacity = 0;
 
     MemTracker* _mem_tracker = nullptr;
+    bool _tracker_exclude_root = false;
 };
 
 } // namespace starrocks

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -532,8 +532,7 @@ TEST(TenANNReaderTest, InitSearcher_ChargesLoadToProcessNotVectorIndex) {
     tenann::SetGlobalIndexCache(saved);
 
     ASSERT_NE(nullptr, fs.captured) << "loader never opened the index file via fs";
-    EXPECT_EQ(process, fs.captured) << "index load charged to '" << fs.captured->label()
-                                    << "', expected 'process'";
+    EXPECT_EQ(process, fs.captured) << "index load charged to '" << fs.captured->label() << "', expected 'process'";
     EXPECT_NE(vi, fs.captured);
     EXPECT_NE(&fake_query, fs.captured);
 }

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -29,6 +29,8 @@
 #include "base/testutil/assert.h"
 #include "common/status.h"
 #include "fs/fs_memory.h"
+#include "runtime/current_thread.h"
+#include "runtime/env/global_env.h"
 #include "runtime/mem_tracker.h"
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
@@ -349,6 +351,35 @@ TEST_F(VectorIndexCacheTest, ShutdownAndShrink_WithSelfReferentialEntry_NoDeadlo
     c.reset();
 }
 
+// Regression guard for the process-tracker double-count. A heap-resident HNSW index
+// is charged to the process tracker once by the allocator hook during load
+// (count #1); VectorIndexCache must NOT charge it a second time. The cache is built
+// with exclude_root so its DynamicCache labels the vector_index tracker WITHOUT
+// re-propagating to process. Reverting VectorIndexCache to a plain set_mem_tracker
+// (additive consume) makes process carry BOTH copies and fails the process assert
+// below -- that is the bug this test exists to catch.
+//
+// The mem_hook -> MemTracker wiring is stubbed in BE_TEST (mem_hook.cpp routes to
+// g_mem_usage, not the tracker tree), so count #1 is modeled with an explicit
+// consume on the process tracker; its net effect on the process counter is identical
+// to the allocator hook's.
+TEST(VectorIndexCacheDoubleCountTest, InsertDoesNotDoubleCountProcessTracker) {
+    MemTracker process(-1, "process", nullptr);
+    MemTracker vector_index(-1, "vector_index", &process);
+    VectorIndexCache cache(/*capacity=*/64 * 1024, &vector_index);
+
+    constexpr int64_t kHookBytes = 8192;  // allocator hook charge during load (count #1)
+    constexpr int64_t kIndexBytes = 4096; // tenann index memory_usage() (count #2)
+
+    process.consume(kHookBytes); // count #1 (allocator hook, modeled)
+
+    tenann::IndexCacheHandle h;
+    cache.Insert(tenann::CacheKey("/idx.vi"), make_dummy_ref(kIndexBytes), &h); // count #2 via cache
+
+    EXPECT_EQ(kIndexBytes, vector_index.consumption()); // vector_index labels the index size
+    EXPECT_EQ(kHookBytes, process.consumption());       // process counted ONCE (not 8192 + 4096)
+}
+
 // === Sibling helpers under storage/index/vector ===
 
 TEST(TenannErrorToStatusTest, NotFoundVariantsMapToNotFound) {
@@ -441,6 +472,70 @@ TEST(TenANNReaderTest, InitSearcher_MalformedFile_ReturnsNonOk) {
     EXPECT_FALSE(st.ok()) << "loader should surface tenann::Error / std::exception, not crash";
 
     tenann::SetGlobalIndexCache(saved);
+}
+
+// A FileSystem that records which mem tracker is active when the index file is
+// opened. VectorIndexFileReader::open() (-> fs->new_random_access_file) runs inside
+// TenANNReader's loader, under the loader's SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER,
+// so the captured tracker is exactly the one the allocator hook would charge
+// index-load allocations to in production.
+namespace {
+class TrackerProbeFileSystem : public MemoryFileSystem {
+public:
+    using MemoryFileSystem::new_random_access_file;
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
+                                                                       const std::string& fname) override {
+        captured = CurrentThread::mem_tracker();
+        return MemoryFileSystem::new_random_access_file(opts, fname);
+    }
+    MemTracker* captured = nullptr;
+};
+} // namespace
+
+// Covers the tenann_index_reader.cpp change that the DynamicCache-level tests can't:
+// index-load allocations must be charged to the PROCESS tracker, not vector_index
+// and not the originating query's tracker. The allocator hook is stubbed in BE_TEST
+// (mem_hook.cpp -> g_mem_usage), so instead of observing a real allocation we capture
+// CurrentThread::mem_tracker() during the load -- that IS the tracker the hook keys
+// off, so verifying it pins the accounting target.
+//
+// Reverting the loader to vector_index_mem_tracker() -> captured == vi -> fails.
+// Dropping the scoped setter entirely -> captured == the ambient query tracker -> fails.
+TEST(TenANNReaderTest, InitSearcher_ChargesLoadToProcessNotVectorIndex) {
+    auto* process = GlobalEnv::GetInstance()->process_mem_tracker();
+    auto* vi = GlobalEnv::GetInstance()->vector_index_mem_tracker();
+    ASSERT_NE(nullptr, process);
+    ASSERT_NE(nullptr, vi);
+
+    // Missing path on purpose: open() still calls new_random_access_file (where the
+    // probe captures the active tracker) but then fails NotFound, so the loader bails
+    // before ReadIndexFile -- we never feed garbage to faiss, which can SIGSEGV on
+    // malformed input. The tracker we want to assert on is already captured by then.
+    TrackerProbeFileSystem fs;
+
+    MemTracker cache_tracker(-1, "vi_cache_probe");
+    VectorIndexCache cache(/*capacity=*/1024, &cache_tracker);
+    auto* saved = tenann::GetGlobalIndexCache();
+    tenann::SetGlobalIndexCache(&cache);
+
+    // Simulate the load being triggered while running under a query's mem tracker
+    // (distinct from both process and vector_index). The loader must redirect the
+    // load to process regardless.
+    MemTracker fake_query(-1, "fake_query_ambient");
+    {
+        CurrentThreadMemTrackerSetter ambient(&fake_query);
+        TenANNReader r;
+        auto meta = make_minimal_meta();
+        // Load runs the probe fs, then fails NotFound (return ignored).
+        (void)r.init_searcher(meta, "/no/such/probe.vi", &fs);
+    }
+    tenann::SetGlobalIndexCache(saved);
+
+    ASSERT_NE(nullptr, fs.captured) << "loader never opened the index file via fs";
+    EXPECT_EQ(process, fs.captured) << "index load charged to '" << fs.captured->label()
+                                    << "', expected 'process'";
+    EXPECT_NE(vi, fs.captured);
+    EXPECT_NE(&fake_query, fs.captured);
 }
 
 TEST(VectorIndexCacheEntryTest, StreamingOperatorPrintsTag) {

--- a/be/test/util/dynamic_cache_test.cpp
+++ b/be/test/util/dynamic_cache_test.cpp
@@ -86,6 +86,99 @@ TEST(DynamicCacheTest, cache2) {
     }
 }
 
+// Default tracker accounting is additive: a plain consume() walks the ancestor
+// chain, so the cache tracker AND its root (process) tracker both grow. This is the
+// long-standing behavior other DynamicCache users rely on.
+TEST(DynamicCacheTest, mem_tracker_default_additive) {
+    MemTracker root(-1, "root", nullptr);
+    MemTracker child(-1, "child", &root);
+    DynamicCache<int32_t, int64_t> cache(1000);
+    cache.set_mem_tracker(&child); // default: exclude_root = false
+
+    auto* e = cache.get_or_create(1);
+    cache.update_object_size(e, 100);
+    EXPECT_EQ(100, child.consumption());
+    EXPECT_EQ(100, root.consumption());
+
+    cache.release(e);
+    cache.clear();
+    EXPECT_EQ(0, child.consumption());
+    EXPECT_EQ(0, root.consumption());
+}
+
+// With exclude_root, the cache tracker labels usage WITHOUT re-adding to the root
+// (process) tracker. This is required for caches whose objects live in the normal
+// heap (e.g. the vector index cache): the allocator hook already charges those bytes
+// to process once, so an additive consume here would double-count process and can
+// spuriously trip the process mem_limit.
+TEST(DynamicCacheTest, mem_tracker_exclude_root) {
+    MemTracker root(-1, "root", nullptr);
+    MemTracker child(-1, "child", &root);
+    DynamicCache<int32_t, int64_t> cache(1000);
+    cache.set_mem_tracker_excluding_root(&child);
+
+    auto* e = cache.get_or_create(1);
+    cache.update_object_size(e, 100);
+    EXPECT_EQ(100, child.consumption()); // child is labeled
+    EXPECT_EQ(0, root.consumption());    // root is NOT double-charged
+
+    cache.release(e);
+    cache.clear();
+    EXPECT_EQ(0, child.consumption()); // release_without_root returns child to zero
+    EXPECT_EQ(0, root.consumption()); // root was never touched
+}
+
+// End-to-end reproduction of the process double-count, at the MemTracker level.
+//
+// The real bug stacks two charges on the process tracker for the same heap bytes:
+//   count #1: the allocator hook charges process once while the index loads;
+//   count #2: DynamicCache::update_object_size charges memory_usage() again.
+// The mem_hook -> MemTracker wiring is stubbed in BE_TEST builds (mem_hook.cpp
+// routes to g_mem_usage, not the tracker tree), so we stand in for count #1 with an
+// explicit consume() on the process tracker -- its net effect on the process counter
+// is identical to the hook's. Count #2 exercises the real cache code path.
+TEST(DynamicCacheTest, mem_tracker_no_double_count_on_process) {
+    constexpr int64_t kHookBytes = 4096;    // what the allocator hook charges process
+    constexpr int64_t kLogicalBytes = 4000; // what the cache reports via memory_usage()
+
+    // Additive cache (pre-fix behavior): process carries BOTH copies -> double-count.
+    {
+        MemTracker process(-1, "process", nullptr);
+        MemTracker vi(-1, "vector_index", &process);
+        DynamicCache<int32_t, int64_t> cache(1000);
+        cache.set_mem_tracker(&vi);
+
+        process.consume(kHookBytes); // count #1 (allocator hook, modeled)
+        auto* e = cache.get_or_create(1);
+        cache.update_object_size(e, kLogicalBytes); // count #2 (cache), propagates to process
+        EXPECT_EQ(kHookBytes + kLogicalBytes, process.consumption());
+        cache.release(e);
+        cache.clear();
+    }
+
+    // exclude_root cache (the fix): process is counted exactly once.
+    {
+        MemTracker process(-1, "process", nullptr);
+        MemTracker vi(-1, "vector_index", &process);
+        DynamicCache<int32_t, int64_t> cache(1000);
+        cache.set_mem_tracker_excluding_root(&vi);
+
+        process.consume(kHookBytes); // count #1 (allocator hook, modeled)
+        auto* e = cache.get_or_create(1);
+        cache.update_object_size(e, kLogicalBytes); // count #2 now labels vi only
+        EXPECT_EQ(kHookBytes, process.consumption()); // process: single count
+        EXPECT_EQ(kLogicalBytes, vi.consumption());   // vi: labels the logical size
+
+        cache.release(e);
+        cache.clear();
+        EXPECT_EQ(kHookBytes, process.consumption()); // cache release must NOT touch process
+        EXPECT_EQ(0, vi.consumption());
+
+        process.release(kHookBytes); // free-side hook (modeled): full cycle returns to zero
+        EXPECT_EQ(0, process.consumption());
+    }
+}
+
 TEST(DynamicCacheTest, get_all_entries) {
     DynamicCache<int32_t, int64_t> cache(100);
     for (int i = 0; i < 20; i++) {

--- a/be/test/util/dynamic_cache_test.cpp
+++ b/be/test/util/dynamic_cache_test.cpp
@@ -125,7 +125,7 @@ TEST(DynamicCacheTest, mem_tracker_exclude_root) {
     cache.release(e);
     cache.clear();
     EXPECT_EQ(0, child.consumption()); // release_without_root returns child to zero
-    EXPECT_EQ(0, root.consumption()); // root was never touched
+    EXPECT_EQ(0, root.consumption());  // root was never touched
 }
 
 // End-to-end reproduction of the process double-count, at the MemTracker level.
@@ -165,7 +165,7 @@ TEST(DynamicCacheTest, mem_tracker_no_double_count_on_process) {
 
         process.consume(kHookBytes); // count #1 (allocator hook, modeled)
         auto* e = cache.get_or_create(1);
-        cache.update_object_size(e, kLogicalBytes); // count #2 now labels vi only
+        cache.update_object_size(e, kLogicalBytes);   // count #2 now labels vi only
         EXPECT_EQ(kHookBytes, process.consumption()); // process: single count
         EXPECT_EQ(kLogicalBytes, vi.consumption());   // vi: labels the logical size
 


### PR DESCRIPTION
## Why I'm doing:

The HNSW/tenann vector index lives in the normal heap, so the global allocator hook charges its bytes to the process mem tracker once while the index loads. `VectorIndexCache` then accounted the same bytes a second time: `DynamicCache::update_object_size` did a plain `consume()` on the `vector_index` tracker, which is a child of `process` and therefore propagated the bytes up to `process` again.

A cached index thus appeared twice in the process counter (real heap once + cache label once), inflating it by a full copy of every cached index. On a node with large indexes this pushed the process counter past `mem_limit` and caused spurious `MEM_LIMIT_EXCEEDED` for every query, even though real RSS was far below the limit (e.g. observed `process_mem_bytes` 26.77GB = jemalloc 15.27GB + vector_index 11.43GB, with RSS only 14.7GB).

## What I'm doing:

Fix the accounting without disturbing the self-balancing allocator-hook pair (its alloc `+` / free `-` already cancel on `process`). `DynamicCache` gains `set_mem_tracker_excluding_root()`, which routes the cache's accounting through `consume_without_root`/`release_without_root` so the cache tracker labels usage without re-adding it to the root (process) tracker — the same idiom `segment_replicate_executor` already uses for brpc send buffers. The existing `set_mem_tracker()` (additive) is unchanged, so other `DynamicCache` users keep their current behavior. `VectorIndexCache` opts into the new variant, and `TenANNReader` charges index-load allocations to the process tracker instead of the vector_index tracker (the hook already counts these heap bytes on process once; pointing it at vector_index would double the vector_index label and leak it on eviction). After the fix the process counter reflects the index exactly once and stays balanced across insert/evict cycles, while the `vector_index` tracker still reports the logical index size.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5