### PR TITLE
[Enhancement] Replace offset implementation in BinaryColumn by AdaptiveOffsets

### DIFF
--- a/be/src/column/append_with_mask.cpp
+++ b/be/src/column/append_with_mask.cpp
@@ -14,6 +14,8 @@
 
 #include "column/append_with_mask.h"
 
+#include <type_traits>
+
 #include "base/simd/simd.h"
 #include "column/adaptive_nullable_column.h"
 #include "column/array_column.h"
@@ -165,43 +167,48 @@ Status AppendWithMaskVisitor<PositiveSelect>::append_binary_impl(BinaryColumnBas
         return Status::OK();
     }
 
-    const auto* src_offsets = src_column->get_offset().data();
+    const auto& src_offsets = src_column->get_offset();
     const auto* src_bytes = src_column->raw_bytes();
 
     size_t total_bytes = 0;
-    for (size_t i = 0; i < _count; ++i) {
-        if (is_selected(_mask[i])) {
-            total_bytes += src_offsets[i + 1] - src_offsets[i];
+    src_offsets.visit_storage([&](const auto& src_offsets_buf) {
+        for (size_t i = 0; i < _count; ++i) {
+            if (is_selected(_mask[i])) {
+                total_bytes += src_offsets_buf[i + 1] - src_offsets_buf[i];
+            }
         }
-    }
+    });
 
     auto& offsets = column->get_offset();
     auto& bytes = column->get_bytes();
     size_t old_rows = offsets.size() - 1;
     size_t old_bytes = bytes.size();
-    offsets.resize(old_rows + selected + 1);
+    offsets.resize_uninitialized(old_rows + selected + 1, old_bytes + total_bytes);
     bytes.resize(old_bytes + total_bytes);
 
-    auto* dest_offsets = offsets.data() + old_rows + 1;
     auto* dest_bytes = bytes.data() + old_bytes;
 
-    T current_offset = offsets[old_rows];
-    if (current_offset != static_cast<T>(old_bytes)) {
-        current_offset = static_cast<T>(old_bytes);
-        offsets[old_rows] = current_offset;
-    }
-    size_t copied = 0;
-    for (size_t i = 0; i < _count; ++i) {
-        if (is_selected(_mask[i])) {
-            const T start = src_offsets[i];
-            const T end = src_offsets[i + 1];
-            const T len = end - start;
-            strings::memcpy_inlined(dest_bytes + copied, src_bytes + start, len);
-            copied += len;
-            current_offset += len;
-            *dest_offsets++ = current_offset;
+    using Offsets = typename BinaryColumnBase<T>::Offsets;
+    Offsets::visit_storage_pair(offsets, src_offsets, [&](auto& dst_offsets_buf, const auto& src_offsets_buf) {
+        using DstValue = typename std::decay_t<decltype(dst_offsets_buf)>::value_type;
+        const auto* __restrict src_offsets_data = src_offsets_buf.data();
+        auto* __restrict dest_offsets = dst_offsets_buf.data() + old_rows + 1;
+
+        uint64_t current_offset = old_bytes;
+        dst_offsets_buf[old_rows] = static_cast<DstValue>(current_offset);
+        size_t copied = 0;
+        for (size_t i = 0; i < _count; ++i) {
+            if (is_selected(_mask[i])) {
+                const uint64_t start = src_offsets_data[i];
+                const uint64_t end = src_offsets_data[i + 1];
+                const uint64_t len = end - start;
+                strings::memcpy_inlined(dest_bytes + copied, src_bytes + start, len);
+                copied += len;
+                current_offset += len;
+                *dest_offsets++ = static_cast<DstValue>(current_offset);
+            }
         }
-    }
+    });
 
     column->invalidate_slice_cache();
     return Status::OK();

--- a/be/src/column/arrow/arrow_to_starrocks_converter.cpp
+++ b/be/src/column/arrow/arrow_to_starrocks_converter.cpp
@@ -266,8 +266,8 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         offsets.visit_storage([&](auto& offsets_buf) {
             using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
             auto* offsets_data = offsets_buf.data() + column_start_idx + 1;
-            for (auto i = 0; i < num_elements; ++i) {
-                offsets_data[i] = static_cast<OffsetValue>(base_offset + (i + 1) * width);
+            for (size_t i = 0; i < num_elements; ++i) {
+                offsets_data[i] = static_cast<OffsetValue>(base_offset + static_cast<uint64_t>(i + 1) * width);
             }
         });
     }
@@ -286,10 +286,11 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         offsets.visit_storage([&](auto& offsets_buf) {
             using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
             auto* offsets_data = offsets_buf.data() + column_start_idx + 1;
-            for (auto i = 0; i < num_elements; ++i) {
+            for (size_t i = 0; i < num_elements; ++i) {
                 size_t array_idx = array_start_idx + i;
                 if (!array->IsNull(array_idx)) {
-                    strings::memcpy_inlined(bytes_start + bytes_off, array_data + i * width, width);
+                    strings::memcpy_inlined(bytes_start + bytes_off, array_data + static_cast<size_t>(i) * width,
+                                            width);
                     bytes_off += width;
                 }
                 offsets_data[i] = static_cast<OffsetValue>(bytes_off);

--- a/be/src/column/arrow/arrow_to_starrocks_converter.cpp
+++ b/be/src/column/arrow/arrow_to_starrocks_converter.cpp
@@ -253,23 +253,12 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
     static void optimize_not_nullable_fixed_size_binary(const ArrowArrayType* array, size_t array_start_idx,
                                                         size_t num_elements, ColumnType* column,
                                                         size_t column_start_idx) {
+        DCHECK_EQ(column_start_idx, column->size());
         uint32_t width = array->byte_width();
-        column->resize(column->size() + num_elements);
         const auto* array_data = array->GetValue(array_start_idx);
-        auto& bytes = column->get_bytes();
-        auto& offsets = column->get_offset();
-        size_t copy_size = width * num_elements;
-        bytes.resize(bytes.size() + width * num_elements);
-        const auto base_offset = offsets[column_start_idx];
-        strings::memcpy_inlined(bytes.data() + base_offset, array_data, copy_size);
-        offsets.ensure_width_for_value(base_offset + copy_size);
-        offsets.visit_storage([&](auto& offsets_buf) {
-            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
-            auto* offsets_data = offsets_buf.data() + column_start_idx + 1;
-            for (size_t i = 0; i < num_elements; ++i) {
-                offsets_data[i] = static_cast<OffsetValue>(base_offset + static_cast<uint64_t>(i + 1) * width);
-            }
-        });
+        auto ret = column->append_continuous_fixed_length_strings(reinterpret_cast<const char*>(array_data),
+                                                                  num_elements, static_cast<int>(width));
+        DCHECK(ret);
     }
 
     static void optimize_nullable_fixed_size_binary(const ArrowArrayType* array, size_t array_start_idx,
@@ -325,16 +314,6 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         });
     }
 
-    // Fill num_elements# empty string into column, started at position column_start_idx
-    static void fill_empty_string(ColumnType* column, size_t column_start_idx, size_t num_elements) {
-        column->resize(column->size() + num_elements);
-        auto& offsets = column->get_offset();
-        const auto base_offset = offsets[column_start_idx];
-        offsets.visit_storage([&](auto& offsets_buf) {
-            std::fill_n(offsets_buf.data() + column_start_idx + 1, num_elements, base_offset);
-        });
-    }
-
     static Status length_exceeds_limit_error(int length, int limit) {
         std::string s = (LT == TYPE_VARCHAR) ? "varchar" : ((LT == TYPE_CHAR) ? "char" : "binary");
         return Status::InternalError(strings::Substitute("Length($0) exceeds limit($1) of $2", length, limit, s));
@@ -355,7 +334,8 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
             uint32_t width = concrete_array->byte_width();
             // FixedSizeBinary's length exceeds maximum length of varchar/var
             if (width > max_length) {
-                fill_empty_string(concrete_column, column_start_idx, num_elements);
+                DCHECK_EQ(column_start_idx, concrete_column->size());
+                concrete_column->append_default(num_elements);
                 // Invalid data are regarded as nulls if target Column is nullable and is_strict is
                 // false; a not-nullable column can not accept nulls, so discards invalid data;
                 // Strict-mode(is_strict=true) loading also discards invalid data.

--- a/be/src/column/arrow/arrow_to_starrocks_converter.cpp
+++ b/be/src/column/arrow/arrow_to_starrocks_converter.cpp
@@ -18,6 +18,8 @@
 #include <arrow/compute/api.h>
 #include <fmt/format.h>
 
+#include <type_traits>
+
 #include "arrow/array/array_binary.h"
 #include "arrow/array/array_nested.h"
 #include "arrow/scalar.h"
@@ -226,14 +228,14 @@ struct ArrowConverter {
 
 // {List, Binary, String}Type in arrow use int32_t as offset type, so offsets can be copied via SIMD,
 // Large{List, Binary, String}Type use int64_t, so must copy offset elements one by one.
-template <typename T>
+template <typename T, typename DstOffset>
 void offsets_copy(const T* __restrict arrow_offsets_data, T arrow_base_offset, size_t num_elements,
-                  uint32_t* __restrict offsets_data, uint32_t base_offset) {
+                  DstOffset* __restrict offsets_data, uint64_t base_offset) {
     for (auto i = 0; i < num_elements; ++i) {
         // never change following code to
         // base_offsets - arrow_base_offset + arrow_offsets_data[i],
         // that would cause underflow for unsigned int;
-        offsets_data[i] = base_offset + (arrow_offsets_data[i] - arrow_base_offset);
+        offsets_data[i] = static_cast<DstOffset>(base_offset + (arrow_offsets_data[i] - arrow_base_offset));
     }
 }
 
@@ -260,9 +262,14 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         bytes.resize(bytes.size() + width * num_elements);
         const auto base_offset = offsets[column_start_idx];
         strings::memcpy_inlined(bytes.data() + base_offset, array_data, copy_size);
-        for (auto i = 0; i < num_elements; ++i) {
-            offsets[column_start_idx + i + 1] = base_offset + (i + 1) * width;
-        }
+        offsets.ensure_width_for_value(base_offset + copy_size);
+        offsets.visit_storage([&](auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            auto* offsets_data = offsets_buf.data() + column_start_idx + 1;
+            for (auto i = 0; i < num_elements; ++i) {
+                offsets_data[i] = static_cast<OffsetValue>(base_offset + (i + 1) * width);
+            }
+        });
     }
 
     static void optimize_nullable_fixed_size_binary(const ArrowArrayType* array, size_t array_start_idx,
@@ -275,15 +282,19 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         size_t bytes_off = bytes.size();
         bytes.resize(bytes_off + width * num_elements);
         auto* bytes_start = (uint8_t*)&bytes.front();
-        for (auto i = 0; i < num_elements; ++i) {
-            size_t array_idx = array_start_idx + i;
-            size_t offsets_idx = column_start_idx + i + 1;
-            if (!array->IsNull(array_idx)) {
-                strings::memcpy_inlined(bytes_start + bytes_off, array_data + i * width, width);
-                bytes_off += width;
+        offsets.ensure_width_for_value(bytes_off + width * num_elements);
+        offsets.visit_storage([&](auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            auto* offsets_data = offsets_buf.data() + column_start_idx + 1;
+            for (auto i = 0; i < num_elements; ++i) {
+                size_t array_idx = array_start_idx + i;
+                if (!array->IsNull(array_idx)) {
+                    strings::memcpy_inlined(bytes_start + bytes_off, array_data + i * width, width);
+                    bytes_off += width;
+                }
+                offsets_data[i] = static_cast<OffsetValue>(bytes_off);
             }
-            offsets[offsets_idx] = bytes_off;
-        }
+        });
         bytes.resize(bytes_off);
     }
 
@@ -303,10 +314,14 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         bytes.resize(bytes.size() + copy_size);
         const auto base_offset = offsets[column_start_idx];
         strings::memcpy_inlined(bytes.data() + base_offset, array_data, copy_size);
-        auto* offsets_data = &offsets[column_start_idx + 1];
-        auto* arrow_offsets_data = array->raw_value_offsets() + array_start_idx + 1;
         const auto arrow_base_offset = array->value_offset(array_start_idx);
-        offsets_copy<ArrowOffsetType>(arrow_offsets_data, arrow_base_offset, num_elements, offsets_data, base_offset);
+        auto* arrow_offsets_data = array->raw_value_offsets() + array_start_idx + 1;
+        offsets.ensure_width_for_value(base_offset + copy_size);
+        offsets.visit_storage([&](auto& offsets_buf) {
+            auto* offsets_data = offsets_buf.data() + column_start_idx + 1;
+            offsets_copy<ArrowOffsetType>(arrow_offsets_data, arrow_base_offset, num_elements, offsets_data,
+                                          base_offset);
+        });
     }
 
     // Fill num_elements# empty string into column, started at position column_start_idx
@@ -314,8 +329,9 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         column->resize(column->size() + num_elements);
         auto& offsets = column->get_offset();
         const auto base_offset = offsets[column_start_idx];
-        auto* offsets_data = &offsets[column_start_idx + 1];
-        std::fill_n(offsets_data, num_elements, base_offset);
+        offsets.visit_storage([&](auto& offsets_buf) {
+            std::fill_n(offsets_buf.data() + column_start_idx + 1, num_elements, base_offset);
+        });
     }
 
     static Status length_exceeds_limit_error(int length, int limit) {

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -14,6 +14,8 @@
 
 #include "column/binary_column.h"
 
+#include <cstring>
+
 #include "base/container/raw_container.h"
 #include "base/hash/hash_util.hpp"
 #include "column/bytes.h"
@@ -56,35 +58,46 @@ void BinaryColumnBase<T>::append(const Slice& str) {
 }
 
 template <typename T>
-template <typename SrcOffset>
-void BinaryColumnBase<T>::_append_binary_impl(const BinaryColumnBase<SrcOffset>& src, size_t offset, size_t count) {
-    static_assert(sizeof(SrcOffset) <= sizeof(Offset));
-    const auto& src_offsets = src.get_offset();
-    const uint8_t* src_base = src.raw_bytes();
-    auto& dst_bytes = get_bytes();
-    dst_bytes.insert(dst_bytes.end(), src_base + src_offsets[offset], src_base + src_offsets[offset + count]);
-
-    const size_t num_prev_offsets = _offsets.size();
-    _offsets.resize(num_prev_offsets + count);
-    auto* new_offsets = _offsets.data() + num_prev_offsets;
-
-    // new_offsets[i] = src_offsets[offset + i + 1] + delta
-    // where delta = dst_last_offset - src_offsets[offset]
-    if constexpr (std::is_same_v<T, SrcOffset>) {
-        // Same offset width: bulk-copy then adjust.
-        strings::memcpy_inlined(new_offsets, src_offsets.data() + offset + 1, count * sizeof(Offset));
-        const auto delta = _offsets[num_prev_offsets - 1] - src_offsets[offset];
-        for (size_t i = 0; i < count; i++) {
-            new_offsets[i] += delta;
-        }
-    } else {
-        // Different offset width (uint32_t -> uint64_t): convert element by element.
-        const auto delta =
-                static_cast<Offset>(_offsets[num_prev_offsets - 1]) - static_cast<Offset>(src_offsets[offset]);
-        for (size_t i = 0; i < count; i++) {
-            new_offsets[i] = static_cast<Offset>(src_offsets[offset + 1 + i]) + delta;
-        }
+void BinaryColumnBase<T>::_append_binary_impl(const Offsets& src_offsets, const uint8_t* src_base, size_t offset,
+                                              size_t count) {
+    if (UNLIKELY(count == 0)) {
+        return;
     }
+
+    const uint64_t src_begin = src_offsets[offset];
+    const uint64_t src_end = src_offsets[offset + count];
+    const size_t copy_bytes = src_end - src_begin;
+
+    auto& dst_bytes = get_bytes();
+    const uint64_t dst_begin = _offsets.back();
+    const uint64_t dst_end = dst_begin + copy_bytes;
+
+    const size_t old_bytes_size = dst_bytes.size();
+    dst_bytes.resize(old_bytes_size + copy_bytes);
+    if (copy_bytes != 0) {
+        strings::memcpy_inlined(dst_bytes.data() + old_bytes_size, src_base + src_begin, copy_bytes);
+    }
+
+    const size_t old_offsets_size = _offsets.size();
+    _offsets.resize_uninitialized(old_offsets_size + count, dst_end);
+
+    Offsets::visit_storage_pair(_offsets, src_offsets, [&](auto& dst_buf, const auto& src_buf) {
+        using DstValue = typename std::decay_t<decltype(dst_buf)>::value_type;
+        using SrcValue = typename std::decay_t<decltype(src_buf)>::value_type;
+        DstValue* __restrict dst_ptr = dst_buf.data() + old_offsets_size;
+        const SrcValue* __restrict src_ptr = src_buf.data() + offset + 1;
+
+        if constexpr (std::is_same_v<SrcValue, DstValue>) {
+            const DstValue delta = static_cast<DstValue>(dst_begin - src_begin);
+            for (size_t i = 0; i < count; ++i) {
+                dst_ptr[i] = src_ptr[i] + delta;
+            }
+        } else {
+            for (size_t i = 0; i < count; ++i) {
+                dst_ptr[i] = static_cast<DstValue>(static_cast<uint64_t>(src_ptr[i]) - src_begin + dst_begin);
+            }
+        }
+    });
 
     invalidate_slice_cache();
 }
@@ -93,30 +106,168 @@ template <typename T>
 void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
     DCHECK(offset + count <= src.size());
 
-    // Same offset type.
-    const bool src_is_same_type = std::is_same_v<T, uint32_t> ? src.is_binary() : src.is_large_binary();
-    if (src_is_same_type) {
-        _append_binary_impl(down_cast<const BinaryColumnBase<T>&>(src), offset, count);
+    if (src.is_binary()) {
+        if (UNLIKELY(count == 0)) {
+            return;
+        }
+        const auto& binary = down_cast<const BinaryColumn&>(src);
+        _append_binary_impl(binary.get_offset(), binary.raw_bytes(), offset, count);
         return;
     }
-
-    // Cross-type path: only LargeBinaryColumn can append from BinaryColumn, not the reverse.
     if constexpr (std::is_same_v<T, uint64_t>) {
-        if (src.is_binary()) {
-            _append_binary_impl(down_cast<const BinaryColumn&>(src), offset, count);
+        if (src.is_large_binary()) {
+            if (UNLIKELY(count == 0)) {
+                return;
+            }
+            const auto& binary = down_cast<const LargeBinaryColumn&>(src);
+            _append_binary_impl(binary.get_offset(), binary.raw_bytes(), offset, count);
             return;
         }
     }
 
-    bool dst_is_large = std::is_same_v<T, uint64_t>;
-    bool src_is_large_binary = src.is_large_binary();
     CHECK(false) << "BinaryColumnBase::append: incompatible column type"
-                 << " dst_is_large=" << dst_is_large << " src_is_large_binary=" << src_is_large_binary;
+                 << " src.is_binary=" << src.is_binary() << " src.is_large_binary=" << src.is_large_binary();
+}
+
+template <typename T>
+__attribute__((noinline)) void BinaryColumnBase<T>::_append_selective_general(
+        const BinaryColumnBase<T>& src_column, const uint32_t* indexes, uint32_t size, size_t prev_num_offsets,
+        uint64_t dst_begin) {
+    auto& bytes = get_bytes();
+    const auto& src_offsets = src_column.get_offset();
+
+    auto copy_ranges_and_write_offsets = [&](auto* dst_offsets, uint8_t* __restrict dest_bytes,
+                                             const uint8_t* __restrict src_bytes, const auto* range_data) {
+        using DstValue = std::remove_pointer_t<decltype(dst_offsets)>;
+        uint64_t cur_offset = dst_begin;
+
+        if (src_column._total_bytes() > 32 * 1024 * 1024ull) {
+            for (size_t i = 0; i < size; ++i) {
+                if (i + 16 < size) {
+                    // If the source column is large enough, use prefetch to speed up copying.
+                    __builtin_prefetch(src_bytes + range_data[i * 2 + 32]);
+                }
+                const size_t str_size = range_data[i * 2 + 1] - range_data[i * 2];
+                strings::memcpy_inlined(dest_bytes + cur_offset, src_bytes + range_data[i * 2], str_size);
+                cur_offset += str_size;
+                dst_offsets[i] = static_cast<DstValue>(cur_offset);
+            }
+        } else {
+            for (size_t i = 0; i < size; ++i) {
+                const size_t str_size = range_data[i * 2 + 1] - range_data[i * 2];
+                // Only copy 16 bytes extra when src_column is small enough, because the overhead of copying 16 bytes
+                // will be large when src_column is large enough.
+                strings::memcpy_inlined_overflow16(dest_bytes + cur_offset, src_bytes + range_data[i * 2],
+                                                   static_cast<ssize_t>(str_size));
+                cur_offset += str_size;
+                dst_offsets[i] = static_cast<DstValue>(cur_offset);
+            }
+        }
+    };
+
+    // Reuse destination offsets as the temporary [src_begin, src_end] range buffer only when source offsets
+    // are physically uint32_t. Large source offsets may exceed the destination's final offset range; storing
+    // them in _offsets as scratch data could force an unnecessary promotion to uint64_t.
+    if (LIKELY(!_offsets.is_large() && !src_offsets.is_large())) {
+        _offsets.resize_uninitialized(prev_num_offsets + static_cast<size_t>(size) * 2);
+        auto* range_data = _offsets.small_storage().data() + prev_num_offsets;
+        const auto* __restrict src_offset_data = src_offsets.small_storage().data();
+
+        for (size_t i = 0; i < size; ++i) {
+            const uint32_t src_idx = indexes[i];
+            range_data[i * 2] = src_offset_data[src_idx];
+            range_data[i * 2 + 1] = src_offset_data[src_idx + 1];
+        }
+
+        uint64_t append_bytes = 0;
+        for (size_t i = 0; i < size; ++i) {
+            append_bytes += range_data[i * 2 + 1] - range_data[i * 2];
+        }
+
+        const uint64_t dst_end = dst_begin + append_bytes;
+        if (LIKELY(dst_end <= std::numeric_limits<uint32_t>::max())) {
+            bytes.resize(dst_end);
+            const auto* __restrict src_bytes = src_column._data_base();
+            auto* __restrict dest_bytes = bytes.data();
+            copy_ranges_and_write_offsets(range_data, dest_bytes, src_bytes, range_data);
+            _offsets.resize(prev_num_offsets + size);
+            invalidate_slice_cache();
+            return;
+        }
+
+        _offsets.ensure_width_for_value(dst_end);
+        bytes.resize(dst_end);
+        const auto* __restrict src_bytes = src_column._data_base();
+        auto* __restrict dest_bytes = bytes.data();
+        auto* large_range_data = _offsets.large_storage().data() + prev_num_offsets;
+        copy_ranges_and_write_offsets(large_range_data, dest_bytes, src_bytes, large_range_data);
+        _offsets.resize(prev_num_offsets + size);
+    } else if (!src_offsets.is_large()) {
+        // resize for scratch data
+        _offsets.resize_uninitialized(prev_num_offsets + static_cast<size_t>(size) * 2);
+
+        // Branch one rejected this case only because the destination offsets are large, so the
+        // destination storage must be uint64_t here while the source storage is uint32_t.
+        auto* range_data = _offsets.large_storage().data() + prev_num_offsets;
+        const auto* src_offset_data = src_offsets.small_storage().data();
+
+        uint64_t small_append_bytes = 0;
+        for (size_t i = 0; i < size; ++i) {
+            const uint32_t src_idx = indexes[i];
+            // assign for scratch data
+            range_data[i * 2] = src_offset_data[src_idx];
+            range_data[i * 2 + 1] = src_offset_data[src_idx + 1];
+            small_append_bytes += range_data[i * 2 + 1] - range_data[i * 2];
+        }
+
+        const uint64_t dst_end = dst_begin + small_append_bytes;
+        bytes.resize(dst_end);
+        const auto* __restrict src_bytes = src_column._data_base();
+        auto* __restrict dest_bytes = bytes.data();
+
+        copy_ranges_and_write_offsets(range_data, dest_bytes, src_bytes, range_data);
+
+        _offsets.resize(prev_num_offsets + size);
+    } else {
+        // use a separate temporary buffer for source ranges when source offsets are large.
+        Buffer<uint64_t> ranges;
+        raw::stl_vector_resize_uninitialized(&ranges, static_cast<size_t>(size) * 2);
+        auto* __restrict range_data = ranges.data();
+        const auto* __restrict src_offset_data = src_offsets.large_storage().data();
+
+        uint64_t append_bytes = 0;
+        for (size_t i = 0; i < size; ++i) {
+            const uint32_t src_idx = indexes[i];
+            range_data[i * 2] = src_offset_data[src_idx];
+            range_data[i * 2 + 1] = src_offset_data[src_idx + 1];
+            append_bytes += range_data[i * 2 + 1] - range_data[i * 2];
+        }
+
+        const uint64_t dst_end = dst_begin + append_bytes;
+        _offsets.resize_uninitialized(prev_num_offsets + size, dst_end);
+
+        bytes.resize(dst_end);
+        const auto* __restrict src_bytes = src_column._data_base();
+        auto* __restrict dest_bytes = bytes.data();
+
+        // The destination width is decided by dst_end at the resize above, so only the
+        // destination side needs runtime dispatch.
+        _offsets.visit_storage([&](auto& dst_buf) {
+            auto* dst_offsets = dst_buf.data() + prev_num_offsets;
+            copy_ranges_and_write_offsets(dst_offsets, dest_bytes, src_bytes, range_data);
+        });
+    }
+
+    invalidate_slice_cache();
 }
 
 template <typename T>
 void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* indexes, uint32_t from,
                                            const uint32_t size) {
+    if (UNLIKELY(size == 0)) {
+        return;
+    }
+
     if (src.is_binary_view()) {
         src.append_selective_to(*this, indexes, from, size);
         return;
@@ -126,88 +277,120 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
 
     const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
     auto& bytes = get_bytes();
+    const auto& src_offsets = src_column.get_offset();
 
     const size_t prev_num_offsets = _offsets.size();
-    const size_t prev_num_rows = prev_num_offsets - 1;
+    const uint64_t dst_begin = _offsets.back();
 
-    _offsets.resize(prev_num_offsets + size * 2);
-    auto* __restrict new_offsets = _offsets.data() + prev_num_offsets;
-    const auto* __restrict src_offsets = src_column.get_offset().data();
+    // seperate hot path
+    if (LIKELY(!_offsets.is_large() && !src_offsets.is_large())) {
+        auto& dst_offsets_buf = _offsets.small_storage();
+        raw::stl_vector_resize_uninitialized(&dst_offsets_buf, prev_num_offsets + static_cast<size_t>(size) * 2);
+        auto* __restrict range_data = dst_offsets_buf.data() + prev_num_offsets;
+        const auto* __restrict src_offset_data = src_offsets.small_storage().data();
 
-    // Buffer i-th start offset and end offset in new_offsets[i * 2] and new_offsets[i * 2 + 1].
-    for (size_t i = 0; i < size; i++) {
-        const uint32_t src_idx = indexes[i];
-        new_offsets[i * 2] = src_offsets[src_idx];
-        new_offsets[i * 2 + 1] = src_offsets[src_idx + 1];
-    }
-
-    // Write bytes
-    {
-        size_t num_bytes = bytes.size();
-        for (size_t i = 0; i < size; i++) {
-            num_bytes += new_offsets[i * 2 + 1] - new_offsets[i * 2];
+        for (size_t i = 0; i < size; ++i) {
+            const uint32_t src_idx = indexes[i];
+            range_data[i * 2] = src_offset_data[src_idx];
+            range_data[i * 2 + 1] = src_offset_data[src_idx + 1];
         }
-        bytes.resize(num_bytes);
-        const auto* __restrict src_bytes = src_column._data_base();
-        auto* __restrict dest_bytes = bytes.data();
-        size_t cur_offset = _offsets[prev_num_rows];
 
-        const size_t src_bytes_size = src_column._total_bytes();
-        if (src_bytes_size > 32 * 1024 * 1024ull) {
-            for (size_t i = 0; i < size; i++) {
-                if (i + 16 < size) {
-                    // If the source column is large enough, use prefetch to speed up copying.
-                    __builtin_prefetch(src_bytes + new_offsets[i * 2 + 32]);
+        uint64_t append_bytes = 0;
+        for (size_t i = 0; i < size; ++i) {
+            append_bytes += range_data[i * 2 + 1] - range_data[i * 2];
+        }
+
+        const uint64_t dst_end = dst_begin + append_bytes;
+        if (LIKELY(dst_end <= std::numeric_limits<uint32_t>::max())) {
+            bytes.resize(dst_end);
+            const auto* __restrict src_bytes = src_column._data_base();
+            auto* __restrict dest_bytes = bytes.data();
+
+            uint32_t cur_offset = static_cast<uint32_t>(dst_begin);
+            if (src_column._total_bytes() > 32 * 1024 * 1024ull) {
+                for (size_t i = 0; i < size; ++i) {
+                    if (i + 16 < size) {
+                        // If the source column is large enough, use prefetch to speed up copying.
+                        __builtin_prefetch(src_bytes + range_data[i * 2 + 32]);
+                    }
+                    const uint32_t str_size = range_data[i * 2 + 1] - range_data[i * 2];
+                    strings::memcpy_inlined(dest_bytes + cur_offset, src_bytes + range_data[i * 2], str_size);
+                    cur_offset += str_size;
                 }
-                const T str_size = new_offsets[i * 2 + 1] - new_offsets[i * 2];
-                strings::memcpy_inlined(dest_bytes + cur_offset, src_bytes + new_offsets[i * 2], str_size);
-                cur_offset += str_size;
+            } else {
+                for (size_t i = 0; i < size; ++i) {
+                    const uint32_t str_size = range_data[i * 2 + 1] - range_data[i * 2];
+                    // Only copy 16 bytes extra when src_column is small enough, because the overhead of copying 16
+                    // bytes will be large when src_column is large enough.
+                    strings::memcpy_inlined_overflow16(dest_bytes + cur_offset, src_bytes + range_data[i * 2],
+                                                       str_size);
+                    cur_offset += str_size;
+                }
             }
-        } else {
-            for (size_t i = 0; i < size; i++) {
-                const T str_size = new_offsets[i * 2 + 1] - new_offsets[i * 2];
-                // Only copy 16 bytes extra when src_column is small enough, because the overhead of copying 16 bytes
-                // will be large when src_column is large enough.
-                strings::memcpy_inlined_overflow16(dest_bytes + cur_offset, src_bytes + new_offsets[i * 2], str_size);
-                cur_offset += str_size;
+
+            uint32_t dst_offset = static_cast<uint32_t>(dst_begin);
+            for (size_t i = 0; i < size; ++i) {
+                dst_offset += range_data[i * 2 + 1] - range_data[i * 2];
+                range_data[i] = dst_offset;
             }
+            dst_offsets_buf.resize(prev_num_offsets + size);
+            invalidate_slice_cache();
+            return;
         }
+
+        dst_offsets_buf.resize(prev_num_offsets);
     }
 
-    // Write offsets.
-    for (int64_t i = 0; i < size; i++) {
-        new_offsets[i] = new_offsets[i - 1] + (new_offsets[i * 2 + 1] - new_offsets[i * 2]);
-    }
-    _offsets.resize(prev_num_offsets + size);
-
-    invalidate_slice_cache();
+    _append_selective_general(src_column, indexes, size, prev_num_offsets, dst_begin);
 }
 
 template <typename T>
 void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
-    auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
-    auto& src_offsets = src_column.get_offset();
-    const uint8_t* src_bytes = src_column._data_base();
+    if (UNLIKELY(size == 0)) {
+        return;
+    }
+
+    const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
+    const auto& src_offsets = src_column.get_offset();
+    const uint64_t src_begin = src_offsets[index];
+    const uint64_t src_end = src_offsets[index + 1];
+    const size_t str_size = src_end - src_begin;
     auto& bytes = get_bytes();
 
-    size_t cur_row_count = _offsets.size() - 1;
-    size_t cur_byte_size = bytes.size();
+    const size_t prev_num_offsets = _offsets.size();
+    const uint64_t dst_begin = _offsets.back();
+    const uint64_t dst_end = dst_begin + static_cast<uint64_t>(str_size) * size;
 
-    _offsets.resize(cur_row_count + size + 1);
-    for (size_t i = 0; i < size; i++) {
-        uint32_t row_idx = index;
-        T str_size = src_offsets[row_idx + 1] - src_offsets[row_idx];
-        _offsets[cur_row_count + i + 1] = _offsets[cur_row_count + i] + str_size;
-        cur_byte_size += str_size;
+    if (str_size == 0) {
+        _offsets.append_empty_values(size);
+        invalidate_slice_cache();
+        return;
     }
-    bytes.resize(cur_byte_size);
 
-    auto* dest_bytes = bytes.data();
-    for (size_t i = 0; i < size; i++) {
-        uint32_t row_idx = index;
-        T str_size = src_offsets[row_idx + 1] - src_offsets[row_idx];
-        strings::memcpy_inlined(dest_bytes + _offsets[cur_row_count + i], src_bytes + src_offsets[row_idx], str_size);
-    }
+    _offsets.resize_uninitialized(prev_num_offsets + size, dst_end);
+    const size_t cur_row_count = prev_num_offsets - 1;
+    Offsets::visit_storage_pair(_offsets, src_offsets, [&](auto& dst_buf, const auto& src_buf) {
+        auto* __restrict dst_offsets = dst_buf.data();
+        const auto* __restrict src_offset_data = src_buf.data();
+        for (size_t i = 0; i < size; ++i) {
+            const uint32_t row_idx = index;
+            const uint64_t row_size = src_offset_data[row_idx + 1] - src_offset_data[row_idx];
+            dst_offsets[cur_row_count + i + 1] = dst_offsets[cur_row_count + i] + row_size;
+        }
+    });
+
+    bytes.resize(dst_end);
+    auto* __restrict dest_bytes = bytes.data();
+    src_offsets.visit_storage([&](const auto& src_buf) {
+        const auto* __restrict src_offset_data = src_buf.data();
+        const auto* __restrict src_bytes = src_column._data_base();
+        for (size_t i = 0; i < size; ++i) {
+            const uint32_t row_idx = index;
+            const uint64_t row_size = src_offset_data[row_idx + 1] - src_offset_data[row_idx];
+            strings::memcpy_inlined(dest_bytes + _offsets[cur_row_count + i],
+                                    src_bytes + src_offset_data[row_idx], row_size);
+        }
+    });
 
     invalidate_slice_cache();
 }
@@ -215,56 +398,108 @@ void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_
 //TODO(fzh): optimize copy using SIMD
 template <typename T>
 StatusOr<MutableColumnPtr> BinaryColumnBase<T>::replicate(const Buffer<uint32_t>& offsets) {
+    const size_t src_rows = offsets.size() - 1; // this->size() may be larger than offsets->size() - 1
+    const auto* __restrict repeat_offsets = offsets.data();
+
     auto dest = BinaryColumnBase<T>::create();
     auto& dest_offsets = dest->get_offset();
     auto& dest_bytes = dest->get_bytes();
-    auto src_size = offsets.size() - 1; // this->size() may be large than offsets->size() -1
-    size_t total_size = 0;              // total size to copy
-    for (auto i = 0; i < src_size; ++i) {
-        auto bytes_size = _offsets[i + 1] - _offsets[i];
-        total_size += bytes_size * (offsets[i + 1] - offsets[i]);
-    }
+    uint64_t total_size = 0; // total size to copy
 
-    if (total_size >= Column::MAX_CAPACITY_LIMIT) {
-        return Status::InternalError("replicated column size will exceed the limit");
-    }
+    _offsets.visit_storage([&](const auto& src_buf) {
+        const auto* __restrict src_offset_data = src_buf.data();
+        for (size_t i = 0; i < src_rows; ++i) {
+            const uint64_t bytes_size = src_offset_data[i + 1] - src_offset_data[i];
+            total_size += bytes_size * (repeat_offsets[i + 1] - repeat_offsets[i]);
+        }
+    });
 
     dest_bytes.resize(total_size);
-    dest_offsets.resize(dest_offsets.size() + offsets.back());
+    dest_offsets.resize(static_cast<size_t>(offsets.back()) + 1, total_size);
 
     const uint8_t* src_bytes = _data_base();
-    T pos = 0;
-    for (auto i = 0; i < src_size; ++i) {
-        auto bytes_size = _offsets[i + 1] - _offsets[i];
-        for (auto j = offsets[i]; j < offsets[i + 1]; ++j) {
-            // _data_base() returns _resource for zero-copy columns where _bytes is empty.
-            strings::memcpy_inlined(dest_bytes.data() + pos, src_bytes + _offsets[i], bytes_size);
-            pos += bytes_size;
-            dest_offsets[j + 1] = pos;
+    auto* dest_bytes_data = dest_bytes.data();
+    Offsets::visit_storage_pair(_offsets, dest_offsets, [&](const auto& src_buf, auto& dst_buf) {
+        using DstValue = typename std::decay_t<decltype(dst_buf)>::value_type;
+        const auto* __restrict src_offset_data = src_buf.data();
+        auto* __restrict dst_offset_data = dst_buf.data();
+        uint64_t pos = 0;
+
+        dst_offset_data[0] = 0;
+        for (size_t i = 0; i < src_rows; ++i) {
+            const uint64_t src_begin = src_offset_data[i];
+            const size_t bytes_size = src_offset_data[i + 1] - src_begin;
+            for (uint32_t j = repeat_offsets[i]; j < repeat_offsets[i + 1]; ++j) {
+                strings::memcpy_inlined(dest_bytes_data + pos, src_bytes + src_begin, bytes_size);
+                pos += bytes_size;
+                dst_offset_data[j + 1] = static_cast<DstValue>(pos);
+            }
+
         }
-    }
+    });
 
     return dest;
 }
 
 template <typename T>
 bool BinaryColumnBase<T>::append_strings(const Slice* data, size_t size) {
-    auto& bytes = get_bytes();
-    const size_t prev_num_offsets = _offsets.size();
-    _offsets.resize(prev_num_offsets + size);
-    // offsets[i] represents the beginning address (included) of the new `i`-th string.
-    // offsets[i + 1] represents the end address (excluded) of the new `i`-th string.
-    auto* offsets = _offsets.data() + prev_num_offsets - 1;
-    for (size_t i = 0; i < size; i++) {
-        offsets[i + 1] = offsets[i] + data[i].size;
+    if (UNLIKELY(size == 0)) {
+        return true;
     }
 
-    bytes.resize(_offsets.back());
-    auto* bytes_ptr = bytes.data();
-    for (size_t i = 0; i < size; i++) {
-        const auto* const p = reinterpret_cast<const Bytes::value_type*>(data[i].data);
-        strings::memcpy_inlined(bytes_ptr + offsets[i], p, data[i].size);
+    auto& bytes = get_bytes();
+    uint64_t append_bytes = 0;
+    for (size_t i = 0; i < size; ++i) {
+        append_bytes += data[i].size;
     }
+
+    if (append_bytes == 0) {
+        _offsets.append_empty_values(size);
+        invalidate_slice_cache();
+        return true;
+    }
+
+    const size_t prev_num_offsets = _offsets.size();
+    const uint64_t dst_begin = _offsets.back();
+    const uint64_t dst_end = dst_begin + append_bytes;
+    if (LIKELY(!_offsets.is_large() && dst_end <= std::numeric_limits<uint32_t>::max())) {
+        auto& offsets = _offsets.small_storage();
+        raw::stl_vector_resize_uninitialized(&offsets, prev_num_offsets + size);
+        bytes.resize(dst_end);
+
+        auto* bytes_ptr = bytes.data();
+        auto* __restrict dst_offsets = offsets.data() + prev_num_offsets;
+        uint64_t cur_offset = dst_begin;
+        for (size_t i = 0; i < size; ++i) {
+            const size_t str_size = data[i].size;
+            const auto* const p = reinterpret_cast<const Bytes::value_type*>(data[i].data);
+            strings::memcpy_inlined(bytes_ptr + cur_offset, p, str_size);
+            cur_offset += str_size;
+            dst_offsets[i] = static_cast<uint32_t>(cur_offset);
+        }
+        DCHECK_EQ(cur_offset, dst_end);
+
+        invalidate_slice_cache();
+        return true;
+    }
+
+    _offsets.resize_uninitialized(prev_num_offsets + size, dst_end);
+    bytes.resize(dst_end);
+
+    // The offsets must be large here: either they already were, or dst_end > UINT32_MAX
+    // just promoted them in the resize above.
+    DCHECK(_offsets.is_large());
+    auto* bytes_ptr = bytes.data();
+    auto* __restrict dst_offsets = _offsets.large_storage().data() + prev_num_offsets;
+    uint64_t cur_offset = dst_begin;
+    for (size_t i = 0; i < size; ++i) {
+        const size_t str_size = data[i].size;
+        const auto* const p = reinterpret_cast<const Bytes::value_type*>(data[i].data);
+        strings::memcpy_inlined(bytes_ptr + cur_offset, p, str_size);
+        cur_offset += str_size;
+        dst_offsets[i] = cur_offset;
+    }
+    DCHECK_EQ(cur_offset, dst_end);
 
     invalidate_slice_cache();
     return true;
@@ -279,24 +514,29 @@ void append_fixed_length(const Slice* data, size_t data_size, Bytes* bytes,
 template <typename T, size_t copy_length>
 void append_fixed_length(const Slice* data, size_t data_size, Bytes* bytes,
                          typename BinaryColumnBase<T>::Offsets* offsets) {
-    size_t size = bytes->size();
+    uint64_t new_bytes_size = bytes->size();
     for (size_t i = 0; i < data_size; i++) {
         const auto& s = data[i];
-        size += s.size;
+        new_bytes_size += s.size;
     }
 
-    size_t offset = bytes->size();
-    bytes->resize(size + copy_length);
+    uint64_t offset = bytes->size();
+    bytes->resize(new_bytes_size + copy_length);
 
-    size_t rows = data_size;
-    size_t length = offsets->size();
-    raw::stl_vector_resize_uninitialized(offsets, offsets->size() + rows);
+    const size_t rows = data_size;
+    const size_t prev_num_offsets = offsets->size();
+    offsets->resize_uninitialized(prev_num_offsets + rows, new_bytes_size);
 
-    for (size_t i = 0; i < rows; ++i) {
-        memcpy(&(*bytes)[offset], data[i].get_data(), copy_length);
-        offset += data[i].get_size();
-        (*offsets)[length++] = offset;
-    }
+    offsets->visit_storage([&](auto& dst_buf) {
+        using DstValue = typename std::decay_t<decltype(dst_buf)>::value_type;
+        auto* __restrict dst_offsets = dst_buf.data() + prev_num_offsets;
+
+        for (size_t i = 0; i < rows; ++i) {
+            memcpy(&(*bytes)[offset], data[i].get_data(), copy_length);
+            offset += data[i].get_size();
+            dst_offsets[i] = static_cast<DstValue>(offset);
+        }
+    });
 
     bytes->resize(offset);
 }
@@ -328,69 +568,85 @@ bool BinaryColumnBase<T>::append_strings_overflow(const Slice* data, size_t size
 
 template <typename T>
 bool BinaryColumnBase<T>::append_continuous_strings(const Slice* data, size_t size) {
-    if (size == 0) {
+    if (UNLIKELY(size == 0)) {
         return true;
     }
+
     auto& bytes = get_bytes();
-    size_t new_size = bytes.size();
+    const uint64_t old_bytes_size = bytes.size();
     const auto* p = reinterpret_cast<const uint8_t*>(data[0].data);
     const auto* q = reinterpret_cast<const uint8_t*>(data[size - 1].data + data[size - 1].size);
     bytes.insert(bytes.end(), p, q);
 
-    _offsets.reserve(_offsets.size() + size);
-    for (size_t i = 0; i < size; i++) {
-        const auto& s = data[i];
-        new_size += s.size;
-        _offsets.emplace_back(new_size);
-    }
-    DCHECK_EQ(bytes.size(), new_size);
+    const size_t prev_num_offsets = _offsets.size();
+    const uint64_t new_size = bytes.size();
+    _offsets.resize_uninitialized(prev_num_offsets + size, new_size);
+
+    _offsets.visit_storage([&](auto& dst_buf) {
+        using DstValue = typename std::decay_t<decltype(dst_buf)>::value_type;
+        auto* __restrict dst_offsets = dst_buf.data() + prev_num_offsets;
+        uint64_t offset = old_bytes_size;
+
+        for (size_t i = 0; i < size; ++i) {
+            offset += data[i].size;
+            dst_offsets[i] = static_cast<DstValue>(offset);
+        }
+        DCHECK_EQ(offset, new_size);
+    });
+
     invalidate_slice_cache();
     return true;
 }
 
 template <typename T>
 bool BinaryColumnBase<T>::append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) {
-    if (size == 0) return true;
+    if (UNLIKELY(size == 0)) return true;
     auto& bytes = get_bytes();
-    size_t bytes_size = bytes.size();
+    const uint64_t old_bytes_size = bytes.size();
+    const uint64_t new_bytes_size = old_bytes_size + static_cast<uint64_t>(fixed_length) * size;
 
     // copy blob
-    size_t data_size = size * fixed_length;
-    const auto* p = reinterpret_cast<const uint8_t*>(data);
-    const auto* q = reinterpret_cast<const uint8_t*>(data + data_size);
-    bytes.insert(bytes.end(), p, q);
+    const size_t data_size = size * fixed_length;
+    bytes.resize(new_bytes_size);
+    strings::memcpy_inlined(bytes.data() + old_bytes_size, data, data_size);
+    DCHECK_EQ(bytes.size(), new_bytes_size);
 
     // copy offsets
-    starrocks::raw::stl_vector_resize_uninitialized(&_offsets, _offsets.size() + size);
-    // _offsets.resize(_offsets.size() + size);
-    T* off_data = _offsets.data() + _offsets.size() - size;
+    const size_t prev_num_offsets = _offsets.size();
+    _offsets.resize_uninitialized(prev_num_offsets + size, new_bytes_size);
 
-    int i = 0;
-
+    _offsets.visit_storage([&](auto& dst_buf) {
+        using DstValue = typename std::decay_t<decltype(dst_buf)>::value_type;
+        auto* off_data = dst_buf.data() + prev_num_offsets;
+        size_t i = 0;
+        uint64_t offset = old_bytes_size;
 #ifdef __AVX2__
-    if constexpr (std::is_same_v<T, uint32_t>) {
-        if ((bytes_size + fixed_length * size) < std::numeric_limits<uint32_t>::max()) {
-            const int times = static_cast<const int>(size / 8);
+        if constexpr (std::is_same_v<DstValue, uint32_t>) {
+            if (new_bytes_size <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+                const size_t times = size / 8;
 
 #define FX(m) (m * fixed_length)
-#define BFX(m) (static_cast<int>(bytes_size + m * fixed_length))
-            __m256i base = _mm256_set_epi32(BFX(8), BFX(7), BFX(6), BFX(5), BFX(4), BFX(3), BFX(2), BFX(1));
-            __m256i delta = _mm256_set_epi32(FX(8), FX(8), FX(8), FX(8), FX(8), FX(8), FX(8), FX(8));
-            for (int t = 0; t < times; t++) {
-                _mm256_storeu_si256((__m256i*)off_data, base);
-                base = _mm256_add_epi32(base, delta);
-                off_data += 8;
-            }
+#define BFX(m) (static_cast<int>(old_bytes_size + m * fixed_length))
+                __m256i base = _mm256_set_epi32(BFX(8), BFX(7), BFX(6), BFX(5), BFX(4), BFX(3), BFX(2), BFX(1));
+                __m256i delta = _mm256_set_epi32(FX(8), FX(8), FX(8), FX(8), FX(8), FX(8), FX(8), FX(8));
+                for (size_t t = 0; t < times; t++) {
+                    _mm256_storeu_si256((__m256i*)off_data, base);
+                    base = _mm256_add_epi32(base, delta);
+                    off_data += 8;
+                }
 
-            i = times * 8;
-            bytes_size += fixed_length * i;
+                i = times * 8;
+                offset += static_cast<uint64_t>(fixed_length) * i;
+            }
         }
-    }
 #endif
-    for (; i < size; i++) {
-        bytes_size += fixed_length;
-        *(off_data++) = static_cast<T>(bytes_size);
-    }
+        for (; i < size; i++) {
+            offset += fixed_length;
+            *(off_data++) = static_cast<DstValue>(offset);
+        }
+        DCHECK_EQ(offset, new_bytes_size);
+    });
+
     return true;
 }
 
@@ -462,17 +718,16 @@ void BinaryColumnBase<T>::append_value_multiple_times(const void* value, size_t 
 
 template <typename T>
 void BinaryColumnBase<T>::build_slices(Container& slices) const {
-    if constexpr (std::is_same_v<T, uint32_t>) {
-        DCHECK_LT(_total_bytes(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";
-    }
-
     DCHECK(_offsets.size() > 0);
 
     slices.resize(_offsets.size() - 1);
     const uint8_t* data_ptr = _data_base();
-    for (size_t i = 0; i < _offsets.size() - 1; ++i) {
-        slices[i] = {data_ptr + _offsets[i], _offsets[i + 1] - _offsets[i]};
-    }
+    _offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offsets = offsets_buf.data();
+        for (size_t i = 0; i + 1 < offsets_buf.size(); ++i) {
+            slices[i] = {data_ptr + offsets[i], offsets[i + 1] - offsets[i]};
+        }
+    });
 }
 
 template <typename T>
@@ -485,9 +740,12 @@ void BinaryColumnBase<T>::_build_german_strings() const {
     _german_strings.resize(num_rows);
 
     const auto* base = _data_base();
-    for (auto i = 0; i < num_rows; ++i) {
-        _german_strings[i] = GermanString(base + _offsets[i], _offsets[i + 1] - _offsets[i]);
-    }
+    _offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offsets = offsets_buf.data();
+        for (size_t i = 0; i < num_rows; ++i) {
+            _german_strings[i] = GermanString(base + offsets[i], offsets[i + 1] - offsets[i]);
+        }
+    });
     _german_strings_cache = true;
 }
 
@@ -527,26 +785,11 @@ void BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes
     const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
     size_t replace_num = src.size();
     bool need_resize = false;
-    for (size_t i = 0; i < replace_num; ++i) {
-        DCHECK_LT(indexes[i], _offsets.size());
-        T cur_len = _offsets[indexes[i] + 1] - _offsets[indexes[i]];
-        T new_len = src_column._offsets[i + 1] - src_column._offsets[i];
-        if (cur_len != new_len) {
-            need_resize = true;
-            break;
-        }
-    }
 
-    if (!need_resize) {
-        auto& bytes = get_bytes();
-        auto* dest_bytes = bytes.data();
-        const uint8_t* src_bytes = src_column._data_base();
-        const auto& src_offsets = src_column.get_offset();
-        for (size_t i = 0; i < replace_num; ++i) {
-            T str_size = src_offsets[i + 1] - src_offsets[i];
-            strings::memcpy_inlined(dest_bytes + _offsets[indexes[i]], src_bytes + src_offsets[i], str_size);
-        }
-    } else {
+    const auto& dst_offsets_ref = _offsets;
+    const auto& src_offsets_ref = src_column._offsets;
+
+    auto rebuild_column = [&]() {
         auto new_binary_column = BinaryColumnBase<T>::create();
         size_t idx_begin = 0;
         for (size_t i = 0; i < replace_num; i++) {
@@ -561,7 +804,67 @@ void BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes
             new_binary_column->append(*this, indexes[replace_num - 1] + 1, remain_count);
         }
         swap_column(*new_binary_column);
+    };
+
+    if (LIKELY(!_offsets.is_large() && !src_column._offsets.is_large())) {
+        const auto* __restrict dst_offsets = _offsets.small_storage().data();
+        const auto* __restrict src_offsets = src_column._offsets.small_storage().data();
+        for (size_t i = 0; i < replace_num; ++i) {
+            DCHECK_LT(indexes[i], _offsets.size());
+            const size_t cur_len = dst_offsets[indexes[i] + 1] - dst_offsets[indexes[i]];
+            const size_t new_len = src_offsets[i + 1] - src_offsets[i];
+            if (cur_len != new_len) {
+                need_resize = true;
+                break;
+            }
+        }
+
+        if (!need_resize) {
+            auto& bytes = get_bytes();
+            auto* dest_bytes = bytes.data();
+            const uint8_t* src_bytes = src_column._data_base();
+            for (size_t i = 0; i < replace_num; ++i) {
+                const size_t src_offset = src_offsets[i];
+                const size_t str_size = src_offsets[i + 1] - src_offset;
+                strings::memcpy_inlined(dest_bytes + dst_offsets[indexes[i]], src_bytes + src_offset, str_size);
+            }
+            return;
+        }
+
+    } else {
+        Offsets::visit_storage_pair(dst_offsets_ref, src_offsets_ref, [&](const auto& dst_buf, const auto& src_buf) {
+            const auto* __restrict dst_offsets = dst_buf.data();
+            const auto* __restrict src_offsets = src_buf.data();
+            for (size_t i = 0; i < replace_num; ++i) {
+                DCHECK_LT(indexes[i], _offsets.size());
+                const size_t cur_len = dst_offsets[indexes[i] + 1] - dst_offsets[indexes[i]];
+                const size_t new_len = src_offsets[i + 1] - src_offsets[i];
+                if (cur_len != new_len) {
+                    need_resize = true;
+                    break;
+                }
+            }
+        });
+
+        if (!need_resize) {
+            auto& bytes = get_bytes();
+            auto* dest_bytes = bytes.data();
+            const uint8_t* src_bytes = src_column._data_base();
+            Offsets::visit_storage_pair(dst_offsets_ref, src_offsets_ref, [&](const auto& dst_buf,
+                                                                              const auto& src_buf) {
+                const auto* __restrict dst_offsets = dst_buf.data();
+                const auto* __restrict src_offsets = src_buf.data();
+                for (size_t i = 0; i < replace_num; ++i) {
+                    const size_t src_offset = src_offsets[i];
+                    const size_t str_size = src_offsets[i + 1] - src_offset;
+                    strings::memcpy_inlined(dest_bytes + dst_offsets[indexes[i]], src_bytes + src_offset, str_size);
+                }
+            });
+            return;
+        }
     }
+
+    rebuild_column();
 }
 
 template <typename T>
@@ -571,7 +874,9 @@ void BinaryColumnBase<T>::assign(size_t n, size_t idx) {
             std::string(reinterpret_cast<const char*>(base + _offsets[idx]), _offsets[idx + 1] - _offsets[idx]);
     _resource.reset();
     _bytes.clear();
+    _bytes.reserve(value.size() * n);
     _offsets.clear();
+    _offsets.reserve(n + 1);
     _offsets.emplace_back(0);
     const auto* const start = reinterpret_cast<const Bytes::value_type*>(value.data());
     const uint8_t* const end = start + value.size();
@@ -590,14 +895,14 @@ void BinaryColumnBase<T>::remove_first_n_values(size_t count) {
         return;
     }
 
-    size_t remain_size = _offsets.size() - 1 - count;
+    const size_t remain_size = _offsets.size() - 1 - count;
     if (remain_size == 0) {
         // Drop the zero-copy backing so the column doesn't keep an external owner
         // alive while reporting itself empty.
-        _resource = {};
+        _resource.reset();
         _bytes.clear();
-        _offsets.resize(1);
-        _offsets[0] = 0;
+        _offsets.clear();
+        _offsets.emplace_back(0);
         invalidate_slice_cache();
         return;
     }
@@ -605,9 +910,8 @@ void BinaryColumnBase<T>::remove_first_n_values(size_t count) {
     // In-place memmove writes into _bytes, so unshare from any zero-copy backing first.
     _ensure_materialized();
 
-    T bytes_to_remove = _offsets[count];
-    T total_bytes = _offsets.back();
-    T remaining_bytes = total_bytes - bytes_to_remove;
+    const uint64_t bytes_to_remove = _offsets[count];
+    const uint64_t remaining_bytes = _offsets.back() - bytes_to_remove;
 
     // Move bytes in-place using memmove (handles overlapping regions)
     if (remaining_bytes > 0) {
@@ -615,40 +919,19 @@ void BinaryColumnBase<T>::remove_first_n_values(size_t count) {
     }
     _bytes.resize(remaining_bytes);
 
-    // Adjust offsets in-place: shift and subtract delta
-    for (size_t i = 0; i <= remain_size; ++i) {
-        _offsets[i] = _offsets[i + count] - bytes_to_remove;
-    }
+    // Adjust offsets in-place: shift and subtract delta. Writes trail reads (i < i + count),
+    // and values only shrink, so the current width always fits.
+    _offsets.visit_storage([&](auto& buf) {
+        using Value = typename std::decay_t<decltype(buf)>::value_type;
+        auto* __restrict data = buf.data();
+        const Value delta = static_cast<Value>(bytes_to_remove);
+        for (size_t i = 0; i <= remain_size; ++i) {
+            data[i] = data[i + count] - delta;
+        }
+    });
     _offsets.resize(remain_size + 1);
 
     invalidate_slice_cache();
-}
-
-template <typename T>
-MutableColumnPtr BinaryColumnBase<T>::cut(size_t start, size_t length) const {
-    auto result = this->create();
-
-    if (start >= size() || length == 0) {
-        return result;
-    }
-
-    size_t upper = std::min(start + length, _offsets.size());
-    T start_offset = _offsets[start];
-
-    // offset re-compute
-    result->get_offset().resize(upper - start + 1);
-    // Always set offsets[0] to 0, in order to easily get element
-    result->get_offset()[0] = 0;
-    for (size_t i = start + 1, j = 1; i < upper + 1; ++i, ++j) {
-        result->get_offset()[j] = _offsets[i] - start_offset;
-    }
-
-    // copy value
-    const uint8_t* base = _data_base();
-    result->get_bytes().resize(_offsets[upper] - _offsets[start]);
-    strings::memcpy_inlined(result->get_bytes().data(), base + _offsets[start], _offsets[upper] - _offsets[start]);
-
-    return result;
 }
 
 template <typename T>
@@ -659,72 +942,76 @@ size_t BinaryColumnBase<T>::filter_range(const Filter& filter, size_t from, size
     auto& bytes = get_bytes();
     uint8_t* data = bytes.data();
 
+    _offsets.visit_storage([&](auto& offsets_buf) {
+        auto* offset_data = offsets_buf.data();
+
 #ifdef __AVX2__
-    const uint8_t* f_data = filter.data();
+        const uint8_t* f_data = filter.data();
 
-    int simd_bits = 256;
-    int batch_nums = simd_bits / (8 * (int)sizeof(uint8_t));
-    __m256i all0 = _mm256_setzero_si256();
+        int simd_bits = 256;
+        int batch_nums = simd_bits / (8 * (int)sizeof(uint8_t));
+        __m256i all0 = _mm256_setzero_si256();
 
-    while (start_offset + batch_nums < to) {
-        __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + start_offset));
-        uint32_t mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
+        while (start_offset + batch_nums < to) {
+            __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + start_offset));
+            uint32_t mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
 
-        if (mask == 0) {
-            // all no hit, pass
-        } else if (mask == 0xffffffff) {
-            // all hit, copy all
+            if (mask == 0) {
+                // all no hit, pass
+            } else if (mask == 0xffffffff) {
+                // all hit, copy all
 
-            // copy data
-            T size = _offsets[start_offset + batch_nums] - _offsets[start_offset];
-            memmove(data + _offsets[result_offset], data + _offsets[start_offset], size);
+                // copy data
+                const size_t bytes_size = offset_data[start_offset + batch_nums] - offset_data[start_offset];
+                memmove(data + offset_data[result_offset], data + offset_data[start_offset], bytes_size);
 
-            // set offsets, try vectorized
-            T* offset_data = _offsets.data();
-            for (int i = 0; i < batch_nums; ++i) {
-                // TODO: performance, all sub one same offset ?
-                offset_data[result_offset + i + 1] = offset_data[result_offset + i] +
-                                                     offset_data[start_offset + i + 1] - offset_data[start_offset + i];
+                // set offsets, try vectorized
+                for (int i = 0; i < batch_nums; ++i) {
+                    // TODO: performance, all sub one same offset ?
+                    offset_data[result_offset + i + 1] =
+                            offset_data[result_offset + i] + offset_data[start_offset + i + 1] -
+                            offset_data[start_offset + i];
+                }
+
+                result_offset += batch_nums;
+            } else {
+                // skip not hit row, it's will reduce compare when filter layout is sparse,
+                // like "00010001...", but is ineffective when the filter layout is dense.
+
+                uint32_t zero_count = Bits::CountTrailingZerosNonZero32(mask);
+                uint32_t i = zero_count;
+                while (i < batch_nums) {
+                    mask = zero_count < 31 ? mask >> (zero_count + 1) : 0;
+
+                    const size_t bytes_size = offset_data[start_offset + i + 1] - offset_data[start_offset + i];
+                    // copy date
+                    memmove(data + offset_data[result_offset], data + offset_data[start_offset + i], bytes_size);
+
+                    // set offsets
+                    offset_data[result_offset + 1] = offset_data[result_offset] + bytes_size;
+                    zero_count = Bits::CountTrailingZeros32(mask);
+                    result_offset += 1;
+                    i += (zero_count + 1);
+                }
             }
-
-            result_offset += batch_nums;
-        } else {
-            // skip not hit row, it's will reduce compare when filter layout is sparse,
-            // like "00010001...", but is ineffective when the filter layout is dense.
-
-            uint32_t zero_count = Bits::CountTrailingZerosNonZero32(mask);
-            uint32_t i = zero_count;
-            while (i < batch_nums) {
-                mask = zero_count < 31 ? mask >> (zero_count + 1) : 0;
-
-                T size = _offsets[start_offset + i + 1] - _offsets[start_offset + i];
-                // copy date
-                memmove(data + _offsets[result_offset], data + _offsets[start_offset + i], size);
-
-                // set offsets
-                _offsets[result_offset + 1] = _offsets[result_offset] + size;
-                zero_count = Bits::CountTrailingZeros32(mask);
-                result_offset += 1;
-                i += (zero_count + 1);
-            }
+            start_offset += batch_nums;
         }
-        start_offset += batch_nums;
-    }
 #endif
 
-    for (auto i = start_offset; i < to; ++i) {
-        if (filter[i]) {
-            DCHECK_GE(_offsets[i + 1], _offsets[i]);
-            T size = _offsets[i + 1] - _offsets[i];
-            // copy data
-            memmove(data + _offsets[result_offset], data + _offsets[i], size);
+        for (auto i = start_offset; i < to; ++i) {
+            if (filter[i]) {
+                DCHECK_GE(offset_data[i + 1], offset_data[i]);
+                const size_t bytes_size = offset_data[i + 1] - offset_data[i];
+                // copy data
+                memmove(data + offset_data[result_offset], data + offset_data[i], bytes_size);
 
-            // set offsets
-            _offsets[result_offset + 1] = _offsets[result_offset] + size;
+                // set offsets
+                offset_data[result_offset + 1] = offset_data[result_offset] + bytes_size;
 
-            result_offset++;
+                result_offset++;
+            }
         }
-    }
+    });
 
     this->resize(result_offset);
     return result_offset;
@@ -740,13 +1027,43 @@ template <typename T>
 uint32_t BinaryColumnBase<T>::max_one_element_serialize_size() const {
     uint32_t max_size = 0;
     size_t length = _offsets.size() - 1;
-    for (size_t i = 0; i < length; ++i) {
-        // it's safe to cast, because max size of one string is 2^32
-        uint32_t curr_length = _offsets[i + 1] - _offsets[i];
-        max_size = std::max(max_size, curr_length);
-    }
+    _offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offsets = offsets_buf.data();
+        for (size_t i = 0; i < length; ++i) {
+            // it's safe to cast, because max size of one string is 2^32
+            const size_t curr_length = offsets[i + 1] - offsets[i];
+            DCHECK_LE(curr_length, std::numeric_limits<uint32_t>::max());
+            max_size = std::max(max_size, static_cast<uint32_t>(curr_length));
+        }
+    });
     // TODO: may be overflow here, i will solve it later
     return max_size + sizeof(uint32_t);
+}
+
+template <bool IsNullable, typename Offset>
+static inline __attribute__((always_inline)) void serialize_binary_batch_at_interval_impl(
+        uint8_t* dst, size_t byte_interval, uint32_t max_row_size, size_t start, size_t count,
+        const uint8_t* null_masks, const uint8_t* __restrict bytes, const Offset* __restrict offsets) {
+    const size_t end_index = start + count;
+    for (size_t i = start; i < end_index; ++i, dst += byte_interval) {
+        if constexpr (IsNullable) {
+            if (null_masks[i]) {
+                *dst = 0xFF; // Invalid UTF-8 string.
+                continue;
+            }
+        }
+
+        const auto begin = offsets[i];
+        const auto end = offsets[i + 1];
+        const size_t length = end - begin;
+        if (length > max_row_size) {
+            *dst = 0xFF;
+        } else if (length > 0 && bytes[end - 1] == 0) {
+            *dst = 0xFF;
+        } else {
+            strings::memcpy_inlined(dst, bytes + begin, length);
+        }
+    }
 }
 
 template <typename T>
@@ -766,24 +1083,17 @@ size_t BinaryColumnBase<T>::serialize_batch_at_interval_with_null_masks(uint8_t*
         if constexpr (IsNullable) {
             dst++; // reserve one byte for null flag
         }
+        if (UNLIKELY(count == 0)) {
+            return max_row_size;
+        }
 
         const uint8_t* bytes = _data_base();
-        for (size_t i = start; i < start + count; ++i, dst += byte_interval) {
-            if constexpr (IsNullable) {
-                if (null_masks[i]) {
-                    *dst = 0xFF; // Invalid UTF-8 string.
-                    continue;
-                }
-            }
-
-            const size_t length = _offsets[i + 1] - _offsets[i];
-            if (length > max_row_size) {
-                *dst = 0xFF;
-            } else if (length > 0 && bytes[_offsets[i + 1] - 1] == 0) {
-                *dst = 0xFF;
-            } else {
-                strings::memcpy_inlined(dst, bytes + _offsets[i], length);
-            }
+        if (LIKELY(!_offsets.is_large())) {
+            serialize_binary_batch_at_interval_impl<IsNullable>(dst, byte_interval, max_row_size, start, count,
+                                                                null_masks, bytes, _offsets.small_storage().data());
+        } else {
+            serialize_binary_batch_at_interval_impl<IsNullable>(dst, byte_interval, max_row_size, start, count,
+                                                                null_masks, bytes, _offsets.large_storage().data());
         }
 
         return max_row_size;
@@ -807,9 +1117,17 @@ uint32_t BinaryColumnBase<T>::serialize_default(uint8_t* pos) const {
 template <typename T>
 void BinaryColumnBase<T>::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                                           uint32_t max_one_row_size) const {
-    for (size_t i = 0; i < chunk_size; ++i) {
-        slice_sizes[i] += serialize(i, dst + i * max_one_row_size + slice_sizes[i]);
-    }
+    const uint8_t* base = _data_base();
+    uint32_t* sizes = slice_sizes.data();
+
+    _offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offsets_data = offsets_buf.data();
+        uint8_t* row = dst;
+        for (size_t i = 0; i < chunk_size; ++i) {
+            sizes[i] += serialize_binary_element(offsets_data, i, base, row + sizes[i]);
+            row += max_one_row_size;
+        }
+    });
 }
 
 template <typename T>
@@ -837,26 +1155,53 @@ void BinaryColumnBase<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size
     }
 }
 
+template <typename Offset>
+__attribute__((noinline)) static void serialize_binary_batch_nullable_impl(
+        uint8_t* dst, uint32_t* __restrict sizes, size_t chunk_size, uint32_t max_one_row_size,
+        const uint8_t* __restrict null_masks, const uint8_t* __restrict base, const Offset* __restrict offsets_data) {
+    uint8_t* row = dst;
+    for (size_t i = 0; i < chunk_size; ++i) {
+        uint8_t* pos = row + sizes[i];
+        const uint8_t null_flag = null_masks[i];
+        *pos = null_flag;
+        sizes[i] += sizeof(bool);
+        row += max_one_row_size;
+
+        if (!null_flag) {
+            sizes[i] += serialize_binary_element(offsets_data, i, base, pos + sizeof(bool));
+        }
+    }
+}
+
 template <typename T>
 void BinaryColumnBase<T>::serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes,
                                                           size_t chunk_size, uint32_t max_one_row_size,
                                                           const uint8_t* null_masks, bool has_null) const {
+    if (UNLIKELY(chunk_size == 0)) {
+        return;
+    }
+
     uint32_t* sizes = slice_sizes.data();
+    const uint8_t* base = _data_base();
 
     if (!has_null) {
-        for (size_t i = 0; i < chunk_size; ++i) {
-            memcpy(dst + i * max_one_row_size + sizes[i], &has_null, sizeof(bool));
-            sizes[i] += static_cast<uint32_t>(sizeof(bool)) +
-                        serialize(i, dst + i * max_one_row_size + sizes[i] + sizeof(bool));
-        }
-    } else {
-        for (size_t i = 0; i < chunk_size; ++i) {
-            memcpy(dst + i * max_one_row_size + sizes[i], null_masks + i, sizeof(bool));
-            sizes[i] += sizeof(bool);
-
-            if (!null_masks[i]) {
-                sizes[i] += serialize(i, dst + i * max_one_row_size + sizes[i]);
+        _offsets.visit_storage([&](const auto& offsets_buf) {
+            const auto* __restrict offsets_data = offsets_buf.data();
+            uint8_t* row = dst;
+            for (size_t i = 0; i < chunk_size; ++i) {
+                uint8_t* pos = row + sizes[i];
+                *pos = 0; // null flag: not null
+                sizes[i] += sizeof(bool) + serialize_binary_element(offsets_data, i, base, pos + sizeof(bool));
+                row += max_one_row_size;
             }
+        });
+    } else {
+        if (LIKELY(!_offsets.is_large())) {
+            serialize_binary_batch_nullable_impl(dst, sizes, chunk_size, max_one_row_size, null_masks, base,
+                                                 _offsets.small_storage().data());
+        } else {
+            serialize_binary_batch_nullable_impl(dst, sizes, chunk_size, max_one_row_size, null_masks, base,
+                                                 _offsets.large_storage().data());
         }
     }
 }
@@ -917,8 +1262,8 @@ int64_t BinaryColumnBase<T>::xor_checksum(uint32_t from, uint32_t to) const {
 
 template <typename T>
 void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
-    T start = _offsets[idx];
-    T len = _offsets[idx + 1] - start;
+    size_t start = _offsets[idx];
+    size_t len = _offsets[idx + 1] - start;
     const char* base = reinterpret_cast<const char*>(_data_base());
     if (_is_binary_type) {
         buf->push_binary(base + start, len);
@@ -947,17 +1292,6 @@ std::string BinaryColumnBase<T>::raw_item_value(size_t idx) const {
     return s;
 }
 
-// find first overflow point in offsets[start,end)
-// return the first overflow point or end if not found
-size_t find_first_overflow_point(const BinaryColumnBase<uint32_t>::Offsets& offsets, size_t start, size_t end) {
-    for (size_t i = start; i < end - 1; i++) {
-        if (offsets[i] > offsets[i + 1]) {
-            return i + 1;
-        }
-    }
-    return end;
-}
-
 template <typename T>
 StatusOr<MutableColumnPtr> BinaryColumnBase<T>::upgrade_if_overflow() {
     static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
@@ -965,32 +1299,25 @@ StatusOr<MutableColumnPtr> BinaryColumnBase<T>::upgrade_if_overflow() {
     if constexpr (std::is_same_v<T, uint32_t>) {
         if (_offsets.size() > Column::MAX_CAPACITY_LIMIT) {
             return Status::InternalError("column size exceed the limit");
-        } else if (get_immutable_bytes().size() >= Column::MAX_CAPACITY_LIMIT) {
-            auto new_column = BinaryColumnBase<uint64_t>::create();
-            new_column->get_offset().resize(_offsets.size());
-            new_column->get_bytes().swap(get_bytes());
-
-            size_t base = 0;
-            size_t start = 0;
-            size_t end = _offsets.size();
-
-            // TODO: There may be better implementations which improve performance
-            while (start < end) {
-                size_t mid = find_first_overflow_point(_offsets, start, end);
-                for (size_t i = start; i < mid; i++) {
-                    new_column->get_offset()[i] = static_cast<uint64_t>(_offsets[i]) + base;
-                }
-                base += Column::MAX_CAPACITY_LIMIT;
-                start = mid;
-            }
-
-            // NOTE(yanz): in BinaryColumnBase, we have an invariant that `_offsets.back == _bytes.size()`;  
-            // and since _bytes has been moved to new_column, we have to clear _offset to keep the invariant.
-            _offsets.clear();
-            return new_column;
-        } else {
+        }
+        // Keep the pre-AdaptiveOffsets contract: upgrade only when the current content
+        // overflows uint32_t offsets. is_large() alone is not the trigger -- it is sticky,
+        // so a column that grew past the limit and then shrank keeps uint64_t storage but
+        // must stay in this class.
+        if (get_immutable_bytes().size() < Column::MAX_CAPACITY_LIMIT) {
             return nullptr;
         }
+        DCHECK(_offsets.is_large());
+
+        auto new_column = BinaryColumnBase<uint64_t>::create();
+        new_column->get_bytes().swap(get_bytes());
+        new_column->get_offset() = std::move(_offsets);
+
+        // Keep the moved-from column internally consistent until the caller replaces it.
+        _offsets.reset();
+        _offsets.emplace_back(0);
+        invalidate_slice_cache();
+        return new_column;
     } else {
         return nullptr;
     }
@@ -1003,67 +1330,61 @@ StatusOr<MutableColumnPtr> BinaryColumnBase<T>::downgrade() {
     if constexpr (std::is_same_v<T, uint32_t>) {
         return nullptr;
     } else {
-        if (get_immutable_bytes().size() >= Column::MAX_CAPACITY_LIMIT) {
+        if (_offsets.back() >= Column::MAX_CAPACITY_LIMIT) {
             return Status::InternalError("column size exceed the limit, can't downgrade");
-        } else {
-            auto new_column = BinaryColumn::create();
-            new_column->get_offset().resize(_offsets.size());
-            new_column->get_bytes().swap(get_bytes());
-
-            for (size_t i = 0; i < _offsets.size(); i++) {
-                new_column->get_offset()[i] = static_cast<uint32_t>(_offsets[i]);
-            }
-            _offsets.resize(0);
-            return new_column;
         }
+
+        auto new_column = BinaryColumn::create();
+        auto& dst_offsets = new_column->get_offset();
+        dst_offsets.resize_uninitialized(_offsets.size(), _offsets.back());
+        Offsets::visit_storage_pair(dst_offsets, _offsets, [&](auto& dst_buf, const auto& src_buf) {
+            using DstValue = typename std::decay_t<decltype(dst_buf)>::value_type;
+            using SrcValue = typename std::decay_t<decltype(src_buf)>::value_type;
+            auto* __restrict dst_offsets_data = dst_buf.data();
+            const auto* __restrict src_offsets = src_buf.data();
+
+            if constexpr (std::is_same_v<SrcValue, DstValue>) {
+                strings::memcpy_inlined(dst_offsets_data, src_offsets, _offsets.size() * sizeof(DstValue));
+            } else {
+                for (size_t i = 0; i < _offsets.size(); i++) {
+                    dst_offsets_data[i] = static_cast<DstValue>(src_offsets[i]);
+                }
+            }
+        });
+
+        new_column->get_bytes().swap(get_bytes());
+
+        // Keep the moved-from column internally consistent until the caller replaces it.
+        _offsets.reset();
+        _offsets.emplace_back(0);
+        invalidate_slice_cache();
+        return new_column;
     }
 }
 
 template <typename T>
 bool BinaryColumnBase<T>::has_large_column() const {
     static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
-
-    if constexpr (std::is_same_v<T, uint64_t>) {
-        return true;
-    } else {
-        return false;
-    }
+    return std::is_same_v<T, uint64_t>;
 }
 
 template <typename T>
 Status BinaryColumnBase<T>::capacity_limit_reached() const {
     static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
-    if constexpr (std::is_same_v<T, uint32_t>) {
-        // The size limit of a single element is 2^32 - 1.
-        // The size limit of all elements is 2^32 - 1.
-        // The number limit of elements is 2^32 - 1.
-        if (get_immutable_bytes().size() >= Column::MAX_CAPACITY_LIMIT) {
-            return Status::CapacityLimitExceed(
-                    strings::Substitute("Total byte size of binary column exceed the limit: $0",
-                                        std::to_string(Column::MAX_CAPACITY_LIMIT)));
-        } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
-            return Status::CapacityLimitExceed(
-                    strings::Substitute("Total row count of binary column exceed the limit: $0",
-                                        std::to_string(Column::MAX_CAPACITY_LIMIT)));
-        } else {
-            return Status::OK();
-        }
-    } else {
-        // The size limit of a single element is 2^32 - 1.
-        // The size limit of all elements is 2^64 - 1.
-        // The number limit of elements is 2^32 - 1.
-        if (get_immutable_bytes().size() >= Column::MAX_LARGE_CAPACITY_LIMIT) {
-            return Status::CapacityLimitExceed(
-                    strings::Substitute("Total byte size of large binary column exceed the limit: $0",
-                                        std::to_string(Column::MAX_LARGE_CAPACITY_LIMIT)));
-        } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
-            return Status::CapacityLimitExceed(
-                    strings::Substitute("Total row count of large binary column exceed the limit: $0",
-                                        std::to_string(Column::MAX_CAPACITY_LIMIT)));
-        } else {
-            return Status::OK();
-        }
+    // The size limit of a single element is 2^32 - 1.
+    // The size limit of all elements is 2^64 - 1.
+    // The number limit of elements is 2^32 - 1.
+    const char* column_name = has_large_column() ? "large binary column" : "binary column";
+    if (get_immutable_bytes().size() >= Column::MAX_LARGE_CAPACITY_LIMIT) {
+        return Status::CapacityLimitExceed(strings::Substitute("Total byte size of $0 exceed the limit: $1",
+                                                               column_name,
+                                                               std::to_string(Column::MAX_LARGE_CAPACITY_LIMIT)));
+    } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
+        return Status::CapacityLimitExceed(strings::Substitute("Total row count of $0 exceed the limit: $1",
+                                                               column_name,
+                                                               std::to_string(Column::MAX_CAPACITY_LIMIT)));
     }
+    return Status::OK();
 }
 
 template class BinaryColumnBase<uint32_t>;

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -130,9 +130,10 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
 }
 
 template <typename T>
-__attribute__((noinline)) void BinaryColumnBase<T>::_append_selective_general(
-        const BinaryColumnBase<T>& src_column, const uint32_t* indexes, uint32_t size, size_t prev_num_offsets,
-        uint64_t dst_begin) {
+__attribute__((noinline)) void BinaryColumnBase<T>::_append_selective_general(const BinaryColumnBase<T>& src_column,
+                                                                              const uint32_t* indexes, uint32_t size,
+                                                                              size_t prev_num_offsets,
+                                                                              uint64_t dst_begin) {
     auto& bytes = get_bytes();
     const auto& src_offsets = src_column.get_offset();
 
@@ -387,8 +388,8 @@ void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_
         for (size_t i = 0; i < size; ++i) {
             const uint32_t row_idx = index;
             const uint64_t row_size = src_offset_data[row_idx + 1] - src_offset_data[row_idx];
-            strings::memcpy_inlined(dest_bytes + _offsets[cur_row_count + i],
-                                    src_bytes + src_offset_data[row_idx], row_size);
+            strings::memcpy_inlined(dest_bytes + _offsets[cur_row_count + i], src_bytes + src_offset_data[row_idx],
+                                    row_size);
         }
     });
 
@@ -434,7 +435,6 @@ StatusOr<MutableColumnPtr> BinaryColumnBase<T>::replicate(const Buffer<uint32_t>
                 pos += bytes_size;
                 dst_offset_data[j + 1] = static_cast<DstValue>(pos);
             }
-
         }
     });
 
@@ -850,16 +850,17 @@ void BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes
             auto& bytes = get_bytes();
             auto* dest_bytes = bytes.data();
             const uint8_t* src_bytes = src_column._data_base();
-            Offsets::visit_storage_pair(dst_offsets_ref, src_offsets_ref, [&](const auto& dst_buf,
-                                                                              const auto& src_buf) {
-                const auto* __restrict dst_offsets = dst_buf.data();
-                const auto* __restrict src_offsets = src_buf.data();
-                for (size_t i = 0; i < replace_num; ++i) {
-                    const size_t src_offset = src_offsets[i];
-                    const size_t str_size = src_offsets[i + 1] - src_offset;
-                    strings::memcpy_inlined(dest_bytes + dst_offsets[indexes[i]], src_bytes + src_offset, str_size);
-                }
-            });
+            Offsets::visit_storage_pair(dst_offsets_ref, src_offsets_ref,
+                                        [&](const auto& dst_buf, const auto& src_buf) {
+                                            const auto* __restrict dst_offsets = dst_buf.data();
+                                            const auto* __restrict src_offsets = src_buf.data();
+                                            for (size_t i = 0; i < replace_num; ++i) {
+                                                const size_t src_offset = src_offsets[i];
+                                                const size_t str_size = src_offsets[i + 1] - src_offset;
+                                                strings::memcpy_inlined(dest_bytes + dst_offsets[indexes[i]],
+                                                                        src_bytes + src_offset, str_size);
+                                            }
+                                        });
             return;
         }
     }
@@ -968,9 +969,9 @@ size_t BinaryColumnBase<T>::filter_range(const Filter& filter, size_t from, size
                 // set offsets, try vectorized
                 for (int i = 0; i < batch_nums; ++i) {
                     // TODO: performance, all sub one same offset ?
-                    offset_data[result_offset + i + 1] =
-                            offset_data[result_offset + i] + offset_data[start_offset + i + 1] -
-                            offset_data[start_offset + i];
+                    offset_data[result_offset + i + 1] = offset_data[result_offset + i] +
+                                                         offset_data[start_offset + i + 1] -
+                                                         offset_data[start_offset + i];
                 }
 
                 result_offset += batch_nums;
@@ -1156,9 +1157,11 @@ void BinaryColumnBase<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size
 }
 
 template <typename Offset>
-__attribute__((noinline)) static void serialize_binary_batch_nullable_impl(
-        uint8_t* dst, uint32_t* __restrict sizes, size_t chunk_size, uint32_t max_one_row_size,
-        const uint8_t* __restrict null_masks, const uint8_t* __restrict base, const Offset* __restrict offsets_data) {
+__attribute__((noinline)) static void serialize_binary_batch_nullable_impl(uint8_t* dst, uint32_t* __restrict sizes,
+                                                                           size_t chunk_size, uint32_t max_one_row_size,
+                                                                           const uint8_t* __restrict null_masks,
+                                                                           const uint8_t* __restrict base,
+                                                                           const Offset* __restrict offsets_data) {
     uint8_t* row = dst;
     for (size_t i = 0; i < chunk_size; ++i) {
         uint8_t* pos = row + sizes[i];
@@ -1380,9 +1383,8 @@ Status BinaryColumnBase<T>::capacity_limit_reached() const {
                                                                column_name,
                                                                std::to_string(Column::MAX_LARGE_CAPACITY_LIMIT)));
     } else if (_offsets.size() >= Column::MAX_CAPACITY_LIMIT) {
-        return Status::CapacityLimitExceed(strings::Substitute("Total row count of $0 exceed the limit: $1",
-                                                               column_name,
-                                                               std::to_string(Column::MAX_CAPACITY_LIMIT)));
+        return Status::CapacityLimitExceed(strings::Substitute(
+                "Total row count of $0 exceed the limit: $1", column_name, std::to_string(Column::MAX_CAPACITY_LIMIT)));
     }
     return Status::OK();
 }

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -255,9 +255,7 @@ public:
 
     void append_default() override { _offsets.emplace_back(_bytes.size()); }
 
-    void append_default(size_t count) override {
-        _offsets.append_empty_values(count);
-    }
+    void append_default(size_t count) override { _offsets.append_empty_values(count); }
 
     StatusOr<MutableColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -20,6 +20,7 @@
 #include <type_traits>
 
 #include "base/string/slice.h"
+#include "column/adaptive_offsets.h"
 #include "column/bytes.h"
 #include "column/column.h"
 #include "column/container_resource.h"
@@ -57,6 +58,21 @@ private:
     bool _is_large = false;
 };
 
+// Serialize the |idx|-th binary value as [uint32_t length][bytes] into |pos| and return the
+// number of bytes written. This is the single definition of the binary serialize wire format:
+// the per-element serialize() and the batch serializers all encode through it, each dispatching
+// the offsets width once at its own boundary.
+template <typename Offset>
+ALWAYS_INLINE uint32_t serialize_binary_element(const Offset* __restrict offsets, size_t idx,
+                                                const uint8_t* __restrict base, uint8_t* pos) {
+    // max size of one string is 2^32, so use uint32_t not Offset
+    const auto offset = offsets[idx];
+    const auto binary_size = static_cast<uint32_t>(offsets[idx + 1] - offset);
+    strings::memcpy_inlined(pos, &binary_size, sizeof(uint32_t));
+    strings::memcpy_inlined(pos + sizeof(uint32_t), base + offset, binary_size);
+    return sizeof(uint32_t) + binary_size;
+}
+
 template <typename T>
 class BinaryColumnBase final : public CowFactory<ColumnFactory<Column, BinaryColumnBase<T>>, BinaryColumnBase<T>> {
     friend class CowFactory<ColumnFactory<Column, BinaryColumnBase<T>>, BinaryColumnBase<T>>;
@@ -64,8 +80,15 @@ class BinaryColumnBase final : public CowFactory<ColumnFactory<Column, BinaryCol
 public:
     using ValueType = Slice;
 
-    using Offset = T;
-    using Offsets = Buffer<T>;
+    /*
+     * Use AdaptiveOffsets instead of Buffer<T> to store offsets, which can automatically promote to uint64_t
+     * when the offset value exceeds UINT32_MAX.
+     * For the compatibility reason, we still reserve the binaryColumn/LargeBinaryColumn interface for the callers,
+     * But we will re-implement them using the newly added AdaptiveOffsets.
+     *
+     * Important NOTE: Even upgrade offset from Buffer<T> -> AdaptiveOffsets, max size of single element is still 2^32 !!!!
+    */
+    using Offsets = AdaptiveOffsets;
     using Byte = uint8_t;
     using Bytes = raw::RawVectorPad16<uint8_t, ColumnAllocator<uint8_t>>;
 
@@ -77,7 +100,7 @@ public:
     // and then we don't need explicitly emplace_back zero value
     BinaryColumnBase() { _offsets.emplace_back(0); }
     // Default value is empty string
-    explicit BinaryColumnBase(size_t size) : _offsets(size + 1, 0) {}
+    explicit BinaryColumnBase(size_t size) { _offsets.resize(size + 1, 0); }
     BinaryColumnBase(Bytes bytes, Offsets offsets) : _bytes(std::move(bytes)), _offsets(std::move(offsets)) {
         if (_offsets.empty()) {
             _offsets.emplace_back(0);
@@ -134,20 +157,34 @@ public:
     size_t type_size() const override { return sizeof(Slice); }
 
     size_t byte_size() const override {
-        size_t data_size = _resource.empty() ? _bytes.size() : _offsets.back();
-        return data_size * sizeof(uint8_t) + _offsets.size() * sizeof(Offset);
+        if (LIKELY(_resource.empty())) {
+            if (LIKELY(!_offsets.is_large())) {
+                const auto& offsets = _offsets.small_storage();
+                return _bytes.size() + offsets.size() * sizeof(uint32_t);
+            }
+            const auto& offsets = _offsets.large_storage();
+            return _bytes.size() + offsets.size() * sizeof(uint64_t);
+        }
+
+        return _offsets.visit_storage([&](const auto& offsets) -> size_t {
+            using OffsetValue = typename std::decay_t<decltype(offsets)>::value_type;
+            return offsets.back() + offsets.size() * sizeof(OffsetValue);
+        });
     }
 
     size_t byte_size(size_t from, size_t size) const override {
         DCHECK_LE(from + size, this->size()) << "Range error";
-        return (_offsets[from + size] - _offsets[from]) + size * sizeof(Offset);
+        return (_offsets[from + size] - _offsets[from]) + size * _offsets.element_size();
     }
 
     size_t byte_size(size_t idx) const override { return _offsets[idx + 1] - _offsets[idx] + sizeof(uint32_t); }
 
     Slice get_slice(size_t idx) const {
         const uint8_t* base = _data_base();
-        return Slice(base + _offsets[idx], _offsets[idx + 1] - _offsets[idx]);
+        return _offsets.visit_storage([&](const auto& offsets) -> Slice {
+            const auto offset = offsets[idx];
+            return Slice(base + offset, offsets[idx + 1] - offset);
+        });
     }
 
     const char* get_string_begin() const { return reinterpret_cast<const char*>(_data_base()); }
@@ -219,7 +256,7 @@ public:
     void append_default() override { _offsets.emplace_back(_bytes.size()); }
 
     void append_default(size_t count) override {
-        _offsets.insert(_offsets.end(), count, static_cast<uint32_t>(_bytes.size()));
+        _offsets.append_empty_values(count);
     }
 
     StatusOr<MutableColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
@@ -231,15 +268,10 @@ public:
     uint32_t max_one_element_serialize_size() const override;
 
     ALWAYS_INLINE uint32_t serialize(size_t idx, uint8_t* pos) const override {
-        // max size of one string is 2^32, so use uint32_t not T
-        auto binary_size = static_cast<uint32_t>(_offsets[idx + 1] - _offsets[idx]);
-        T offset = _offsets[idx];
         const uint8_t* base = _data_base();
-
-        strings::memcpy_inlined(pos, &binary_size, sizeof(uint32_t));
-        strings::memcpy_inlined(pos + sizeof(uint32_t), base + offset, binary_size);
-
-        return sizeof(uint32_t) + binary_size;
+        return _offsets.visit_storage([&](const auto& offsets) -> uint32_t {
+            return serialize_binary_element(offsets.data(), idx, base, pos);
+        });
     }
 
     size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, uint32_t max_row_size,
@@ -277,7 +309,6 @@ public:
         return p;
     }
 
-    MutableColumnPtr cut(size_t start, size_t length) const;
     size_t filter_range(const Filter& filter, size_t start, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
@@ -338,7 +369,7 @@ public:
 
     size_t container_memory_usage() const override {
         size_t bytes_memory = _resource.empty() ? _bytes.capacity() : 0;
-        return bytes_memory + _offsets.capacity() * sizeof(_offsets[0]);
+        return bytes_memory + _offsets.memory_usage();
     }
 
     size_t reference_memory_usage(size_t from, size_t size) const override { return 0; }
@@ -385,8 +416,9 @@ public:
     void build_slices(Container& slices) const;
 
 private:
-    template <typename SrcOffset>
-    void _append_binary_impl(const BinaryColumnBase<SrcOffset>& src, size_t offset, size_t count);
+    void _append_binary_impl(const Offsets& src_offsets, const uint8_t* src_base, size_t offset, size_t count);
+    void _append_selective_general(const BinaryColumnBase<T>& src_column, const uint32_t* indexes, uint32_t size,
+                                   size_t prev_num_offsets, uint64_t dst_begin);
 
     void _build_german_strings() const;
     void _ensure_materialized();

--- a/be/src/column/column_builder.h
+++ b/be/src/column/column_builder.h
@@ -148,15 +148,16 @@ public:
     // reserve bytes_size bytes for Bytes. size of offsets
     // and null_column are deterministic, so proper memory
     // room can be allocated, but bytes' size is non-deterministic,
-    // so just reserve moderate memory room. offsets need no
-    // initialization(raw::make_room), because it is overwritten
-    // fully. null_columns should be zero-out(resize), just
-    // slot corresponding to null elements is marked to 1.
+    // so just reserve moderate memory room. Offset slots are initialized so
+    // scalar set() remains promotion-safe even when bytes_size is only an estimate.
+    // null_columns should be zero-out(resize), just slot corresponding to null
+    // elements is marked to 1.
     void resize(size_t num_rows, size_t bytes_size) {
         _column->get_bytes().reserve(bytes_size);
         auto& offsets = _column->get_offset();
-        raw::make_room(&offsets, num_rows + 1);
-        offsets[0] = 0;
+        offsets.ensure_width_for_value(bytes_size);
+        offsets.resize(num_rows + 1, 0);
+        offsets.set(0, 0);
         _null_column->get_data().resize(num_rows);
     }
 
@@ -166,21 +167,21 @@ public:
         Bytes& bytes = _column->get_bytes();
         Offsets& offsets = _column->get_offset();
         NullColumn::Container& nulls = _null_column->get_data();
-        offsets[i + 1] = bytes.size();
+        offsets.set(i + 1, bytes.size());
         nulls[i] = 1;
     }
 
     void append_empty(size_t i) {
         Bytes& bytes = _column->get_bytes();
         Offsets& offsets = _column->get_offset();
-        offsets[i + 1] = bytes.size();
+        offsets.set(i + 1, bytes.size());
     }
 
     void append(uint8_t* begin, uint8_t* end, size_t i) {
         Bytes& bytes = _column->get_bytes();
         Offsets& offsets = _column->get_offset();
         bytes.insert(bytes.end(), begin, end);
-        offsets[i + 1] = bytes.size();
+        offsets.set(i + 1, bytes.size());
     }
     // for concat and concat_ws, several columns are concatenated
     // together into a string, so append must be invoked as many times
@@ -202,7 +203,7 @@ public:
     void append_complete(size_t i) {
         Bytes& bytes = _column->get_bytes();
         Offsets& offsets = _column->get_offset();
-        offsets[i + 1] = bytes.size();
+        offsets.set(i + 1, bytes.size());
     }
 
     // move current ptr backwards for n bytes, used in concat_ws

--- a/be/src/column/column_hash/column_hash.cpp
+++ b/be/src/column/column_hash/column_hash.cpp
@@ -237,17 +237,21 @@ public:
         const auto& offsets = column.get_offset();
         const auto& bytes = column.get_immutable_bytes();
         const auto column_size = column.size();
-        _selector.for_each([&](uint32_t idx) {
-            // Skip out-of-bounds indices (preserve hash seed)
-            if (idx >= column_size) {
-                return;
-            }
-            uint32_t* slot_ptr = slot(idx);
-            auto len = offsets[idx + 1] - offsets[idx];
-            // For empty strings, don't modify the hash (hash with 0 bytes preserves the seed)
-            if (len > 0) {
-                *slot_ptr = HashFunction::hash(bytes.data() + offsets[idx], static_cast<int32_t>(len), *slot_ptr);
-            }
+        offsets.visit_storage([&](const auto& offsets_buf) {
+            const auto* __restrict offset_data = offsets_buf.data();
+            _selector.for_each([&](uint32_t idx) {
+                // Skip out-of-bounds indices (preserve hash seed)
+                if (idx >= column_size) {
+                    return;
+                }
+                uint32_t* slot_ptr = slot(idx);
+                auto len = offset_data[idx + 1] - offset_data[idx];
+                // For empty strings, don't modify the hash (hash with 0 bytes preserves the seed)
+                if (len > 0) {
+                    *slot_ptr = HashFunction::hash(bytes.data() + offset_data[idx], static_cast<int32_t>(len),
+                                                   *slot_ptr);
+                }
+            });
         });
         return Status::OK();
     }

--- a/be/src/column/column_hash/column_hash.cpp
+++ b/be/src/column/column_hash/column_hash.cpp
@@ -248,8 +248,8 @@ public:
                 auto len = offset_data[idx + 1] - offset_data[idx];
                 // For empty strings, don't modify the hash (hash with 0 bytes preserves the seed)
                 if (len > 0) {
-                    *slot_ptr = HashFunction::hash(bytes.data() + offset_data[idx], static_cast<int32_t>(len),
-                                                   *slot_ptr);
+                    *slot_ptr =
+                            HashFunction::hash(bytes.data() + offset_data[idx], static_cast<int32_t>(len), *slot_ptr);
                 }
             });
         });

--- a/be/src/column/segmented_chunk.cpp
+++ b/be/src/column/segmented_chunk.cpp
@@ -15,6 +15,7 @@
 #include "column/segmented_chunk.h"
 
 #include <algorithm>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -114,9 +115,9 @@ public:
         }
 #endif
 
-        output_offsets.resize(_size + 1);
         size_t num_bytes = 0;
         size_t from = _from;
+        auto str_sizes = std::make_unique_for_overwrite<size_t[]>(_size);
         for (size_t i = 0; i < _size; i++) {
             size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
@@ -124,23 +125,35 @@ public:
             DCHECK_LT(segment_offset, columns[segment_id]->size());
 
             const Offsets& src_offsets = *input_offsets[segment_id];
-            Offset str_size = src_offsets[segment_offset + 1] - src_offsets[segment_offset];
+            const size_t str_size = src_offsets[segment_offset + 1] - src_offsets[segment_offset];
 
-            output_offsets[i + 1] = output_offsets[i] + str_size;
+            str_sizes[i] = str_size;
             num_bytes += str_size;
         }
+        output_offsets.resize_uninitialized(_size + 1, num_bytes);
+        output_offsets.visit_storage([&](auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            offsets_buf[0] = 0;
+            uint64_t offset = 0;
+            for (size_t i = 0; i < _size; i++) {
+                offset += str_sizes[i];
+                offsets_buf[i + 1] = static_cast<OffsetValue>(offset);
+            }
+        });
         output_bytes.resize(num_bytes);
 
         Byte* dest_bytes = output_bytes.data();
+        size_t dest_offset = 0;
         for (size_t i = 0; i < _size; i++) {
             size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
             const Byte* src_bytes = input_bytes[segment_id];
             const Offsets& src_offsets = *input_offsets[segment_id];
-            Offset str_size = src_offsets[segment_offset + 1] - src_offsets[segment_offset];
+            const size_t str_size = str_sizes[i];
             const Byte* str_data = src_bytes + src_offsets[segment_offset];
 
-            strings::memcpy_inlined(dest_bytes + output_offsets[i], str_data, str_size);
+            strings::memcpy_inlined(dest_bytes + dest_offset, str_data, str_size);
+            dest_offset += str_size;
         }
 
 #ifndef NDEBUG

--- a/be/src/column/sorting/sort_permute.cpp
+++ b/be/src/column/sorting/sort_permute.cpp
@@ -178,25 +178,40 @@ public:
         slices.reserve(_perm.size());
         size_t added_bytes = 0;
 
-        for (auto& p : _perm) {
-            Slice slice = down_cast<const BinaryColumnBase<T>*>(_columns[PermTraits::chunk(p)])
-                                  ->get_slice(PermTraits::index(p));
-            added_bytes += slice.get_size();
-            slices.push_back(slice);
+        if constexpr (std::is_same_v<typename PermRange::value_type, SmallPermuteItem>) {
+            const auto* src_column = down_cast<const ColumnType*>(_columns[0]);
+            for (auto& p : _perm) {
+                Slice slice = src_column->get_slice(p.index_in_chunk);
+                added_bytes += slice.get_size();
+                slices.push_back(slice);
+            }
+        } else {
+            for (auto& p : _perm) {
+                Slice slice = down_cast<const BinaryColumnBase<T>*>(_columns[PermTraits::chunk(p)])
+                                      ->get_slice(PermTraits::index(p));
+                added_bytes += slice.get_size();
+                slices.push_back(slice);
+            }
         }
-
-        bytes.resize(bytes.size() + added_bytes);
-        offsets.reserve(offsets.size() + _perm.size());
 
         DCHECK(!offsets.empty());
-        auto curr_offset = offsets.back();
+        const size_t old_offsets_size = offsets.size();
+        uint64_t curr_offset = offsets.back();
+        bytes.resize(bytes.size() + added_bytes);
+        offsets.resize_uninitialized(old_offsets_size + _perm.size(), curr_offset + added_bytes);
         auto* const byte_ptr = bytes.data();
 
-        for (Slice slice : slices) {
-            strings::memcpy_inlined(byte_ptr + curr_offset, slice.get_data(), slice.get_size());
-            curr_offset += slice.get_size();
-            offsets.push_back(curr_offset);
-        }
+        offsets.visit_storage([&](auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            auto* __restrict dst_offsets = offsets_buf.data() + old_offsets_size;
+
+            for (size_t i = 0; i < slices.size(); ++i) {
+                Slice slice = slices[i];
+                strings::memcpy_inlined(byte_ptr + curr_offset, slice.get_data(), slice.get_size());
+                curr_offset += slice.get_size();
+                dst_offsets[i] = static_cast<OffsetValue>(curr_offset);
+            }
+        });
 
         dst->invalidate_slice_cache();
 

--- a/be/src/data_workflows/load/push_broker_reader.cpp
+++ b/be/src/data_workflows/load/push_broker_reader.cpp
@@ -155,7 +155,7 @@ ColumnPtr PushBrokerReader::_padding_char_column(const ColumnPtr& column, const 
                                                  size_t num_rows) {
     const Column* data_column = ColumnHelper::get_data_column(column.get());
     const auto* binary = down_cast<const BinaryColumn*>(data_column);
-    const auto offsets = binary->get_offset();
+    const auto& offsets = binary->get_offset();
     uint32_t len = slot_desc->type().len;
 
     // Padding 0 to CHAR field, the storage bitmap index and zone map need it.
@@ -165,16 +165,20 @@ ColumnPtr PushBrokerReader::_padding_char_column(const ColumnPtr& column, const 
     new_offset.resize(num_rows + 1);
     new_bytes.assign(num_rows * len, 0); // padding 0
 
-    uint32_t from = 0;
+    size_t from = 0;
     auto bytes = binary->get_immutable_bytes();
-    for (size_t i = 0; i < num_rows; ++i) {
-        uint32_t copy_data_len = std::min(len, offsets[i + 1] - offsets[i]);
-        strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offsets[i], copy_data_len);
-        from += len; // no copy data will be 0
-    }
+    offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offset_data = offsets_buf.data();
+        for (size_t i = 0; i < num_rows; ++i) {
+            size_t copy_data_len = std::min<size_t>(len, offset_data[i + 1] - offset_data[i]);
+            strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[i], copy_data_len);
+            from += len; // no copy data will be 0
+        }
+    });
 
+    new_offset.set(0, 0);
     for (size_t i = 1; i <= num_rows; ++i) {
-        new_offset[i] = len * i;
+        new_offset.set(i, static_cast<uint64_t>(len) * i);
     }
 
     if (slot_desc->is_nullable()) {

--- a/be/src/data_workflows/load/push_broker_reader.cpp
+++ b/be/src/data_workflows/load/push_broker_reader.cpp
@@ -176,7 +176,6 @@ ColumnPtr PushBrokerReader::_padding_char_column(const ColumnPtr& column, const 
         }
     });
 
-    new_offset.set(0, 0);
     for (size_t i = 1; i <= num_rows; ++i) {
         new_offset.set(i, static_cast<uint64_t>(len) * i);
     }

--- a/be/src/exec/data_sinks/tablet_sink.cpp
+++ b/be/src/exec/data_sinks/tablet_sink.cpp
@@ -1172,22 +1172,25 @@ namespace {
 // the memcpy entirely: their padding is already correct because the buffer is zeroed.
 void pad_char_values(const Offsets& offset, const Bytes& bytes, uint32_t len, size_t num_rows, const uint8_t* null_data,
                      Bytes& new_bytes) {
-    uint32_t from = 0;
-    if (null_data != nullptr && SIMD::count_nonzero(null_data, num_rows) > num_rows / 8) {
-        for (size_t j = 0; j < num_rows; ++j) {
-            if (!null_data[j]) {
-                uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-                strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
+    size_t from = 0;
+    offset.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offset_data = offsets_buf.data();
+        if (null_data != nullptr && SIMD::count_nonzero(null_data, num_rows) > num_rows / 8) {
+            for (size_t j = 0; j < num_rows; ++j) {
+                if (!null_data[j]) {
+                    size_t copy_data_len = std::min<size_t>(len, offset_data[j + 1] - offset_data[j]);
+                    strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[j], copy_data_len);
+                }
+                from += len;
             }
-            from += len;
+        } else {
+            for (size_t j = 0; j < num_rows; ++j) {
+                size_t copy_data_len = std::min<size_t>(len, offset_data[j + 1] - offset_data[j]);
+                strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[j], copy_data_len);
+                from += len;
+            }
         }
-    } else {
-        for (size_t j = 0; j < num_rows; ++j) {
-            uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-            strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
-            from += len;
-        }
-    }
+    });
 }
 } // namespace
 
@@ -1217,7 +1220,7 @@ void OlapTableSink::_padding_char_column(Chunk* chunk) {
             pad_char_values(offset, bytes, len, num_rows, null_data, new_bytes);
 
             for (size_t j = 1; j <= num_rows; ++j) {
-                new_offset[j] = len * j;
+                new_offset.set(j, static_cast<uint64_t>(len) * j);
             }
 
             if (desc->is_nullable()) {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -255,7 +255,7 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
         size_t offset_size = dict->dictionaryOffset.size();
         size_t dict_size = offset_size - 1;
         const int64_t* offset_data = dict->dictionaryOffset.data();
-        offsets.resize(offset_size);
+        offsets.resize_uninitialized(offset_size, content_size);
 
         if (slot_desc->type().type == TYPE_CHAR) {
             // for char type, dict strings are also padded with spaces.
@@ -269,15 +269,15 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
                 size_t old_size = offset_data[i + 1] - offset_data[i];
                 size_t new_size = remove_trailing_spaces(s, old_size);
                 bytes.insert(bytes.end(), s, s + new_size);
-                offsets[i] = total_size;
+                offsets.set(i, total_size);
                 total_size += new_size;
             }
-            offsets[dict_size] = total_size;
+            offsets.set(dict_size, total_size);
         } else {
             bytes.insert(bytes.end(), start, end);
             // type mismatch, have to use loop to assign.
             for (size_t i = 0; i < offset_size; i++) {
-                offsets[i] = offset_data[i];
+                offsets.set(i, offset_data[i]);
             }
         }
 

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/hdfs_scanner/jni_scanner.h"
 
+#include <type_traits>
 #include <utility>
 
 #include "base/utility/defer_op.h"
@@ -177,9 +178,17 @@ Status JniScanner::_append_string_data(const FillColumnArgs& args) {
 
     int total_length = offset_ptr[args.num_rows];
     bytes.resize(total_length);
-    offsets.resize(args.num_rows + 1);
-
-    memcpy(offsets.data(), offset_ptr, (args.num_rows + 1) * sizeof(uint32_t));
+    offsets.resize_uninitialized(args.num_rows + 1, total_length);
+    offsets.visit_storage([&](auto& offsets_buf) {
+        using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+        if constexpr (std::is_same_v<OffsetValue, uint32_t>) {
+            memcpy(offsets_buf.data(), offset_ptr, (args.num_rows + 1) * sizeof(uint32_t));
+        } else {
+            for (size_t i = 0; i <= args.num_rows; ++i) {
+                offsets_buf[i] = static_cast<uint64_t>(offset_ptr[i]);
+            }
+        }
+    });
     memcpy(bytes.data(), column_ptr, total_length);
     return Status::OK();
 }

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -139,9 +139,12 @@ size_t JoinHashMapSelector::_get_binary_column_max_size(RuntimeState* state, con
     auto bytes = binary_column->get_immutable_bytes();
 
     bool has_tail_zero = false;
-    for (size_t i = offsets.size() - 1; i > 0 && offsets[i] > 0; i--) {
-        has_tail_zero |= bytes[offsets[i] - 1] == 0;
-    }
+    offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offset_data = offsets_buf.data();
+        for (size_t i = offsets_buf.size() - 1; i > 0 && offset_data[i] > 0; i--) {
+            has_tail_zero |= bytes[offset_data[i] - 1] == 0;
+        }
+    });
     if (has_tail_zero) {
         return 0;
     }

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -188,8 +188,10 @@ public:
         size_t old_size = bytes.size();
 
         size_t one_element_size = sizeof(ImmediateType) + sizeof(int64_t);
-        bytes.resize(one_element_size * chunk_size);
-        dst_column->get_offset().resize(chunk_size + 1);
+        const size_t final_size = old_size + one_element_size * chunk_size;
+        bytes.resize(final_size);
+        auto& offsets = dst_column->get_offset();
+        offsets.resize(chunk_size + 1);
 
         [[maybe_unused]] const auto* src_column = down_cast<const InputColumnType*>(src[0].get());
         int64_t count = 1;
@@ -211,7 +213,7 @@ public:
             memcpy(bytes.data() + old_size, &result, sizeof(ImmediateType));
             memcpy(bytes.data() + old_size + sizeof(ImmediateType), &count, sizeof(int64_t));
             old_size += one_element_size;
-            dst_column->get_offset()[i + 1] = old_size;
+            offsets.set(i + 1, old_size);
         }
     }
 

--- a/be/src/exprs/agg/covariance.h
+++ b/be/src/exprs/agg/covariance.h
@@ -169,8 +169,10 @@ public:
         if constexpr (isCorelation) {
             one_element_size += (sizeof(double) * 2);
         }
-        bytes.resize(one_element_size * chunk_size);
-        dst_column->get_offset().resize(chunk_size + 1);
+        const size_t final_size = old_size + one_element_size * chunk_size;
+        bytes.resize(final_size);
+        auto& offsets = dst_column->get_offset();
+        offsets.resize(chunk_size + 1);
 
         const auto* src_column0 = down_cast<const InputColumnType*>(src[0].get());
         const auto* src_column1 = down_cast<const InputColumnType*>(src[1].get());
@@ -197,8 +199,7 @@ public:
                        sizeof(double));
             }
             old_size += one_element_size;
-
-            dst_column->get_offset()[i + 1] = old_size;
+            offsets.set(i + 1, old_size);
         }
     }
 };

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -510,36 +510,35 @@ public:
         Bytes& bytes = dst_column->get_bytes();
 
         const auto* src_column = down_cast<const ColumnType*>(src[0].get());
-        if constexpr (IsSlice<T>) {
-            bytes.reserve(chunk_size * (sizeof(uint32_t) + src_column->get_slice(0).size));
-        } else {
-            bytes.reserve(chunk_size * sizeof(T));
-        }
-        dst_column->get_offset().resize(chunk_size + 1);
-
         size_t old_size = bytes.size();
+
+        size_t final_size = old_size;
+        if constexpr (IsSlice<T>) {
+            for (size_t i = 0; i < chunk_size; ++i) {
+                final_size += sizeof(uint32_t) + src_column->get_slice(i).size;
+            }
+        } else {
+            final_size += chunk_size * sizeof(T);
+        }
+
+        bytes.resize(final_size);
+        auto& offsets = dst_column->get_offset();
+        offsets.resize(chunk_size + 1);
+
         for (size_t i = 0; i < chunk_size; ++i) {
             if constexpr (IsSlice<T>) {
                 Slice key = src_column->get_slice(i);
-                size_t new_size = old_size + key.size + sizeof(uint32_t);
-                bytes.resize(new_size);
-
                 auto size = (uint32_t)key.size;
                 memcpy(bytes.data() + old_size, &size, sizeof(uint32_t));
                 old_size += sizeof(uint32_t);
                 memcpy(bytes.data() + old_size, key.data, key.size);
                 old_size += key.size;
-                dst_column->get_offset()[i + 1] = new_size;
             } else {
                 T key = src_column->immutable_data()[i];
-
-                size_t new_size = old_size + sizeof(T);
-                bytes.resize(new_size);
                 memcpy(bytes.data() + old_size, &key, sizeof(T));
-
-                dst_column->get_offset()[i + 1] = new_size;
-                old_size = new_size;
+                old_size += sizeof(T);
             }
+            offsets.set(i + 1, old_size);
         }
     }
 

--- a/be/src/exprs/agg/ds_hll_count_distinct.h
+++ b/be/src/exprs/agg/ds_hll_count_distinct.h
@@ -150,7 +150,7 @@ public:
             bytes.resize(new_size);
             hll.serialize(bytes.data() + old_size);
 
-            result->get_offset()[i + 1] = new_size;
+            result->get_offset().set(i + 1, new_size);
             old_size = new_size;
         }
     }

