### PR TITLE
[BugFix] Skip CTE references when collecting view tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -82,6 +82,7 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.Relation;
@@ -94,6 +95,7 @@ import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.UnionRelation;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
@@ -140,9 +142,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -738,6 +742,8 @@ public class AnalyzerUtils {
 
     private static class TableCollector extends AstTraverser<Void, Void> {
         protected Map<TableName, Table> tables;
+        private final Deque<Set<String>> cteNameScopes = new ArrayDeque<>();
+        private final Deque<Boolean> recursiveCteScopes = new ArrayDeque<>();
 
         public TableCollector() {
             this.tables = Maps.newHashMap();
@@ -752,6 +758,36 @@ public class AnalyzerUtils {
         @Override
         public Void visitQueryStatement(QueryStatement statement, Void context) {
             return visit(statement.getQueryRelation());
+        }
+
+        @Override
+        public Void visitSelect(SelectRelation node, Void context) {
+            if (!node.hasWithClause()) {
+                return super.visitSelect(node, context);
+            }
+            cteNameScopes.push(new HashSet<>());
+            recursiveCteScopes.push(node.isHasRecursiveCTE());
+            try {
+                return super.visitSelect(node, context);
+            } finally {
+                recursiveCteScopes.pop();
+                cteNameScopes.pop();
+            }
+        }
+
+        @Override
+        public Void visitSetOp(SetOperationRelation node, Void context) {
+            if (!node.hasWithClause()) {
+                return super.visitSetOp(node, context);
+            }
+            cteNameScopes.push(new HashSet<>());
+            recursiveCteScopes.push(node.isHasRecursiveCTE());
+            try {
+                return super.visitSetOp(node, context);
+            } finally {
+                recursiveCteScopes.pop();
+                cteNameScopes.pop();
+            }
         }
 
         // ------------------------------------------- DML Statement -------------------------------------------------------
@@ -790,9 +826,84 @@ public class AnalyzerUtils {
 
         @Override
         public Void visitTable(TableRelation node, Void context) {
+            if (isUnresolvedCteReference(node)) {
+                return null;
+            }
             Table table = node.getTable();
             tables.put(node.getName(), table);
             return null;
+        }
+
+        @Override
+        public Void visitCTE(CTERelation node, Void context) {
+            if (node.isRecursive() && !node.isAnchor()) {
+                // An analyzed recursive member consumes the current CTE through a non-anchor CTERelation.
+                // Do not expand its definition again, or the collector will revisit the same recursive member.
+                return null;
+            }
+            if (cteNameScopes.isEmpty()) {
+                return super.visitCTE(node, context);
+            }
+            if (isInRecursiveCteScope() && node.getCteQueryStatement().getQueryRelation()
+                    instanceof UnionRelation unionRelation) {
+                visitRecursiveCteDefinition(node, unionRelation, context);
+            } else {
+                visit(node.getCteQueryStatement(), context);
+            }
+            addCteName(cteNameScopes.peek(), node);
+            return null;
+        }
+
+        private void visitRecursiveCteDefinition(CTERelation cteRelation, SetOperationRelation setOperationRelation,
+                                                 Void context) {
+            List<QueryRelation> relations = setOperationRelation.getRelations();
+            if (relations.isEmpty()) {
+                return;
+            }
+            // Mirror QueryAnalyzer.tryProcessRecursiveCte: the first set-op child is the anchor.
+            // The current CTE name is not visible there, so a same-named table must still be collected.
+            visit(relations.get(0), context);
+
+            // Only recursive members can see the current CTE name. Keep that visibility in a temporary
+            // scope so unresolved self-references are skipped without hiding anchor base tables.
+            Set<String> recursiveNames = new HashSet<>();
+            addCteName(recursiveNames, cteRelation);
+            cteNameScopes.push(recursiveNames);
+            try {
+                for (int i = 1; i < relations.size(); i++) {
+                    visit(relations.get(i), context);
+                }
+            } finally {
+                cteNameScopes.pop();
+            }
+        }
+
+        private boolean isInRecursiveCteScope() {
+            return !recursiveCteScopes.isEmpty() && recursiveCteScopes.peek();
+        }
+
+        private void addCteName(Set<String> names, CTERelation cteRelation) {
+            if (!Strings.isNullOrEmpty(cteRelation.getName())) {
+                names.add(cteRelation.getName());
+            }
+        }
+
+        private boolean isUnresolvedCteReference(TableRelation node) {
+            if (node.getTable() != null || cteNameScopes.isEmpty()) {
+                return false;
+            }
+            TableName tableName = node.getName();
+            if (tableName == null || !Strings.isNullOrEmpty(tableName.getCatalog()) ||
+                    !Strings.isNullOrEmpty(tableName.getDb()) || Strings.isNullOrEmpty(tableName.getTbl())) {
+                return false;
+            }
+            String tableNameWithoutDb = tableName.getTbl();
+            for (Set<String> cteNames : cteNameScopes) {
+                if (cteNames.contains(tableNameWithoutDb)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
@@ -26,10 +26,14 @@ import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.UtFrameUtils;
@@ -173,6 +177,87 @@ public class AnalyzeUtilTest {
                 "with tp2cte as (select * from tprimary2 where v2 < 10) delete from tprimary using " +
                         "tp2cte where tprimary.pk = tp2cte.pk"));
         Assertions.assertEquals("[test.tprimary2, test.tprimary]", m.keySet().toString());
+    }
+
+    @Test
+    public void testCollectTableAndViewSkipsCteReferenceWithoutAnalyze() {
+        String sql = "with x as (select v1 from db2.t0) " +
+                "select db1.t0.v1 from db1.t0 join x on db1.t0.v1 = x.v1";
+        StatementBase statementBase = SqlParser.parse(sql, 0L).get(0);
+        Map<TableName, Table> m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        Set<String> tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        Set<String> expectedTables = new HashSet<>(Lists.newArrayList("db1.t0", "db2.t0"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+    }
+
+    @Test
+    public void testCollectTableAndViewKeepsBaseTableInsideCteDefinitionWithoutAnalyze() {
+        String sql = "with t0 as (select * from t0) select * from t0";
+        StatementBase statementBase = SqlParser.parse(sql, 0L).get(0);
+        Map<TableName, Table> m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        Set<String> tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        Set<String> expectedTables = new HashSet<>(Lists.newArrayList("t0"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+
+        sql = "with x as (select * from y), y as (select * from t0) select * from y";
+        statementBase = SqlParser.parse(sql, 0L).get(0);
+        m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        expectedTables = new HashSet<>(Lists.newArrayList("y", "t0"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+
+        sql = "with X as (select * from t0) select * from x";
+        statementBase = SqlParser.parse(sql, 0L).get(0);
+        m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        expectedTables = new HashSet<>(Lists.newArrayList("t0", "x"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+
+        sql = "with recursive cte(n) as " +
+                "(select v1 from t0 union all select n from cte where n < 10) select * from cte";
+        statementBase = SqlParser.parse(sql, 0L).get(0);
+        m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        expectedTables = new HashSet<>(Lists.newArrayList("t0"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+
+        sql = "with recursive cte(n) as " +
+                "(select v1 from cte union all select n from cte where n < 10) select * from cte";
+        statementBase = SqlParser.parse(sql, 0L).get(0);
+        m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        expectedTables = new HashSet<>(Lists.newArrayList("cte"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+
+        sql = "with recursive cte as (select v1 from t0 except select v1 from cte) select * from cte";
+        statementBase = SqlParser.parse(sql, 0L).get(0);
+        m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        expectedTables = new HashSet<>(Lists.newArrayList("t0", "cte"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
+
+        sql = "with recursive cte as " +
+                "(select v1 from t0 union all select v1 + 1 from cte where v1 < 10) select * from cte";
+        statementBase = SqlParser.parse(sql, 0L).get(0);
+        QueryStatement queryStatement = (QueryStatement) statementBase;
+        CTERelation cteRelation = queryStatement.getQueryRelation().getCteRelations().get(0);
+        SetOperationRelation setOperationRelation =
+                (SetOperationRelation) cteRelation.getCteQueryStatement().getQueryRelation();
+        SelectRelation recursiveMember = (SelectRelation) setOperationRelation.getRelations().get(1);
+        recursiveMember.setRelation(new CTERelation(cteRelation.getCteMouldId(), cteRelation.getName(),
+                cteRelation.getColumnOutputNames(), cteRelation.getCteQueryStatement(), true, false));
+        m = AnalyzerUtils.collectAllTableAndView(statementBase);
+        tableNames = m.keySet().stream().map(TableName::toString).collect(Collectors.toSet());
+        expectedTables = new HashSet<>(Lists.newArrayList("t0"));
+
+        Assertions.assertEquals(expectedTables, tableNames);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`SECURITY INVOKER` views collect underlying table refs from the stored view definition before analyzer binding. If the view definition contains a CTE, the parse-only table collector can treat the CTE name as a real table. The invoker privilege check then looks up that CTE name as a base table and can fail with an NPE, causing a query that should succeed to fail.

## What I'm doing:

- Track visible CTE names while collecting table refs from select and set-operation relations.
- Skip unresolved, unqualified table relations that match visible CTE names.
- Add a regression test for parse-only table collection on a query that joins a base table with a CTE.

Fixes: POST-1612

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
