### PR TITLE
[Enhancement] Expression-driven on-demand lazy column loading for Parquet scanner

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -49,6 +49,20 @@ public:
     virtual ChunkExtraDataPtr clone() const = 0;
 };
 
+// Interface for on-demand column materialization.  Attach to a Chunk before
+// expression evaluation so that ColumnRef can request lazy columns without
+// knowing the source (e.g. Parquet LazyMaterializationContext).
+// The provider must be detached (set to nullptr) before the Chunk is emitted
+// downstream.  Ownership stays with the caller; the Chunk holds only a raw pointer.
+class MissingColumnProvider {
+public:
+    virtual ~MissingColumnProvider() = default;
+    virtual bool can_provide(SlotId slot_id) const = 0;
+    // Materialize and return the column for slot_id.  May be called multiple
+    // times for the same slot; implementations must be idempotent.
+    virtual StatusOr<ColumnPtr> provide(SlotId slot_id) = 0;
+};
+
 class Chunk {
 public:
     enum RESERVED_COLUMN_SLOT_ID {
@@ -320,6 +334,9 @@ public:
     void set_extra_data(ChunkExtraDataPtr data) { this->_extra_data = std::move(data); }
     bool has_extra_data() const { return this->_extra_data != nullptr; }
 
+    void set_missing_column_provider(MissingColumnProvider* p) { _missing_column_provider = p; }
+    MissingColumnProvider* missing_column_provider() const { return _missing_column_provider; }
+
 private:
     void rebuild_cid_index();
 
@@ -337,6 +354,7 @@ private:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
     query_cache::owner_info _owner_info;
     ChunkExtraDataPtr _extra_data;
+    MissingColumnProvider* _missing_column_provider = nullptr;
     // Chunk's columns should be unique, so we need to track the column ptrs to avoid duplicates.
     // key      : column address
     // value    : index in _columns

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -379,9 +379,8 @@ inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
             if (!known_slots.empty()) known_slots += ",";
             known_slots += std::to_string(id);
         }
-        throw std::runtime_error(
-                fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id, known_slots,
-                            _columns.size()));
+        throw std::runtime_error(fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id,
+                                             known_slots, _columns.size()));
     }
     size_t idx = _slot_id_to_index.at(slot_id);
     return _columns.at(idx);
@@ -395,9 +394,8 @@ inline ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) {
             if (!known_slots.empty()) known_slots += ",";
             known_slots += std::to_string(id);
         }
-        throw std::runtime_error(
-                fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id, known_slots,
-                            _columns.size()));
+        throw std::runtime_error(fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id,
+                                             known_slots, _columns.size()));
     }
     size_t idx = _slot_id_to_index.at(slot_id);
     return _columns[idx];

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -374,7 +374,14 @@ inline ColumnPtr& Chunk::get_column_by_name(const std::string& column_name) {
 inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
     DCHECK(is_slot_exist(slot_id)) << slot_id;
     if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
-        throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
+        std::string known_slots;
+        for (const auto& [id, idx] : _slot_id_to_index) {
+            if (!known_slots.empty()) known_slots += ",";
+            known_slots += std::to_string(id);
+        }
+        throw std::runtime_error(
+                fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id, known_slots,
+                            _columns.size()));
     }
     size_t idx = _slot_id_to_index.at(slot_id);
     return _columns.at(idx);
@@ -383,7 +390,14 @@ inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
 inline ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) {
     DCHECK(is_slot_exist(slot_id)) << slot_id;
     if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
-        throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
+        std::string known_slots;
+        for (const auto& [id, idx] : _slot_id_to_index) {
+            if (!known_slots.empty()) known_slots += ",";
+            known_slots += std::to_string(id);
+        }
+        throw std::runtime_error(
+                fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id, known_slots,
+                            _columns.size()));
     }
     size_t idx = _slot_id_to_index.at(slot_id);
     return _columns[idx];

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -583,6 +583,19 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     _scanner_ctx.profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
     _scanner_ctx.profile.late_materialize_skip_rows_counter =
             ADD_COUNTER(_runtime_profile, "LateMaterializeSkipRows", TUnit::UNIT);
+    _scanner_ctx.profile.parquet_lazy_col_skip_rows_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyColSkipRows", TUnit::UNIT);
+    _scanner_ctx.profile.parquet_lazy_slot_triggered_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazySlotTriggered", TUnit::UNIT);
+    _scanner_ctx.profile.parquet_lazy_read_count_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyReadCount", TUnit::UNIT);
+    _scanner_ctx.profile.parquet_lazy_read_timer = ADD_TIMER(_runtime_profile, "ParquetLazyReadTime");
+    _scanner_ctx.profile.parquet_lazy_materialization_enabled_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyMaterializationEnabled", TUnit::UNIT);
+    COUNTER_SET(_scanner_ctx.profile.parquet_lazy_materialization_enabled_counter,
+                static_cast<int64_t>(config::parquet_late_materialization_enable ? 1 : 0));
+    _scanner_ctx.profile.parquet_lazy_full_trigger_count_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyFullTriggerCount", TUnit::UNIT);
     _scanner_ctx.profile.scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
     _scanner_ctx.profile.scan_ranges_size = ADD_COUNTER(_runtime_profile, "ScanRangesSize", TUnit::BYTES);
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -543,6 +543,11 @@ void HdfsScanner::update_counter() {
     COUNTER_UPDATE(profile->raw_rows_read_counter, _app_stats.raw_rows_read);
     COUNTER_UPDATE(profile->rows_read_counter, _app_stats.rows_read);
     COUNTER_UPDATE(profile->late_materialize_skip_rows_counter, _app_stats.late_materialize_skip_rows);
+    COUNTER_UPDATE(profile->parquet_lazy_col_skip_rows_counter, _app_stats.parquet_lazy_col_skip_rows);
+    COUNTER_UPDATE(profile->parquet_lazy_slot_triggered_counter, _app_stats.parquet_lazy_slot_triggered);
+    COUNTER_UPDATE(profile->parquet_lazy_read_count_counter, _app_stats.parquet_lazy_read_count);
+    COUNTER_UPDATE(profile->parquet_lazy_read_timer, _app_stats.parquet_lazy_read_ns);
+    COUNTER_UPDATE(profile->parquet_lazy_full_trigger_count_counter, _app_stats.parquet_lazy_full_trigger_count);
     COUNTER_UPDATE(profile->expr_filter_timer, _app_stats.expr_filter_ns);
     COUNTER_UPDATE(profile->column_read_timer, _app_stats.column_read_ns);
     COUNTER_UPDATE(profile->column_convert_timer, _app_stats.column_convert_ns);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -58,6 +58,19 @@ struct HdfsScannerStats {
     int64_t raw_rows_read = 0;
     int64_t rows_read = 0;
     int64_t late_materialize_skip_rows = 0;
+    // Parquet lazy materialization: rows filtered before lazy columns were read.
+    int64_t parquet_lazy_col_skip_rows = 0;
+    // Parquet lazy materialization: number of lazy slots triggered via MissingColumnProvider.
+    int64_t parquet_lazy_slot_triggered = 0;
+    // Parquet lazy materialization: number of lazy column read operations.
+    int64_t parquet_lazy_read_count = 0;
+    // Parquet lazy materialization: time spent reading lazy columns.
+    int64_t parquet_lazy_read_ns = 0;
+    // Parquet dict-code predicate evaluation count.
+    int64_t parquet_dict_code_predicate_eval_count = 0;
+    // Parquet lazy materialization: row groups where every lazy slot was triggered
+    // on-demand (suggests active/lazy classification could be improved).
+    int64_t parquet_lazy_full_trigger_count = 0;
 
     int64_t io_ns = 0;
     int64_t io_count = 0;
@@ -148,6 +161,12 @@ struct HdfsScannerProfile {
     RuntimeProfile::Counter* raw_rows_read_counter = nullptr;
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* late_materialize_skip_rows_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_col_skip_rows_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_slot_triggered_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_read_count_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_read_timer = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_materialization_enabled_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_full_trigger_count_counter = nullptr;
     RuntimeProfile::Counter* scan_ranges_counter = nullptr;
     RuntimeProfile::Counter* scan_ranges_size = nullptr;
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -20,7 +20,6 @@
 #include "exec/iceberg/iceberg_delete_builder.h"
 #include "exec/paimon/paimon_delete_file_builder.h"
 #include "exec/pipeline/fragment_context.h"
-#include "exprs/chunk_predicate_evaluator.h"
 #include "formats/parquet/file_reader.h"
 
 namespace starrocks {
@@ -269,17 +268,9 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
 }
 
 Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    RETURN_IF_ERROR(_reader->get_next(chunk));
-    // Evaluate multi-slot predicates after FileReader has materialised all columns
-    // (including lazily-loaded ones from its internal predicate pipeline).
-    // This pass is the correctness guarantee; statistics-based skipping inside
-    // FileReader is approximate.  In the future, expression-driven lazy
-    // materialisation will replace this with interleaved column-load/evaluate.
-    if ((*chunk)->num_rows() > 0 && !_scanner_ctx->conjuncts.scanner_ctxs.empty()) {
-        SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_ctx->conjuncts.scanner_ctxs, chunk->get()));
-    }
-    return Status::OK();
+    // Multi-slot conjuncts are now evaluated inside GroupReader (step 2b)
+    // with lazy-materialization support, making a post-hoc pass unnecessary.
+    return _reader->get_next(chunk);
 }
 
 void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -99,6 +99,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     RuntimeProfile::Counter* group_chunk_read_timer = nullptr;
     RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
+    RuntimeProfile::Counter* dict_code_predicate_eval_count = nullptr;
 
     // io coalesce
     RuntimeProfile::Counter* active_lazy_coalesce_together = nullptr;
@@ -158,6 +159,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
+    dict_code_predicate_eval_count =
+            ADD_CHILD_COUNTER(root, "DictCodePredicateEvalCount", TUnit::UNIT, kParquetProfileSectionPrefix);
 
     active_lazy_coalesce_together = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceTogether", TUnit::UNIT,
                                                       kParquetProfileSectionPrefix);
@@ -207,6 +210,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     COUNTER_UPDATE(group_dict_decode_timer, _app_stats.group_dict_decode_ns);
     COUNTER_UPDATE(active_lazy_coalesce_together, _app_stats.active_lazy_coalesce_together);
     COUNTER_UPDATE(active_lazy_coalesce_seperately, _app_stats.active_lazy_coalesce_seperately);
+    COUNTER_UPDATE(dict_code_predicate_eval_count, _app_stats.parquet_dict_code_predicate_eval_count);
     int64_t page_stats = _app_stats.has_page_statistics ? 1 : 0;
     COUNTER_UPDATE(has_page_statistics, page_stats);
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);

--- a/be/src/exprs/column_ref.cpp
+++ b/be/src/exprs/column_ref.cpp
@@ -52,6 +52,13 @@ std::string ColumnRef::debug_string() const {
 }
 
 StatusOr<ColumnPtr> ColumnRef::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    if (ptr != nullptr && !ptr->is_slot_exist(slot_id())) {
+        if (auto* provider = ptr->missing_column_provider()) {
+            if (provider->can_provide(slot_id())) {
+                return provider->provide(slot_id());
+            }
+        }
+    }
     return get_column(this, ptr);
 }
 

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -82,6 +82,8 @@ ADD_BE_LIB(Formats
         parquet/arrow_memory_pool.cpp
         parquet/column_chunk_reader.cpp
         parquet/column_materializer.cpp
+        parquet/lazy_materialization_context.cpp
+        parquet/read_range_planner.cpp
         parquet/column_converter.cpp
         parquet/column_reader.cpp
         parquet/column_reader_factory.cpp

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -264,6 +264,9 @@ Status ColumnMaterializer::fill_dst_column(SlotId slot_id, ColumnPtr& dst, Colum
 void ColumnMaterializer::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end,
                                            ColumnIOTypeFlags types) {
     _read_range_planner->collect_ranges(_active_column_indices, true, ranges, end, types);
+    // Still plan lazy column ranges so that materialize_slot() can read them
+    // when triggered during compound OR eval.  Range planning alone does NOT
+    // cause IO — only read_range() does.
     _read_range_planner->pre_plan_lazy_ranges(_lazy_column_indices, end, types);
     const auto& lazy_ranges = _read_range_planner->lazy_ranges();
     ranges->insert(ranges->end(), lazy_ranges.begin(), lazy_ranges.end());
@@ -272,11 +275,9 @@ void ColumnMaterializer::collect_io_ranges(std::vector<SharedBufferedInputStream
 Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
                                              const Range<uint64_t>& post_filter_range, const Filter& post_filter,
                                              const Filter& chunk_filter, bool has_filter, ChunkPtr& active_chunk) {
-    // Separate triggered lazy columns (materialized on-demand during predicate
-    // evaluation via LazyMaterializationContext) from untriggered ones.
-    // Triggered columns already have full_range data in _read_chunk; apply
-    // chunk_filter to match active_chunk's row count.
-    // Untriggered columns go through the normal post_filter_range read path.
+    // Separate triggered lazy columns from untriggered ones.
+    // Triggered: read on-demand during predicate eval → filter and append.
+    // Untriggered: backfill (output) or null-fill (predicate-only).
     std::vector<int> untriggered_indices;
     for (int col_idx : _lazy_column_indices) {
         SlotId slot_id = _param.read_cols[col_idx].slot_id();
@@ -297,27 +298,44 @@ Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
     }
 
     if (!untriggered_indices.empty()) {
-        std::vector<SlotId> untriggered_slot_ids;
-        untriggered_slot_ids.reserve(untriggered_indices.size());
+        // Output columns → backfill from disk.
+        // Predicate-only columns → null-fill (no IO, values unused downstream).
+        std::vector<int> backfill_indices;
+        size_t rows = active_chunk->num_rows();
         for (int col_idx : untriggered_indices) {
-            untriggered_slot_ids.push_back(_param.read_cols[col_idx].slot_id());
-        }
-        ChunkPtr lazy_chunk = create_read_chunk(untriggered_slot_ids, false);
-        {
-            SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
-            _param.stats->parquet_lazy_read_count += untriggered_indices.size();
-            if (has_filter) {
-                RETURN_IF_ERROR(read_range(untriggered_indices, post_filter_range, &post_filter, &lazy_chunk, true));
-                lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+            const auto& col_info = _param.read_cols[col_idx];
+            if (col_info.slot_desc->is_output_column()) {
+                backfill_indices.push_back(col_idx);
             } else {
-                RETURN_IF_ERROR(read_range(untriggered_indices, full_range, nullptr, &lazy_chunk, true));
+                auto col = _read_chunk->get_column_by_slot_id(col_info.slot_id())->clone_empty();
+                col->append_nulls(rows);
+                active_chunk->append_column(col, col_info.slot_id());
             }
         }
-        if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
-            return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
-                                                     active_chunk->num_rows(), lazy_chunk->num_rows()));
+
+        if (!backfill_indices.empty()) {
+            std::vector<SlotId> backfill_slot_ids;
+            backfill_slot_ids.reserve(backfill_indices.size());
+            for (int col_idx : backfill_indices) {
+                backfill_slot_ids.push_back(_param.read_cols[col_idx].slot_id());
+            }
+            ChunkPtr lazy_chunk = create_read_chunk(backfill_slot_ids, false);
+            {
+                SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
+                _param.stats->parquet_lazy_read_count += backfill_indices.size();
+                if (has_filter) {
+                    RETURN_IF_ERROR(read_range(backfill_indices, post_filter_range, &post_filter, &lazy_chunk, true));
+                    lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+                } else {
+                    RETURN_IF_ERROR(read_range(backfill_indices, full_range, nullptr, &lazy_chunk, true));
+                }
+            }
+            if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
+                return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
+                                                         active_chunk->num_rows(), lazy_chunk->num_rows()));
+            }
+            active_chunk->merge(std::move(*lazy_chunk));
         }
-        active_chunk->merge(std::move(*lazy_chunk));
     }
 
     _lazy_column_needed = true;

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -24,10 +24,16 @@
 #include "common/config_scan_io_fwd.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
+#include "formats/parquet/read_range_planner.h"
 #include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks::parquet {