--- a/be/src/exprs/agg/ds_theta_count_distinct.h
+++ b/be/src/exprs/agg/ds_theta_count_distinct.h
@@ -136,7 +136,7 @@ public:
             bytes.resize(new_size);
             theta.serialize(bytes.data() + old_size);
 
-            result->get_offset()[i + 1] = new_size;
+            result->get_offset().set(i + 1, new_size);
             old_size = new_size;
         }
     }

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -250,14 +250,14 @@ public:
                     auto& offsets = dst_column->get_offset();
                     offsets.resize_uninitialized(chunk_size + 1, new_size);
 
-                    Offsets::visit_storage_pair(offsets, column_value->get_offset(),
-                                                [&](auto& offsets_buf, const auto& value_offsets) {
-                        column_sep->get_offset().visit_storage([&](const auto& sep_offsets) {
-                            serialize_column_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
-                                                        column_value->get_string_begin(), sep_offsets,
-                                                        column_sep->get_string_begin());
-                        });
-                    });
+                    Offsets::visit_storage_pair(
+                            offsets, column_value->get_offset(), [&](auto& offsets_buf, const auto& value_offsets) {
+                                column_sep->get_offset().visit_storage([&](const auto& sep_offsets) {
+                                    serialize_column_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
+                                                                column_value->get_string_begin(), sep_offsets,
+                                                                column_sep->get_string_begin());
+                                });
+                            });
                     DCHECK_EQ(old_size, new_size);
                 }
             } else {
@@ -271,12 +271,12 @@ public:
                     auto& offsets = dst_column->get_offset();
                     offsets.resize_uninitialized(chunk_size + 1, new_size);
 
-                    Offsets::visit_storage_pair(offsets, column_value->get_offset(),
-                                                [&](auto& offsets_buf, const auto& value_offsets) {
-                        serialize_const_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
-                                                   column_value->get_string_begin(), sep.get_data(),
-                                                   static_cast<uint32_t>(sep.size));
-                    });
+                    Offsets::visit_storage_pair(
+                            offsets, column_value->get_offset(), [&](auto& offsets_buf, const auto& value_offsets) {
+                                serialize_const_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
+                                                           column_value->get_string_begin(), sep.get_data(),
+                                                           static_cast<uint32_t>(sep.size));
+                            });
                     DCHECK_EQ(old_size, new_size);
                 }
             }
