### PR TITLE
[Enhancement] update staros to v4.2-rc2

### DIFF
--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -22,7 +22,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20260526.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v4.2-rc1
+ARG starlet_tag=v4.2-rc2
 # build for which linux distro: centos7|ubuntu
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.

--- a/docs/en/developers/mac-compile-run-test.md
+++ b/docs/en/developers/mac-compile-run-test.md
@@ -387,13 +387,13 @@ The macOS compilation implementation follows these principles:
 
 **Q: Getting "protobuf version mismatch" error during compilation**
 
-A: Make sure the BE CMake build is using `thirdparty/installed/bin/protoc` (version 3.14.0) instead of system or Homebrew's protobuf:
+A: Make sure the BE CMake build is using `thirdparty/installed/bin/protoc` (version 3.16.1) instead of system or Homebrew's protobuf:
 
 ```bash
 # Check protobuf version
 /Users/kks/git/starrocks/thirdparty/installed/bin/protoc --version
 
-# Should output: libprotoc 3.14.0
+# Should output: libprotoc 3.16.1
 ```
 
 **Q: Out of memory during compilation**

--- a/docs/zh/developers/mac-compile-run-test.md
+++ b/docs/zh/developers/mac-compile-run-test.md
@@ -387,13 +387,13 @@ macOS 版本编译的实现遵循以下原则：
 
 **Q: 编译时报错 "protobuf version mismatch"**
 
-A: 确保 BE 的 CMake 构建使用 `thirdparty/installed/bin/protoc` (版本 3.14.0)，而不是系统或 Homebrew 的 protobuf：
+A: 确保 BE 的 CMake 构建使用 `thirdparty/installed/bin/protoc` (版本 3.16.1)，而不是系统或 Homebrew 的 protobuf：
 
 ```bash
 # 检查 protobuf 版本
 /Users/kks/git/starrocks/thirdparty/installed/bin/protoc --version
 
-# 应该输出：libprotoc 3.14.0
+# 应该输出：libprotoc 3.16.1
 ```
 
 **Q: 编译时内存不足**

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -81,7 +81,7 @@ under the License.
         <paimon.version>1.3.1</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <iceberg.version>1.10.0</iceberg.version>
-        <staros.version>4.2-rc1</staros.version>
+        <staros.version>4.2-rc2</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
         <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
         <jetty.version>9.4.58.v20250814</jetty.version>

--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -269,10 +269,10 @@ let
       md5 = "282e54a68911f516b15d07136c78592b";
       sha256 = "19hprnr6c87490m8531vl9ygnhzbkw7whz1yy1lk09njzjq8xccj";
     };
