### PR TITLE
[Enhancement] Enable ColumnExprPredicate pushdown for FLOAT/DOUBLE.

### DIFF
--- a/be/src/storage/primitive/column_expr_predicate.cpp
+++ b/be/src/storage/primitive/column_expr_predicate.cpp
@@ -18,6 +18,7 @@
 #include "storage/primitive/column_predicate_factory.h"
 #include "storage/primitive/inverted_index_common.h"
 #include "storage/primitive/inverted_index_iterator.h"
+#include "storage/primitive/zone_map_detail.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -176,6 +177,15 @@ bool ColumnExprPredicate::is_negated_expr() const {
 bool ColumnExprPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
     // if expr does not satisfy monotonicity, we can not apply zone map.
     if (!_monotonic) return true;
+    // A NaN FLOAT/DOUBLE min/max endpoint is unorderable: evaluating the (IEEE) expression
+    // on it yields all-false, which would wrongly prune a page/segment that may still hold
+    // matching finite rows (e.g. legacy NaN-polluted zonemaps, or a pure-NaN page that must
+    // remain reachable by != / IS NOT NULL). Keep conservatively. Mirrors the guard in the
+    // typed comparison predicates (column_predicate_cmp.cpp).
+    const LogicalType ltype = _type_info->type();
+    if (zonemap_endpoint_is_nan(ltype, detail.min_value()) || zonemap_endpoint_is_nan(ltype, detail.max_value())) {
+        return true;
+    }
     // construct column and chunk by zone map
     TypeDescriptor type_desc = TypeDescriptor::from_storage_type_info(_type_info.get());
     MutableColumnPtr col = ColumnHelper::create_column(type_desc, detail.has_null());

--- a/be/src/storage/primitive/column_not_in_predicate.cpp
+++ b/be/src/storage/primitive/column_not_in_predicate.cpp
@@ -98,6 +98,16 @@ public:
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
         if (detail.min_or_null_value() == detail.max_value()) {
+            // For FLOAT/DOUBLE a [c,c] zone may hide a NaN that the zonemap writer dropped from
+            // min/max (NaN is excluded from the orderable range). Since NaN is NOT IN any finite set
+            // (NaN != c for all c), that hidden NaN row matches this predicate, so single-value
+            // pruning below would wrongly drop a page that still holds a matching row. Without a
+            // persisted NaN marker we cannot prove NaN-absence, so keep. Compile-time no-op for
+            // non-float field types. (A legacy NaN endpoint is also kept: it either compares unequal
+            // here and falls through to the final keep, or lands on this same guard.)
+            if constexpr (lt_is_float<field_type>) {
+                return true;
+            }
             const auto type_info = this->type_info();
             for (const ValueType& v : _values) {
                 if (type_info->cmp(Datum(v), detail.max_value()) == 0) {

--- a/be/src/storage/primitive/column_predicate_cmp.cpp
+++ b/be/src/storage/primitive/column_predicate_cmp.cpp
@@ -591,6 +591,14 @@ public:
         const auto& max = detail.max_value();
         const auto type_info = this->type_info();
         if (min == max) {
+            // For FLOAT/DOUBLE a [c,c] zone may hide a NaN that the zonemap writer dropped from
+            // min/max (NaN is excluded from the orderable range). Since NaN != c is true, that
+            // hidden NaN row matches this predicate, so single-value pruning would wrongly drop a
+            // page that still holds a matching row. Without a persisted NaN marker we cannot prove
+            // NaN-absence, so keep conservatively. Compile-time no-op for non-float field types.
+            if constexpr (lt_is_float<field_type>) {
+                return true;
+            }
             return type_info->cmp(Datum(this->_value), min) != 0;
         }
         return true;

--- a/be/src/storage/primitive/column_predicate_cmp.cpp
+++ b/be/src/storage/primitive/column_predicate_cmp.cpp
@@ -30,6 +30,7 @@
 #include "storage/primitive/rowid_types.h"
 #include "storage/primitive/zone_map_detail.h"
 #include "types/datum.h"
+#include "types/logical_type.h"
 #include "types/olap_type_infra.h"
 #include "types/type_info.h"
 
@@ -276,6 +277,19 @@ public:
     }
 
 protected:
+    // For FLOAT/DOUBLE, a NaN min/max ZoneMap endpoint is unorderable: TypeInfo::cmp
+    // returns 0 for any (finite, NaN) pair, which makes range/equality pruning drop
+    // pages that may contain matching rows. Treat any NaN endpoint conservatively
+    // (keep the page). Compile-time no-op for non-float field types.
+    bool zonemap_has_nan_endpoint(const ZoneMapDetail& detail) const {
+        if constexpr (lt_is_float<field_type>) {
+            return zonemap_endpoint_is_nan(field_type, detail.min_value()) ||
+                   zonemap_endpoint_is_nan(field_type, detail.max_value());
+        } else {
+            return false;
+        }
+    }
+
     PredicateType _predicate;
     ValueType _value;
 };
@@ -290,6 +304,9 @@ public:
             : Base(PredicateType::kGE, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        if (this->zonemap_has_nan_endpoint(detail)) {
+            return true;
+        }
         const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(this->_value), max) <= 0;
     }