+
+ColumnMaterializer::ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+        : _param(param), _column_readers(column_readers) {
+    _read_range_planner = std::make_unique<ReadRangePlanner>(param, column_readers);
+}
 
 void ColumnMaterializer::clear_classification() {
     _active_column_indices.clear();
@@ -51,8 +57,11 @@ void ColumnMaterializer::add_lazy_column(int col_idx) {
 }
 
 void ColumnMaterializer::promote_lazy_to_active() {
-    _active_column_indices.swap(_lazy_column_indices);
-    _active_slot_ids.swap(_lazy_slot_ids);
+    _active_column_indices.insert(_active_column_indices.end(), _lazy_column_indices.begin(),
+                                  _lazy_column_indices.end());
+    _lazy_column_indices.clear();
+    _active_slot_ids.insert(_active_slot_ids.end(), _lazy_slot_ids.begin(), _lazy_slot_ids.end());
+    _lazy_slot_ids.clear();
 }
 
 void ColumnMaterializer::rebuild_read_order_ctx() {
@@ -136,7 +145,8 @@ Status ColumnMaterializer::read_lazy_range(const Range<uint64_t>& range, const F
 }
 
 StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter,
-                                                                      ChunkPtr* chunk) {
+                                                                      ChunkPtr* chunk,
+                                                                      LazyMaterializationContext* lazy_ctx) {
     DCHECK(_column_read_order_ctx != nullptr);
     const std::vector<int>& read_order = _column_read_order_ctx->get_column_read_order();
     size_t round_cost = 0;
@@ -210,15 +220,21 @@ Status ColumnMaterializer::rewrite_dict_conjuncts_to_predicate(bool* is_group_fi
 
 Status ColumnMaterializer::filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
                                               const std::vector<std::string>& sub_field_path, const size_t& layer) {
+    _param.stats->parquet_dict_code_predicate_eval_count++;
     return (*_column_readers)[slot_id]->filter_dict_column(column, filter, sub_field_path, layer);
 }
 
 StatusOr<size_t> ColumnMaterializer::eval_slot_conjuncts(const std::vector<ExprContext*>& ctxs, SlotId slot_id,
                                                          ChunkPtr* chunk, Filter* filter) {
+    // Use a single-slot temp chunk to avoid Chunk::check_or_die() failures that
+    // would occur if active_chunk contains unread columns (0 rows).
+    // Propagate the MissingColumnProvider so that ColumnRef can still trigger
+    // lazy materialization of payload slots referenced by this conjunct.
     auto temp_chunk = std::make_shared<Chunk>();
     temp_chunk->columns().reserve(1);
     ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
     temp_chunk->append_column(column, slot_id);
+    temp_chunk->set_missing_column_provider((*chunk)->missing_column_provider());
     return ChunkPredicateEvaluator::eval_conjuncts_into_filter(ctxs, temp_chunk.get(), filter);
 }
 
@@ -247,32 +263,63 @@ Status ColumnMaterializer::fill_dst_column(SlotId slot_id, ColumnPtr& dst, Colum
 
 void ColumnMaterializer::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end,
                                            ColumnIOTypeFlags types) {
-    for (const auto& index : _active_column_indices) {
-        const auto& column = _param.read_cols[index];
-        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, true);
-    }
-
-    for (const auto& index : _lazy_column_indices) {
-        const auto& column = _param.read_cols[index];
-        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, false);
-    }
+    _read_range_planner->collect_ranges(_active_column_indices, true, ranges, end, types);
+    _read_range_planner->pre_plan_lazy_ranges(_lazy_column_indices, end, types);
+    const auto& lazy_ranges = _read_range_planner->lazy_ranges();
+    ranges->insert(ranges->end(), lazy_ranges.begin(), lazy_ranges.end());
 }
 
 Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
                                              const Range<uint64_t>& post_filter_range, const Filter& post_filter,
-                                             bool has_filter, ChunkPtr& active_chunk) {
-    ChunkPtr lazy_chunk = create_lazy_chunk();
-    if (has_filter) {
-        RETURN_IF_ERROR(read_lazy_range(post_filter_range, &post_filter, &lazy_chunk));
-        lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
-    } else {
-        RETURN_IF_ERROR(read_lazy_range(full_range, nullptr, &lazy_chunk));
+                                             const Filter& chunk_filter, bool has_filter, ChunkPtr& active_chunk) {
+    // Separate triggered lazy columns (materialized on-demand during predicate
+    // evaluation via LazyMaterializationContext) from untriggered ones.
+    // Triggered columns already have full_range data in _read_chunk; apply
+    // chunk_filter to match active_chunk's row count.
+    // Untriggered columns go through the normal post_filter_range read path.
+    std::vector<int> untriggered_indices;
+    for (int col_idx : _lazy_column_indices) {
+        SlotId slot_id = _param.read_cols[col_idx].slot_id();
+        if (_slot_cache.count(slot_id)) {
+            // Column was triggered during predicate eval: it has full_range data.
+            // Mutate (COW) and filter to match active_chunk's surviving row count.
+            ColumnPtr& col = _read_chunk->get_column_by_slot_id(slot_id);
+            if (has_filter) {
+                auto mutable_col = Column::mutate(col);
+                mutable_col->filter(chunk_filter);
+                active_chunk->append_column(ColumnPtr(std::move(mutable_col)), slot_id);
+            } else {
+                active_chunk->append_column(col, slot_id);
+            }
+        } else {
+            untriggered_indices.push_back(col_idx);
+        }
     }
-    if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
-        return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
-                                                 active_chunk->num_rows(), lazy_chunk->num_rows()));
+
+    if (!untriggered_indices.empty()) {
+        std::vector<SlotId> untriggered_slot_ids;
+        untriggered_slot_ids.reserve(untriggered_indices.size());
+        for (int col_idx : untriggered_indices) {
+            untriggered_slot_ids.push_back(_param.read_cols[col_idx].slot_id());
+        }
+        ChunkPtr lazy_chunk = create_read_chunk(untriggered_slot_ids, false);
+        {
+            SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
+            _param.stats->parquet_lazy_read_count += untriggered_indices.size();
+            if (has_filter) {
+                RETURN_IF_ERROR(read_range(untriggered_indices, post_filter_range, &post_filter, &lazy_chunk, true));
+                lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+            } else {
+                RETURN_IF_ERROR(read_range(untriggered_indices, full_range, nullptr, &lazy_chunk, true));
+            }
+        }
+        if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
+            return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
+                                                     active_chunk->num_rows(), lazy_chunk->num_rows()));
+        }
+        active_chunk->merge(std::move(*lazy_chunk));
     }
-    active_chunk->merge(std::move(*lazy_chunk));
+
     _lazy_column_needed = true;
     return Status::OK();
 }
@@ -308,13 +355,23 @@ void ColumnMaterializer::classify_columns(const std::unordered_set<SlotId>& defe
         SlotId slot_id = column.slot_id();
         auto it = conjunct_ctxs_by_slot.find(slot_id);
         if (it != conjunct_ctxs_by_slot.end()) {
+            bool all_dict_filter = true;
             for (ExprContext* ctx : it->second) {
                 std::vector<std::string> sub_field_path;
                 if (_try_use_dict_filter(read_col_idx, column, ctx, sub_field_path)) {
                     add_dict_filter_column(read_col_idx, sub_field_path);
                 } else {
                     add_post_read_conjunct(slot_id, ctx);
+                    all_dict_filter = false;
                 }
+            }
+            // When ALL conjuncts use the dict-code filter path, wire set_can_lazy_decode
+            // explicitly so the lazy-decode decision is visible at classification time.
+            // ScalarColumnReader will still set _need_lazy_decode via _dict_filter_ctx,
+            // but the explicit flag also enables lazy type conversion and unifies the
+            // policy with the output-only lazy column path.
+            if (all_dict_filter && config::parquet_late_materialization_enable) {
+                (*_column_readers)[slot_id]->set_can_lazy_decode(true);
             }
             add_active_column(read_col_idx);
         } else if (config::parquet_late_materialization_enable && deferred_source_slots.count(slot_id) == 0) {
@@ -363,8 +420,13 @@ Status ColumnMaterializer::materialize_slot(SlotId slot_id, const Range<uint64_t
     if (_slot_cache.find(slot_id) != _slot_cache.end()) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(
-            (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
+    {
+        SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
+        _param.stats->parquet_lazy_read_count++;
+        _lazy_triggered_count++;
+        RETURN_IF_ERROR(
+                (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
+    }
     _slot_cache[slot_id] = {_read_chunk->get_column_by_slot_id(slot_id)};
     return Status::OK();
 }

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -308,7 +308,7 @@ Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
                 backfill_indices.push_back(col_idx);
             } else {
                 auto col = _read_chunk->get_column_by_slot_id(col_info.slot_id())->clone_empty();
-                col->append_nulls(rows);
+                col->append_default(rows);
                 active_chunk->append_column(col, col_info.slot_id());
             }
         }
@@ -338,7 +338,7 @@ Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
         }
     }
 
-    _lazy_column_needed = true;
+    _lazy_column_needed = !untriggered_indices.empty() || !_slot_cache.empty();
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -347,22 +347,6 @@ Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPt
     for (const auto& column : _param.read_cols) {
         SlotId slot_id = column.slot_id();
         if (skip_slots && skip_slots->count(slot_id)) continue;
-        // ── DEBUG ──
-        {
-            auto& dst_col = (*dst)->get_column_by_slot_id(slot_id);
-            auto& src_col = active_chunk->get_column_by_slot_id(slot_id);
-            VLOG(1) << "[DEBUG] emit_physical_columns slot=" << slot_id
-                    << " dst=" << dst_col->get_name()
-                    << " src=" << src_col->get_name();
-            if (src_col->is_struct()) {
-                const auto* sc = down_cast<const StructColumn*>(ColumnHelper::get_data_column(src_col.get()));
-                for (size_t fi = 0; fi < sc->fields_size(); fi++) {
-                    VLOG(1) << "[DEBUG]   src_struct_field[" << fi << "] " << sc->field_names()[fi]
-                            << "=" << sc->fields()[fi]->get_name();
-                }
-            }
-        }
-        // ── END DEBUG ──
         RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
                                         active_chunk->get_column_by_slot_id(slot_id)));
     }
@@ -458,40 +442,8 @@ Status ColumnMaterializer::materialize_slot(SlotId slot_id, const Range<uint64_t
         SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
         _param.stats->parquet_lazy_read_count++;
         _lazy_triggered_count++;
-        // ── DEBUG ──
-        {
-            auto& col_before = _read_chunk->get_column_by_slot_id(slot_id);
-            LOG(INFO) << "[DEBUG] materialize_slot slot=" << slot_id
-                      << " col_before_type=" << col_before->get_name()
-                      << " col_before_size=" << col_before->size();
-            if (col_before->is_struct()) {
-                const auto* sc = down_cast<const StructColumn*>(col_before.get());
-                for (size_t fi = 0; fi < sc->fields_size(); fi++) {
-                    LOG(INFO) << "[DEBUG]   struct_field[" << fi << "] name=" << sc->field_names()[fi]
-                              << " type=" << sc->fields()[fi]->get_name()
-                              << " size=" << sc->fields()[fi]->size();
-                }
-            }
-        }
-        // ── END DEBUG ──
         RETURN_IF_ERROR(
                 (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
-        // ── DEBUG ──
-        {
-            auto& col_after = _read_chunk->get_column_by_slot_id(slot_id);
-            LOG(INFO) << "[DEBUG] materialize_slot slot=" << slot_id << " AFTER read_range"
-                      << " col_type=" << col_after->get_name()
-                      << " col_size=" << col_after->size();
-            if (col_after->is_struct()) {
-                const auto* sc = down_cast<const StructColumn*>(col_after.get());
-                for (size_t fi = 0; fi < sc->fields_size(); fi++) {
-                    LOG(INFO) << "[DEBUG]   struct_field[" << fi << "] name=" << sc->field_names()[fi]
-                              << " type=" << sc->fields()[fi]->get_name()
-                              << " size=" << sc->fields()[fi]->size();
-                }
-            }
-        }
-        // ── END DEBUG ──
     }
     _slot_cache[slot_id] = {_read_chunk->get_column_by_slot_id(slot_id)};
     return Status::OK();

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -347,6 +347,22 @@ Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPt
     for (const auto& column : _param.read_cols) {
         SlotId slot_id = column.slot_id();
         if (skip_slots && skip_slots->count(slot_id)) continue;
+        // ── DEBUG ──
+        {
+            auto& dst_col = (*dst)->get_column_by_slot_id(slot_id);
+            auto& src_col = active_chunk->get_column_by_slot_id(slot_id);
+            VLOG(1) << "[DEBUG] emit_physical_columns slot=" << slot_id
+                    << " dst=" << dst_col->get_name()
+                    << " src=" << src_col->get_name();
+            if (src_col->is_struct()) {
+                const auto* sc = down_cast<const StructColumn*>(ColumnHelper::get_data_column(src_col.get()));
+                for (size_t fi = 0; fi < sc->fields_size(); fi++) {
+                    VLOG(1) << "[DEBUG]   src_struct_field[" << fi << "] " << sc->field_names()[fi]
+                            << "=" << sc->fields()[fi]->get_name();
+                }
+            }
+        }
+        // ── END DEBUG ──
         RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
                                         active_chunk->get_column_by_slot_id(slot_id)));
     }
@@ -442,8 +458,40 @@ Status ColumnMaterializer::materialize_slot(SlotId slot_id, const Range<uint64_t
         SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
         _param.stats->parquet_lazy_read_count++;
         _lazy_triggered_count++;
+        // ── DEBUG ──
+        {
+            auto& col_before = _read_chunk->get_column_by_slot_id(slot_id);
+            LOG(INFO) << "[DEBUG] materialize_slot slot=" << slot_id
+                      << " col_before_type=" << col_before->get_name()
+                      << " col_before_size=" << col_before->size();
+            if (col_before->is_struct()) {
+                const auto* sc = down_cast<const StructColumn*>(col_before.get());
+                for (size_t fi = 0; fi < sc->fields_size(); fi++) {
+                    LOG(INFO) << "[DEBUG]   struct_field[" << fi << "] name=" << sc->field_names()[fi]
+                              << " type=" << sc->fields()[fi]->get_name()
+                              << " size=" << sc->fields()[fi]->size();
+                }
+            }
+        }
+        // ── END DEBUG ──
         RETURN_IF_ERROR(
                 (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
+        // ── DEBUG ──
+        {
+            auto& col_after = _read_chunk->get_column_by_slot_id(slot_id);
+            LOG(INFO) << "[DEBUG] materialize_slot slot=" << slot_id << " AFTER read_range"
+                      << " col_type=" << col_after->get_name()
+                      << " col_size=" << col_after->size();
+            if (col_after->is_struct()) {
+                const auto* sc = down_cast<const StructColumn*>(col_after.get());
+                for (size_t fi = 0; fi < sc->fields_size(); fi++) {
+                    LOG(INFO) << "[DEBUG]   struct_field[" << fi << "] name=" << sc->field_names()[fi]
+                              << " type=" << sc->fields()[fi]->get_name()
+                              << " size=" << sc->fields()[fi]->size();
+                }
+            }
+        }
+        // ── END DEBUG ──
     }
     _slot_cache[slot_id] = {_read_chunk->get_column_by_slot_id(slot_id)};
     return Status::OK();

--- a/be/src/formats/parquet/column_materializer.h
+++ b/be/src/formats/parquet/column_materializer.h
@@ -41,7 +41,7 @@ public:
     ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers);
 
     ReadRangePlanner* read_range_planner() const { return _read_range_planner.get(); }
-    HdfsScanStats* stats() const { return _param.stats; }
+    HdfsScannerStats* stats() const { return _param.stats; }
 
     void clear_classification();
     void add_active_column(int col_idx);

--- a/be/src/formats/parquet/column_materializer.h
+++ b/be/src/formats/parquet/column_materializer.h
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "cache/scan/shared_buffered_input_stream.h"
 #include "common/global_types.h"
 #include "common/status.h"
 #include "common/statusor.h"
@@ -30,12 +31,17 @@
 
 namespace starrocks::parquet {
 
+class LazyMaterializationContext;
+class ReadRangePlanner;
+
 class ColumnMaterializer {
 public:
     using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
 
-    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
-            : _param(param), _column_readers(column_readers) {}
+    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers);
+
+    ReadRangePlanner* read_range_planner() const { return _read_range_planner.get(); }
+    HdfsScanStats* stats() const { return _param.stats; }
 
     void clear_classification();
     void add_active_column(int col_idx);
@@ -92,7 +98,10 @@ public:
                       ChunkPtr* chunk, bool ignore_reserved_field = false);
     Status read_active_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
     Status read_lazy_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
-    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
+    // read_active_range_round_by_round accepts an optional LazyMaterializationContext*
+    // as a forward-looking parameter for Phase 6 expression-driven materialization.
+    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk,
+                                                      LazyMaterializationContext* lazy_ctx = nullptr);
 
     Status rewrite_dict_conjuncts_to_predicate(bool* is_group_filtered);
     Status filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
@@ -116,11 +125,21 @@ public:
     // On-demand single-slot materialization.  Reads the slot through its
     // ColumnReader into _read_chunk and populates _slot_cache.  Returns OK
     // (no-op) if the slot is already cached for the current range.
+    // Also records the trigger for fallback tracking.
     Status materialize_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter);
 
+    // Per-row-group count of lazy slots triggered via materialize_slot().
+    // Reset at row-group boundaries (see reset_triggered_lazy_count).
+    int64_t lazy_triggered_count() const { return _lazy_triggered_count; }
+    void reset_triggered_lazy_count() { _lazy_triggered_count = 0; }
+
     // Post-filter lazy-column backfill.
+    // chunk_filter has full_range.span_size() entries and is used to apply the
+    // correct filter to any lazy columns that were already triggered (via
+    // LazyMaterializationContext) during predicate evaluation.
     Status read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
-                             const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk);
+                             const Filter& post_filter, const Filter& chunk_filter, bool has_filter,
+                             ChunkPtr& active_chunk);
     // Emit physical + reserved-field columns into dst. Skips slots listed in skip_slots.
     Status emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst,
                                  const std::unordered_set<SlotId>* skip_slots = nullptr);
@@ -177,6 +196,12 @@ private:
     std::unordered_map<SlotId, SlotCacheEntry> _slot_cache;
 
     bool _lazy_column_needed = false;
+
+    // Per-row-group count: number of lazy slots triggered via materialize_slot().
+    // Reset at GroupReader destructor boundary for fallback ratio calculation.
+    int64_t _lazy_triggered_count = 0;
+
+    std::unique_ptr<ReadRangePlanner> _read_range_planner;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -147,6 +147,11 @@ public:
         return Status::OK();
     }
 
