### PR TITLE
[BugFix] Prevent Parquet temporary dict-code columns from leaking to upper layers (backport #74452)

### DIFF
--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -537,7 +537,11 @@ private:
         // assign null infos
         size_t null_cnt = null_infos.num_nulls;
         // resize data
-        auto* binary_column = ColumnHelper::get_binary_column(dst);
+        auto* data_column = ColumnHelper::get_data_column(dst);
+        if (UNLIKELY(!data_column->is_binary())) {
+            return Status::InternalError("DictDecoder<Slice> expected a binary destination column");
+        }
+        auto* binary_column = down_cast<BinaryColumn*>(data_column);
         size_t read_count = count - null_cnt;
 
         if (read_count == 0) {
@@ -559,7 +563,6 @@ private:
             if (UNLIKELY(flag)) {
                 return Status::InternalError("Index not in dictionary bounds");
             }
-            auto* binary_column = ColumnHelper::get_binary_column(dst);
             size_t cnt = 0;
             for (int i = 0; i < count; ++i) {
                 if (filter[i] && !is_nulls[i]) {
@@ -626,7 +629,11 @@ private:
             if (dst->is_nullable()) {
                 down_cast<NullableColumn*>(dst)->null_column_raw_ptr()->append_default(count);
             }
-            auto* binary_column = ColumnHelper::get_binary_column(dst);
+            auto* data_column = ColumnHelper::get_data_column(dst);
+            if (UNLIKELY(!data_column->is_binary())) {
+                return Status::InternalError("DictDecoder<Slice> expected a binary destination column");
+            }
+            auto* binary_column = down_cast<BinaryColumn*>(data_column);
             for (int i = 0; i < count; ++i) {
                 if (filter[i]) {
                     binary_column->append(_dict[_indexes[i]]);

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -14,6 +14,7 @@
 
 #include "formats/parquet/scalar_column_reader.h"
 
+#include "common/compiler_util.h"
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/parquet_block_split_bloom_filter.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
@@ -448,16 +449,36 @@ StatusOr<bool> RawColumnReader::_row_group_bloom_filter(const std::vector<const 
     return filtered;
 }
 
+// If `column` still refers to one of the reader's temporary columns, a previous fill_dst_column()
+// was skipped (e.g. the whole range was filtered out and GroupReader::get_next() continued without
+// filling). Restore the caller-visible column to the original destination column so that no
+// temporary column can leak out of the reader. The set of temporary columns is reader-specific and
+// reported through the _is_tmp_column() override.
+Status RawColumnReader::_restore_tmp_column(ColumnPtr& column) {
+    if (!_is_tmp_column(column)) {
+        return Status::OK();
+    }
+    if (UNLIKELY(_ori_column == nullptr)) {
+        return Status::InternalError("Parquet reader found a temporary column without an original destination column");
+    }
+    column->as_mutable_raw_ptr()->reset_column();
+    _ori_column->as_mutable_raw_ptr()->reset_column();
+    column = _ori_column;
+    _ori_column = nullptr;
+    return Status::OK();
+}
+
 // ScalarColumnReader
 
 Status ScalarColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    _need_lazy_decode =
+    RETURN_IF_ERROR(_restore_tmp_column(dst));
+    const bool need_lazy_decode =
             _dict_filter_ctx != nullptr || (_can_lazy_dict_decode && filter != nullptr &&
                                             SIMD::count_nonzero(*filter) * 1.0 / filter->size() < FILTER_RATIO);
-    ColumnContentType content_type = !_need_lazy_decode ? ColumnContentType::VALUE : ColumnContentType::DICT_CODE;
+    ColumnContentType content_type = !need_lazy_decode ? ColumnContentType::VALUE : ColumnContentType::DICT_CODE;
     auto need_lazy_covert = _can_lazy_convert && _converter->need_convert;
-    if (_need_lazy_decode) {
+    if (need_lazy_decode) {
         return _read_range_impl<true, false>(range, filter, content_type, dst);
     } else if (need_lazy_covert) {
         return _read_range_impl<false, true>(range, filter, content_type, dst);
@@ -491,14 +512,17 @@ bool ScalarColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decode
 }
 
 Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
-    auto need_lazy_covert = _can_lazy_convert && _converter->need_convert;
-    if (_need_lazy_decode) {
+    // Dispatch on what the src column actually is rather than on flags like `_need_lazy_decode`:
+    // those flags are recomputed by every read_range() call, so when a fill is skipped (e.g. all
+    // rows of a range are filtered out) and a later read flips the flag, flag-based dispatch would
+    // hand the raw Int32 dictionary-code column to the upper layer as if it were the value column.
+    if (_is_dict_code_column(src)) {
         return _fill_dst_column_impl<true, false>(dst, src);
-    } else if (need_lazy_covert) {
-        return _fill_dst_column_impl<false, true>(dst, src);
-    } else {
-        return _fill_dst_column_impl<false, false>(dst, src);
     }
+    if (_is_intermediate_column(src)) {
+        return _fill_dst_column_impl<false, true>(dst, src);
+    }
+    return _fill_dst_column_impl<false, false>(dst, src);
 }
 
 template <bool LAZY_DICT_DECODE, bool LAZY_CONVERT>
@@ -510,6 +534,7 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
                     TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
         }
         _ori_column = dst;
+        _tmp_code_column->as_mutable_raw_ptr()->reset_column();
         dst = _tmp_code_column;
         dst->as_mutable_raw_ptr()->reserve(range.span_size());
         SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
@@ -522,6 +547,7 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
             if (_tmp_intermediate_column == nullptr) {
                 _tmp_intermediate_column = _converter->create_src_column();
             }
+            _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
             _tmp_intermediate_column->as_mutable_raw_ptr()->reserve(range.span_size());
             {
                 SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
@@ -567,6 +593,10 @@ Status ScalarColumnReader::_dict_decode(ColumnPtr& dst, ColumnPtr& src) {
 template <bool LAZY_DICT_DECODE, bool LAZY_CONVERT>
 Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src) {
     if constexpr (LAZY_DICT_DECODE) {
+        if (UNLIKELY(!_is_dict_code_column(src))) {
+            return Status::InternalError(
+                    "Parquet lazy dictionary decode source column is not a dictionary code column");
+        }
         if (_dict_filter_ctx != nullptr && !_dict_filter_ctx->is_decode_needed) {
             dst->as_mutable_raw_ptr()->append_default(src->size());
             src->as_mutable_raw_ptr()->reset_column();
@@ -574,20 +604,39 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
             static_assert(!LAZY_CONVERT, "LAZY_DICT_DECODE && LAZY_CONVERT == true is not supported by now");
             RETURN_IF_ERROR(_dict_decode(dst, src));
         }
+        if (UNLIKELY(_ori_column == nullptr)) {
+            return Status::InternalError("Parquet lazy dictionary decode lost original destination column");
+        }
         src = _ori_column;
+        _ori_column = nullptr;
     } else {
         if constexpr (LAZY_CONVERT) {
+            if (UNLIKELY(!_is_intermediate_column(src))) {
+                return Status::InternalError("Parquet lazy conversion source column is not an intermediate column");
+            }
             {
                 SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
                 RETURN_IF_ERROR(_converter->convert(src, dst->as_mutable_raw_ptr()));
             }
             src->as_mutable_raw_ptr()->reset_column();
+            if (UNLIKELY(_ori_column == nullptr)) {
+                return Status::InternalError("Parquet lazy conversion lost original destination column");
+            }
             src = _ori_column;
+            _ori_column = nullptr;
         } else {
             dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
         }
     }
     return Status::OK();
+}
+
+bool ScalarColumnReader::_is_dict_code_column(const ColumnPtr& column) const {
+    return _tmp_code_column != nullptr && column.get() == _tmp_code_column.get();
+}
+
+bool ScalarColumnReader::_is_intermediate_column(const ColumnPtr& column) const {
+    return _tmp_intermediate_column != nullptr && column.get() == _tmp_intermediate_column.get();
 }
 
 void ScalarColumnReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
@@ -609,6 +658,7 @@ void ScalarColumnReader::collect_column_io_range(std::vector<io::SharedBufferedI
 
 Status LowCardColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
+    RETURN_IF_ERROR(_restore_tmp_column(dst));
     ColumnContentType content_type = ColumnContentType::DICT_CODE;
 
     if (_dict_code == nullptr) {
@@ -616,6 +666,7 @@ Status LowCardColumnReader::read_range(const Range<uint64_t>& range, const Filte
                 TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
     }
     _ori_column = dst;
+    _dict_code->as_mutable_raw_ptr()->reset_column();
     dst = _dict_code;
     dst->as_mutable_raw_ptr()->reserve(range.span_size());
 
@@ -646,6 +697,9 @@ bool LowCardColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decod
 }
 
 Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
+    if (UNLIKELY(!_is_dict_code_column(src))) {
+        return Status::InternalError("Parquet low-cardinality source column is not a dictionary code column");
+    }
     size_t num_rows = src->size();
     if (!_code_convert_map.has_value()) {
         RETURN_IF_ERROR(_check_current_dict());
@@ -680,9 +734,17 @@ Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     }
 
     src->as_mutable_raw_ptr()->reset_column();
+    if (UNLIKELY(_ori_column == nullptr)) {
+        return Status::InternalError("Parquet low-cardinality reader lost original destination column");
+    }
     src = _ori_column;
+    _ori_column = nullptr;
 
     return Status::OK();
+}
+
+bool LowCardColumnReader::_is_dict_code_column(const ColumnPtr& column) const {
+    return _dict_code != nullptr && column.get() == _dict_code.get();
 }
 
 Status LowCardColumnReader::_check_current_dict() {
@@ -745,12 +807,14 @@ void LowCardColumnReader::collect_column_io_range(std::vector<io::SharedBuffered
 
 Status LowRowsColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
+    RETURN_IF_ERROR(_restore_tmp_column(dst));
     ColumnContentType content_type = ColumnContentType::VALUE;
 
     if (_tmp_column == nullptr) {
         _tmp_column = ColumnHelper::create_column(TYPE_VARCHAR_DESC, true);
     }
     _ori_column = dst;
+    _tmp_column->as_mutable_raw_ptr()->reset_column();
     dst = _tmp_column;
     dst->as_mutable_raw_ptr()->reserve(range.span_size());
 
@@ -761,6 +825,9 @@ Status LowRowsColumnReader::read_range(const Range<uint64_t>& range, const Filte
 }
 
 Status LowRowsColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
+    if (UNLIKELY(!_is_tmp_column(src))) {
+        return Status::InternalError("Parquet low-rows source column is not a temporary string column");
+    }
     dst->as_mutable_raw_ptr()->resize(src->size());
 
     const ColumnPtr& readed_column = src;
@@ -789,9 +856,17 @@ Status LowRowsColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     }
 
     src->as_mutable_raw_ptr()->reset_column();
+    if (UNLIKELY(_ori_column == nullptr)) {
+        return Status::InternalError("Parquet low-rows reader lost original destination column");
+    }
     src = _ori_column;
+    _ori_column = nullptr;
 
     return Status::OK();
+}
+
+bool LowRowsColumnReader::_is_tmp_column(const ColumnPtr& column) const {
+    return _tmp_column != nullptr && column.get() == _tmp_column.get();
 }
 
 void LowRowsColumnReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -126,12 +126,24 @@ protected:
                                            CompoundNodeType pred_relation, const TypeDescriptor& col_type,
                                            const uint64_t rg_first_row, const uint64_t rg_num_rows) const;
 
+    // If `column` still refers to one of this reader's internal temporary columns, a previous
+    // fill_dst_column() was skipped (e.g. the whole range was filtered out and
+    // GroupReader::get_next() continued without filling). Restore the caller-visible column to the
+    // original destination column so that no temporary column can leak out of the reader.
+    Status _restore_tmp_column(ColumnPtr& column);
+    // Whether `column` is one of this reader's internal temporary columns. Overridden by readers
+    // that swap in a temporary column (dict-code / intermediate / low-rows string) during read.
+    virtual bool _is_tmp_column(const ColumnPtr& column) const { return false; }
+
     const ColumnReaderOptions& _opts;
 
     std::unique_ptr<StoredColumnReader> _reader;
 
     const tparquet::ColumnChunk* _chunk_metadata = nullptr;
     std::unique_ptr<ColumnOffsetIndexCtx> _offset_index_ctx;
+    // Original destination column saved when a temporary column is swapped in during read_range();
+    // restored by _restore_tmp_column()/fill_dst_column() once the temporary column is consumed.
+    ColumnPtr _ori_column = nullptr;
 };
 
 class ScalarColumnReader final : public RawColumnReader {
@@ -203,6 +215,12 @@ private:
 
     Status _dict_decode(ColumnPtr& dst, ColumnPtr& src);
 
+    bool _is_dict_code_column(const ColumnPtr& column) const;
+    bool _is_intermediate_column(const ColumnPtr& column) const;
+    bool _is_tmp_column(const ColumnPtr& column) const override {
+        return _is_dict_code_column(column) || _is_intermediate_column(column);
+    }
+
     std::unique_ptr<ColumnConverter> _converter;
 
     std::unique_ptr<ColumnDictFilterContext> _dict_filter_ctx;
@@ -213,11 +231,9 @@ private:
     bool _can_lazy_convert = false;
     // we use lazy decode adaptively because of RLE && decoder may be better than filter && decoder
     static constexpr double FILTER_RATIO = 0.2;
-    bool _need_lazy_decode = false;
     // dict code
     ColumnPtr _tmp_code_column = nullptr;
     ColumnPtr _tmp_intermediate_column = nullptr;
-    ColumnPtr _ori_column = nullptr;
 };
 
 class LowCardColumnReader final : public RawColumnReader {
@@ -270,6 +286,8 @@ public:
 
 private:
     Status _check_current_dict();
+    bool _is_dict_code_column(const ColumnPtr& column) const;
+    bool _is_tmp_column(const ColumnPtr& column) const override { return _is_dict_code_column(column); }
 
     std::unique_ptr<ColumnDictFilterContext> _dict_filter_ctx;
 
@@ -279,7 +297,6 @@ private:
     std::optional<std::vector<int16_t>> _code_convert_map;
 
     ColumnPtr _dict_code = nullptr;
-    ColumnPtr _ori_column = nullptr;
 };
 
 class LowRowsColumnReader final : public RawColumnReader {
@@ -309,11 +326,12 @@ public:
                                  ColumnIOTypeFlags types, bool active) override;
 
 private:
+    bool _is_tmp_column(const ColumnPtr& column) const override;
+
     const GlobalDictMap* _dict = nullptr;
     const SlotId _slot_id;
 
     ColumnPtr _tmp_column = nullptr;
-    ColumnPtr _ori_column = nullptr;
 };
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/dict_encoding_test.cpp
+++ b/be/test/formats/parquet/dict_encoding_test.cpp
@@ -213,4 +213,81 @@ TEST(DictEncodingReadTest, BinaryPageTest) {
     constexpr LogicalType DICT_TYPE = LogicalType::TYPE_INT;
     dict_encoding_test<DICT_TYPE, TARGET_TYPE>();
 }
+
+// Build a ready-to-read DictDecoder<Slice> backed by an int-keyed dictionary, mirroring the setup
+// in dict_encoding_test().
+static void setup_slice_dict_decoder(DictDecoder<Slice>* decoder, FakeDictDecoder<TYPE_VARCHAR>* inner_decoder,
+                                     faststring* backing) {
+    faststring fs;
+    RleEncoder<int32_t> encoder(&fs, 32);
+    for (size_t i = 0; i < 4096; ++i) {
+        encoder.Put(i % 9 + 1, 10);
+    }
+    backing->resize(fs.length() + 1);
+    backing->data()[0] = 32;
+    memcpy(backing->data() + 1, fs.data(), fs.length());
+    ASSERT_OK(decoder->set_data(Slice(backing->data(), backing->length())));
+    ASSERT_OK(decoder->set_dict(10, 10, inner_decoder));
+}
+
+// DictDecoder<Slice> must reject a non-binary destination column instead of blindly down-casting it
+// to BinaryColumn. This guards the path that could otherwise let a temporary Int32 dict-code column
+// reach a string slot. Exercises both the filtered _next_batch_value() path and the
+// next_value_batch_with_nulls() path.
+TEST(DictEncodingReadTest, BinaryDestinationTypeGuard) {
+    constexpr size_t count = 100;
+
+    // 1. _next_batch_value() with a filter: a binary destination succeeds.
+    {
+        DictDecoder<Slice> decoder;
+        FakeDictDecoder<TYPE_VARCHAR> inner_decoder;
+        faststring backing;
+        setup_slice_dict_decoder(&decoder, &inner_decoder, &backing);
+
+        auto dst = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true);
+        auto filter = std::make_unique<uint8_t[]>(count);
+        memset(filter.get(), 0x01, count);
+        filter[0] = 0;
+        ASSERT_OK(decoder.next_batch(count, ColumnContentType::VALUE, dst.get(), filter.get()));
+        EXPECT_EQ(dst.get()->size(), count);
+    }
+
+    // 2. _next_batch_value() with a filter: a non-binary destination is rejected.
+    {
+        DictDecoder<Slice> decoder;
+        FakeDictDecoder<TYPE_VARCHAR> inner_decoder;
+        faststring backing;
+        setup_slice_dict_decoder(&decoder, &inner_decoder, &backing);
+
+        auto dst = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        auto filter = std::make_unique<uint8_t[]>(count);
+        memset(filter.get(), 0x01, count);
+        auto st = decoder.next_batch(count, ColumnContentType::VALUE, dst.get(), filter.get());
+        ASSERT_FALSE(st.ok());
+    }
+
+    // 3. next_value_batch_with_nulls(): a non-binary destination is rejected.
+    {
+        DictDecoder<Slice> decoder;
+        FakeDictDecoder<TYPE_VARCHAR> inner_decoder;
+        faststring backing;
+        setup_slice_dict_decoder(&decoder, &inner_decoder, &backing);
+
+        NullInfos infos;
+        infos.reset_with_capacity(count);
+        infos.num_nulls = 0;
+        for (size_t i = 0; i < count; ++i) {
+            infos.nulls_data()[i] = i % 2;
+            infos.num_nulls += infos.nulls_data()[i];
+        }
+        // num_ranges > 2 routes to next_value_batch_with_nulls() rather than the row-by-row fallback.
+        infos.num_ranges = count / 2;
+
+        auto dst = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        auto filter = std::make_unique<uint8_t[]>(count);
+        memset(filter.get(), 0x01, count);
+        auto st = decoder.next_batch_with_nulls(count, infos, ColumnContentType::VALUE, dst.get(), filter.get());
+        ASSERT_FALSE(st.ok());
+    }
+}
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <random>
 #include <set>
@@ -26,6 +27,8 @@
 #include "cache/mem_cache/lrucache_engine.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "common/logging.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exprs/binary_predicate.h"
@@ -53,6 +56,18 @@ namespace starrocks::parquet {
 
 static HdfsScannerStats g_hdfs_stats;
 using starrocks::HdfsScannerContext;
+
+static const ColumnPtr& get_struct_field_column(const ColumnPtr& column, const std::string& field_name) {
+    const auto* struct_column = down_cast<const StructColumn*>(ColumnHelper::get_data_column(column.get()));
+    auto field_column = struct_column->field_column(field_name);
+    CHECK(field_column.ok()) << field_column.status();
+    return field_column.value();
+}
+
+static void expect_string_data_column(const ColumnPtr& column) {
+    const Column* data_column = ColumnHelper::get_data_column(column.get());
+    EXPECT_TRUE(data_column->is_binary() || data_column->is_binary_view());
+}
 
 class FileReaderTest : public testing::Test {
 public:
@@ -2765,7 +2780,10 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
     std::vector<std::string> subfield_path({"c_struct", "c0"});
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "55",
                                                     &ctx->conjunct_ctxs_by_slot[3]);
-    auto file_reader = _create_file_reader(struct_in_struct_file_path);
+    // Use a small chunk size so that the scan takes multiple rounds and some ranges are fully
+    // filtered out by the dict filter (hit_count == 0), exercising the temporary dict-code
+    // column restore path in ScalarColumnReader.
+    auto file_reader = _create_file_reader(struct_in_struct_file_path, 13);
 
     auto chunk = std::make_shared<Chunk>();
     chunk->append_column(ColumnHelper::create_column(TYPE_INT_DESC, true), chunk->num_columns());
@@ -2791,6 +2809,11 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
         total_row_nums += chunk->num_rows();
         if (chunk->num_rows() != 0) {
             ASSERT_EQ("{c0:'55',c_struct:{c0:'55',c1:'46'}}", chunk->get_column_by_slot_id(3)->debug_item(0));
+            const auto& c_struct_struct = chunk->get_column_by_slot_id(3);
+            expect_string_data_column(get_struct_field_column(c_struct_struct, "c0"));
+            const auto& c_struct = get_struct_field_column(c_struct_struct, "c_struct");
+            expect_string_data_column(get_struct_field_column(c_struct, "c0"));
+            expect_string_data_column(get_struct_field_column(c_struct, "c1"));
         }
     }
     EXPECT_EQ(100, total_row_nums);


### PR DESCRIPTION
## Why I'm doing:

When a nested STRUCT VARCHAR subfield is read with the Parquet dict-filter or lazy dict-decode path, the reader temporarily replaces the caller-visible `ColumnPtr` with an internal `Int32` dictionary-code column (`_tmp_code_column`). There are two gaps in the old state management:

1. When a fill is skipped — e.g. an entire range is filtered out so `GroupReader::get_next()` continues with `hit_count == 0` before calling `_fill_dst_chunk()` — the subfield `ColumnPtr` is left pointing at the `Int32` temporary column.
2. `fill_dst_column()` dispatched on the recomputable `_need_lazy_decode` flag rather than on what `src` actually is. When a later `read_range()` flipped the flag, the raw `Int32` column was swapped into the output chunk as if it were the value column.

The upper `Project` then evaluated `VARCHAR = 'literal'` over that `Int32` column. In an ASAN/debug build this trips `ColumnHelper::cast_to_raw<TYPE_VARCHAR>` (`expected type: 17, actual type: integral-4`); in release it is an unchecked `down_cast`, so the `Int32Column` is read as a `BinaryColumn` and the CN crashes with SIGSEGV in `UnpackConstColumnBinaryFunction<VARCHAR>`.

## What I'm doing:

Root fix in the Parquet reader so the internal dict-code column can never escape:

- Dispatch `fill_dst_column()` on the actual `src` column identity (`_is_dict_code_column` / `_is_intermediate_column`) instead of the recomputable `_need_lazy_decode` flag, and remove that flag.
- Restore any leftover temporary column at `read_range()` entry, and reset `_ori_column` after each fill, across `ScalarColumnReader` / `LowCardColumnReader` / `LowRowsColumnReader`.
- `DictDecoder<Slice>` verifies the destination data column is a binary column before writing values.

UT added in `file_reader_test.cpp` covering the skipped-fill restore path (small chunk size forcing `hit_count == 0`), and in `dict_encoding_test.cpp` verifying `DictDecoder<Slice>` rejects a non-binary destination column.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