@@ -340,6 +357,9 @@ public:
             : Base(PredicateType::kGT, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        if (this->zonemap_has_nan_endpoint(detail)) {
+            return true;
+        }
         const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(this->_value), max) < 0;
     }
@@ -390,6 +410,9 @@ public:
             : Base(PredicateType::kLE, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        if (this->zonemap_has_nan_endpoint(detail)) {
+            return true;
+        }
         const auto& min = detail.min_or_null_value();
         const auto& max = detail.max_value();
         return (this->type_info()->cmp(Datum(this->_value), min) >= 0) & !max.is_null();
@@ -441,6 +464,9 @@ public:
             : Base(PredicateType::kLT, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        if (this->zonemap_has_nan_endpoint(detail)) {
+            return true;
+        }
         const auto& min = detail.min_or_null_value();
         const auto& max = detail.max_value();
         return (this->type_info()->cmp(Datum(this->_value), min) > 0) & !max.is_null();
@@ -492,6 +518,9 @@ public:
             : Base(PredicateType::kEQ, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        if (this->zonemap_has_nan_endpoint(detail)) {
+            return true;
+        }
         const auto& min = detail.min_or_null_value();
         const auto& max = detail.max_value();
         const auto type_info = this->type_info();
@@ -555,6 +584,9 @@ public:
             : Base(PredicateType::kNE, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        if (this->zonemap_has_nan_endpoint(detail)) {
+            return true;
+        }
         const auto& min = detail.min_or_null_value();
         const auto& max = detail.max_value();
         const auto type_info = this->type_info();

--- a/be/src/storage/primitive/zone_map_detail.h
+++ b/be/src/storage/primitive/zone_map_detail.h
@@ -14,11 +14,32 @@
 
 #pragma once
 
+#include <cmath>
 #include <utility>
 
 #include "types/datum.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
+
+// A FLOAT/DOUBLE ZoneMap endpoint holding NaN is unorderable: TypeInfo::cmp returns 0 for
+// any (finite, NaN) pair, and evaluating an IEEE expression on it yields all-false, so
+// range/equality pruning would wrongly drop a page/segment that may still hold matching
+// rows (legacy NaN-polluted zonemaps, or a pure-NaN page reachable by != / IS NOT NULL).
+// Callers must treat such an endpoint conservatively (keep the page). Returns false for
+// non-float types and for NULL.
+inline bool zonemap_endpoint_is_nan(LogicalType ltype, const Datum& d) {
+    if (d.is_null()) {
+        return false;
+    }
+    if (ltype == TYPE_FLOAT) {
+        return std::isnan(d.get_float());
+    }
+    if (ltype == TYPE_DOUBLE) {
+        return std::isnan(d.get_double());
+    }
+    return false;
+}
 
 class ZoneMapDetail {
 public:

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -36,6 +36,8 @@
 
 #include <bthread/sys_futex.h>
 
+#include <cmath>
+
 #include "base/hash/unaligned_access.h"
 #include "column/chunk_factory.h"
 #include "column/column_helper.h"
@@ -49,6 +51,7 @@
 #include "storage/rowset/indexed_column_reader.h"
 #include "storage/rowset/indexed_column_writer.h"
 #include "storage/types.h"
+#include "types/logical_type.h"
 #include "types/olap_type_infra.h"
 #include "types/storage_type_traits.h"
 #include "types/type_info.h"
@@ -155,6 +158,11 @@ struct ZoneMap {
     bool has_null = false;
     // has_not_null means whether zone has none-null value
     bool has_not_null = false;
+    // has_value means min_value/max_value hold a real ORDERABLE value (finite, non-NaN).
+    // Separate from has_not_null: a pure-NaN FLOAT/DOUBLE zone has non-null rows
+    // (has_not_null=true) but no orderable min/max (has_value=false). Writer-internal
+    // only; never serialized to ZoneMapPB.
+    bool has_value = false;
 
     void to_proto(ZoneMapPB* dst, TypeInfo* type_info) const {
         dst->set_min(min_value.to_zone_map_string(type_info));
@@ -210,6 +218,7 @@ private:
         zone_map->max_value.reset(_type_info);
         zone_map->has_null = false;
         zone_map->has_not_null = false;
+        zone_map->has_value = false;
     }
 
     TypeInfo* _type_info;
@@ -255,11 +264,37 @@ void ZoneMapIndexWriterImpl<LT>::_truncate_string_minmax_if_needed(ZoneMap<LT>* 
 
 template <LogicalType type>
 void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) {
-    if (count > 0) {
-        const auto* vals = reinterpret_cast<const CppType*>(values);
-        auto [pmin, pmax] = std::minmax_element(vals, vals + count);
+    if (count == 0) {
+        return;
+    }
+    const auto* vals = reinterpret_cast<const CppType*>(values);
 
-        if (_page_zone_map.has_not_null) {
+    const CppType* pmin = nullptr;
+    const CppType* pmax = nullptr;
+    if constexpr (lt_is_float<type>) {
+        // NaN breaks the total order assumed by '<' / '>'. Exclude it from the
+        // orderable min/max so it cannot lock or widen the zone map range.
+        for (size_t i = 0; i < count; ++i) {
+            const CppType v = unaligned_load<CppType>(vals + i);
+            if (std::isnan(v)) {
+                continue;
+            }
+            if (pmin == nullptr || v < unaligned_load<CppType>(pmin)) {
+                pmin = vals + i;
+            }
+            if (pmax == nullptr || v > unaligned_load<CppType>(pmax)) {
+                pmax = vals + i;
+            }
+        }
+    } else {
+        auto mm = std::minmax_element(vals, vals + count);
+        pmin = mm.first;
+        pmax = mm.second;
+    }
+
+    if (pmin != nullptr) {
+        // This batch has at least one orderable (non-NaN) value.
+        if (_page_zone_map.has_value) {
             if (unaligned_load<CppType>(pmin) < _page_zone_map.min_value.value) {
                 _page_zone_map.min_value.resize_container_for_fit(_type_info, pmin);
                 _type_info->direct_copy(&_page_zone_map.min_value.value, pmin);
@@ -277,16 +312,31 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
             _page_zone_map.max_value.resize_container_for_fit(_type_info, pmax);
             _type_info->direct_copy(&_page_zone_map.max_value.value, pmax);
             _truncate_string_minmax_if_needed(&_page_zone_map);
+
+            _page_zone_map.has_value = true;
         }
-        _page_zone_map.has_not_null = true;
+    } else if (!_page_zone_map.has_value) {
+        // Whole batch is NaN and no orderable value recorded yet: stash a NaN as a
+        // placeholder so this page (which DOES contain non-null rows) can serialize a
+        // min/max. has_value stays false, so this NaN is never merged into the segment
+        // zone map nor compared against later finite batches. (Placeholder strategy a.)
+        _page_zone_map.min_value.resize_container_for_fit(_type_info, vals);
+        _type_info->direct_copy(&_page_zone_map.min_value.value, vals);
+        _page_zone_map.max_value.resize_container_for_fit(_type_info, vals);
+        _type_info->direct_copy(&_page_zone_map.max_value.value, vals);
     }
+
+    // NaN is a value, not NULL: the page has non-null rows.
+    _page_zone_map.has_not_null = true;
 }
 
 template <LogicalType type>
 Status ZoneMapIndexWriterImpl<type>::flush() {
-    // Update segment zone map.
-    if (_page_zone_map.has_not_null) {
-        if (_segment_zone_map.has_not_null) {
+    // Update segment zone map. Only pages carrying an orderable (non-NaN) value
+    // contribute to the segment min/max; a pure-NaN page must not lock or widen the
+    // segment range via NaN's broken '<' ordering.
+    if (_page_zone_map.has_value) {
+        if (_segment_zone_map.has_value) {
             if (_page_zone_map.min_value.value < _segment_zone_map.min_value.value) {
                 _segment_zone_map.min_value.resize_container_for_fit(_type_info, &_page_zone_map.min_value.value);
                 _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value);
@@ -304,7 +354,21 @@ Status ZoneMapIndexWriterImpl<type>::flush() {
             _segment_zone_map.max_value.resize_container_for_fit(_type_info, &_page_zone_map.max_value.value);
             _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value);
             _truncate_string_minmax_if_needed(&_segment_zone_map);
+
+            _segment_zone_map.has_value = true;
         }
+    } else if (_page_zone_map.has_not_null && !_segment_zone_map.has_value && !_segment_zone_map.has_not_null) {
+        // Pure-NaN page and the segment has no value/rows yet: carry the NaN placeholder
+        // forward so a segment made entirely of NaN pages still serializes min/max with
+        // has_not_null=true. segment has_value stays false; the first finite page (if any)
+        // overwrites via the else branch above (which copies without comparison).
+        _segment_zone_map.min_value.resize_container_for_fit(_type_info, &_page_zone_map.min_value.value);
+        _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value);
+        _segment_zone_map.max_value.resize_container_for_fit(_type_info, &_page_zone_map.max_value.value);
+        _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value);
+    }
+
+    if (_page_zone_map.has_not_null) {
         _segment_zone_map.has_not_null = true;
     }
 

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -261,6 +261,8 @@ constexpr bool support_column_expr_predicate(LogicalType ltype) {
     case TYPE_INT:      /* 5 */
     case TYPE_BIGINT:   /* 6 */
     case TYPE_LARGEINT: /* 7 */
+    case TYPE_FLOAT:    /* 8 */
+    case TYPE_DOUBLE:   /* 9 */
     case TYPE_VARCHAR:  /* 10 */
     case TYPE_DATE:     /* 11 */
     case TYPE_DATETIME: /* 12 */

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -36,6 +36,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <cstdlib>
 #include <memory>
 #include <string>
 
@@ -49,6 +51,11 @@
 #include "storage/tablet_schema_helper.h"
 
 namespace starrocks {
+
+// Parse a ZoneMapPB min/max string (produced by TypeInfo::to_string) back to double.
+static inline double zm_to_double(const std::string& s) {
+    return std::strtod(s.c_str(), nullptr);
+}
 
 class ColumnZoneMapTest : public testing::Test {
 protected:
@@ -327,6 +334,138 @@ TEST_F(ColumnZoneMapTest, AllNullPage) {
     // segment zonemap
     const auto& segment_zonemap = index_meta.zone_map_index().segment_zone_map();
     check_result(segment_zonemap, false, false, "", "", true, false);
+}
+
+// A page containing a mix of NaN and finite values must report the FINITE range,
+// not NaN. NaN is placed first so std::minmax_element on unfixed code deterministically
+// locks min/max to NaN (NaN incumbent is never dislodged by '<').
+TEST_F(ColumnZoneMapTest, DoubleMixedNaNKeepsFiniteRange) {
+    std::string filename = kTestDir + "/DoubleMixedNaNKeepsFiniteRange";
+    TypeInfoPtr type_info = get_type_info(TYPE_DOUBLE);
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    double nan_v = std::nan("");
+    std::vector<double> vals = {nan_v, 2.0, 5.0};
+    writer->add_values(vals.data(), vals.size());
+    ASSERT_OK(writer->flush());
+
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    ASSERT_EQ(1, reader.num_pages());
+    const auto& zm = reader.page_zone_maps()[0];
+    ASSERT_TRUE(zm.has_not_null());
+    ASSERT_FALSE(zm.has_null());
+    ASSERT_EQ(2.0, zm_to_double(zm.min()));
+    ASSERT_EQ(5.0, zm_to_double(zm.max()));
+}
+
+// Multi-batch within one page: an all-NaN batch must not lock min/max so a later
+// finite batch in the same page is recorded correctly.
+TEST_F(ColumnZoneMapTest, DoubleNaNBatchThenFiniteBatch) {
+    std::string filename = kTestDir + "/DoubleNaNBatchThenFiniteBatch";
+    TypeInfoPtr type_info = get_type_info(TYPE_DOUBLE);
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    double nan_v = std::nan("");
+    std::vector<double> b1 = {nan_v, nan_v};
+    std::vector<double> b2 = {2.0, 5.0};
+    writer->add_values(b1.data(), b1.size());
+    writer->add_values(b2.data(), b2.size()); // same page, no flush between
+    ASSERT_OK(writer->flush());
+
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    const auto& zm = reader.page_zone_maps()[0];
+    ASSERT_TRUE(zm.has_not_null());
+    ASSERT_EQ(2.0, zm_to_double(zm.min()));
+    ASSERT_EQ(5.0, zm_to_double(zm.max()));
+}
+
+// Invariant lock (passes before AND after the fix): a pure-NaN page has non-null
+// rows, so has_not_null must stay true (otherwise IS NOT NULL would wrongly prune).
+// Placeholder strategy (a): min/max are NaN.
+TEST_F(ColumnZoneMapTest, DoubleAllNaNPageKeepsHasNotNull) {
+    std::string filename = kTestDir + "/DoubleAllNaNPageKeepsHasNotNull";
+    TypeInfoPtr type_info = get_type_info(TYPE_DOUBLE);
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    std::vector<double> vals(5, std::nan(""));
+    writer->add_values(vals.data(), vals.size());
+    ASSERT_OK(writer->flush());
+
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    const auto& zm = reader.page_zone_maps()[0];
+    ASSERT_TRUE(zm.has_not_null());
+    ASSERT_FALSE(zm.has_null());
+    ASSERT_TRUE(std::isnan(zm_to_double(zm.min())));
+    ASSERT_TRUE(std::isnan(zm_to_double(zm.max())));
+
+    // The pure-NaN SEGMENT must also keep has_not_null=true with NaN min/max (the flush
+    // placeholder path), not [TYPE_MIN, TYPE_MIN] which the read-side guard could not detect.
+    const auto& seg = index_meta.zone_map_index().segment_zone_map();
+    ASSERT_TRUE(seg.has_not_null());
+    ASSERT_FALSE(seg.has_null());
+    ASSERT_TRUE(std::isnan(zm_to_double(seg.min())));
+    ASSERT_TRUE(std::isnan(zm_to_double(seg.max())));
+}
+
+// Compaction-style segment merge (report §12): an all-NaN page flushed before a
+// finite page must not poison the SEGMENT range. Segment must report the finite range.
+TEST_F(ColumnZoneMapTest, DoubleSegmentNaNPageThenFinitePage) {
+    std::string filename = kTestDir + "/DoubleSegmentNaNPageThenFinitePage";
+    TypeInfoPtr type_info = get_type_info(TYPE_DOUBLE);
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    double nan_v = std::nan("");
+    std::vector<double> p0(3, nan_v);
+    writer->add_values(p0.data(), p0.size());
+    ASSERT_OK(writer->flush()); // page 0: all NaN
+
+    std::vector<double> p1 = {2500.0, 2999.0};
+    writer->add_values(p1.data(), p1.size());
+    ASSERT_OK(writer->flush()); // page 1: finite
+
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    const auto& seg = index_meta.zone_map_index().segment_zone_map();
+    ASSERT_TRUE(seg.has_not_null());
+    ASSERT_EQ(2500.0, zm_to_double(seg.min()));
+    ASSERT_EQ(2999.0, zm_to_double(seg.max()));
+}
+
+// FLOAT mirror of the mixed-page case to confirm both float types are covered.
+TEST_F(ColumnZoneMapTest, FloatMixedNaNKeepsFiniteRange) {
+    std::string filename = kTestDir + "/FloatMixedNaNKeepsFiniteRange";
+    TypeInfoPtr type_info = get_type_info(TYPE_FLOAT);
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    float nan_v = std::nanf("");
+    std::vector<float> vals = {nan_v, 2.0f, 5.0f};
+    writer->add_values(vals.data(), vals.size());
+    ASSERT_OK(writer->flush());
+
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    const auto& zm = reader.page_zone_maps()[0];
+    ASSERT_TRUE(zm.has_not_null());
+    ASSERT_EQ(2.0, zm_to_double(zm.min()));
+    ASSERT_EQ(5.0, zm_to_double(zm.max()));
 }
 
 // Test for int

--- a/be/test/storage_primitive/column_predicate_test.cpp
+++ b/be/test/storage_primitive/column_predicate_test.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <vector>
 
 #include "base/testutil/assert.h"
@@ -19,6 +20,7 @@
 #include "gtest/gtest.h"
 #include "runtime/runtime_filter.h"
 #include "storage/primitive/column_predicate_factory.h"
+#include "storage/primitive/zone_map_detail.h"
 
 namespace starrocks {
 
@@ -42,6 +44,55 @@ static inline std::string to_string(const std::vector<uint16_t>& values) {
     std::string s = ss.str();
     s.pop_back();
     return s;
+}
+
+// Fix B: a NaN ZoneMap endpoint is unorderable; every comparison predicate must
+// keep the page (conservative), because TypeInfo::cmp(finite, NaN) == 0 otherwise
+// makes GT/LT/EQ/NE prune pages that may hold matching rows (report §10/§11).
+TEST(ColumnPredicateNaNZoneMapTest, DoubleNaNEndpointKeepsPage) {
+    TypeInfoPtr ti = get_type_info(TYPE_DOUBLE);
+    double nan_v = std::nan("");
+    ZoneMapDetail nan_detail(Datum(nan_v), Datum(nan_v), false); // min=max=NaN, has_null=false
+
+    std::unique_ptr<ColumnPredicate> gt(new_column_gt_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    std::unique_ptr<ColumnPredicate> lt(new_column_lt_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    std::unique_ptr<ColumnPredicate> ge(new_column_ge_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    std::unique_ptr<ColumnPredicate> le(new_column_le_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    std::unique_ptr<ColumnPredicate> eq(new_column_eq_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    std::unique_ptr<ColumnPredicate> ne(new_column_ne_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+
+    ASSERT_TRUE(gt->zone_map_filter(nan_detail));
+    ASSERT_TRUE(lt->zone_map_filter(nan_detail));
+    ASSERT_TRUE(ge->zone_map_filter(nan_detail));
+    ASSERT_TRUE(le->zone_map_filter(nan_detail));
+    ASSERT_TRUE(eq->zone_map_filter(nan_detail));
+    ASSERT_TRUE(ne->zone_map_filter(nan_detail));
+}
+
+// Guard: finite endpoints must still prune normally (the NaN guard must not
+// over-keep). GT 3000 against [0,100] -> no row can match -> prune (false).
+TEST(ColumnPredicateNaNZoneMapTest, DoubleFiniteEndpointStillPrunes) {
+    TypeInfoPtr ti = get_type_info(TYPE_DOUBLE);
+    ZoneMapDetail finite_detail(Datum((double)0.0), Datum((double)100.0), false);
+
+    std::unique_ptr<ColumnPredicate> gt(new_column_gt_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    std::unique_ptr<ColumnPredicate> lt(new_column_lt_predicate_from_datum(ti, 0, Datum((double)-1.0)));
+
+    ASSERT_FALSE(gt->zone_map_filter(finite_detail)); // 3000 > max(100) -> prune
+    ASSERT_FALSE(lt->zone_map_filter(finite_detail)); // -1 < min(0)   -> prune
+}
+
+// FLOAT mirror.
+TEST(ColumnPredicateNaNZoneMapTest, FloatNaNEndpointKeepsPage) {
+    TypeInfoPtr ti = get_type_info(TYPE_FLOAT);
+    float nan_v = std::nanf("");
+    ZoneMapDetail nan_detail(Datum(nan_v), Datum(nan_v), false);
+
+    std::unique_ptr<ColumnPredicate> gt(new_column_gt_predicate_from_datum(ti, 0, Datum((float)3000.0f)));
+    std::unique_ptr<ColumnPredicate> eq(new_column_eq_predicate_from_datum(ti, 0, Datum((float)3000.0f)));
+
+    ASSERT_TRUE(gt->zone_map_filter(nan_detail));
+    ASSERT_TRUE(eq->zone_map_filter(nan_detail));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/storage_primitive/column_predicate_test.cpp
+++ b/be/test/storage_primitive/column_predicate_test.cpp
@@ -60,6 +60,10 @@ TEST(ColumnPredicateNaNZoneMapTest, DoubleNaNEndpointKeepsPage) {
     std::unique_ptr<ColumnPredicate> le(new_column_le_predicate_from_datum(ti, 0, Datum((double)3000.0)));
     std::unique_ptr<ColumnPredicate> eq(new_column_eq_predicate_from_datum(ti, 0, Datum((double)3000.0)));
     std::unique_ptr<ColumnPredicate> ne(new_column_ne_predicate_from_datum(ti, 0, Datum((double)3000.0)));
+    // NotIn has no explicit NaN-endpoint guard; it must still keep a pure-NaN [NaN,NaN] page
+    // (NaN is NOT IN any finite set) via its min==max float guard / fall-through keep.
+    std::unique_ptr<ColumnPredicate> not_in(
+            new_column_not_in_predicate_from_datum(ti, 0, std::vector<Datum>{Datum((double)3000.0)}));
 
     ASSERT_TRUE(gt->zone_map_filter(nan_detail));
     ASSERT_TRUE(lt->zone_map_filter(nan_detail));
@@ -67,6 +71,7 @@ TEST(ColumnPredicateNaNZoneMapTest, DoubleNaNEndpointKeepsPage) {
     ASSERT_TRUE(le->zone_map_filter(nan_detail));
     ASSERT_TRUE(eq->zone_map_filter(nan_detail));
     ASSERT_TRUE(ne->zone_map_filter(nan_detail));
+    ASSERT_TRUE(not_in->zone_map_filter(nan_detail));
 }
 
 // Guard: finite endpoints must still prune normally (the NaN guard must not
@@ -90,9 +95,58 @@ TEST(ColumnPredicateNaNZoneMapTest, FloatNaNEndpointKeepsPage) {
 
     std::unique_ptr<ColumnPredicate> gt(new_column_gt_predicate_from_datum(ti, 0, Datum((float)3000.0f)));
     std::unique_ptr<ColumnPredicate> eq(new_column_eq_predicate_from_datum(ti, 0, Datum((float)3000.0f)));
+    std::unique_ptr<ColumnPredicate> not_in(
+            new_column_not_in_predicate_from_datum(ti, 0, std::vector<Datum>{Datum((float)3000.0f)}));
 
     ASSERT_TRUE(gt->zone_map_filter(nan_detail));
     ASSERT_TRUE(eq->zone_map_filter(nan_detail));
+    ASSERT_TRUE(not_in->zone_map_filter(nan_detail));
+}
+
+// A mixed FLOAT/DOUBLE page {NaN, c, c} is serialized by the zonemap writer as [c, c]
+// (NaN excluded from the orderable min/max), leaving NO NaN endpoint. Since NaN != c is
+// true, the hidden NaN row matches != / NOT IN, so single-value pruning would wrongly drop
+// the page. For float, NE/NotIn must KEEP a single-value zone (the NaN-endpoint guard cannot
+// fire here because both endpoints are finite).
+TEST(ColumnPredicateNaNZoneMapTest, DoubleCollapsedSingleValueZoneKeepsForNeAndNotIn) {
+    TypeInfoPtr ti = get_type_info(TYPE_DOUBLE);
+    ZoneMapDetail single_detail(Datum((double)1.0), Datum((double)1.0), false); // [1.0, 1.0], finite
+
+    std::unique_ptr<ColumnPredicate> ne(new_column_ne_predicate_from_datum(ti, 0, Datum((double)1.0)));
+    std::unique_ptr<ColumnPredicate> not_in(
+            new_column_not_in_predicate_from_datum(ti, 0, std::vector<Datum>{Datum((double)1.0)}));
+
+    ASSERT_TRUE(ne->zone_map_filter(single_detail));     // != 1.0 must KEEP (a hidden NaN matches)
+    ASSERT_TRUE(not_in->zone_map_filter(single_detail)); // NOT IN (1.0) must KEEP
+}
+
+// FLOAT mirror.
+TEST(ColumnPredicateNaNZoneMapTest, FloatCollapsedSingleValueZoneKeepsForNeAndNotIn) {
+    TypeInfoPtr ti = get_type_info(TYPE_FLOAT);
+    ZoneMapDetail single_detail(Datum((float)1.0f), Datum((float)1.0f), false);
+
+    std::unique_ptr<ColumnPredicate> ne(new_column_ne_predicate_from_datum(ti, 0, Datum((float)1.0f)));
+    std::unique_ptr<ColumnPredicate> not_in(
+            new_column_not_in_predicate_from_datum(ti, 0, std::vector<Datum>{Datum((float)1.0f)}));
+
+    ASSERT_TRUE(ne->zone_map_filter(single_detail));
+    ASSERT_TRUE(not_in->zone_map_filter(single_detail));
+}
+
+// Regression: non-float single-value pruning must be unchanged (NaN cannot occur for INT),
+// so the conservative float-only guard must not weaken integer NE/NotIn pruning.
+TEST(ColumnPredicateNaNZoneMapTest, IntSingleValueZoneStillPrunesNeAndNotIn) {
+    TypeInfoPtr ti = get_type_info(TYPE_INT);
+    ZoneMapDetail single_detail(Datum((int32_t)5), Datum((int32_t)5), false); // [5, 5]
+
+    std::unique_ptr<ColumnPredicate> ne_hit(new_column_ne_predicate_from_datum(ti, 0, Datum((int32_t)5)));
+    std::unique_ptr<ColumnPredicate> ne_miss(new_column_ne_predicate_from_datum(ti, 0, Datum((int32_t)7)));
+    std::unique_ptr<ColumnPredicate> not_in_hit(
+            new_column_not_in_predicate_from_datum(ti, 0, std::vector<Datum>{Datum((int32_t)5)}));
+
+    ASSERT_FALSE(ne_hit->zone_map_filter(single_detail));     // != 5 on [5,5] -> no match -> prune
+    ASSERT_TRUE(ne_miss->zone_map_filter(single_detail));     // != 7 on [5,5] -> all match -> keep
+    ASSERT_FALSE(not_in_hit->zone_map_filter(single_detail)); // NOT IN (5) on [5,5] -> prune
 }
 
 // NOLINTNEXTLINE

--- a/be/test/types/logical_type_test.cpp
+++ b/be/test/types/logical_type_test.cpp
@@ -50,6 +50,23 @@ TEST(LogicalTypeTest, TypePredicates) {
     EXPECT_FALSE(is_binary_type(TYPE_VARCHAR));
 }
 
+// Regression test for support_column_expr_predicate: the white-list used by
+// ChunkPredicateBuilder::build_column_expr_predicates() to decide whether a
+// predicate can be lowered into the segment-level pred_tree as a
+// ColumnExprPredicate. FLOAT/DOUBLE were previously excluded, blocking
+// zone-map pruning and late materialization on those columns even though
+// ColumnExprPredicate evaluation reuses the original ExprContext and has no
+// precision concern.
+TEST(LogicalTypeTest, SupportColumnExprPredicateForFloatAndDouble) {
+    EXPECT_TRUE(support_column_expr_predicate(TYPE_FLOAT));
+    EXPECT_TRUE(support_column_expr_predicate(TYPE_DOUBLE));
+
+    // Non per-row scalar types must still be rejected.
+    EXPECT_FALSE(support_column_expr_predicate(TYPE_HLL));
+    EXPECT_FALSE(support_column_expr_predicate(TYPE_JSON));
+    EXPECT_FALSE(support_column_expr_predicate(TYPE_ARRAY));
+}
+
 namespace {
 
 struct DispatchLogicalTypeFunctor {

--- a/test/sql/test_zonemap_nan/R/test_zonemap_nan_pruning
+++ b/test/sql/test_zonemap_nan/R/test_zonemap_nan_pruning
@@ -1,0 +1,108 @@
+-- name: test_zonemap_nan_pruning
+CREATE TABLE t_zm_nan (
+    id BIGINT,
+    val DOUBLE
+) PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_zm_nan VALUES
+  (1, (1e308*10)-(1e308*10)),
+  (2, (1e308*10)-(1e308*10)),
+  (3, (1e308*10)-(1e308*10)),
+  (4, 100.0),
+  (5, 200.0),
+  (6, 300.0),
+  (7, 400.0),
+  (8, 500.0);
+-- result:
+-- !result
+SELECT COUNT(*) FROM t_zm_nan;
+-- result:
+8
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val IS NULL;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val != val;
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val > 250;
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val < 250;
+-- result:
+2
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val = 300;
+-- result:
+1
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val >= 300;
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val != 300;
+-- result:
+7
+-- !result
+SELECT COUNT(*) FROM t_zm_nan WHERE val IS NOT NULL;
+-- result:
+8
+-- !result
+DROP TABLE t_zm_nan;
+-- result:
+-- !result
+-- name: test_zonemap_all_nan
+CREATE TABLE t_zm_allnan (
+    id BIGINT,
+    val DOUBLE
+) PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_zm_allnan VALUES
+  (1, (1e308*10)-(1e308*10)),
+  (2, (1e308*10)-(1e308*10)),
+  (3, (1e308*10)-(1e308*10)),
+  (4, (1e308*10)-(1e308*10));
+-- result:
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan;
+-- result:
+4
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val IS NULL;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val != val;
+-- result:
+4
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val = val;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val IS NOT NULL;
+-- result:
+4
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val > 100;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val < 100;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t_zm_allnan WHERE val != 100;
+-- result:
+4
+-- !result
+DROP TABLE t_zm_allnan;
+-- result:
+-- !result

--- a/test/sql/test_zonemap_nan/T/test_zonemap_nan_pruning
+++ b/test/sql/test_zonemap_nan/T/test_zonemap_nan_pruning
@@ -1,0 +1,57 @@
+-- name: test_zonemap_nan_pruning
+-- Regression for the FLOAT/DOUBLE ZoneMap NaN-pollution mis-prune.
+-- A typed NaN (Inf - Inf) poisons the segment zonemap min/max to [-nan,-nan];
+-- before the fix, ordered predicates pruned the whole segment -> wrong (empty) results.
+-- NOTE: CAST('NaN' AS DOUBLE) becomes NULL in StarRocks, so typed NaN must come from
+-- arithmetic. The "val IS NULL = 0" / "val != val = 3" asserts fail loudly if the NaN
+-- generation ever silently degrades to NULL.
+CREATE TABLE t_zm_nan (
+    id BIGINT,
+    val DOUBLE
+) PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO t_zm_nan VALUES
+  (1, (1e308*10)-(1e308*10)),
+  (2, (1e308*10)-(1e308*10)),
+  (3, (1e308*10)-(1e308*10)),
+  (4, 100.0),
+  (5, 200.0),
+  (6, 300.0),
+  (7, 400.0),
+  (8, 500.0);
+SELECT COUNT(*) FROM t_zm_nan;
+SELECT COUNT(*) FROM t_zm_nan WHERE val IS NULL;
+SELECT COUNT(*) FROM t_zm_nan WHERE val != val;
+SELECT COUNT(*) FROM t_zm_nan WHERE val > 250;
+SELECT COUNT(*) FROM t_zm_nan WHERE val < 250;
+SELECT COUNT(*) FROM t_zm_nan WHERE val = 300;
+SELECT COUNT(*) FROM t_zm_nan WHERE val >= 300;
+SELECT COUNT(*) FROM t_zm_nan WHERE val != 300;
+SELECT COUNT(*) FROM t_zm_nan WHERE val IS NOT NULL;
+DROP TABLE t_zm_nan;
+
+-- name: test_zonemap_all_nan
+-- A column that is ENTIRELY typed NaN -> a pure-NaN segment. Its zonemap must keep
+-- has_not_null=true (NaN is non-null), so IS NOT NULL / != still reach the rows; ordered
+-- predicates correctly match nothing. End-to-end counterpart to the C++ test
+-- DoubleAllNaNPageKeepsHasNotNull. The discriminating assert is "val IS NOT NULL = 4":
+-- if the pure-NaN segment were mismarked all-null, it would wrongly return 0.
+CREATE TABLE t_zm_allnan (
+    id BIGINT,
+    val DOUBLE
+) PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO t_zm_allnan VALUES
+  (1, (1e308*10)-(1e308*10)),
+  (2, (1e308*10)-(1e308*10)),
+  (3, (1e308*10)-(1e308*10)),
+  (4, (1e308*10)-(1e308*10));
+SELECT COUNT(*) FROM t_zm_allnan;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val IS NULL;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val != val;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val = val;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val IS NOT NULL;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val > 100;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val < 100;
+SELECT COUNT(*) FROM t_zm_allnan WHERE val != 100;
+DROP TABLE t_zm_allnan;


### PR DESCRIPTION
## Why I'm doing:
A typed NaN (e.g. (1e308*10)-(1e308*10) = Inf-Inf) breaks the IEEE total order,
so std::minmax_element selects it as an endpoint and poisons the FLOAT/DOUBLE
ZoneMap min/max to [NaN,NaN]. The zone-map filter is not NaN-aware, so ordered
predicates wrongly prune whole pages/segments and return empty/short results.
Enabling ColumnExprPredicate pushdown for FLOAT/DOUBLE routed float predicates
through the zone-map filter and exposed this on the read path; compaction also
propagated the pollution into merged segments.

Write side (zone_map_index.cpp): add a writer-internal has_value flag, separate
from has_not_null (NaN is a non-null value). add_values excludes NaN from the
orderable min/max accumulation; flush gates the page->segment merge on has_value
so a NaN page can neither lock nor widen the segment range. A page/segment that
is entirely NaN serializes a NaN placeholder with has_not_null=true so
IS NOT NULL / != still reach those rows.

Read side: treat a NaN FLOAT/DOUBLE ZoneMap endpoint conservatively (keep the
page) so already-poisoned on-disk segments are not mis-pruned. Applied in both
the typed comparison predicates (column_predicate_cmp.cpp) and
ColumnExprPredicate::zone_map_filter -- the latter is the active float path once
pushdown is enabled. Both delegate to a shared zonemap_endpoint_is_nan() in
storage/primitive/zone_map_detail.h.
## What I'm doing:

Fixes #issue


**-  Before optimization：**

SQL: SELECT  * FROM t WHERE col_double = 268351851.75
```
               - SegmentRead: 723.224ms
                 - __MAX_OF_SegmentRead: 1s20ms
                 - __MIN_OF_SegmentRead: 359.443ms
             - RawRowsRead: 300.000M (300000000)
               - __MAX_OF_RawRowsRead: 13.631M (13631488)
               - __MIN_OF_RawRowsRead: 5.243M (5242880)
             - ReadPagesNum: 290.966K (290966)
               - __MAX_OF_ReadPagesNum: 13.219K (13219)
               - __MIN_OF_ReadPagesNum: 5.082K (5082)
```
SQL:  SELECT  * FROM t WHERE col_double = -999999999.0
```         
              - SegmentRead: 735.858ms
                 - __MAX_OF_SegmentRead: 1s66ms
                 - __MIN_OF_SegmentRead: 416.457ms
             - RawRowsRead: 300.000M (300000000)
               - __MAX_OF_RawRowsRead: 13.631M (13631488)
               - __MIN_OF_RawRowsRead: 5.243M (5242880)
             - ReadPagesNum: 290.920K (290920)
               - __MAX_OF_ReadPagesNum: 13.217K (13217)
               - __MIN_OF_ReadPagesNum: 5.084K (5084)
```
**-  After optimization：**

SQL: SELECT  * FROM t WHERE col_double = 268351851.75
```
               - SegmentRead: 87.676ms
                 - __MAX_OF_SegmentRead: 120.390ms
                 - __MIN_OF_SegmentRead: 68.066ms
             - RawRowsRead: 300.000M (300000000)
               - __MAX_OF_RawRowsRead: 12.583M (12582912)
               - __MIN_OF_RawRowsRead: 7.340M (7340032)
             - ReadPagesNum: 36.628K (36628)
               - __MAX_OF_ReadPagesNum: 1.536K (1536)
               - __MIN_OF_ReadPagesNum: 896
```
SQL:  SELECT  * FROM t WHERE col_double = -999999999.0
```         
              - SegmentZoneMapFilterRows: 300.000M (300000000)
             - RawRowsRead: 0
             - ReadPagesNum: 0
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