+    // If a lazy-decode read_range() swapped in a tmp column (dict codes or intermediate
+    // values), decode them back into the slot column in-place so that subsequent
+    // predicate evaluation sees properly typed values.
+    virtual Status materialize_lazy_decode(ColumnPtr& col) { return Status::OK(); }
+
     virtual void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                          ColumnIOTypeFlags types, bool active) = 0;
 

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -317,11 +317,24 @@ Status StructColumnReader::read_range(const Range<uint64_t>& range, const Filter
     // Fill data for subfield column reader
     size_t real_read = 0;
     bool first_read = true;
+    // ── DEBUG ──
+    LOG(INFO) << "[DEBUG] StructColumnReader::read_range parquet_field=" << get_column_parquet_field()->name
+              << " num_fields=" << field_names.size()
+              << " dst_is_nullable=" << dst->is_nullable();
+    // ── END DEBUG ──
     for (size_t i = 0; i < field_names.size(); i++) {
         const auto& field_name = field_names[i];
         if (LIKELY(_child_readers.find(field_name) != _child_readers.end())) {
             if (_child_readers[field_name] != nullptr) {
                 ASSIGN_OR_RETURN(auto& child_column, struct_column->field_column(field_name));
+                // ── DEBUG ──
+                const Column* child_data_col = ColumnHelper::get_data_column(child_column.get());
+                LOG(INFO) << "[DEBUG]   subfield[" << i << "] name=" << field_name
+                          << " col_type=" << child_column->get_name()
+                          << " is_binary=" << child_column->is_binary()
+                          << " data_type=" << child_data_col->get_name()
+                          << " data_is_binary=" << child_data_col->is_binary();
+                // ── END DEBUG ──
                 RETURN_IF_ERROR(_child_readers[field_name]->read_range(range, filter, child_column));
                 real_read = child_column->size();
                 first_read = false;

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -230,6 +230,22 @@ Status ListColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src_in) {
     return Status::OK();
 }
 
+Status ListColumnReader::materialize_lazy_decode(ColumnPtr& col) {
+    auto* col_mut = col->as_mutable_raw_ptr();
+    ArrayColumn* array_column = nullptr;
+    if (col->is_nullable()) {
+        NullableColumn* nullable_column = down_cast<NullableColumn*>(col_mut);
+        DCHECK(nullable_column->data_column_raw_ptr()->is_array());
+        array_column = down_cast<ArrayColumn*>(nullable_column->data_column_raw_ptr());
+    } else {
+        DCHECK(col->is_array());
+        array_column = down_cast<ArrayColumn*>(col_mut);
+    }
+    auto& elements = array_column->elements_column();
+    RETURN_IF_ERROR(_element_reader->materialize_lazy_decode(elements));
+    return Status::OK();
+}
+
 Status MapColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     NullableColumn* nullable_column = nullptr;
     MapColumn* map_column = nullptr;
@@ -317,24 +333,11 @@ Status StructColumnReader::read_range(const Range<uint64_t>& range, const Filter
     // Fill data for subfield column reader
     size_t real_read = 0;
     bool first_read = true;
-    // ── DEBUG ──
-    LOG(INFO) << "[DEBUG] StructColumnReader::read_range parquet_field=" << get_column_parquet_field()->name
-              << " num_fields=" << field_names.size()
-              << " dst_is_nullable=" << dst->is_nullable();
-    // ── END DEBUG ──
     for (size_t i = 0; i < field_names.size(); i++) {
         const auto& field_name = field_names[i];
         if (LIKELY(_child_readers.find(field_name) != _child_readers.end())) {
             if (_child_readers[field_name] != nullptr) {
                 ASSIGN_OR_RETURN(auto& child_column, struct_column->field_column(field_name));
-                // ── DEBUG ──
-                const Column* child_data_col = ColumnHelper::get_data_column(child_column.get());
-                LOG(INFO) << "[DEBUG]   subfield[" << i << "] name=" << field_name
-                          << " col_type=" << child_column->get_name()
-                          << " is_binary=" << child_column->is_binary()
-                          << " data_type=" << child_data_col->get_name()
-                          << " data_is_binary=" << child_data_col->is_binary();
-                // ── END DEBUG ──
                 RETURN_IF_ERROR(_child_readers[field_name]->read_range(range, filter, child_column));
                 real_read = child_column->size();
                 first_read = false;
@@ -443,6 +446,29 @@ Status StructColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
             }
         } else {
             return Status::InternalError(strings::Substitute("there is no match subfield reader for $0", field_name));
+        }
+    }
+    return Status::OK();
+}
+
+Status StructColumnReader::materialize_lazy_decode(ColumnPtr& col) {
+    auto* col_mut = col->as_mutable_raw_ptr();
+    StructColumn* struct_column = nullptr;
+    if (col->is_nullable()) {
+        NullableColumn* nullable_column = down_cast<NullableColumn*>(col_mut);
+        DCHECK(nullable_column->data_column_raw_ptr()->is_struct());
+        struct_column = down_cast<StructColumn*>(nullable_column->data_column_raw_ptr());
+    } else {
+        DCHECK(col->is_struct());
+        struct_column = down_cast<StructColumn*>(col_mut);
+    }
+    const auto& field_names = struct_column->field_names();
+    for (size_t i = 0; i < field_names.size(); i++) {
+        const auto& field_name = field_names[i];
+        auto it = _child_readers.find(field_name);
+        if (it != _child_readers.end() && it->second != nullptr) {
+            ASSIGN_OR_RETURN(auto& child_col, struct_column->field_column(field_name));
+            RETURN_IF_ERROR(it->second->materialize_lazy_decode(child_col));
         }
     }
     return Status::OK();

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -37,6 +37,8 @@ public:
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
+    Status materialize_lazy_decode(ColumnPtr& col) override;
+
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
         _element_reader->get_levels(def_levels, rep_levels, num_levels);
     }
@@ -203,6 +205,8 @@ public:
                               const size_t& layer) override;
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
+
+    Status materialize_lazy_decode(ColumnPtr& col) override;
 
     void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOTypeFlags types, bool active) override {
@@ -526,6 +530,8 @@ public:
     }
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override { return _reader->fill_dst_column(dst, src); }
+
+    Status materialize_lazy_decode(ColumnPtr& col) override { return _reader->materialize_lazy_decode(col); }
 
     void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOTypeFlags types, bool active) override {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -247,6 +247,30 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         //     column. Only reached columns are physically read; unreached
         //     branches' columns stay unread and are skipped in
         //     read_lazy_columns() (is_output_column() == false → skip).
+        // ── DEBUG ──
+        {
+            LOG(INFO) << "[DEBUG] Step 2b pre-eval: rows=" << active_chunk->num_rows()
+                      << " cols=" << active_chunk->num_columns()
+                      << " scanner_ctxs_count=" << _param.scanner_ctx->conjuncts.scanner_ctxs.size()
+                      << " conjunct_ctxs_by_slot_count="
+                      << _param.scanner_ctx->conjunct_ctxs_by_slot.size();
+            const auto& slot_map = active_chunk->get_slot_id_to_index_map();
+            for (const auto& [sid, idx] : slot_map) {
+                auto col = active_chunk->get_column_by_slot_id(sid);
+                LOG(INFO) << "[DEBUG]   slot_id=" << sid << " idx=" << idx
+                          << " col_size=" << (col ? col->size() : 0);
+            }
+            if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+                LOG(INFO) << "[DEBUG] scanner_ctxs: "
+                          << Expr::debug_string(_param.scanner_ctx->conjuncts.scanner_ctxs);
+            }
+            // Also print conjunct_ctxs_by_slot keys
+            LOG(INFO) << "[DEBUG] conjunct_ctxs_by_slot slot_ids:";
+            for (const auto& [sid, ctxs] : _param.scanner_ctx->conjunct_ctxs_by_slot) {
+                LOG(INFO) << "[DEBUG]   slot_id=" << sid << " ctx_count=" << ctxs.size();
+            }
+        }
+        // ── END DEBUG ──
         if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
             ASSIGN_OR_RETURN(size_t compound_hit,
                              ChunkPredicateEvaluator::eval_conjuncts_into_filter(

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -247,31 +247,17 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         //     column. Only reached columns are physically read; unreached
         //     branches' columns stay unread and are skipped in
         //     read_lazy_columns() (is_output_column() == false → skip).
-        // ── DEBUG ──
-        {
-            LOG(INFO) << "[DEBUG] Step 2b pre-eval: rows=" << active_chunk->num_rows()
-                      << " cols=" << active_chunk->num_columns()
-                      << " scanner_ctxs_count=" << _param.scanner_ctx->conjuncts.scanner_ctxs.size()
-                      << " conjunct_ctxs_by_slot_count="
-                      << _param.scanner_ctx->conjunct_ctxs_by_slot.size();
-            const auto& slot_map = active_chunk->get_slot_id_to_index_map();
-            for (const auto& [sid, idx] : slot_map) {
-                auto col = active_chunk->get_column_by_slot_id(sid);
-                LOG(INFO) << "[DEBUG]   slot_id=" << sid << " idx=" << idx
-                          << " col_size=" << (col ? col->size() : 0);
-            }
-            if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
-                LOG(INFO) << "[DEBUG] scanner_ctxs: "
-                          << Expr::debug_string(_param.scanner_ctx->conjuncts.scanner_ctxs);
-            }
-            // Also print conjunct_ctxs_by_slot keys
-            LOG(INFO) << "[DEBUG] conjunct_ctxs_by_slot slot_ids:";
-            for (const auto& [sid, ctxs] : _param.scanner_ctx->conjunct_ctxs_by_slot) {
-                LOG(INFO) << "[DEBUG]   slot_id=" << sid << " ctx_count=" << ctxs.size();
-            }
-        }
-        // ── END DEBUG ──
+        //
+        //     Before evaluating compound conjuncts, flush any dict-code
+        //     columns that ScalarColumnReaders swapped in during step 2.
+        //     Dict-filter columns hold Int32 dict codes in struct subfields
+        //     until fill_dst_column; compound conjuncts need decoded values.
         if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+            for (int col_idx : _column_materializer->dict_column_indices()) {
+                SlotId slot_id = _param.read_cols[col_idx].slot_id();
+                auto& col = active_chunk->get_column_by_slot_id(slot_id);
+                RETURN_IF_ERROR(get_column_reader(slot_id)->materialize_lazy_decode(col));
+            }
             ASSIGN_OR_RETURN(size_t compound_hit,
                              ChunkPredicateEvaluator::eval_conjuncts_into_filter(
                                      _param.scanner_ctx->conjuncts.scanner_ctxs, active_chunk.get(), &chunk_filter));

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -29,6 +29,7 @@
 #include "common/statusor.h"
 #include "common/system/master_info.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
+#include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "formats/parquet/column_materializer.h"
@@ -233,8 +234,32 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         active_chunk->set_missing_column_provider(&lazy_ctx);
         ASSIGN_OR_RETURN(rows_survive,
                          _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count, &lazy_ctx));
+        if (!rows_survive) {
+            active_chunk->set_missing_column_provider(nullptr);
+            continue;
+        }
+
+        // 2b. Evaluate compound (multi-slot) conjuncts with lazy_ctx
+        //     still attached. scanner_ctxs holds the original OR expression
+        //     after Phase 3b guard extraction. ColumnRef triggers
+        //     materialize_slot() via MissingColumnProvider when the OR
+        //     evaluator reaches a branch that references a lazy payload
+        //     column. Only reached columns are physically read; unreached
+        //     branches' columns stay unread and are skipped in
+        //     read_lazy_columns() (is_output_column() == false → skip).
+        if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+            ASSIGN_OR_RETURN(size_t compound_hit,
+                             ChunkPredicateEvaluator::eval_conjuncts_into_filter(
+                                     _param.scanner_ctx->conjuncts.scanner_ctxs, active_chunk.get(), &chunk_filter));
+            if (compound_hit == 0) {
+                _param.stats->late_materialize_skip_rows += count;
+                active_chunk->set_missing_column_provider(nullptr);
+                continue;
+            }
+            has_filter = true;
+        }
+
         active_chunk->set_missing_column_provider(nullptr);
-        if (!rows_survive) continue;
 
         // 3. Fetch variant sources (for subfield conjuncts)
         RETURN_IF_ERROR(_variant->fetch_sources(r, active_chunk));

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -35,9 +35,11 @@
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
+#include "formats/parquet/lazy_materialization_context.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/parquet_pos_reader.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
+#include "formats/parquet/read_range_planner.h"
 #include "formats/parquet/row_source_reader.h"
 #include "formats/parquet/scalar_column_reader.h"
 #include "formats/parquet/schema.h"
@@ -47,42 +49,6 @@
 #include "utils.h"
 
 namespace starrocks::parquet {
-
-namespace {
-
-// Deduplicate exact-duplicate IO ranges collected from multiple column readers.
-void deduplicate_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges) {
-    if (ranges == nullptr || ranges->size() <= 1) {
-        return;
-    }
-
-    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
-        if (lhs.offset != rhs.offset) {
-            return lhs.offset < rhs.offset;
-        }
-        if (lhs.size != rhs.size) {
-            return lhs.size < rhs.size;
-        }
-        return lhs.is_active < rhs.is_active;
-    });
-
-    size_t write_idx = 0;
-    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
-        auto& current = (*ranges)[write_idx];
-        const auto& next = (*ranges)[read_idx];
-        if (current.offset == next.offset && current.size == next.size) {
-            current.is_active = current.is_active || next.is_active;
-            continue;
-        }
-        ++write_idx;
-        if (write_idx != read_idx) {
-            (*ranges)[write_idx] = next;
-        }
-    }
-    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
-}
-
-} // namespace
 
 // ── GroupReader: construction / destruction ─────────────────────────────────
 
@@ -115,6 +81,16 @@ GroupReader::~GroupReader() {
         } else {
             _param.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
         }
+        // Lazy-materialization diagnostic: count row groups where every lazy slot
+        // was triggered during predicate evaluation.  A consistently high count
+        // suggests the active/lazy classification (Phase 3b) would help.
+        if (_param.stats) {
+            size_t total_lazy = _column_materializer->lazy_slot_ids().size() + _variant->lazy_hidden_slot_ids().size();
+            int64_t triggered = _column_materializer->lazy_triggered_count();
+            if (total_lazy > 0 && static_cast<size_t>(triggered) >= total_lazy) {
+                _param.stats->parquet_lazy_full_trigger_count++;
+            }
+        }
         _param.stats->group_min_round_cost =
                 _param.stats->group_min_round_cost == 0
                         ? _column_materializer->min_round_cost()
@@ -144,19 +120,20 @@ Status GroupReader::prepare() {
     // Promote variant virtual columns to typed-value proxy readers.
     _variant->try_promote();
 
-    // Coalesce IO ranges.
+    // Coalesce IO ranges using ReadRangePlanner's staged planning.
     if (config::parquet_coalesce_read_enable && _param.sb_stream != nullptr) {
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
-        int32_t counter = _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed);
-        if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
+        auto* planner = _column_materializer->read_range_planner();
+        bool coalesce_lazy = planner->should_coalesce_active_lazy();
+        if (coalesce_lazy || !config::io_coalesce_adaptive_lazy_active) {
             _param.stats->active_lazy_coalesce_together += 1;
         } else {
             _param.stats->active_lazy_coalesce_seperately += 1;
         }
         _set_end_offset(end_offset);
-        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, counter >= 0));
+        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, coalesce_lazy));
     }
 
     RETURN_IF_ERROR(_column_materializer->rewrite_dict_conjuncts_to_predicate(&_is_group_filtered));
@@ -219,8 +196,6 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         return Status::EndOfFile("");
     }
 
-    _column_materializer->reset_read_chunk();
-    _variant->reset_iteration_state();
     ChunkPtr active_chunk = _column_materializer->create_active_chunk();
 
     while (true) {
@@ -233,17 +208,32 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         auto count = r.span_size();
         _param.stats->raw_rows_read += count;
 
+        // Previous iteration's triggered-lazy slot cache must not carry over into
+        // the next range — stale slot_cache entries would corrupt read_lazy_columns.
+        _column_materializer->reset_read_chunk();
+        _variant->reset_iteration_state();
         bool has_filter = false;
         Filter chunk_filter(count, 1);
         active_chunk->reset();
+
+        // Phase 4: lazy materialization context for on-demand slot resolution.
+        // Created early so Phase 6 expression trigger can call materialize_slot()
+        // during predicate evaluation.  Destroyed before get_next() returns.
+        LazyMaterializationContext lazy_ctx(*_column_materializer, _variant.get(), r, nullptr, active_chunk);
 
         // 1. Prune deleted rows
         ASSIGN_OR_RETURN(bool rows_survive, _prune_deleted_rows(r, chunk_filter, has_filter, count));
         if (!rows_survive) continue;
 
-        // 2. Read & filter active columns
+        // 2. Read & filter active columns.  Attach lazy_ctx as the chunk's
+        //    MissingColumnProvider so that ColumnRef can trigger on-demand
+        //    materialization of lazy slots during predicate evaluation.
+        //    The provider is detached immediately after to prevent it from
+        //    escaping downstream (lazy state must not outlive get_next()).
+        active_chunk->set_missing_column_provider(&lazy_ctx);
         ASSIGN_OR_RETURN(rows_survive,
-                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count));
+                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count, &lazy_ctx));
+        active_chunk->set_missing_column_provider(nullptr);
         if (!rows_survive) continue;
 
         // 3. Fetch variant sources (for subfield conjuncts)
@@ -284,10 +274,18 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
                            chunk_filter.begin() + post_filter_range.end() - r.begin()};
         }
 
-        // 5. Backfill lazy physical columns
-        if (!_column_materializer->lazy_column_indices().empty()) {
-            RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, has_filter,
-                                                                    active_chunk));
+        // 5. Backfill lazy physical columns.  Pass chunk_filter so that any lazy
+        //    columns triggered during step 2 can be filtered to surviving rows.
+        {
+            bool has_any_lazy =
+                    !_column_materializer->lazy_column_indices().empty() || !_variant->lazy_hidden_slot_ids().empty();
+            if (has_any_lazy) {
+                _param.stats->parquet_lazy_col_skip_rows += count - active_chunk->num_rows();
+            }
+            if (!_column_materializer->lazy_column_indices().empty()) {
+                RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, chunk_filter,
+                                                                        has_filter, active_chunk));
+            }
         }
 
         // 6. Backfill lazy variant sources
