### PR TITLE
[Refactor] Rename FormatsIO to FormatCore

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -174,13 +174,13 @@ Core runtime building blocks without full Runtime/Exec/Storage coupling.
 - Core tests: `runtime_core_test`
 - Remediation: Keep RuntimeCore restricted to core runtime infrastructure; move service/storage/stream-load/integration code into Runtime.
 
-### FormatsIO (`formatsio`)
-Format-oriented output stream primitives above RuntimeCore, FSCore, and Types.
-- Targets: `FormatsIO`
+### FormatCore (`formatcore`)
+Format-oriented core primitives above RuntimeCore, FSCore, and Types.
+- Targets: `FormatCore`
 - Allowed internal include prefixes: `formats/io/`, `runtime/`, `fs/`, `types/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
 - Allowed target deps: `RuntimeCore`, `FSCore`, `Types`, `Common`, `Base`, `Gutil`, `StarRocksGen`
-- Core tests: `formats_io_test`
-- Remediation: Keep FormatsIO limited to reusable format output stream primitives; move connector orchestration and higher execution policy upward.
+- Core tests: `format_core_test`
+- Remediation: Keep FormatCore limited to reusable format primitives; move connector orchestration and higher execution policy upward.
 
 ### RuntimeEnv (`runtimeenv`)
 Process-scoped runtime environment resources below full Runtime and above RuntimeCore.

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -545,7 +545,6 @@ set(STARROCKS_LINK_LIBS
     ${WL_WHOLE_ARCHIVE_PREFIX} Exprs ${WL_WHOLE_ARCHIVE_SUFFIX}
     FileSystem
     Formats
-    FormatsIO
     Storage
     Rowset
     Runtime
@@ -554,6 +553,7 @@ set(STARROCKS_LINK_LIBS
     Script
     orc
     ${WL_END_GROUP}
+    FormatCore
     ExecRuntime
     ComputeEnv
     ExecPrimitive

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -312,16 +312,16 @@
       "remediation": "Keep RuntimeCore restricted to core runtime infrastructure; move service/storage/stream-load/integration code into Runtime."
     },
     {
-      "id": "formatsio",
-      "doc_label": "FormatsIO",
-      "summary": "Format-oriented output stream primitives above RuntimeCore, FSCore, and Types.",
-      "owned_targets": ["FormatsIO"],
+      "id": "formatcore",
+      "doc_label": "FormatCore",
+      "summary": "Format-oriented core primitives above RuntimeCore, FSCore, and Types.",
+      "owned_targets": ["FormatCore"],
       "owned_globs": ["be/src/formats/io/**"],
       "allowed_include_prefixes": ["formats/io/", "runtime/", "fs/", "types/", "common/", "base/", "gutil/", "gen_cpp/"],
       "allowed_target_deps": ["RuntimeCore", "FSCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
-      "allowed_test_targets": ["formats_io_test"],
-      "allowed_test_link_deps": ["FormatsIO", "RuntimeCore", "FSCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
-      "remediation": "Keep FormatsIO limited to reusable format output stream primitives; move connector orchestration and higher execution policy upward."
+      "allowed_test_targets": ["format_core_test"],
+      "allowed_test_link_deps": ["FormatCore", "RuntimeCore", "FSCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "remediation": "Keep FormatCore limited to reusable format primitives; move connector orchestration and higher execution policy upward."
     },
     {
       "id": "runtimeenv",

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -541,4 +541,4 @@ ADD_BE_LIB(Exec
 )
 
 target_link_libraries(Exec PUBLIC ExecRuntime ExecPrimitive ExecSchemaScannerCore ExecSchemaScanners ExecJoinCore RuntimeEnv ComputeEnv Cache)
-target_link_libraries(Exec PRIVATE FormatsIO Platform)
+target_link_libraries(Exec PRIVATE FormatCore Platform)

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -14,12 +14,12 @@
 
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/formats")
 
-ADD_BE_LIB(FormatsIO
+ADD_BE_LIB(FormatCore
         io/async_flush_output_stream.cpp
         io/formatted_output_stream_file.cpp
         )
 
-target_link_libraries(FormatsIO PUBLIC
+target_link_libraries(FormatCore PUBLIC
         RuntimeCore
         FSCore
         Types
@@ -115,6 +115,6 @@ ADD_BE_LIB(Formats
         file_writer.cpp
         )
 
-target_link_libraries(Formats PUBLIC FormatsIO Cache)
+target_link_libraries(Formats PUBLIC FormatCore Cache)
 
 add_subdirectory(orc/apache-orc)

--- a/be/test/formats/CMakeLists.txt
+++ b/be/test/formats/CMakeLists.txt
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(FORMATS_IO_TEST_FILES
+set(FORMAT_CORE_TEST_FILES
     ../base/cxa_throw_wrap.cpp
     io/async_flush_output_stream_test.cpp
     io/formatted_output_stream_file_test.cpp
 )
 
-set(FORMATS_IO_TEST_LINK_LIBS
-    FormatsIO
+set(FORMAT_CORE_TEST_LINK_LIBS
+    FormatCore
     RuntimeCore
     FSCore
     Types
@@ -36,8 +36,8 @@ set(FORMATS_IO_TEST_LINK_LIBS
     ${WL_END_GROUP}
 )
 
-add_library(starrocks_formats_io_test_objs OBJECT ${FORMATS_IO_TEST_FILES})
-target_link_libraries(starrocks_formats_io_test_objs PRIVATE StarRocksPCH)
-set_target_properties(starrocks_formats_io_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
-add_executable(formats_io_test $<TARGET_OBJECTS:starrocks_formats_io_test_objs>)
-target_link_libraries(formats_io_test ${FORMATS_IO_TEST_LINK_LIBS} gtest_main)
+add_library(starrocks_format_core_test_objs OBJECT ${FORMAT_CORE_TEST_FILES})
+target_link_libraries(starrocks_format_core_test_objs PRIVATE StarRocksPCH)
+set_target_properties(starrocks_format_core_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
+add_executable(format_core_test $<TARGET_OBJECTS:starrocks_format_core_test_objs>)
+target_link_libraries(format_core_test ${FORMAT_CORE_TEST_LINK_LIBS} gtest_main)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
