### PR TITLE
[BugFix] Null-check rowset before reading gtid in schema change

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -880,9 +880,6 @@ Status SchemaChangeHandler::_do_process_alter_tablet_normal(const TAlterTabletRe
 
         for (auto& version : versions_to_be_changed) {
             rowsets_to_change.push_back(base_tablet->get_rowset_by_version(version));
-            if (rowsets_to_change.back()->rowset_meta()->gtid() > sc_params.gtid) {
-                sc_params.gtid = rowsets_to_change.back()->rowset_meta()->gtid();
-            }
             if (rowsets_to_change.back() == nullptr) {
                 std::vector<Version> base_tablet_versions;
                 base_tablet->list_versions(&base_tablet_versions);
@@ -896,6 +893,9 @@ Status SchemaChangeHandler::_do_process_alter_tablet_normal(const TAlterTabletRe
                     ss << ver << ",";
                 }
                 return Status::InternalError(fmt::format("fail to get rowset by version: {}", ss.str()));
+            }
+            if (rowsets_to_change.back()->rowset_meta()->gtid() > sc_params.gtid) {
+                sc_params.gtid = rowsets_to_change.back()->rowset_meta()->gtid();
             }
             // prepare tablet reader to prevent rowsets being compacted
             std::unique_ptr<TabletReader> tablet_reader =


### PR DESCRIPTION
## Why I'm doing:

During a data-rewriting schema change (for example adding a generated column, which goes through `sc_directly`), `SchemaChangeHandler::_do_process_alter_tablet_normal` collects the base tablet's versions to convert. For each version it calls `base_tablet->get_rowset_by_version(version)` and pushes the result into `rowsets_to_change`.

`get_rowset_by_version` can return `nullptr` — the existing code already guards against this with a `nullptr` check that returns a `fail to get rowset by version` error. However, a later-added `gtid` comparison was placed **before** that null check:

```cpp
rowsets_to_change.push_back(base_tablet->get_rowset_by_version(version));
if (rowsets_to_change.back()->rowset_meta()->gtid() > sc_params.gtid) {   // dereferences before the null check
    sc_params.gtid = rowsets_to_change.back()->rowset_meta()->gtid();
}
if (rowsets_to_change.back() == nullptr) {                                // null check comes after
    ...
    return Status::InternalError("fail to get rowset by version: ...");
}
```

When `get_rowset_by_version` returns `nullptr`, the `->rowset_meta()->gtid()` dereference crashes the BE with `SIGSEGV @0x48`, turning what should have been a graceful error return into a hard crash.

## What I'm doing:

Move the existing `nullptr` check **ahead of** the `gtid` comparison, so the null return value is detected first. When the rowset is missing we return the existing `fail to get rowset by version` error instead of dereferencing a null pointer. The error message and its content are unchanged, and no other logic is modified.

Related issue: https://github.com/StarRocks/StarRocksTest/issues/11420

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
