### PR TITLE
[Enhancement] IVM: re-derive the maintenance query at refresh instead of freezing it

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -893,6 +893,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return formatInsertSql("INSERT INTO");
     }
 
+    public String getIVMTaskDefinition(String selectSql) {
+        return formatInsertSql("INSERT INTO", selectSql);
+    }
+
     /**
      * Build an INSERT SQL for this MV. Uses an explicit column list only when the schema
      * has storage-filled columns (AUTO_INCREMENT) that the query doesn't produce. Otherwise
@@ -900,10 +904,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * which {@code InsertAnalyzer} rejects if listed explicitly.
      */
     private String formatInsertSql(String insertKeyword) {
+        return formatInsertSql(insertKeyword, getMVQueryDefinedSql());
+    }
+
+    private String formatInsertSql(String insertKeyword, String selectSql) {
         String targetSpec = hasAutoIncrementColumn()
                 ? String.format("`%s` (%s)", getName(), queryProducedColumnList())
                 : String.format("`%s`", getName());
-        return String.format("%s %s %s", insertKeyword, targetSpec, getMVQueryDefinedSql());
+        return String.format("%s %s %s", insertKeyword, targetSpec, selectSql);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -889,6 +889,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return formatInsertSql("insert overwrite");
     }
 
+    public String getTaskDefinition(String selectSql) {
+        return formatInsertSql("insert overwrite", selectSql);
+    }
+
     public String getIVMTaskDefinition(String selectSql) {
         return formatInsertSql("INSERT INTO", selectSql);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -889,10 +889,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return formatInsertSql("insert overwrite");
     }
 