@@ -297,11 +297,11 @@ public:
                 auto& offsets = dst_column->get_offset();
                 offsets.resize_uninitialized(chunk_size + 1, new_size);
 
-                Offsets::visit_storage_pair(offsets, column_value->get_offset(),
-                                            [&](auto& offsets_buf, const auto& value_offsets) {
-                    serialize_const_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
-                                               column_value->get_string_begin(), sep, size_sep);
-                });
+                Offsets::visit_storage_pair(
+                        offsets, column_value->get_offset(), [&](auto& offsets_buf, const auto& value_offsets) {
+                            serialize_const_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
+                                                       column_value->get_string_begin(), sep, size_sep);
+                        });
                 DCHECK_EQ(old_size, new_size);
             }
         }

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 #include "base/string/utf8.h"
 #include "column/array_column.h"
@@ -196,6 +197,42 @@ public:
         return old_size;
     }
 
+    template <typename DstOffsets, typename ValueOffsets, typename SepOffsets>
+    void serialize_column_sep_values(Bytes& bytes, size_t& old_size, size_t chunk_size, DstOffsets& dst_offsets,
+                                     const ValueOffsets& value_offsets, const char* value_base,
+                                     const SepOffsets& sep_offsets, const char* sep_base) const {
+        using DstOffset = typename std::decay_t<DstOffsets>::value_type;
+        dst_offsets[0] = 0;
+        for (size_t i = 0; i < chunk_size; ++i) {
+            const uint64_t value_begin = value_offsets[i];
+            const uint64_t value_end = value_offsets[i + 1];
+            const uint64_t sep_begin = sep_offsets[i];
+            const uint64_t sep_end = sep_offsets[i + 1];
+            const auto size_value = static_cast<uint32_t>(value_end - value_begin);
+            const auto size_sep = static_cast<uint32_t>(sep_end - sep_begin);
+
+            old_size = serialize_sep_and_value(bytes, old_size, size_value, size_sep, sep_base + sep_begin,
+                                               value_base + value_begin);
+            dst_offsets[i + 1] = static_cast<DstOffset>(old_size);
+        }
+    }
+
+    template <typename DstOffsets, typename ValueOffsets>
+    void serialize_const_sep_values(Bytes& bytes, size_t& old_size, size_t chunk_size, DstOffsets& dst_offsets,
+                                    const ValueOffsets& value_offsets, const char* value_base, const char* sep,
+                                    uint32_t size_sep) const {
+        using DstOffset = typename std::decay_t<DstOffsets>::value_type;
+        dst_offsets[0] = 0;
+        for (size_t i = 0; i < chunk_size; ++i) {
+            const uint64_t value_begin = value_offsets[i];
+            const uint64_t value_end = value_offsets[i + 1];
+            const auto size_value = static_cast<uint32_t>(value_end - value_begin);
+
+            old_size = serialize_sep_and_value(bytes, old_size, size_value, size_sep, sep, value_base + value_begin);
+            dst_offsets[i + 1] = static_cast<DstOffset>(old_size);
+        }
+    }
+
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
         if (src.size() > 1) {
@@ -210,19 +247,18 @@ public:
                     size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_immutable_bytes().size() +
                                       column_sep->get_immutable_bytes().size();
                     bytes.resize(new_size);
-                    dst_column->get_offset().resize(chunk_size + 1);
+                    auto& offsets = dst_column->get_offset();
+                    offsets.resize_uninitialized(chunk_size + 1, new_size);
 
-                    for (size_t i = 0; i < chunk_size; ++i) {
-                        auto value = column_value->get_slice(i);
-                        auto sep = column_sep->get_slice(i);
-
-                        uint32_t size_value = value.get_size();
-                        uint32_t size_sep = sep.get_size();
-
-                        old_size = serialize_sep_and_value(bytes, old_size, size_value, size_sep, sep.get_data(),
-                                                           value.get_data());
-                        dst_column->get_offset()[i + 1] = old_size;
-                    }
+                    Offsets::visit_storage_pair(offsets, column_value->get_offset(),
+                                                [&](auto& offsets_buf, const auto& value_offsets) {
+                        column_sep->get_offset().visit_storage([&](const auto& sep_offsets) {
+                            serialize_column_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
+                                                        column_value->get_string_begin(), sep_offsets,
+                                                        column_sep->get_string_begin());
+                        });
+                    });
+                    DCHECK_EQ(old_size, new_size);
                 }
             } else {
                 Slice sep = ColumnHelper::get_const_value<TYPE_VARCHAR>(src[1]);
@@ -232,18 +268,16 @@ public:
                     size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_immutable_bytes().size() +
                                       chunk_size * sep.size;
                     bytes.resize(new_size);
-                    dst_column->get_offset().resize(chunk_size + 1);
+                    auto& offsets = dst_column->get_offset();
+                    offsets.resize_uninitialized(chunk_size + 1, new_size);
 
-                    for (size_t i = 0; i < chunk_size; ++i) {
-                        auto value = column_value->get_slice(i);
-
-                        uint32_t size_value = value.get_size();
-                        uint32_t size_sep = sep.size;
-
-                        old_size = serialize_sep_and_value(bytes, old_size, size_value, size_sep, sep.get_data(),
-                                                           value.get_data());
-                        dst_column->get_offset()[i + 1] = old_size;
-                    }
+                    Offsets::visit_storage_pair(offsets, column_value->get_offset(),
+                                                [&](auto& offsets_buf, const auto& value_offsets) {
+                        serialize_const_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
+                                                   column_value->get_string_begin(), sep.get_data(),
+                                                   static_cast<uint32_t>(sep.size));
+                    });
+                    DCHECK_EQ(old_size, new_size);
                 }
             }
         } else { //", "
@@ -260,15 +294,15 @@ public:
                 size_t new_size = 2 * chunk_size * sizeof(uint32_t) + column_value->get_immutable_bytes().size() +
                                   size_sep * chunk_size;
                 bytes.resize(new_size);
-                dst_column->get_offset().resize(chunk_size + 1);
+                auto& offsets = dst_column->get_offset();
+                offsets.resize_uninitialized(chunk_size + 1, new_size);
 
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    auto value = column_value->get_slice(i);
-                    uint32_t size_value = value.get_size();
-
-                    old_size = serialize_sep_and_value(bytes, old_size, size_value, size_sep, sep, value.get_data());
-                    dst_column->get_offset()[i + 1] = old_size;
-                }
+                Offsets::visit_storage_pair(offsets, column_value->get_offset(),
+                                            [&](auto& offsets_buf, const auto& value_offsets) {
+                    serialize_const_sep_values(bytes, old_size, chunk_size, offsets_buf, value_offsets,
+                                               column_value->get_string_begin(), sep, size_sep);
+                });
+                DCHECK_EQ(old_size, new_size);
             }
         }
     }

