### PR TITLE
[BugFix] Fix heap-use-after-free in HiveDataSource when ColumnExprPredicates outlive their pooled Exprs

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -92,6 +92,14 @@ HiveDataSource::HiveDataSource(const HiveDataSourceProvider* provider, const TSc
 HiveDataSource::HiveDataSource(const HiveDataSourceProvider* provider, const THdfsScanRange& hdfs_scan_range)
         : _provider(provider), _scan_range(hdfs_scan_range) {}
 
+HiveDataSource::~HiveDataSource() {
+    // ColumnExprPredicate objects in predicate_free_pool hold ExprContext references
+    // whose _root pointers point into _pool.  _pool is destroyed before _scanner_ctx
+    // (reverse member-declaration order), so we must destroy the ColumnExprPredicates
+    // here — in the destructor body — while _pool is still alive.
+    _scanner_ctx.predicates.predicate_free_pool.clear();
+}
+
 Status HiveDataSource::_check_all_slots_nullable() {
     for (const auto* slot : _tuple_desc->slots()) {
         if (!slot->is_nullable()) {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -68,7 +68,7 @@ protected:
 
 class HiveDataSource final : public DataSource {
 public:
-    ~HiveDataSource() override = default;
+    ~HiveDataSource() override;
 
     HiveDataSource(const HiveDataSourceProvider* provider, const TScanRange& scan_range);
     HiveDataSource(const HiveDataSourceProvider* provider, const THdfsScanRange& hdfs_scan_range);


### PR DESCRIPTION
## Why I'm doing:

ASAN crash reported in [StarRocksTest#11423](https://github.com/StarRocks/StarRocksTest/issues/11423), triggered by `test_global_dict_on_lake`.

```
ERROR: AddressSanitizer: heap-use-after-free
READ in starrocks::ExprContext::close() be/src/exprs/expr_context.cpp:112
  <- ColumnExprPredicate::~ColumnExprPredicate() column_expr_predicate.cpp:46
  <- HdfsScannerContext::PredicateState::~PredicateState()
  <- HiveDataSource::~HiveDataSource()
freed by:
  ObjectPool::~ObjectPool()
  <- HiveDataSource::~HiveDataSource()
```

## What I'm doing:

Fixes #issue

`HiveDataSource` has two relevant members declared in this order:

```cpp
HdfsScannerContext _scanner_ctx;  // declared first → destroyed last
ObjectPool _pool;                 // declared last  → destroyed first
```

`_pool` owns the `Expr` nodes (e.g. `VectorizedBinaryPredicate`) created in `_init_conjunct_ctxs()`.  
`_scanner_ctx.predicates.predicate_free_pool` owns `ColumnExprPredicate` objects whose cloned `ExprContext::_root` pointers point into those same `_pool`-owned nodes.

Because C++ destroys members in reverse-declaration order, `_pool` is destroyed **before** `_scanner_ctx`.  
When `_scanner_ctx` is then destroyed, `ColumnExprPredicate::~ColumnExprPredicate()` calls `ExprContext::close()` → `_root->close()` on already-freed memory.

The member order cannot be simply reversed: the existing comment explains that `JniScanner` objects stored in `_pool` dereference `_scanner_ctx` during their own destruction (`JniScanner::~JniScanner → close()`), requiring `_scanner_ctx` to outlive `_pool`.

**Fix:** add an explicit destructor body that calls `predicate_free_pool.clear()` before any member destruction begins.  The destructor body executes while all members are still alive, so `ExprContext::close()` safely accesses `_root` through the live `_pool`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5