-    public String getIVMTaskDefinition() {
-        return formatInsertSql("INSERT INTO");
-    }
-
     public String getIVMTaskDefinition(String selectSql) {
         return formatInsertSql("INSERT INTO", selectSql);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -16,7 +16,6 @@ package com.starrocks.scheduler.mv;
 
 import com.google.common.base.Strings;
 import com.starrocks.catalog.BaseTableInfo;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
@@ -25,20 +24,17 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.analyzer.mv.IvmSchemaCompat;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.statistic.StatisticUtils;
-import com.starrocks.type.ScalarType;
-import com.starrocks.type.Type;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -141,65 +137,7 @@ public final class MVRefreshSchemaChecker {
         QueryStatement queryStmt = (QueryStatement) statements.get(0);
         Analyzer.analyze(queryStmt, context);
 
-        // Align by position, not name: stored MV cols and analyzer Fields are both in the
-        // SELECT-list output order, so position i pairs them. Name lookup would break MVs
-        // created with explicit column aliases — CREATE MV (x, y) AS SELECT k, v — where the
-        // stored column is named x but the analyzer Field is named k. Position is the only
-        // stable correspondence.
-        // Hidden stored cols (IVM __ROW_ID__, __AGG_STATE_<func>) keep their position but are
-        // skipped — their analyzer-derived nullability diverges from stored NOT NULL on
-        // unchanged schemas. Drift that affects the user-visible projection is caught via
-        // "cannot be resolved"; a base widening that keeps the user-visible output type
-        // unchanged but mutates the hidden state type is not detected here.
         List<Field> derivedFields = queryStmt.getQueryRelation().getRelationFields().getAllFields();
-        List<Column> orderedAll = mv.getOrderedOutputColumns(true);
-        if (derivedFields.size() != orderedAll.size()) {
-            // Stored col count must match analyzer output of the persisted SELECT. A mismatch
-            // implies base schema changed in a way that altered the SELECT's output arity
-            // (DROP of a SELECT * column expanded at CREATE time would normally throw
-            // "cannot be resolved" first; this is a defensive catch).
-            throw new SemanticException(MaterializedViewExceptions.inactiveReasonForColumnChanged(
-                    Collections.singleton("column count " + orderedAll.size() + " vs " + derivedFields.size())));
-        }
-        for (int i = 0; i < orderedAll.size(); i++) {
-            Column existed = orderedAll.get(i);
-            if (existed.isHidden()) {
-                continue;
-            }
-            Field derivedField = derivedFields.get(i);
-            Type derivedNormalized = AnalyzerUtils.transformTableColumnType(derivedField.getType(), false);
-            if (!isColumnCompatible(existed, derivedNormalized)) {
-                // Render derived as a Column only for the error message — gives the canonical
-                // OLAP `(name type NULL/NOT NULL ...)` format.
-                Column derived = new Column(existed.getName(), derivedNormalized, derivedField.isNullable());
-                String reason = MaterializedViewExceptions.inactiveReasonForColumnNotCompatible(
-                        existed.toString(), derived.toString());
-                throw new SemanticException(reason);
-            }
-        }
-    }
-
-    // matchesType recurses through ARRAY / MAP / STRUCT — catches inner-type drift like
-    // STRUCT<a INT> → STRUCT<a BIGINT> (Spark/Trino ALTER on iceberg) that PrimitiveType.equals
-    // misses because non-scalars all return INVALID_TYPE. CHAR/VARCHAR widths stay
-    // interchangeable to avoid false positives on iceberg `string`.
-    // Nullability skipped: analyzer's NULL on rewritten IVM SELECT diverges from stored NOT NULL.
-    // Decimal precision: matchesType only buckets by primitive (DECIMAL32/64/128/256), so
-    // DECIMAL(10,2) → DECIMAL(18,2) (both DECIMAL64, same scale) would pass — overflow at
-    // refresh INSERT instead. Explicit precision check guards against this.
-    // Visible for MVRefreshSchemaCheckerTest.
-    static boolean isColumnCompatible(Column existed, Type derivedType) {
-        if (!existed.getType().matchesType(derivedType)) {
-            return false;
-        }
-        if (existed.getType().isDecimalOfAnyVersion() && derivedType.isDecimalOfAnyVersion()) {
-            ScalarType existedScalar = (ScalarType) existed.getType();
-            ScalarType derivedScalar = (ScalarType) derivedType;
-            if (existedScalar.getScalarPrecision() != derivedScalar.getScalarPrecision()
-                    || existedScalar.getScalarScale() != derivedScalar.getScalarScale()) {
-                return false;
-            }
-        }
-        return true;
+        IvmSchemaCompat.compare(derivedFields, mv);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -136,10 +136,11 @@ public final class MVRefreshSchemaChecker {
         mvDb.map(Database::getFullName).ifPresent(context::setDatabase);
 
         QueryStatement queryStmt;
-        // Gate on getRowIdStrategy()!=null (== has __ROW_ID__ = IVM schema), not the refresh mode: an
-        // IVM MV needs the re-derived comparison, but a non-IVM-eligible AUTO MV (plain PCT schema) must
-        // take the viewDefineSql branch -- else derive() throws and the healthy MV is falsely inactivated.
-        if (mv.getRowIdStrategy() != null) {
+        // Require BOTH an IVM refresh mode AND the __ROW_ID__ schema -- a real IVM MV has both. Mode alone
+        // misfires on a non-IVM-eligible AUTO MV (plain PCT schema); the __ROW_ID__ column alone misfires
+        // on a PCT MV that merely outputs a column named __ROW_ID__ (not a reserved name). Either misfire
+        // makes derive() throw -> the healthy MV is falsely inactivated.
+        if (mv.getCurrentRefreshMode().isIncrementalOrAuto() && mv.getRowIdStrategy() != null) {
             queryStmt = IvmRefreshDefinition.deriveRewrittenQuery(context, mv);
         } else {
             List<StatementBase> statements = SqlParser.parse(selectSql, context.getSessionVariable());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -26,6 +26,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.analyzer.mv.IvmRefreshDefinition;
 import com.starrocks.sql.analyzer.mv.IvmSchemaCompat;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
@@ -79,10 +80,10 @@ public final class MVRefreshSchemaChecker {
             return;
         }
 
-        // Use the same query refresh actually runs: ivmDefineSql for IVM (post-rewrite, with
-        // synthetic state-column expressions like sum_state_merge(...)), and viewDefineSql
-        // for PCT via the fallback in getMVQueryDefinedSql.
-        String selectSql = mv.getMVQueryDefinedSql();
+        // IVM derives its rewritten query (with hidden __ROW_ID__ / __AGG_STATE_* columns) at
+        // refresh time, so the schema check must compare against that same rewrite, not the
+        // original user query. PCT compares against viewDefineSql directly.
+        String selectSql = mv.getViewDefineSql();
         if (Strings.isNullOrEmpty(selectSql)) {
             return;
         }
@@ -130,12 +131,17 @@ public final class MVRefreshSchemaChecker {
         Optional<Database> mvDb = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(mv.getDbId());
         mvDb.map(Database::getFullName).ifPresent(context::setDatabase);
 
-        List<StatementBase> statements = SqlParser.parse(selectSql, context.getSessionVariable());
-        if (statements.isEmpty() || !(statements.get(0) instanceof QueryStatement)) {
-            return;
+        QueryStatement queryStmt;
+        if (mv.getCurrentRefreshMode().isIncremental()) {
+            queryStmt = IvmRefreshDefinition.deriveRewrittenQuery(context, mv);
+        } else {
+            List<StatementBase> statements = SqlParser.parse(selectSql, context.getSessionVariable());
+            if (statements.isEmpty() || !(statements.get(0) instanceof QueryStatement)) {
+                return;
+            }
+            queryStmt = (QueryStatement) statements.get(0);
+            Analyzer.analyze(queryStmt, context);
         }
-        QueryStatement queryStmt = (QueryStatement) statements.get(0);
-        Analyzer.analyze(queryStmt, context);
 
         List<Field> derivedFields = queryStmt.getQueryRelation().getRelationFields().getAllFields();
         IvmSchemaCompat.compare(derivedFields, mv);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -124,7 +124,11 @@ public final class MVRefreshSchemaChecker {
         return msg.contains("cannot be resolved")
                 || msg.contains("column schema not compatible")
                 || msg.contains("base table schema changed for columns")
-                || msg.contains("No matching function with signature");
+                || msg.contains("No matching function with signature")
+                // IVM re-derive incompatibility (row-id strategy flip / no longer IVM-rewritable) is a
+                // drop-and-recreate condition -- inactivate with the reason, don't retry forever.
+                || msg.contains("row-id strategy")
+                || msg.contains("is not an IVM query");
     }
 
     private static void analyzeAndCompareSchema(MaterializedView mv, ConnectContext context, String selectSql) {
@@ -132,7 +136,10 @@ public final class MVRefreshSchemaChecker {
         mvDb.map(Database::getFullName).ifPresent(context::setDatabase);
 
         QueryStatement queryStmt;
-        if (mv.getCurrentRefreshMode().isIncremental()) {
+        // isIncrementalOrAuto, not isIncremental: legacy AUTO-mode IVM MVs also carry the hidden
+        // __ROW_ID__/__AGG_STATE schema, so they must re-derive too -- else the viewDefineSql branch
+        // (fewer columns) trips the arity check and falsely inactivates them.
+        if (mv.getCurrentRefreshMode().isIncrementalOrAuto()) {
             queryStmt = IvmRefreshDefinition.deriveRewrittenQuery(context, mv);
         } else {
             List<StatementBase> statements = SqlParser.parse(selectSql, context.getSessionVariable());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -136,10 +136,10 @@ public final class MVRefreshSchemaChecker {
         mvDb.map(Database::getFullName).ifPresent(context::setDatabase);
 
         QueryStatement queryStmt;
-        // isIncrementalOrAuto, not isIncremental: legacy AUTO-mode IVM MVs also carry the hidden
-        // __ROW_ID__/__AGG_STATE schema, so they must re-derive too -- else the viewDefineSql branch
-        // (fewer columns) trips the arity check and falsely inactivates them.
-        if (mv.getCurrentRefreshMode().isIncrementalOrAuto()) {
+        // Gate on getRowIdStrategy()!=null (== has __ROW_ID__ = IVM schema), not the refresh mode: an
+        // IVM MV needs the re-derived comparison, but a non-IVM-eligible AUTO MV (plain PCT schema) must
+        // take the viewDefineSql branch -- else derive() throws and the healthy MV is falsely inactivated.
+        if (mv.getRowIdStrategy() != null) {
             queryStmt = IvmRefreshDefinition.deriveRewrittenQuery(context, mv);
         } else {
             List<StatementBase> statements = SqlParser.parse(selectSql, context.getSessionVariable());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -60,6 +60,7 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.mv.IVMAnalyzer;
+import com.starrocks.sql.analyzer.mv.IvmRefreshDefinition;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.TableRelation;
@@ -556,21 +557,23 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                     .collect(Collectors.toSet());
             changeDefaultConnectContextIfNeeded(ctx, baseTables);
 
-            InsertStmt insertStmt = null;
+            // Lock skeleton from the original query: parsed (not analyzed) only to collect the target MV +
+            // base-table locks. Re-derive inside the lock since its analyze must hold the lock.
+            InsertStmt lockSkeleton;
             try (Timer ignored = Tracers.watchScope("MVRefreshParser")) {
-                // generate insert statement from defined query
-                insertStmt = generateInsertAst(ctx, PCellSortedSet.of(), mv.getIVMTaskDefinition());
+                lockSkeleton = generateInsertAst(ctx, PCellSortedSet.of(), mv.getIVMTaskDefinition(mv.getViewDefineSql()));
             }
 
-            PlannerMetaLocker locker = new PlannerMetaLocker(ctx, insertStmt);
+            PlannerMetaLocker locker = new PlannerMetaLocker(ctx, lockSkeleton);
             if (!locker.tryLock(Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
                 throw new LockTimeoutException("Failed to lock database in prepareRefreshPlan");
             }
+            InsertStmt insertStmt;
             try (ConnectContext.ScopeGuard guard = ctx.bindScope()) {
-                // analyze the insert statement
                 try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {
+                    String derivedSelectSql = IvmRefreshDefinition.derive(ctx, mv);
+                    insertStmt = generateInsertAst(ctx, PCellSortedSet.of(), mv.getIVMTaskDefinition(derivedSelectSql));
                     analyzeInsertStmt(insertStmt);
-                    // build the insert plan
                     insertStmt = buildInsertPlan(insertStmt);
                     ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -226,10 +226,10 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, predicateBuilder);
         try {
             // An IVM MV's full rebuild must INSERT the rewritten query (hidden __ROW_ID__/__AGG_STATE
-            // columns), re-derived inside the lock. Gate on getRowIdStrategy()!=null (== has __ROW_ID__),
-            // not the refresh mode: an AUTO MV whose query isn't IVM-eligible has a plain PCT schema and
-            // must NOT re-derive.
-            if (mv.getRowIdStrategy() != null) {
+            // columns), re-derived inside the lock. Require BOTH an IVM mode AND the __ROW_ID__ schema:
+            // mode alone misfires on a non-IVM AUTO MV, __ROW_ID__ alone on a PCT MV that merely outputs a
+            // column named __ROW_ID__. Either misfire fails this terminal PCT refresh.
+            if (mv.getCurrentRefreshMode().isIncrementalOrAuto() && mv.getRowIdStrategy() != null) {
                 insertStmt = generateInsertAst(ctx, mvToRefreshedPartitions,
                         mv.getTaskDefinition(IvmRefreshDefinition.derive(ctx, mv)));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -227,8 +227,8 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         try {
             // An IVM MV's full rebuild must INSERT the rewritten query (with the hidden
             // __ROW_ID__/__AGG_STATE columns it adds), re-derived here inside the lock -- not the
-            // user query that getTaskDefinition() returns.
-            if (mv.getCurrentRefreshMode().isIncremental()) {
+            // user query that getTaskDefinition() returns. isIncrementalOrAuto covers legacy AUTO MVs.
+            if (mv.getCurrentRefreshMode().isIncrementalOrAuto()) {
                 insertStmt = generateInsertAst(ctx, mvToRefreshedPartitions,
                         mv.getTaskDefinition(IvmRefreshDefinition.derive(ctx, mv)));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -50,6 +50,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.analyzer.mv.IvmRefreshDefinition;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.PCellSetMapping;
@@ -224,6 +225,13 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         PCTPredicateBuilder predicateBuilder = new PCTPredicateBuilder(mvPctRefreshPartitioner);
         MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, predicateBuilder);
         try {
+            // An IVM MV's full rebuild must INSERT the rewritten query (with the hidden
+            // __ROW_ID__/__AGG_STATE columns it adds), re-derived here inside the lock -- not the
+            // user query that getTaskDefinition() returns.
+            if (mv.getCurrentRefreshMode().isIncremental()) {
+                insertStmt = generateInsertAst(ctx, mvToRefreshedPartitions,
+                        mv.getTaskDefinition(IvmRefreshDefinition.derive(ctx, mv)));
+            }
             // Analyze and prepare a partition & Rebuild insert statement by
             // considering to-refresh partitions of ref tables/ mv
             try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -225,10 +225,11 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         PCTPredicateBuilder predicateBuilder = new PCTPredicateBuilder(mvPctRefreshPartitioner);
         MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, predicateBuilder);
         try {
-            // An IVM MV's full rebuild must INSERT the rewritten query (with the hidden
-            // __ROW_ID__/__AGG_STATE columns it adds), re-derived here inside the lock -- not the
-            // user query that getTaskDefinition() returns. isIncrementalOrAuto covers legacy AUTO MVs.
-            if (mv.getCurrentRefreshMode().isIncrementalOrAuto()) {
+            // An IVM MV's full rebuild must INSERT the rewritten query (hidden __ROW_ID__/__AGG_STATE
+            // columns), re-derived inside the lock. Gate on getRowIdStrategy()!=null (== has __ROW_ID__),
+            // not the refresh mode: an AUTO MV whose query isn't IVM-eligible has a plain PCT schema and
+            // must NOT re-derive.
+            if (mv.getRowIdStrategy() != null) {
                 insertStmt = generateInsertAst(ctx, mvToRefreshedPartitions,
                         mv.getTaskDefinition(IvmRefreshDefinition.derive(ctx, mv)));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3322,7 +3322,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
         materializedView.setSimpleDefineSql(stmt.getSimpleViewDef());
         materializedView.setOriginalViewDefineSql(stmt.getOriginalViewDefineSql());
-        materializedView.setIvmDefineSql(stmt.getIvmViewDef());
+        if (!Strings.isNullOrEmpty(stmt.getIvmViewDef())) {
+            materializedView.setIvmDefineSql(stmt.getIvmViewDef());
+        }
         materializedView.setOriginalDBName(stmt.getOriginalDBName());
         // current refresh mode
         materializedView.setCurrentRefreshMode(stmt.getCurrentRefreshMode());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -378,7 +378,6 @@ public class MaterializedViewAnalyzer {
                     queryStatement = result.queryStatement();
                     // re-analyze again
                     Analyzer.analyze(queryStatement, context);
-                    statement.setIvmViewDef(AstToSQLBuilder.buildSimple(queryStatement));
                     statement.setQueryStatement(queryStatement);
                     // All incremental MVs are PK tables; the row-id strategy decides how __ROW_ID__ is sourced.
                     statement.setKeysType(KeysType.PRIMARY_KEYS);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -159,6 +159,8 @@ public class IVMAnalyzer {
     private final ConnectContext connectContext;
     private final CreateMaterializedViewStatement statement;
     private final QueryStatement queryStatement;
+    // null at CREATE -> deduce per keys; non-null at refresh -> use the MV's pinned version.
+    private Integer pinnedEncodeRowIdVersion;
 
     public IVMAnalyzer(ConnectContext connectContext,
                        CreateMaterializedViewStatement statement,
@@ -181,9 +183,20 @@ public class IVMAnalyzer {
      * - If incremental refresh is supported, the result must not be none.
      */
     public Optional<IVMAnalyzeResult> rewrite(MaterializedView.RefreshMode refreshMode) {
+        return rewriteInternal(refreshMode, null, refreshMode.isIncremental());
+    }
+
+    public Optional<IVMAnalyzeResult> rewriteForRefresh(MaterializedView.RefreshMode refreshMode,
+                                                        int pinnedEncodeRowIdVersion) {
+        return rewriteInternal(refreshMode, pinnedEncodeRowIdVersion, false);
+    }
+
+    private Optional<IVMAnalyzeResult> rewriteInternal(MaterializedView.RefreshMode refreshMode,
+                                                       Integer pinnedVersion, boolean runTrial) {
         if (!refreshMode.isIncremental() && !refreshMode.isAuto()) {
             return Optional.empty();
         }
+        this.pinnedEncodeRowIdVersion = pinnedVersion;
 
         try {
             QueryRelation queryRelation = queryStatement.getQueryRelation();
@@ -195,8 +208,8 @@ public class IVMAnalyzer {
                     : RowIdStrategy.AUTO_INCREMENT;
             // Trial-rewrite catches drift the analyzer-level checks can't: e.g. a new logical
             // operator without a matching IvmDelta*Rule, or a combinator's metadata that no
-            // longer matches the BE state-union path. INCREMENTAL only.
-            if (refreshMode.isIncremental()) {
+            // longer matches the BE state-union path. CREATE only; refresh builds the real plan next.
+            if (runTrial) {
                 IvmTrialRewriter.runTrial(connectContext, statement, queryStatement);
             }
             IVMAnalyzeResult result = IVMAnalyzeResult.of(queryStatement, strategy, refreshMode);
@@ -413,7 +426,9 @@ public class IVMAnalyzer {
 
         // Build the row ID from the group keys, normalized like the refresh aggregate (see normalizeGroupKeys).
         List<Expr> rowIdKeys = normalizeGroupKeys(groupByExprs);
-        int encodeRowIdVersion = IvmOpUtils.deduceEncodeRowIdVersion(rowIdKeys);
+        int encodeRowIdVersion = (pinnedEncodeRowIdVersion != null)
+                ? IvmOpUtils.getEncodeRowIdVersionChecked(pinnedEncodeRowIdVersion)
+                : IvmOpUtils.deduceEncodeRowIdVersion(rowIdKeys);
         if (statement != null) {
             statement.setEncodeRowIdVersion(encodeRowIdVersion);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinition.java
@@ -20,10 +20,12 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -43,8 +45,11 @@ public final class IvmRefreshDefinition {
      * the refresh-time schema checker.
      */
     public static QueryStatement deriveRewrittenQuery(ConnectContext ctx, MaterializedView mv) {
-        QueryStatement qs = (QueryStatement) SqlParser.parse(mv.getViewDefineSql(),
-                ctx.getSessionVariable()).get(0);
+        List<StatementBase> statements = SqlParser.parse(mv.getViewDefineSql(), ctx.getSessionVariable());
+        if (statements.isEmpty() || !(statements.get(0) instanceof QueryStatement)) {
+            throw new SemanticException("MV %s has no valid query definition to re-derive", mv.getName());
+        }
+        QueryStatement qs = (QueryStatement) statements.get(0);
         Analyzer.analyze(qs, ctx);
 
         IVMAnalyzer analyzer = new IVMAnalyzer(ctx, null, qs);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinition.java
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.parser.SqlParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * Re-derives the IVM maintenance query (the rewritten SELECT producing hidden __ROW_ID__ /
+ * __AGG_STATE_* columns) from the MV's original user query at refresh time, instead of reading
+ * a frozen persisted string.
+ */
+public final class IvmRefreshDefinition {
+    private static final Logger LOG = LogManager.getLogger(IvmRefreshDefinition.class);
+
+    private IvmRefreshDefinition() {
+    }
+
+    /**
+     * Re-runs the IVM rewrite with the MV's pinned encode version (no trial) and enforces the
+     * row-id strategy gate. Returns the analyzed rewritten query; shared by {@link #derive} and
+     * the refresh-time schema checker.
+     */
+    public static QueryStatement deriveRewrittenQuery(ConnectContext ctx, MaterializedView mv) {
+        QueryStatement qs = (QueryStatement) SqlParser.parse(mv.getViewDefineSql(),
+                ctx.getSessionVariable()).get(0);
+        Analyzer.analyze(qs, ctx);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(ctx, null, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewriteForRefresh(mv.getCurrentRefreshMode(), mv.getEncodeRowIdVersion());
+        if (result.isEmpty()) {
+            throw new SemanticException("MV %s definition is not an IVM query at refresh", mv.getName());
+        }
+
+        QueryStatement rewritten = result.get().queryStatement();
+        // The rewrite prepends __ROW_ID__ / appends __AGG_STATE columns whose output names lag until
+        // re-analysis; buildSimple and getRelationFields below both read those names.
+        Analyzer.analyze(rewritten, ctx);
+
+        if (result.get().rowIdStrategy() != mv.getRowIdStrategy()) {
+            throw new SemanticException(
+                    "IVM MV %s: re-derived row-id strategy %s does not match stored %s; "
+                            + "drop and recreate the MV",
+                    mv.getName(), result.get().rowIdStrategy(), mv.getRowIdStrategy());
+        }
+        return rewritten;
+    }
+
+    /** Derive the maintenance SELECT SQL the incremental refresh will run. */
+    public static String derive(ConnectContext ctx, MaterializedView mv) {
+        QueryStatement rewritten = deriveRewrittenQuery(ctx, mv);
+        IvmSchemaCompat.compare(rewritten.getQueryRelation().getRelationFields().getAllFields(), mv);
+        String derivedSql = AstToSQLBuilder.buildSimple(rewritten);
+        warnIfDiffersFromFrozen(mv, ctx, derivedSql);
+        return derivedSql;
+    }
+
+    private static void warnIfDiffersFromFrozen(MaterializedView mv, ConnectContext ctx, String derivedSql) {
+        String frozen = mv.getIvmDefineSql();
+        if (frozen == null || frozen.isEmpty()) {
+            return;
+        }
+        // Normalize the frozen text through the same serializer before comparing: it was produced by
+        // a different serializer than derivedSql, so a raw compare false-positives.
+        try {
+            QueryStatement frozenQs = (QueryStatement) SqlParser.parse(frozen,
+                    ctx.getSessionVariable()).get(0);
+            Analyzer.analyze(frozenQs, ctx);
+            String normalizedFrozen = AstToSQLBuilder.buildSimple(frozenQs);
+            if (!normalizedFrozen.equals(derivedSql)) {
+                LOG.warn("[IvmRefreshDefinition] MV {} was built by an older rewrite; re-derived "
+                        + "definition differs from the frozen one (verify data, consider rebuild)",
+                        mv.getName());
+            }
+        } catch (Exception e) {
+            LOG.warn("[IvmRefreshDefinition] MV {} frozen-text diff check skipped: {}",
+                    mv.getName(), e.getMessage());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompat.java
@@ -33,7 +33,7 @@ public final class IvmSchemaCompat {
 
     /**
      * Position-aligned compatibility check between an analyzed query's output fields and a stored
-     * MV schema. Hidden IVM columns (__ROW_ID__, __AGG_STATE_*) keep their position but are skipped.
+     * MV schema, including hidden IVM columns (__ROW_ID__, __AGG_STATE_*).
      */
     public static void compare(List<Field> derivedFields, MaterializedView mv) {
         List<Column> orderedAll = mv.getOrderedOutputColumns(true);
@@ -43,12 +43,13 @@ public final class IvmSchemaCompat {
         }
         for (int i = 0; i < orderedAll.size(); i++) {
             Column existed = orderedAll.get(i);
-            if (existed.isHidden()) {
-                continue;
-            }
             Field derivedField = derivedFields.get(i);
             Type derivedNormalized = AnalyzerUtils.transformTableColumnType(derivedField.getType(), false);
-            if (!isColumnCompatible(existed, derivedNormalized)) {
+            // Validate hidden IVM columns (__ROW_ID__, __AGG_STATE_*) rather than skip them: a re-derived
+            // rewriter can drift a hidden column's type, or its identity -- the __AGG_STATE_* name encodes
+            // the agg function/args -- while the visible projection and arity hold.
+            if (!isColumnCompatible(existed, derivedNormalized)
+                    || (existed.isHidden() && !existed.getName().equalsIgnoreCase(derivedField.getName()))) {
                 Column derived = new Column(existed.getName(), derivedNormalized, derivedField.isNullable());
                 throw new SemanticException(MaterializedViewExceptions.inactiveReasonForColumnNotCompatible(
                         existed.toString(), derived.toString()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompat.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class IvmSchemaCompat {
+
+    private IvmSchemaCompat() {
+    }
+
+    /**
+     * Position-aligned compatibility check between an analyzed query's output fields and a stored
+     * MV schema. Hidden IVM columns (__ROW_ID__, __AGG_STATE_*) keep their position but are skipped.
+     */
+    public static void compare(List<Field> derivedFields, MaterializedView mv) {
+        List<Column> orderedAll = mv.getOrderedOutputColumns(true);
+        if (derivedFields.size() != orderedAll.size()) {
+            throw new SemanticException(MaterializedViewExceptions.inactiveReasonForColumnChanged(
+                    Collections.singleton("column count " + orderedAll.size() + " vs " + derivedFields.size())));
+        }
+        for (int i = 0; i < orderedAll.size(); i++) {
+            Column existed = orderedAll.get(i);
+            if (existed.isHidden()) {
+                continue;
+            }
+            Field derivedField = derivedFields.get(i);
+            Type derivedNormalized = AnalyzerUtils.transformTableColumnType(derivedField.getType(), false);
+            if (!isColumnCompatible(existed, derivedNormalized)) {
+                Column derived = new Column(existed.getName(), derivedNormalized, derivedField.isNullable());
+                throw new SemanticException(MaterializedViewExceptions.inactiveReasonForColumnNotCompatible(
+                        existed.toString(), derived.toString()));
+            }
+        }
+    }
+
+    // matchesType recurses through ARRAY / MAP / STRUCT — catches inner-type drift like
+    // STRUCT<a INT> → STRUCT<a BIGINT> (Spark/Trino ALTER on iceberg) that PrimitiveType.equals
+    // misses because non-scalars all return INVALID_TYPE. CHAR/VARCHAR widths stay
+    // interchangeable to avoid false positives on iceberg `string`.
+    // Nullability skipped: analyzer's NULL on rewritten IVM SELECT diverges from stored NOT NULL.
+    // Decimal precision: matchesType only buckets by primitive (DECIMAL32/64/128/256), so
+    // DECIMAL(10,2) → DECIMAL(18,2) (both DECIMAL64, same scale) would pass — overflow at
+    // refresh INSERT instead. Explicit precision check guards against this.
+    public static boolean isColumnCompatible(Column existed, Type derivedType) {
+        if (!existed.getType().matchesType(derivedType)) {
+            return false;
+        }
+        if (existed.getType().isDecimalOfAnyVersion() && derivedType.isDecimalOfAnyVersion()) {
+            ScalarType existedScalar = (ScalarType) existed.getType();
+            ScalarType derivedScalar = (ScalarType) derivedType;
+            if (existedScalar.getScalarPrecision() != derivedScalar.getScalarPrecision()
+                    || existedScalar.getScalarScale() != derivedScalar.getScalarScale()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
@@ -118,6 +118,11 @@ public class IvmOpUtils {
         return encodeRowIdFuncName;
     }
 
+    public static int getEncodeRowIdVersionChecked(int version) {
+        getEncodeRowIdFunctionNameChecked(version);
+        return version;
+    }
+
     /**
      * Build the row id function expression for IVM.
      * For multi unique keys, use ENCODE_ROW_ID to encode them to a varbinary and use FROM_BINARY to convert it into

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.scheduler.mv;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.scheduler.mv.ivm.MVIVMIcebergTestBase;
 import com.starrocks.sql.analyzer.mv.IvmSchemaCompat;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.CharType;
@@ -28,6 +30,7 @@ import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -39,7 +42,17 @@ import java.util.Arrays;
  * rejects {@code ALTER ... ADD FIELD / DROP FIELD} clauses on non-OLAP tables, but the iceberg
  * table can still be modified out of band.
  */
-public class MVRefreshSchemaCheckerTest {
+public class MVRefreshSchemaCheckerTest extends MVIVMIcebergTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVIVMIcebergTestBase.beforeClass();
+    }
+
+    @Override
+    public void advanceTableVersionTo(long toVersion) {
+        // the checker only parses/analyzes against the current schema; no refresh is run here.
+    }
 
     private static boolean isCompatible(Column existed, Type derivedType) {
         return IvmSchemaCompat.isColumnCompatible(existed, derivedType);
@@ -162,5 +175,27 @@ public class MVRefreshSchemaCheckerTest {
         StructType driftedElem = struct(new StructField("a", IntegerType.BIGINT));
         Column existed = new Column("arr", new ArrayType(originalElem));
         Assertions.assertFalse(isCompatible(existed, new ArrayType(driftedElem)));
+    }
+
+    /**
+     * Pins Task 6: with no frozen ivmDefineSql (every new IVM MV), the checker must re-derive the
+     * rewritten query so its arity (including the hidden __ROW_ID__/__AGG_STATE columns) matches the
+     * stored schema, rather than tripping "column count" on the original user-query fallback and
+     * falsely inactivating the MV.
+     */
+    @Test
+    public void testCheckerOnNewIvmMvNoFrozenTextDoesNotFalseDrift() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_checker_no_drift "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_checker_no_drift");
+            Assertions.assertTrue(mv.getCurrentRefreshMode().isIncremental(),
+                    "guard: this shape must resolve to an incremental MV, else the test is vacuous");
+            MVRefreshSchemaChecker.checkExternalBaseSchemaCompat(mv);
+            Assertions.assertTrue(mv.isActive(),
+                    "new IVM MV with unchanged external base must stay active, not false-trip schema drift");
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
@@ -200,9 +200,9 @@ public class MVRefreshSchemaCheckerTest extends MVIVMIcebergTestBase {
     }
 
     /**
-     * Pins the AUTO-mode gap: a legacy AUTO-mode IVM MV also carries the hidden __ROW_ID__/__AGG_STATE
-     * schema, so the checker must re-derive it (isIncrementalOrAuto), not fall to the viewDefineSql
-     * branch whose fewer columns would false-trip the arity check and inactivate a healthy MV.
+     * Pins the AUTO-mode IVM case: an IVM MV (has __ROW_ID__) refreshing in AUTO mode must still
+     * re-derive (gate is getRowIdStrategy() != null), not fall to the viewDefineSql branch whose
+     * fewer columns would false-trip the arity check and inactivate a healthy MV.
      */
     @Test
     public void testCheckerOnAutoModeIvmMvDoesNotFalseDrift() throws Exception {
@@ -215,9 +215,33 @@ public class MVRefreshSchemaCheckerTest extends MVIVMIcebergTestBase {
             // AUTO is no longer creatable via SQL; promote in-memory to mimic a legacy AUTO IVM MV.
             mv.setCurrentRefreshMode(MaterializedView.RefreshMode.AUTO);
             Assertions.assertTrue(mv.getCurrentRefreshMode().isAuto());
+            Assertions.assertNotNull(mv.getRowIdStrategy(), "this MV IS an IVM MV (has __ROW_ID__)");
             MVRefreshSchemaChecker.checkExternalBaseSchemaCompat(mv);
             Assertions.assertTrue(mv.isActive(),
                     "AUTO-mode IVM MV with unchanged external base must stay active, not false-trip schema drift");
+        });
+    }
+
+    /**
+     * Pins the non-IVM AUTO case: an AUTO-mode MV whose query was NOT materialized as IVM has a plain
+     * PCT schema (no __ROW_ID__, getRowIdStrategy() == null), so the checker must take the viewDefineSql
+     * branch, NOT re-derive (else derive trips and the healthy MV is falsely inactivated).
+     */
+    @Test
+    public void testCheckerOnAutoModeNonIvmMvIsNotReDerived() throws Exception {
+        // PCT-created => no IVM rewrite => no __ROW_ID__; then promote to AUTO to mimic a legacy /
+        // ALTER'd AUTO MV that was never IVM-eligible.
+        String ddl = "CREATE MATERIALIZED VIEW mv_checker_auto_pct "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"pct\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_checker_auto_pct");
+            Assertions.assertNull(mv.getRowIdStrategy(), "PCT-schema MV has no __ROW_ID__");
+            mv.setCurrentRefreshMode(MaterializedView.RefreshMode.AUTO);
+            MVRefreshSchemaChecker.checkExternalBaseSchemaCompat(mv);
+            Assertions.assertTrue(mv.isActive(),
+                    "AUTO-mode non-IVM MV (plain PCT schema) must not be re-derived / false-inactivated");
         });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
@@ -198,4 +198,26 @@ public class MVRefreshSchemaCheckerTest extends MVIVMIcebergTestBase {
                     "new IVM MV with unchanged external base must stay active, not false-trip schema drift");
         });
     }
+
+    /**
+     * Pins the AUTO-mode gap: a legacy AUTO-mode IVM MV also carries the hidden __ROW_ID__/__AGG_STATE
+     * schema, so the checker must re-derive it (isIncrementalOrAuto), not fall to the viewDefineSql
+     * branch whose fewer columns would false-trip the arity check and inactivate a healthy MV.
+     */
+    @Test
+    public void testCheckerOnAutoModeIvmMvDoesNotFalseDrift() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_checker_auto "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_checker_auto");
+            // AUTO is no longer creatable via SQL; promote in-memory to mimic a legacy AUTO IVM MV.
+            mv.setCurrentRefreshMode(MaterializedView.RefreshMode.AUTO);
+            Assertions.assertTrue(mv.getCurrentRefreshMode().isAuto());
+            MVRefreshSchemaChecker.checkExternalBaseSchemaCompat(mv);
+            Assertions.assertTrue(mv.isActive(),
+                    "AUTO-mode IVM MV with unchanged external base must stay active, not false-trip schema drift");
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshSchemaCheckerTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler.mv;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.sql.analyzer.mv.IvmSchemaCompat;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.CharType;
 import com.starrocks.type.DecimalType;
@@ -33,7 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
- * Covers {@link MVRefreshSchemaChecker#isColumnCompatible} for cases the SR SQL test framework
+ * Covers {@link IvmSchemaCompat#isColumnCompatible} for cases the SR SQL test framework
  * cannot reach: iceberg STRUCT/ARRAY/MAP field-level ALTER from Spark/Trino. SR SQL itself
  * rejects {@code ALTER ... ADD FIELD / DROP FIELD} clauses on non-OLAP tables, but the iceberg
  * table can still be modified out of band.
@@ -41,7 +42,7 @@ import java.util.Arrays;
 public class MVRefreshSchemaCheckerTest {
 
     private static boolean isCompatible(Column existed, Type derivedType) {
-        return MVRefreshSchemaChecker.isColumnCompatible(existed, derivedType);
+        return IvmSchemaCompat.isColumnCompatible(existed, derivedType);
     }
 
     private static StructType struct(StructField... fields) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -615,6 +615,24 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
     }
 
     @Test
+    public void testFirstFullRefreshOfAggregateIvmMvRebuildsRewrittenInsert() throws Exception {
+        // First refresh (no TVR baseline) of an aggregate IVM MV full-rebuilds through the
+        // hybrid -> PCT path, whose INSERT must use the re-derived rewritten query (the hidden
+        // __ROW_ID__/__AGG_STATE columns it adds), not the user query. Without the re-derive the
+        // positional INSERT mismatches the MV schema ("target column count doesn't match select").
+        // The other IVM tests seed a TVR baseline (skipping this path), so this is the only cover.
+        String query = "SELECT data, count(id) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY data;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        advanceTableVersionTo(2);
+        MVTaskRunProcessor proc = getMVTaskRunProcessor(mv);
+        Assertions.assertTrue(proc.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        Assertions.assertTrue(
+                ((MVHybridRefreshProcessor) proc.getMVRefreshProcessor()).getCurrentProcessor()
+                        instanceof MVPCTRefreshProcessor,
+                "first refresh with no baseline must full-rebuild via the PCT path");
+    }
+
+    @Test
     public void testAutoRefreshFallbackCanPersistCheckpointForNextIvm() throws Exception {
         String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -1488,7 +1488,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         // builds its plan from getTaskDefinition() and is unaffected.
         new MockUp<MaterializedView>() {
             @Mock
-            public String getIVMTaskDefinition() {
+            public String getIVMTaskDefinition(String selectSql) {
                 throw new SemanticException("injected IVM plan failure");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -735,8 +735,9 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
 
     /**
      * Aggregate incremental MV (QUERY_COMPUTED): refresh SQL uses positional form since
-     * the schema has no AUTO_INCREMENT columns; the query itself produces {@code __ROW_ID__}
-     * via encode(group_by_keys).
+     * the schema has no AUTO_INCREMENT columns. New MVs no longer persist the rewritten
+     * ivmDefineSql, so the no-arg task definition falls back to the original user query;
+     * the __ROW_ID__-producing rewrite is re-derived at refresh time, not frozen here.
      */
     @Test
     public void testGetIVMTaskDefinitionForQueryComputedUsesPositionalForm() throws Exception {
@@ -752,8 +753,28 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                     "aggregate MV uses positional INSERT, got: " + sql);
             assertFalse(sql.startsWith("INSERT INTO `mv_taskdef_agg` ("),
                     "no explicit column list expected (no AUTO_INCREMENT columns), got: " + sql);
-            assertTrue(sql.contains(IvmOpUtils.COLUMN_ROW_ID),
-                    "__ROW_ID__ must appear in the SELECT alias (produced by encode), got: " + sql);
+            assertFalse(sql.contains(IvmOpUtils.COLUMN_ROW_ID),
+                    "no-arg task definition falls back to the original query (no frozen __ROW_ID__), got: " + sql);
+        });
+    }
+
+    /**
+     * New IVM MVs no longer persist the rewritten ivmDefineSql (refresh re-derives it), but
+     * CREATE must still derive the column schema from the rewritten tree — including the
+     * hidden __ROW_ID__ column.
+     */
+    @Test
+    public void testIncrementalMvDoesNotPersistIvmDefineSqlButKeepsRowId() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_no_frozen_ivmdef "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_no_frozen_ivmdef");
+            assertTrue(mv.getIvmDefineSql() == null || mv.getIvmDefineSql().isEmpty(),
+                    "new IVM MV must not persist a frozen ivmDefineSql, got: " + mv.getIvmDefineSql());
+            assertNotNull(mv.getColumn(IvmOpUtils.COLUMN_ROW_ID),
+                    "schema derivation must still add the hidden __ROW_ID__ column");
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.mv.ivm.MVIVMIcebergTestBase;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.KeysType;
@@ -793,6 +794,28 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
             assertTrue(idPos < dataPos && dataPos < datePos,
                     "INSERT column list must be in SELECT order (id, data, date), got: " + sql);
         });
+    }
+
+    @Test
+    public void testRewriteForRefreshUsesPinnedVersionAndStrategy() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_rf "
+                + "REFRESH DEFERRED MANUAL PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, null, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> r =
+                analyzer.rewriteForRefresh(MaterializedView.RefreshMode.INCREMENTAL, 0);
+
+        assertTrue(r.isPresent(), "GROUP BY query must be retractable");
+        assertEquals(RowIdStrategy.QUERY_COMPUTED, r.get().rowIdStrategy());
+        // Re-analyze so buildSimple sees the prepended __ROW_ID__/__AGG_STATE columns,
+        // mirroring the CREATE path (MaterializedViewAnalyzer re-analyzes before serializing).
+        Analyzer.analyze(r.get().queryStatement(), connectContext);
+        String sql = AstToSQLBuilder.buildSimple(r.get().queryStatement());
+        assertTrue(sql.contains(IvmOpUtils.COLUMN_ROW_ID), "rewritten query must project __ROW_ID__, got: " + sql);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -722,7 +722,7 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                 + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
         starRocksAssert.withMaterializedView(ddl, () -> {
             MaterializedView mv = getMv("test", "mv_taskdef_nonagg");
-            String sql = mv.getIVMTaskDefinition();
+            String sql = mv.getIVMTaskDefinition(mv.getViewDefineSql());
 
             assertTrue(sql.startsWith("INSERT INTO `mv_taskdef_nonagg` ("),
                     "must use explicit column list form, got: " + sql);
@@ -734,10 +734,9 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
-     * Aggregate incremental MV (QUERY_COMPUTED): refresh SQL uses positional form since
-     * the schema has no AUTO_INCREMENT columns. New MVs no longer persist the rewritten
-     * ivmDefineSql, so the no-arg task definition falls back to the original user query;
-     * the __ROW_ID__-producing rewrite is re-derived at refresh time, not frozen here.
+     * Aggregate incremental MV (QUERY_COMPUTED): the INSERT uses positional form because the
+     * schema has no AUTO_INCREMENT columns (contrast the non-agg case, which needs an explicit
+     * column list to omit the storage-filled __ROW_ID__).
      */
     @Test
     public void testGetIVMTaskDefinitionForQueryComputedUsesPositionalForm() throws Exception {
@@ -747,14 +746,12 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                 + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
         starRocksAssert.withMaterializedView(ddl, () -> {
             MaterializedView mv = getMv("test", "mv_taskdef_agg");
-            String sql = mv.getIVMTaskDefinition();
+            String sql = mv.getIVMTaskDefinition(mv.getViewDefineSql());
 
             assertTrue(sql.startsWith("INSERT INTO `mv_taskdef_agg` "),
                     "aggregate MV uses positional INSERT, got: " + sql);
             assertFalse(sql.startsWith("INSERT INTO `mv_taskdef_agg` ("),
                     "no explicit column list expected (no AUTO_INCREMENT columns), got: " + sql);
-            assertFalse(sql.contains(IvmOpUtils.COLUMN_ROW_ID),
-                    "no-arg task definition falls back to the original query (no frozen __ROW_ID__), got: " + sql);
         });
     }
 
@@ -797,7 +794,7 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                 + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
         starRocksAssert.withMaterializedView(ddl, () -> {
             MaterializedView mv = getMv("test", "mv_reordered_nonagg");
-            String sql = mv.getIVMTaskDefinition();
+            String sql = mv.getIVMTaskDefinition(mv.getViewDefineSql());
 
             assertTrue(sql.startsWith("INSERT INTO `mv_reordered_nonagg` ("),
                     "must use explicit column list form, got: " + sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinitionTest.java
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.scheduler.mv.ivm.MVIVMIcebergTestBase;
+import com.starrocks.sql.analyzer.SemanticException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IvmRefreshDefinitionTest extends MVIVMIcebergTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVIVMIcebergTestBase.beforeClass();
+    }
+
+    @Override
+    public void advanceTableVersionTo(long toVersion) {
+        // refresh is never run here; re-derivation only parses/analyzes the stored query.
+    }
+
+    @Test
+    public void testDeriveProducesRewrittenSelect() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_derive "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_derive");
+            String sql = IvmRefreshDefinition.derive(connectContext, mv);
+
+            assertNotNull(sql);
+            assertTrue(sql.contains("from_binary"),
+                    "re-derived maintenance SELECT must encode __ROW_ID__ via from_binary, got: " + sql);
+            assertTrue(sql.contains("count_combine") || sql.contains("__AGG_STATE"),
+                    "re-derived maintenance SELECT must project an agg-state column, got: " + sql);
+        });
+    }
+
+    @Test
+    public void testStrategyGateThrowsOnMismatch() {
+        // DISTINCT query re-derives to QUERY_COMPUTED; the stored strategy is forced to
+        // AUTO_INCREMENT so the gate in deriveRewrittenQuery must reject the mismatch.
+        String distinctSql = "SELECT DISTINCT id FROM `iceberg0`.`unpartitioned_db`.`t0`";
+        MaterializedView mv = Mockito.mock(MaterializedView.class);
+        Mockito.when(mv.getName()).thenReturn("mv_strategy_drift");
+        Mockito.when(mv.getViewDefineSql()).thenReturn(distinctSql);
+        Mockito.when(mv.getCurrentRefreshMode()).thenReturn(MaterializedView.RefreshMode.INCREMENTAL);
+        Mockito.when(mv.getEncodeRowIdVersion()).thenReturn(0);
+        Mockito.when(mv.getRowIdStrategy()).thenReturn(RowIdStrategy.AUTO_INCREMENT);
+        Mockito.when(mv.getIvmDefineSql()).thenReturn(null);
+
+        SemanticException ex = assertThrows(SemanticException.class,
+                () -> IvmRefreshDefinition.derive(connectContext, mv),
+                "strategy mismatch (stored AUTO_INCREMENT vs re-derived QUERY_COMPUTED) must throw");
+        String msg = ex.getMessage().toLowerCase();
+        assertTrue(msg.contains("strategy") || msg.contains("drop"),
+                "error must mention the strategy gate / drop-recreate, got: " + ex.getMessage());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmRefreshDefinitionTest.java
@@ -16,11 +16,16 @@ package com.starrocks.sql.analyzer.mv;
 
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.mv.ivm.MVIVMIcebergTestBase;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.parser.SqlParser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -74,5 +79,59 @@ public class IvmRefreshDefinitionTest extends MVIVMIcebergTestBase {
         String msg = ex.getMessage().toLowerCase();
         assertTrue(msg.contains("strategy") || msg.contains("drop"),
                 "error must mention the strategy gate / drop-recreate, got: " + ex.getMessage());
+    }
+
+    /** Pins the load-bearing assumption: derive() output re-parses + re-serializes to itself. */
+    @Test
+    public void testDeriveRoundTripStable() throws Exception {
+        assertRoundTripStable("scan",
+                "SELECT id, data FROM `iceberg0`.`unpartitioned_db`.`t0`");
+        assertRoundTripStable("group-by-column",
+                "SELECT id, count(data) AS c FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id");
+        assertRoundTripStable("group-by-ordinal",
+                "SELECT id, count(data) AS c FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY 1");
+        assertRoundTripStable("distinct",
+                "SELECT DISTINCT id FROM `iceberg0`.`unpartitioned_db`.`t0`");
+        assertRoundTripStable("all-constant-group-by",
+                "SELECT 1, count(data) AS c FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY 1");
+        assertRoundTripStable("sum",
+                "SELECT id, sum(c1) AS s FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id");
+        assertRoundTripStable("max",
+                "SELECT id, max(c1) AS m FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id");
+    }
+
+    private void assertRoundTripStable(String label, String query) throws Exception {
+        String mvName = "mv_rt_" + label.replace('-', '_');
+        String ddl = "CREATE MATERIALIZED VIEW " + mvName + " "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS " + query;
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", mvName);
+            String once = IvmRefreshDefinition.derive(connectContext, mv);
+
+            QueryStatement reparsed = (QueryStatement) SqlParser.parse(once,
+                    connectContext.getSessionVariable()).get(0);
+            Analyzer.analyze(reparsed, connectContext);
+            assertEquals(once, AstToSQLBuilder.buildSimple(reparsed),
+                    "buildSimple not idempotent for: " + label);
+        });
+    }
+
+    /** Pins retroactivity: derive() re-derives the query and ignores any persisted frozen ivmDefineSql. */
+    @Test
+    public void testDeriveIgnoresFrozenIvmDefineSql() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_frozen_ignored "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, count(data) AS cnt FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_frozen_ignored");
+            String derived = IvmRefreshDefinition.derive(connectContext, mv);
+
+            mv.setIvmDefineSql("SELECT 1 AS broken");
+            assertEquals(derived, IvmRefreshDefinition.derive(connectContext, mv),
+                    "derive must re-derive from the user query, not consult the frozen ivmDefineSql");
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompatTest.java
@@ -35,8 +35,16 @@ public class IvmSchemaCompatTest {
         return c;
     }
 
-    private static Field field(Type type) {
-        return new Field(null, type, null, null, true, true);
+    private static Field field(String name, Type type) {
+        return new Field(name, type, null, null, true, true);
+    }
+
+    private static List<Column> storedSchema() {
+        return Arrays.asList(
+                hidden("__ROW_ID__", IntegerType.BIGINT),
+                new Column("k", IntegerType.INT),
+                new Column("cnt", IntegerType.BIGINT),
+                hidden("__AGG_STATE_count__", IntegerType.BIGINT));
     }
 
     private static MaterializedView mvWithColumns(List<Column> columns) {
@@ -47,29 +55,43 @@ public class IvmSchemaCompatTest {
 
     @Test
     public void testArityMismatchThrows() {
-        List<Column> stored = Arrays.asList(
-                hidden("__ROW_ID__", IntegerType.BIGINT),
-                new Column("k", IntegerType.INT),
-                new Column("cnt", IntegerType.BIGINT),
-                hidden("__AGG_STATE_count__", IntegerType.BIGINT));
-        MaterializedView mv = mvWithColumns(stored);
-        List<Field> derived = Arrays.asList(field(IntegerType.INT), field(IntegerType.BIGINT));
+        MaterializedView mv = mvWithColumns(storedSchema());
+        List<Field> derived = Arrays.asList(field("k", IntegerType.INT), field("cnt", IntegerType.BIGINT));
         Assertions.assertThrows(SemanticException.class, () -> IvmSchemaCompat.compare(derived, mv));
     }
 
     @Test
     public void testCompatiblePasses() {
-        List<Column> stored = Arrays.asList(
-                hidden("__ROW_ID__", IntegerType.BIGINT),
-                new Column("k", IntegerType.INT),
-                new Column("cnt", IntegerType.BIGINT),
-                hidden("__AGG_STATE_count__", IntegerType.BIGINT));
-        MaterializedView mv = mvWithColumns(stored);
+        MaterializedView mv = mvWithColumns(storedSchema());
         List<Field> derived = Arrays.asList(
-                field(IntegerType.BIGINT),
-                field(IntegerType.INT),
-                field(IntegerType.BIGINT),
-                field(IntegerType.BIGINT));
+                field("__ROW_ID__", IntegerType.BIGINT),
+                field("k", IntegerType.INT),
+                field("cnt", IntegerType.BIGINT),
+                field("__AGG_STATE_count__", IntegerType.BIGINT));
         Assertions.assertDoesNotThrow(() -> IvmSchemaCompat.compare(derived, mv));
+    }
+
+    @Test
+    public void testHiddenColumnTypeDriftThrows() {
+        // hidden __AGG_STATE_count__ drifts BIGINT -> INT: caught, not skipped
+        MaterializedView mv = mvWithColumns(storedSchema());
+        List<Field> derived = Arrays.asList(
+                field("__ROW_ID__", IntegerType.BIGINT),
+                field("k", IntegerType.INT),
+                field("cnt", IntegerType.BIGINT),
+                field("__AGG_STATE_count__", IntegerType.INT));
+        Assertions.assertThrows(SemanticException.class, () -> IvmSchemaCompat.compare(derived, mv));
+    }
+
+    @Test
+    public void testHiddenColumnIdentityDriftThrows() {
+        // the __AGG_STATE_* name encodes the agg function; count -> sum at the same type is caught
+        MaterializedView mv = mvWithColumns(storedSchema());
+        List<Field> derived = Arrays.asList(
+                field("__ROW_ID__", IntegerType.BIGINT),
+                field("k", IntegerType.INT),
+                field("cnt", IntegerType.BIGINT),
+                field("__AGG_STATE_sum__", IntegerType.BIGINT));
+        Assertions.assertThrows(SemanticException.class, () -> IvmSchemaCompat.compare(derived, mv));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IvmSchemaCompatTest.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IvmSchemaCompatTest {
+
+    private static Column hidden(String name, Type type) {
+        Column c = new Column(name, type);
+        c.setIsHidden(true);
+        return c;
+    }
+
+    private static Field field(Type type) {
+        return new Field(null, type, null, null, true, true);
+    }
+
+    private static MaterializedView mvWithColumns(List<Column> columns) {
+        MaterializedView mv = Mockito.mock(MaterializedView.class);
+        Mockito.when(mv.getOrderedOutputColumns(true)).thenReturn(columns);
+        return mv;
+    }
+
+    @Test
+    public void testArityMismatchThrows() {
+        List<Column> stored = Arrays.asList(
+                hidden("__ROW_ID__", IntegerType.BIGINT),
+                new Column("k", IntegerType.INT),
+                new Column("cnt", IntegerType.BIGINT),
+                hidden("__AGG_STATE_count__", IntegerType.BIGINT));
+        MaterializedView mv = mvWithColumns(stored);
+        List<Field> derived = Arrays.asList(field(IntegerType.INT), field(IntegerType.BIGINT));
+        Assertions.assertThrows(SemanticException.class, () -> IvmSchemaCompat.compare(derived, mv));
+    }
+
+    @Test
+    public void testCompatiblePasses() {
+        List<Column> stored = Arrays.asList(
+                hidden("__ROW_ID__", IntegerType.BIGINT),
+                new Column("k", IntegerType.INT),
+                new Column("cnt", IntegerType.BIGINT),
+                hidden("__AGG_STATE_count__", IntegerType.BIGINT));
+        MaterializedView mv = mvWithColumns(stored);
+        List<Field> derived = Arrays.asList(
+                field(IntegerType.BIGINT),
+                field(IntegerType.INT),
+                field(IntegerType.BIGINT),
+                field(IntegerType.BIGINT));
+        Assertions.assertDoesNotThrow(() -> IvmSchemaCompat.compare(derived, mv));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

IVM (incremental materialized view) maintenance used to **freeze** the rewritten maintenance query into a persisted `ivmDefineSql` at CREATE time and execute that frozen text on every refresh. The rewritten query is the user query plus the hidden group-identity column `__ROW_ID__` (`from_binary(encode_row_id(keys))`) and, for aggregates, the mergeable `__AGG_STATE_*` columns.

Because the rewrite was frozen, **bugfixes to the rewriter could not reach already-created MVs**. For example the positional-`GROUP BY` / `SELECT DISTINCT` `__ROW_ID__` fix in #74493 only helped *newly* created MVs; existing MVs kept executing their stale, buggy frozen text and produced wrong results until dropped and re-created. The encode scheme was also baked into the SQL literal with no room to evolve.

## What I'm doing:

Re-derive the IVM maintenance query from the MV's original `viewDefineSql` **on every refresh** (re-running the current, fixed rewriter), instead of executing a frozen string. So rewriter fixes apply **retroactively** to existing MVs on their next refresh.

Fixes #issue: N/A — internal IVM refresh-mechanism change (no separate tracking issue); makes rewriter fixes such as #74493 apply retroactively to existing MVs.

**Mechanism**
- New `IvmRefreshDefinition.derive(ctx, mv)` / `deriveRewrittenQuery(ctx, mv)`: parse `viewDefineSql` → analyze → re-run the IVM rewrite with the MV's **pinned** `encodeRowIdVersion` (no trial) → analyze again → validate → `buildSimple`.
- New IVM MVs **stop persisting** `ivmDefineSql` (`MaterializedViewAnalyzer` / `LocalMetastore`); both refresh paths re-derive instead. The field is kept Gson-nullable for old metadata.
- Two correctness gates at refresh, both fail loudly with a "drop & recreate" message instead of silently writing wrong data:
  - **row-id strategy gate**: the re-derived `RowIdStrategy` must equal the stored one;
  - **shape gate** (`IvmSchemaCompat`): the re-derived output columns (incl. hidden `__ROW_ID__`/`__AGG_STATE`) must match the stored MV schema, reusing the CREATE-time column derivation so type equivalence stays identical.
- Both refresh paths re-derive: the IVM-delta path (`MVIVMRefreshProcessor`) **and** the PCT full-rebuild path (`MVPCTRefreshProcessor`, used for an MV's first refresh / when no delta baseline exists). The IVM-MV predicate is `isIncrementalOrAuto()` so legacy AUTO-mode IVM MVs are handled too. `MVRefreshSchemaChecker` (external-base drift) re-derives the same way so its column comparison matches the stored hidden-column schema.
- For legacy MVs that still carry a frozen `ivmDefineSql`, a one-time WARN is logged if the re-derived definition differs (advisory only; refresh always uses the re-derived result).

**Behavior change** — existing IVM MVs created before this change carry a persisted `ivmDefineSql`; their refresh now executes the **re-derived** query instead of that frozen text (this is exactly how rewriter fixes become retroactive). New IVM MVs persist no frozen text. PCT (non-IVM) refresh and `SHOW CREATE MATERIALIZED VIEW` are unchanged. The persisted `Task.definition` of an IVM MV now displays the user query rather than the rewritten INSERT (display only — the executed plan is always re-derived). On **downgrade** to a pre-change binary, a new IVM MV (empty `ivmDefineSql`) falls back to the un-rewritten user query: for aggregate / `DISTINCT` MVs the old binary's own schema check rejects it with a **clear error** (`base table schema check failed … column count N vs M`, refresh fails — verified on a dev cluster), and a scan MV's user query equals its maintenance query so it refreshes correctly. Downgrade therefore fails loudly or stays correct — it does not silently produce wrong data. (Upgrade is smooth: an existing MV with a frozen `ivmDefineSql` re-derives on its next refresh — also verified on a dev cluster.)

**Verification**
- FE unit tests: re-derive round-trip stability across query shapes (scan, `GROUP BY` col/ordinal, `DISTINCT`, all-constant, sum/max); retroactivity (frozen buggy text is ignored); strategy/shape gates; schema-checker no-false-drift for INCREMENTAL **and** AUTO MVs; the PCT first-refresh full-rebuild of an aggregate MV (validated to fail without the fix). Full IVM + MV suites green (239 tests), checkstyle clean.
- End-to-end on a dev cluster (real iceberg base): aggregate MV with positional `GROUP BY 1,2` and `SELECT DISTINCT` MV both refresh to data that matches the direct query exactly (0 mismatched rows), through both the PCT full-rebuild and the IVM-delta path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