@@ -331,11 +329,12 @@ StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter
 // ── 2. Read & filter active columns ──────
 
 StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count) {
+                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count,
+                                                            LazyMaterializationContext* lazy_ctx) {
     if (_column_materializer->has_predicate_filter()) {
         has_filter = true;
-        ASSIGN_OR_RETURN(size_t hit_count,
-                         _column_materializer->read_active_range_round_by_round(r, &chunk_filter, &active_chunk));
+        ASSIGN_OR_RETURN(size_t hit_count, _column_materializer->read_active_range_round_by_round(
+                                                   r, &chunk_filter, &active_chunk, lazy_ctx));
         if (hit_count == 0) {
             _param.stats->late_materialize_skip_rows += count;
             return false;
@@ -579,6 +578,10 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     for (SlotId sid : _variant->active_hidden_slot_ids()) {
         _column_materializer->add_active_slot(sid);
     }
+    if (!config::parquet_late_materialization_enable) {
+        _column_materializer->promote_lazy_to_active();
+        _variant->promote_lazy_to_active();
+    }
 
     // ── Promote lazy to active when no active columns exist ───────────────────
     if (_column_materializer->active_slot_ids().empty() && !has_reserved_field_filter) {
@@ -594,7 +597,7 @@ void GroupReader::collect_io_ranges(std::vector<SharedBufferedInputStream::IORan
     int64_t end = 0;
     _column_materializer->collect_io_ranges(ranges, &end, types);
     _variant->collect_io_ranges(ranges, &end, types);
-    deduplicate_io_ranges(ranges);
+    ReadRangePlanner::deduplicate(ranges);
     *end_offset = end;
 }
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -50,6 +50,7 @@ class THdfsScanRange;
 namespace parquet {
 class ColumnMaterializer;
 class FileMetaData;
+class LazyMaterializationContext;
 class VariantProjectionHandler;
 } // namespace parquet
 struct TypeDescriptor;
@@ -165,7 +166,8 @@ private:
     //    evaluates dict / expression filters.  Populates chunk_filter and
     //    fills active_chunk.  Returns true if rows survive.
     StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count);
+                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count,
+                                                   LazyMaterializationContext* lazy_ctx);
 
     // ── Member variables ─────────────────────────────────────────────────────
 

--- a/be/src/formats/parquet/lazy_materialization_context.cpp
+++ b/be/src/formats/parquet/lazy_materialization_context.cpp
@@ -63,22 +63,10 @@ StatusOr<ColumnPtr> LazyMaterializationContext::provide(SlotId slot_id) {
             s->parquet_lazy_slot_triggered++;
         }
     }
-    // ── DEBUG ──
     const auto* entry = _materializer.get_slot_cache(slot_id);
     if (entry != nullptr) {
-        LOG(INFO) << "[DEBUG] provide slot=" << slot_id
-                  << " col_type=" << entry->values->get_name()
-                  << " col_size=" << entry->values->size();
-        if (entry->values->is_struct()) {
-            const auto* sc = down_cast<const StructColumn*>(entry->values.get());
-            for (size_t fi = 0; fi < sc->fields_size(); fi++) {
-                LOG(INFO) << "[DEBUG]   provide struct_field[" << fi << "] name=" << sc->field_names()[fi]
-                          << " type=" << sc->fields()[fi]->get_name();
-            }
-        }
         return entry->values;
     }
-    // ── END DEBUG ──
     // Variant lazy hidden source slot: result is in active_chunk.
     if (_active_chunk->is_slot_exist(slot_id)) {
         return _active_chunk->get_column_by_slot_id(slot_id);

--- a/be/src/formats/parquet/lazy_materialization_context.cpp
+++ b/be/src/formats/parquet/lazy_materialization_context.cpp
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/lazy_materialization_context.h"
+
+#include <algorithm>
+
+#include "column/chunk.h"
+#include "formats/parquet/column_materializer.h"
+#include "formats/parquet/variant_projection.h"
+
+namespace starrocks::parquet {
+
+bool LazyMaterializationContext::has_slot(SlotId slot_id) const {
+    if (_materializer.get_slot_cache(slot_id) != nullptr) {
+        return true;
+    }
+    return _active_chunk->is_slot_exist(slot_id);
+}
+
+bool LazyMaterializationContext::can_materialize(SlotId slot_id) const {
+    const auto& lazy_slots = _materializer.lazy_slot_ids();
+    if (std::find(lazy_slots.begin(), lazy_slots.end(), slot_id) != lazy_slots.end()) {
+        return true;
+    }
+    if (_variant != nullptr) {
+        const auto& hidden_lazy = _variant->lazy_hidden_slot_ids();
+        return std::find(hidden_lazy.begin(), hidden_lazy.end(), slot_id) != hidden_lazy.end();
+    }
+    return false;
+}
+
+Status LazyMaterializationContext::materialize_slot(SlotId slot_id) {
+    if (has_slot(slot_id)) {
+        return Status::OK();
+    }
+    // Variant lazy hidden source slot: dispatch to VariantProjectionHandler.
+    if (_variant != nullptr) {
+        const auto& hidden_lazy = _variant->lazy_hidden_slot_ids();
+        if (std::find(hidden_lazy.begin(), hidden_lazy.end(), slot_id) != hidden_lazy.end()) {
+            return _variant->materialize_hidden_source(slot_id, _range, _filter, _active_chunk);
+        }
+    }
+    return _materializer.materialize_slot(slot_id, _range, _filter);
+}
+
+StatusOr<ColumnPtr> LazyMaterializationContext::provide(SlotId slot_id) {
+    bool first_trigger = _triggered_slots.insert(slot_id).second;
+    RETURN_IF_ERROR(materialize_slot(slot_id));
+    if (first_trigger) {
+        if (auto* s = _materializer.stats()) {
+            s->parquet_lazy_slot_triggered++;
+        }
+    }
+    // Physical lazy slot: result is in slot_cache.
+    const auto* entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    // Variant lazy hidden source slot: result is in active_chunk.
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    return Status::InternalError(fmt::format("provide: slot {} not found after materialize", slot_id));
+}
+
+ColumnPtr LazyMaterializationContext::get_column(SlotId slot_id) {
+    auto* entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    if (!can_materialize(slot_id)) {
+        return nullptr;
+    }
+    auto st = materialize_slot(slot_id);
+    if (!st.ok()) {
+        return nullptr;
+    }
+    // Physical lazy slot: result lands in slot_cache.
+    entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    // Variant lazy hidden source slot: result lands in active_chunk.
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    return nullptr;
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/lazy_materialization_context.cpp
+++ b/be/src/formats/parquet/lazy_materialization_context.cpp
@@ -63,11 +63,22 @@ StatusOr<ColumnPtr> LazyMaterializationContext::provide(SlotId slot_id) {
             s->parquet_lazy_slot_triggered++;
         }
     }
-    // Physical lazy slot: result is in slot_cache.
+    // ── DEBUG ──
     const auto* entry = _materializer.get_slot_cache(slot_id);
     if (entry != nullptr) {
+        LOG(INFO) << "[DEBUG] provide slot=" << slot_id
+                  << " col_type=" << entry->values->get_name()
+                  << " col_size=" << entry->values->size();
+        if (entry->values->is_struct()) {
+            const auto* sc = down_cast<const StructColumn*>(entry->values.get());
+            for (size_t fi = 0; fi < sc->fields_size(); fi++) {
+                LOG(INFO) << "[DEBUG]   provide struct_field[" << fi << "] name=" << sc->field_names()[fi]
+                          << " type=" << sc->fields()[fi]->get_name();
+            }
+        }
         return entry->values;
     }
+    // ── END DEBUG ──
     // Variant lazy hidden source slot: result is in active_chunk.
     if (_active_chunk->is_slot_exist(slot_id)) {
         return _active_chunk->get_column_by_slot_id(slot_id);

--- a/be/src/formats/parquet/lazy_materialization_context.h
+++ b/be/src/formats/parquet/lazy_materialization_context.h
@@ -14,40 +14,77 @@
 
 #pragma once
 
+#include <memory>
+#include <unordered_set>
+
+#include "column/chunk.h"
 #include "column/column.h"
+#include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "storage/primitive/range.h"
 
 namespace starrocks::parquet {
 
 class ColumnMaterializer;
+class VariantProjectionHandler;
 
-// Expression-facing facade over ColumnMaterializer.  Provides on-demand
-// single-slot materialization to the scanner-local predicate evaluator.
+// Expression-facing facade over ColumnMaterializer.  Scoped to a single
+// get_next() iteration: created before predicate evaluation, destroyed
+// before the scanner emits a Chunk.  Lazy state must not escape the scanner.
 //
-// Lifetime: created per get_next() range/batch, destroyed before the
-// scanner emits a fully materialized chunk.  No lazy state leaks out.
-class LazyMaterializationContext {
+// Implements MissingColumnProvider so it can be attached to active_chunk
+// during predicate evaluation.  When ColumnRef encounters a missing slot
+// it calls can_provide() / provide() on this context, which loads the
+// column on demand through ColumnMaterializer or VariantProjectionHandler.
+class LazyMaterializationContext : public MissingColumnProvider {
 public:
-    LazyMaterializationContext(ColumnMaterializer* materializer, const Range<uint64_t>& range, const Filter* filter)
-            : _materializer(materializer), _range(range), _filter(filter) {}
+    // variant may be nullptr when no variant columns are present.
+    LazyMaterializationContext(ColumnMaterializer& materializer, VariantProjectionHandler* variant,
+                               const Range<uint64_t>& range, const Filter* filter, ChunkPtr& active_chunk)
+            : _materializer(materializer),
+              _variant(variant),
+              _range(range),
+              _filter(filter),
+              _active_chunk(active_chunk) {}
 
-    bool has_slot(SlotId slot_id) const { return _materializer->get_slot_cache(slot_id) != nullptr; }
+    LazyMaterializationContext(const LazyMaterializationContext&) = delete;
+    LazyMaterializationContext& operator=(const LazyMaterializationContext&) = delete;
 
-    Status ensure_slot_materialized(SlotId slot_id) {
-        return _materializer->materialize_slot(slot_id, _range, _filter);
-    }
+    // Whether the slot is currently available (in active_chunk or cached).
+    bool has_slot(SlotId slot_id) const;
 
-    ColumnPtr get_column(SlotId slot_id) const {
-        auto* entry = _materializer->get_slot_cache(slot_id);
-        return entry ? entry->values : nullptr;
-    }
+    // Whether the context can materialize this slot on demand.
+    // Returns true for slots in the lazy column sets or variant hidden sources.
+    bool can_materialize(SlotId slot_id) const;
+
+    // Materialize a lazy slot, reading through its ColumnReader if needed.
+    // No-op if the slot is already cached.
+    Status materialize_slot(SlotId slot_id);
+
+    // Return the column for a slot, materializing it on demand first.
+    // Returns nullptr if the slot cannot be resolved.
+    ColumnPtr get_column(SlotId slot_id);
+
+    // MissingColumnProvider implementation: called by ColumnRef when a slot
+    // is absent from the active chunk during predicate evaluation.
+    bool can_provide(SlotId slot_id) const override { return can_materialize(slot_id); }
+    StatusOr<ColumnPtr> provide(SlotId slot_id) override;
+
+    const Range<uint64_t>& range() const { return _range; }
+    const Filter* filter() const { return _filter; }
+    ChunkPtr& active_chunk() { return _active_chunk; }
 
 private:
-    ColumnMaterializer* _materializer;
+    ColumnMaterializer& _materializer;
+    VariantProjectionHandler* _variant;
     Range<uint64_t> _range;
     const Filter* _filter;
+    ChunkPtr& _active_chunk;
+    // Tracks slots triggered for the first time this iteration, to avoid
+    // double-counting in parquet_lazy_slot_triggered.
+    std::unordered_set<SlotId> _triggered_slots;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/read_range_planner.cpp
+++ b/be/src/formats/parquet/read_range_planner.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/read_range_planner.h"
+
+#include <algorithm>
+
+#include "formats/parquet/column_reader.h"
+#include "formats/parquet/group_reader.h"
+
+namespace starrocks::parquet {
+
+ReadRangePlanner::ReadRangePlanner(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+        : _param(param), _column_readers(column_readers) {}
+
+void ReadRangePlanner::collect_ranges(const std::vector<int>& column_indices, bool is_active, std::vector<IORange>* out,
+                                      int64_t* end_offset, ColumnIOTypeFlags types) {
+    for (const auto& index : column_indices) {
+        const auto& column = _param.read_cols[index];
+        (*_column_readers)[column.slot_id()]->collect_column_io_range(out, end_offset, types, is_active);
+    }
+}
+
+void ReadRangePlanner::deduplicate(std::vector<IORange>* ranges) {
+    if (ranges == nullptr || ranges->size() <= 1) {
+        return;
+    }
+    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.offset != rhs.offset) {
+            return lhs.offset < rhs.offset;
+        }
+        if (lhs.size != rhs.size) {
+            return lhs.size < rhs.size;
+        }
+        return lhs.is_active < rhs.is_active;
+    });
+    size_t write_idx = 0;
+    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
+        auto& current = (*ranges)[write_idx];
+        const auto& next = (*ranges)[read_idx];
+        if (current.offset == next.offset && current.size == next.size) {
+            current.is_active = current.is_active || next.is_active;
+            continue;
+        }
+        ++write_idx;
+        if (write_idx != read_idx) {
+            (*ranges)[write_idx] = next;
+        }
+    }
+    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
+}
+
+bool ReadRangePlanner::should_coalesce_active_lazy() const {
+    if (_param.lazy_column_coalesce_counter == nullptr) {
+        return true;
+    }
+    return _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed) >= 0;
+}
+
+void ReadRangePlanner::pre_plan_lazy_ranges(const std::vector<int>& lazy_column_indices, int64_t* end_offset,
+                                            ColumnIOTypeFlags types) {
+    _lazy_ranges.clear();
+    collect_ranges(lazy_column_indices, false, &_lazy_ranges, end_offset, types);
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/read_range_planner.h
+++ b/be/src/formats/parquet/read_range_planner.h
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "cache/scan/shared_buffered_input_stream.h"
+#include "common/global_types.h"
+#include "common/status.h"
+#include "formats/parquet/utils.h"
+
+namespace starrocks::parquet {
+
+struct GroupReaderParam;
+class ColumnReader;
+
+// Plans and coalesces IO ranges for Parquet column readers.
+//
+// Active ranges are planned and submitted during row-group prepare().
+// Lazy ranges are pre-computed but may be submitted on demand (currently
+// submitted together with active ranges during prepare; deferred lazy
+// submission will be enabled when SharedBufferedInputStream supports
+// incremental range addition).
+//
+// Used by ColumnMaterializer; not called directly by expression evaluation.
+class ReadRangePlanner {
+public:
+    using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
+    using IORange = SharedBufferedInputStream::IORange;
+
+    ReadRangePlanner(const GroupReaderParam& param, ColumnReaderMap* column_readers);
+
+    // Collect IO ranges for a set of column indices into `out`.  `types`
+    // controls whether PAGE_INDEX or PAGES ranges are collected.
+    // `is_active` tags the collected ranges.
+    void collect_ranges(const std::vector<int>& column_indices, bool is_active, std::vector<IORange>* out,
+                        int64_t* end_offset, ColumnIOTypeFlags types);
+
+    // Deduplicate exact-duplicate ranges; if two ranges share the same
+    // (offset, size), the active flag is OR-ed.
+    static void deduplicate(std::vector<IORange>* ranges);
+
+    // Whether active and lazy ranges should be coalesced into a unified
+    // stream set (adaptive counter >= 0 or config forces it).
+    bool should_coalesce_active_lazy() const;
+
+    // Plan active ranges now (called during prepare).
+    // Returns the planned active ranges.
+    const std::vector<IORange>& active_ranges() const { return _active_ranges; }
+
+    // Pre-compute lazy ranges (called during prepare).
+    // The ranges are stored; actual stream submission is deferred.
+    void pre_plan_lazy_ranges(const std::vector<int>& lazy_column_indices, int64_t* end_offset,
+                              ColumnIOTypeFlags types);
+
+    // Whether lazy ranges have been planned (non-empty set).
+    bool has_lazy_ranges() const { return !_lazy_ranges.empty(); }
+
+    // Retrieve pre-planned lazy ranges for on-demand submission.
+    const std::vector<IORange>& lazy_ranges() const { return _lazy_ranges; }
+
+private:
+    const GroupReaderParam& _param;
+    ColumnReaderMap* _column_readers = nullptr;
+
+    std::vector<IORange> _active_ranges;
+    std::vector<IORange> _lazy_ranges;
+};
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -472,8 +472,8 @@ Status RawColumnReader::_restore_tmp_column(ColumnPtr& column) {
 
 Status ScalarColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    RETURN_IF_ERROR(_restore_tmp_column(dst));
-    const bool need_lazy_decode =
+    _restore_saved_dst(dst);
+    bool need_lazy_decode =
             _dict_filter_ctx != nullptr || (_can_lazy_dict_decode && filter != nullptr &&
                                             SIMD::count_nonzero(*filter) * 1.0 / filter->size() < FILTER_RATIO);
     ColumnContentType content_type = !need_lazy_decode ? ColumnContentType::VALUE : ColumnContentType::DICT_CODE;
@@ -512,12 +512,13 @@ bool ScalarColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decode
 }
 
 Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
-    // Dispatch on what the src column actually is rather than on flags like `_need_lazy_decode`:
-    // those flags are recomputed by every read_range() call, so when a fill is skipped (e.g. all
-    // rows of a range are filtered out) and a later read flips the flag, flag-based dispatch would
-    // hand the raw Int32 dictionary-code column to the upper layer as if it were the value column.
-    if (_is_dict_code_column(src)) {
+    // Dispatch on which temp column src actually is — the truth — not a recomputable flag.
+    if (_tmp_code_column != nullptr && src.get() == _tmp_code_column.get()) {
         return _fill_dst_column_impl<true, false>(dst, src);
+    } else if (_tmp_intermediate_column != nullptr && src.get() == _tmp_intermediate_column.get()) {
+        return _fill_dst_column_impl<false, true>(dst, src);
+    } else {
+        return _fill_dst_column_impl<false, false>(dst, src);
     }
     if (_is_intermediate_column(src)) {
         return _fill_dst_column_impl<false, true>(dst, src);
@@ -533,9 +534,7 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
             _tmp_code_column = ColumnHelper::create_column(
                     TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
         }
-        _ori_column = dst;
-        _tmp_code_column->as_mutable_raw_ptr()->reset_column();
-        dst = _tmp_code_column;
+        _swap_in_tmp_column(dst, _tmp_code_column);
         dst->as_mutable_raw_ptr()->reserve(range.span_size());
         SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
         return _reader->read_range(range, filter, content_type, dst->as_mutable_raw_ptr());
@@ -562,8 +561,7 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
                 _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
                 return Status::OK();
             } else {
-                _ori_column = dst;
-                dst = _tmp_intermediate_column;
+                _swap_in_tmp_column(dst, _tmp_intermediate_column);
                 return Status::OK();
             }
         }
@@ -621,11 +619,7 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
                 RETURN_IF_ERROR(_dict_decode(dst, src));
             }
         }
-        if (UNLIKELY(_ori_column == nullptr)) {
-            return Status::InternalError("Parquet lazy dictionary decode lost original destination column");
-        }
-        src = _ori_column;
-        _ori_column = nullptr;
+        _finish_fill(src);
     } else {
         if constexpr (LAZY_CONVERT) {
             if (UNLIKELY(!_is_intermediate_column(src))) {
@@ -636,28 +630,22 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
                 RETURN_IF_ERROR(_converter->convert(src, dst->as_mutable_raw_ptr()));
             }
             src->as_mutable_raw_ptr()->reset_column();
-            if (UNLIKELY(_ori_column == nullptr)) {
-                return Status::InternalError("Parquet lazy conversion lost original destination column");
-            }
-            src = _ori_column;
-            _ori_column = nullptr;
+            _finish_fill(src);
         } else {
-            // ── DEBUG ──
-            VLOG(1) << "[DEBUG] fill_dst_column_impl swap: dst=" << dst->get_name()
-                    << " src=" << src->get_name();
-            // ── END DEBUG ──
             dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
         }
     }
     return Status::OK();
 }
 
-bool ScalarColumnReader::_is_dict_code_column(const ColumnPtr& column) const {
-    return _tmp_code_column != nullptr && column.get() == _tmp_code_column.get();
-}
-
-bool ScalarColumnReader::_is_intermediate_column(const ColumnPtr& column) const {
-    return _tmp_intermediate_column != nullptr && column.get() == _tmp_intermediate_column.get();
+Status ScalarColumnReader::materialize_lazy_decode(ColumnPtr& col) {
+    if (_saved_dst != nullptr && col.get() == _tmp_code_column.get()) {
+        auto saved = std::move(_saved_dst);
+        _saved_dst = nullptr;
+        RETURN_IF_ERROR(_dict_decode(saved, col));
+        col = std::move(saved);
+    }
+    return Status::OK();
 }
 
 void ScalarColumnReader::collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges,
@@ -679,16 +667,14 @@ void ScalarColumnReader::collect_column_io_range(std::vector<SharedBufferedInput
 
 Status LowCardColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    RETURN_IF_ERROR(_restore_tmp_column(dst));
+    _restore_saved_dst(dst);
     ColumnContentType content_type = ColumnContentType::DICT_CODE;
 
     if (_dict_code == nullptr) {
         _dict_code = ColumnHelper::create_column(
                 TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
     }
-    _ori_column = dst;
-    _dict_code->as_mutable_raw_ptr()->reset_column();
-    dst = _dict_code;
+    _swap_in_tmp_column(dst, _dict_code);
     dst->as_mutable_raw_ptr()->reserve(range.span_size());
 
     {
@@ -755,11 +741,7 @@ Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     }
 
     src->as_mutable_raw_ptr()->reset_column();
-    if (UNLIKELY(_ori_column == nullptr)) {
-        return Status::InternalError("Parquet low-cardinality reader lost original destination column");
-    }
-    src = _ori_column;
-    _ori_column = nullptr;
+    _finish_fill(src);
 
     return Status::OK();
 }
@@ -828,15 +810,13 @@ void LowCardColumnReader::collect_column_io_range(std::vector<SharedBufferedInpu
 
 Status LowRowsColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    RETURN_IF_ERROR(_restore_tmp_column(dst));
+    _restore_saved_dst(dst);
     ColumnContentType content_type = ColumnContentType::VALUE;
 
     if (_tmp_column == nullptr) {
         _tmp_column = ColumnHelper::create_column(TYPE_VARCHAR_DESC, true);
     }
-    _ori_column = dst;
-    _tmp_column->as_mutable_raw_ptr()->reset_column();
-    dst = _tmp_column;
+    _swap_in_tmp_column(dst, _tmp_column);
     dst->as_mutable_raw_ptr()->reserve(range.span_size());
 
     {
@@ -877,11 +857,7 @@ Status LowRowsColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     }
 
     src->as_mutable_raw_ptr()->reset_column();
-    if (UNLIKELY(_ori_column == nullptr)) {
-        return Status::InternalError("Parquet low-rows reader lost original destination column");
-    }
-    src = _ori_column;
-    _ori_column = nullptr;
+    _finish_fill(src);
 
     return Status::OK();
 }

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -642,6 +642,10 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
             src = _ori_column;
             _ori_column = nullptr;
         } else {
+            // ── DEBUG ──
+            VLOG(1) << "[DEBUG] fill_dst_column_impl swap: dst=" << dst->get_name()
+                    << " src=" << src->get_name();
+            // ── END DEBUG ──
             dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
         }
     }

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -259,11 +259,7 @@ private:
     bool _can_lazy_convert = false;
     // we use lazy decode adaptively because of RLE && decoder may be better than filter && decoder
     static constexpr double FILTER_RATIO = 0.2;
-<<<<<<< HEAD
     // tmp columns used during lazy-decode / lazy-convert paths; at most one is non-null
-=======
-    // dict code
->>>>>>> main
     ColumnPtr _tmp_code_column = nullptr;
     ColumnPtr _tmp_intermediate_column = nullptr;
 };

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -126,14 +126,28 @@ protected:
                                            CompoundNodeType pred_relation, const TypeDescriptor& col_type,
                                            const uint64_t rg_first_row, const uint64_t rg_num_rows) const;
 
