### PR TITLE
[BugFix] Fix heap-use-after-free in HiveDataSource destructor caused by predicates outliving _pool

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -771,7 +771,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
     if (hdfs_scan_node.__isset.column_access_paths && _scanner_ctx.column_access_paths.empty()) {
         bool failed = false;
-        auto path_resolver = make_column_access_path_resolver(state, state->obj_pool());
+        auto path_resolver = make_column_access_path_resolver(state, &_pool);
         for (const auto& thrift_path : hdfs_scan_node.column_access_paths) {
             auto st = ColumnAccessPath::create(thrift_path, path_resolver);
             if (LIKELY(st.ok())) {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -962,7 +962,7 @@ void HiveDataSource::close(RuntimeState* state) {
     // ExprContexts whose root() Expr* lives in HiveDataSource::_pool
     // (ExprContext::clone() shares _root, it does NOT deep-copy the tree).
     // Release predicates here while _pool is still alive.
-    _scanner_ctx->predicates = {};
+    _scanner_ctx.predicates = {};
     ExprExecutor::close(_scanner_ctx.conjuncts.min_max_ctxs, state);
     ExprExecutor::close(_partition_filter.conjunct_ctxs, state);
     ExprExecutor::close(_scanner_ctx.partition_expr_ctxs, state);

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -958,6 +958,11 @@ void HiveDataSource::close(RuntimeState* state) {
         }
         _scanner->close();
     }
+    // ColumnExprPredicate destructors call ExprContext::close() on cloned
+    // ExprContexts whose root() Expr* lives in HiveDataSource::_pool
+    // (ExprContext::clone() shares _root, it does NOT deep-copy the tree).
+    // Release predicates here while _pool is still alive.
+    _scanner_ctx->predicates = {};
     ExprExecutor::close(_scanner_ctx.conjuncts.min_max_ctxs, state);
     ExprExecutor::close(_partition_filter.conjunct_ctxs, state);
     ExprExecutor::close(_scanner_ctx.partition_expr_ctxs, state);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -359,12 +359,6 @@ void HdfsScanner::close() noexcept {
     update_counter();
     do_close(_runtime_state);
     _file.reset(nullptr);
-
-    // ColumnExprPredicate destructors call ExprContext::close() on cloned
-    // ExprContexts whose root() Expr* lives in HiveDataSource::_pool
-    // (ExprContext::clone() shares _root, it does NOT deep-copy the tree).
-    // Release predicates here while _pool is still alive.
-    _scanner_ctx->predicates = {};
 }
 
 StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_file(

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -210,6 +210,13 @@ Status HdfsScanner::_build_scanner_context() {
     ScanConjunctsManagerOptions opts;
     opts.conjunct_ctxs_ptr = &_scanner_ctx->conjuncts.all_ctxs;
     opts.tuple_desc = _scanner_ctx->tuple_desc;
+    // Must use the fragment-scoped pool (runtime_state->obj_pool()), not
+    // _scanner_ctx->obj_pool.  BoxedExpr::expr_context() deep-copies Expr
+    // nodes into this pool, and those nodes are later referenced by cloned
+    // ExprContexts inside ColumnExprPredicate (which live in the predicates
+    // struct and outlive the data source's _pool).  Using any shorter-lived
+    // pool would free the Expr nodes before the predicates are destroyed,
+    // causing the same use-after-free pattern described in HdfsScanner::close().
     opts.obj_pool = _runtime_state->obj_pool();
     opts.runtime_filters = _scanner_ctx->runtime_filter_collector;
     opts.runtime_state = _runtime_state;
@@ -352,6 +359,12 @@ void HdfsScanner::close() noexcept {
     update_counter();
     do_close(_runtime_state);
     _file.reset(nullptr);
+
+    // ColumnExprPredicate destructors call ExprContext::close() on cloned
+    // ExprContexts whose root() Expr* lives in HiveDataSource::_pool
+    // (ExprContext::clone() shares _root, it does NOT deep-copy the tree).
+    // Release predicates here while _pool is still alive.
+    _scanner_ctx->predicates = {};
 }
 
 StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_file(


### PR DESCRIPTION
## Why I'm doing:

PR #74643 moved `PredicateState` from a pool-allocated `HdfsScannerState` into `HdfsScannerContext` as an embedded value struct. This changed the destruction order:

Before: everything was in `_pool`, LIFO destruction ensured predicates were destroyed before Expr nodes.

After: `_pool` destroys first (frees Expr nodes), then `_scanner_ctx` destroys (predicates access freed Expr nodes).

## What I'm doing:

`ExprContext::clone()` never deep-copies the expression tree — it shares `_root` with the original. So cloned `ExprContext`s inside `ColumnExprPredicate` reference Expr nodes in `HiveDataSource::_pool`. When `_pool` is destroyed before `_scanner_ctx` (C++ reverse declaration order), predicate destructors call `ExprContext::close()` on freed Expr nodes:

```
~HiveDataSource()
  → _pool destroyed first          // Expr nodes freed
  → _scanner_ctx destroyed second  // predicates destroyed
      → ColumnExprPredicate::~ColumnExprPredicate()
          → ExprContext::close() → accesses freed _root  ← use-after-free
```

Fix: release `_scanner_ctx->predicates` in `HdfsScanner::close()` (called by `HiveDataSource::close()` before `_pool` is destroyed), so predicate destructors run while Expr nodes are still valid. Also add a comment explaining why `ScanConjunctsManagerOptions::obj_pool` must be the fragment pool — any shorter-lived pool would create the same use-after-free pattern for the `BoxedExpr` code path.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11423

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