--- a/be/src/exprs/agg/hll_ndv.h
+++ b/be/src/exprs/agg/hll_ndv.h
@@ -110,9 +110,10 @@ public:
 
         Bytes& bytes = result->get_bytes();
         bytes.reserve(chunk_size * 10);
-        result->get_offset().resize(chunk_size + 1);
-
         size_t old_size = bytes.size();
+        auto& offsets = result->get_offset();
+        offsets.resize(chunk_size + 1);
+
         for (size_t i = 0; i < chunk_size; ++i) {
             HyperLogLog hll;
             uint64_t value = HashUtil::murmur_hash64A<T>(datas[i], HashUtil::MURMUR_SEED);
@@ -123,8 +124,7 @@ public:
             size_t new_size = old_size + hll.max_serialized_size();
             bytes.resize(new_size);
             hll.serialize(bytes.data() + old_size);
-
-            result->get_offset()[i + 1] = new_size;
+            offsets.set(i + 1, new_size);
             old_size = new_size;
         }
     }

--- a/be/src/exprs/agg/intersect_count.h
+++ b/be/src/exprs/agg/intersect_count.h
@@ -142,7 +142,7 @@ public:
         const auto* key_column = down_cast<const InputColumnType*>(src[1].get());
 
         // compute bytes for serialization for this chunk.
