### PR TITLE
[Enhancement] Skip SQL credential redaction when no credential marker is present

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
@@ -176,6 +176,14 @@ public class SqlCredentialRedactor {
             return sql;
         }
 
+        // Fast path: most statements carry no credentials. Skip the regex passes (and their
+        // StringBuilder allocations) entirely when there is no credential marker. This guards the
+        // hot audit path (ConnectProcessor.formatStmt redacts every statement as defense in depth),
+        // which is otherwise re-run on every prepared-statement execution and shows up as FE CPU.
+        if (!mayNeedCredentialRedaction(sql)) {
+            return sql;
+        }
+
         sql = redactKeyValueCredentials(sql);
         sql = redactSqlCredentialClause(sql, IDENTIFIED_BY_PATTERN, 1, 2, 3);
         sql = redactIdentifiedWithClause(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -294,6 +294,27 @@ public class SqlCredentialRedactorTest {
     }
 
     @Test
+    public void testRedactFastPathReturnsSameInstanceForNonCredentialSql() {
+        // When the SQL carries no credential marker, redact() must short-circuit and return the
+        // input instance as-is, without running any regex pass or allocating a new string. The
+        // regex passes always rebuild the string via StringBuilder.toString(), so reference
+        // equality is a precise probe that the fast path was taken. This keeps the hot audit path
+        // (run on every prepared-statement execution) cheap.
+        String plainQuery = "SELECT a, b, c FROM t0 JOIN t1 ON t0.id = t1.id WHERE t0.v > 10 ORDER BY a";
+        Assertions.assertSame(plainQuery, SqlCredentialRedactor.redact(plainQuery));
+
+        String insertQuery = "INSERT INTO t0 VALUES (1, 'abc'), (2, 'def')";
+        Assertions.assertSame(insertQuery, SqlCredentialRedactor.redact(insertQuery));
+
+        // Sanity: SQL that actually carries a credential marker must NOT take the fast path and
+        // still gets redacted into a different string.
+        String credentialSql = "CREATE USER 'u1' IDENTIFIED BY 'secret'";
+        String redacted = SqlCredentialRedactor.redact(credentialSql);
+        Assertions.assertNotSame(credentialSql, redacted);
+        Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED BY '***'", redacted);
+    }
+
+    @Test
     public void testMultipleCredentials() {
         String sql = "CREATE STORAGE VOLUME test_volume\n" +
                 "TYPE = S3\n" +


### PR DESCRIPTION
## Why I'm doing:

`ConnectProcessor.formatStmt()` redacts every audited statement as defense in depth, so `SqlCredentialRedactor.redact()` runs on the audit hot path for every statement, including every prepared-statement execution (`handleExecute` -> `auditAfterExec` -> `formatStmt`). `redact()` always runs four regex passes and allocates four intermediate strings even when the SQL carries no credential at all.

After #70360 extended the redactor to also mask `IDENTIFIED BY` / `IDENTIFIED WITH` / `SET PASSWORD` clauses, each `redact()` call became four full re2 scans plus four `StringBuilder` allocations. Combined with the unconditional defense-in-depth redaction added in #69383, this runs on every statement and shows up as high FE CPU under prepared-statement workloads, where the same statement is executed at high frequency.

## What I'm doing:

Short-circuit `redact()` with the existing cheap `mayNeedCredentialRedaction()` check (a single lowercase scan for credential markers): when the text has no credential marker, return the input unchanged without running any regex pass. The check already covers every key handled by the redaction patterns (`IDENTIFIED`, `password`, and all credential property keys), so when it returns false none of the patterns can match and the output is identical to before — this is a pure fast path. All `redact()` call sites benefit, including the audit hot path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5