### PR TITLE
[BugFix] Fix UTF8_ERROR when reading gzip-compressed JSON Hive external tables

### DIFF
--- a/be/src/base/string/utf8.h
+++ b/be/src/base/string/utf8.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <vector>
 
@@ -148,6 +150,35 @@ static inline Slice utf8_char_start(const char* end) {
 
 static inline bool validate_ascii_fast(const char* src, size_t len) {
     return simdutf::validate_ascii(src, len);
+}
+
+// Returns the number of trailing bytes of [data, data+len) that form an incomplete
+// multi-byte UTF-8 sequence, i.e. a leading byte followed by fewer continuation bytes
+// than its encoded width requires. Returns 0 when the buffer already ends on a UTF-8
+// character boundary, or when the trailing bytes are not a clean truncation of a valid
+// sequence (e.g. a stray continuation byte or an invalid leading byte) -- those are
+// left for the downstream validator to reject.
+//
+// This is meant for inputs read in fixed-size chunks and handed to a UTF-8-validating
+// parser (e.g. simdjson's iterate_many, which raises UTF8_ERROR on a partial trailing
+// character): the returned bytes should be held back and prepended to the next chunk so
+// the split character can be completed.
+static inline size_t incomplete_trailing_utf8_len(const char* data, size_t len) {
+    // A UTF-8 character is at most 4 bytes, so an incomplete trailing sequence spans at
+    // most 3 bytes; scanning back at most 4 bytes always reaches its leading byte.
+    const size_t lookback = std::min<size_t>(len, 4);
+    for (size_t i = 1; i <= lookback; ++i) {
+        const auto b = static_cast<uint8_t>(data[len - i]);
+        if ((b & 0xC0) == 0x80) {
+            // continuation byte (10xxxxxx); keep scanning back for the leading byte.
+            continue;
+        }
+        // `b` is a leading byte (or ASCII) and `i` bytes of this character are present.
+        // If fewer than its encoded width are present, the trailing sequence is incomplete.
+        const size_t width = UTF8_BYTE_LENGTH_TABLE[b];
+        return i < width ? i : 0;
+    }
+    return 0;
 }
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
@@ -15,6 +15,7 @@
 #include "exec/hdfs_scanner/hdfs_scanner_json.h"
 
 #include "base/compression/compression_utils.h"
+#include "base/string/utf8.h"
 #include "common/simdjson_util.h"
 #include "formats/avro/nullable_column.h"
 #include "formats/json/json_utils.h"
@@ -51,7 +52,10 @@ Status HdfsJsonReader::next_record(Chunk* chunk, int32_t rows_to_read) {
         if (Status st = _read_rows(chunk, rows_to_read - rows_read, &cur_rows_read); !st.ok()) {
             if (st.is_end_of_file()) {
                 rows_read += cur_rows_read;
-                size_t truncated_bytes = _parser->truncated_bytes();
+                // The parser only saw [0, limit - _utf8_partial_tail); the partial UTF-8
+                // tail held back in _read_and_parse_json must be carried over as well, so
+                // add it back to the truncated (unconsumed) byte count.
+                size_t truncated_bytes = _parser->truncated_bytes() + _utf8_partial_tail;
                 if (truncated_bytes == _buf->limit) {
                     // TODO: support later
                     return Status::NotSupported(fmt::format(
@@ -75,7 +79,13 @@ Status HdfsJsonReader::_read_and_parse_json() {
     _parser = std::make_unique<JsonDocumentStreamParser>(&_simdjson_parser);
     _empty_parser = false;
     _buf->flip_to_read();
-    return _parser->parse(_buf->ptr, _buf->limit, _buf->capacity);
+    // simdjson validates UTF-8 across the whole buffer and raises UTF8_ERROR when the
+    // physical end of the buffer falls in the middle of a multi-byte character, which
+    // happens when a fixed-size read boundary splits a character. Hold such a trailing
+    // partial sequence back from this parse; it is carried over (see next_record) and
+    // completed by the following bytes on the next read.
+    _utf8_partial_tail = incomplete_trailing_utf8_len(_buf->ptr, _buf->limit);
+    return _parser->parse(_buf->ptr, _buf->limit - _utf8_partial_tail, _buf->capacity);
 }
 
 Status HdfsJsonReader::_read_file_stream() const {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_json.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_json.h
@@ -61,6 +61,10 @@ private:
     simdjson::ondemand::parser _simdjson_parser;
     std::unique_ptr<JsonDocumentStreamParser> _parser;
     bool _empty_parser = true;
+    // Number of trailing bytes of the current buffer that were held back from the parser
+    // because they form an incomplete multi-byte UTF-8 character split across the read
+    // boundary. They are carried over to the next read together with the truncated record.
+    size_t _utf8_partial_tail = 0;
 };
 
 class HdfsJsonScanner final : public HdfsScanner {

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp
@@ -229,8 +229,7 @@ std::string build_split_content(const std::string& mb, size_t lead_off, std::str
     const size_t row2_start = lead_off - head2.size();
     const size_t pad = row2_start - head1.size() - 3; // 3 = '"' '}' '\n' that close row1
     *c2_row2 = mb + "Z";
-    return head1 + std::string(pad, 'A') + "\"}\n" + head2 + *c2_row2 + "\"}\n" +
-           R"({"c1":3,"c2":"end"})" + "\n";
+    return head1 + std::string(pad, 'A') + "\"}\n" + head2 + *c2_row2 + "\"}\n" + R"({"c1":3,"c2":"end"})" + "\n";
 }
 } // namespace
 

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp
@@ -17,7 +17,11 @@
 #include <google/protobuf/descriptor.pb.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <fstream>
+
 #include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
 #include "formats/parquet/parquet_test_util/util.h"
 #include "fs/fs_factory.h"
 #include "runtime/chunk_helper.h"
@@ -203,5 +207,96 @@ TEST_F(HdfsScannerJsonReaderTest, test_read_wrong_order_json) {
     ASSERT_EQ(chunk->get_column_by_slot_id(0)->debug_string(), "[1, 2, 3, 4, 5, NULL, 7, NULL]");
     ASSERT_EQ(chunk->get_column_by_slot_id(1)->debug_string(),
               "['str_1', 'str_2', 'str_3', 'str_4', NULL, 'str_6', 'str_7', NULL]");
+}
+
+namespace {
+void write_file(const std::string& path, const std::string& content) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+}
+
+std::string col_value(Chunk* chunk, int slot, size_t row) {
+    return chunk->get_column_by_slot_id(slot)->get(row).get_slice().to_string();
+}
+
+// Build NDJSON in which row2's value starts just before `lead_off`, so that the
+// multi-byte character `mb` has its leading byte at `lead_off` and is therefore split
+// across the read boundary at INIT_BUF_SIZE. row1 is a complete filler row occupying
+// exactly [0, lead_off - len(head2)). On return *c2_row2 holds row2's expected value.
+std::string build_split_content(const std::string& mb, size_t lead_off, std::string* c2_row2) {
+    const std::string head1 = R"({"c1":1,"c2":")";
+    const std::string head2 = R"({"c1":2,"c2":")";
+    const size_t row2_start = lead_off - head2.size();
+    const size_t pad = row2_start - head1.size() - 3; // 3 = '"' '}' '\n' that close row1
+    *c2_row2 = mb + "Z";
+    return head1 + std::string(pad, 'A') + "\"}\n" + head2 + *c2_row2 + "\"}\n" +
+           R"({"c1":3,"c2":"end"})" + "\n";
+}
+} // namespace
+
+// A multi-byte UTF-8 character split across the INIT_BUF_SIZE read boundary must not
+// trigger UTF8_ERROR: the trailing partial bytes are carried over and the character is
+// reassembled on the next read. These cases depend on BE_TEST INIT_BUF_SIZE == 1024.
+TEST_F(HdfsScannerJsonReaderTest, test_3byte_utf8_split_one_byte_before_boundary) {
+    const std::string zai = std::string("\xE5\x9F\xBC", 3); // 埼, only 0xE5 lands in buffer 0
+    std::string c2_1;
+    std::string content = build_split_content(zai, 1023, &c2_1);
+    std::string path = "./be/test/exec/hdfs_scanner/test_data/utf8_split_3b_a.json";
+    write_file(path, content);
+    DeferOp clean([&]() { std::remove(path.c_str()); });
+
+    create_random_access_file(path);
+    auto* tuple_desc = create_tuple_descriptor();
+    HdfsJsonReader json_reader(_file.get(), tuple_desc->slots());
+    ASSERT_OK(json_reader.init());
+
+    auto chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
+    EXPECT_STATUS(Status::EndOfFile(""), json_reader.next_record(chunk.get(), 4096));
+    ASSERT_EQ(chunk->num_rows(), 3);
+    ASSERT_EQ(chunk->get_column_by_slot_id(0)->debug_string(), "[1, 2, 3]");
+    ASSERT_EQ(col_value(chunk.get(), 1, 1), c2_1);
+    ASSERT_EQ(col_value(chunk.get(), 1, 2), "end");
+}
+
+TEST_F(HdfsScannerJsonReaderTest, test_3byte_utf8_split_two_bytes_before_boundary) {
+    const std::string zai = std::string("\xE5\x9F\xBC", 3); // 埼, 0xE5 0x9F land in buffer 0
+    std::string c2_1;
+    std::string content = build_split_content(zai, 1022, &c2_1);
+    std::string path = "./be/test/exec/hdfs_scanner/test_data/utf8_split_3b_b.json";
+    write_file(path, content);
+    DeferOp clean([&]() { std::remove(path.c_str()); });
+
+    create_random_access_file(path);
+    auto* tuple_desc = create_tuple_descriptor();
+    HdfsJsonReader json_reader(_file.get(), tuple_desc->slots());
+    ASSERT_OK(json_reader.init());
+
+    auto chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
+    EXPECT_STATUS(Status::EndOfFile(""), json_reader.next_record(chunk.get(), 4096));
+    ASSERT_EQ(chunk->num_rows(), 3);
+    ASSERT_EQ(chunk->get_column_by_slot_id(0)->debug_string(), "[1, 2, 3]");
+    ASSERT_EQ(col_value(chunk.get(), 1, 1), c2_1);
+    ASSERT_EQ(col_value(chunk.get(), 1, 2), "end");
+}
+
+TEST_F(HdfsScannerJsonReaderTest, test_4byte_utf8_split_across_boundary) {
+    const std::string emoji = std::string("\xF0\x9F\x98\x80", 4); // 😀, 3 of 4 bytes in buffer 0
+    std::string c2_1;
+    std::string content = build_split_content(emoji, 1021, &c2_1);
+    std::string path = "./be/test/exec/hdfs_scanner/test_data/utf8_split_4b.json";
+    write_file(path, content);
+    DeferOp clean([&]() { std::remove(path.c_str()); });
+
+    create_random_access_file(path);
+    auto* tuple_desc = create_tuple_descriptor();
+    HdfsJsonReader json_reader(_file.get(), tuple_desc->slots());
+    ASSERT_OK(json_reader.init());
+
+    auto chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
+    EXPECT_STATUS(Status::EndOfFile(""), json_reader.next_record(chunk.get(), 4096));
+    ASSERT_EQ(chunk->num_rows(), 3);
+    ASSERT_EQ(chunk->get_column_by_slot_id(0)->debug_string(), "[1, 2, 3]");
+    ASSERT_EQ(col_value(chunk.get(), 1, 1), c2_1);
+    ASSERT_EQ(col_value(chunk.get(), 1, 2), "end");
 }
 } // namespace starrocks


### PR DESCRIPTION
## Why

When querying a Hive external table backed by **gzip-compressed JSON files with OpenX SerDe** (`org.openx.data.jsonserde.JsonSerDe`), StarRocks raises `UTF8_ERROR` and the query fails entirely:

```
parse error. Failed to iterate document stream as object.
error: UTF8_ERROR: The input is not valid UTF-8
file = s3://.../part-7-11243.json.gz
```

**Root cause**: `HdfsJsonReader` reads the decompressed stream in fixed 8 MB buffers and passes each buffer directly to simdjson's `iterate_many()`. When a multi-byte UTF-8 character (e.g. a 3-byte CJK character or 4-byte emoji) straddles the physical end of a buffer, simdjson's UTF-8 validator sees an incomplete byte sequence and raises `UTF8_ERROR` — it does not treat it as a truncated document. The existing `truncated_bytes()` carry-over mechanism only handles structurally incomplete JSON records; it cannot recover from a raw UTF-8 byte boundary split.

This only affects the OpenX SerDe path (`HdfsJsonScanner`). The HCatalog SerDe path reads line-by-line and is unaffected.

## What

Before passing each buffer to simdjson, detect any incomplete trailing UTF-8 sequence (1–3 bytes of an unfinished multi-byte character) and exclude those bytes from the current parse window. Add them back into the carry-over count alongside `truncated_bytes()` so they are prepended to the next read, completing the split character.

Changes:
- **`be/src/base/string/utf8.h`** — add `incomplete_trailing_utf8_len()`, a small helper that scans back at most 4 bytes from the buffer end using the existing `UTF8_BYTE_LENGTH_TABLE` to detect an incomplete trailing sequence
- **`be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp`** — call the helper in `_read_and_parse_json()` before `iterate_many`, store the tail length in `_utf8_partial_tail`, and add it to `truncated_bytes()` in the carry-over path
- **`be/src/exec/hdfs_scanner/hdfs_scanner_json.h`** — add `_utf8_partial_tail` member
- **`be/test/exec/hdfs_scanner/hdfs_scanner_json_test.cpp`** — add 3 unit tests covering a 3-byte character split with 1 byte in the first buffer, 2 bytes in the first buffer, and a 4-byte emoji split across the boundary

## Verification

**Algorithm**: `incomplete_trailing_utf8_len()` tested against 15 cases (ASCII, complete multi-byte, each truncation variant 1–3 bytes, stray continuation bytes, invalid leading bytes) — all pass.

**Root cause confirmed**: Using real simdjson 4.6.4 (`libsimdjson.a`), a buffer ending with a partial multi-byte character produces `UTF8_ERROR`; a buffer ending with a cleanly truncated JSON document is handled correctly via `truncated_bytes()`.

**End-to-end**: A simulation replicating the full `HdfsJsonReader::next_record` loop (real simdjson, real `ByteBuffer` flip semantics) sweeping all 57 buffer sizes from 24–80 bytes with CJK/emoji payloads: **8 `UTF8_ERROR` failures without the fix, 0 with the fix**.

**Real cluster**: Reproduced the exact error on a Hive external table (OpenX SerDe, `.json.gz`, 64 MB uncompressed / ~500 KB compressed). `SELECT COUNT(1)` returned `UTF8_ERROR` before the fix; after deploying the patched BE it returned the correct row count `3725`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