-        int new_size = 0;
+        size_t new_size = 0;
         std::vector<BitmapIntersect<BitmapRuntimeCppType<LT>>> intersect_chunks;
         intersect_chunks.reserve(chunk_size);
         for (int i = 0; i < chunk_size; ++i) {
@@ -168,16 +168,17 @@ public:
         auto* dst_column = down_cast<BinaryColumn*>(dst.get());
         Bytes& bytes = dst_column->get_bytes();
         size_t old_size = bytes.size();
-        bytes.resize(new_size);
-
-        dst_column->get_offset().resize(chunk_size + 1);
+        const size_t final_size = old_size + new_size;
+        bytes.resize(final_size);
+        auto& offsets = dst_column->get_offset();
+        offsets.resize(chunk_size + 1);
 
         // serialize for every row of this chunk.
         for (int i = 0; i < chunk_size; ++i) {
             auto& intersect = intersect_chunks[i];
             intersect.serialize(reinterpret_cast<char*>(bytes.data() + old_size));
             old_size += intersect.size();
-            dst_column->get_offset()[i + 1] = old_size;
+            offsets.set(i + 1, old_size);
         }
     }
 

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <numeric>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include "base/utility/defer_op.h"
@@ -313,26 +312,17 @@ public:
         auto& serialized_bytes = serialized_column->get_bytes();
         const auto& offsets = serialized_column->get_offset();
 
-        if (serialized_bytes.size() > std::numeric_limits<int>::max()) {
-            ctx->set_error("serialized column size is too large");
+        const size_t java_max_buffer_size = std::numeric_limits<int>::max();
+        if (offsets.is_large() || offsets.back() > java_max_buffer_size ||
+            serialized_bytes.size() > java_max_buffer_size ||
+            offsets.size() > java_max_buffer_size / sizeof(uint32_t)) {
+            ctx->set_error("Java UDAF does not support BinaryColumn with large offsets or bytes");
             return;
         }
 
-        auto buffer_array = offsets.visit_storage([&](const auto& offsets_buf) -> jobject {
-            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
-            if constexpr (std::is_same_v<OffsetValue, uint32_t>) {
-                return helper.batch_create_bytebuf(serialized_bytes.data(), offsets_buf.data(), start, start + size);
-            } else {
-                // Sticky-large storage whose values are already bounded by the INT_MAX check
-                // above: materialize uint32_t offsets for the JNI ABI.
-                Buffer<uint32_t> u32_offsets;
-                u32_offsets.resize(offsets_buf.size());
-                for (size_t i = 0; i < offsets_buf.size(); ++i) {
-                    u32_offsets[i] = static_cast<uint32_t>(offsets_buf[i]);
-                }
-                return helper.batch_create_bytebuf(serialized_bytes.data(), u32_offsets.data(), start, start + size);
-            }
-        });
+        const auto& offsets_buf = offsets.small_storage();
+        auto buffer_array =
+                helper.batch_create_bytebuf(serialized_bytes.data(), offsets_buf.data(), start, start + size);
         RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         // batch call merge

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "base/utility/defer_op.h"
@@ -317,7 +318,21 @@ public:
             return;
         }
 
-        auto buffer_array = helper.batch_create_bytebuf(serialized_bytes.data(), offsets.data(), start, start + size);
+        auto buffer_array = offsets.visit_storage([&](const auto& offsets_buf) -> jobject {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            if constexpr (std::is_same_v<OffsetValue, uint32_t>) {
+                return helper.batch_create_bytebuf(serialized_bytes.data(), offsets_buf.data(), start, start + size);
+            } else {
+                // Sticky-large storage whose values are already bounded by the INT_MAX check
+                // above: materialize uint32_t offsets for the JNI ABI.
+                Buffer<uint32_t> u32_offsets;
+                u32_offsets.resize(offsets_buf.size());
+                for (size_t i = 0; i < offsets_buf.size(); ++i) {
+                    u32_offsets[i] = static_cast<uint32_t>(offsets_buf[i]);
+                }
+                return helper.batch_create_bytebuf(serialized_bytes.data(), u32_offsets.data(), start, start + size);
+            }
+        });
         RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         // batch call merge

--- a/be/src/exprs/agg/maxmin_by.h
+++ b/be/src/exprs/agg/maxmin_by.h
@@ -518,7 +518,7 @@ public:
         size_t new_size = old_size;
         for (size_t i = 0; i < chunk_size; ++i) {
             if (src[1]->is_null(i)) {
-                result->get_offset()[i + 1] = old_size;
+                result->get_offset().set(i + 1, old_size);
                 DCHECK(dst->is_nullable());
                 down_cast<NullableColumn*>(dst.get())->set_has_null(true);
             } else {
@@ -572,7 +572,7 @@ public:
                         data_column->serialize(i, p);
                     }
                 }
-                result->get_offset()[i + 1] = new_size;
+                result->get_offset().set(i + 1, new_size);
                 old_size = new_size;
             }
         }
@@ -770,7 +770,7 @@ public:
             if (src[1]->is_null(i)) {
                 auto* dst_nullable_column = down_cast<NullableColumn*>(dst.get());
                 dst_nullable_column->set_has_null(true);
-                result->get_offset()[i + 1] = old_size;
+                result->get_offset().set(i + 1, old_size);
             } else {
                 size_t new_size = old_size;
                 auto is_null = src[0]->only_null() || src[0]->is_null(i);
@@ -815,7 +815,7 @@ public:
                     p += sizeof(size_t);
                     data_column->serialize(i, p);
                 }
-                result->get_offset()[i + 1] = new_size;
+                result->get_offset().set(i + 1, new_size);
                 old_size = new_size;
             }
         }

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -161,7 +161,7 @@ public:
             memcpy(bytes.data() + old_size, &quantile, sizeof(double));
             percentile.serialize(bytes.data() + old_size + sizeof(double));
 
-            result->get_offset()[i + 1] = new_size;
+            result->get_offset().set(i + 1, new_size);
             old_size = new_size;
         }
     }
@@ -249,7 +249,7 @@ public:
                     memcpy(bytes.data() + old_size, &quantile, sizeof(double));
                     percentile.serialize(bytes.data() + old_size + sizeof(double));
                     old_size = new_size;
-                    result->get_offset()[i + 1] = new_size;
+                    result->get_offset().set(i + 1, new_size);
                 }
             } else {
                 // TODO: optimize for empty weight but should not happen frequently
@@ -261,7 +261,7 @@ public:
                     memcpy(bytes.data() + old_size, &quantile, sizeof(double));
                     empty_percentile.serialize(bytes.data() + old_size + sizeof(double));
                     old_size = new_size;
-                    result->get_offset()[i + 1] = new_size;
+                    result->get_offset().set(i + 1, new_size);
                 }
             }
         } else {
@@ -278,7 +278,7 @@ public:
                 memcpy(bytes.data() + old_size, &quantile, sizeof(double));
                 percentile.serialize(bytes.data() + old_size + sizeof(double));
                 old_size = new_size;
-                result->get_offset()[i + 1] = new_size;
+                result->get_offset().set(i + 1, new_size);
             }
         }
     }
@@ -431,7 +431,7 @@ public:
             // Write TDigest
             percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
 
-            result->get_offset()[i + 1] = new_size;
+            result->get_offset().set(i + 1, new_size);
             old_size = new_size;
         }
     }
@@ -596,7 +596,7 @@ public:
                     percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
 
                     old_size = new_size;
-                    result->get_offset()[i + 1] = new_size;
+                    result->get_offset().set(i + 1, new_size);
                 }
             } else {
                 // TODO: optimize for empty weight but should not happen frequently
@@ -614,7 +614,7 @@ public:
                     empty_percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
 
                     old_size = new_size;
-                    result->get_offset()[i + 1] = new_size;
+                    result->get_offset().set(i + 1, new_size);
                 }
             }
         } else {
@@ -638,7 +638,7 @@ public:
                 percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
 
                 old_size = new_size;
-                result->get_offset()[i + 1] = new_size;
+                result->get_offset().set(i + 1, new_size);
             }
         }
     }

--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -273,7 +273,12 @@ public:
                 reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t) +
                                                 total_items_size * sizeof(InputCppType)));
 
-        column->get_offset().emplace_back(new_size);
+        auto& offsets = column->get_offset();
+        if (LIKELY(!offsets.is_large() && new_size <= std::numeric_limits<uint32_t>::max())) {
+            offsets.small_storage().emplace_back(static_cast<uint32_t>(new_size));
+        } else {
+            offsets.emplace_back(new_size);
+        }
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,

--- a/be/src/exprs/agg/variance.h
+++ b/be/src/exprs/agg/variance.h
@@ -162,8 +162,10 @@ public:
         size_t old_size = bytes.size();
 
         size_t one_element_size = sizeof(TResult) * 2 + sizeof(int64_t);
-        bytes.resize(one_element_size * chunk_size);
-        dst_column->get_offset().resize(chunk_size + 1);
+        const size_t final_size = old_size + one_element_size * chunk_size;
+        bytes.resize(final_size);
+        auto& offsets = dst_column->get_offset();
+        offsets.resize(chunk_size + 1);
 
         const auto* src_column = down_cast<const InputColumnType*>(src[0].get());
 
@@ -182,7 +184,7 @@ public:
             memcpy(bytes.data() + old_size + sizeof(TResult), &m2, sizeof(TResult));
             memcpy(bytes.data() + old_size + sizeof(TResult) * 2, &count, sizeof(int64_t));
             old_size += one_element_size;
-            dst_column->get_offset()[i + 1] = old_size;
+            offsets.set(i + 1, old_size);
         }
     }
 

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -206,8 +206,10 @@ class RankWindowFunction final : public WindowFunction<RankState> {
                     size_t end) const override {
         DCHECK_GT(end, start);
         auto* column = down_cast<Int64Column*>(dst);
+        auto* data = column->get_data().data();
+        const int64_t rank = this->data(state).rank;
         for (size_t i = start; i < end; ++i) {
-            column->get_data()[i] = this->data(state).rank;
+            data[i] = rank;
         }
     }
 

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <memory>
+#include <type_traits>
 
 #include "base/bit/bit_mask.h"
 #include "base/orlp/pdqsort.h"
