### PR TITLE
[Tool] Fix module-risk briefing comment upsert (restore pull-requests:write)

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -247,12 +247,6 @@ jobs:
     concurrency:
       group: ai-sr-skills-module-risk-${{ github.event.number }}
       cancel-in-progress: true
-    # Least privilege: only this job posts the sticky comment (Issues comments API), so issues:write
-    # lives here, not workflow-wide where it would also reach assign-reviewer's GITHUB_TOKEN.
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: write
     continue-on-error: true
     if: >
       (github.event.action == 'opened' || github.event.action == 'reopened' ||


### PR DESCRIPTION
## Why I'm doing:

After #74798 scoped the `module-risk` job's permissions, its sticky-comment upsert started failing on every PR with `GraphQL: Resource not accessible by integration (addComment)`. Posting/editing a comment on a pull request (`gh pr comment` / GraphQL `addComment`, and the PATCH on the issue-comments endpoint when the subject is a PR) requires `pull-requests: write`. The job-level block instead had `pull-requests: read` plus an unnecessary `issues: write`, so the token was denied.

## What I'm doing:

Remove the `module-risk` job-level `permissions` block so the job inherits the top-level `pull-requests: write` — the configuration that worked before #74798. `issues: write` was never required for PR comments and is dropped (so it is no longer granted anywhere). The job-level `concurrency` added in #74798 (so a `synchronize` run does not cancel the opened-only `assign-reviewer`) is unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr
