### PR TITLE
[BugFix] Honor page cache in global late-materialization lookup

### DIFF
--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -20,7 +20,6 @@
 #include "base/status.h"
 #include "base/status_fmt.hpp"
 #include "base/statusor.h"
-#include "common/config.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "exec/olap_scan_node.h"
 #include "exec/pipeline/fragment_context.h"
@@ -132,6 +131,7 @@ private:
     std::vector<ColumnAccessPathPtr> _column_access_paths;
     ColumnIdToGlobalDictMap* _global_dicts = nullptr;
     OlapScanLazyMaterializationContext* _glm_ctx = nullptr;
+    bool _use_page_cache = false;
 };
 
 class LakeScanTabletAdaptor final : public LookUpTabletAdaptor {
@@ -166,6 +166,7 @@ private:
     ColumnIdToGlobalDictMap* _global_dicts = nullptr;
     LakeScanLazyMaterializationContext* _glm_ctx = nullptr;
     std::vector<lake::RowsetPtr> _rowsets;
+    bool _use_page_cache = false;
 };
 
 Status OlapScanTabletAdaptor::init(int64_t tablet_id) {
@@ -175,6 +176,7 @@ Status OlapScanTabletAdaptor::init(int64_t tablet_id) {
 }
 
 Status OlapScanTabletAdaptor::init_schema(RuntimeState* state) {
+    _use_page_cache = state->use_page_cache();
     const auto& thrift_olap_scan_node = _glm_ctx->scan_node();
 
     if (thrift_olap_scan_node.__isset.schema_id && thrift_olap_scan_node.schema_id > 0 &&
@@ -233,10 +235,11 @@ auto OlapScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     RowsetReadOptions rs_opts;
     rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
     rs_opts.profile = nullptr;
-    // Mirror the normal scan path: the late-materialization lookup must honor the
-    // page cache (gated by the same config as the scan), otherwise every fetched
-    // column page is re-decompressed per row locator. See lake_connector.cpp.
-    rs_opts.use_page_cache = !config::disable_storage_page_cache;
+    // Honor the same page-cache policy as the normal scan (RuntimeState::use_page_cache(),
+    // which already respects the disable_storage_page_cache config and the session var).
+    // Otherwise the lookup bypasses StoragePageCache and re-decompresses every fetched
+    // column page per row locator. See olap_chunk_source.cpp.
+    rs_opts.use_page_cache = _use_page_cache;
     rs_opts.stats = &_stats;
     rs_opts.global_dictmaps = _global_dicts;
     rs_opts.column_access_paths = &_column_access_paths;
@@ -266,6 +269,7 @@ Status LakeScanTabletAdaptor::init(int64_t tablet_id) {
 }
 
 Status LakeScanTabletAdaptor::init_schema(RuntimeState* state) {
+    _use_page_cache = state->use_page_cache();
     auto* tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
     const auto& lake_scan_node = _glm_ctx->scan_node();
 
@@ -348,11 +352,12 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     RowsetReadOptions rs_opts;
     rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
     rs_opts.profile = nullptr;
-    // Mirror the normal scan path: the late-materialization lookup must honor the
-    // page cache (gated by the same config as the scan), otherwise every fetched
-    // column page is re-decompressed per row locator. See lake_connector.cpp.
-    rs_opts.use_page_cache = !config::disable_storage_page_cache;
-    rs_opts.lake_io_opts.fill_data_cache = true;
+    // Honor the same page-cache policy as the normal scan (RuntimeState::use_page_cache(),
+    // which already respects the disable_storage_page_cache config and the session var).
+    // Otherwise the lookup bypasses StoragePageCache and re-decompresses every fetched
+    // column page per row locator. See lake_connector.cpp. Data-cache (fill_data_cache)
+    // is left at its default so the lookup does not override the scan's per-range policy.
+    rs_opts.use_page_cache = _use_page_cache;
     rs_opts.stats = &_stats;
     rs_opts.global_dictmaps = _global_dicts;
     rs_opts.column_access_paths = &_column_access_paths;

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -20,6 +20,7 @@
 #include "base/status.h"
 #include "base/status_fmt.hpp"
 #include "base/statusor.h"
+#include "common/config.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "exec/olap_scan_node.h"
 #include "exec/pipeline/fragment_context.h"
@@ -232,6 +233,10 @@ auto OlapScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     RowsetReadOptions rs_opts;
     rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
     rs_opts.profile = nullptr;
+    // Mirror the normal scan path: the late-materialization lookup must honor the
+    // page cache (gated by the same config as the scan), otherwise every fetched
+    // column page is re-decompressed per row locator. See lake_connector.cpp.
+    rs_opts.use_page_cache = !config::disable_storage_page_cache;
     rs_opts.stats = &_stats;
     rs_opts.global_dictmaps = _global_dicts;
     rs_opts.column_access_paths = &_column_access_paths;
@@ -343,6 +348,11 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     RowsetReadOptions rs_opts;
     rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
     rs_opts.profile = nullptr;
+    // Mirror the normal scan path: the late-materialization lookup must honor the
+    // page cache (gated by the same config as the scan), otherwise every fetched
+    // column page is re-decompressed per row locator. See lake_connector.cpp.
+    rs_opts.use_page_cache = !config::disable_storage_page_cache;
+    rs_opts.lake_io_opts.fill_data_cache = true;
     rs_opts.stats = &_stats;
     rs_opts.global_dictmaps = _global_dicts;
     rs_opts.column_access_paths = &_column_access_paths;


### PR DESCRIPTION
## Why I'm doing:

The global late-materialization (GLM) fetch path builds its `RowsetReadOptions` without setting `use_page_cache`, so it falls back to the default `false` (`be/src/storage/rowset/rowset_options.h`) and bypasses the `StoragePageCache`. As a result, every column page touched by the per-row-locator lookup is re-read and re-decompressed instead of being served from cache. The normal scan path does set this (see `be/src/connector/lake_connector.cpp`), so the lookup path is inconsistent.

This shows up as wasted CN CPU and lower QPS. On a shared-data ANN top-K workload (`SELECT id ... ORDER BY approx_*_distance(v, q) LIMIT k`), where the LIMIT is already pushed into the index so late materialization yields no row reduction, the extra uncached lookup is pure overhead and costs ~28% QPS. A perf inverted call-graph attributed ~22% of CN CPU to `LZ4_decompress_safe` + `bshuf_*` reached exclusively via `NativeLookUpTask::_late_materialize_by_row_locators` -> `SegmentIterator` -> `read_and_decompress_page`. Results are correct; the impact is purely performance.

## What I'm doing:

Set `use_page_cache` on the `RowsetReadOptions` built in both `OlapScanTabletAdaptor::get_iterator` and `LakeScanTabletAdaptor::get_iterator` (`be/src/exec/pipeline/lookup/tablet_adaptor.cpp`), gated on `config::disable_storage_page_cache` exactly as the normal scan path is. The lake path additionally sets `lake_io_opts.fill_data_cache = true` to mirror the scan behavior. This benefits all queries that go through GLM late materialization, not only vector search.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5