@@ -847,33 +848,36 @@ private:
     }
 
     static void _reverse_binary_column(Column* column, const Buffer<uint32_t>& array_offsets, size_t chunk_size) {
-        auto& offsets = down_cast<BinaryColumn*>(column)->get_offset();
-        // convert offset ot size
-        for (size_t i = offsets.size() - 1; i > 0; i--) {
-            offsets[i] = offsets[i] - offsets[i - 1];
-        }
-
-        for (size_t i = 0; i < chunk_size; i++) {
-            size_t begin = array_offsets[i];
-            size_t end = array_offsets[i + 1];
-
-            // revert size
-            std::reverse(offsets.begin() + begin + 1, offsets.begin() + end + 1);
-
-            // convert size to offset
-            for (size_t j = begin; j < end; j++) {
-                offsets[j + 1] = offsets[j] + offsets[j + 1];
+        auto* binary_column = down_cast<BinaryColumn*>(column);
+        auto& offsets = binary_column->get_offset();
+        auto& bytes = binary_column->get_bytes();
+        offsets.visit_storage([&](auto& offsets_buf) {
+            // convert offset ot size
+            for (size_t i = offsets_buf.size() - 1; i > 0; i--) {
+                offsets_buf[i] = offsets_buf[i] - offsets_buf[i - 1];
             }
 
-            // revert all byte of one array
-            auto& bytes = down_cast<BinaryColumn*>(column)->get_bytes();
-            std::reverse(bytes.begin() + offsets[begin], bytes.begin() + offsets[end]);
+            for (size_t i = 0; i < chunk_size; i++) {
+                size_t begin = array_offsets[i];
+                size_t end = array_offsets[i + 1];
 
-            // revert string one by one
-            for (size_t j = begin; j < end; j++) {
-                std::reverse(bytes.begin() + offsets[j], bytes.begin() + offsets[j + 1]);
+                // revert size
+                std::reverse(offsets_buf.begin() + begin + 1, offsets_buf.begin() + end + 1);
+
+                // convert size to offset
+                for (size_t j = begin; j < end; j++) {
+                    offsets_buf[j + 1] = offsets_buf[j] + offsets_buf[j + 1];
+                }
+
+                // revert all byte of one array
+                std::reverse(bytes.begin() + offsets_buf[begin], bytes.begin() + offsets_buf[end]);
+
+                // revert string one by one
+                for (size_t j = begin; j < end; j++) {
+                    std::reverse(bytes.begin() + offsets_buf[j], bytes.begin() + offsets_buf[j + 1]);
+                }
             }
-        }
+        });
     }
 
     static void _reverse_json_column(Column* column, const Buffer<uint32_t>& array_offsets, size_t chunk_size) {
@@ -2291,62 +2295,72 @@ private:
         const char* str_bytes = reinterpret_cast<const char*>(str_column->raw_bytes());
         const uint32_t target_len = static_cast<uint32_t>(target.size);
 
-        size_t j = 0;
-        constexpr int kSimdWidth = SIMD::kStringLenSimdWidth;
+        size_t found = 0;
+        str_offsets.visit_storage([&](const auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            const auto* offsets_data = offsets_buf.data();
+            size_t j = 0;
+            constexpr int kSimdWidth = SIMD::kStringLenSimdWidth;
 
-        for (; j + kSimdWidth <= array_size; j += kSimdWidth) {
-            size_t base = array_offset + j;
+            if constexpr (std::is_same_v<OffsetValue, uint32_t>) {
+                for (; j + kSimdWidth <= array_size; j += kSimdWidth) {
+                    size_t base = array_offset + j;
 
-            if constexpr (CheckNull) {
-                bool all_null = true;
-                for (int k = 0; k < kSimdWidth; k++) {
-                    if (elements_null_data[base + k] == 0) {
-                        all_null = false;
-                        break;
+                    if constexpr (CheckNull) {
+                        bool all_null = true;
+                        for (int k = 0; k < kSimdWidth; k++) {
+                            if (elements_null_data[base + k] == 0) {
+                                all_null = false;
+                                break;
+                            }
+                        }
+                        if (all_null) {
+                            continue;
+                        }
                     }
-                }
-                if (all_null) {
-                    continue;
-                }
-            }
 
-            uint32_t mask = SIMD::length_eq_mask(str_offsets.data(), base, target_len);
-            if (mask == 0) {
-                continue;
-            }
-
-            while (mask) {
-                uint32_t bit = __builtin_ctz(mask);
-                size_t elem_idx = base + bit;
-
-                if constexpr (CheckNull) {
-                    if (elements_null_data[elem_idx]) {
-                        mask &= (mask - 1);
+                    uint32_t mask = SIMD::length_eq_mask(offsets_data, base, target_len);
+                    if (mask == 0) {
                         continue;
                     }
-                }
 
-                const char* elem_ptr = str_bytes + str_offsets[elem_idx];
-                if (memcmp(elem_ptr, target.data, target_len) == 0) {
-                    return j + bit + 1;
+                    while (mask) {
+                        uint32_t bit = __builtin_ctz(mask);
+                        size_t elem_idx = base + bit;
+
+                        if constexpr (CheckNull) {
+                            if (elements_null_data[elem_idx]) {
+                                mask &= (mask - 1);
+                                continue;
+                            }
+                        }
+
+                        const char* elem_ptr = str_bytes + offsets_data[elem_idx];
+                        if (memcmp(elem_ptr, target.data, target_len) == 0) {
+                            found = j + bit + 1;
+                            return;
+                        }
+                        mask &= (mask - 1);
+                    }
                 }
-                mask &= (mask - 1);
             }
-        }
-        for (; j < array_size; j++) {
-            size_t elem_idx = array_offset + j;
-            if constexpr (CheckNull) {
-                if (elements_null_data[elem_idx]) continue;
-            }
-            uint32_t elem_len = str_offsets[elem_idx + 1] - str_offsets[elem_idx];
-            if (elem_len == target_len) {
-                const char* elem_ptr = str_bytes + str_offsets[elem_idx];
-                if (memcmp(elem_ptr, target.data, target_len) == 0) {
-                    return j + 1;
+
+            for (; j < array_size; j++) {
+                size_t elem_idx = array_offset + j;
+                if constexpr (CheckNull) {
+                    if (elements_null_data[elem_idx]) continue;
+                }
+                uint32_t elem_len = offsets_data[elem_idx + 1] - offsets_data[elem_idx];
+                if (elem_len == target_len) {
+                    const char* elem_ptr = str_bytes + offsets_data[elem_idx];
+                    if (memcmp(elem_ptr, target.data, target_len) == 0) {
+                        found = j + 1;
+                        return;
+                    }
                 }
             }
-        }
-        return 0;
+        });
+        return found;
     }
 
     static void _build_hash_table(const ColumnPtr& column, ArrayContainsState* state) {

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1443,7 +1443,7 @@ DEFINE_STRING_UNARY_FN_WITH_IMPL(DoubleCastToString, v) {
         for (int i = 0; i < size; ++i) {                                                                    \
             auto f = fmt::format_int(r1[i]);                                                                \
             bytes.insert(bytes.end(), (uint8_t*)f.data(), (uint8_t*)f.data() + f.size());                   \
-            offset[i + 1] = bytes.size();                                                                   \
+            offset.set(i + 1, bytes.size());                                                               \
         }                                                                                                   \
         return result;                                                                                      \
     }
@@ -1475,13 +1475,13 @@ DEFINE_INT_CAST_TO_STRING(TYPE_BIGINT, TYPE_VARCHAR);
             for (int i = 0; i < size; ++i) {                                                                \
                 r1[i].to_string(dst + off, MAX_LEN);                                                        \
                 off += MAX_LEN;                                                                             \
-                offset[i + 1] = static_cast<uint32_t>(off);                                                 \
+                offset.set(i + 1, off);                                                 \
             }                                                                                               \
         } else {                                                                                            \
             for (int i = 0; i < size; ++i) {                                                                \
                 int len = r1[i].to_string(dst + off, MAX_LEN);                                              \
                 if (LIKELY(len > 0)) off += len;                                                            \
-                offset[i + 1] = static_cast<uint32_t>(off);                                                 \
+                offset.set(i + 1, off);                                                 \
             }                                                                                               \
         }                                                                                                   \
         bytes.resize(off);                                                                                  \

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1475,13 +1475,13 @@ DEFINE_INT_CAST_TO_STRING(TYPE_BIGINT, TYPE_VARCHAR);
             for (int i = 0; i < size; ++i) {                                                                \
                 r1[i].to_string(dst + off, MAX_LEN);                                                        \
                 off += MAX_LEN;                                                                             \
-                offset.set(i + 1, off);                                                 \
+                offset.set(i + 1, off);                                                                     \
             }                                                                                               \
         } else {                                                                                            \
             for (int i = 0; i < size; ++i) {                                                                \
                 int len = r1[i].to_string(dst + off, MAX_LEN);                                              \
                 if (LIKELY(len > 0)) off += len;                                                            \
-                offset.set(i + 1, off);                                                 \
+                offset.set(i + 1, off);                                                                     \
             }                                                                                               \
         }                                                                                                   \
         bytes.resize(off);                                                                                  \

--- a/be/src/exprs/decimal_cast_expr.h
+++ b/be/src/exprs/decimal_cast_expr.h
@@ -404,9 +404,9 @@ struct DecimalNonDecimalCast<overflow_mode, DecimalType, StringType, DecimalLTGu
         auto result = BinaryColumn::create();
         auto& bytes = result->get_bytes();
         auto& offsets = result->get_offset();
-        raw::make_room(&offsets, num_rows + 1);
-        offsets[0] = 0;
         size_t max_length = decimal_precision_limit<DecimalCppType> + 4;
+        offsets.make_room(num_rows + 1, num_rows * max_length);
+        offsets.set(0, 0);
         bytes.resize(num_rows * max_length);
         auto bytes_data = &bytes.front();
         auto data_column = ColumnHelper::cast_to_raw<DecimalType>(column);
@@ -418,7 +418,7 @@ struct DecimalNonDecimalCast<overflow_mode, DecimalType, StringType, DecimalLTGu
             auto s = DecimalV3Cast::to_string<DecimalCppType>(data[i], precision, scale);
             strings::memcpy_inlined(bytes_data + bytes_off, s.data(), s.size());
             bytes_off += s.size();
-            offsets[i + 1] = bytes_off;
+            offsets.set(i + 1, bytes_off);
         }
         bytes.resize(bytes_off);
         return result;

--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -351,38 +351,40 @@ StatusOr<ColumnPtr> LikePredicate::constant_substring_fn(FunctionContext* contex
         size_t type_size = res->type_size();
         memset(res->mutable_raw_data(), 1, res->size() * type_size);
     } else {
-        const Buffer<uint32_t>& offsets = haystack->get_offset();
+        const auto& offsets = haystack->get_offset();
         res->resize(haystack->size());
 
         const char* begin = haystack->get_string_begin();
-        const char* pos = begin;
         const char* end = haystack->get_string_end();
 
-        /// Current index in the array of strings.
-        size_t i = 0;
+        offsets.visit_storage([&](const auto& offsets_buf) {
+            const auto* __restrict offset_data = offsets_buf.data();
+            const char* pos = begin;
 
-        auto searcher = VolnitskyUTF8(needle.data, needle.size, end - pos);
-        /// We will search for the next occurrence in all strings at once.
-        while (pos < end && end != (pos = searcher.search(pos, end - pos))) {
-            /// Determine which index it refers to.
-            while (begin + offsets[i + 1] <= pos) {
-                res->get_data()[i] = false;
+            /// Current index in the array of strings.
+            size_t i = 0;
+
+            auto searcher = VolnitskyUTF8(needle.data, needle.size, end - pos);
+            /// We will search for the next occurrence in all strings at once.
+            while (pos < end && end != (pos = searcher.search(pos, end - pos))) {
+                /// Determine which index it refers to.
+                while (begin + offset_data[i + 1] <= pos) {
+                    res->get_data()[i] = false;
+                    ++i;
+                }
+                const char* row_end = begin + offset_data[i + 1];
+
+                /// We check that the entry does not pass through the boundaries of strings.
+                res->get_data()[i] = pos + needle.size <= row_end;
+                pos = row_end;
                 ++i;
             }
-            /// We check that the entry does not pass through the boundaries of strings.
-            if (pos + needle.size > begin + offsets[i + 1]) {
-                res->get_data()[i] = false;
-            } else {
-                res->get_data()[i] = true;
-            }
-            pos = begin + offsets[i + 1];
-            ++i;
-        }
 
-        if (i < res->size()) {
-            size_t type_size = res->type_size();
-            memset(res->mutable_raw_data() + i * type_size, 0, (res->size() - i) * type_size);
-        }
+            if (i < res->size()) {
+                size_t type_size = res->type_size();
+                memset(res->mutable_raw_data() + i * type_size, 0, (res->size() - i) * type_size);
+            }
+        });
     }
 
     if (columns[0]->has_null()) {

--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -80,28 +80,32 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
         start_pos = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(start_pos_expansion);
     }
 
-    const Buffer<uint32_t>& offsets = haystack->get_offset();
+    const auto& offsets = haystack->get_offset();
     Slice needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_ptr);
     auto res = RunTimeColumnType<TYPE_INT>::create();
     res->resize(haystack->size());
+    auto* __restrict result_data = res->get_data().data();
 
     if (needle.size == 0) {
         // if needle is empty string, at legal start position in haystack
-        for (size_t i = 0; i < haystack->size(); ++i) {
-            int32_t start = start_pos->get_data()[i];
-            if (start <= 0) {
-                // start is zero or negative, the result is zero
-                res->get_data()[i] = 0;
-            } else if (start == 1) {
-                // needle and haystack are all empty, the result is one
-                res->get_data()[i] = 1;
-            } else if (start > offsets[i + 1] - offsets[i]) {
-                // start larger than haystack size, the result is zero
-                res->get_data()[i] = 0;
-            } else {
-                res->get_data()[i] = start;
+        offsets.visit_storage([&](const auto& offsets_buf) {
+            const auto* __restrict offset_data = offsets_buf.data();
+            for (size_t i = 0; i < haystack->size(); ++i) {
+                int32_t start = start_pos->get_data()[i];
+                if (start <= 0) {
+                    // start is zero or negative, the result is zero
+                    result_data[i] = 0;
+                } else if (start == 1) {
+                    // needle and haystack are all empty, the result is one
+                    result_data[i] = 1;
+                } else if (start > offset_data[i + 1] - offset_data[i]) {
+                    // start larger than haystack size, the result is zero
+                    result_data[i] = 0;
+                } else {
+                    result_data[i] = start;
+                }
             }
-        }
+        });
         if (res_null != nullptr) {
             return NullableColumn::create(std::move(res), std::move(res_null));
         } else {
@@ -109,43 +113,49 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
         }
     }
 
-    const char* begin = haystack->get_slice(0).data;
-    const char* pos = begin;
-    const char* end = pos + haystack->get_immutable_bytes().size();
+    const char* begin = haystack->get_string_begin();
+    const char* end = haystack->get_string_end();
 
-    /// Current index in the array of strings.
-    size_t i = 0;
+    offsets.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offset_data = offsets_buf.data();
+        const char* pos = begin;
 
-    auto searcher = LocateCaseSensitiveUTF8::createSearcherInBigHaystack(needle.data, needle.size, end - pos);
+        /// Current index in the array of strings.
+        size_t i = 0;
 
-    /// We will search for the next occurrence in all strings at once.
-    while (pos < end && end != (pos = searcher.search(pos, end - pos))) {
-        /// Determine which index it refers to.
-        while (begin + offsets[i + 1] <= pos) {
-            res->get_data()[i] = 0;
+        auto searcher = LocateCaseSensitiveUTF8::createSearcherInBigHaystack(needle.data, needle.size, end - pos);
+
+        /// We will search for the next occurrence in all strings at once.
+        while (pos < end && end != (pos = searcher.search(pos, end - pos))) {
+            /// Determine which index it refers to.
+            while (begin + offset_data[i + 1] <= pos) {
+                result_data[i] = 0;
+                ++i;
+            }
+            int32_t start = start_pos->get_data()[i];
+            const char* row_begin = begin + offset_data[i];
+            const char* row_end = begin + offset_data[i + 1];
+
+            /// We check that the entry does not pass through the boundaries of strings.
+            if (start <= 0 || pos + needle.size > row_end) {
+                result_data[i] = 0;
+            } else {
+                size_t res_pos = 1 + utf8_len(row_begin, pos);
+                if (res_pos < start) {
+                    pos = skip_leading_utf8(pos, row_end, start - res_pos);
+                    continue;
+                }
+                result_data[i] = res_pos;
+            }
+            pos = row_end;
             ++i;
         }
-        int32_t start = start_pos->get_data()[i];
 
-        /// We check that the entry does not pass through the boundaries of strings.
-        if (start <= 0 || pos + needle.size > begin + offsets[i + 1]) {
-            res->get_data()[i] = 0;
-        } else {
-            size_t res_pos = 1 + utf8_len(begin + offsets[i], pos);
-            if (res_pos < start) {
-                pos = skip_leading_utf8(pos, begin + offsets[i + 1], start - res_pos);
-                continue;
-            }
-            res->get_data()[i] = res_pos;
+        if (i < res->size()) {
+            size_t type_size = res->type_size();
+            memset(res->mutable_raw_data() + i * type_size, 0, (res->size() - i) * type_size);
         }
-        pos = begin + offsets[i + 1];
-        ++i;
-    }
-
-    if (i < res->size()) {
-        size_t type_size = res->type_size();
-        memset(res->mutable_raw_data() + i * type_size, 0, (res->size() - i) * type_size);
-    }
+    });
 
     if (res_null != nullptr) {
         return NullableColumn::create(std::move(res), std::move(res_null));

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -279,8 +279,8 @@ static inline void ascii_substr(const BinaryColumn* src, Bytes* bytes, Offsets* 
         for (size_t i = 0; i < size; ++i) {
             auto s = src->get_slice(i);
             ascii_substr_per_slice<off_is_negative, allow_out_of_left_bound>(
-                    &s, off, len, binary_column_empty_op_fast<DstOffset>,
-                    binary_column_non_empty_op_fast<DstOffset>, bytes, dst_offset_data, i);
+                    &s, off, len, binary_column_empty_op_fast<DstOffset>, binary_column_non_empty_op_fast<DstOffset>,
+                    bytes, dst_offset_data, i);
         }
     });
 }

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include "base/container/raw_container.h"
 #include "base/crypto/sm3.h"
@@ -81,7 +82,14 @@ static const RE2 FIXED_LITERAL_RE(R"(^[^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]+$)", re2::
     THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(VARNAME_LINENUM(res), func_name); \
     return VARNAME_LINENUM(res);
 
+// 4 GiB cap for speculative initial byte-buffer reservations in string functions.
+constexpr size_t STRING_FUNCTION_INITIAL_RESERVE_LIMIT = static_cast<size_t>(UINT32_MAX) + 1;
+// 16 MiB threshold for concat/concat_ws small-output fast paths.
 constexpr size_t CONCAT_SMALL_OPTIMIZE_THRESHOLD = 16 << 20;
+
+static inline size_t capped_string_function_initial_reserve(size_t size) {
+    return std::min(size, STRING_FUNCTION_INITIAL_RESERVE_LIMIT);
+}
 
 // ascii_substr_per_slice can compute substr directly via pointer arithmetics
 // if s is an ASCII string, so it is faster than its utf8 counterparts significantly.
@@ -242,23 +250,39 @@ static inline void utf8_substr_from_right_per_slice(Slice* s, int off, int len, 
 }
 
 static inline void binary_column_empty_op(Bytes* bytes, Offsets* offsets, size_t i) {
-    (*offsets)[i + 1] = bytes->size();
+    offsets->set(i + 1, bytes->size());
 }
 
 static inline void binary_column_non_empty_op(uint8_t* begin, uint8_t* end, Bytes* bytes, Offsets* offsets, size_t i) {
     bytes->insert(bytes->end(), begin, end);
-    (*offsets)[i + 1] = bytes->size();
+    offsets->set(i + 1, bytes->size());
+}
+
+template <typename OffsetValue>
+static inline void binary_column_empty_op_fast(Bytes* bytes, OffsetValue* offsets, size_t i) {
+    offsets[i + 1] = static_cast<OffsetValue>(bytes->size());
+}
+
+template <typename OffsetValue>
+static inline void binary_column_non_empty_op_fast(uint8_t* begin, uint8_t* end, Bytes* bytes, OffsetValue* offsets,
+                                                   size_t i) {
+    bytes->insert(bytes->end(), begin, end);
+    offsets[i + 1] = static_cast<OffsetValue>(bytes->size());
 }
 
 template <bool off_is_negative, bool allow_out_of_left_bound>
 static inline void ascii_substr(const BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
     const auto size = src->size();
-    size_t i = 0;
-    for (; i < size; ++i) {
-        auto s = src->get_slice(i);
-        ascii_substr_per_slice<off_is_negative, allow_out_of_left_bound>(&s, off, len, binary_column_empty_op,
-                                                                         binary_column_non_empty_op, bytes, offsets, i);
-    }
+    offsets->visit_storage([&](auto& dst_offsets) {
+        using DstOffset = typename std::decay_t<decltype(dst_offsets)>::value_type;
+        auto* __restrict dst_offset_data = dst_offsets.data();
+        for (size_t i = 0; i < size; ++i) {
+            auto s = src->get_slice(i);
+            ascii_substr_per_slice<off_is_negative, allow_out_of_left_bound>(
+                    &s, off, len, binary_column_empty_op_fast<DstOffset>,
+                    binary_column_non_empty_op_fast<DstOffset>, bytes, dst_offset_data, i);
+        }
+    });
 }
 
 static inline void utf8_substr_from_left(const BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
@@ -436,9 +460,9 @@ ColumnPtr substr_const_not_null(const Columns& columns, const BinaryColumn* src,
         return result;
     }
 
+    // The size of substr result never exceeds the counterpart of the source column.
+    size_t reserved = src->get_immutable_bytes().size();
     if (len > 0) {
-        // the size of substr result never exceeds the counterpart of the source column.
-        size_t reserved = src->get_immutable_bytes().size();
         // when start pos is negative, the result of substr take last abs(pos) chars,
         // thus length of the result is less than abs(pos) and len.
         int min_len = len;
@@ -449,11 +473,11 @@ ColumnPtr substr_const_not_null(const Columns& columns, const BinaryColumn* src,
         if (INT_MAX / min_len > size) {
             reserved = std::min(min_len * size, reserved);
         }
-        bytes.reserve(reserved);
+        bytes.reserve(capped_string_function_initial_reserve(reserved));
     }
 
-    raw::make_room(&offsets, size + 1);
-    offsets[0] = 0;
+    offsets.make_room(size + 1, reserved);
+    offsets.set(0, 0);
 
     auto src_bytes = src->get_immutable_bytes();
     auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes.size());
@@ -499,9 +523,9 @@ ColumnPtr right_const_not_null(const Columns& columns, const BinaryColumn* src, 
         reserved = std::min(reserved, size * len);
     }
 
-    bytes.reserve(reserved);
-    raw::make_room(&offsets, size + 1);
-    offsets[0] = 0;
+    bytes.reserve(capped_string_function_initial_reserve(reserved));
+    offsets.make_room(size + 1, reserved);
+    offsets.set(0, 0);
     auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes_size);
     if (is_ascii) {
         // off_is_negative=true, off=-len
@@ -691,7 +715,7 @@ static inline ColumnPtr substr_not_const(FunctionContext* context, const starroc
 
     const auto rows_num = columns[0]->size();
     NullableBinaryColumnBuilder result;
-    result.resize(rows_num, src->byte_size());
+    result.resize(rows_num, capped_string_function_initial_reserve(src->byte_size()));
 
     auto src_bytes = src->get_immutable_bytes();
     auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes.size());
@@ -715,7 +739,7 @@ static inline ColumnPtr right_not_const(FunctionContext* context, const starrock
 
     auto src_bytes = src->get_immutable_bytes();
     auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes.size());
-    result.resize(rows_num, src->byte_size());
+    result.resize(rows_num, capped_string_function_initial_reserve(src->byte_size()));
 
     if (is_ascii) {
         ascii_right_not_const(rows_num, &str_viewer, &len_viewer, &result);
@@ -800,20 +824,20 @@ public:
         auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
         auto& nulls = builder.get_null_data();
 
-        raw::make_room(&dst_offsets, num_rows + 1);
-        dst_offsets[0] = 0;
+        dst_offsets.resize(num_rows + 1);
+        dst_offsets.set(0, 0);
         nulls.resize(num_rows);
         bool has_null = false;
         size_t dst_off = 0;
         for (auto i = 0; i < num_rows; ++i) {
             auto len = len_array[i];
             if (UNLIKELY((uint32_t)len > get_olap_string_max_length())) {
-                dst_offsets[i + 1] = dst_off;
+                dst_offsets.set(i + 1, dst_off);
                 has_null = true;
                 nulls[i] = 1;
             } else {
                 dst_off += len;
-                dst_offsets[i + 1] = dst_off;
+                dst_offsets.set(i + 1, dst_off);
             }
         }
         dst_bytes.resize(dst_off, ' ');
@@ -899,8 +923,6 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
         dst_offsets.resize(num_rows + 1);
         return builder.build(ColumnHelper::is_all_const(columns));
     } else {
-        raw::make_room(&dst_offsets, num_rows + 1);
-        dst_offsets[0] = 0;
         size_t reserved = static_cast<size_t>(times) * src_offsets.back();
         if (reserved > get_olap_string_max_length() * num_rows) {
             reserved = 0;
@@ -911,6 +933,8 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
                 }
             }
         }
+        dst_offsets.make_room(num_rows + 1, reserved);
+        dst_offsets.set(0, 0);
         dst_bytes.resize(reserved);
     }
 
@@ -919,7 +943,7 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
     for (auto i = 0; i < num_rows; ++i) {
         auto s = src->get_slice(i);
         if (s.size == 0) {
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
         // if result exceed STRING_MAX_LENGTH
@@ -927,14 +951,14 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
         if (s.size * times > get_olap_string_max_length()) {
             dst_nulls[i] = 1;
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
         fast_repeat(dst_curr, (uint8_t*)s.data, s.size, times);
         const size_t dst_slice_size = s.size * times;
         dst_curr += dst_slice_size;
         dst_off += dst_slice_size;
-        dst_offsets[i + 1] = dst_off;
+        dst_offsets.set(i + 1, dst_off);
     }
 
     dst_bytes.resize(dst_off);
@@ -956,8 +980,8 @@ static inline ColumnPtr repeat_not_const(const Columns& columns) {
     auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
     auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     dst_nulls.resize(num_rows);
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.resize(num_rows + 1);
+    dst_offsets.set(0, 0);
 
     bool has_null = false;
     size_t dst_off = 0;
@@ -966,12 +990,12 @@ static inline ColumnPtr repeat_not_const(const Columns& columns) {
         if (str_viewer.is_null(i) || times_viewer.is_null(i)) {
             dst_nulls[i] = 1;
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
 
         if (str_viewer.value(i).size == 0 || times_viewer.value(i) <= 0) {
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
 
@@ -981,12 +1005,12 @@ static inline ColumnPtr repeat_not_const(const Columns& columns) {
         if (s.size * n > get_olap_string_max_length()) {
             dst_nulls[i] = 1;
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
 
         dst_off += n * s.size;
-        dst_offsets[i + 1] = dst_off;
+        dst_offsets.set(i + 1, dst_off);
     }
 
     dst_bytes.resize(dst_off);
@@ -1208,10 +1232,10 @@ static inline ColumnPtr translate_with_ascii_const_nonnull_from_and_to(const Col
         return dst;
     }
 
-    const int num_src_bytes = src_offsets.back();
+    const size_t num_src_bytes = src_offsets.back();
     dst_bytes.resize(num_src_bytes);
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.make_room(num_rows + 1, num_src_bytes);
+    dst_offsets.set(0, 0);
 
     uint8_t* dst_begin = dst_bytes.data();
     size_t dst_offset = 0;
@@ -1221,7 +1245,7 @@ static inline ColumnPtr translate_with_ascii_const_nonnull_from_and_to(const Col
         const Slice s = src->get_slice(i);
         size_t num_row_bytes = translate_string_with_ascii_map(s, ascii_map, dst_begin + dst_offset);
         dst_offset += num_row_bytes;
-        dst_offsets[i + 1] = dst_offset;
+        dst_offsets.set(i + 1, dst_offset);
     }
 
     dst_bytes.resize(dst_offset);
@@ -1258,13 +1282,13 @@ static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Colu
     }
 
     const auto& src_offsets = src->get_offset();
-    const int num_src_bytes = src_offsets.back();
+    const size_t num_src_bytes = src_offsets.back();
     // The `dst_bytes` can be at most four times larger than `src_bytes`, as in the worst-case scenario, each
     // `src_bytes` corresponds to a one-byte UTF-8 character, while each dst_bytes is replaced by a four-byte
     // UTF-8 character.
     dst_bytes.reserve(std::min<size_t>(16ULL, num_src_bytes * 4));
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.resize(num_rows + 1);
+    dst_offsets.set(0, 0);
     dst_nulls.resize(num_rows);
 
     bool has_null = false;
@@ -1285,11 +1309,11 @@ static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Colu
         const auto [is_null, num_row_bytes] = translate_string_with_utf8_map(src_encoded_values, utf8_map, dst_begin);
         if (is_null) {
             has_null = true;
-            dst_offsets[i + 1] = dst_offset;
+            dst_offsets.set(i + 1, dst_offset);
             dst_nulls[i] = 1;
         } else {
             dst_offset += num_row_bytes;
-            dst_offsets[i + 1] = dst_offset;
+            dst_offsets.set(i + 1, dst_offset);
         }
     }
 
@@ -1327,10 +1351,10 @@ ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const Tran
     }
 
     const auto& src_offsets = src_viewer.column()->get_offset();
-    const int num_src_bytes = src_offsets.back();
+    const size_t num_src_bytes = src_offsets.back();
     dst_bytes.reserve(std::min<size_t>(16ULL, num_src_bytes * 4));
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.resize(num_rows + 1);
+    dst_offsets.set(0, 0);
     dst_nulls.resize(num_rows);
 
     bool has_null = false;
@@ -1341,7 +1365,7 @@ ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const Tran
     for (int i = 0; i < num_rows; i++) {
         if (src_viewer.is_null(i) || from_viewer.is_null(i) || to_viewer.is_null(i)) {
             has_null = true;
-            dst_offsets[i + 1] = dst_offset;
+            dst_offsets.set(i + 1, dst_offset);
             dst_nulls[i] = 1;
             continue;
         }
@@ -1356,7 +1380,7 @@ ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const Tran
             size_t num_row_bytes =
                     translate_string_with_ascii_map(src, local_state.ascii_map, dst_bytes.data() + dst_offset);
             dst_offset += num_row_bytes;
-            dst_offsets[i + 1] = dst_offset;
+            dst_offsets.set(i + 1, dst_offset);
         } else {
             src_encoded_values.clear();
             src_encoded_values.reserve(src.size);
@@ -1369,11 +1393,11 @@ ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const Tran
                     translate_string_with_utf8_map(src_encoded_values, local_state.utf8_map, dst_begin);
             if (is_null) {
                 has_null = true;
-                dst_offsets[i + 1] = dst_offset;
+                dst_offsets.set(i + 1, dst_offset);
                 dst_nulls[i] = 1;
             } else {
                 dst_offset += num_row_bytes;
-                dst_offsets[i + 1] = dst_offset;
+                dst_offsets.set(i + 1, dst_offset);
             }
         }
     }
@@ -1457,8 +1481,8 @@ static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, const Bina
     auto& dst_bytes = result->get_bytes();
 
     dst_bytes.resize(num_rows * len);
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.make_room(num_rows + 1, static_cast<uint64_t>(num_rows) * len);
+    dst_offsets.set(0, 0);
 
     uint8_t* dst_begin = dst_bytes.data();
     size_t dst_off = 0;
@@ -1469,7 +1493,7 @@ static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, const Bina
         if (s.size >= len) {
             strings::memcpy_inlined(dst_begin + dst_off, s.data, len);
             dst_off += len;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
         const size_t fill_len = len - s.size;
@@ -1492,7 +1516,7 @@ static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, const Bina
             dst_off += s.size;
         }
 
-        dst_offsets[i + 1] = dst_off;
+        dst_offsets.set(i + 1, dst_off);
     }
     dst_bytes.resize(dst_off);
     return result;
@@ -1510,8 +1534,8 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
     auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
     auto& dst_nulls = builder.get_null_data();
 
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.resize(num_rows + 1);
+    dst_offsets.set(0, 0);
 
     Bytes dst_bytes;
     dst_bytes.reserve(16ULL << 20);
@@ -1530,7 +1554,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
                 dst_bytes.resize(dst_off + real_len);
                 strings::memcpy_inlined(dst_bytes.data() + dst_off, s.data, real_len);
                 dst_off += real_len;
-                dst_offsets[i + 1] = dst_off;
+                dst_offsets.set(i + 1, dst_off);
                 continue;
             }
             fill_len = len - skipped_chars;
@@ -1540,7 +1564,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
                 dst_bytes.resize(dst_off + len);
                 strings::memcpy_inlined(dst_bytes.data() + dst_off, s.data, len);
                 dst_off += len;
-                dst_offsets[i + 1] = dst_off;
+                dst_offsets.set(i + 1, dst_off);
                 continue;
             }
             fill_len = len - s.size;
@@ -1561,7 +1585,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
         if (dst_slice_size > get_olap_string_max_length()) {
             dst_nulls[i] = 1;
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
 
@@ -1582,7 +1606,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
             strings::memcpy_inlined(dst_begin + dst_off, s.data, s.size);
             dst_off += s.size;
         }
-        dst_offsets[i + 1] = dst_off;
+        dst_offsets.set(i + 1, dst_off);
     }
     dst_bytes.resize(dst_off);
     builder.data_column_raw_ptr()->get_bytes().swap(reinterpret_cast<Bytes&>(dst_bytes));
@@ -1662,7 +1686,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
         // NULL if any [str, len, pad] is NULL
         if (str_viewer.is_null(i) || len_viewer.is_null(i) || fill_viewer.is_null(i)) {
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             dst_nulls[i] = 1;
             continue;
         }
@@ -1671,13 +1695,13 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
         // NULL if len < 0 || len > get_olap_string_max_length()
         if ((uint32)len > get_olap_string_max_length()) {
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             dst_nulls[i] = 1;
             continue;
         }
         // empty string if len = 0
         if (len == 0) {
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
         auto str = str_viewer.value(i);
@@ -1695,7 +1719,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
                 dst_bytes.resize(dst_off + len);
                 strings::memcpy_inlined(dst_bytes.data() + dst_off, str.data, len);
                 dst_off += len;
-                dst_offsets[i + 1] = dst_off;
+                dst_offsets.set(i + 1, dst_off);
                 continue;
             }
             fill_len = len - str.size;
@@ -1708,7 +1732,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
                 dst_bytes.resize(dst_off + real_len);
                 strings::memcpy_inlined(dst_bytes.data() + dst_off, str.data, real_len);
                 dst_off += real_len;
-                dst_offsets[i + 1] = dst_off;
+                dst_offsets.set(i + 1, dst_off);
                 continue;
             }
             fill_len = len - skipped_chars;
@@ -1720,7 +1744,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
             dst_bytes.resize(dst_off + str.size);
             strings::memcpy_inlined(dst_bytes.data() + dst_off, str.data, str.size);
             dst_off += str.size;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
 
@@ -1731,7 +1755,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
         // result is oversize, return NULL
         if (dst_slice_size > get_olap_string_max_length()) {
             has_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             dst_nulls[i] = 1;
             continue;
         }
@@ -1755,7 +1779,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
             strings::memcpy_inlined(dst_begin + dst_off, str.data, str.size);
             dst_off += str.size;
         }
-        dst_offsets[i + 1] = dst_off;
+        dst_offsets.set(i + 1, dst_off);
     }
     DCHECK(dst_bytes.size() == dst_off);
     builder.data_column_raw_ptr()->get_bytes().swap(reinterpret_cast<Bytes&>(dst_bytes));
@@ -1861,7 +1885,7 @@ StatusOr<ColumnPtr> StringFunctions::append_trailing_char_if_absent(FunctionCont
 
         dst_data.resize(src_data.size() + row_num);
         dst_offsets.resize(row_num + 1);
-        dst_offsets[0] = 0;
+        dst_offsets.set(0, 0);
 
         size_t src_offset = 0;
         size_t dst_offset = 0;
@@ -1882,7 +1906,7 @@ StatusOr<ColumnPtr> StringFunctions::append_trailing_char_if_absent(FunctionCont
                 ++dst_offset;
             }
 
-            dst_offsets[row + 1] = dst_offset;
+            dst_offsets.set(row + 1, dst_offset);
         }
         if (!dst_data.empty()) {
             dst_data.resize(dst_offsets.back());
@@ -1988,7 +2012,7 @@ void utf8_case_toggle(ImmBytes src_bytes, const Offsets& src_offsets, Bytes* dst
     size_t current_dst_size = dst_bytes->size();
 
     size_t current_offset = 0;
-    (*dst_offsets)[0] = 0;
+    dst_offsets->set(0, 0);
     for (size_t i = 0; i < num_rows; i++) {
         const auto* src_data = reinterpret_cast<const char*>(src_bytes.data() + src_offsets[i]);
         size_t src_len = src_offsets[i + 1] - src_offsets[i];
@@ -2024,7 +2048,7 @@ void utf8_case_toggle(ImmBytes src_bytes, const Offsets& src_offsets, Bytes* dst
             throw std::runtime_error(fmt::format("Failed to convert case: {}", u_errorName(err_code)));
         }
         current_offset += dst_size;
-        (*dst_offsets)[i + 1] = current_offset;
+        dst_offsets->set(i + 1, current_offset);
     };
     dst_bytes->resize(current_offset);
 }
@@ -2038,7 +2062,7 @@ ColumnPtr StringCaseToggleFunction<to_upper>::evaluate(const ColumnPtr& v1) {
     auto dst = RunTimeColumnType<TYPE_VARCHAR>::create();
     auto& dst_offsets = dst->get_offset();
     auto& dst_bytes = dst->get_bytes();
-    dst_offsets.assign(src_offsets.begin(), src_offsets.end());
+    dst_offsets = src_offsets;
     if constexpr (to_upper) {
         vectorized_toggle_case<'a', 'z'>(src_bytes, &dst_bytes);
     } else {
@@ -2065,7 +2089,7 @@ public:
         auto& dst_offsets = dst->get_offset();
         auto& dst_bytes = dst->get_bytes();
         if (validate_ascii_fast(reinterpret_cast<const char*>(src_bytes.data()), src_bytes.size())) {
-            dst_offsets.assign(src_offsets.begin(), src_offsets.end());
+            dst_offsets = src_offsets;
             // if all characters are ascii, we process them with the fast path
             if constexpr (to_upper) {
                 vectorized_toggle_case<'a', 'z'>(src_bytes, &dst_bytes);
@@ -2209,7 +2233,7 @@ struct ReverseFunction {
         auto& dst_bytes = result->get_bytes();
         auto& dst_offsets = result->get_offset();
 
-        dst_offsets.assign(src_offsets.begin(), src_offsets.end());
+        dst_offsets = src_offsets;
         dst_bytes.resize(src_bytes.size());
 
         const auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes.size());
@@ -2337,7 +2361,7 @@ static inline void trim_per_slice(const BinaryColumn* src, const size_t i, Bytes
                                   [[maybe_unused]] size_t* trailing_spaces_num) {
     auto s = src->get_slice(i);
     if (UNLIKELY(s.size == 0)) {
-        (*offsets)[i + 1] = bytes->size();
+        offsets->set(i + 1, bytes->size());
         return;
     }
 
@@ -2365,7 +2389,7 @@ static inline void trim_per_slice(const BinaryColumn* src, const size_t i, Bytes
     }
 
     bytes->insert(bytes->end(), (uint8*)from_ptr, (uint8*)to_ptr);
-    (*offsets)[i + 1] = bytes->size();
+    offsets->set(i + 1, bytes->size());
 }
 
 template <TrimType trim_type, size_t simd_threshold, bool trim_single, bool trim_utf8>
@@ -2379,9 +2403,10 @@ struct AdaptiveTrimFunction {
         auto& dst_bytes = dst->get_bytes();
 
         const auto num_rows = src->size();
-        raw::make_room(&dst_offsets, num_rows + 1);
-        dst_offsets[0] = 0;
-        dst_bytes.reserve(src->get_immutable_bytes().size());
+        const auto src_bytes_size = src->get_immutable_bytes().size();
+        dst_offsets.make_room(num_rows + 1, src_bytes_size);
+        dst_offsets.set(0, 0);
+        dst_bytes.reserve(capped_string_function_initial_reserve(src_bytes_size));
 
         size_t i = 0;
         const auto sample_num = std::min(num_rows, 100ul);
@@ -2516,8 +2541,8 @@ struct SubstrTrimFunction {
         auto& dst_bytes = dst->get_bytes();
 
         const auto num_rows = src->size();
-        raw::make_room(&dst_offsets, num_rows + 1);
-        dst_offsets[0] = 0;
+        dst_offsets.make_room(num_rows + 1, src->get_immutable_bytes().size());
+        dst_offsets.set(0, 0);
         dst_bytes.reserve(src->get_immutable_bytes().size());
 
         const char* rdata = remstr.data();
@@ -2543,7 +2568,7 @@ struct SubstrTrimFunction {
                 }
             }
             dst_bytes.insert(dst_bytes.end(), (uint8_t*)from, (uint8_t*)to);
-            dst_offsets[i + 1] = dst_bytes.size();
+            dst_offsets.set(i + 1, dst_bytes.size());
         }
         return dst;
     }
@@ -2989,8 +3014,8 @@ static inline ColumnPtr concat_const_not_null(Columns const& columns, const Bina
     auto is_null = false;
 
     const auto num_rows = src->size();
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.resize(num_rows + 1);
+    dst_offsets.set(0, 0);
     nulls.resize(num_rows);
 
     auto& tail = state->tail;
@@ -3003,12 +3028,12 @@ static inline ColumnPtr concat_const_not_null(Columns const& columns, const Bina
         const auto dst_slice_size = s.size + tail_size;
         if (LIKELY(dst_slice_size <= get_olap_string_max_length())) {
             dst_off += dst_slice_size;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
         } else {
             // return NULL for an oversize result
             nulls[i] = 1;
             is_null = true;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
         }
     }
 
@@ -3042,8 +3067,8 @@ static inline ColumnPtr concat_not_const_small(std::vector<ColumnViewer<TYPE_VAR
     auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
     auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     dst_nulls.resize(num_rows);
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.make_room(num_rows + 1, dst_bytes_max_size);
+    dst_offsets.set(0, 0);
     dst_bytes.resize(dst_bytes_max_size);
 
     auto* dst_begin = (uint8_t*)dst_bytes.data();
@@ -3061,7 +3086,7 @@ static inline ColumnPtr concat_not_const_small(std::vector<ColumnViewer<TYPE_VAR
         if (is_null) {
             has_null = true;
             dst_nulls[i] = 1;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
         size_t dst_slice_len = 0;
@@ -3082,7 +3107,7 @@ static inline ColumnPtr concat_not_const_small(std::vector<ColumnViewer<TYPE_VAR
             dst_nulls[i] = 1;
             dst_off -= dst_slice_len;
         }
-        dst_offsets[i + 1] = dst_off;
+        dst_offsets.set(i + 1, dst_off);
     }
     dst_bytes.resize(dst_off);
     builder.set_has_null(has_null);
@@ -3169,8 +3194,8 @@ ColumnPtr concat_ws_small(ColumnViewer<TYPE_VARCHAR>& sep_viewer, std::vector<Co
     auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
     auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     dst_nulls.resize(num_rows);
-    raw::make_room(&dst_offsets, num_rows + 1);
-    dst_offsets[0] = 0;
+    dst_offsets.make_room(num_rows + 1, dst_bytes_max_size);
+    dst_offsets.set(0, 0);
     dst_bytes.resize(dst_bytes_max_size);
     auto* dst_begin = (uint8_t*)dst_bytes.data();
     size_t dst_off = 0;
@@ -3179,7 +3204,7 @@ ColumnPtr concat_ws_small(ColumnViewer<TYPE_VARCHAR>& sep_viewer, std::vector<Co
         if (sep_viewer.is_null(i)) {
             has_null = true;
             dst_nulls[i] = 1;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
             continue;
         }
 
@@ -3210,14 +3235,14 @@ ColumnPtr concat_ws_small(ColumnViewer<TYPE_VARCHAR>& sep_viewer, std::vector<Co
             dst_off -= dst_slice_size;
             has_null = true;
             dst_nulls[i] = 1;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
         } else if (LIKELY(dst_slice_size > 0)) {
             // just rewind last sep
             dst_off -= sep.size;
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
         } else {
             // empty result, no need to rewind
-            dst_offsets[i + 1] = dst_off;
+            dst_offsets.set(i + 1, dst_off);
         }
     }
     dst_bytes.resize(dst_off);
@@ -4015,14 +4040,14 @@ static StatusOr<ColumnPtr> hyperscan_vec_evaluate(const BinaryColumn* src, Strin
     auto& dst_offsets = dst->get_offset();
     auto& dst_bytes = dst->get_bytes();
 
-    raw::make_room(&dst_offsets, num_rows + 1);
+    dst_offsets.make_room(num_rows + 1, data_count());
     dst_bytes.reserve(data_count());
 
     // copy data row by row with replacements applied
     char* cursor = reinterpret_cast<char*>(dst_bytes.data());
     size_t match_index = 0;
     size_t match_size = match_info_chain_in_one_row.info_chain.size();
-    dst_offsets[0] = 0;
+    dst_offsets.set(0, 0);
 
     for (size_t i = 0; i < num_rows; i++) {
         size_t row_start = src_offsets[i];
@@ -4047,7 +4072,7 @@ static StatusOr<ColumnPtr> hyperscan_vec_evaluate(const BinaryColumn* src, Strin
         cursor += row_end - last_to;
 
         // Calculate offset for this row
-        dst_offsets[i + 1] = cursor - reinterpret_cast<char*>(dst_bytes.data());
+        dst_offsets.set(i + 1, cursor - reinterpret_cast<char*>(dst_bytes.data()));
     }
     DCHECK(match_index == match_size);
     DCHECK(dst_offsets.back() == data_count());

--- a/be/src/exprs/utility_functions.cpp
+++ b/be/src/exprs/utility_functions.cpp
@@ -29,6 +29,7 @@
 #include <cstdlib>
 #include <limits>
 #include <random>
+#include <type_traits>
 
 #include "base/network/cidr.h"
 #include "base/network/network_util.h"
@@ -125,14 +126,19 @@ StatusOr<ColumnPtr> UtilityFunctions::uuid(FunctionContext* ctx, const Columns& 
     auto& bytes = res->get_bytes();
     auto& offsets = res->get_offset();
 
-    offsets.resize(num_rows + 1);
-    bytes.resize(36 * num_rows);
+    const uint64_t total_bytes = static_cast<uint64_t>(36) * num_rows;
+
+    offsets.resize_uninitialized(num_rows + 1, total_bytes);
+    bytes.resize(total_bytes);
 
     char* ptr = reinterpret_cast<char*>(bytes.data());
 
-    for (int i = 0; i < num_rows; ++i) {
-        offsets[i + 1] = offsets[i] + 36;
-    }
+    offsets.visit_storage([&](auto& offsets_buf) {
+        using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+        for (int i = 0; i <= num_rows; ++i) {
+            offsets_buf[i] = static_cast<OffsetValue>(static_cast<uint64_t>(36) * i);
+        }
+    });
 
 #ifdef __SSE4_2__
     alignas(16) static constexpr const char hex_chars[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
@@ -251,13 +257,21 @@ StatusOr<ColumnPtr> UtilityFunctions::uuid_v7(FunctionContext* ctx, const Column
     auto& bytes = res->get_bytes();
     auto& offsets = res->get_offset();
 
-    offsets.resize(num_rows + 1);
-    bytes.resize(36 * num_rows);
+    const uint64_t total_bytes = static_cast<uint64_t>(36) * num_rows;
+
+    offsets.resize_uninitialized(num_rows + 1, total_bytes);
+    bytes.resize(total_bytes);
 
     char* ptr = reinterpret_cast<char*>(bytes.data());
 
+    offsets.visit_storage([&](auto& offsets_buf) {
+        using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+        for (int i = 0; i <= num_rows; ++i) {
+            offsets_buf[i] = static_cast<OffsetValue>(static_cast<uint64_t>(36) * i);
+        }
+    });
+
     for (int i = 0; i < num_rows; ++i) {
-        offsets[i + 1] = offsets[i] + 36;
         auto uuid = ThreadLocalUUIDGenerator::next_uuid_v7();
         std::string uuid_str = boost::uuids::to_string(uuid);
         memcpy(ptr, uuid_str.c_str(), 36);

--- a/be/src/formats/orc/column_reader.cpp
+++ b/be/src/formats/orc/column_reader.cpp
@@ -523,7 +523,7 @@ Status StringColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col, si
 
     auto& vo = values->get_offset();
     // We can resize directly
-    raw::stl_vector_resize_uninitialized(&vo, vo.size() + size);
+    vo.resize_uninitialized(vo.size() + size, vb.size() + len);
 
     size_t write_pos = vb.size();
     if (cvb->hasNulls) {
@@ -535,10 +535,10 @@ Status StringColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col, si
                     strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], str_size);
                     write_pos += str_size;
                     // Need plus 1 for offset
-                    vo[i + 1] = write_pos;
+                    vo.set(i + 1, write_pos);
                 } else {
                     // Need plus 1 for offset
-                    vo[i + 1] = write_pos;
+                    vo.set(i + 1, write_pos);
                 }
             }
         } else {
@@ -547,10 +547,10 @@ Status StringColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col, si
                     strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], data->length[cvb_pos]);
                     write_pos += data->length[cvb_pos];
                     // Need plus 1 for offset
-                    vo[i + 1] = write_pos;
+                    vo.set(i + 1, write_pos);
                 } else {
                     // Need plus 1 for offset
-                    vo[i + 1] = write_pos;
+                    vo.set(i + 1, write_pos);
                 }
             }
         }
@@ -562,15 +562,18 @@ Status StringColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col, si
                 strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], str_size);
                 write_pos += str_size;
                 // Need plus 1 for offset
-                vo[i + 1] = write_pos;
+                vo.set(i + 1, write_pos);
             }
         } else {
-            for (size_t i = col_start, cvb_pos = from; i < col_start + size; ++i, ++cvb_pos) {
-                strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], data->length[cvb_pos]);
-                write_pos += data->length[cvb_pos];
-                // Need plus 1 for offset
-                vo[i + 1] = write_pos;
-            }
+            vo.visit_storage([&](auto& offsets) {
+                using OffsetValue = typename std::decay_t<decltype(offsets)>::value_type;
+                for (size_t i = col_start, cvb_pos = from; i < col_start + size; ++i, ++cvb_pos) {
+                    strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], data->length[cvb_pos]);
+                    write_pos += data->length[cvb_pos];
+                    // Need plus 1 for offset
+                    offsets[i + 1] = static_cast<OffsetValue>(write_pos);
+                }
+            });
         }
     }
 