-    "protobuf-3.14.0.tar.gz" = {
-      url = "https://github.com/google/protobuf/archive/v3.14.0.tar.gz";
-      md5 = "0c9d2a96f3656ba7ef3b23b533fb6170";
-      sha256 = "04v1q7g6kx9nwm1fs8dix27iszh3ycnsidf8wry00mnns02zdxfh";
+    "protobuf-3.16.1.tar.gz" = {
+      url = "https://github.com/google/protobuf/archive/v3.16.1.tar.gz";
+      md5 = "6294f01dedea72a76b9e113369f55097";
+      sha256 = "0zsxh0lxcn874rmhjzcqqx1bhqpnxalvh2yscsgr9x1d1fq5i4gv";
     };
     "pulsar-client-3.3.0.tar.gz" = {
       url = "https://github.com/apache/pulsar-client-cpp/archive/refs/tags/v3.3.0.tar.gz";
@@ -464,7 +464,7 @@ let
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
       "openssl-OpenSSL_1_1_1m.tar.gz"
       "thrift-0.23.0.tar.gz"
-      "protobuf-3.14.0.tar.gz"
+      "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
       "glog-0.7.1.tar.gz"
       "googletest-release-1.10.0.tar.gz"
@@ -535,7 +535,7 @@ let
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
       "openssl-OpenSSL_1_1_1m.tar.gz"
       "thrift-0.23.0.tar.gz"
-      "protobuf-3.14.0.tar.gz"
+      "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
       "glog-0.7.1.tar.gz"
       "googletest-release-1.10.0.tar.gz"
@@ -604,7 +604,7 @@ let
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
       "openssl-OpenSSL_1_1_1m.tar.gz"
       "thrift-0.23.0.tar.gz"
-      "protobuf-3.14.0.tar.gz"
+      "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
       "glog-0.7.1.tar.gz"
       "googletest-release-1.10.0.tar.gz"

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v4.2-rc1
+export STARLET_ARTIFACTS_TAG=v4.2-rc2

--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -51,10 +51,10 @@ TENANN_MD5SUM="b48f21ada7aeb153245a8c8a25a534d9"
 #TENANN_MD5SUM="11b35d1d7aea0c48ba6d7c60633a7348"
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-centos7_arm64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-centos7_arm64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="901cbd54823c73588a6f43e4d3b32e44"
+STARCACHE_MD5SUM="3cfef8be7a06a71108174599eac6a9c9"
 
 # pprof
 PPROF_DOWNLOAD="https://github.com/StarRocks/pprof/releases/download/release%2F20260610/pprof-linux-arm64"

--- a/thirdparty/vars-ubuntu22-aarch64.sh
+++ b/thirdparty/vars-ubuntu22-aarch64.sh
@@ -22,7 +22,7 @@
 #####################################################
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-ubuntu22_arm64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-ubuntu22_arm64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="9ad0c4f45e931459d9699a6f25e6019a"
+STARCACHE_MD5SUM="78f2030bfd5772a700d731ff864279a2"

--- a/thirdparty/vars-ubuntu22-x86_64.sh
+++ b/thirdparty/vars-ubuntu22-x86_64.sh
@@ -28,7 +28,7 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-ubuntu22-x86_64"
 JINDOSDK_MD5SUM="52236053391091591c2d09684791e810"
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-ubuntu22_amd64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-ubuntu22_amd64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="e0f776ad3b33545b6d5754e3e2d915cc"
+STARCACHE_MD5SUM="b3dcf073ac1869fb0851cb5c83e2cbcc"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -46,10 +46,10 @@ TENANN_SOURCE="tenann-v0.5.1-rc1"
 TENANN_MD5SUM="a1b3c1507797ad9ae02f9690a1387cfc"
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-centos7_amd64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-centos7_amd64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="23b115d131c8c7738c9a57c41d7b791f"
+STARCACHE_MD5SUM="4f75bfdaf4956ea7433822bf51eb7a08"
 
 # pprof
 PPROF_DOWNLOAD="https://github.com/StarRocks/pprof/releases/download/release%2F20260610/pprof-linux-amd64"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -103,10 +103,10 @@ THRIFT_SOURCE=thrift-0.23.0
 THRIFT_MD5SUM="7b62f4258ded41e233a638fe8b9fcf64"
 
 # protobuf
-PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.14.0.tar.gz"
-PROTOBUF_NAME=protobuf-3.14.0.tar.gz
-PROTOBUF_SOURCE=protobuf-3.14.0
-PROTOBUF_MD5SUM="0c9d2a96f3656ba7ef3b23b533fb6170"
+PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.16.1.tar.gz"
+PROTOBUF_NAME=protobuf-3.16.1.tar.gz
+PROTOBUF_SOURCE=protobuf-3.16.1
+PROTOBUF_MD5SUM="6294f01dedea72a76b9e113369f55097"
 
 # gflags
 GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

staros has released v4.2-rc2. Update StarRocks to depend on the new staros/starlet release so the bug fixes and improvements shipped in v4.2-rc2 are picked up by the build.

v4.2-rc2 also bumps staros's bundled C++ protobuf from `3.14.0` to `3.16.1` (staros #1256). The starlet artifacts in v4.2-rc2 are generated with protoc `3.16.1`, and the generated `.pb.h` enforce `PROTOBUF_VERSION >= 3016000` at compile time. StarRocks BE links against starlet and includes those headers, so the bundled C++ protobuf must be bumped to a matching version as well, otherwise BE fails to compile with a protobuf version mismatch.

## What I'm doing:

- Bump `staros.version` in `fe/pom.xml` from `4.2-rc1` to `4.2-rc2` (the FE starmgr/starclient maven artifacts).
- Bump `STARLET_ARTIFACTS_TAG` in `thirdparty/starlet-artifacts-version.sh` from `v4.2-rc1` to `v4.2-rc2` (the BE starlet artifacts docker image tag).
- Bump the `starlet_tag` build arg in `docker/dockerfiles/dev-env/dev-env.Dockerfile` from `v4.2-rc1` to `v4.2-rc2` so the dev-env image pulls the matching starlet artifacts.
- starcache is intentionally kept at `v4.2-rc1`, since this staros release does not include a starcache update.
- Bump the bundled C++ protobuf in `thirdparty/vars.sh` from `3.14.0` to `3.16.1` (`PROTOBUF_DOWNLOAD`/`NAME`/`SOURCE` and the verified `PROTOBUF_MD5SUM` `6294f01dedea72a76b9e113369f55097`), matching staros #1256, so BE can compile and link against starlet v4.2-rc2's `3.16.1`-generated headers.
- Update the protoc version referenced in the macOS compile FAQ (`docs/en/developers/mac-compile-run-test.md` and `docs/zh/...`) from `3.14.0` to `3.16.1`.

> NOTE: the pre-built thirdparty tarball on the CDN must be rebuilt and republished with protobuf `3.16.1` (and `dev-env.Dockerfile`'s `thirdparty_url` bumped to the new tarball) before CI can compile against it; otherwise CI keeps using the old `3.14.0` thirdparty and fails to build starlet's `3.16.1` headers.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5