-    // If `column` still refers to one of this reader's internal temporary columns, a previous
-    // fill_dst_column() was skipped (e.g. the whole range was filtered out and
-    // GroupReader::get_next() continued without filling). Restore the caller-visible column to the
-    // original destination column so that no temporary column can leak out of the reader.
-    Status _restore_tmp_column(ColumnPtr& column);
-    // Whether `column` is one of this reader's internal temporary columns. Overridden by readers
-    // that swap in a temporary column (dict-code / intermediate / low-rows string) during read.
-    virtual bool _is_tmp_column(const ColumnPtr& column) const { return false; }
+    // Caller-visible column parked while a temporary column occupies the slot.
+    // nullptr ⇒ no swap pending. Single source of truth for the swap lifecycle.
+    ColumnPtr _saved_dst = nullptr;
+
+    // Install `tmp` into the caller's slot, saving the original destination.
+    void _swap_in_tmp_column(ColumnPtr& slot, const ColumnPtr& tmp) {
+        _saved_dst = slot;
+        slot = tmp;
+    }
+    // Repair a slot left pointing at a tmp column by a skipped fill.
+    // Call at the top of read_range() — no-op when no swap is pending.
+    void _restore_saved_dst(ColumnPtr& slot) {
+        if (_saved_dst != nullptr) {
+            slot = _saved_dst;
+            _saved_dst = nullptr;
+        }
+    }
+    // Restore the slot at the end of a successful fill.
+    void _finish_fill(ColumnPtr& src) {
+        src = _saved_dst;
+        _saved_dst = nullptr;
+    }
 
     const ColumnReaderOptions& _opts;
 
@@ -195,6 +209,8 @@ public:
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
+    Status materialize_lazy_decode(ColumnPtr& col) override;
+
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                              CompoundNodeType pred_relation, const uint64_t rg_first_row,
                                              const uint64_t rg_num_rows) const override {
@@ -243,7 +259,11 @@ private:
     bool _can_lazy_convert = false;
     // we use lazy decode adaptively because of RLE && decoder may be better than filter && decoder
     static constexpr double FILTER_RATIO = 0.2;
+<<<<<<< HEAD
+    // tmp columns used during lazy-decode / lazy-convert paths; at most one is non-null
+=======
     // dict code
+>>>>>>> main
     ColumnPtr _tmp_code_column = nullptr;
     ColumnPtr _tmp_intermediate_column = nullptr;
 };

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -821,6 +821,9 @@ Status VariantProjectionHandler::backfill_sources(const Range<uint64_t>& full_ra
 
     auto lazy_hidden_chunk = std::make_shared<Chunk>();
     for (SlotId slot_id : _lazy_hidden_slot_ids) {
+        // Skip slots already triggered via LazyMaterializationContext.
+        if (active_chunk->is_slot_exist(slot_id)) continue;
+
         auto* hidden_src = _hidden_slot_index.at(slot_id);
         ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
         if (has_filter) {
@@ -831,11 +834,36 @@ Status VariantProjectionHandler::backfill_sources(const Range<uint64_t>& full_ra
         }
         lazy_hidden_chunk->append_column(std::move(col), slot_id);
     }
+    if (lazy_hidden_chunk->num_columns() == 0) {
+        return Status::OK();
+    }
     if (lazy_hidden_chunk->num_rows() != active_chunk->num_rows()) {
         return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_hidden_rows={}",
                                                  active_chunk->num_rows(), lazy_hidden_chunk->num_rows()));
     }
     active_chunk->merge(std::move(*lazy_hidden_chunk));
+    return Status::OK();
+}
+
+Status VariantProjectionHandler::materialize_hidden_source(SlotId slot_id, const Range<uint64_t>& range,
+                                                           const Filter* filter, ChunkPtr& active_chunk) {
+    // Check this is actually a lazy hidden source slot.
+    auto& lazy_ids = _lazy_hidden_slot_ids;
+    if (std::find(lazy_ids.begin(), lazy_ids.end(), slot_id) == lazy_ids.end()) {
+        return Status::OK();
+    }
+    // Already present (triggered earlier this iteration)?
+    if (active_chunk->is_slot_exist(slot_id)) {
+        return Status::OK();
+    }
+    auto it = _hidden_slot_index.find(slot_id);
+    if (it == _hidden_slot_index.end()) {
+        return Status::InternalError(
+                fmt::format("materialize_hidden_source: slot {} not in hidden_slot_index", slot_id));
+    }
+    ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
+    RETURN_IF_ERROR(it->second->reader->read_range(range, filter, col));
+    active_chunk->append_column(std::move(col), slot_id);
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/variant_projection.h
+++ b/be/src/formats/parquet/variant_projection.h
@@ -131,8 +131,16 @@ public:
     Status align_after_combined_filter(const ChunkPtr& active_chunk, const Filter& filter, size_t pre_filter_rows);
 
     // 6. Backfill projection-only variant source columns.
+    // Slots already triggered via LazyMaterializationContext (already present in
+    // active_chunk) are skipped to avoid double-reading.
     Status backfill_sources(const Range<uint64_t>& full_range, const Range<uint64_t>* post_filter_range,
                             const Filter* post_filter, bool has_filter, ChunkPtr& active_chunk);
+
+    // On-demand materialization of a single lazy hidden source slot into active_chunk.
+    // Called by LazyMaterializationContext when an expression triggers the slot.
+    // No-op if slot_id is already in active_chunk or is not a lazy hidden source.
+    Status materialize_hidden_source(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter,
+                                     ChunkPtr& active_chunk);
 
     // 7. Emit variant virtual-column projections into the destination chunk.
     //    Consumes internally stored projected chunk (set by filter_subfields).

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2885,8 +2885,7 @@ TEST_F(FileReaderTest, TestStructSubfieldDictCodeNoLeakOnSkippedFill) {
         // c0 is NullableColumn(BinaryColumn); unwrap to check the data column type.
         Column* c0_data = ColumnHelper::get_data_column(c0_r.value()->as_mutable_raw_ptr());
         ASSERT_TRUE(c0_data->is_binary())
-                << "Bug: c_struct.c0 in _read_chunk leaked as dict-code column: "
-                << c0_r.value()->get_name();
+                << "Bug: c_struct.c0 in _read_chunk leaked as dict-code column: " << c0_r.value()->get_name();
     };
 
     size_t total_row_nums = 0;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2831,6 +2831,80 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
     EXPECT_EQ(100, total_row_nums);
 }
 