@@ -669,27 +672,30 @@ Status VarbinaryColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col,
 
     // vb is using RawVectorPad16, resize will not initialize vector
     vb.resize(vb.size() + len);
-    raw::stl_vector_resize_uninitialized(&vo, vo.size() + size);
+    vo.resize_uninitialized(vo.size() + size, vb.size());
 
     if (cvb->hasNulls) {
-        for (size_t i = col_start, cvb_pos = from; i < col_start + size; ++i, ++cvb_pos) {
-            if (cvb->notNull[cvb_pos]) {
+        vo.visit_storage([&](auto& offsets) {
+            using OffsetValue = typename std::decay_t<decltype(offsets)>::value_type;
+            for (size_t i = col_start, cvb_pos = from; i < col_start + size; ++i, ++cvb_pos) {
+                if (cvb->notNull[cvb_pos]) {
+                    strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], data->length[cvb_pos]);
+                    write_pos += data->length[cvb_pos];
+                }
+                // Plus 1 for offset
+                offsets[i + 1] = static_cast<OffsetValue>(write_pos);
+            }
+        });
+    } else {
+        vo.visit_storage([&](auto& offsets) {
+            using OffsetValue = typename std::decay_t<decltype(offsets)>::value_type;
+            for (size_t i = col_start, cvb_pos = from; i < col_start + size; ++i, ++cvb_pos) {
                 strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], data->length[cvb_pos]);
                 write_pos += data->length[cvb_pos];
                 // Plus 1 for offset
-                vo[i + 1] = write_pos;
-            } else {
-                // Plus 1 for offset
-                vo[i + 1] = write_pos;
+                offsets[i + 1] = static_cast<OffsetValue>(write_pos);
             }
-        }
-    } else {
-        for (size_t i = col_start, cvb_pos = from; i < col_start + size; ++i, ++cvb_pos) {
-            strings::memcpy_inlined(&vb[write_pos], data->data[cvb_pos], data->length[cvb_pos]);
-            write_pos += data->length[cvb_pos];
-            // Plus 1 for offset
-            vo[i + 1] = write_pos;
-        }
+        });
     }
     return Status::OK();
 }

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "base/bit/rle_encoding.h"
@@ -550,20 +551,28 @@ private:
             uint32_t* lengths = _temp_lengths.data();
             char** datas = _temp_datas.data();
 
+            uint64_t total_length = 0;
             for (size_t i = 0; i < read_count; ++i) {
                 datas[i] = _slices[i].data;
                 lengths[i] = _slices[i].size;
+                total_length += lengths[i];
             }
 
             // relocate offsets
             auto& offsets = binary_column->get_offset();
             size_t prev_offsets = offsets.size();
-            size_t cnt = 0;
-            raw::stl_vector_resize_uninitialized(&offsets, count + prev_offsets);
-            for (size_t i = 0; i < count; ++i) {
-                offset += is_nulls[i] ? 0 : lengths[cnt++];
-                offsets[prev_offsets + i] = offset;
-            }
+            const uint64_t final_offset = offset + total_length;
+            offsets.resize_uninitialized(count + prev_offsets, final_offset);
+            const uint32_t* lengths_ptr = lengths;
+            offsets.visit_storage([prev_offsets, count, offset, is_nulls, lengths_ptr](auto& offsets_buf) mutable {
+                using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+                auto* __restrict dst_offsets = offsets_buf.data() + prev_offsets;
+                size_t cnt = 0;
+                for (size_t i = 0; i < count; ++i) {
+                    offset += is_nulls[i] ? 0 : lengths_ptr[cnt++];
+                    dst_offsets[i] = static_cast<OffsetValue>(offset);
+                }
+            });
 
             if (read_count == 0) {
                 return Status::OK();

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstring>
+#include <type_traits>
 
 #include "base/bit/bit_stream_utils.h"
 #include "base/bit/bit_util.h"
@@ -216,6 +217,7 @@ public:
         char** datas = _temp_datas.data();
         size_t i = 0;
         size_t cursor = _offset;
+        size_t total_length = 0;
         //
         for (i = 0; (i < read_count) & (_offset < _data.size); ++i) {
             uint32_t length = decode_fixed32_le(reinterpret_cast<const uint8_t*>(_data.data) + cursor);
@@ -224,6 +226,7 @@ public:
             cursor += length;
             lengths[i] = length;
             max_size = max_size > length ? max_size : length;
+            total_length += length;
         }
 
         _offset = cursor;
@@ -236,15 +239,21 @@ public:
             auto& offsets = binary_column->get_offset();
             auto& bytes = binary_column->get_bytes();
             size_t prev_offsets = offsets.size();
-            raw::stl_vector_resize_uninitialized(&offsets, count + prev_offsets);
             size_t offset = bytes.size();
+            size_t final_offset = offset + total_length;
+            offsets.resize_uninitialized(count + prev_offsets, final_offset);
             size_t cnt = 0;
-            for (size_t i = 0; i < count; ++i) {
-                offset += is_nulls[i] ? 0 : lengths[cnt++];
-                offsets[prev_offsets + i] = offset;
-            }
+            const uint32_t* lengths_ptr = lengths;
+            offsets.visit_storage([prev_offsets, count, is_nulls, lengths_ptr, offset, cnt](auto& offsets_buf) mutable {
+                using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+                auto* dst_offsets = offsets_buf.data() + prev_offsets;
+                for (size_t i = 0; i < count; ++i) {
+                    offset += is_nulls[i] ? 0 : lengths_ptr[cnt++];
+                    dst_offsets[i] = static_cast<OffsetValue>(offset);
+                }
+            });
 
-            binary_column->get_bytes().reserve(offset);
+            binary_column->get_bytes().reserve(final_offset);
         }
 
         if (read_count == 0) {
@@ -564,13 +573,18 @@ public:
         }
         auto& offsets = binary_column->get_offset();
         size_t prev_offsets = offsets.size();
-        raw::stl_vector_resize_uninitialized(&offsets, count + prev_offsets);
+        size_t final_offset = offset + read_count * _type_length;
+        offsets.resize_uninitialized(count + prev_offsets, final_offset);
         {
             // fill offset columns
-            for (size_t i = 0; i < count; ++i) {
-                offset += is_nulls[i] ? 0 : _type_length;
-                offsets[prev_offsets + i] = offset;
-            }
+            offsets.visit_storage([prev_offsets, count, is_nulls, type_length = _type_length, offset](auto& offsets_buf) mutable {
+                using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+                auto* dst_offsets = offsets_buf.data() + prev_offsets;
+                for (size_t i = 0; i < count; ++i) {
+                    offset += is_nulls[i] ? 0 : type_length;
+                    dst_offsets[i] = static_cast<OffsetValue>(offset);
+                }
+            });
         }
         DCHECK_EQ(binary_column->get_bytes().size(), binary_column->get_offset().back());
 

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -577,14 +577,15 @@ public:
         offsets.resize_uninitialized(count + prev_offsets, final_offset);
         {
             // fill offset columns
-            offsets.visit_storage([prev_offsets, count, is_nulls, type_length = _type_length, offset](auto& offsets_buf) mutable {
-                using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
-                auto* dst_offsets = offsets_buf.data() + prev_offsets;
-                for (size_t i = 0; i < count; ++i) {
-                    offset += is_nulls[i] ? 0 : type_length;
-                    dst_offsets[i] = static_cast<OffsetValue>(offset);
-                }
-            });
+            offsets.visit_storage(
+                    [prev_offsets, count, is_nulls, type_length = _type_length, offset](auto& offsets_buf) mutable {
+                        using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+                        auto* dst_offsets = offsets_buf.data() + prev_offsets;
+                        for (size_t i = 0; i < count; ++i) {
+                            offset += is_nulls[i] ? 0 : type_length;
+                            dst_offsets[i] = static_cast<OffsetValue>(offset);
+                        }
+                    });
         }
         DCHECK_EQ(binary_column->get_bytes().size(), binary_column->get_offset().back());
 

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -435,10 +435,13 @@ Status LevelBuilder::_write_byte_array_column_chunk(const LevelBuilderContext& c
     auto values = new ::parquet::ByteArray[col->size()];
     DeferOp defer([&] { delete[] values; });
 
-    for (size_t i = 0; i < col->size(); i++) {
-        values[i].len = static_cast<uint32_t>(vo[i + 1] - vo[i]);
-        values[i].ptr = reinterpret_cast<const uint8_t*>(vb.data() + vo[i]);
-    }
+    vo.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offsets = offsets_buf.data();
+        for (size_t i = 0; i < col->size(); i++) {
+            values[i].len = static_cast<uint32_t>(offsets[i + 1] - offsets[i]);
+            values[i].ptr = reinterpret_cast<const uint8_t*>(vb.data() + offsets[i]);
+        }
+    });
 
     write_leaf_callback(LevelBuilderResult{
             .num_levels = ctx._num_levels,

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
 #include "base/coding.h"
 #include "base/compression/compression_headers.h"
@@ -257,7 +258,7 @@ public:
         auto bytes = column.get_immutable_bytes();
         const auto& offsets = column.get_offset();
         int64_t res = sizeof(T) * 2;
-        int64_t offsets_size = offsets.size() * sizeof(typename BinaryColumnBase<T>::Offset);
+        int64_t offsets_size = offsets.size() * sizeof(T);
         if (is_integer_encoding_enabled(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
             res += sizeof(uint64_t) +
                    std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size)));
@@ -291,7 +292,7 @@ public:
         }
 
         //TODO: if T is uint32_t, `offsets_size` may be overflow
-        T offsets_size = offsets.size() * sizeof(typename BinaryColumnBase<T>::Offset);
+        T offsets_size = offsets.size() * sizeof(T);
         if constexpr (std::is_same_v<T, uint32_t>) {
             buff = write_little_endian_32(offsets_size, buff);
         } else {
@@ -299,12 +300,21 @@ public:
         }
         if (is_integer_encoding_enabled(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
             if (sizeof(T) == 4) { // only support sorted 32-bit integers
-                buff = encode_integers<true>(offsets.data(), offsets_size, buff, encode_level);
+                buff = offsets.visit_storage([&](const auto& offsets_buf) {
+                    auto offset_data = _get_offsets_data<T>(offsets_buf);
+                    return encode_integers<true>(offset_data.data(), offsets_size, buff, encode_level);
+                });
             } else {
-                buff = encode_integers<false>(offsets.data(), offsets_size, buff, encode_level);
+                buff = offsets.visit_storage([&](const auto& offsets_buf) {
+                    auto offset_data = _get_offsets_data<T>(offsets_buf);
+                    return encode_integers<false>(offset_data.data(), offsets_size, buff, encode_level);
+                });
             }
         } else {
-            buff = write_raw(offsets.data(), offsets_size, buff);
+            buff = offsets.visit_storage([&](const auto& offsets_buf) {
+                auto offset_data = _get_offsets_data<T>(offsets_buf);
+                return write_raw(offset_data.data(), offsets_size, buff);
+            });
         }
         return buff;
     }
@@ -335,15 +345,32 @@ public:
         } else {
             ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &offset_bytes_size));
         }
-        raw::make_room(&column->get_offset(), offset_bytes_size / sizeof(typename BinaryColumnBase<T>::Offset));
+        Buffer<T> offsets;
+        raw::make_room(&offsets, offset_bytes_size / sizeof(T));
 
         if (is_integer_encoding_enabled(encode_level) && offset_bytes_size >= ENCODE_SIZE_LIMIT) {
             constexpr bool is_i32 = sizeof(T) == 4;
-            ASSIGN_OR_RETURN(buff, decode_integers<is_i32>(buff, end, column->get_offset().data(), offset_bytes_size));
+            ASSIGN_OR_RETURN(buff, decode_integers<is_i32>(buff, end, offsets.data(), offset_bytes_size));
         } else {
-            ASSIGN_OR_RETURN(buff, read_raw(buff, end, column->get_offset().data(), offset_bytes_size));
+            ASSIGN_OR_RETURN(buff, read_raw(buff, end, offsets.data(), offset_bytes_size));
+        }
+        if constexpr (std::is_same_v<T, uint32_t>) {
+            column->get_offset().set_small_buffer(std::move(offsets));
+        } else {
+            column->get_offset().set_large_buffer(std::move(offsets));
         }
         return buff;
