### PR TITLE
[Enhancement] Share deserialized Iceberg table across metadata scan tasks

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1079,6 +1079,11 @@ CONF_mBool(pipeline_enable_large_column_checker, "true");
 // The number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
 CONF_mDouble(pipeline_connector_scan_thread_num_per_cpu, "8");
+// Max number of distinct iceberg tables whose deserialized metadata is cached and shared across
+// metadata scan tasks on one BE/CN. One entry holds one table's metadata reused by all its
+// concurrent scan tasks, so the cap is the number of distinct tables scanned at once, not the task
+// count. Raise it if the JNI metadata scanner logs eviction under size pressure.
+CONF_mInt32(iceberg_metadata_table_cache_capacity, "128");
 // Queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // The number of execution threads for pipeline engine.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -509,6 +509,7 @@
         "connector_io_tasks_adjust_smooth",
         "scan_use_query_mem_ratio",
         "connector_scan_use_query_mem_ratio",
+        "iceberg_metadata_table_cache_capacity",
         "enable_short_key_for_one_column_filter",
         "desc_hint_split_range",
         "olap_string_max_length",

--- a/be/src/common/config_scan_io_fwd.h
+++ b/be/src/common/config_scan_io_fwd.h
@@ -53,6 +53,12 @@ CONF_Int32(metric_late_materialization_ratio, "1000");
 // Do pre-aggregate if effect greater than the factor, factor range:[1-100].
 CONF_Int16(pre_aggregate_factor, "80");
 
+// Max number of distinct iceberg tables whose deserialized metadata is cached and shared across
+// metadata scan tasks on one BE/CN. One entry holds one table's metadata reused by all its
+// concurrent scan tasks, so the cap is the number of distinct tables scanned at once, not the task
+// count. Raise it if the JNI metadata scanner logs eviction under size pressure.
+CONF_mInt32(iceberg_metadata_table_cache_capacity, "128");
+
 CONF_mBool(use_default_dop_when_shared_scan, "true");
 
 /// For parallel scan on the single tablet.

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -21,6 +21,7 @@
 #include "column/map_column.h"
 #include "column/runtime_type_traits.h"
 #include "column/struct_column.h"
+#include "common/config_scan_io_fwd.h"
 #include "fmt/core.h"
 #include "fs/credential/cloud_configuration_factory.h"
 #include "runtime/descriptors_ext.h"