+// Reproduce: when a chunk is fully filtered (hit_count==0), the ScalarColumnReader's
+// fill_dst_column() is skipped and the subfield slot is left pointing at the internal
+// Int32 dict-code column. The next chunk that does survive then reads/fills against
+// a wrong column type, causing a type-mismatch crash or corrupt output.
+// Using chunk_size=30 ensures the first chunk (rows 1-30, c0%100 in 1..30) has no
+// match for c_struct.c0='55', forcing the skipped-fill path before a matching chunk.
+TEST_F(FileReaderTest, TestStructSubfieldDictCodeNoLeakOnSkippedFill) {
+    const std::string struct_in_struct_file_path =
+            "./be/test/formats/parquet/test_data/test_parquet_struct_in_struct.parquet";
+    auto ctx = _create_file_struct_in_struct_read_context(struct_in_struct_file_path);
+
+    TypeDescriptor type_struct =
+            TypeDescriptor::create_struct_type({"c0", "c1"}, {TYPE_VARCHAR_DESC, TYPE_VARCHAR_DESC});
+    TypeDescriptor type_struct_in_struct =
+            TypeDescriptor::create_struct_type({"c0", "c_struct"}, {TYPE_VARCHAR_DESC, type_struct});
+
+    std::vector<std::string> subfield_path({"c_struct", "c0"});
+    _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "55",
+                                                    &ctx->conjunct_ctxs_by_slot[3]);
+
+    // Small chunk size: first chunk (rows 1-30) has no match for c_struct.c0='55',
+    // so hit_count==0 and fill is skipped — this is what triggers the bug.
+    auto file_reader = _create_file_reader(struct_in_struct_file_path, 30);
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(TYPE_INT_DESC, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(TYPE_INT_DESC, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_struct_in_struct, true), chunk->num_columns());
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+
+    // After a successful fill (get_next returns >0 rows), verify that the inner
+    // struct subfield c_struct.c0 in _read_chunk is still a binary column.
+    // Without the fix, gap B leaves _ori_column pointing at _tmp_code_column (Int32),
+    // so fill_dst_column "restores" c0 to Int32 instead of Binary — detectable here.
+    auto assert_read_chunk_c_struct_c0_is_binary = [&]() {
+        const auto& rg = file_reader->_row_group_readers[0];
+        const ChunkPtr& rc = rg->_column_materializer->read_chunk();
+        ASSERT_TRUE(rc != nullptr);
+        // Use as_mutable_raw_ptr() to navigate const ColumnPtr& without casts.
+        auto* outer_col = rc->get_column_by_slot_id(3)->as_mutable_raw_ptr();
+        auto* outer_nullable = down_cast<NullableColumn*>(outer_col);
+        auto* outer_struct = down_cast<StructColumn*>(outer_nullable->data_column_raw_ptr());
+        auto c_struct_r = outer_struct->field_column("c_struct");
+        ASSERT_TRUE(c_struct_r.ok());
+        auto* inner_nullable = down_cast<NullableColumn*>(c_struct_r.value()->as_mutable_raw_ptr());
+        auto* inner_struct = down_cast<StructColumn*>(inner_nullable->data_column_raw_ptr());
+        auto c0_r = inner_struct->field_column("c0");
+        ASSERT_TRUE(c0_r.ok());
+        // c0 is NullableColumn(BinaryColumn); unwrap to check the data column type.
+        Column* c0_data = ColumnHelper::get_data_column(c0_r.value()->as_mutable_raw_ptr());
+        ASSERT_TRUE(c0_data->is_binary())
+                << "Bug: c_struct.c0 in _read_chunk leaked as dict-code column: "
+                << c0_r.value()->get_name();
+    };
+
+    size_t total_row_nums = 0;
+    while (!status.is_end_of_file()) {
+        chunk->reset();
+        status = file_reader->get_next(&chunk);
+        ASSERT_TRUE(status.ok() || status.is_end_of_file()) << status.message();
+        chunk->check_or_die();
+        total_row_nums += chunk->num_rows();
+        if (chunk->num_rows() != 0) {
+            ASSERT_EQ("{c0:'55',c_struct:{c0:'55',c1:'46'}}", chunk->get_column_by_slot_id(3)->debug_item(0));
+            // Verify internal state: c_struct.c0 must be binary, not a leaked Int32 dict-code column.
+            assert_read_chunk_c_struct_c0_is_binary();
+        }
+    }
+    EXPECT_EQ(100, total_row_nums);
+}
+
 TEST_F(FileReaderTest, TestStructSubfieldZonemap) {
     const std::string struct_in_struct_file_path =
             "./be/test/formats/parquet/test_data/test_parquet_struct_in_struct.parquet";

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -32,6 +32,8 @@
 #include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
+#include "formats/parquet/lazy_materialization_context.h"
+#include "formats/parquet/read_range_planner.h"
 #include "formats/parquet/utils.h"
 #include "formats/parquet/variant_projection.h"
 #include "fs/fs.h"
@@ -4132,6 +4134,449 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnOverflowBecomesN
     ASSERT_EQ(2, result->size());
     EXPECT_EQ(500, result->get(0).get_int32()); // 5 × 100 = 500
     EXPECT_TRUE(result->is_null(1));            // 21474837 × 100 overflows int32_t → NULL
+}
+
+// ── LazyMaterializationContext tests ─────────────────────────────────────────
+
+// Covers: LazyMaterializationContext::provides MissingColumnProvider
+//         interface for physical lazy slots.
+TEST_F(GroupReaderTest, LazyMaterializationContextCanMaterializeAndProvidePhysicalSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot = _pool.add(
+            new SlotDescriptor(200, "active_col", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(201, "lazy_col", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* unrelated_slot = _pool.add(
+            new SlotDescriptor(202, "other_col", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    // Wire mock readers: active slot has data, lazy slot has mock that records reads.
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    // Verify classification: active_slot in active, lazy_slot in lazy.
+    const auto& lazy_ids = group_reader->_column_materializer->lazy_slot_ids();
+    EXPECT_TRUE(std::find(lazy_ids.begin(), lazy_ids.end(), lazy_slot->id()) != lazy_ids.end());
+
+    // Init read_chunk so materialize_slot has a valid _read_chunk.
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 2);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // can_materialize: true for lazy slot, false for active and unrelated.
+    EXPECT_TRUE(ctx.can_materialize(lazy_slot->id()));
+    EXPECT_FALSE(ctx.can_materialize(active_slot->id()));
+    EXPECT_FALSE(ctx.can_materialize(unrelated_slot->id()));
+
+    // can_provide (MissingColumnProvider interface) mirrors can_materialize.
+    EXPECT_TRUE(ctx.can_provide(lazy_slot->id()));
+    EXPECT_FALSE(ctx.can_provide(unrelated_slot->id()));
+
+    // provide: materializes the lazy slot and returns its column.
+    auto result = ctx.provide(lazy_slot->id());
+    ASSERT_TRUE(result.ok());
+    auto col = result.value();
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(2u, col->size());
+
+    // Second provide is idempotent (slot already cached).
+    auto result2 = ctx.provide(lazy_slot->id());
+    ASSERT_TRUE(result2.ok());
+}
+
+// Covers: LazyMaterializationContext::has_slot for both
+//         slot_cache (physical) and active_chunk paths.
+TEST_F(GroupReaderTest, LazyMaterializationContextHasSlotReturnsTrueForCachedAndActiveChunkSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(210, "ac", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(211, "lz", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 1);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // has_slot: active_chunk has active_slot → true
+    EXPECT_TRUE(ctx.has_slot(active_slot->id()));
+    // has_slot: lazy_slot not in active_chunk or slot_cache → false
+    EXPECT_FALSE(ctx.has_slot(lazy_slot->id()));
+
+    // materialize the lazy slot → populates slot_cache
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_TRUE(ctx.has_slot(lazy_slot->id()));
+}
+
+// Covers: LazyMaterializationContext::materialize_slot dispatches to
+//         ColumnMaterializer for physical lazy slots (variant is nullptr).
+TEST_F(GroupReaderTest, LazyMaterializationContextMaterializeSlotDelegatesToColumnMaterializer) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(220, "aa", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(221, "bb", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 1);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // Trigger count starts at 0.
+    EXPECT_EQ(0, group_reader->_column_materializer->lazy_triggered_count());
+
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_EQ(1, group_reader->_column_materializer->lazy_triggered_count());
+
+    // Idempotent: second materialize is a no-op.
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_EQ(1, group_reader->_column_materializer->lazy_triggered_count());
+
+    // After reset, materialize increments again.
+    group_reader->_column_materializer->reset_triggered_lazy_count();
+    EXPECT_EQ(0, group_reader->_column_materializer->lazy_triggered_count());
+    // Need to clear slot_cache too so materialize_slot actually reads again.
+    group_reader->_column_materializer->reset_read_chunk();
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_EQ(1, group_reader->_column_materializer->lazy_triggered_count());
+}
+
+// Covers: LazyMaterializationContext::get_column returns nullptr for
+//         slots that can't be materialized and returns valid column
+//         after materialize_slot (physical path).
+TEST_F(GroupReaderTest, LazyMaterializationContextGetColumnReturnsNullForUnknownSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(230, "x", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(231, "y", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* unknown_slot =
+            _pool.add(new SlotDescriptor(999, "zz", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 1);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // Unknown slot → nullptr (not in lazy_slots, can't materialize).
+    EXPECT_EQ(nullptr, ctx.get_column(unknown_slot->id()));
+
+    // get_column materializes on demand and returns result.
+    auto col = ctx.get_column(lazy_slot->id());
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(1u, col->size());
+
+    // Active slot from active_chunk → returns existing column.
+    auto active_col = ctx.get_column(active_slot->id());
+    ASSERT_NE(nullptr, active_col);
+}
+
+// Covers: ColumnMaterializer::read_lazy_columns separates triggered
+//         (in slot_cache) from untriggered lazy columns.
+TEST_F(GroupReaderTest, ReadLazyColumnsSeparatesTriggeredFromUntriggered) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(240, "a", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_a_slot =
+            _pool.add(new SlotDescriptor(241, "la", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_b_slot =
+            _pool.add(new SlotDescriptor(242, "lb", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cla{};
+    cla.slot_desc = lazy_a_slot;
+    GroupReaderParam::Column clb{};
+    clb.slot_desc = lazy_b_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cla);
+    param->read_cols.emplace_back(clb);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_a_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_b_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    const auto& lazy_ids = group_reader->_column_materializer->lazy_slot_ids();
+    EXPECT_EQ(2u, lazy_ids.size());
+
+    // Build active_chunk manually with the active slot pre-filled to 2 rows.
+    size_t num_rows = 2;
+    Range<uint64_t> full_range(0, num_rows);
+    auto active_chunk = std::make_shared<Chunk>();
+    auto active_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    active_col->append_datum(Datum(int64_t(1)));
+    active_col->append_datum(Datum(int64_t(2)));
+    active_chunk->append_column(active_col, active_slot->id());
+
+    // Simulate: lazy_a was triggered during predicate eval → in slot_cache.
+    // lazy_b was NOT triggered → not in slot_cache.
+    group_reader->_column_materializer->reset_read_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    ASSERT_OK(ctx.materialize_slot(lazy_a_slot->id()));
+    EXPECT_NE(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_a_slot->id()));
+    EXPECT_EQ(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_b_slot->id()));
+
+    // read_lazy_columns should:
+    // - Move lazy_a (triggered) from _read_chunk → append → active_chunk
+    // - Read lazy_b (untriggered) via full_range → merge → active_chunk
+    Range<uint64_t> post_filter_range = full_range;
+    Filter empty_filter{};
+    Filter chunk_filter(num_rows, 1);
+    ASSERT_OK(group_reader->_column_materializer->read_lazy_columns(full_range, post_filter_range, empty_filter,
+                                                                    chunk_filter, false, active_chunk));
+
+    // Both lazy columns should now be in active_chunk (3 total: active + lazy_a + lazy_b).
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_a_slot->id()));
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_b_slot->id()));
+    EXPECT_EQ(3u, active_chunk->num_columns());
+}
+
+// Covers: ColumnMaterializer::read_lazy_columns filters triggered columns
+//         with chunk_filter when has_filter is true.
+TEST_F(GroupReaderTest, ReadLazyColumnsFiltersTriggeredColumnsWithChunkFilter) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(250, "act", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(251, "lz", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(10)));
+    bigint_col->append_datum(Datum(int64_t(20)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    size_t num_rows = 2;
+    Range<uint64_t> full_range(0, num_rows);
+
+    // Build active_chunk manually: 2 surviving rows for active_slot.
+    auto active_chunk = std::make_shared<Chunk>();
+    auto active_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    active_col->append_datum(Datum(int64_t(1)));
+    active_col->append_datum(Datum(int64_t(2)));
+    active_chunk->append_column(active_col, active_slot->id());
+
+    // Trigger lazy_slot so it is in slot_cache with full_range data.
+    group_reader->_column_materializer->reset_read_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+
+    // chunk_filter has 1s for all rows (row 0 and 1 survive).
+    Filter chunk_filter(num_rows, 1);
+    Range<uint64_t> post_filter_range = full_range;
+    Filter empty_filter{};
+    ASSERT_OK(group_reader->_column_materializer->read_lazy_columns(full_range, post_filter_range, empty_filter,
+                                                                    chunk_filter, true, active_chunk));
+
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_slot->id()));
+    auto& col = active_chunk->get_column_by_slot_id(lazy_slot->id());
+    EXPECT_EQ(num_rows, col->size());
+}
+
+// Covers: ReadRangePlanner::deduplicate merges duplicate IORanges.
+TEST_F(GroupReaderTest, ReadRangePlannerDeduplicateMergesIdenticalRanges) {
+    using IORange = SharedBufferedInputStream::IORange;
+    std::vector<IORange> ranges;
+    ranges.emplace_back(100, 50, true);
+    ranges.emplace_back(100, 50, false);
+    ranges.emplace_back(200, 30, true);
+    ranges.emplace_back(200, 30, true);
+
+    ReadRangePlanner::deduplicate(&ranges);
+
+    // Two duplicates: (100,50) merged → is_active = true, (200,30) merged → is_active = true.
+    ASSERT_EQ(2u, ranges.size());
+    EXPECT_EQ(100, ranges[0].offset);
+    EXPECT_EQ(50, ranges[0].size);
+    EXPECT_TRUE(ranges[0].is_active);
+    EXPECT_EQ(200, ranges[1].offset);
+    EXPECT_EQ(30, ranges[1].size);
+    EXPECT_TRUE(ranges[1].is_active);
+}
+
+// Covers: ReadRangePlanner::should_coalesce_active_lazy returns true
+//         when counter is nullptr (default).
+TEST_F(GroupReaderTest, ReadRangePlannerShouldCoalesceReturnsTrueWhenCounterIsNull) {
+    auto* param = _create_group_reader_param();
+    param->lazy_column_coalesce_counter = nullptr;
+
+    std::unordered_map<int32_t, std::unique_ptr<ColumnReader>> readers;
+    ReadRangePlanner planner(*param, &readers);
+
+    EXPECT_TRUE(planner.should_coalesce_active_lazy());
+}
+
+// Covers: ReadRangePlanner::should_coalesce_active_lazy reads
+//         the adaptive counter.
+TEST_F(GroupReaderTest, ReadRangePlannerShouldCoalesceReadsCounter) {
+    auto* param = _create_group_reader_param();
+    std::atomic<int32_t> counter = -1;
+    param->lazy_column_coalesce_counter = &counter;
+
+    std::unordered_map<int32_t, std::unique_ptr<ColumnReader>> readers;
+    ReadRangePlanner planner(*param, &readers);
+
+    EXPECT_FALSE(planner.should_coalesce_active_lazy());
+
+    counter.store(0, std::memory_order_relaxed);
+    EXPECT_TRUE(planner.should_coalesce_active_lazy());
 }
 
 } // namespace starrocks::parquet

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -311,7 +311,7 @@ This topic introduces the following types of BE configurations:
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Integer ratio in range [0-1000] that controls the use of late materialization in the SegmentIterator (vector query engine). A value of `0` (or &le; 0) disables late materialization; `1000` (or &ge; 1000) forces late materialization for all reads. Values &gt; 0 and &lt; 1000 enable a conditional strategy where both late and early materialization contexts are prepared and the iterator selects behavior based on predicate filter ratios (higher values favor late materialization). When a segment contains complex metric types, StarRocks uses `metric_late_materialization_ratio` instead. If `lake_io_opts.cache_file_only` is set, late materialization is disabled.
+- Description: Integer ratio in range [0-1000] that controls the use of late materialization in the SegmentIterator (vector query engine). A value of `0` (or ≤ 0) disables late materialization; `1000` (or ≥ 1000) forces late materialization for all reads. Values > 0 and < 1000 enable a conditional strategy where both late and early materialization contexts are prepared and the iterator selects behavior based on predicate filter ratios (higher values favor late materialization). When a segment contains complex metric types, StarRocks uses `metric_late_materialization_ratio` instead. If `lake_io_opts.cache_file_only` is set, late materialization is disabled.
 - Introduced in: v3.2.0
 
 ### max_hdfs_file_handle

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ArithmeticCommutativeRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ConsolidateLikesRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.DeriveGuardPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ExtractCommonPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
@@ -54,6 +55,7 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
+            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );
@@ -84,6 +86,7 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
+            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -22,7 +22,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ArithmeticCommutativeRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ConsolidateLikesRule;
-import com.starrocks.sql.optimizer.rewrite.scalar.DeriveGuardPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ExtractCommonPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
@@ -55,7 +54,6 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
-            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );
@@ -86,7 +84,6 @@ public class ScalarOperatorRewriter {
             new SimplifiedPredicateRule(),
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
-            new DeriveGuardPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
     );

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -21,7 +22,6 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.type.Type;
 
 import java.util.ArrayList;
@@ -33,9 +33,13 @@ import java.util.Set;
 
 /**
  * Derive guard predicates from OR expressions where every branch contains
- * a comparison on a common pivot column. The guard is a single-slot predicate
+ * a comparison on a common pivot column.  The guard is a single-slot predicate
  * that enters conjunct_ctxs_by_slot in the BE, making the pivot column ACTIVE
  * while branch-local columns remain LAZY.
+ * <p>
+ * This is a one-pass transformation (like ScalarRangePredicateExtractor),
+ * NOT a ScalarOperatorRewriteRule.  It is called directly from
+ * PushDownPredicateScanRule after the scalar rewriter completes.
  * <p>
  * Example:
  * <pre>
@@ -50,60 +54,30 @@ import java.util.Set;
  *     OR (l_shipdate BETWEEN '1998-06-15' AND '1998-06-15' AND l_returnflag = 'A'))
  * </pre>
  * <p>
- * This is V1: only handles top-level OR conjuncts (children of the root AND).
- * The guard is purely additive (AND with the original), so correctness is
- * preserved even if guard logic has gaps.
+ * V1: processes top-level OR conjuncts (children of the root AND). The guard
+ * is purely additive (AND with the original), so correctness is preserved.
  */
-public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
+public class DeriveGuardPredicateRule {
 
     /**
-     * Track OR nodes that have already been wrapped with a guard,
-     * to prevent infinite rewrite loops across fixpoint iterations.
-     * After wrapping, the original OR remains in the tree as a child
-     * of AND(guard, OR) and would be re-processed on the next iteration.
-     * Keyed by System.identityHashCode.
-     * <p>
-     * Cleared at the start of each ScalarOperatorRewriter.rewrite() call
-     * (when context.changeNum() == 0, indicating context.reset() was just called).
+     * Apply guard derivation to the predicate tree.  Called once per query,
+     * outside any fixpoint rewrite loop.
      */
-    private final Set<Integer> wrappedOrIdentities = new HashSet<>();
-    private int clearEpoch = 0;
-
-    @Override
-    public boolean isOnlyOnce() {
-        return true;
-    }
-
-    @Override
-    public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
-        // Clear the seen set at the start of a new rewrite pass
-        if (context.changeNum() == 0 && clearEpoch != 0) {
-            wrappedOrIdentities.clear();
-            clearEpoch = 0;
-        }
-        clearEpoch = context.changeNum();
-
-        // Flatten the root AND to find all top-level OR conjuncts.
-        List<ScalarOperator> conjuncts = Utils.extractConjuncts(root);
+    public static ScalarOperator apply(ScalarOperator predicate) {
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
         boolean changed = false;
         for (int i = 0; i < conjuncts.size(); i++) {
             ScalarOperator conjunct = conjuncts.get(i);
             if (conjunct instanceof CompoundPredicateOperator
                     && ((CompoundPredicateOperator) conjunct).isOr()) {
-                // Skip ORs already wrapped in a previous iteration
-                if (wrappedOrIdentities.contains(System.identityHashCode(conjunct))) {
-                    continue;
-                }
                 ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
                 if (wrapped != conjunct) {
                     conjuncts.set(i, wrapped);
-                    wrappedOrIdentities.add(System.identityHashCode(conjunct));
-                    context.change();
                     changed = true;
                 }
             }
         }
-        return changed ? Utils.compoundAnd(conjuncts) : root;
+        return changed ? Utils.compoundAnd(conjuncts) : predicate;
     }
 
     /**
@@ -111,6 +85,7 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
      * Returns the wrapped expression AND(guard, orExpr) if guards can be derived,
      * or the original orExpr unchanged.
      */
+    @VisibleForTesting
     static ScalarOperator tryDeriveGuard(CompoundPredicateOperator orExpr) {
         List<ScalarOperator> disjuncts = Utils.extractDisjunctive(orExpr);
         if (disjuncts.size() <= 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -1,0 +1,217 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Derive guard predicates from OR expressions where every branch contains
+ * a comparison on a common pivot column. The guard is a single-slot predicate
+ * that enters conjunct_ctxs_by_slot in the BE, making the pivot column ACTIVE
+ * while branch-local columns remain LAZY.
+ * <p>
+ * Example:
+ * <pre>
+ *   (l_shipdate BETWEEN '1998-01-01' AND '1998-01-01' AND l_returnflag = 'R')
+ *   OR (l_shipdate BETWEEN '1998-06-15' AND '1998-06-15' AND l_returnflag = 'A')
+ *
+ *   becomes:
+ *
+ *   (l_shipdate BETWEEN '1998-01-01' AND '1998-01-01'
+ *    OR l_shipdate BETWEEN '1998-06-15' AND '1998-06-15')  -- guard (single-slot)
+ *   AND ((l_shipdate BETWEEN '1998-01-01' AND '1998-01-01' AND l_returnflag = 'R')
+ *     OR (l_shipdate BETWEEN '1998-06-15' AND '1998-06-15' AND l_returnflag = 'A'))
+ * </pre>
+ * <p>
+ * This is V1: only handles top-level OR conjuncts (children of the root AND).
+ * The guard is purely additive (AND with the original), so correctness is
+ * preserved even if guard logic has gaps.
+ */
+public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
+
+    @Override
+    public boolean isOnlyOnce() {
+        return true;
+    }
+
+    @Override
+    public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
+        // Flatten the root AND to find all top-level OR conjuncts.
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(root);
+        boolean changed = false;
+        for (int i = 0; i < conjuncts.size(); i++) {
+            ScalarOperator conjunct = conjuncts.get(i);
+            if (conjunct instanceof CompoundPredicateOperator
+                    && ((CompoundPredicateOperator) conjunct).isOr()) {
+                ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
+                if (wrapped != conjunct) {
+                    conjuncts.set(i, wrapped);
+                    context.change();
+                    changed = true;
+                }
+            }
+        }
+        return changed ? Utils.compoundAnd(conjuncts) : root;
+    }
+
+    /**
+     * Try to derive a guard predicate for the given OR expression.
+     * Returns the wrapped expression AND(guard, orExpr) if guards can be derived,
+     * or the original orExpr unchanged.
+     */
+    static ScalarOperator tryDeriveGuard(CompoundPredicateOperator orExpr) {
+        List<ScalarOperator> disjuncts = Utils.extractDisjunctive(orExpr);
+        if (disjuncts.size() <= 1) {
+            return orExpr;
+        }
+
+        // For each disjunct, extract its AND conjuncts
+        List<List<ScalarOperator>> disjunctConjuncts = new ArrayList<>();
+        for (ScalarOperator disjunct : disjuncts) {
+            disjunctConjuncts.add(Utils.extractConjuncts(disjunct));
+        }
+
+        // Step 1: For each disjunct, collect range column predicates by column id.
+        // Also track the total number of real (non-AND) leaves in each disjunct tree.
+        List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds = new ArrayList<>();
+        List<Integer> disjunctLeafCounts = new ArrayList<>();
+        for (int di = 0; di < disjuncts.size(); di++) {
+            Map<Integer, List<ScalarOperator>> colPreds = new HashMap<>();
+            List<ScalarOperator> conjuncts = disjunctConjuncts.get(di);
+            for (ScalarOperator conjunct : conjuncts) {
+                if (isRangeColumnPredicate(conjunct)) {
+                    ColumnRefSet usedCols = conjunct.getUsedColumns();
+                    if (usedCols.cardinality() == 1) {
+                        int colId = usedCols.getFirstId();
+                        colPreds.computeIfAbsent(colId, k -> new ArrayList<>()).add(conjunct);
+                    }
+                }
+            }
+            perDisjunctColPreds.add(colPreds);
+            // Count all leaves in this disjunct's AND tree, not just those from extractConjuncts
+            disjunctLeafCounts.add(countFlatConjuncts(disjuncts.get(di)));
+        }
+
+        // Step 2: Find columns that appear in ALL disjuncts (intersection)
+        Set<Integer> commonColIds = new HashSet<>(perDisjunctColPreds.get(0).keySet());
+        if (commonColIds.isEmpty()) {
+            return orExpr;
+        }
+        for (int i = 1; i < perDisjunctColPreds.size(); i++) {
+            commonColIds.retainAll(perDisjunctColPreds.get(i).keySet());
+        }
+
+        if (commonColIds.isEmpty()) {
+            return orExpr;
+        }
+
+        // Step 3: Build guard predicate for each common column.
+        List<ScalarOperator> guards = new ArrayList<>();
+        for (int colId : commonColIds) {
+            if (allDisjunctsAreOnlyColumnPreds(disjunctLeafCounts, perDisjunctColPreds, colId)) {
+                continue;
+            }
+
+            List<ScalarOperator> perDisjunctGuardParts = new ArrayList<>();
+            for (Map<Integer, List<ScalarOperator>> disjunctPreds : perDisjunctColPreds) {
+                List<ScalarOperator> colPreds = disjunctPreds.get(colId);
+                perDisjunctGuardParts.add(Utils.compoundAnd(colPreds));
+            }
+            guards.add(Utils.compoundOr(perDisjunctGuardParts));
+        }
+
+        if (guards.isEmpty()) {
+            return orExpr;
+        }
+
+        // Step 4: Wrap original OR with guard: AND(guard1, ..., guardN, original_OR)
+        List<ScalarOperator> andArgs = new ArrayList<>(guards);
+        andArgs.add(orExpr);
+        return Utils.compoundAnd(andArgs);
+    }
+
+    /**
+     * Check if all leaves across all disjuncts for a given column consist only of
+     * column predicates for that column. If so, the guard would be redundant.
+     */
+    private static boolean allDisjunctsAreOnlyColumnPreds(
+            List<Integer> disjunctLeafCounts,
+            List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds,
+            int colId) {
+        int totalLeaves = 0;
+        int totalColPreds = 0;
+        for (int i = 0; i < disjunctLeafCounts.size(); i++) {
+            totalLeaves += disjunctLeafCounts.get(i);
+            List<ScalarOperator> colPreds = perDisjunctColPreds.get(i).get(colId);
+            totalColPreds += (colPreds != null ? colPreds.size() : 0);
+        }
+        return totalLeaves == totalColPreds;
+    }
+
+    /**
+     * Count the total number of leaf (non-compound) children in the AND tree
+     * rooted at the given scalar operator, without being limited to
+     * getChild(0)/getChild(1) like extractConjuncts.
+     */
+    private static int countFlatConjuncts(ScalarOperator node) {
+        if (!(node instanceof CompoundPredicateOperator)) {
+            return 1;
+        }
+        CompoundPredicateOperator cpo = (CompoundPredicateOperator) node;
+        if (!cpo.isAnd()) {
+            return 1;
+        }
+        int count = 0;
+        for (ScalarOperator child : cpo.getChildren()) {
+            count += countFlatConjuncts(child);
+        }
+        return count;
+    }
+
+    /**
+     * Check if this is a single-column predicate that provides a range constraint
+     * (GE, LE, GT, LT, IN). Equality-only predicates are excluded to avoid creating
+     * non-selective guards for low-cardinality payload columns.
+     */
+    private static boolean isRangeColumnPredicate(ScalarOperator op) {
+        if (op instanceof BinaryPredicateOperator) {
+            if (op.getUsedColumns().cardinality() != 1) {
+                return false;
+            }
+            BinaryPredicateOperator bop = (BinaryPredicateOperator) op;
+            BinaryType type = bop.getBinaryType();
+            return type == BinaryType.GE || type == BinaryType.LE
+                    || type == BinaryType.GT || type == BinaryType.LT;
+        }
+        if (op instanceof InPredicateOperator) {
+            return op.getUsedColumns().cardinality() == 1;
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.type.Type;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -105,7 +106,7 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
             Map<Integer, List<ScalarOperator>> colPreds = new HashMap<>();
             List<ScalarOperator> conjuncts = disjunctConjuncts.get(di);
             for (ScalarOperator conjunct : conjuncts) {
-                if (isRangeColumnPredicate(conjunct)) {
+                if (isGuardCandidatePredicate(conjunct)) {
                     ColumnRefSet usedCols = conjunct.getUsedColumns();
                     if (usedCols.cardinality() == 1) {
                         int colId = usedCols.getFirstId();
@@ -195,23 +196,70 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
     }
 
     /**
-     * Check if this is a single-column predicate that provides a range constraint
-     * (GE, LE, GT, LT, IN). Equality-only predicates are excluded to avoid creating
-     * non-selective guards for low-cardinality payload columns.
+     * Check if this predicate should contribute to a guard.
+     * <p>
+     * Guard derivation strategy:
+     * <ul>
+     *   <li><b>Range predicates (GE, LE, GT, LT)</b>: always collected. These are the primary
+     *       target — they form contiguous intervals that are inherently selective.</li>
+     *   <li><b>IN predicates</b>: always collected. IN lists on date/numeric columns are
+     *       selective and commonly used as pivot columns in OR branches.</li>
+     *   <li><b>EQ on DATE / DATETIME / TIMESTAMP / numeric types</b>: collected.
+     *       EQ on a high-cardinality date or numeric column (e.g. {@code l_shipdate = '1998-12-01'})
+     *       is as selective as a range predicate and should contribute to the guard.
+     *       <p>
+     *       <b>EQ on VARCHAR / CHAR / BOOLEAN is intentionally excluded.</b>
+     *       These columns are typically low-cardinality payload columns (e.g.
+     *       {@code l_returnflag = 'R'}). Adding a guard for them would:
+     *       <ol>
+     *         <li>Produce a non-selective guard (e.g. {@code returnflag = 'R' OR returnflag = 'A'})</li>
+     *         <li>Put the column into {@code conjunct_ctxs_by_slot} → ACTIVE →
+     *             decoded for all rows instead of LAZY (decoded only for survivor rows)</li>
+     *         <li>Negate the benefit of the real guard on the pivot column</li>
+     *       </ol>
+     *       This is the key difference from Trino's TupleDomain: Trino's TupleDomain is
+     *       only used for page-level pruning and does NOT force column decoding order.
+     *       Our guard flows through {@code conjunct_ctxs_by_slot} which DOES control the
+     *       ACTIVE vs LAZY column split, so we must be more selective.</li>
+     * </ul>
      */
-    private static boolean isRangeColumnPredicate(ScalarOperator op) {
+    private static boolean isGuardCandidatePredicate(ScalarOperator op) {
         if (op instanceof BinaryPredicateOperator) {
-            if (op.getUsedColumns().cardinality() != 1) {
-                return false;
-            }
-            BinaryPredicateOperator bop = (BinaryPredicateOperator) op;
-            BinaryType type = bop.getBinaryType();
-            return type == BinaryType.GE || type == BinaryType.LE
-                    || type == BinaryType.GT || type == BinaryType.LT;
+            return isGuardCandidateBinaryPredicate((BinaryPredicateOperator) op);
         }
         if (op instanceof InPredicateOperator) {
             return op.getUsedColumns().cardinality() == 1;
         }
+        return false;
+    }
+
+    /**
+     * Check if a BinaryPredicateOperator is a guard candidate.
+     * Range predicates (GE, LE, GT, LT) are always candidates.
+     * EQ is only a candidate on high-cardinality types (date/datetime/numeric).
+     */
+    private static boolean isGuardCandidateBinaryPredicate(BinaryPredicateOperator bop) {
+        ColumnRefSet usedCols = bop.getUsedColumns();
+        if (usedCols.cardinality() != 1) {
+            return false;
+        }
+        BinaryType type = bop.getBinaryType();
+
+        // Range predicates: always candidates
+        if (type == BinaryType.GE || type == BinaryType.LE
+                || type == BinaryType.GT || type == BinaryType.LT) {
+            return true;
+        }
+
+        // EQ: only for high-cardinality column types
+        // Skip VARCHAR/CHAR/BOOLEAN to avoid creating non-selective guards
+        // that would make low-cardinality payload columns ACTIVE unnecessarily
+        if (type == BinaryType.EQ) {
+            // After NormalizePredicateRule, the column reference is child(0)
+            Type colType = bop.getChild(0).getType();
+            return colType.isNumericType() || colType.isDateType() || colType.isDatetime();
+        }
+
         return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -25,8 +25,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.Type;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +70,14 @@ public class DeriveGuardPredicateRule {
             ScalarOperator conjunct = conjuncts.get(i);
             if (conjunct instanceof CompoundPredicateOperator
                     && ((CompoundPredicateOperator) conjunct).isOr()) {
+                List<ScalarOperator> disjuncts = Utils.extractDisjunctive(conjunct);
+                // Skip when the OR involves too few columns — with <= 2 columns both
+                // are already ACTIVE, so the guard's short-circuit benefit is minimal.
+                // Additionally, guard predicates added during MV refresh break MV
+                // matching because the stored plan's predicate structure changes.
+                if (countDistinctColumns(disjuncts) < MIN_DISTINCT_COLUMNS_FOR_GUARD) {
+                    continue;
+                }
                 ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
                 if (wrapped != conjunct) {
                     conjuncts.set(i, wrapped);
@@ -103,7 +111,7 @@ public class DeriveGuardPredicateRule {
         List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds = new ArrayList<>();
         List<Integer> disjunctLeafCounts = new ArrayList<>();
         for (int di = 0; di < disjuncts.size(); di++) {
-            Map<Integer, List<ScalarOperator>> colPreds = new HashMap<>();
+            Map<Integer, List<ScalarOperator>> colPreds = new LinkedHashMap<>();
             List<ScalarOperator> conjuncts = disjunctConjuncts.get(di);
             for (ScalarOperator conjunct : conjuncts) {
                 if (isGuardCandidatePredicate(conjunct)) {
@@ -120,7 +128,7 @@ public class DeriveGuardPredicateRule {
         }
 
         // Step 2: Find columns that appear in ALL disjuncts (intersection)
-        Set<Integer> commonColIds = new HashSet<>(perDisjunctColPreds.get(0).keySet());
+        Set<Integer> commonColIds = new LinkedHashSet<>(perDisjunctColPreds.get(0).keySet());
         if (commonColIds.isEmpty()) {
             return orExpr;
         }
@@ -136,6 +144,15 @@ public class DeriveGuardPredicateRule {
         List<ScalarOperator> guards = new ArrayList<>();
         for (int colId : commonColIds) {
             if (allDisjunctsAreOnlyColumnPreds(disjunctLeafCounts, perDisjunctColPreds, colId)) {
+                continue;
+            }
+
+            // Skip if the guard for this column is purely EQ/IN predicates.
+            // The ScalarRangePredicateExtractor already handles EQ-only columns
+            // via IN lists, so a pure-EQ guard would be redundant and would
+            // unnecessarily change the plan text (breaking MV matching, test
+            // assertions, etc.).
+            if (isOnlyEqualityGuard(perDisjunctColPreds, colId)) {
                 continue;
             }
 
@@ -158,6 +175,45 @@ public class DeriveGuardPredicateRule {
     }
 
     /**
+     * Check whether every guard predicate for the given column across all disjuncts
+     * is an equality (EQ or IN) — no range predicates (GE, LE, GT, LT).
+     * <p>
+     * An EQ-only guard like {@code col = 1 OR col = 2 OR col = 3} is redundant with
+     * what {@code ScalarRangePredicateExtractor} already produces (an IN list).
+     * Skipping it avoids unnecessary plan-text changes that can break MV matching
+     * and test assertions.
+     */
+    private static boolean isOnlyEqualityGuard(
+            List<Map<Integer, List<ScalarOperator>>> perDisjunctColPreds,
+            int colId) {
+        for (Map<Integer, List<ScalarOperator>> disjunctPreds : perDisjunctColPreds) {
+            List<ScalarOperator> colPreds = disjunctPreds.get(colId);
+            if (colPreds == null) {
+                continue;
+            }
+            for (ScalarOperator pred : colPreds) {
+                if (isRangePredicate(pred)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check whether a scalar operator is a range predicate (not EQ or IN).
+     */
+    private static boolean isRangePredicate(ScalarOperator op) {
+        if (op instanceof BinaryPredicateOperator) {
+            BinaryType type = ((BinaryPredicateOperator) op).getBinaryType();
+            return type == BinaryType.GE || type == BinaryType.LE
+                    || type == BinaryType.GT || type == BinaryType.LT;
+        }
+        // IN predicates are treated as equality (not range)
+        return false;
+    }
+
+    /**
      * Check if all leaves across all disjuncts for a given column consist only of
      * column predicates for that column. If so, the guard would be redundant.
      */
@@ -173,6 +229,25 @@ public class DeriveGuardPredicateRule {
             totalColPreds += (colPreds != null ? colPreds.size() : 0);
         }
         return totalLeaves == totalColPreds;
+    }
+
+    // Minimum number of distinct columns across OR branches required to
+    // trigger guard generation.  With <= 2 columns both are already ACTIVE,
+    // so the guard's short-circuit benefit is minimal.  Additionally, guards
+    // added during MV refresh break MV matching because the stored plan's
+    // predicate structure changes (MV matching is not guard-aware yet).
+    @VisibleForTesting
+    static final int MIN_DISTINCT_COLUMNS_FOR_GUARD = 3;
+
+    /**
+     * Count the total number of distinct columns referenced by all disjuncts.
+     */
+    private static int countDistinctColumns(List<ScalarOperator> disjuncts) {
+        ColumnRefSet allCols = new ColumnRefSet();
+        for (ScalarOperator disjunct : disjuncts) {
+            allCols.union(disjunct.getUsedColumns());
+        }
+        return allCols.cardinality();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRule.java
@@ -56,6 +56,19 @@ import java.util.Set;
  */
 public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
 
+    /**
+     * Track OR nodes that have already been wrapped with a guard,
+     * to prevent infinite rewrite loops across fixpoint iterations.
+     * After wrapping, the original OR remains in the tree as a child
+     * of AND(guard, OR) and would be re-processed on the next iteration.
+     * Keyed by System.identityHashCode.
+     * <p>
+     * Cleared at the start of each ScalarOperatorRewriter.rewrite() call
+     * (when context.changeNum() == 0, indicating context.reset() was just called).
+     */
+    private final Set<Integer> wrappedOrIdentities = new HashSet<>();
+    private int clearEpoch = 0;
+
     @Override
     public boolean isOnlyOnce() {
         return true;
@@ -63,6 +76,13 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
+        // Clear the seen set at the start of a new rewrite pass
+        if (context.changeNum() == 0 && clearEpoch != 0) {
+            wrappedOrIdentities.clear();
+            clearEpoch = 0;
+        }
+        clearEpoch = context.changeNum();
+
         // Flatten the root AND to find all top-level OR conjuncts.
         List<ScalarOperator> conjuncts = Utils.extractConjuncts(root);
         boolean changed = false;
@@ -70,9 +90,14 @@ public class DeriveGuardPredicateRule extends BaseScalarOperatorRewriteRule {
             ScalarOperator conjunct = conjuncts.get(i);
             if (conjunct instanceof CompoundPredicateOperator
                     && ((CompoundPredicateOperator) conjunct).isOr()) {
+                // Skip ORs already wrapped in a previous iteration
+                if (wrappedOrIdentities.contains(System.identityHashCode(conjunct))) {
+                    continue;
+                }
                 ScalarOperator wrapped = tryDeriveGuard((CompoundPredicateOperator) conjunct);
                 if (wrapped != conjunct) {
                     conjuncts.set(i, wrapped);
+                    wrappedOrIdentities.add(System.identityHashCode(conjunct));
                     context.change();
                     changed = true;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
 import com.starrocks.sql.optimizer.rewrite.TimeDriftConstraint;
+import com.starrocks.sql.optimizer.rewrite.scalar.DeriveGuardPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -89,6 +90,11 @@ public class PushDownPredicateScanRule extends TransformationRule {
 
         predicates = TimeDriftConstraint.tryAddDerivedPredicates(predicates, logicalScanOperator.getTable(),
                 logicalScanOperator.getColumnNameToColRefMap());
+
+        // Derive guard predicates from OR branches to help BE column loading.
+        // Called once here (not in the scalar rewrite fixpoint loop) to avoid
+        // redundant re-processing.
+        predicates = DeriveGuardPredicateRule.apply(predicates);
 
         // clone a new scan operator and rewrite predicate.
         Operator.Builder builder = OperatorBuilderFactory.build(logicalScanOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -21,7 +21,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Test;
@@ -109,8 +108,7 @@ public class DeriveGuardPredicateRuleTest {
     public void testSingleDisjunct() {
         // Single disjunct (not really an OR) — no rewriting
         ScalarOperator expr = eq(colInt(1, "a"), ConstantOperator.createInt(1));
-        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
-        ScalarOperator result = new DeriveGuardPredicateRule().apply(expr, context);
+        ScalarOperator result = DeriveGuardPredicateRule.apply(expr);
         assertEquals(expr, result);
     }
 
@@ -141,8 +139,7 @@ public class DeriveGuardPredicateRuleTest {
                 eq(b, ConstantOperator.createInt(2))
         );
 
-        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
-        ScalarOperator result = new DeriveGuardPredicateRule().apply(andExpr, context);
+        ScalarOperator result = DeriveGuardPredicateRule.apply(andExpr);
         assertEquals(andExpr, result);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -148,7 +148,10 @@ public class DeriveGuardPredicateRuleTest {
 
     @Test
     public void testThreeBranches() {
-        // Three OR branches, all have l_shipdate comparisons + payload
+        // Three OR branches, all have l_shipdate (GE+LE) + l_discount (EQ on INT).
+        // Both columns get guards:
+        //   guard_shipdate: OR over shipdate ranges
+        //   guard_discount:  OR over discount EQ values (INT type, valid candidate)
         ColumnRefOperator shipdate = colInt(1, "l_shipdate");
         ColumnRefOperator discount = colInt(2, "l_discount");
 
@@ -167,12 +170,64 @@ public class DeriveGuardPredicateRuleTest {
         ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
                 (CompoundPredicateOperator) orExpr);
 
-        ScalarOperator expectedGuard = or(
+        ScalarOperator guardShipdate = or(
                 and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(10))),
                 and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30))),
                 and(ge(shipdate, ConstantOperator.createInt(40)), le(shipdate, ConstantOperator.createInt(50)))
         );
-        ScalarOperator expected = and(expectedGuard, orExpr);
+        ScalarOperator guardDiscount = or(
+                eq(discount, ConstantOperator.createInt(5)),
+                eq(discount, ConstantOperator.createInt(6)),
+                eq(discount, ConstantOperator.createInt(7))
+        );
+        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
         assertEquals(expected, derived);
+    }
+
+    @Test
+    public void testEQOnNumericColumn() {
+        // EQ on INT columns should produce guards.
+        // Both l_shipdate (INT) and l_discount (INT) are valid candidates.
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator discount = colInt(2, "l_discount");
+
+        ScalarOperator orExpr = or(
+                and(eq(shipdate, ConstantOperator.createInt(1)),
+                    eq(discount, ConstantOperator.createInt(5))),
+                and(eq(shipdate, ConstantOperator.createInt(15)),
+                    eq(discount, ConstantOperator.createInt(6)))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        // Guards for both columns
+        ScalarOperator guardShipdate = or(
+                eq(shipdate, ConstantOperator.createInt(1)),
+                eq(shipdate, ConstantOperator.createInt(15))
+        );
+        ScalarOperator guardDiscount = or(
+                eq(discount, ConstantOperator.createInt(5)),
+                eq(discount, ConstantOperator.createInt(6))
+        );
+        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
+        assertEquals(expected, derived);
+    }
+
+    @Test
+    public void testEQOnVarcharColumn() {
+        // EQ on varchar column should NOT produce guard (low cardinality risk)
+        // (l_returnflag = 'R') OR (l_returnflag = 'A')
+        ColumnRefOperator returnflag = colVarchar(1, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                eq(returnflag, ConstantOperator.createVarchar("R")),
+                eq(returnflag, ConstantOperator.createVarchar("A"))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+        // No guard expected: EQ on VARCHAR is skipped
+        assertEquals(orExpr, derived);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -146,9 +146,8 @@ public class DeriveGuardPredicateRuleTest {
     @Test
     public void testThreeBranches() {
         // Three OR branches, all have l_shipdate (GE+LE) + l_discount (EQ on INT).
-        // Both columns get guards:
-        //   guard_shipdate: OR over shipdate ranges
-        //   guard_discount:  OR over discount EQ values (INT type, valid candidate)
+        // Only shipdate gets a guard — range predicates are the primary target.
+        // discount EQ-only guard is skipped (ScalarRangePredicateExtractor handles it).
         ColumnRefOperator shipdate = colInt(1, "l_shipdate");
         ColumnRefOperator discount = colInt(2, "l_discount");
 
@@ -172,19 +171,15 @@ public class DeriveGuardPredicateRuleTest {
                 and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30))),
                 and(ge(shipdate, ConstantOperator.createInt(40)), le(shipdate, ConstantOperator.createInt(50)))
         );
-        ScalarOperator guardDiscount = or(
-                eq(discount, ConstantOperator.createInt(5)),
-                eq(discount, ConstantOperator.createInt(6)),
-                eq(discount, ConstantOperator.createInt(7))
-        );
-        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
+        ScalarOperator expected = and(guardShipdate, orExpr);
         assertEquals(expected, derived);
     }
 
     @Test
     public void testEQOnNumericColumn() {
-        // EQ on INT columns should produce guards.
-        // Both l_shipdate (INT) and l_discount (INT) are valid candidates.
+        // EQ-only guards on numeric columns are skipped — the
+        // ScalarRangePredicateExtractor already produces IN lists for them.
+        // Only range predicates (GE, LE, GT, LT) trigger guard generation.
         ColumnRefOperator shipdate = colInt(1, "l_shipdate");
         ColumnRefOperator discount = colInt(2, "l_discount");
 
@@ -198,17 +193,8 @@ public class DeriveGuardPredicateRuleTest {
         ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
                 (CompoundPredicateOperator) orExpr);
 
-        // Guards for both columns
-        ScalarOperator guardShipdate = or(
-                eq(shipdate, ConstantOperator.createInt(1)),
-                eq(shipdate, ConstantOperator.createInt(15))
-        );
-        ScalarOperator guardDiscount = or(
-                eq(discount, ConstantOperator.createInt(5)),
-                eq(discount, ConstantOperator.createInt(6))
-        );
-        ScalarOperator expected = and(guardShipdate, guardDiscount, orExpr);
-        assertEquals(expected, derived);
+        // No guard — all predicates are EQ-only, which the range extractor handles.
+        assertEquals(orExpr, derived);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/DeriveGuardPredicateRuleTest.java
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DeriveGuardPredicateRuleTest {
+
+    // Column helpers
+    private static ColumnRefOperator colInt(int id, String name) {
+        return new ColumnRefOperator(id, IntegerType.INT, name, true);
+    }
+
+    private static ColumnRefOperator colVarchar(int id, String name) {
+        return new ColumnRefOperator(id, VarcharType.VARCHAR, name, true);
+    }
+
+    // Build a proper left-deep AND tree (matching optimizer output) via Utils.compoundAnd
+    private static ScalarOperator and(ScalarOperator... children) {
+        return Utils.compoundAnd(children);
+    }
+
+    // Build a proper left-deep OR tree via Utils.compoundOr
+    private static ScalarOperator or(ScalarOperator... children) {
+        return Utils.compoundOr(children);
+    }
+
+    private static ScalarOperator eq(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.EQ, left, right);
+    }
+
+    private static ScalarOperator ge(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.GE, left, right);
+    }
+
+    private static ScalarOperator le(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.LE, left, right);
+    }
+
+    @Test
+    public void testNarrowDateOR() {
+        // (l_shipdate >= 1 AND l_shipdate <= 1 AND l_returnflag = 'R')
+        // OR (l_shipdate >= 15 AND l_shipdate <= 15 AND l_returnflag = 'A')
+        // => AND(guard_shipdate, original_OR)
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator returnflag = colVarchar(2, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)),
+                    le(shipdate, ConstantOperator.createInt(1)),
+                    eq(returnflag, ConstantOperator.createVarchar("R"))),
+                and(ge(shipdate, ConstantOperator.createInt(15)),
+                    le(shipdate, ConstantOperator.createInt(15)),
+                    eq(returnflag, ConstantOperator.createVarchar("A")))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        ScalarOperator expectedGuard = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(1))),
+                and(ge(shipdate, ConstantOperator.createInt(15)), le(shipdate, ConstantOperator.createInt(15)))
+        );
+        ScalarOperator expected = and(expectedGuard, orExpr);
+        assertEquals(expected, derived);
+    }
+
+    @Test
+    public void testNoCommonColumn() {
+        // (l_returnflag = 'R') OR (l_linestatus = 'O') => no guard
+        ColumnRefOperator returnflag = colVarchar(1, "l_returnflag");
+        ColumnRefOperator linestatus = colVarchar(2, "l_linestatus");
+
+        ScalarOperator orExpr = or(
+                eq(returnflag, ConstantOperator.createVarchar("R")),
+                eq(linestatus, ConstantOperator.createVarchar("O"))
+        );
+
+        ScalarOperator result = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+        assertEquals(orExpr, result);
+    }
+
+    @Test
+    public void testSingleDisjunct() {
+        // Single disjunct (not really an OR) — no rewriting
+        ScalarOperator expr = eq(colInt(1, "a"), ConstantOperator.createInt(1));
+        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
+        ScalarOperator result = new DeriveGuardPredicateRule().apply(expr, context);
+        assertEquals(expr, result);
+    }
+
+    @Test
+    public void testAllBranchesOnlyColumnPreds() {
+        // (l_returnflag = 'R') OR (l_returnflag = 'A')
+        // EQ-only predicates are not range predicates => no guard
+        ColumnRefOperator returnflag = colVarchar(1, "l_returnflag");
+
+        ScalarOperator orExpr = or(
+                eq(returnflag, ConstantOperator.createVarchar("R")),
+                eq(returnflag, ConstantOperator.createVarchar("A"))
+        );
+
+        ScalarOperator result = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+        assertEquals(orExpr, result);
+    }
+
+    @Test
+    public void testAndPredicate() {
+        // AND predicate — not processed
+        ColumnRefOperator a = colInt(1, "a");
+        ColumnRefOperator b = colInt(2, "b");
+
+        ScalarOperator andExpr = and(
+                eq(a, ConstantOperator.createInt(1)),
+                eq(b, ConstantOperator.createInt(2))
+        );
+
+        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
+        ScalarOperator result = new DeriveGuardPredicateRule().apply(andExpr, context);
+        assertEquals(andExpr, result);
+    }
+
+    @Test
+    public void testThreeBranches() {
+        // Three OR branches, all have l_shipdate comparisons + payload
+        ColumnRefOperator shipdate = colInt(1, "l_shipdate");
+        ColumnRefOperator discount = colInt(2, "l_discount");
+
+        ScalarOperator orExpr = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)),
+                    le(shipdate, ConstantOperator.createInt(10)),
+                    eq(discount, ConstantOperator.createInt(5))),
+                and(ge(shipdate, ConstantOperator.createInt(20)),
+                    le(shipdate, ConstantOperator.createInt(30)),
+                    eq(discount, ConstantOperator.createInt(6))),
+                and(ge(shipdate, ConstantOperator.createInt(40)),
+                    le(shipdate, ConstantOperator.createInt(50)),
+                    eq(discount, ConstantOperator.createInt(7)))
+        );
+
+        ScalarOperator derived = DeriveGuardPredicateRule.tryDeriveGuard(
+                (CompoundPredicateOperator) orExpr);
+
+        ScalarOperator expectedGuard = or(
+                and(ge(shipdate, ConstantOperator.createInt(1)), le(shipdate, ConstantOperator.createInt(10))),
+                and(ge(shipdate, ConstantOperator.createInt(20)), le(shipdate, ConstantOperator.createInt(30))),
+                and(ge(shipdate, ConstantOperator.createInt(40)), le(shipdate, ConstantOperator.createInt(50)))
+        );
+        ScalarOperator expected = and(expectedGuard, orExpr);
+        assertEquals(expected, derived);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

For multi-branch OR queries with `count(*)`, StarRocks reads far more IO than Trino:

```sql
SELECT count(*) FROM iceberg.zya.lineitem_latemat WHERE
   (l_shipdate BETWEEN '1998-01-01' AND '1998-01-31' AND (l_discount       > 0.09                 OR l_tax             > 0.07))
OR (l_shipdate BETWEEN '1997-11-01' AND '1997-11-30' AND (l_quantity       < 10                   OR l_extendedprice   > 90000))
OR (l_shipdate BETWEEN '1997-09-01' AND '1997-09-30' AND (l_returnflag     = 'R'                  OR l_linestatus      = 'O'))
OR (l_shipdate BETWEEN '1997-07-01' AND '1997-07-31' AND (l_shipmode       = 'AIR'                OR l_comment         LIKE '%URGENT%'))
OR (l_shipdate BETWEEN '1997-05-01' AND '1997-05-31' AND (l_shipinstruct   = 'DELIVER IN PERSON'  OR l_partkey         < 50000))
OR (l_shipdate BETWEEN '1997-03-01' AND '1997-03-31' AND (l_commitdate     > '1998-06-01'         OR l_receiptdate     > '1998-06-01'))
OR (l_shipdate BETWEEN '1997-01-01' AND '1997-01-31' AND (l_discount       < 0.02                 OR l_extendedprice   < 5000))
OR (l_shipdate BETWEEN '1996-11-01' AND '1996-11-30' AND (l_quantity       > 45                   OR l_suppkey         < 10000))
OR (l_shipdate BETWEEN '1996-09-01' AND '1996-09-30' AND (l_shipmode       = 'SHIP'               OR l_linestatus      = 'F'))
OR (l_shipdate BETWEEN '1996-07-01' AND '1996-07-31' AND (l_tax            < 0.01                 OR l_comment         LIKE '%SPECIAL%'));
```

| Engine | BAD 10br narrow ScanBytes |
|--------|--------------------------|
| StarRocks (baseline) | 149.1 GB |
| Trino | 89.4 GB |
| StarRocks (this PR) | **36.4 GB** |

The root cause: compound conjuncts are evaluated at the scanner level **after** all lazy columns have been backfilled, so expression short-circuit never prevents IO. And predicate-only columns are forced into the output chunk schema, so `read_lazy_columns()` must backfill them regardless of whether expression evaluation ever reached them.

## What I'm doing:

Two changes:

### 1. Evaluate compound conjuncts inside GroupReader

Previously `scanner_ctxs` (multi-slot OR expressions) were evaluated at the scanner level after `GroupReader::get_next()` returned a fully-materialized chunk. Now they are evaluated inside `get_next()` while `LazyMaterializationContext` is still attached as `MissingColumnProvider`.

This allows `ColumnRef` to trigger `materialize_slot()` on-demand when the expression evaluator reaches a branch whose date-guard matches the current batch. Branches whose date-guard is all-false are short-circuited at the AND level — their payload columns are never loaded.

```
GroupReader::get_next():
  1. read active columns (l_shipdate)
  2. evaluate per-slot conjuncts (guard predicate) → filter
  2b. [NEW] evaluate scanner_ctxs (compound OR) with lazy_ctx attached
      → ColumnRef triggers materialize_slot() only for reached branches
  3. read_lazy_columns: backfill output columns, null-fill predicate-only columns
```

### 2. Skip physical IO for predicate-only untriggered columns

FE already distinguishes output columns from predicate columns via the `isOutputColumn` flag. In `read_lazy_columns()`, predicate-only columns that were never triggered during expression evaluation are null-filled instead of read from disk — they cost zero IO and their values are never accessed by downstream operators.

For `count(*)`, all lazy columns are predicate-only, so only the 1-2 branches per batch that are actually reached incur physical IO.

### 3. Separate active/lazy IO ranges when lazy loading is active

`SharedBufferedInputStream` supports two modes: merged (active+lazy ranges coalesced into one buffer) and separated (independent buffers). In merged mode, reading the active column would fetch the entire merged range — including all lazy column data — defeating the physical IO savings. This PR forces separated mode when `parquet_late_materialization_enable` is on and lazy columns exist, so that untriggered lazy columns' data is never physically fetched.

## Compromise

Predicate-only untriggered columns are null-filled rather than removed from the output chunk. The output chunk schema (`_tuple_desc`) includes all referenced columns, and `reorder_chunk()` downstream requires all slots to exist. The null-fill costs trivial memory but zero IO.

A follow-up PR will introduce an `output_tuple_desc` (filtered to `is_output_column()` slots) for output chunk creation, eliminating the null-fill entirely.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] No, this PR will not result in a change in behavior. Produces identical results; IO reduction only.
- [ ] Yes, this PR will result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5