+    }
+
+private:
+    template <typename DstOffset, typename SrcOffsets>
+    static Buffer<DstOffset> _get_offsets_data(const SrcOffsets& src_offsets) {
+        Buffer<DstOffset> dst_offsets;
+        raw::stl_vector_resize_uninitialized(&dst_offsets, src_offsets.size());
+        for (size_t i = 0; i < src_offsets.size(); ++i) {
+            dst_offsets[i] = static_cast<DstOffset>(src_offsets[i]);
+        }
+        return dst_offsets;
     }
 };
 

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -153,7 +153,7 @@ void ChunkHelper::padding_char_column(const starrocks::TabletSchemaCSPtr& tschem
 
     const uint64_t final_offset = static_cast<uint64_t>(len) * num_rows;
     new_offset.resize_uninitialized(num_rows + 1, final_offset);
-    new_bytes.assign(num_rows * len, 0); // padding 0
+    new_bytes.assign(final_offset, 0); // padding 0
 
     size_t from = 0;
     offset.visit_storage([&](const auto& offsets_buf) {

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -385,8 +385,6 @@ bool ChunkPipelineAccumulator::is_finished() const {
     return _finalized && _out_chunk == nullptr && _in_chunk == nullptr;
 }
 
-
-
 CommonExprEvalScopeGuard::CommonExprEvalScopeGuard(const ChunkPtr& chunk,
                                                    const std::map<SlotId, ExprContext*>& common_expr_ctxs)
         : _chunk(chunk), _common_expr_ctxs(common_expr_ctxs) {}

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -14,7 +14,9 @@
 
 #include "storage/chunk_helper.h"
 
+#include <memory>
 #include <numeric>
+#include <type_traits>
 #include <utility>
 
 #include "base/coding.h"
@@ -149,54 +151,59 @@ void ChunkHelper::padding_char_column(const starrocks::TabletSchemaCSPtr& tschem
     // |schema| maybe partial columns in vertical compaction, so get char column length by name.
     uint32_t len = tschema->column(tschema->field_index(field.name())).length();
 
-    new_offset.resize(num_rows + 1);
+    const uint64_t final_offset = static_cast<uint64_t>(len) * num_rows;
+    new_offset.resize_uninitialized(num_rows + 1, final_offset);
     new_bytes.assign(num_rows * len, 0); // padding 0
 
-    uint32_t from = 0;
-    // Optimization: skip memcpy for null rows when there are many nulls
-    // The buffer is pre-zeroed, so null rows already have valid padding
-    if (field.is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(column);
-        if (!nullable_column->has_null()) {
-            // No nulls: avoid the extra count_nonzero pass and keep the tight loop
-            for (size_t j = 0; j < num_rows; ++j) {
-                uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-                strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
-                from += len;
-            }
-        } else {
-            const uint8_t* null_data = nullable_column->null_column()->get_data().data();
-            size_t null_count = SIMD::count_nonzero(null_data, num_rows);
-            // Only use sparse iteration if more than 12.5% of rows are null
-            if (null_count > num_rows / 8) {
+    size_t from = 0;
+    offset.visit_storage([&](const auto& offsets_buf) {
+        const auto* __restrict offset_data = offsets_buf.data();
+        // Optimization: skip memcpy for null rows when there are many nulls.
+        // The buffer is pre-zeroed, so null rows already have valid padding.
+        if (field.is_nullable()) {
+            auto* nullable_column = down_cast<NullableColumn*>(column);
+            if (!nullable_column->has_null()) {
                 for (size_t j = 0; j < num_rows; ++j) {
-                    if (!null_data[j]) {
-                        uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-                        strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
-                    }
+                    size_t copy_data_len = std::min<size_t>(len, offset_data[j + 1] - offset_data[j]);
+                    strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[j], copy_data_len);
                     from += len;
                 }
             } else {
-                // Low null ratio: original loop without branch
-                for (size_t j = 0; j < num_rows; ++j) {
-                    uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-                    strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
-                    from += len;
+                const uint8_t* null_data = nullable_column->null_column()->get_data().data();
+                size_t null_count = SIMD::count_nonzero(null_data, num_rows);
+                if (null_count > num_rows / 8) {
+                    for (size_t j = 0; j < num_rows; ++j) {
+                        if (!null_data[j]) {
+                            size_t copy_data_len = std::min<size_t>(len, offset_data[j + 1] - offset_data[j]);
+                            strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[j],
+                                                    copy_data_len);
+                        }
+                        from += len;
+                    }
+                } else {
+                    for (size_t j = 0; j < num_rows; ++j) {
+                        size_t copy_data_len = std::min<size_t>(len, offset_data[j + 1] - offset_data[j]);
+                        strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[j], copy_data_len);
+                        from += len;
+                    }
                 }
             }
+        } else {
+            for (size_t j = 0; j < num_rows; ++j) {
+                size_t copy_data_len = std::min<size_t>(len, offset_data[j + 1] - offset_data[j]);
+                strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset_data[j], copy_data_len);
+                from += len;
+            }
         }
-    } else {
-        // Non-nullable: original loop
-        for (size_t j = 0; j < num_rows; ++j) {
-            uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-            strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
-            from += len;
-        }
-    }
+    });
 
-    for (size_t j = 1; j <= num_rows; ++j) {
-        new_offset[j] = static_cast<uint32_t>(len * j);
-    }
+    new_offset.visit_storage([&](auto& offsets_buf) {
+        using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+        auto* __restrict offset_data = offsets_buf.data();
+        for (size_t j = 0; j <= num_rows; ++j) {
+            offset_data[j] = static_cast<OffsetValue>(static_cast<uint64_t>(len) * j);
+        }
+    });
 
     if (field.is_nullable()) {
         auto* nullable_column = down_cast<NullableColumn*>(column);
@@ -377,6 +384,8 @@ bool ChunkPipelineAccumulator::need_input() const {
 bool ChunkPipelineAccumulator::is_finished() const {
     return _finalized && _out_chunk == nullptr && _in_chunk == nullptr;
 }
+
+
 
 CommonExprEvalScopeGuard::CommonExprEvalScopeGuard(const ChunkPtr& chunk,
                                                    const std::map<SlotId, ExprContext*>& common_expr_ctxs)

--- a/be/src/storage/primitive/column_predicate_cmp.cpp
+++ b/be/src/storage/primitive/column_predicate_cmp.cpp
@@ -1005,29 +1005,30 @@ public:
             binary_column = down_cast<const BinaryColumn*>(column);
         }
 
-        const auto& offsets = binary_column->get_offset();
-        const uint32_t* offset_data = offsets.data();
-        uint16_t new_size = 0;
+        return binary_column->get_offset().visit_storage([&](const auto& offsets) -> StatusOr<uint16_t> {
+            const auto* offset_data = offsets.data();
+            uint16_t new_size = 0;
 
-        if (!column->has_null()) {
-            // Non-nullable column: just check length != 0
-            for (uint16_t i = 0; i < sel_size; ++i) {
-                uint16_t data_idx = sel[i];
-                uint32_t len = offset_data[data_idx + 1] - offset_data[data_idx];
-                sel[new_size] = data_idx;
-                new_size += (len != 0); // Branchless: increment only if len > 0
+            if (!column->has_null()) {
+                // Non-nullable column: just check length != 0
+                for (uint16_t i = 0; i < sel_size; ++i) {
+                    uint16_t data_idx = sel[i];
+                    auto len = offset_data[data_idx + 1] - offset_data[data_idx];
+                    sel[new_size] = data_idx;
+                    new_size += (len != 0); // Branchless: increment only if len > 0
+                }
+            } else {
+                // Nullable column: check not null AND length != 0
+                const uint8_t* is_null = down_cast<const NullableColumn*>(column)->immutable_null_column_data().data();
+                for (uint16_t i = 0; i < sel_size; ++i) {
+                    uint16_t data_idx = sel[i];
+                    auto len = offset_data[data_idx + 1] - offset_data[data_idx];
+                    sel[new_size] = data_idx;
+                    new_size += (!is_null[data_idx]) & (len != 0); // Branchless
+                }
             }
-        } else {
-            // Nullable column: check not null AND length != 0
-            const uint8_t* is_null = down_cast<const NullableColumn*>(column)->immutable_null_column_data().data();
-            for (uint16_t i = 0; i < sel_size; ++i) {
-                uint16_t data_idx = sel[i];
-                uint32_t len = offset_data[data_idx + 1] - offset_data[data_idx];
-                sel[new_size] = data_idx;
-                new_size += (!is_null[data_idx]) & (len != 0); // Branchless
-            }
-        }
-        return new_size;
+            return new_size;
+        });
     }
 
 private:

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <limits>
 #include <sstream>
+#include <type_traits>
 
 #include "base/container/raw_container.h"
 #include "base/simd/simd.h"
@@ -115,16 +116,19 @@ Status BinaryPlainPageDecoder<Type>::get_dict_filter_selection(const std::vector
             const uint32_t chunk_elems = end - begin;
 
             BinaryColumn::Offsets offsets;
-            offsets.resize(chunk_elems + 1);
-            offsets[0] = 0;
-
             const uint32_t base_abs_off = offset_uncheck(static_cast<int>(begin));
-            // Intermediate offsets: i in (begin, end)
-            for (uint32_t i = begin + 1; i < end; ++i) {
-                offsets[i - begin] = offset_uncheck(static_cast<int>(i)) - base_abs_off;
-            }
             const uint32_t chunk_bytes = offset(static_cast<int>(end)) - base_abs_off;
-            offsets[chunk_elems] = chunk_bytes;
+            offsets.resize_uninitialized(chunk_elems + 1, chunk_bytes);
+            offsets.visit_storage([&](auto& offsets_buf) {
+                using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+                offsets_buf[0] = 0;
+                // Intermediate offsets: i in (begin, end)
+                for (uint32_t i = begin + 1; i < end; ++i) {
+                    offsets_buf[i - begin] =
+                            static_cast<OffsetValue>(offset_uncheck(static_cast<int>(i)) - base_abs_off);
+                }
+                offsets_buf[chunk_elems] = static_cast<OffsetValue>(chunk_bytes);
+            });
 
             ContainerResource container(_page_handle, &_data[base_abs_off], chunk_bytes);
             auto dict_chunk_column = BinaryColumn::create(std::move(container), std::move(offsets));
@@ -224,30 +228,35 @@ bool BinaryPlainPageDecoder<Type>::append_range(uint32_t idx, uint32_t end, Colu
         auto& offsets = down_cast<BinaryColumn*>(data_column)->get_offset();
         DCHECK_GE(offsets.size(), 1);
 
-        uint32_t begin_offset = offsets.back();
+        const uint64_t begin_offset = offsets.back();
         size_t current_offset_sz = offsets.size();
-        offsets.resize(current_offset_sz + end - idx);
-
         const uint32_t page_data_offset = offset_uncheck(idx);
-        // vectorized loop
-        for (uint32_t i = idx; i < end - 1; i++) {
+        const uint32_t append_bytes_length = offset(end) - page_data_offset;
+        const uint64_t final_offset = begin_offset + append_bytes_length;
+        offsets.resize_uninitialized(current_offset_sz + end - idx, final_offset);
+        offsets.visit_storage([&](auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            auto* dst_offsets = offsets_buf.data() + current_offset_sz;
+            // vectorized loop
+            for (uint32_t i = idx; i < end - 1; i++) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-            auto offset = _offsets_ptr[i + 1];
+                auto offset = _offsets_ptr[i + 1];
 #else
-            // direct call offset_uncheck() will break auto-vectorized
-            // maybe we can remove this condition compile after we upgrade the toolchain
-            auto offset = offset_uncheck(i + 1);
+                // direct call offset_uncheck() will break auto-vectorized
+                // maybe we can remove this condition compile after we upgrade the toolchain
+                auto offset = offset_uncheck(i + 1);
 #endif
-            uint32_t current_offset = offset - page_data_offset + begin_offset;
-            offsets[current_offset_sz++] = current_offset;
-        }
+                const uint64_t current_offset = begin_offset + static_cast<uint64_t>(offset - page_data_offset);
+                *dst_offsets++ = static_cast<OffsetValue>(current_offset);
+            }
 
-        for (uint32_t i = end - 1; i < end; i++) {
-            uint32_t current_offset = offset(i + 1) - page_data_offset + begin_offset;
-            offsets[current_offset_sz++] = current_offset;
-        }
+            for (uint32_t i = end - 1; i < end; i++) {
+                const uint64_t current_offset =
+                        begin_offset + static_cast<uint64_t>(offset(i + 1) - page_data_offset);
+                *dst_offsets++ = static_cast<OffsetValue>(current_offset);
+            }
+        });
 
-        size_t append_bytes_length = offsets.back() - begin_offset;
         size_t old_bytes_size = bytes.size();
 
         bytes.resize(old_bytes_size + append_bytes_length);
@@ -345,7 +354,7 @@ Status BinaryPlainPageDecoder<Type>::next_range_with_filter(
 
         BinaryColumn::Offsets temp_offsets;
         temp_offsets.resize(num_rows + 1);
-        temp_offsets[0] = 0;
+        temp_offsets.set(0, 0);
 
         const uint32_t page_data_offset = offset_uncheck(idx);
         for (uint32_t i = idx; i < end - 1; i++) {
@@ -358,12 +367,12 @@ Status BinaryPlainPageDecoder<Type>::next_range_with_filter(
 #endif
 
             uint32_t current_offset = offset - page_data_offset;
-            temp_offsets[i - idx + 1] = current_offset;
+            temp_offsets.set(i - idx + 1, current_offset);
         }
 
         for (uint32_t i = end - 1; i < end; i++) {
             uint32_t current_offset = offset(i + 1) - page_data_offset;
-            temp_offsets[i - idx + 1] = current_offset;
+            temp_offsets.set(i - idx + 1, current_offset);
         }
 
         size_t data_length = temp_offsets.back();

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -251,8 +251,7 @@ bool BinaryPlainPageDecoder<Type>::append_range(uint32_t idx, uint32_t end, Colu
             }
 
             for (uint32_t i = end - 1; i < end; i++) {
-                const uint64_t current_offset =
-                        begin_offset + static_cast<uint64_t>(offset(i + 1) - page_data_offset);
+                const uint64_t current_offset = begin_offset + static_cast<uint64_t>(offset(i + 1) - page_data_offset);
                 *dst_offsets++ = static_cast<OffsetValue>(current_offset);
             }
         });

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -47,6 +47,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 
 #include "base/coding.h"
 #include "base/string/faststring.h"
@@ -259,30 +260,35 @@ public:
     // Get offsets for zero-copy construction
     void get_offsets_for_zero_copy(BinaryColumn::Offsets& offsets) const {
         offsets.clear();
-        offsets.resize(_num_elems + 1);
-        offsets[0] = 0; // Start from 0
         if (_num_elems == 0) {
+            offsets.resize(1, 0);
             return;
         }
 
         uint32_t base_offset = offset_uncheck(0); // Get the base offset
-        for (uint32_t i = 0; i < _num_elems - 1; ++i) {
+        const uint32_t total_bytes = offset(_num_elems) - base_offset;
+        offsets.resize_uninitialized(_num_elems + 1, total_bytes);
+        offsets.visit_storage([&](auto& offsets_buf) {
+            using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            offsets_buf[0] = 0; // Start from 0
+            for (uint32_t i = 0; i < _num_elems - 1; ++i) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-            auto offset = _offsets_ptr[i + 1];
+                auto offset = _offsets_ptr[i + 1];
 #else
-            // direct call offset_uncheck() will break auto-vectorized
-            // maybe we can remove this condition compile after we upgrade the toolchain
-            auto offset = offset_uncheck(i + 1);
+                // direct call offset_uncheck() will break auto-vectorized
+                // maybe we can remove this condition compile after we upgrade the toolchain
+                auto offset = offset_uncheck(i + 1);
 #endif
-            // Convert absolute offset to relative offset from base
-            uint32_t current_offset = offset - base_offset;
-            offsets[i + 1] = current_offset;
-        }
+                // Convert absolute offset to relative offset from base
+                uint32_t current_offset = offset - base_offset;
+                offsets_buf[i + 1] = static_cast<OffsetValue>(current_offset);
+            }
 
-        for (uint32_t i = _num_elems - 1; i < _num_elems; i++) {
-            uint32_t current_offset = offset(i + 1) - base_offset;
-            offsets[i + 1] = current_offset;
-        }
+            for (uint32_t i = _num_elems - 1; i < _num_elems; i++) {
+                uint32_t current_offset = offset(i + 1) - base_offset;
+                offsets_buf[i + 1] = static_cast<OffsetValue>(current_offset);
+            }
+        });
     }
 
     // Dictionary-page predicate cache (used by BinaryDictPageDecoder):

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -14,6 +14,7 @@
 
 #include "udf/java/java_data_converter.h"
 
+#include <limits>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -146,8 +147,16 @@ private:
 
 Status JavaArrayConverter::do_visit(const BinaryColumn& column) {
     size_t num_rows = column.size();
+    const auto& column_offsets = column.get_offset();
+    const size_t java_max_buffer_size = std::numeric_limits<int>::max();
+    if (column_offsets.is_large() || column_offsets.back() > java_max_buffer_size ||
+        column.get_immutable_bytes().size() > java_max_buffer_size ||
+        column_offsets.size() > java_max_buffer_size / sizeof(uint32_t)) {
+        return Status::NotSupported("Java UDF does not support BinaryColumn with large offsets or bytes");
+    }
+
     auto bytes = byte_buffer(column.get_immutable_bytes());
-    auto offsets = byte_buffer(column.get_offset());
+    auto offsets = column_offsets.visit_storage([&](const auto& offsets_buf) { return byte_buffer(offsets_buf); });
     const auto& method_map = _helper.method_map();
     if (auto iter = method_map.find(JNIPrimTypeId<Slice>::id); iter != method_map.end()) {
         ASSIGN_OR_RETURN(_result, _helper.invoke_static_method(iter->second, num_rows, handle(_nulls_buffer),

--- a/be/src/udf/java/java_native_method.cpp
+++ b/be/src/udf/java/java_native_method.cpp
@@ -52,9 +52,8 @@ public:
             column_offsets.size() > java_max_buffer_size / sizeof(uint32_t)) {
             return Status::NotSupported("Java UDF does not support BinaryColumn with large offsets or bytes");
         }
-        column_offsets.visit_storage([&](const auto& offsets) {
-            _jarr[_idx++] = reinterpret_cast<int64_t>(offsets.data());
-        });
+        column_offsets.visit_storage(
+                [&](const auto& offsets) { _jarr[_idx++] = reinterpret_cast<int64_t>(offsets.data()); });
         _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_immutable_bytes().data());
         return Status::OK();
     }

--- a/be/src/udf/java/java_native_method.cpp
+++ b/be/src/udf/java/java_native_method.cpp
@@ -14,6 +14,7 @@
 
 #include "udf/java/java_native_method.h"
 
+#include <limits>
 #include <new>
 #include <type_traits>
 
@@ -44,7 +45,16 @@ public:
     }
 
     Status do_visit(const BinaryColumn& column) {
-        _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_offset().data());
+        const auto& column_offsets = column.get_offset();
+        const size_t java_max_buffer_size = std::numeric_limits<int>::max();
+        if (column_offsets.is_large() || column_offsets.back() > java_max_buffer_size ||
+            column.get_immutable_bytes().size() > java_max_buffer_size ||
+            column_offsets.size() > java_max_buffer_size / sizeof(uint32_t)) {
+            return Status::NotSupported("Java UDF does not support BinaryColumn with large offsets or bytes");
+        }
+        column_offsets.visit_storage([&](const auto& offsets) {
+            _jarr[_idx++] = reinterpret_cast<int64_t>(offsets.data());
+        });
         _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_immutable_bytes().data());
         return Status::OK();
     }

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1148,7 +1148,7 @@ PARALLEL_TEST(ArrayColumnTest, test_replicate) {
     column->offsets_column_raw_ptr()->append(6);
     column->offsets_column_raw_ptr()->append(6);
 
-    Offsets off;
+    Buffer<uint32_t> off;
     off.emplace_back(0);
     off.emplace_back(3);
     off.emplace_back(5);

--- a/be/test/column/binary_column_core_test.cpp
+++ b/be/test/column/binary_column_core_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -21,6 +22,8 @@
 
 namespace starrocks {
 namespace {
+
+constexpr uint64_t kLargeOffset = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;
 
 std::string slice_to_string(const Slice& s) {
     return std::string(s.data, s.size);
@@ -62,6 +65,82 @@ TEST(BinaryColumnCoreTest, LargeBinaryAppendSelective) {
     ASSERT_EQ(2, dst->size());
     EXPECT_EQ("long-value-3", slice_to_string(dst->get_slice(0)));
     EXPECT_EQ("long-value-1", slice_to_string(dst->get_slice(1)));
+}
+
+TEST(BinaryColumnCoreTest, StickyLargeOffsetsRemainBinaryAndAppend) {
+    auto src = BinaryColumn::create();
+    src->append("a");
+    src->append("bb");
+    src->append("ccc");
+    src->get_offset().ensure_width_for_value(kLargeOffset);
+    ASSERT_TRUE(src->get_offset().is_large());
+    EXPECT_TRUE(src->is_binary());
+    EXPECT_FALSE(src->has_large_column());
+    EXPECT_EQ(6, src->byte_size(1));
+
+    auto upgraded = src->upgrade_if_overflow();
+    ASSERT_TRUE(upgraded.ok());
+    ASSERT_TRUE(upgraded.value() == nullptr);
+
+    auto dst = BinaryColumn::create();
+    dst->append(*src, 1, 2);
+    ASSERT_EQ(2, dst->size());
+    EXPECT_EQ("bb", slice_to_string(dst->get_slice(0)));
+    EXPECT_EQ("ccc", slice_to_string(dst->get_slice(1)));
+
+    const uint32_t selected_indexes[] = {2, 0, 1};
+    auto selected = BinaryColumn::create();
+    selected->append_selective(*src, selected_indexes, 0, 2);
+    ASSERT_EQ(2, selected->size());
+    EXPECT_EQ("ccc", slice_to_string(selected->get_slice(0)));
+    EXPECT_EQ("a", slice_to_string(selected->get_slice(1)));
+
+    auto large_dst = LargeBinaryColumn::create();
+    large_dst->append(*src, 0, 2);
+    ASSERT_EQ(2, large_dst->size());
+    EXPECT_EQ("a", slice_to_string(large_dst->get_slice(0)));
+    EXPECT_EQ("bb", slice_to_string(large_dst->get_slice(1)));
+
+    Buffer<uint32_t> repeats = {0, 2, 2, 3};
+    auto replicated = src->replicate(repeats);
+    ASSERT_TRUE(replicated.ok());
+    ASSERT_EQ(3, replicated.value()->size());
+    EXPECT_EQ("a", replicated.value()->get(0).get_slice().to_string());
+    EXPECT_EQ("a", replicated.value()->get(1).get_slice().to_string());
+    EXPECT_EQ("ccc", replicated.value()->get(2).get_slice().to_string());
+}
+
+TEST(BinaryColumnCoreTest, StickyLargeBinaryDowngradesWhenOffsetsFit) {
+    auto src = LargeBinaryColumn::create();
+    src->append("x");
+    src->append("yy");
+    src->get_offset().ensure_width_for_value(kLargeOffset);
+    ASSERT_TRUE(src->get_offset().is_large());
+
+    auto downgraded = src->downgrade();
+    ASSERT_TRUE(downgraded.ok());
+    ASSERT_TRUE(downgraded.value() != nullptr);
+    EXPECT_TRUE(downgraded.value()->is_binary());
+    ASSERT_EQ(2, downgraded.value()->size());
+    EXPECT_EQ("x", downgraded.value()->get(0).get_slice().to_string());
+    EXPECT_EQ("yy", downgraded.value()->get(1).get_slice().to_string());
+}
+
+TEST(BinaryColumnCoreTest, AppendValueMultipleTimesHandlesStickyLargeOffsets) {
+    auto src = BinaryColumn::create();
+    src->append("a");
+    src->append("bbbb");
+    src->get_offset().ensure_width_for_value(kLargeOffset);
+
+    auto dst = BinaryColumn::create();
+    dst->get_offset().ensure_width_for_value(kLargeOffset);
+    dst->append_value_multiple_times(*src, 1, 3);
+
+    ASSERT_TRUE(dst->get_offset().is_large());
+    ASSERT_EQ(3, dst->size());
+    EXPECT_EQ("bbbb", slice_to_string(dst->get_slice(0)));
+    EXPECT_EQ("bbbb", slice_to_string(dst->get_slice(1)));
+    EXPECT_EQ("bbbb", slice_to_string(dst->get_slice(2)));
 }
 
 } // namespace starrocks

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -117,13 +117,13 @@ PARALLEL_TEST(BinaryColumnTest, test_get_data) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_byte_size) {
     auto column = BinaryColumn::create();
-    ASSERT_EQ(sizeof(BinaryColumn::Offset), column->byte_size());
+    ASSERT_EQ(sizeof(uint32_t), column->byte_size());
     std::string s("test_string");
     for (int i = 0; i < 10; i++) {
         column->append(s);
     }
     ASSERT_EQ(10, column->size());
-    ASSERT_EQ(10 * s.size() + 11 * sizeof(BinaryColumn::Offset), column->byte_size());
+    ASSERT_EQ(10 * s.size() + 11 * sizeof(uint32_t), column->byte_size());
     //                            ^^^ one more element in offset array.
 }
 
@@ -602,7 +602,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    Offsets offsets;
+    Buffer<uint32_t> offsets;
     offsets.emplace_back(0);
     offsets.emplace_back(3);
     offsets.emplace_back(5);

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -346,7 +346,7 @@ PARALLEL_TEST(ConstColumnTest, test_replicate) {
 
     ASSERT_EQ(3, c1->size());
 
-    Offsets offsets;
+    Buffer<uint32_t> offsets;
     offsets.emplace_back(0);
     offsets.emplace_back(2);
     offsets.emplace_back(5);

--- a/be/test/column/fixed_length_column_extended_test.cpp
+++ b/be/test/column/fixed_length_column_extended_test.cpp
@@ -650,7 +650,7 @@ TEST(FixedLengthColumnTest, test_replicate) {
     column->append(7);
     column->append(3);
 
-    Offsets offsets;
+    Buffer<uint32_t> offsets;
     offsets.emplace_back(0);
     offsets.emplace_back(3);
     offsets.emplace_back(5);

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -396,7 +396,7 @@ PARALLEL_TEST(NullableColumnTest, test_replicate) {
     column->append_datum({});
     column->append_datum((int32_t)4);
 
-    Offsets offsets;
+    Buffer<uint32_t> offsets;
     offsets.emplace_back(0);
     offsets.emplace_back(2);
     offsets.emplace_back(4);

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -209,9 +209,9 @@ TEST(StructColumnTest, equals) {
 TEST(StructColumnTest, test_byte_size) {
     auto col = create_test_column();
 
-    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(BinaryColumn::Offset) * 2 + 11 + 2 * 2, col->byte_size());
-    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 6 + 2, col->byte_size(1, 1));
-    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 5 + 2, col->byte_size(0));
+    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(uint32_t) * 2 + 11 + 2 * 2, col->byte_size());
+    ASSERT_EQ(sizeof(uint64_t) + sizeof(uint32_t) + 6 + 2, col->byte_size(1, 1));
+    ASSERT_EQ(sizeof(uint64_t) + sizeof(uint32_t) + 5 + 2, col->byte_size(0));
 }
 
 TEST(StructColumnTest, test_resize) {

--- a/be/test/serde/serde_test.cpp
+++ b/be/test/serde/serde_test.cpp
@@ -736,7 +736,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column) {
     auto c2 = BinaryColumn::create();
     c1->append_strings(strings.data(), strings.size());
 
-    ASSERT_EQ(c1->byte_size() + sizeof(uint32_t) * 2, ColumnArraySerde::max_serialized_size(*c1));
+    ASSERT_EQ(c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) + sizeof(uint32_t) * 2,
+              ColumnArraySerde::max_serialized_size(*c1));
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
@@ -767,7 +768,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, large_binary_column) {
     auto c2 = LargeBinaryColumn::create();
     c1->append_strings(strings.data(), strings.size());
 
-    ASSERT_EQ(c1->byte_size() + sizeof(uint64_t) * 2, ColumnArraySerde::max_serialized_size(*c1));
+    ASSERT_EQ(c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) + sizeof(uint64_t) * 2,
+              ColumnArraySerde::max_serialized_size(*c1));
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -242,9 +242,8 @@ TEST_F(ChunkHelperTest, PaddingNullableCharColumnSkipsNullRowsWhenNullsAreDense)
 
     auto* data_column = down_cast<BinaryColumn*>(result->data_column_raw_ptr());
     expect_padded_char_column(*data_column,
-                              {padded_char("ab", 4), padded_char("", 4), padded_char("wxyzq", 4),
-                               padded_char("", 4), padded_char("defg", 4), padded_char("hi", 4),
-                               padded_char("", 4), padded_char("", 4)});
+                              {padded_char("ab", 4), padded_char("", 4), padded_char("wxyzq", 4), padded_char("", 4),
+                               padded_char("defg", 4), padded_char("hi", 4), padded_char("", 4), padded_char("", 4)});
 }
 
 TEST_F(ChunkHelperTest, PaddingNullableCharColumnCopiesAllRowsWhenNullsAreSparse) {
@@ -267,10 +266,9 @@ TEST_F(ChunkHelperTest, PaddingNullableCharColumnCopiesAllRowsWhenNullsAreSparse
     EXPECT_FALSE(result->is_null(7));
 
     auto* data_column = down_cast<BinaryColumn*>(result->data_column_raw_ptr());
-    expect_padded_char_column(*data_column,
-                              {padded_char("a", 4), padded_char("bc", 4), padded_char("def", 4),
-                               padded_char("nullv", 4), padded_char("wxyzq", 4), padded_char("m", 4),
-                               padded_char("no", 4), padded_char("pqrs", 4)});
+    expect_padded_char_column(
+            *data_column, {padded_char("a", 4), padded_char("bc", 4), padded_char("def", 4), padded_char("nullv", 4),
+                           padded_char("wxyzq", 4), padded_char("m", 4), padded_char("no", 4), padded_char("pqrs", 4)});
 }
 
 class ChunkPipelineAccumulatorTest : public ::testing::Test {

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -14,6 +14,11 @@
 
 #include "storage/chunk_helper.h"
 
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
 #include "column/column_helper.h"
@@ -30,6 +35,64 @@
 #include "types/logical_type.h"
 
 namespace starrocks {
+
+namespace {
+
+TabletSchemaCSPtr create_char_tablet_schema(size_t length) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(1024);
+    schema_pb.set_next_column_unique_id(1);
+
+    ColumnPB* column = schema_pb.add_column();
+    column->set_unique_id(0);
+    column->set_name("c0");
+    column->set_type("CHAR");
+    column->set_is_key(true);
+    column->set_is_nullable(true);
+    column->set_length(length);
+    column->set_index_length(length);
+
+    return TabletSchema::create(schema_pb);
+}
+
+NullableColumn::MutablePtr make_nullable_binary_column(const std::vector<std::string_view>& values,
+                                                       const std::vector<uint8_t>& nulls) {
+    CHECK_EQ(values.size(), nulls.size());
+
+    auto data_column = BinaryColumn::create();
+    for (std::string_view value : values) {
+        data_column->append(Slice(value));
+    }
+
+    auto null_column = NullColumn::create();
+    null_column->get_data().insert(null_column->get_data().end(), nulls.begin(), nulls.end());
+    auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    nullable_column->update_has_null();
+    return nullable_column;
+}
+
+std::string padded_char(std::string_view value, size_t length) {
+    std::string result(value.substr(0, length));
+    result.resize(length, char(0));
+    return result;
+}
+
+void expect_padded_char_column(const BinaryColumn& column, const std::vector<std::string>& expected) {
+    const auto& offsets = column.get_offset();
+    ASSERT_EQ(expected.size() + 1, offsets.size());
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        EXPECT_EQ(i * 4, offsets[i]);
+    }
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        Slice value = column.get_slice(i);
+        EXPECT_EQ(expected[i], std::string(value.data, value.size));
+    }
+}
+
+} // namespace
 
 class ChunkHelperTest : public ::testing::Test {
 protected:
@@ -156,6 +219,58 @@ TEST_F(ChunkHelperTest, Accumulator) {
     auto output = accumulator.pull();
     EXPECT_EQ(nullptr, output);
     EXPECT_TRUE(accumulator.reach_limit());
+}
+
+TEST_F(ChunkHelperTest, PaddingNullableCharColumnSkipsNullRowsWhenNullsAreDense) {
+    auto tablet_schema = create_char_tablet_schema(4);
+    Field field = ChunkHelper::convert_field(0, tablet_schema->column(0));
+    auto column = make_nullable_binary_column({"ab", "null", "wxyzq", "skip", "defg", "hi", "null", ""},
+                                              {0, 1, 0, 1, 0, 0, 1, 0});
+
+    ChunkHelper::padding_char_column(tablet_schema, field, column.get());
+
+    auto* result = down_cast<NullableColumn*>(column.get());
+    ASSERT_TRUE(result->has_null());
+    EXPECT_FALSE(result->is_null(0));
+    EXPECT_TRUE(result->is_null(1));
+    EXPECT_FALSE(result->is_null(2));
+    EXPECT_TRUE(result->is_null(3));
+    EXPECT_FALSE(result->is_null(4));
+    EXPECT_FALSE(result->is_null(5));
+    EXPECT_TRUE(result->is_null(6));
+    EXPECT_FALSE(result->is_null(7));
+
+    auto* data_column = down_cast<BinaryColumn*>(result->data_column_raw_ptr());
+    expect_padded_char_column(*data_column,
+                              {padded_char("ab", 4), padded_char("", 4), padded_char("wxyzq", 4),
+                               padded_char("", 4), padded_char("defg", 4), padded_char("hi", 4),
+                               padded_char("", 4), padded_char("", 4)});
+}
+
+TEST_F(ChunkHelperTest, PaddingNullableCharColumnCopiesAllRowsWhenNullsAreSparse) {
+    auto tablet_schema = create_char_tablet_schema(4);
+    Field field = ChunkHelper::convert_field(0, tablet_schema->column(0));
+    auto column = make_nullable_binary_column({"a", "bc", "def", "nullv", "wxyzq", "m", "no", "pqrs"},
+                                              {0, 0, 0, 1, 0, 0, 0, 0});
+
+    ChunkHelper::padding_char_column(tablet_schema, field, column.get());
+
+    auto* result = down_cast<NullableColumn*>(column.get());
+    ASSERT_TRUE(result->has_null());
+    EXPECT_FALSE(result->is_null(0));
+    EXPECT_FALSE(result->is_null(1));
+    EXPECT_FALSE(result->is_null(2));
+    EXPECT_TRUE(result->is_null(3));
+    EXPECT_FALSE(result->is_null(4));
+    EXPECT_FALSE(result->is_null(5));
+    EXPECT_FALSE(result->is_null(6));
+    EXPECT_FALSE(result->is_null(7));
+
+    auto* data_column = down_cast<BinaryColumn*>(result->data_column_raw_ptr());
+    expect_padded_char_column(*data_column,
+                              {padded_char("a", 4), padded_char("bc", 4), padded_char("def", 4),
+                               padded_char("nullv", 4), padded_char("wxyzq", 4), padded_char("m", 4),
+                               padded_char("no", 4), padded_char("pqrs", 4)});
 }
 
 class ChunkPipelineAccumulatorTest : public ::testing::Test {

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -172,6 +172,53 @@ TEST_F(BinaryPlainPageTest, test_reserve_head) {
               "['first value', 'second value', 'third value', 'fourth value', 'fifth value', 'first value']");
 }
 
+TEST_F(BinaryPlainPageTest, TestGetOffsetsForZeroCopy) {
+    {
+        PageBuilderOptions options;
+        options.data_page_size = 256 * 1024;
+        BinaryPlainPageBuilder builder(options);
+
+        OwnedSlice page = builder.finish()->build();
+        BinaryPlainPageDecoder<TYPE_VARCHAR> decoder(page.slice());
+        ASSERT_OK(decoder.init());
+
+        BinaryColumn::Offsets offsets;
+        decoder.get_offsets_for_zero_copy(offsets);
+
+        ASSERT_EQ(1, offsets.size());
+        EXPECT_EQ(0, offsets[0]);
+        EXPECT_FALSE(offsets.is_large());
+    }
+
+    {
+        PageBuilderOptions options;
+        options.data_page_size = 256 * 1024;
+        BinaryPlainPageBuilder builder(options);
+        Slice slices[] = {
+                "alpha",
+                "",
+                "bb",
+                "ccc",
+        };
+
+        ASSERT_EQ(4, builder.add((const uint8_t*)slices, 4));
+        OwnedSlice page = builder.finish()->build();
+        BinaryPlainPageDecoder<TYPE_VARCHAR> decoder(page.slice());
+        ASSERT_OK(decoder.init());
+
+        BinaryColumn::Offsets offsets;
+        decoder.get_offsets_for_zero_copy(offsets);
+
+        ASSERT_EQ(5, offsets.size());
+        EXPECT_FALSE(offsets.is_large());
+        EXPECT_EQ(0, offsets[0]);
+        EXPECT_EQ(5, offsets[1]);
+        EXPECT_EQ(5, offsets[2]);
+        EXPECT_EQ(7, offsets[3]);
+        EXPECT_EQ(10, offsets[4]);
+    }
+}
+
 TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
     PageBuilderOptions options;
     options.data_page_size = 256 * 1024;

--- a/be/test/udf/java/java_native_method_test.cpp
+++ b/be/test/udf/java/java_native_method_test.cpp
@@ -74,9 +74,8 @@ TEST_F(JavaNativeMethodTest, get_addrs_int) {
         const Column* data_column = down_cast<const NullableColumn*>(column.get())->data_column().get();
         const auto* binary_column = down_cast<const BinaryColumn*>(data_column);
         ASSERT_EQ(results[0], (jlong)nullable_column->null_column_data().data());
-        binary_column->get_offset().visit_storage([&](const auto& offsets) {
-            ASSERT_EQ(results[1], (jlong)offsets.data());
-        });
+        binary_column->get_offset().visit_storage(
+                [&](const auto& offsets) { ASSERT_EQ(results[1], (jlong)offsets.data()); });
         ASSERT_EQ(results[2], (jlong)binary_column->get_immutable_bytes().data());
         env->DeleteLocalRef(arr);
     }

--- a/be/test/udf/java/java_native_method_test.cpp
+++ b/be/test/udf/java/java_native_method_test.cpp
@@ -74,7 +74,9 @@ TEST_F(JavaNativeMethodTest, get_addrs_int) {
         const Column* data_column = down_cast<const NullableColumn*>(column.get())->data_column().get();
         const auto* binary_column = down_cast<const BinaryColumn*>(data_column);
         ASSERT_EQ(results[0], (jlong)nullable_column->null_column_data().data());
-        ASSERT_EQ(results[1], (jlong)binary_column->get_offset().data());
+        binary_column->get_offset().visit_storage([&](const auto& offsets) {
+            ASSERT_EQ(results[1], (jlong)offsets.data());
+        });
         ASSERT_EQ(results[2], (jlong)binary_column->get_immutable_bytes().data());
         env->DeleteLocalRef(arr);
     }


### PR DESCRIPTION
## What I'm doing:
In previous pr, AdaptiveOffsets was introduced but it does not be used at all. In this pr, we replace the original offset implementation in BinaryColumn by AdaptiveOffsets which make the BinaryColumn can represent the data with total size > 4GiB.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