@@ -656,6 +657,7 @@ std::unique_ptr<JniScanner> create_iceberg_metadata_jni_scanner(const JniScanner
     jni_scanner_params["serialized_table"] = options.scan_node->serialized_table;
     jni_scanner_params["load_column_stats"] = options.scan_node->load_column_stats ? "true" : "false";
     jni_scanner_params["scanner_type"] = options.scan_node->metadata_table_type;
+    jni_scanner_params["table_cache_max_entries"] = std::to_string(config::iceberg_metadata_table_cache_capacity);
 
     const std::string scanner_factory_class = "com/starrocks/connector/iceberg/IcebergMetadataScannerFactory";
     return std::make_unique<JniScanner>(scanner_factory_class, jni_scanner_params);

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -439,6 +439,15 @@ This topic introduces the following types of BE configurations:
 - Description: The number of scan threads assigned to Pipeline Connector per CPU core in the BE node. This configuration is changed to dynamic from v3.1.7 onwards.
 - Introduced in: -
 
+### iceberg_metadata_table_cache_capacity
+
+- Default: 128
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The number of Iceberg tables the JNI metadata scanner caches on a BE/CN node. During a metadata scan, a table's metadata is deserialized once and reused by all scan tasks of that table instead of once per task. Increase it if the metadata scanner logs cache eviction.
+- Introduced in: -
+
 ### pipeline_enable_large_column_checker
 
 - Default: true

--- a/docs/ja/administration/management/BE_parameters/query_loading.md
+++ b/docs/ja/administration/management/BE_parameters/query_loading.md
@@ -440,6 +440,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: BEノードのCPUコアごとにPipeline Connectorに割り当てられるスキャン・スレッドの数。この設定はv3.1.7以降、動的に変更されます。
 - 導入バージョン: -
 
+### iceberg_metadata_table_cache_capacity
+
+- デフォルト: 128
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: JNI メタデータスキャナーが BE/CN ノードでキャッシュする Iceberg テーブルの数。メタデータスキャン中、テーブルのメタデータはタスクごとではなく 1 回だけデシリアライズされ、そのテーブルのすべてのスキャンタスクで再利用されます。メタデータスキャナーがキャッシュの退避をログに記録する場合は、この値を大きくしてください。
+- 導入バージョン: -
+
 ### pipeline_poller_timeout_guard_ms
 
 - デフォルト: -1

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -427,6 +427,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE 节点中每个 CPU 核心分配给 Pipeline Connector 的扫描线程数量。自 v3.1.7 起变为动态参数。
 - 引入版本：-
 
+### iceberg_metadata_table_cache_capacity
+
+- 默认值：128
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：JNI 元数据扫描器在单个 BE/CN 节点上缓存的 Iceberg 表数量。在元数据扫描期间，一张表的元数据只反序列化一次，并由该表的所有扫描任务复用，而不是每个任务各反序列化一次。如果元数据扫描器在日志中记录到缓存逐出，可调大该值。
+- 引入版本：-
+
 ### pipeline_enable_large_column_checker
 
 - 默认值：true

--- a/java-extensions/hadoop-ext/src/test/java/com/starrocks/connector/share/iceberg/SerializableTableTest.java
+++ b/java-extensions/hadoop-ext/src/test/java/com/starrocks/connector/share/iceberg/SerializableTableTest.java
@@ -24,11 +24,19 @@ import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SerializableTableTest {
@@ -80,6 +88,35 @@ public class SerializableTableTest {
 
         assertNotNull(serializable.schema());
         assertNotNull(serializable.locationProvider());
+    }
+
+    @Test
+    public void testConcurrentLazyAccessIsConsistent() throws Exception {
+        // The deserialized table is shared across scan tasks, so its lazy fields are read concurrently.
+        // The double-checked-locking init must publish a single instance, never a half-built or duplicate one.
+        SerializableTable table = new SerializableTable(createTable(new HashMap<>()), new InMemoryFileIO());
+        int threads = 32;
+        CyclicBarrier gate = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<Schema>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(pool.submit(() -> {
+                    gate.await();
+                    table.specs();
+                    table.sortOrder();
+                    return table.schema();
+                }));
+            }
+            Schema first = futures.get(0).get(10, TimeUnit.SECONDS);
+            assertNotNull(first);
+            for (Future<Schema> future : futures) {
+                assertSame(first, future.get(10, TimeUnit.SECONDS),
+                        "double-checked lazy init must publish a single schema instance");
+            }
+        } finally {
+            pool.shutdownNow();
+        }
     }
 
     private Table createTable(Map<String, String> properties) {

--- a/java-extensions/iceberg-metadata-reader/pom.xml
+++ b/java-extensions/iceberg-metadata-reader/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>iceberg-aws</artifactId>
             <version>${iceberg.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScanner.java
@@ -29,17 +29,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static org.apache.iceberg.util.SerializationUtil.deserializeFromBase64;
-
 public abstract class AbstractIcebergMetadataScanner extends ConnectorScanner {
     private static final Logger LOG = LogManager.getLogger(AbstractIcebergMetadataScanner.class);
-    protected final String serializedTable;
+    protected String serializedTable;
     protected final String[] requiredFields;
     private final String[] metadataColumnNames;
     private final String[] metadataColumnTypes;
     private ColumnType[] requiredTypes;
     private final String[] nestedFields;
     private final int fetchSize;
+    private final int tableCacheMaxEntries;
     protected final ClassLoader classLoader;
     protected Table table;
     protected FileIO fileIO;
@@ -49,6 +48,16 @@ public abstract class AbstractIcebergMetadataScanner extends ConnectorScanner {
     // max 1000 entries large enough for most use cases
     private static final TableFileIOCache TABLE_FILE_IO_CACHE = new TableFileIOCache(600, 1000);
 
+    // Shares the deserialized table across scan tasks of the same payload so heap is
+    // O(distinct_concurrent_tables * metadata_size) instead of O(scan_pool_size * metadata_size).
+    // Same 600s TTL as the FileIO cache since the table carries credential-bound FileIO. Built lazily
+    // on first scan (its capacity comes from the BE config via params, which a static initializer
+    // cannot see) and rebuilt when that mutable capacity changes at runtime.
+    private static final long TABLE_CACHE_TTL_SECONDS = 600;
+    private static final int DEFAULT_TABLE_CACHE_MAX_ENTRIES = 128;
+    private static volatile DeserializedTableCache tableCache;
+    private static volatile int tableCacheCapacity = -1;
+
     public AbstractIcebergMetadataScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
         this.requiredFields = params.get("required_fields").split(",");
@@ -57,13 +66,34 @@ public abstract class AbstractIcebergMetadataScanner extends ConnectorScanner {
         this.metadataColumnTypes = params.get("metadata_column_types").split("#");
         this.serializedTable = params.get("serialized_table");
         this.timezone = params.getOrDefault("time_zone", TimeZone.getDefault().getID());
+        this.tableCacheMaxEntries = Integer.parseInt(
+                params.getOrDefault("table_cache_max_entries", String.valueOf(DEFAULT_TABLE_CACHE_MAX_ENTRIES)));
         this.classLoader = this.getClass().getClassLoader();
+    }
+
+    // BE passes the current iceberg_metadata_table_cache_capacity on every scanner, so a runtime
+    // change to that mutable config takes effect on the next scan: the cache is rebuilt with the new
+    // capacity. Rebuilding drops cached entries, but capacity changes are rare.
+    static DeserializedTableCache tableCache(int maxEntries) {
+        DeserializedTableCache cache = tableCache;
+        if (cache != null && tableCacheCapacity == maxEntries) {
+            return cache;
+        }
+        synchronized (AbstractIcebergMetadataScanner.class) {
+            if (tableCache == null || tableCacheCapacity != maxEntries) {
+                tableCache = new DeserializedTableCache(TABLE_CACHE_TTL_SECONDS, maxEntries);
+                tableCacheCapacity = maxEntries;
+            }
+            return tableCache;
+        }
     }
 
     @Override
     public void open() throws IOException {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            this.table = deserializeFromBase64(serializedTable);
+            this.table = tableCache(tableCacheMaxEntries).get(serializedTable);
+            // the base64 payload is tens of MB; drop the reference once the shared table is resolved
+            this.serializedTable = null;
             this.fileIO = TABLE_FILE_IO_CACHE.get(table);
             parseRequiredTypes();
             initOffHeapTableWriter(requiredTypes, requiredFields, fetchSize);

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/DeserializedTableCache.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/DeserializedTableCache.java
@@ -1,0 +1,137 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalListener;
+import org.apache.iceberg.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.iceberg.util.SerializationUtil.deserializeFromBase64;
+
+/**
+ * Shares the deserialized Iceberg {@link Table} across scan tasks of the same table on one node.
+ *
+ * <p>Without this cache every metadata scan task deserializes its own private copy of the full
+ * table from the base64 {@code serialized_table} payload, so heap cost is
+ * O(scan_thread_pool_size * table_metadata_size). The cache keys by the payload so identical
+ * payloads (same table, same snapshot, same credentials) resolve to a single shared instance,
+ * reducing that to roughly O(distinct_concurrent_tables * table_metadata_size).
+ *
+ * <p>Keying: a SHA-256 over the payload string. The payload is the only thing available before
+ * deserialization, and a cryptographic digest is required because a colliding key would silently
+ * return a different table's metadata. A cheap {@code hashCode} is not acceptable here.
+ *
+ * <p>Bounding: by entry count, not by serialized size. One entry holds one table, and all scan
+ * tasks of the same table on a node share that single payload, so the entry count equals the
+ * number of distinct tables scanned concurrently — a handful, not the scan-pool size. A byte
+ * weight cannot be used honestly: the dominant retained cost is the lazily materialized full
+ * {@code TableMetadata} (populated only when a scanner calls {@code snapshot()}/{@code history()}),
+ * which is absent from the payload and unknown at insertion time. {@code maximumSize} therefore
+ * caps worst-case retention at maxEntries * per-table-metadata, the only honest bound available.
+ *
+ * <p>When concurrent distinct tables exceed {@code maxEntries}, an active table can be size-evicted
+ * and re-deserialized by its later tasks (correctness is unaffected, but the duplicate copy and the
+ * repeated parse are wasted). That is logged so the operator can raise the bound; see the
+ * size-eviction warning below.
+ *
+ * <p>Expiry uses {@code expireAfterWrite} (not {@code expireAfterAccess}) because the table carries
+ * a {@code FileIO} bound to credentials that can expire; the TTL matches the FileIO cache.
+ */
+public class DeserializedTableCache {
+    private static final Logger LOG = LoggerFactory.getLogger(DeserializedTableCache.class);
+
+    // Throttle: warn on the first size-eviction (early signal) and then once per this many.
+    private static final long EVICTION_LOG_INTERVAL = 100;
+
+    private final Cache<String, Table> cache;
+    private final int maxEntries;
+    private final AtomicLong sizeEvictions = new AtomicLong();
+
+    public DeserializedTableCache(long expireSeconds, int maxEntries) {
+        this.maxEntries = maxEntries;
+        this.cache = CacheBuilder.newBuilder()
+                // single segment so maximumSize is an exact bound rather than an approximate
+                // per-segment split; safe here because the cache is cold-path (a few distinct
+                // tables) and loads run off-lock
+                .concurrencyLevel(1)
+                .expireAfterWrite(expireSeconds, TimeUnit.SECONDS)
+                .maximumSize(maxEntries)
+                .removalListener((RemovalListener<String, Table>) notification -> {
+                    if (notification.getCause() == RemovalCause.SIZE) {
+                        onSizeEviction();
+                    }
+                })
+                .build();
+    }
+
+    public Table get(String serializedTable) {
+        return get(serializedTable, () -> deserializeFromBase64(serializedTable));
+    }
+
+    // Single-flight: exactly one loader call runs per key; concurrent callers of the same key block
+    // on it and share the result. The loader seam lets tests count and delay deserialization.
+    Table get(String payload, Callable<Table> loader) {
+        String cacheKey = sha256Hex(payload);
+        try {
+            return cache.get(cacheKey, () -> {
+                LOG.debug("DeserializedTableCache miss for key {}", cacheKey);
+                return loader.call();
+            });
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException("Failed to deserialize iceberg table", cause);
+        }
+    }
+
+    private void onSizeEviction() {
+        long count = sizeEvictions.incrementAndGet();
+        if (count == 1 || count % EVICTION_LOG_INTERVAL == 0) {
+            LOG.warn("DeserializedTableCache evicted {} entries under size pressure (maxEntries={}). "
+                            + "Concurrent distinct iceberg metadata tables exceed the cache, so some are being "
+                            + "re-deserialized; raise iceberg_metadata_table_cache_capacity if this keeps growing.",
+                    count, maxEntries);
+        }
+    }
+
+    private static String sha256Hex(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(bytes.length * 2);
+            for (byte b : bytes) {
+                sb.append(Character.forDigit((b >> 4) & 0xf, 16));
+                sb.append(Character.forDigit(b & 0xf, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+}

--- a/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScannerTest.java
+++ b/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/AbstractIcebergMetadataScannerTest.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class AbstractIcebergMetadataScannerTest {
+
+    // The deserialized-table cache is a lazily built singleton whose capacity comes from the mutable
+    // BE config; it must be rebuilt when that capacity changes so the runtime knob actually applies.
+    @Test
+    public void testTableCacheRebuildsOnCapacityChange() {
+        DeserializedTableCache first = AbstractIcebergMetadataScanner.tableCache(64);
+        assertSame(first, AbstractIcebergMetadataScanner.tableCache(64), "same capacity reuses the cache");
+
+        DeserializedTableCache rebuilt = AbstractIcebergMetadataScanner.tableCache(128);
+        assertNotSame(first, rebuilt, "changed capacity rebuilds the cache");
+        assertSame(rebuilt, AbstractIcebergMetadataScanner.tableCache(128), "stable after rebuild");
+    }
+
+    // The cache capacity is read from the table_cache_max_entries param the BE passes per scanner.
+    @Test
+    public void testConstructorReadsCacheCapacityFromParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put("required_fields", "content");
+        params.put("metadata_column_names", "content");
+        params.put("metadata_column_types", "int");
+        params.put("serialized_table", "payload");
+        params.put("table_cache_max_entries", "64");
+
+        AbstractIcebergMetadataScanner scanner = new AbstractIcebergMetadataScanner(1, params) {
+            @Override
+            protected void doOpen() {
+            }
+
+            @Override
+            protected int doGetNext() {
+                return 0;
+            }
+
+            @Override
+            protected void doClose() {
+            }
+
+            @Override
+            protected void initReader() {
+            }
+        };
+
+        assertNotNull(scanner);
+    }
+}

--- a/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/DeserializedTableCacheTest.java
+++ b/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/DeserializedTableCacheTest.java
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.connector.share.iceberg.SerializableTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializationUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class DeserializedTableCacheTest {
+
+    private static final int NO_EVICTION = 1024;
+
+    private static final Schema SCHEMA = new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get())
+    );
+
+    // #2 single-flight: many threads racing on the same key must trigger exactly one load and all
+    // share the one resulting instance. The barrier + delayed loader widen the miss window so a
+    // broken single-flight would actually be observed (multiple loads / distinct instances).
+    @Test
+    public void testSingleFlightDeserializesOncePerKey() throws Exception {
+        DeserializedTableCache cache = new DeserializedTableCache(600, NO_EVICTION);
+        int threads = 64;
+        AtomicInteger loadCount = new AtomicInteger();
+        CyclicBarrier gate = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<Table>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(pool.submit(() -> {
+                    gate.await();
+                    return cache.get("same-payload", () -> {
+                        loadCount.incrementAndGet();
+                        Thread.sleep(20);
+                        return makeTable();
+                    });
+                }));
+            }
+            Table first = futures.get(0).get(10, TimeUnit.SECONDS);
+            for (Future<Table> future : futures) {
+                assertSame(first, future.get(10, TimeUnit.SECONDS), "all callers must share one instance");
+            }
+            assertEquals(1, loadCount.get(), "loader must run exactly once per key");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // #3 isolation: distinct payloads must not collide on the hashed key; a cache hit must not re-run
+    // the loader and must return the instance stored for that exact payload.
+    @Test
+    public void testDistinctPayloadsAreIsolated() {
+        DeserializedTableCache cache = new DeserializedTableCache(600, NO_EVICTION);
+        Table a = cache.get("payload-A", DeserializedTableCacheTest::makeTable);
+        Table b = cache.get("payload-B", DeserializedTableCacheTest::makeTable);
+        assertNotSame(a, b);
+
+        Table aHit = cache.get("payload-A", () -> {
+            throw new AssertionError("loader must not run on a cache hit");
+        });
+        assertSame(a, aHit);
+    }
+
+    // #4 eviction: with maxEntries=1 a second distinct payload evicts the first; the next access to
+    // the first reloads it (loader runs again) rather than returning a corrupt or stale handle.
+    @Test
+    public void testEntryReloadsAfterSizeEviction() {
+        DeserializedTableCache cache = new DeserializedTableCache(600, 1);
+        AtomicInteger keepLoads = new AtomicInteger();
+
+        cache.get("keep", () -> {
+            keepLoads.incrementAndGet();
+            return makeTable();
+        });
+        // maxEntries=1, so inserting another distinct payload evicts "keep" (LRU)
+        cache.get("other", DeserializedTableCacheTest::makeTable);
+        cache.get("keep", () -> {
+            keepLoads.incrementAndGet();
+            return makeTable();
+        });
+
+        assertEquals(2, keepLoads.get(), "evicted entry must be reloaded on next access");
+    }
+
+    // public get() path: a real serialized payload is deserialized once and then served from cache.
+    @Test
+    public void testGetDeserializesAndCachesRealPayload() {
+        String payload = SerializationUtil.serializeToBase64(makeTable());
+        DeserializedTableCache cache = new DeserializedTableCache(600, NO_EVICTION);
+        Table first = cache.get(payload);
+        assertNotNull(first.schema());
+        assertSame(first, cache.get(payload), "second get must hit the cache");
+    }
+
+    private static Table makeTable() {
+        InMemoryCatalog catalog = new InMemoryCatalog();
+        catalog.initialize("test", new HashMap<>());
+        catalog.createNamespace(Namespace.of("db"));
+        Table table = catalog.createTable(TableIdentifier.of("db", "tbl"), SCHEMA, PartitionSpec.unpartitioned());
+        return new SerializableTable(table, new InMemoryFileIO());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Iceberg metadata-table queries — `SELECT ... FROM tbl$partitions` (and `$files`,
`$snapshots`, ...), plus the internal `tbl$logical_iceberg_metadata` scan that normal
queries run during distributed planning — are served by a JNI metadata scanner, not
by the regular data-file scan path.

On every scan task `AbstractIcebergMetadataScanner` deserializes a private copy of the
full Iceberg `Table` from the base64 `serialized_table` payload, so per-node heap is
O(scan_thread_pool_size × table_metadata_size) instead of
O(distinct_tables × table_metadata_size).

On a metadata-heavy table, running such scans concurrently fans out up to
`pipeline_connector_scan_thread_num_per_cpu × cores` tasks, each retaining its own
private copy of the table. Reported in #74653: a ~60 MB table across ~120 tasks
≈ 7.3 GB of duplicates exhausted a 20 GiB embedded JVM heap on three CNs.

## What I'm doing:

Cache and share the deserialized table across the scan tasks of one table on a node:

- keyed by a SHA-256 of the payload — a cryptographic digest so a key collision
  cannot silently return another table's metadata;
- single-flight loader: one deserialization per payload, so concurrent tasks of the
  same table no longer each parse the metadata JSON;
- bounded by entry count, not byte weight: all tasks of a table share one entry, so
  the bound is the number of distinct tables scanned at once, not the task count.
  A byte weight cannot be honest here — the dominant retained cost (the lazily
  materialized full `TableMetadata`) is unknown at insertion time. Size-eviction is
  logged so the bound can be tuned;
- capacity is the new mutable BE config `iceberg_metadata_table_cache_capacity`
  (default 128);
- `expireAfterWrite` TTL matches the FileIO cache (the table carries credential-bound
  `FileIO`);
- the base64 payload reference is dropped once the shared table is resolved.

Per-node heap drops from O(pool_size × metadata_size) to ~O(distinct_tables × metadata_size).

Fixes #74653

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5