### PR TITLE
[Enhancement] Expression-driven on-demand lazy column loading for parquet scanner

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -49,6 +49,20 @@ public:
     virtual ChunkExtraDataPtr clone() const = 0;
 };
 
+// Interface for on-demand column materialization.  Attach to a Chunk before
+// expression evaluation so that ColumnRef can request lazy columns without
+// knowing the source (e.g. Parquet LazyMaterializationContext).
+// The provider must be detached (set to nullptr) before the Chunk is emitted
+// downstream.  Ownership stays with the caller; the Chunk holds only a raw pointer.
+class MissingColumnProvider {
+public:
+    virtual ~MissingColumnProvider() = default;
+    virtual bool can_provide(SlotId slot_id) const = 0;
+    // Materialize and return the column for slot_id.  May be called multiple
+    // times for the same slot; implementations must be idempotent.
+    virtual StatusOr<ColumnPtr> provide(SlotId slot_id) = 0;
+};
+
 class Chunk {
 public:
     enum RESERVED_COLUMN_SLOT_ID {
@@ -320,6 +334,9 @@ public:
     void set_extra_data(ChunkExtraDataPtr data) { this->_extra_data = std::move(data); }
     bool has_extra_data() const { return this->_extra_data != nullptr; }
 
+    void set_missing_column_provider(MissingColumnProvider* p) { _missing_column_provider = p; }
+    MissingColumnProvider* missing_column_provider() const { return _missing_column_provider; }
+
 private:
     void rebuild_cid_index();
 
@@ -337,6 +354,7 @@ private:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
     query_cache::owner_info _owner_info;
     ChunkExtraDataPtr _extra_data;
+    MissingColumnProvider* _missing_column_provider = nullptr;
     // Chunk's columns should be unique, so we need to track the column ptrs to avoid duplicates.
     // key      : column address
     // value    : index in _columns
@@ -356,7 +374,13 @@ inline ColumnPtr& Chunk::get_column_by_name(const std::string& column_name) {
 inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
     DCHECK(is_slot_exist(slot_id)) << slot_id;
     if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
-        throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
+        std::string known_slots;
+        for (const auto& [id, idx] : _slot_id_to_index) {
+            if (!known_slots.empty()) known_slots += ",";
+            known_slots += std::to_string(id);
+        }
+        throw std::runtime_error(fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id,
+                                             known_slots, _columns.size()));
     }
     size_t idx = _slot_id_to_index.at(slot_id);
     return _columns.at(idx);
@@ -365,7 +389,13 @@ inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
 inline ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) {
     DCHECK(is_slot_exist(slot_id)) << slot_id;
     if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
-        throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
+        std::string known_slots;
+        for (const auto& [id, idx] : _slot_id_to_index) {
+            if (!known_slots.empty()) known_slots += ",";
+            known_slots += std::to_string(id);
+        }
+        throw std::runtime_error(fmt::format("slot_id {} not found (known slots: [{}], num_columns: {})", slot_id,
+                                             known_slots, _columns.size()));
     }
     size_t idx = _slot_id_to_index.at(slot_id);
     return _columns[idx];

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -586,6 +586,27 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     _scanner_ctx.profile.rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
     _scanner_ctx.profile.late_materialize_skip_rows_counter =
             ADD_COUNTER(_runtime_profile, "LateMaterializeSkipRows", TUnit::UNIT);
+    // Row count: rows filtered out before lazy columns were read.
+    _scanner_ctx.profile.parquet_lazy_col_skip_rows_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyColSkipRows", TUnit::UNIT);
+
+    // Event count: how many lazy slots were materialized on-demand during
+    // predicate evaluation via MissingColumnProvider.
+    _scanner_ctx.profile.parquet_lazy_slot_triggered_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazySlotTriggered", TUnit::UNIT);
+
+    // Operation count: lazy column read_range() calls (includes both
+    // on-demand triggers and backfill reads).
+    _scanner_ctx.profile.parquet_lazy_read_count_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyReadCount", TUnit::UNIT);
+
+    // Time spent reading lazy columns (on-demand + backfill).
+    _scanner_ctx.profile.parquet_lazy_read_timer = ADD_TIMER(_runtime_profile, "ParquetLazyReadTime");
+
+    // Row group count: row groups where every classified-lazy column was
+    // triggered on-demand (suggests active/lazy classification misprediction).
+    _scanner_ctx.profile.parquet_lazy_full_trigger_count_counter =
+            ADD_COUNTER(_runtime_profile, "ParquetLazyFullTriggerCount", TUnit::UNIT);
     _scanner_ctx.profile.scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
     _scanner_ctx.profile.scan_ranges_size = ADD_COUNTER(_runtime_profile, "ScanRangesSize", TUnit::BYTES);
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -212,9 +212,11 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
         if (_scanner_ctx->is_first_split) {
             file_record_count = _scanner_ctx->scan_range->record_count;
         }
-        _scanner_ctx->append_or_update_count_column_to_chunk(chunk, file_record_count);
-        _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);
-        _scanner_ctx->append_or_update_extended_column_to_chunk(chunk, 1);
+        // append_side_columns_to_chunk fills per-row count (value=1),
+        // partition, and extended columns first.  The next call overwrites the
+        // count column with the aggregated file record count.
+        RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, 1));
+        _scanner_ctx->append_or_update_count_column_to_chunk(chunk, 1, file_record_count);
         _scanner_ctx->no_more_chunks = true;
         _app_stats.rows_read += 1;
         return Status::OK();
@@ -225,9 +227,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
         // 3 means we output 3 values: min, max, and null
         const size_t row_count = 3;
         (*chunk)->set_num_rows(row_count);
-        _scanner_ctx->append_or_update_min_max_column_to_chunk(chunk, row_count);
-        _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, row_count);
-        _scanner_ctx->append_or_update_extended_column_to_chunk(chunk, row_count);
+        RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, row_count));
         _scanner_ctx->no_more_chunks = true;
         _app_stats.rows_read += row_count;
         return Status::OK();
@@ -236,24 +236,6 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     RETURN_IF_ERROR(_runtime_state->check_mem_limit("get chunk from scanner"));
     Status status = do_get_next(runtime_state, chunk);
     if (status.ok()) {
-        // Simple scanners (Text, Avro, JSON, JNI) cannot push single-slot predicates
-        // into their column readers, so the base class applies them here uniformly.
-        // ORC and Parquet return true because they handle by-slot evaluation
-        // internally via lazy materialisation and dict-filter pipelines.
-        if (!scanner_handles_predicate_by_slot_internally()) {
-            SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-            Filter chunk_filter;
-            RETURN_IF_ERROR(_scanner_ctx->evaluate_on_conjunct_ctxs_by_slot(chunk, &chunk_filter));
-        }
-        // Multi-slot predicates (e.g. "a + b > 5") evaluated here for formats that
-        // cannot handle them internally (Text, Avro, JSON, JNI).  ORC and Parquet
-        // evaluate them inside do_get_next() after all columns are materialised and
-        // return true from scanner_handles_multi_slot_conjuncts_internally().
-        if (!scanner_handles_multi_slot_conjuncts_internally() && !_scanner_ctx->conjuncts.scanner_ctxs.empty()) {
-            SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-            RETURN_IF_ERROR(
-                    ChunkPredicateEvaluator::eval_conjuncts(_scanner_ctx->conjuncts.scanner_ctxs, (*chunk).get()));
-        }
     } else if (status.is_end_of_file()) {
         // do nothing.
     } else {
@@ -493,6 +475,11 @@ void HdfsScanner::update_counter() {
     COUNTER_UPDATE(profile->raw_rows_read_counter, _app_stats.raw_rows_read);
     COUNTER_UPDATE(profile->rows_read_counter, _app_stats.rows_read);
     COUNTER_UPDATE(profile->late_materialize_skip_rows_counter, _app_stats.late_materialize_skip_rows);
+    COUNTER_UPDATE(profile->parquet_lazy_col_skip_rows_counter, _app_stats.parquet_lazy_col_skip_rows);
+    COUNTER_UPDATE(profile->parquet_lazy_slot_triggered_counter, _app_stats.parquet_lazy_slot_triggered);
+    COUNTER_UPDATE(profile->parquet_lazy_read_count_counter, _app_stats.parquet_lazy_read_count);
+    COUNTER_UPDATE(profile->parquet_lazy_read_timer, _app_stats.parquet_lazy_read_ns);
+    COUNTER_UPDATE(profile->parquet_lazy_full_trigger_count_counter, _app_stats.parquet_lazy_full_trigger_count);
     COUNTER_UPDATE(profile->expr_filter_timer, _app_stats.expr_filter_ns);
     COUNTER_UPDATE(profile->column_read_timer, _app_stats.column_read_ns);
     COUNTER_UPDATE(profile->column_convert_timer, _app_stats.column_convert_ns);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -69,20 +69,6 @@ public:
     virtual void do_update_counter(HdfsScannerProfile* profile);
     virtual Status reinterpret_status(const Status& st);
 
-    // ORC and Parquet push conjunct_ctxs_by_slot into their own column-level
-    // readers (lazy materialisation, dict filter, etc.) and do NOT want the base
-    // class to apply them a second time.  All other formats return false so the
-    // base class handles by-slot evaluation uniformly in get_next().
-    virtual bool scanner_handles_predicate_by_slot_internally() const { return false; }
-
-    // True if the scanner evaluates multi-slot predicates (conjuncts->scanner_ctxs)
-    // internally inside do_get_next(), so the base class must not apply them again.
-    // Scanners that return true MUST guarantee row-level correctness; the ORC
-    // search-argument / Parquet statistics pass is only an approximate skip; the
-    // actual predicate must still be evaluated on every returned row.
-    // Future expression-driven Parquet lazy materialisation will also set this true
-    // once it can interleave predicate evaluation with column loading.
-    virtual bool scanner_handles_multi_slot_conjuncts_internally() const { return false; }
     void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
     bool has_split_tasks() const { return _scanner_ctx != nullptr && _scanner_ctx->split.has_split_tasks; }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
@@ -119,15 +119,8 @@ Status HdfsAvroScanner::do_get_next(RuntimeState* state, ChunkPtr* chunk) {
             }
         }
     }
-    // Fill not-existed slots: fills the ___count___ column (count queries) and any
-    // schema-evolution columns absent from this file. Also calls ck->set_num_rows().
-    RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(&ck, row_count));
-
-    // Fill partition and extended constant columns.
-    _scanner_ctx->append_or_update_partition_column_to_chunk(&ck, row_count);
-    _scanner_ctx->append_or_update_extended_column_to_chunk(&ck, row_count);
-
-    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
+    RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(&ck, row_count));
+    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(&ck));
 
     // Note: _app_stats.rows_read is updated by the base class HdfsScanner::get_next
     // after do_get_next returns. Do NOT update it here to avoid double-counting.

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_context.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_context.cpp
@@ -14,7 +14,6 @@
 
 #include "exec/hdfs_scanner/hdfs_scanner_context.h"
 
-#include <algorithm>
 #include <map>
 #include <utility>
 
@@ -93,13 +92,11 @@ void HdfsScannerContext::update_with_none_existed_slot(SlotDescriptor* slot) {
 }
 
 void HdfsScannerContext::update_return_count_columns() {
-    // special handling for ___count__ optimization.
-    // this is different from `can_use_count_optimization` ,  which uses iceberg metadata to return count value
-    // this optimizaton is to fill with `count` rows of default value from parquet/orc header
+    _count_slot.reset();
     std::vector<FormatColumnInfo> updated_columns;
     for (auto& column : materialized_columns) {
         if (column.name() == kCountOptColumnName) {
-            update_with_none_existed_slot(column.slot_desc);
+            _count_slot = column.slot_desc;
         } else {
             updated_columns.emplace_back(column);
         }
@@ -116,9 +113,8 @@ void HdfsScannerContext::update_min_max_columns() {
     for (auto& column : materialized_columns) {
         if (min_max_values.find(column.slot_id()) != min_max_values.end()) {
             // This column has file-level min/max statistics.  Move it to
-            // not_existed_slots so that append_or_update_min_max_column_to_chunk()
-            // fills the column with the statistics values instead of reading the
-            // actual data from the file.
+            // not_existed_slots so that the min-max column is filled with
+            // statistics values instead of reading the actual data from the file.
             update_with_none_existed_slot(column.slot_desc);
         } else if (format_scan_context.options.can_use_any_column) {
             // This column has no min/max statistics (e.g. STRING or TIMESTAMP type
@@ -160,31 +156,23 @@ Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<
 }
 
 Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
+    ChunkPtr& ck = (*chunk);
     if (not_existed_slots.empty()) return Status::OK();
 
-    ChunkPtr& ck = (*chunk);
-
-    if (format_scan_context.options.use_min_max_opt) {
-        append_or_update_min_max_column_to_chunk(chunk, row_count);
-    }
-
     for (auto* slot_desc : not_existed_slots) {
-        if (format_scan_context.options.use_min_max_opt &&
-            scan_range->min_max_values.find(slot_desc->id()) != scan_range->min_max_values.end()) {
-            // handled in min max column
-            continue;
+        if (format_scan_context.options.use_min_max_opt) {
+            auto it = scan_range->min_max_values.find(slot_desc->id());
+            if (it != scan_range->min_max_values.end()) {
+                MutableColumnPtr col = create_min_max_value_column(slot_desc, it->second, row_count);
+                ck->append_or_update_column(std::move(col), slot_desc->id());
+                continue;
+            }
         }
 
         auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
         if (row_count > 0) {
-            if (slot_desc->col_name() == kCountOptColumnName) {
-                TypeDescriptor desc;
-                desc.type = TYPE_BIGINT;
-                col = ColumnHelper::create_column(desc, slot_desc->is_nullable());
-                col->append_datum(int64_t(1));
-                col->assign(row_count, 0);
-            } else if (auto it = materialize_slot_default_values.find(slot_desc->id());
-                       it != materialize_slot_default_values.end()) {
+            if (auto it = materialize_slot_default_values.find(slot_desc->id());
+                it != materialize_slot_default_values.end()) {
                 RETURN_IF_ERROR(fill_default_value_for_not_existed_slot(slot_desc, it->second, row_count, col.get()));
             } else {
                 col->append_default(row_count);
@@ -193,31 +181,26 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
         ck->append_or_update_column(std::move(col), slot_desc->id());
     }
     ck->set_num_rows(row_count);
+    // NOTE: set_num_rows(row_count) must be called AFTER appending columns
+    // and ONLY when not_existed_slots is non-empty.  Chunk::set_num_rows()
+    // calls resize(count) on EVERY column in the chunk, including pre-allocated
+    // stubs (e.g. lazy Parquet columns with 0 rows).  Calling it unconditionally
+    // before the empty-return corrupts those stubs and can cause physical column
+    // emission (fill_dst_column) to double the chunk's row count.
     return Status::OK();
 }
 
-void HdfsScannerContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
-    if (not_existed_slots.empty() || row_count < 0) return;
+void HdfsScannerContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t output_rows, int64_t value) {
+    if (!_count_slot.has_value()) return;
+    auto* slot_desc = _count_slot.value();
     ChunkPtr& ck = (*chunk);
-    auto* slot_desc = not_existed_slots[0];
-    TypeDescriptor desc;
-    desc.type = TYPE_BIGINT;
-    auto col = ColumnHelper::create_column(desc, slot_desc->is_nullable());
-    col->append_datum(int64_t(row_count));
-    ck->append_or_update_column(std::move(col), slot_desc->id());
-    ck->set_num_rows(1);
-}
-
-void HdfsScannerContext::append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
-    for (SlotDescriptor* slot_desc : not_existed_slots) {
-        auto it = scan_range->min_max_values.find(slot_desc->id());
-        if (it == scan_range->min_max_values.end()) {
-            continue;
-        }
-        const TExprMinMaxValue& min_max_value = it->second;
-        MutableColumnPtr col = create_min_max_value_column(slot_desc, min_max_value, row_count);
-        (*chunk)->append_or_update_column(std::move(col), slot_desc->id());
+    auto col = Int64Column::create();
+    if (output_rows > 0) {
+        col->append(value);
+        col->assign(output_rows, 0);
     }
+    ck->append_or_update_column(std::move(col), slot_desc->id());
+    ck->set_num_rows(output_rows);
 }
 
 MutableColumnPtr HdfsScannerContext::create_min_max_value_column(SlotDescriptor* slot_desc,
@@ -330,6 +313,29 @@ Status HdfsScannerContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Fi
     return Status::OK();
 }
 
+Status HdfsScannerContext::evaluate_all_predicates(ChunkPtr* chunk) {
+    SCOPED_RAW_TIMER(&stats->expr_filter_ns);
+    size_t chunk_size = (*chunk)->num_rows();
+    if (chunk_size > 0 && !conjunct_ctxs_by_slot.empty()) {
+        Filter filter(chunk_size, 1);
+        for (auto& it : conjunct_ctxs_by_slot) {
+            ASSIGN_OR_RETURN(chunk_size,
+                             ChunkPredicateEvaluator::eval_conjuncts_into_filter(it.second, chunk->get(), &filter));
+            if (chunk_size == 0) {
+                (*chunk)->set_num_rows(0);
+                return Status::OK();
+            }
+        }
+        if (chunk_size != (*chunk)->num_rows()) {
+            (*chunk)->filter(filter);
+        }
+    }
+    if ((*chunk)->num_rows() > 0 && !conjuncts.scanner_ctxs.empty()) {
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(conjuncts.scanner_ctxs, (*chunk).get()));
+    }
+    return Status::OK();
+}
+
 StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots() {
     if (not_existed_slots.size() == 0) return false;
 
@@ -350,6 +356,16 @@ void HdfsScannerContext::append_or_update_partition_column_to_chunk(ChunkPtr* ch
 
 void HdfsScannerContext::append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
     append_or_update_column_to_chunk(chunk, row_count, extended_columns, extended_values);
+}
+
+Status HdfsScannerContext::append_side_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
+    RETURN_IF_ERROR(append_or_update_not_existed_columns_to_chunk(chunk, row_count));
+    append_or_update_partition_column_to_chunk(chunk, row_count);
+    append_or_update_extended_column_to_chunk(chunk, row_count);
+    if (has_count_column()) {
+        append_or_update_count_column_to_chunk(chunk, row_count, 1);
+    }
+    return Status::OK();
 }
 
 void HdfsScannerContext::append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_context.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_context.cpp
@@ -314,7 +314,7 @@ Status HdfsScannerContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Fi
 }
 
 Status HdfsScannerContext::evaluate_all_predicates(ChunkPtr* chunk) {
-    SCOPED_RAW_TIMER(&stats->expr_filter_ns);
+    SCOPED_RAW_TIMER(&format_scan_context.stats->expr_filter_ns);
     size_t chunk_size = (*chunk)->num_rows();
     if (chunk_size > 0 && !conjunct_ctxs_by_slot.empty()) {
         Filter filter(chunk_size, 1);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_context.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_context.h
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -50,6 +51,12 @@ struct HdfsScannerProfile {
     RuntimeProfile::Counter* raw_rows_read_counter = nullptr;
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* late_materialize_skip_rows_counter = nullptr;
+
+    RuntimeProfile::Counter* parquet_lazy_col_skip_rows_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_slot_triggered_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_read_count_counter = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_read_timer = nullptr;
+    RuntimeProfile::Counter* parquet_lazy_full_trigger_count_counter = nullptr;
     RuntimeProfile::Counter* scan_ranges_counter = nullptr;
     RuntimeProfile::Counter* scan_ranges_size = nullptr;
 
@@ -196,6 +203,11 @@ struct HdfsScannerContext {
 
     std::vector<SlotDescriptor*> not_existed_slots;
 
+    // ___count___ column for COUNT(*) optimization.
+    // Separated from not_existed_slots because it is an execution marker,
+    // not a schema-evolution missing column.
+    std::optional<SlotDescriptor*> _count_slot;
+
     // for iceberg reserved fields
     std::vector<SlotDescriptor*> reserved_field_slots;
 
@@ -241,6 +253,7 @@ struct HdfsScannerContext {
     }
 
     bool can_use_count_optimization() const;
+    bool has_count_column() const { return _count_slot.has_value(); }
 
     bool can_use_min_max_optimization() const;
 
@@ -262,11 +275,19 @@ struct HdfsScannerContext {
     // If there is no partition column in the chunk, append partition column to chunk,
     // otherwise update partition column in chunk
     void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    void append_or_update_min_max_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+    // Emit `output_rows` rows of `value` for the ___count___ column.
+    // Idempotent: if the chunk already has a ___count___ column, this is a no-op.
+    // Used by both the count-opt aggregated path (output_rows=1, value=row_count)
+    // and the per-row fallback (output_rows=row_count, value=1).
+    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t output_rows, int64_t value);
     MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot, const TExprMinMaxValue& value, size_t row_count);
 
     void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+    // Append all side columns (not-existed, partition, extended, count) at once.
+    // Safe when any category is empty — each sub-function is a no-op in that case.
+    Status append_side_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+
     void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,
                                           const std::vector<FormatColumnInfo>& columns, const Columns& values);
 
@@ -276,6 +297,11 @@ struct HdfsScannerContext {
     // other helper functions.
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
     Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
+
+    // Evaluate both single-slot conjuncts (conjunct_ctxs_by_slot) and multi-slot
+    // conjuncts (conjuncts.scanner_ctxs) on the chunk in place.  Safe to call
+    // when either category is empty — each sub-step is a no-op.
+    Status evaluate_all_predicates(ChunkPtr* chunk);
 
     void merge_split_tasks();
 };

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
@@ -228,10 +228,8 @@ Status HdfsJsonScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
 
     if ((*chunk)->num_rows() > 0) {
         size_t rows_read = (*chunk)->num_rows();
-        RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
-        _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, rows_read);
-
-        // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
+        RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, rows_read));
+        RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
     }
 
     return st;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -618,7 +618,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next_count(ChunkPtr* chunk) {
 
     if (!st.is_end_of_file()) return st;
     if (read_num_values == 0) return Status::EndOfFile("No more rows to read");
-    _scanner_ctx->append_or_update_count_column_to_chunk(chunk, read_num_values);
+    _scanner_ctx->append_or_update_count_column_to_chunk(chunk, 1, read_num_values);
     return 1;
 }
 
@@ -699,6 +699,9 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
 
             if (rows_read != 0 && rows_read != ck->num_rows()) {
                 ck->filter(_chunk_filter);
+            }
+            if (_scanner_ctx->has_count_column()) {
+                _scanner_ctx->append_or_update_count_column_to_chunk(chunk, rows_read, 1);
             }
         }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.h
@@ -36,13 +36,6 @@ public:
     Status do_init(RuntimeState* runtime_state, const HdfsScannerContext& scanner_ctx) override;
     void do_update_counter(HdfsScannerProfile* profile) override;
     void disable_use_orc_sargs() { _use_orc_sargs = false; }
-    // ORC handles single-slot predicates internally via lazy materialisation and
-    // per-column reader pushdown; the base class must not apply them a second time.
-    bool scanner_handles_predicate_by_slot_internally() const override { return true; }
-    // ORC evaluates multi-slot predicates at the end of do_get_next() after all
-    // columns (including lazy-loaded ones) are present in the chunk.  The search
-    // argument used during open() is an approximate stripe-level skip only.
-    bool scanner_handles_multi_slot_conjuncts_internally() const override { return true; }
 
 private:
     StatusOr<size_t> _do_get_next(ChunkPtr* chunk);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -20,7 +20,6 @@
 #include "exec/iceberg/iceberg_delete_builder.h"
 #include "exec/paimon/paimon_delete_file_builder.h"
 #include "exec/pipeline/fragment_context.h"
-#include "exprs/chunk_predicate_evaluator.h"
 #include "formats/parquet/file_reader.h"
 
 namespace starrocks {
@@ -99,6 +98,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     RuntimeProfile::Counter* group_chunk_read_timer = nullptr;
     RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
+    RuntimeProfile::Counter* dict_code_predicate_eval_count = nullptr;
 
     // io coalesce
     RuntimeProfile::Counter* active_lazy_coalesce_together = nullptr;
@@ -158,6 +158,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
+    dict_code_predicate_eval_count =
+            ADD_CHILD_COUNTER(root, "DictCodePredicateEvalCount", TUnit::UNIT, kParquetProfileSectionPrefix);
 
     active_lazy_coalesce_together = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceTogether", TUnit::UNIT,
                                                       kParquetProfileSectionPrefix);
@@ -207,6 +209,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
     COUNTER_UPDATE(group_dict_decode_timer, _app_stats.group_dict_decode_ns);
     COUNTER_UPDATE(active_lazy_coalesce_together, _app_stats.active_lazy_coalesce_together);
     COUNTER_UPDATE(active_lazy_coalesce_seperately, _app_stats.active_lazy_coalesce_seperately);
+    COUNTER_UPDATE(dict_code_predicate_eval_count, _app_stats.parquet_dict_code_predicate_eval_count);
     int64_t page_stats = _app_stats.has_page_statistics ? 1 : 0;
     COUNTER_UPDATE(has_page_statistics, page_stats);
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);
@@ -265,17 +268,7 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
 }
 
 Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    RETURN_IF_ERROR(_reader->get_next(chunk));
-    // Evaluate multi-slot predicates after FileReader has materialised all columns
-    // (including lazily-loaded ones from its internal predicate pipeline).
-    // This pass is the correctness guarantee; statistics-based skipping inside
-    // FileReader is approximate.  In the future, expression-driven lazy
-    // materialisation will replace this with interleaved column-load/evaluate.
-    if ((*chunk)->num_rows() > 0 && !_scanner_ctx->conjuncts.scanner_ctxs.empty()) {
-        SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_ctx->conjuncts.scanner_ctxs, chunk->get()));
-    }
-    return Status::OK();
+    return _reader->get_next(chunk);
 }
 
 void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.h
@@ -31,15 +31,6 @@ public:
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerContext& scanner_ctx) override;
     void do_update_counter(HdfsScannerProfile* profile) override;
-    // Parquet handles single-slot predicates via row-group zone-map, page-index,
-    // dict-filter, and lazy materialisation inside FileReader; the base class must
-    // not apply them a second time.
-    bool scanner_handles_predicate_by_slot_internally() const override { return true; }
-    // Parquet evaluates multi-slot predicates at the end of do_get_next() after
-    // FileReader has materialised all columns.  In the future, expression-driven
-    // lazy materialisation will interleave this with column loading for deeper
-    // optimisation — the override keeps the base class from double-applying them.
-    bool scanner_handles_multi_slot_conjuncts_internally() const override { return true; }
 
 private:
     std::shared_ptr<parquet::FileReader> _reader = nullptr;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_partition.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_partition.cpp
@@ -30,6 +30,7 @@ Status HdfsPartitionScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* 
         (*chunk)->append_column(std::move(column), slot->id());
     }
     _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);
+    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
@@ -387,8 +387,8 @@ Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
         }
     }
 
-    RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
-    _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, rows_read);
+    RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, rows_read));
+    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
 
     // Check chunk's row number for each column
     chunk->get()->check_or_die();

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -388,9 +388,8 @@ Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
     // Partition and not-existed columns must be appended before predicate evaluation
     // because ctxs_by_slot may reference non-file or partition slots.
-    RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, chunk_size));
-    _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, chunk_size);
-    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
+    RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, chunk_size));
+    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
     return Status::OK();
 }
 
@@ -488,18 +487,7 @@ class HiveJniScanner : public JniScanner {
 public:
     HiveJniScanner(std::string factory_class, std::map<std::string, std::string> params)
             : JniScanner(std::move(factory_class), std::move(params)) {}
-    Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
 };
-
-Status HiveJniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    // fill chunk with all wanted column exclude partition columns
-    ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
-    RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, chunk_size));
-    // only Hive needs partition columns appended explicitly; Paimon and Hudi append them on the Java side.
-    _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, chunk_size);
-    // conjunct_ctxs_by_slot evaluation is handled uniformly by HdfsScanner::get_next().
-    return Status::OK();
-}
 
 std::unique_ptr<JniScanner> create_hive_jni_scanner(const JniScanner::CreateOptions& options) {
     const auto& scan_range = *(options.scan_range);

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -46,12 +46,7 @@ public:
     Status do_init(RuntimeState* runtime_state, const HdfsScannerContext& scanner_ctx) override;
     virtual Status update_jni_scanner_params();
     Status reinterpret_status(const Status& st) override { return st; }
-
-protected:
     StatusOr<size_t> fill_empty_chunk(ChunkPtr* chunk);
-    // Predicate evaluation/filtering is handled uniformly by HdfsScanner::get_next()
-    // via evaluate_on_conjunct_ctxs_by_slot() and ChunkPredicateEvaluator; JniScanner
-    // does not maintain its own chunk filter.
 
 private:
     struct FillColumnArgs {

--- a/be/src/exprs/column_ref.cpp
+++ b/be/src/exprs/column_ref.cpp
@@ -52,6 +52,13 @@ std::string ColumnRef::debug_string() const {
 }
 
 StatusOr<ColumnPtr> ColumnRef::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    if (ptr != nullptr && !ptr->is_slot_exist(slot_id())) {
+        if (auto* provider = ptr->missing_column_provider()) {
+            if (provider->can_provide(slot_id())) {
+                return provider->provide(slot_id());
+            }
+        }
+    }
     return get_column(this, ptr);
 }
 

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -115,6 +115,8 @@ ADD_BE_LIB(Formats
         parquet/arrow_memory_pool.cpp
         parquet/column_chunk_reader.cpp
         parquet/column_materializer.cpp
+        parquet/lazy_materialization_context.cpp
+        parquet/read_range_planner.cpp
         parquet/column_converter.cpp
         parquet/column_reader.cpp
         parquet/column_reader_factory.cpp

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -24,10 +24,16 @@
 #include "common/config_scan_io_fwd.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
+#include "formats/parquet/read_range_planner.h"
 #include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks::parquet {
+
+ColumnMaterializer::ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+        : _param(param), _column_readers(column_readers) {
+    _read_range_planner = std::make_unique<ReadRangePlanner>(param, column_readers);
+}
 
 void ColumnMaterializer::clear_classification() {
     _active_column_indices.clear();
@@ -51,8 +57,11 @@ void ColumnMaterializer::add_lazy_column(int col_idx) {
 }
 
 void ColumnMaterializer::promote_lazy_to_active() {
-    _active_column_indices.swap(_lazy_column_indices);
-    _active_slot_ids.swap(_lazy_slot_ids);
+    _active_column_indices.insert(_active_column_indices.end(), _lazy_column_indices.begin(),
+                                  _lazy_column_indices.end());
+    _lazy_column_indices.clear();
+    _active_slot_ids.insert(_active_slot_ids.end(), _lazy_slot_ids.begin(), _lazy_slot_ids.end());
+    _lazy_slot_ids.clear();
 }
 
 void ColumnMaterializer::rebuild_read_order_ctx() {
@@ -122,8 +131,16 @@ ChunkPtr ColumnMaterializer::create_read_chunk(const std::vector<SlotId>& slot_i
 
 Status ColumnMaterializer::read_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter,
                                      ChunkPtr* chunk) {
+    // read_slot() deliberately does NOT populate _slot_cache.
+    //
+    // During active-column reads, the column may be in physical form (dict
+    // codes or intermediate values).  Caching it would violate the invariant
+    // that _slot_cache holds only logical (finalized) columns.
+    //
+    // On-demand lazy reads go through materialize_slot() instead, which
+    // finalizes before caching.  read_lazy_columns() detects triggered lazy
+    // slots via _slot_cache populated by materialize_slot(), not read_slot().
     RETURN_IF_ERROR((*_column_readers)[slot_id]->read_range(range, filter, (*chunk)->get_column_by_slot_id(slot_id)));
-    _slot_cache[slot_id] = {(*chunk)->get_column_by_slot_id(slot_id)};
     return Status::OK();
 }
 
@@ -136,7 +153,8 @@ Status ColumnMaterializer::read_lazy_range(const Range<uint64_t>& range, const F
 }
 
 StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter,
-                                                                      ChunkPtr* chunk) {
+                                                                      ChunkPtr* chunk,
+                                                                      LazyMaterializationContext* lazy_ctx) {
     DCHECK(_column_read_order_ctx != nullptr);
     const std::vector<int>& read_order = _column_read_order_ctx->get_column_read_order();
     size_t round_cost = 0;
@@ -179,6 +197,7 @@ StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Rang
         }
 
         if (_post_read_conjuncts_by_slot.find(slot_id) != _post_read_conjuncts_by_slot.end()) {
+            RETURN_IF_ERROR(finalize_active_slot(slot_id, *chunk));
             SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
             std::vector<ExprContext*> ctxs = _post_read_conjuncts_by_slot.at(slot_id);
             ASSIGN_OR_RETURN(hit_count, eval_slot_conjuncts(ctxs, slot_id, chunk, filter));
@@ -210,15 +229,21 @@ Status ColumnMaterializer::rewrite_dict_conjuncts_to_predicate(bool* is_group_fi
 
 Status ColumnMaterializer::filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
                                               const std::vector<std::string>& sub_field_path, const size_t& layer) {
+    _param.stats->parquet_dict_code_predicate_eval_count++;
     return (*_column_readers)[slot_id]->filter_dict_column(column, filter, sub_field_path, layer);
 }
 
 StatusOr<size_t> ColumnMaterializer::eval_slot_conjuncts(const std::vector<ExprContext*>& ctxs, SlotId slot_id,
                                                          ChunkPtr* chunk, Filter* filter) {
+    // Use a single-slot temp chunk to avoid Chunk::check_or_die() failures that
+    // would occur if active_chunk contains unread columns (0 rows).
+    // Propagate the MissingColumnProvider so that ColumnRef can still trigger
+    // lazy materialization of payload slots referenced by this conjunct.
     auto temp_chunk = std::make_shared<Chunk>();
     temp_chunk->columns().reserve(1);
     ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
     temp_chunk->append_column(column, slot_id);
+    temp_chunk->set_missing_column_provider((*chunk)->missing_column_provider());
     return ChunkPredicateEvaluator::eval_conjuncts_into_filter(ctxs, temp_chunk.get(), filter);
 }
 
@@ -247,33 +272,93 @@ Status ColumnMaterializer::fill_dst_column(SlotId slot_id, ColumnPtr& dst, Colum
 
 void ColumnMaterializer::collect_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end,
                                            ColumnIOTypeFlags types) {
-    for (const auto& index : _active_column_indices) {
-        const auto& column = _param.read_cols[index];
-        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, true);
-    }
-
-    for (const auto& index : _lazy_column_indices) {
-        const auto& column = _param.read_cols[index];
-        (*_column_readers)[column.slot_id()]->collect_column_io_range(ranges, end, types, false);
-    }
+    _read_range_planner->collect_ranges(_active_column_indices, true, ranges, end, types);
+    // Still plan lazy column ranges so that materialize_slot() can read them
+    // when triggered during compound OR eval.  Range planning alone does NOT
+    // cause IO — only read_range() does.
+    _read_range_planner->pre_plan_lazy_ranges(_lazy_column_indices, end, types);
+    const auto& lazy_ranges = _read_range_planner->lazy_ranges();
+    ranges->insert(ranges->end(), lazy_ranges.begin(), lazy_ranges.end());
 }
 
 Status ColumnMaterializer::read_lazy_columns(const Range<uint64_t>& full_range,
                                              const Range<uint64_t>& post_filter_range, const Filter& post_filter,
-                                             bool has_filter, ChunkPtr& active_chunk) {
-    ChunkPtr lazy_chunk = create_lazy_chunk();
-    if (has_filter) {
-        RETURN_IF_ERROR(read_lazy_range(post_filter_range, &post_filter, &lazy_chunk));
-        lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+                                             const Filter& chunk_filter, bool has_filter, ChunkPtr& active_chunk) {
+    // Separate triggered lazy columns from untriggered ones.
+    // Triggered: read on-demand during predicate eval → filter and append.
+    // Untriggered: backfill (output) or null-fill (predicate-only).
+    std::vector<int> untriggered_indices;
+    for (int col_idx : _lazy_column_indices) {
+        SlotId slot_id = _param.read_cols[col_idx].slot_id();
+        if (_slot_cache.count(slot_id)) {
+            // Column was triggered during predicate eval: it has full_range data.
+            // Mutate (COW) and filter to match active_chunk's surviving row count.
+            ColumnPtr& col = _read_chunk->get_column_by_slot_id(slot_id);
+            if (has_filter) {
+                auto mutable_col = Column::mutate(col);
+                mutable_col->filter(chunk_filter);
+                active_chunk->append_column(ColumnPtr(std::move(mutable_col)), slot_id);
+            } else {
+                active_chunk->append_column(col, slot_id);
+            }
+            _logical_slot_ids.insert(slot_id);
+        } else {
+            untriggered_indices.push_back(col_idx);
+        }
+    }
+
+    if (!untriggered_indices.empty()) {
+        // Output columns → backfill from disk.
+        // Predicate-only columns → null-fill (no IO, values unused downstream).
+        std::vector<int> backfill_indices;
+        size_t rows = active_chunk->num_rows();
+        for (int col_idx : untriggered_indices) {
+            const auto& col_info = _param.read_cols[col_idx];
+            if (col_info.slot_desc->is_output_column()) {
+                backfill_indices.push_back(col_idx);
+            } else {
+                auto col = _read_chunk->get_column_by_slot_id(col_info.slot_id())->clone_empty();
+                col->append_default(rows);
+                active_chunk->append_column(col, col_info.slot_id());
+                _logical_slot_ids.insert(col_info.slot_id());
+            }
+        }
+
+        if (!backfill_indices.empty()) {
+            std::vector<SlotId> backfill_slot_ids;
+            backfill_slot_ids.reserve(backfill_indices.size());
+            for (int col_idx : backfill_indices) {
+                backfill_slot_ids.push_back(_param.read_cols[col_idx].slot_id());
+            }
+            ChunkPtr lazy_chunk = create_read_chunk(backfill_slot_ids, false);
+            {
+                SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
+                _param.stats->parquet_lazy_read_count += backfill_indices.size();
+                if (has_filter) {
+                    RETURN_IF_ERROR(read_range(backfill_indices, post_filter_range, &post_filter, &lazy_chunk, true));
+                    lazy_chunk->filter_range(post_filter, 0, post_filter_range.span_size());
+                } else {
+                    RETURN_IF_ERROR(read_range(backfill_indices, full_range, nullptr, &lazy_chunk, true));
+                }
+            }
+            if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
+                return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
+                                                         active_chunk->num_rows(), lazy_chunk->num_rows()));
+            }
+            for (int col_idx : backfill_indices) {
+                SlotId slot_id = _param.read_cols[col_idx].slot_id();
+                auto& col = lazy_chunk->get_column_by_slot_id(slot_id);
+                RETURN_IF_ERROR((*_column_readers)[slot_id]->finalize_lazy_state(col));
+                _logical_slot_ids.insert(slot_id);
+            }
+            active_chunk->merge(std::move(*lazy_chunk));
+        }
+        _lazy_column_needed = !backfill_indices.empty();
     } else {
-        RETURN_IF_ERROR(read_lazy_range(full_range, nullptr, &lazy_chunk));
+        _lazy_column_needed = false;
     }
-    if (lazy_chunk->num_rows() != active_chunk->num_rows()) {
-        return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_rows={}",
-                                                 active_chunk->num_rows(), lazy_chunk->num_rows()));
-    }
-    active_chunk->merge(std::move(*lazy_chunk));
-    _lazy_column_needed = true;
+    _lazy_column_needed = _lazy_column_needed || !_slot_cache.empty();
+
     return Status::OK();
 }
 
@@ -282,8 +367,13 @@ Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPt
     for (const auto& column : _param.read_cols) {
         SlotId slot_id = column.slot_id();
         if (skip_slots && skip_slots->count(slot_id)) continue;
-        RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
-                                        active_chunk->get_column_by_slot_id(slot_id)));
+        if (_logical_slot_ids.count(slot_id)) {
+            (*dst)->get_column_by_slot_id(slot_id)->as_mutable_raw_ptr()->swap_column(
+                    *active_chunk->get_column_by_slot_id(slot_id)->as_mutable_raw_ptr());
+        } else {
+            RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
+                                            active_chunk->get_column_by_slot_id(slot_id)));
+        }
     }
     if (!_param.scanner_ctx->reserved_field_slots.empty()) {
         for (const auto* slot : _param.scanner_ctx->reserved_field_slots) {
@@ -293,6 +383,11 @@ Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPt
         }
     }
     return Status::OK();
+}
+
+Status ColumnMaterializer::finalize_active_slot(SlotId slot_id, ChunkPtr& active_chunk) {
+    auto& col = active_chunk->get_column_by_slot_id(slot_id);
+    return (*_column_readers)[slot_id]->finalize_lazy_state(col);
 }
 
 void ColumnMaterializer::classify_columns(const std::unordered_set<SlotId>& deferred_source_slots,
@@ -308,13 +403,23 @@ void ColumnMaterializer::classify_columns(const std::unordered_set<SlotId>& defe
         SlotId slot_id = column.slot_id();
         auto it = conjunct_ctxs_by_slot.find(slot_id);
         if (it != conjunct_ctxs_by_slot.end()) {
+            bool all_dict_filter = true;
             for (ExprContext* ctx : it->second) {
                 std::vector<std::string> sub_field_path;
                 if (_try_use_dict_filter(read_col_idx, column, ctx, sub_field_path)) {
                     add_dict_filter_column(read_col_idx, sub_field_path);
                 } else {
                     add_post_read_conjunct(slot_id, ctx);
+                    all_dict_filter = false;
                 }
+            }
+            // When ALL conjuncts use the dict-code filter path, wire set_can_lazy_decode
+            // explicitly so the lazy-decode decision is visible at classification time.
+            // ScalarColumnReader will still set _need_lazy_decode via _dict_filter_ctx,
+            // but the explicit flag also enables lazy type conversion and unifies the
+            // policy with the output-only lazy column path.
+            if (all_dict_filter && config::parquet_late_materialization_enable) {
+                (*_column_readers)[slot_id]->set_can_lazy_decode(true);
             }
             add_active_column(read_col_idx);
         } else if (config::parquet_late_materialization_enable && deferred_source_slots.count(slot_id) == 0) {
@@ -363,8 +468,14 @@ Status ColumnMaterializer::materialize_slot(SlotId slot_id, const Range<uint64_t
     if (_slot_cache.find(slot_id) != _slot_cache.end()) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(
-            (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
+    {
+        SCOPED_RAW_TIMER(&_param.stats->parquet_lazy_read_ns);
+        _param.stats->parquet_lazy_read_count++;
+        _triggered_lazy_slots.insert(slot_id);
+        RETURN_IF_ERROR(
+                (*_column_readers)[slot_id]->read_range(range, filter, _read_chunk->get_column_by_slot_id(slot_id)));
+    }
+    RETURN_IF_ERROR((*_column_readers)[slot_id]->finalize_lazy_state(_read_chunk->get_column_by_slot_id(slot_id)));
     _slot_cache[slot_id] = {_read_chunk->get_column_by_slot_id(slot_id)};
     return Status::OK();
 }

--- a/be/src/formats/parquet/column_materializer.h
+++ b/be/src/formats/parquet/column_materializer.h
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "cache/scan/shared_buffered_input_stream.h"
 #include "common/global_types.h"
 #include "common/status.h"
 #include "common/statusor.h"
@@ -30,12 +31,17 @@
 
 namespace starrocks::parquet {
 
+class LazyMaterializationContext;
+class ReadRangePlanner;
+
 class ColumnMaterializer {
 public:
     using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
 
-    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers)
-            : _param(param), _column_readers(column_readers) {}
+    ColumnMaterializer(const GroupReaderParam& param, ColumnReaderMap* column_readers);
+
+    ReadRangePlanner* read_range_planner() const { return _read_range_planner.get(); }
+    FormatScannerStats* stats() const { return _param.stats; }
 
     void clear_classification();
     void add_active_column(int col_idx);
@@ -81,6 +87,7 @@ public:
     void reset_read_chunk() {
         if (_read_chunk) _read_chunk->reset();
         _slot_cache.clear();
+        _logical_slot_ids.clear();
     }
 
     ChunkPtr create_active_chunk() const;
@@ -92,7 +99,10 @@ public:
                       ChunkPtr* chunk, bool ignore_reserved_field = false);
     Status read_active_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
     Status read_lazy_range(const Range<uint64_t>& range, const Filter* filter, ChunkPtr* chunk);
-    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
+    // read_active_range_round_by_round accepts an optional LazyMaterializationContext*
+    // as a forward-looking parameter for Phase 6 expression-driven materialization.
+    StatusOr<size_t> read_active_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk,
+                                                      LazyMaterializationContext* lazy_ctx = nullptr);
 
     Status rewrite_dict_conjuncts_to_predicate(bool* is_group_filtered);
     Status filter_dict_column(SlotId slot_id, ColumnPtr& column, Filter* filter,
@@ -103,8 +113,11 @@ public:
     Status fill_dst_column(SlotId slot_id, ColumnPtr& dst, ColumnPtr& src);
 
     // Per-slot cache scoped to the current get_next() range.  Populated by
-    // read_slot(); cleared by reset_read_chunk().  Avoids repeated Parquet
-    // I/O when the same slot is referenced by multiple expression branches.
+    // materialize_slot() (on-demand lazy reads); NOT by read_slot().
+    // Cleared by reset_read_chunk().  All cached entries hold logical
+    // (finalized) columns — never dict codes or intermediate values.
+    // Avoids repeated Parquet I/O when the same slot is referenced by
+    // multiple expression branches during predicate evaluation.
     struct SlotCacheEntry {
         ColumnPtr values;
     };
@@ -114,16 +127,32 @@ public:
     }
 
     // On-demand single-slot materialization.  Reads the slot through its
-    // ColumnReader into _read_chunk and populates _slot_cache.  Returns OK
-    // (no-op) if the slot is already cached for the current range.
+    // ColumnReader into _read_chunk, calls finalize_lazy_state() so that
+    // the cached column is always logical, and populates _slot_cache.
+    // Returns OK (no-op) if the slot is already cached for the current range.
+    // Also records the trigger for fallback tracking.
     Status materialize_slot(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter);
 
+    size_t lazy_triggered_count() const { return _triggered_lazy_slots.size(); }
+
     // Post-filter lazy-column backfill.
+    // chunk_filter has full_range.span_size() entries and is used to apply the
+    // correct filter to any lazy columns that were already triggered (via
+    // LazyMaterializationContext) during predicate evaluation.
     Status read_lazy_columns(const Range<uint64_t>& full_range, const Range<uint64_t>& post_filter_range,
-                             const Filter& post_filter, bool has_filter, ChunkPtr& active_chunk);
+                             const Filter& post_filter, const Filter& chunk_filter, bool has_filter,
+                             ChunkPtr& active_chunk);
     // Emit physical + reserved-field columns into dst. Skips slots listed in skip_slots.
+    // For slots in _logical_slot_ids, uses a direct swap instead of fill_dst_column.
     Status emit_physical_columns(ChunkPtr& active_chunk, ChunkPtr* dst,
                                  const std::unordered_set<SlotId>* skip_slots = nullptr);
+
+    // Finalize an active column from PHYSICAL to LOGICAL before expression
+    // evaluation.  Encapsulates the finalize_lazy_state() call so GroupReader
+    // doesn't need to reach into ColumnReader internals.  Unlike lazy columns,
+    // active columns still go through fill_dst_column() at emit time — pointer
+    // identity dispatch in each reader handles the LOGICAL fallback.
+    Status finalize_active_slot(SlotId slot_id, ChunkPtr& active_chunk);
 
     bool lazy_column_needed() const { return _lazy_column_needed; }
     void set_lazy_column_needed(bool v) { _lazy_column_needed = v; }
@@ -173,10 +202,102 @@ private:
 
     ChunkPtr _read_chunk;
 
-    // Per-range slot cache: populated by read_slot(), cleared by reset_read_chunk().
+    // ============================================================
+    //  Column state lifecycle & tracking sets
+    // ============================================================
+    //
+    // A column in _read_chunk transitions through two states:
+    //
+    //   [unread] ──read_range()──▶ [PHYSICAL] ──finalize_lazy_state()──▶ [LOGICAL]
+    //
+    // PHYSICAL: dict codes (_dict_code / _tmp_code_column) or intermediate
+    //           raw Parquet values before type conversion. Dict filters
+    //           run ON physical columns; post-read conjuncts run AFTER
+    //           finalization.  A column STAYS physical across multiple
+    //           range reads within the same chunk — the reader installs
+    //           its temporary column into the slot and expects the
+    //           caller to either hold it for dict-filter or finalize
+    //           before expression evaluation.
+    //
+    // LOGICAL:  StarRocks native column type (e.g. LowCardDictColumn,
+    //           BinaryColumn).  Once a column is logical it MUST NOT
+    //           re-enter fill_dst_column() — that path expects a
+    //           physical source and will either double-decode or reject
+    //           the column (e.g. LowCardColumnReader checks _is_dict_code_column).
+    //
+    // Per-chunk processing order (get_next() iteration):
+    //
+    //   1. read_active_range_round_by_round()
+    //      - read_slot() reads active columns → PHYSICAL in _read_chunk
+    //      - Dict filters run ON physical columns
+    //      - Post-read conjuncts → finalize_active_slot() → LOGICAL
+    //        (no _logical_slot_ids mark — pointer identity fallback
+    //        in fill_dst_column() handles already-logical columns)
+    //
+    //   2. Compound predicate eval (GroupReader Phase 2b)
+    //      - finalize_active_slot() on all active columns (no
+    //        _logical_slot_ids mark — pointer identity fallback
+    //        in fill_dst_column() handles already-logical columns)
+    //      - ColumnRef for missing lazy slots calls MissingColumnProvider
+    //        → materialize_slot(): read_range() + finalize_lazy_state()
+    //        → column in _read_chunk is LOGICAL, cached in _slot_cache
+    //
+    //   3. read_lazy_columns()
+    //      - Triggered (in _slot_cache): move LOGICAL column from
+    //        _read_chunk → active_chunk (filtered)
+    //      - Untriggered backfill: read_range() → finalize_lazy_state()
+    //        → LOGICAL in lazy_chunk → merge → active_chunk
+    //      - Untriggered predicate-only: append_default (LOGICAL)
+    //      - ALL lazy columns in active_chunk are LOGICAL after this call
+    //      - Populates _logical_slot_ids with every lazy slot processed
+    //
+    //   4. emit_physical_columns()
+    //      - PHYSICAL columns → fill_dst_column() (decode/convert)
+    //      - LOGICAL columns (in _logical_slot_ids) → swap_column
+    //        (bypass fill_dst_column; they're already final)
+    //
+    // Tracking sets:
+    //
+    //   _slot_cache            Per-chunk.
+    //     key=slot_id, value=LOGICAL column pointer in _read_chunk.
+    //     Populated by materialize_slot() (NOT by read_slot()).
+    //     Read by read_lazy_columns() to detect triggered slots.
+    //     All entries hold LOGICAL columns — never dict codes.
+    //     Cleared by reset_read_chunk().
+    //
+    //   _triggered_lazy_slots  Per-row-group.
+    //     Set of slot IDs that materialize_slot() triggered at least
+    //     once in the current row group.  Accumulates across chunks
+    //     for diagnostics (lazy_triggered_count).  NOT cleared by
+    //     reset_read_chunk(); cleared when GroupReader is destroyed.
+    //
+    //   _logical_slot_ids      Per-chunk.
+    //     Set of slot IDs whose column in active_chunk is already
+    //     LOGICAL (finalized, backfilled-and-finalized, or
+    //     default-filled).  Populated by read_lazy_columns().
+    //     Consumed by emit_physical_columns() to decide swap vs fill.
+    //     Cleared by reset_read_chunk().
+
+    // Per-range slot cache: populated by materialize_slot() (NOT read_slot()),
+    // cleared by reset_read_chunk(). All entries hold logical (finalized) columns.
     std::unordered_map<SlotId, SlotCacheEntry> _slot_cache;
 
     bool _lazy_column_needed = false;
+
+    // Per-row-group set of unique lazy slots triggered via materialize_slot().
+    // NOT cleared by reset_read_chunk() — accumulates across ranges within
+    // the same row group to track full-trigger diagnostics.
+    // Lifetime = one row group (owned by GroupReader, destroyed in ~GroupReader).
+    std::unordered_set<SlotId> _triggered_lazy_slots;
+
+    // Per-chunk set of lazy slots whose columns in active_chunk are already
+    // logical (finalized by materialize_slot(), finalized during backfill, or
+    // default-filled). Populated by read_lazy_columns(), consumed by
+    // emit_physical_columns() so those slots bypass fill_dst_column and use a
+    // direct swap instead. Cleared by reset_read_chunk().
+    std::unordered_set<SlotId> _logical_slot_ids;
+
+    std::unique_ptr<ReadRangePlanner> _read_range_planner;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -147,6 +147,20 @@ public:
         return Status::OK();
     }
 
+    // Finalize a column that may be in lazy physical state (dict codes or
+    // intermediate / non-converted values) back to StarRocks logical type.
+    //
+    // This is the evaluate-line boundary: after read_range() may return
+    // Parquet-native physical columns for dict-filter / lazy-convert
+    // performance, but before any StarRocks expression evaluator (ExprContext,
+    // ChunkPredicateEvaluator, compound conjunct) consumes a column, it MUST
+    // be finalized to logical form.  Idempotent / no-op when the column is
+    // already logical.
+    //
+    // Not to be confused with fill_dst_column() which is the emit-time
+    // boundary and may skip decode for predicate-only columns.
+    virtual Status finalize_lazy_state(ColumnPtr& col) { return Status::OK(); }
+
     virtual void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                          ColumnIOTypeFlags types, bool active) = 0;
 

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -230,6 +230,22 @@ Status ListColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src_in) {
     return Status::OK();
 }
 
+Status ListColumnReader::finalize_lazy_state(ColumnPtr& col) {
+    auto* col_mut = col->as_mutable_raw_ptr();
+    ArrayColumn* array_column = nullptr;
+    if (col->is_nullable()) {
+        NullableColumn* nullable_column = down_cast<NullableColumn*>(col_mut);
+        DCHECK(nullable_column->data_column_raw_ptr()->is_array());
+        array_column = down_cast<ArrayColumn*>(nullable_column->data_column_raw_ptr());
+    } else {
+        DCHECK(col->is_array());
+        array_column = down_cast<ArrayColumn*>(col_mut);
+    }
+    auto& elements = array_column->elements_column();
+    RETURN_IF_ERROR(_element_reader->finalize_lazy_state(elements));
+    return Status::OK();
+}
+
 Status MapColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     NullableColumn* nullable_column = nullptr;
     MapColumn* map_column = nullptr;
@@ -430,6 +446,29 @@ Status StructColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
             }
         } else {
             return Status::InternalError(strings::Substitute("there is no match subfield reader for $0", field_name));
+        }
+    }
+    return Status::OK();
+}
+
+Status StructColumnReader::finalize_lazy_state(ColumnPtr& col) {
+    auto* col_mut = col->as_mutable_raw_ptr();
+    StructColumn* struct_column = nullptr;
+    if (col->is_nullable()) {
+        NullableColumn* nullable_column = down_cast<NullableColumn*>(col_mut);
+        DCHECK(nullable_column->data_column_raw_ptr()->is_struct());
+        struct_column = down_cast<StructColumn*>(nullable_column->data_column_raw_ptr());
+    } else {
+        DCHECK(col->is_struct());
+        struct_column = down_cast<StructColumn*>(col_mut);
+    }
+    const auto& field_names = struct_column->field_names();
+    for (size_t i = 0; i < field_names.size(); i++) {
+        const auto& field_name = field_names[i];
+        auto it = _child_readers.find(field_name);
+        if (it != _child_readers.end() && it->second != nullptr) {
+            ASSIGN_OR_RETURN(auto& child_col, struct_column->field_column(field_name));
+            RETURN_IF_ERROR(it->second->finalize_lazy_state(child_col));
         }
     }
     return Status::OK();

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -37,6 +37,8 @@ public:
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
+    Status finalize_lazy_state(ColumnPtr& col) override;
+
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
         _element_reader->get_levels(def_levels, rep_levels, num_levels);
     }
@@ -203,6 +205,8 @@ public:
                               const size_t& layer) override;
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
+
+    Status finalize_lazy_state(ColumnPtr& col) override;
 
     void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOTypeFlags types, bool active) override {
@@ -526,6 +530,8 @@ public:
     }
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override { return _reader->fill_dst_column(dst, src); }
+
+    Status finalize_lazy_state(ColumnPtr& col) override { return _reader->finalize_lazy_state(col); }
 
     void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOTypeFlags types, bool active) override {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -30,6 +30,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "compute_env/runtime_range_pruner.hpp"
+#include "exprs/chunk_predicate_evaluator.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
 #include "formats/parquet/utils.h"
@@ -364,9 +365,8 @@ Status FileReader::get_next(ChunkPtr* chunk) {
         }
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, row_count));
-                _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, row_count);
-                _scanner_ctx->append_or_update_extended_column_to_chunk(chunk, row_count);
+                // partition / not-existed / extended columns are now appended
+                // inside GroupReader::get_next() before emit_physical_columns.
                 _scan_row_count += (*chunk)->num_rows();
             }
             if (status.is_end_of_file()) {
@@ -416,16 +416,20 @@ Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
         size_t read_size = 0;
         if (_scanner_ctx->format_scan_context.options.use_count_opt) {
             read_size = _total_row_count - _scan_row_count;
-            _scanner_ctx->append_or_update_count_column_to_chunk(chunk, read_size);
-            _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);
-            _scanner_ctx->append_or_update_extended_column_to_chunk(chunk, 1);
+            // append_side_columns_to_chunk fills per-row count (value=1),
+            // partition, and extended columns first.  The next call overwrites
+            // the count column with the aggregated file row count.
+            RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, 1));
+            _scanner_ctx->append_or_update_count_column_to_chunk(chunk, 1, read_size);
         } else {
             read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-            RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, read_size));
-            _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, read_size);
-            _scanner_ctx->append_or_update_extended_column_to_chunk(chunk, read_size);
+            RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, read_size));
         }
         _scan_row_count += read_size;
+        if (!_scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+            RETURN_IF_ERROR(
+                    ChunkPredicateEvaluator::eval_conjuncts(_scanner_ctx->conjuncts.scanner_ctxs, (*chunk).get()));
+        }
         return Status::OK();
     }
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -28,7 +28,6 @@
 #include "common/config_scan_io_fwd.h"
 #include "common/statusor.h"
 #include "common/system/master_info.h"
-#include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -182,14 +182,14 @@ const tparquet::RowGroup* GroupReader::get_row_group_metadata() const {
 
 // ── get_next: materialise one chunk from the current row group ──────────────
 //
-// Pipeline:
-//   1. Prune deleted rows  — deletion bitmap
+// Pipeline (7 stages):
+//   1. Prune deleted rows           — deletion bitmap
 //   2. Read & filter active columns — dict / expression predicate pushdown
-//   3. Fetch variant sources (via VariantProjectionHandler)
-//   4. Filter by subfields   (via VariantProjectionHandler)
-//   5. Backfill lazy columns — physical columns without predicates
-//   6. Backfill variant sources (via VariantProjectionHandler)
-//   7. Emit output — decode physical columns + variant projections
+//   3. Evaluate compound predicates — multi-slot conjuncts from scanner_ctxs
+//   4. Evaluate variant predicates  — fetch sources + deferred subfield conjuncts
+//   5. Filter & backfill lazy       — apply combined filter + lazy column backfill
+//   6. Append output side columns   — partition / not-existed / extended / count
+//   7. Emit output                  — variant projections + physical columns
 
 Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
     SCOPED_RAW_TIMER(&_param.stats->group_chunk_read_ns);
@@ -205,179 +205,52 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         }
 
         auto r = _range_iter.next(*row_count);
-        auto count = r.span_size();
-        _param.stats->raw_rows_read += count;
+        _param.stats->raw_rows_read += r.span_size();
 
-        // Per-range state reset.  _slot_cache and _logical_slot_ids are
-        // cleared here; _fetched_hidden_slots is cleared by reset_iteration_state.
         _column_materializer->reset_read_chunk();
         _variant->reset_iteration_state();
 
-        // Rebuild active_chunk per range so that slots appended during
-        // predicate evaluation / lazy backfill / variant projection in a
-        // prior range do not leak into the current range.  Chunk::reset()
-        // preserves slot mappings which can leave stale empty columns.
-        ChunkPtr active_chunk = _column_materializer->create_active_chunk();
+        RowGroupScanState state;
+        state.active_chunk = _column_materializer->create_active_chunk();
+        state.row_count = r.span_size();
+        state.chunk_filter = Filter(state.row_count, 1);
 
-        bool has_filter = false;
-        Filter chunk_filter(count, 1);
-
-        // Phase 4: lazy materialization context for on-demand slot resolution.
-        // Created early so Phase 6 expression trigger can call materialize_slot()
-        // during predicate evaluation.  Destroyed before get_next() returns.
-        LazyMaterializationContext lazy_ctx(*_column_materializer, _variant.get(), r, nullptr, active_chunk);
+        LazyMaterializationContext lazy_ctx(_column_materializer.get(), _variant.get(), r, nullptr, state.active_chunk);
 
         // 1. Prune deleted rows
-        ASSIGN_OR_RETURN(bool rows_survive, _prune_deleted_rows(r, chunk_filter, has_filter, count));
+        ASSIGN_OR_RETURN(bool rows_survive, _prune_deleted_rows(r, state));
         if (!rows_survive) continue;
 
-        // 2. Read & filter active columns.  Attach lazy_ctx as the chunk's
-        //    MissingColumnProvider so that ColumnRef can trigger on-demand
-        //    materialization of lazy slots during predicate evaluation.
-        //    The provider is detached immediately after to prevent it from
-        //    escaping downstream (lazy state must not outlive get_next()).
-        active_chunk->set_missing_column_provider(&lazy_ctx);
-        ASSIGN_OR_RETURN(rows_survive,
-                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count, &lazy_ctx));
+        // 2. Read & filter active columns
+        state.active_chunk->set_missing_column_provider(&lazy_ctx);
+        ASSIGN_OR_RETURN(rows_survive, _read_and_filter_active_columns(r, state, &lazy_ctx));
         if (!rows_survive) {
-            active_chunk->set_missing_column_provider(nullptr);
+            state.active_chunk->set_missing_column_provider(nullptr);
             continue;
         }
 
-        // 2b. Evaluate compound (multi-slot) conjuncts with lazy_ctx
-        //     still attached.  Finalize all active columns to logical form
-        //     first so that compound conjuncts never see dict codes or
-        //     intermediate physical values.  Append partition / not-existed /
-        //     extended columns to active_chunk so that compound conjuncts
-        //     referencing those slots can be evaluated correctly.
-        //
-        //     Single-slot post-read conjuncts are finalized per-slot inside
-        //     read_active_range_round_by_round().  Variant sources are
-        //     finalized in fetch_sources()/backfill_sources()/
-        //     materialize_hidden_source().  Physical emit is handled by
-        //     fill_dst_column() at Phase 7.  The evaluate-line contract is
-        //     therefore covered without eagerly decoding pure-dict-filter
-        //     predicate-only columns.
-        //
-        //     VARIANT virtual projection slots must be materialised before
-        //     compound conjuncts are evaluated: the missing-column provider
-        //     can fill physical lazy / hidden source slots on demand, but
-        //     variant virtual slots are created by emit_projections() which
-        //     runs later.  When a compound conjunct references such a slot,
-        //     we fetch only the needed hidden sources and project only the
-        //     needed virtual slots early.  Because active_chunk is rebuilt
-        //     per range, there is no risk of stale projected slots from a
-        //     prior range that was fully filtered.
-        std::unordered_set<SlotId> early_projected_slots;
-        if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
-            if (!_variant->empty()) {
-                early_projected_slots =
-                        _variant->referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs);
-                if (!early_projected_slots.empty()) {
-                    RETURN_IF_ERROR(_variant->fetch_and_project_virtual_slots(early_projected_slots, r, active_chunk,
-                                                                              _variant->projection_timezone()));
-                }
-            }
+        // 3. Evaluate compound predicates
+        ASSIGN_OR_RETURN(rows_survive, _evaluate_compound_predicates(r, state));
+        state.active_chunk->set_missing_column_provider(nullptr);
+        if (!rows_survive) continue;
 
-            if (active_chunk->num_rows() > 0) {
-                RETURN_IF_ERROR(
-                        _param.scanner_ctx->append_side_columns_to_chunk(&active_chunk, active_chunk->num_rows()));
-            }
-            for (int col_idx : _column_materializer->active_column_indices()) {
-                SlotId slot_id = _param.read_cols[col_idx].slot_id();
-                RETURN_IF_ERROR(_column_materializer->finalize_active_slot(slot_id, active_chunk));
-            }
-            ASSIGN_OR_RETURN(size_t compound_hit,
-                             ChunkPredicateEvaluator::eval_conjuncts_into_filter(
-                                     _param.scanner_ctx->conjuncts.scanner_ctxs, active_chunk.get(), &chunk_filter));
-            if (compound_hit == 0) {
-                _param.stats->late_materialize_skip_rows += count;
-                active_chunk->set_missing_column_provider(nullptr);
-                continue;
-            }
-            has_filter = true;
+        // 4. Evaluate variant predicates
+        ASSIGN_OR_RETURN(rows_survive, _evaluate_variant_predicates(r, state));
+        if (!rows_survive) continue;
+
+        // 5. Apply combined filter and backfill lazy columns
+        ASSIGN_OR_RETURN(rows_survive, _filter_and_backfill_lazy(r, state));
+        if (!rows_survive) continue;
+
+        // 6. Append output side columns BEFORE emit.
+        //    This guarantees all slots exist when fill_dst_column is called in step 7.
+        if (state.active_chunk->num_rows() > 0) {
+            RETURN_IF_ERROR(
+                    _param.scanner_ctx->append_side_columns_to_chunk(chunk, state.active_chunk->num_rows()));
         }
-
-        active_chunk->set_missing_column_provider(nullptr);
-
-        // 3. Fetch variant sources (for subfield conjuncts).
-        //    _fetched_hidden_slots tracks already-populated columns from any
-        //    early fetch in Phase 2b; fetch_sources() skips those.
-        RETURN_IF_ERROR(_variant->fetch_sources(r, active_chunk));
-
-        // 4. Filter by subfields (variant deferred conjuncts)
-        if (_variant->has_deferred_conjuncts()) {
-            ASSIGN_OR_RETURN(Filter vr, _variant->filter_subfields(active_chunk, count, _param.stats,
-                                                                   _variant->projection_timezone()));
-            if (!vr.empty()) {
-                if (SIMD::count_nonzero(vr.data(), vr.size()) == 0) {
-                    continue;
-                }
-                DCHECK_EQ(vr.size(), count);
-                for (size_t i = 0; i < count; i++) {
-                    chunk_filter[i] &= vr[i];
-                }
-                has_filter = true;
-            }
-        }
-
-        // Apply combined chunk_filter to physically reduce active_chunk.
-        if (has_filter) {
-            active_chunk->filter(chunk_filter);
-            if (active_chunk->num_rows() == 0) {
-                continue;
-            }
-            RETURN_IF_ERROR(_variant->align_after_combined_filter(active_chunk, chunk_filter, count));
-        }
-
-        // Compute post-filter range for lazy reads (Phase 5/6).
-        Range<uint64_t> post_filter_range;
-        Filter post_filter;
-        if (has_filter) {
-            post_filter_range = r.filter(&chunk_filter);
-            DCHECK(post_filter_range.span_size() > 0);
-            post_filter = {chunk_filter.begin() + post_filter_range.begin() - r.begin(),
-                           chunk_filter.begin() + post_filter_range.end() - r.begin()};
-        }
-
-        // Append partition, not-existed, and extended columns to the output
-        // chunk BEFORE lazy column backfill and emit.  This guarantees all slots
-        // exist when fill_dst_column is called in step 7.
-        if (active_chunk->num_rows() > 0) {
-            RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(chunk, active_chunk->num_rows()));
-        }
-
-        // 5. Backfill lazy physical columns.  Pass chunk_filter so that any lazy
-        //    columns triggered during step 2 can be filtered to surviving rows.
-        {
-            bool has_any_lazy =
-                    !_column_materializer->lazy_column_indices().empty() || !_variant->lazy_hidden_slot_ids().empty();
-            if (has_any_lazy) {
-                _param.stats->parquet_lazy_col_skip_rows += count - active_chunk->num_rows();
-            }
-            if (!_column_materializer->lazy_column_indices().empty()) {
-                RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, chunk_filter,
-                                                                        has_filter, active_chunk));
-            }
-        }
-
-        // 6. Backfill lazy variant sources
-        RETURN_IF_ERROR(_variant->backfill_sources(r, has_filter ? &post_filter_range : nullptr,
-                                                   has_filter ? &post_filter : nullptr, has_filter, active_chunk));
 
         // 7. Emit output
-        {
-            SCOPED_RAW_TIMER(&_param.stats->group_dict_decode_ns);
-            *row_count = active_chunk->num_rows();
-
-            if (_variant->has_projections()) {
-                RETURN_IF_ERROR(_variant->emit_projections(active_chunk, chunk, _variant->projection_timezone()));
-            }
-            {
-                auto skip_slots = _variant->projection_slot_ids();
-                RETURN_IF_ERROR(_column_materializer->emit_physical_columns(active_chunk, chunk, &skip_slots));
-            }
-        }
+        RETURN_IF_ERROR(_emit_output_columns(state, chunk, row_count));
         break;
     }
 
@@ -386,14 +259,14 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
 
 // ── 1. Prune deleted rows ──────
 
-StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter& chunk_filter, bool& has_filter,
-                                                size_t count) {
+StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, RowGroupScanState& state) {
     if (nullptr == _skip_rows_ctx || !_skip_rows_ctx->has_skip_rows()) {
         return true;
     }
     SCOPED_RAW_TIMER(&_param.stats->build_rowid_filter_ns);
-    ASSIGN_OR_RETURN(has_filter, _skip_rows_ctx->deletion_bitmap->fill_filter(r.begin(), r.end(), chunk_filter));
-    if (SIMD::count_nonzero(chunk_filter.data(), count) == 0) {
+    ASSIGN_OR_RETURN(state.has_filter,
+                     _skip_rows_ctx->deletion_bitmap->fill_filter(r.begin(), r.end(), state.chunk_filter));
+    if (SIMD::count_nonzero(state.chunk_filter.data(), state.row_count) == 0) {
         return false;
     }
     return true;
@@ -401,23 +274,148 @@ StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter
 
 // ── 2. Read & filter active columns ──────
 
-StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count,
+StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, RowGroupScanState& state,
                                                             LazyMaterializationContext* lazy_ctx) {
     if (_column_materializer->has_predicate_filter()) {
-        has_filter = true;
-        ASSIGN_OR_RETURN(size_t hit_count, _column_materializer->read_active_range_round_by_round(
-                                                   r, &chunk_filter, &active_chunk, lazy_ctx));
+        state.has_filter = true;
+        ASSIGN_OR_RETURN(size_t hit_count,
+                         _column_materializer->read_active_range_round_by_round(r, &state.chunk_filter,
+                                                                                &state.active_chunk, lazy_ctx));
         if (hit_count == 0) {
-            _param.stats->late_materialize_skip_rows += count;
+            _param.stats->late_materialize_skip_rows += state.row_count;
             return false;
         }
-    } else if (has_filter) {
-        RETURN_IF_ERROR(_column_materializer->read_active_range(r, &chunk_filter, &active_chunk));
+    } else if (state.has_filter) {
+        RETURN_IF_ERROR(_column_materializer->read_active_range(r, &state.chunk_filter, &state.active_chunk));
     } else {
-        RETURN_IF_ERROR(_column_materializer->read_active_range(r, nullptr, &active_chunk));
+        RETURN_IF_ERROR(_column_materializer->read_active_range(r, nullptr, &state.active_chunk));
     }
     return true;
+}
+
+// ── 3. Evaluate compound predicates ──────
+
+StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>& r, RowGroupScanState& state) {
+    if (_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+        return true;
+    }
+
+    // VARIANT virtual projection slots must be materialised before compound
+    // conjuncts are evaluated.  When a compound conjunct references a variant
+    // virtual slot, fetch the needed hidden sources and project the virtual
+    // slots early.  active_chunk is rebuilt per range so stale slots cannot leak.
+    if (!_variant->empty()) {
+        auto early_projected =
+                _variant->referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs);
+        if (!early_projected.empty()) {
+            RETURN_IF_ERROR(_variant->fetch_and_project_virtual_slots(early_projected, r, state.active_chunk,
+                                                                       _variant->projection_timezone()));
+        }
+    }
+
+    // Append side columns to active_chunk so compound conjuncts referencing
+    // partition / not-existed / extended slots can be evaluated correctly.
+    if (state.active_chunk->num_rows() > 0) {
+        RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(&state.active_chunk,
+                                                                          state.active_chunk->num_rows()));
+    }
+
+    // Finalize all active columns to logical form before compound conjunct eval.
+    for (int col_idx : _column_materializer->active_column_indices()) {
+        SlotId slot_id = _param.read_cols[col_idx].slot_id();
+        RETURN_IF_ERROR(_column_materializer->finalize_active_slot(slot_id, state.active_chunk));
+    }
+
+    ASSIGN_OR_RETURN(size_t compound_hit,
+                     ChunkPredicateEvaluator::eval_conjuncts_into_filter(
+                             _param.scanner_ctx->conjuncts.scanner_ctxs, state.active_chunk.get(),
+                             &state.chunk_filter));
+    if (compound_hit == 0) {
+        _param.stats->late_materialize_skip_rows += state.row_count;
+        return false;
+    }
+    state.has_filter = true;
+    return true;
+}
+
+// ── 4. Evaluate variant predicates ──────
+
+StatusOr<bool> GroupReader::_evaluate_variant_predicates(const Range<uint64_t>& r, RowGroupScanState& state) {
+    // fetch_sources() runs unconditionally: active variant hidden sources are
+    // needed for output even when no deferred conjuncts exist.
+    // _fetched_hidden_slots tracks already-populated columns from any early
+    // fetch during compound eval; fetch_sources() skips those.
+    RETURN_IF_ERROR(_variant->fetch_sources(r, state.active_chunk));
+
+    if (!_variant->has_deferred_conjuncts()) {
+        return true;
+    }
+
+    ASSIGN_OR_RETURN(Filter vr, _variant->filter_subfields(state.active_chunk, state.row_count, _param.stats,
+                                                            _variant->projection_timezone()));
+    if (!vr.empty()) {
+        if (SIMD::count_nonzero(vr.data(), vr.size()) == 0) {
+            return false;
+        }
+        DCHECK_EQ(vr.size(), state.row_count);
+        for (size_t i = 0; i < state.row_count; i++) {
+            state.chunk_filter[i] &= vr[i];
+        }
+        state.has_filter = true;
+    }
+    return true;
+}
+
+// ── 5. Filter & backfill lazy ──────
+
+StatusOr<bool> GroupReader::_filter_and_backfill_lazy(const Range<uint64_t>& r, RowGroupScanState& state) {
+    Range<uint64_t> post_filter_range;
+    Filter post_filter;
+
+    if (state.has_filter) {
+        state.active_chunk->filter(state.chunk_filter);
+        if (state.active_chunk->num_rows() == 0) {
+            return false;
+        }
+        RETURN_IF_ERROR(_variant->align_after_combined_filter(state.active_chunk, state.chunk_filter, state.row_count));
+
+        post_filter_range = r.filter(&state.chunk_filter);
+        DCHECK(post_filter_range.span_size() > 0);
+        post_filter = {state.chunk_filter.begin() + post_filter_range.begin() - r.begin(),
+                        state.chunk_filter.begin() + post_filter_range.end() - r.begin()};
+    }
+
+    bool has_any_lazy =
+            !_column_materializer->lazy_column_indices().empty() || !_variant->lazy_hidden_slot_ids().empty();
+    if (has_any_lazy) {
+        _param.stats->parquet_lazy_col_skip_rows += state.row_count - state.active_chunk->num_rows();
+    }
+    if (!_column_materializer->lazy_column_indices().empty()) {
+        RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, state.chunk_filter,
+                                                                 state.has_filter, state.active_chunk));
+    }
+
+    RETURN_IF_ERROR(_variant->backfill_sources(r,
+                                                state.has_filter ? &post_filter_range : nullptr,
+                                                state.has_filter ? &post_filter : nullptr, state.has_filter,
+                                                state.active_chunk));
+    return true;
+}
+
+// ── 7. Emit output ──────
+
+Status GroupReader::_emit_output_columns(RowGroupScanState& state, ChunkPtr* chunk, size_t* row_count) {
+    SCOPED_RAW_TIMER(&_param.stats->group_dict_decode_ns);
+    *row_count = state.active_chunk->num_rows();
+
+    if (_variant->has_projections()) {
+        RETURN_IF_ERROR(_variant->emit_projections(state.active_chunk, chunk, _variant->projection_timezone()));
+    }
+    {
+        auto skip_slots = _variant->projection_slot_ids();
+        RETURN_IF_ERROR(_column_materializer->emit_physical_columns(state.active_chunk, chunk, &skip_slots));
+    }
+    return Status::OK();
 }
 
 // ── Column reader creation ─────────────────────────────────────────────────

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -242,15 +242,19 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         ASSIGN_OR_RETURN(rows_survive, _filter_and_backfill_lazy(r, state));
         if (!rows_survive) continue;
 
-        // 6. Append output side columns BEFORE emit.
-        //    This guarantees all slots exist when fill_dst_column is called in step 7.
-        if (state.active_chunk->num_rows() > 0) {
-            RETURN_IF_ERROR(
-                    _param.scanner_ctx->append_side_columns_to_chunk(chunk, state.active_chunk->num_rows()));
-        }
-
-        // 7. Emit output
+        // 6. Emit output
         RETURN_IF_ERROR(_emit_output_columns(state, chunk, row_count));
+
+        // 7. Append output side columns AFTER emit.
+        //    Use saved row count because emit_physical_columns swaps columns
+        //    out of active_chunk (active_chunk->num_rows() becomes 0).
+        {
+            size_t saved_rows = (*chunk)->num_rows();
+            if (saved_rows > 0) {
+                RETURN_IF_ERROR(
+                        _param.scanner_ctx->append_side_columns_to_chunk(chunk, saved_rows));
+            }
+        }
         break;
     }
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -28,15 +28,19 @@
 #include "common/config_scan_io_fwd.h"
 #include "common/statusor.h"
 #include "common/system/master_info.h"
+#include "exec/hdfs_scanner/hdfs_scanner.h"
+#include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
+#include "formats/parquet/lazy_materialization_context.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/parquet_pos_reader.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
+#include "formats/parquet/read_range_planner.h"
 #include "formats/parquet/row_source_reader.h"
 #include "formats/parquet/scalar_column_reader.h"
 #include "formats/parquet/schema.h"
@@ -47,42 +51,6 @@
 #include "utils.h"
 
 namespace starrocks::parquet {
-
-namespace {
-
-// Deduplicate exact-duplicate IO ranges collected from multiple column readers.
-void deduplicate_io_ranges(std::vector<SharedBufferedInputStream::IORange>* ranges) {
-    if (ranges == nullptr || ranges->size() <= 1) {
-        return;
-    }
-
-    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
-        if (lhs.offset != rhs.offset) {
-            return lhs.offset < rhs.offset;
-        }
-        if (lhs.size != rhs.size) {
-            return lhs.size < rhs.size;
-        }
-        return lhs.is_active < rhs.is_active;
-    });
-
-    size_t write_idx = 0;
-    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
-        auto& current = (*ranges)[write_idx];
-        const auto& next = (*ranges)[read_idx];
-        if (current.offset == next.offset && current.size == next.size) {
-            current.is_active = current.is_active || next.is_active;
-            continue;
-        }
-        ++write_idx;
-        if (write_idx != read_idx) {
-            (*ranges)[write_idx] = next;
-        }
-    }
-    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
-}
-
-} // namespace
 
 // ── GroupReader: construction / destruction ─────────────────────────────────
 
@@ -115,6 +83,16 @@ GroupReader::~GroupReader() {
         } else {
             _param.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
         }
+        // Lazy-materialization diagnostic: count row groups where every lazy slot
+        // was triggered during predicate evaluation.  A consistently high count
+        // suggests the active/lazy classification (Phase 3b) would help.
+        if (_param.stats) {
+            size_t total_lazy = _column_materializer->lazy_slot_ids().size() + _variant->lazy_hidden_slot_ids().size();
+            size_t triggered = _column_materializer->lazy_triggered_count();
+            if (total_lazy > 0 && static_cast<size_t>(triggered) >= total_lazy) {
+                _param.stats->parquet_lazy_full_trigger_count++;
+            }
+        }
         _param.stats->group_min_round_cost =
                 _param.stats->group_min_round_cost == 0
                         ? _column_materializer->min_round_cost()
@@ -144,19 +122,20 @@ Status GroupReader::prepare() {
     // Promote variant virtual columns to typed-value proxy readers.
     _variant->try_promote();
 
-    // Coalesce IO ranges.
+    // Coalesce IO ranges using ReadRangePlanner's staged planning.
     if (config::parquet_coalesce_read_enable && _param.sb_stream != nullptr) {
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
-        int32_t counter = _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed);
-        if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
+        auto* planner = _column_materializer->read_range_planner();
+        bool coalesce_lazy = planner->should_coalesce_active_lazy();
+        if (coalesce_lazy || !config::io_coalesce_adaptive_lazy_active) {
             _param.stats->active_lazy_coalesce_together += 1;
         } else {
             _param.stats->active_lazy_coalesce_seperately += 1;
         }
         _set_end_offset(end_offset);
-        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, counter >= 0));
+        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, coalesce_lazy));
     }
 
     RETURN_IF_ERROR(_column_materializer->rewrite_dict_conjuncts_to_predicate(&_is_group_filtered));
@@ -219,10 +198,6 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         return Status::EndOfFile("");
     }
 
-    _column_materializer->reset_read_chunk();
-    _variant->reset_iteration_state();
-    ChunkPtr active_chunk = _column_materializer->create_active_chunk();
-
     while (true) {
         if (!_range_iter.has_more()) {
             *row_count = 0;
@@ -233,20 +208,101 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         auto count = r.span_size();
         _param.stats->raw_rows_read += count;
 
+        // Per-range state reset.  _slot_cache and _logical_slot_ids are
+        // cleared here; _fetched_hidden_slots is cleared by reset_iteration_state.
+        _column_materializer->reset_read_chunk();
+        _variant->reset_iteration_state();
+
+        // Rebuild active_chunk per range so that slots appended during
+        // predicate evaluation / lazy backfill / variant projection in a
+        // prior range do not leak into the current range.  Chunk::reset()
+        // preserves slot mappings which can leave stale empty columns.
+        ChunkPtr active_chunk = _column_materializer->create_active_chunk();
+
         bool has_filter = false;
         Filter chunk_filter(count, 1);
-        active_chunk->reset();
+
+        // Phase 4: lazy materialization context for on-demand slot resolution.
+        // Created early so Phase 6 expression trigger can call materialize_slot()
+        // during predicate evaluation.  Destroyed before get_next() returns.
+        LazyMaterializationContext lazy_ctx(*_column_materializer, _variant.get(), r, nullptr, active_chunk);
 
         // 1. Prune deleted rows
         ASSIGN_OR_RETURN(bool rows_survive, _prune_deleted_rows(r, chunk_filter, has_filter, count));
         if (!rows_survive) continue;
 
-        // 2. Read & filter active columns
+        // 2. Read & filter active columns.  Attach lazy_ctx as the chunk's
+        //    MissingColumnProvider so that ColumnRef can trigger on-demand
+        //    materialization of lazy slots during predicate evaluation.
+        //    The provider is detached immediately after to prevent it from
+        //    escaping downstream (lazy state must not outlive get_next()).
+        active_chunk->set_missing_column_provider(&lazy_ctx);
         ASSIGN_OR_RETURN(rows_survive,
-                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count));
-        if (!rows_survive) continue;
+                         _read_and_filter_active_columns(r, chunk_filter, active_chunk, has_filter, count, &lazy_ctx));
+        if (!rows_survive) {
+            active_chunk->set_missing_column_provider(nullptr);
+            continue;
+        }
 
-        // 3. Fetch variant sources (for subfield conjuncts)
+        // 2b. Evaluate compound (multi-slot) conjuncts with lazy_ctx
+        //     still attached.  Finalize all active columns to logical form
+        //     first so that compound conjuncts never see dict codes or
+        //     intermediate physical values.  Append partition / not-existed /
+        //     extended columns to active_chunk so that compound conjuncts
+        //     referencing those slots can be evaluated correctly.
+        //
+        //     Single-slot post-read conjuncts are finalized per-slot inside
+        //     read_active_range_round_by_round().  Variant sources are
+        //     finalized in fetch_sources()/backfill_sources()/
+        //     materialize_hidden_source().  Physical emit is handled by
+        //     fill_dst_column() at Phase 7.  The evaluate-line contract is
+        //     therefore covered without eagerly decoding pure-dict-filter
+        //     predicate-only columns.
+        //
+        //     VARIANT virtual projection slots must be materialised before
+        //     compound conjuncts are evaluated: the missing-column provider
+        //     can fill physical lazy / hidden source slots on demand, but
+        //     variant virtual slots are created by emit_projections() which
+        //     runs later.  When a compound conjunct references such a slot,
+        //     we fetch only the needed hidden sources and project only the
+        //     needed virtual slots early.  Because active_chunk is rebuilt
+        //     per range, there is no risk of stale projected slots from a
+        //     prior range that was fully filtered.
+        std::unordered_set<SlotId> early_projected_slots;
+        if (!_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+            if (!_variant->empty()) {
+                early_projected_slots =
+                        _variant->referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs);
+                if (!early_projected_slots.empty()) {
+                    RETURN_IF_ERROR(_variant->fetch_and_project_virtual_slots(early_projected_slots, r, active_chunk,
+                                                                              _variant->projection_timezone()));
+                }
+            }
+
+            if (active_chunk->num_rows() > 0) {
+                RETURN_IF_ERROR(
+                        _param.scanner_ctx->append_side_columns_to_chunk(&active_chunk, active_chunk->num_rows()));
+            }
+            for (int col_idx : _column_materializer->active_column_indices()) {
+                SlotId slot_id = _param.read_cols[col_idx].slot_id();
+                RETURN_IF_ERROR(_column_materializer->finalize_active_slot(slot_id, active_chunk));
+            }
+            ASSIGN_OR_RETURN(size_t compound_hit,
+                             ChunkPredicateEvaluator::eval_conjuncts_into_filter(
+                                     _param.scanner_ctx->conjuncts.scanner_ctxs, active_chunk.get(), &chunk_filter));
+            if (compound_hit == 0) {
+                _param.stats->late_materialize_skip_rows += count;
+                active_chunk->set_missing_column_provider(nullptr);
+                continue;
+            }
+            has_filter = true;
+        }
+
+        active_chunk->set_missing_column_provider(nullptr);
+
+        // 3. Fetch variant sources (for subfield conjuncts).
+        //    _fetched_hidden_slots tracks already-populated columns from any
+        //    early fetch in Phase 2b; fetch_sources() skips those.
         RETURN_IF_ERROR(_variant->fetch_sources(r, active_chunk));
 
         // 4. Filter by subfields (variant deferred conjuncts)
@@ -284,10 +340,25 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
                            chunk_filter.begin() + post_filter_range.end() - r.begin()};
         }
 
-        // 5. Backfill lazy physical columns
-        if (!_column_materializer->lazy_column_indices().empty()) {
-            RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, has_filter,
-                                                                    active_chunk));
+        // Append partition, not-existed, and extended columns to the output
+        // chunk BEFORE lazy column backfill and emit.  This guarantees all slots
+        // exist when fill_dst_column is called in step 7.
+        if (active_chunk->num_rows() > 0) {
+            RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(chunk, active_chunk->num_rows()));
+        }
+
+        // 5. Backfill lazy physical columns.  Pass chunk_filter so that any lazy
+        //    columns triggered during step 2 can be filtered to surviving rows.
+        {
+            bool has_any_lazy =
+                    !_column_materializer->lazy_column_indices().empty() || !_variant->lazy_hidden_slot_ids().empty();
+            if (has_any_lazy) {
+                _param.stats->parquet_lazy_col_skip_rows += count - active_chunk->num_rows();
+            }
+            if (!_column_materializer->lazy_column_indices().empty()) {
+                RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, chunk_filter,
+                                                                        has_filter, active_chunk));
+            }
         }
 
         // 6. Backfill lazy variant sources
@@ -331,11 +402,12 @@ StatusOr<bool> GroupReader::_prune_deleted_rows(const Range<uint64_t>& r, Filter
 // ── 2. Read & filter active columns ──────
 
 StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count) {
+                                                            ChunkPtr& active_chunk, bool& has_filter, size_t count,
+                                                            LazyMaterializationContext* lazy_ctx) {
     if (_column_materializer->has_predicate_filter()) {
         has_filter = true;
-        ASSIGN_OR_RETURN(size_t hit_count,
-                         _column_materializer->read_active_range_round_by_round(r, &chunk_filter, &active_chunk));
+        ASSIGN_OR_RETURN(size_t hit_count, _column_materializer->read_active_range_round_by_round(
+                                                   r, &chunk_filter, &active_chunk, lazy_ctx));
         if (hit_count == 0) {
             _param.stats->late_materialize_skip_rows += count;
             return false;
@@ -579,6 +651,10 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     for (SlotId sid : _variant->active_hidden_slot_ids()) {
         _column_materializer->add_active_slot(sid);
     }
+    if (!config::parquet_late_materialization_enable) {
+        _column_materializer->promote_lazy_to_active();
+        _variant->promote_lazy_to_active();
+    }
 
     // ── Promote lazy to active when no active columns exist ───────────────────
     if (_column_materializer->active_slot_ids().empty() && !has_reserved_field_filter) {
@@ -594,7 +670,7 @@ void GroupReader::collect_io_ranges(std::vector<SharedBufferedInputStream::IORan
     int64_t end = 0;
     _column_materializer->collect_io_ranges(ranges, &end, types);
     _variant->collect_io_ranges(ranges, &end, types);
-    deduplicate_io_ranges(ranges);
+    ReadRangePlanner::deduplicate(ranges);
     *end_offset = end;
 }
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -246,13 +246,13 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         RETURN_IF_ERROR(_emit_output_columns(state, chunk, row_count));
 
         // 7. Append output side columns AFTER emit.
-        //    Use saved row count because emit_physical_columns swaps columns
-        //    out of active_chunk (active_chunk->num_rows() becomes 0).
-        {
-            size_t saved_rows = (*chunk)->num_rows();
-            if (saved_rows > 0) {
-                RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(chunk, saved_rows));
-            }
+        //    Use *row_count (captured before emit swaps columns out of
+        //    active_chunk) rather than (*chunk)->num_rows() — the latter
+        //    reads the first column's size, which can be 0 when the first
+        //    slot is a partition/not-existed/extended side column that
+        //    hasn't been populated yet.
+        if ((*row_count) > 0) {
+            RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(chunk, (*row_count)));
         }
         break;
     }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -251,8 +251,7 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         {
             size_t saved_rows = (*chunk)->num_rows();
             if (saved_rows > 0) {
-                RETURN_IF_ERROR(
-                        _param.scanner_ctx->append_side_columns_to_chunk(chunk, saved_rows));
+                RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(chunk, saved_rows));
             }
         }
         break;
@@ -282,9 +281,8 @@ StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t
                                                             LazyMaterializationContext* lazy_ctx) {
     if (_column_materializer->has_predicate_filter()) {
         state.has_filter = true;
-        ASSIGN_OR_RETURN(size_t hit_count,
-                         _column_materializer->read_active_range_round_by_round(r, &state.chunk_filter,
-                                                                                &state.active_chunk, lazy_ctx));
+        ASSIGN_OR_RETURN(size_t hit_count, _column_materializer->read_active_range_round_by_round(
+                                                   r, &state.chunk_filter, &state.active_chunk, lazy_ctx));
         if (hit_count == 0) {
             _param.stats->late_materialize_skip_rows += state.row_count;
             return false;
@@ -313,15 +311,15 @@ StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>&
                 _variant->referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs);
         if (!early_projected.empty()) {
             RETURN_IF_ERROR(_variant->fetch_and_project_virtual_slots(early_projected, r, state.active_chunk,
-                                                                       _variant->projection_timezone()));
+                                                                      _variant->projection_timezone()));
         }
     }
 
     // Append side columns to active_chunk so compound conjuncts referencing
     // partition / not-existed / extended slots can be evaluated correctly.
     if (state.active_chunk->num_rows() > 0) {
-        RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(&state.active_chunk,
-                                                                          state.active_chunk->num_rows()));
+        RETURN_IF_ERROR(
+                _param.scanner_ctx->append_side_columns_to_chunk(&state.active_chunk, state.active_chunk->num_rows()));
     }
 
     // Finalize all active columns to logical form before compound conjunct eval.
@@ -330,10 +328,9 @@ StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>&
         RETURN_IF_ERROR(_column_materializer->finalize_active_slot(slot_id, state.active_chunk));
     }
 
-    ASSIGN_OR_RETURN(size_t compound_hit,
-                     ChunkPredicateEvaluator::eval_conjuncts_into_filter(
-                             _param.scanner_ctx->conjuncts.scanner_ctxs, state.active_chunk.get(),
-                             &state.chunk_filter));
+    ASSIGN_OR_RETURN(size_t compound_hit, ChunkPredicateEvaluator::eval_conjuncts_into_filter(
+                                                  _param.scanner_ctx->conjuncts.scanner_ctxs, state.active_chunk.get(),
+                                                  &state.chunk_filter));
     if (compound_hit == 0) {
         _param.stats->late_materialize_skip_rows += state.row_count;
         return false;
@@ -356,7 +353,7 @@ StatusOr<bool> GroupReader::_evaluate_variant_predicates(const Range<uint64_t>& 
     }
 
     ASSIGN_OR_RETURN(Filter vr, _variant->filter_subfields(state.active_chunk, state.row_count, _param.stats,
-                                                            _variant->projection_timezone()));
+                                                           _variant->projection_timezone()));
     if (!vr.empty()) {
         if (SIMD::count_nonzero(vr.data(), vr.size()) == 0) {
             return false;
@@ -386,7 +383,7 @@ StatusOr<bool> GroupReader::_filter_and_backfill_lazy(const Range<uint64_t>& r, 
         post_filter_range = r.filter(&state.chunk_filter);
         DCHECK(post_filter_range.span_size() > 0);
         post_filter = {state.chunk_filter.begin() + post_filter_range.begin() - r.begin(),
-                        state.chunk_filter.begin() + post_filter_range.end() - r.begin()};
+                       state.chunk_filter.begin() + post_filter_range.end() - r.begin()};
     }
 
     bool has_any_lazy =
@@ -396,13 +393,12 @@ StatusOr<bool> GroupReader::_filter_and_backfill_lazy(const Range<uint64_t>& r, 
     }
     if (!_column_materializer->lazy_column_indices().empty()) {
         RETURN_IF_ERROR(_column_materializer->read_lazy_columns(r, post_filter_range, post_filter, state.chunk_filter,
-                                                                 state.has_filter, state.active_chunk));
+                                                                state.has_filter, state.active_chunk));
     }
 
-    RETURN_IF_ERROR(_variant->backfill_sources(r,
-                                                state.has_filter ? &post_filter_range : nullptr,
-                                                state.has_filter ? &post_filter : nullptr, state.has_filter,
-                                                state.active_chunk));
+    RETURN_IF_ERROR(_variant->backfill_sources(r, state.has_filter ? &post_filter_range : nullptr,
+                                               state.has_filter ? &post_filter : nullptr, state.has_filter,
+                                               state.active_chunk));
     return true;
 }
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -158,17 +158,41 @@ private:
     Status _prepare_column_readers() const;
 
     // ── get_next() pipeline phases ───────────────────────────────────────────
-    //
+
+    // Bundles the per-range mutable state that flows through the filter pipeline.
+    struct RowGroupScanState {
+        ChunkPtr active_chunk;
+        Filter chunk_filter;
+        bool has_filter = false;
+        size_t row_count = 0;
+    };
+
     // 1. Prune deleted rows: applies deletion bitmap to produce chunk_filter.
     //    Returns true if rows survive; false to skip this range entirely.
-    StatusOr<bool> _prune_deleted_rows(const Range<uint64_t>& r, Filter& chunk_filter, bool& has_filter, size_t count);
+    StatusOr<bool> _prune_deleted_rows(const Range<uint64_t>& r, RowGroupScanState& state);
 
     // 2. Read & filter active columns: reads active physical columns and
     //    evaluates dict / expression filters.  Populates chunk_filter and
     //    fills active_chunk.  Returns true if rows survive.
-    StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count,
+    StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, RowGroupScanState& state,
                                                    LazyMaterializationContext* lazy_ctx);
+
+    // 3. Evaluate compound (multi-slot) conjuncts via scanner_ctxs.
+    //    Side columns are appended to active_chunk for predicate evaluation.
+    //    lazy_ctx must still be attached.  Returns true if rows survive.
+    StatusOr<bool> _evaluate_compound_predicates(const Range<uint64_t>& r, RowGroupScanState& state);
+
+    // 4. Fetch variant sources (unconditional) and evaluate deferred variant
+    //    conjuncts (conditional).  Returns true if rows survive.
+    StatusOr<bool> _evaluate_variant_predicates(const Range<uint64_t>& r, RowGroupScanState& state);
+
+    // 5. Apply combined chunk_filter, compute post-filter range (internal),
+    //    and backfill lazy physical columns + lazy variant sources.
+    //    Returns true if rows survive filtering; false to skip this range.
+    StatusOr<bool> _filter_and_backfill_lazy(const Range<uint64_t>& r, RowGroupScanState& state);
+
+    // 6. Emit output: variant projections → physical columns into destination chunk.
+    Status _emit_output_columns(RowGroupScanState& state, ChunkPtr* chunk, size_t* row_count);
 
     // ── Member variables ─────────────────────────────────────────────────────
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -51,6 +51,7 @@ class THdfsScanRange;
 namespace parquet {
 class ColumnMaterializer;
 class FileMetaData;
+class LazyMaterializationContext;
 class VariantProjectionHandler;
 } // namespace parquet
 struct TypeDescriptor;
@@ -166,7 +167,8 @@ private:
     //    evaluates dict / expression filters.  Populates chunk_filter and
     //    fills active_chunk.  Returns true if rows survive.
     StatusOr<bool> _read_and_filter_active_columns(const Range<uint64_t>& r, Filter& chunk_filter,
-                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count);
+                                                   ChunkPtr& active_chunk, bool& has_filter, size_t count,
+                                                   LazyMaterializationContext* lazy_ctx);
 
     // ── Member variables ─────────────────────────────────────────────────────
 

--- a/be/src/formats/parquet/lazy_materialization_context.cpp
+++ b/be/src/formats/parquet/lazy_materialization_context.cpp
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/lazy_materialization_context.h"
+
+#include <algorithm>
+
+#include "column/chunk.h"
+#include "formats/parquet/column_materializer.h"
+#include "formats/parquet/variant_projection.h"
+
+namespace starrocks::parquet {
+
+bool LazyMaterializationContext::has_slot(SlotId slot_id) const {
+    if (_materializer.get_slot_cache(slot_id) != nullptr) {
+        return true;
+    }
+    return _active_chunk->is_slot_exist(slot_id);
+}
+
+bool LazyMaterializationContext::can_materialize(SlotId slot_id) const {
+    const auto& lazy_slots = _materializer.lazy_slot_ids();
+    if (std::find(lazy_slots.begin(), lazy_slots.end(), slot_id) != lazy_slots.end()) {
+        return true;
+    }
+    if (_variant != nullptr) {
+        const auto& hidden_lazy = _variant->lazy_hidden_slot_ids();
+        return std::find(hidden_lazy.begin(), hidden_lazy.end(), slot_id) != hidden_lazy.end();
+    }
+    return false;
+}
+
+Status LazyMaterializationContext::materialize_slot(SlotId slot_id) {
+    // Variant lazy hidden sources are dispatched to VariantProjectionHandler
+    // before checking has_slot(), because they live outside the regular
+    // slot_cache / slot_id_index.  materialize_hidden_source() own dedup
+    // via _fetched_hidden_slots.
+    if (_variant != nullptr) {
+        const auto& hidden_lazy = _variant->lazy_hidden_slot_ids();
+        if (std::find(hidden_lazy.begin(), hidden_lazy.end(), slot_id) != hidden_lazy.end()) {
+            return _variant->materialize_hidden_source(slot_id, _range, _filter, _active_chunk);
+        }
+    }
+    if (has_slot(slot_id)) {
+        return Status::OK();
+    }
+    return _materializer.materialize_slot(slot_id, _range, _filter);
+}
+
+StatusOr<ColumnPtr> LazyMaterializationContext::provide(SlotId slot_id) {
+    bool first_trigger = _triggered_slots.insert(slot_id).second;
+    RETURN_IF_ERROR(materialize_slot(slot_id));
+    if (first_trigger) {
+        if (auto* s = _materializer.stats()) {
+            s->parquet_lazy_slot_triggered++;
+        }
+    }
+    const auto* entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    // Variant lazy hidden source slot: result is in active_chunk.
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    return Status::InternalError(fmt::format("provide: slot {} not found after materialize", slot_id));
+}
+
+ColumnPtr LazyMaterializationContext::get_column(SlotId slot_id) {
+    auto* entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    if (!can_materialize(slot_id)) {
+        return nullptr;
+    }
+    auto st = materialize_slot(slot_id);
+    if (!st.ok()) {
+        return nullptr;
+    }
+    // Physical lazy slot: result lands in slot_cache.
+    entry = _materializer.get_slot_cache(slot_id);
+    if (entry != nullptr) {
+        return entry->values;
+    }
+    // Variant lazy hidden source slot: result lands in active_chunk.
+    if (_active_chunk->is_slot_exist(slot_id)) {
+        return _active_chunk->get_column_by_slot_id(slot_id);
+    }
+    return nullptr;
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/lazy_materialization_context.cpp
+++ b/be/src/formats/parquet/lazy_materialization_context.cpp
@@ -23,14 +23,14 @@
 namespace starrocks::parquet {
 
 bool LazyMaterializationContext::has_slot(SlotId slot_id) const {
-    if (_materializer.get_slot_cache(slot_id) != nullptr) {
+    if (_materializer->get_slot_cache(slot_id) != nullptr) {
         return true;
     }
     return _active_chunk->is_slot_exist(slot_id);
 }
 
 bool LazyMaterializationContext::can_materialize(SlotId slot_id) const {
-    const auto& lazy_slots = _materializer.lazy_slot_ids();
+    const auto& lazy_slots = _materializer->lazy_slot_ids();
     if (std::find(lazy_slots.begin(), lazy_slots.end(), slot_id) != lazy_slots.end()) {
         return true;
     }
@@ -55,18 +55,18 @@ Status LazyMaterializationContext::materialize_slot(SlotId slot_id) {
     if (has_slot(slot_id)) {
         return Status::OK();
     }
-    return _materializer.materialize_slot(slot_id, _range, _filter);
+    return _materializer->materialize_slot(slot_id, _range, _filter);
 }
 
 StatusOr<ColumnPtr> LazyMaterializationContext::provide(SlotId slot_id) {
     bool first_trigger = _triggered_slots.insert(slot_id).second;
     RETURN_IF_ERROR(materialize_slot(slot_id));
     if (first_trigger) {
-        if (auto* s = _materializer.stats()) {
+        if (auto* s = _materializer->stats()) {
             s->parquet_lazy_slot_triggered++;
         }
     }
-    const auto* entry = _materializer.get_slot_cache(slot_id);
+    const auto* entry = _materializer->get_slot_cache(slot_id);
     if (entry != nullptr) {
         return entry->values;
     }
@@ -78,7 +78,7 @@ StatusOr<ColumnPtr> LazyMaterializationContext::provide(SlotId slot_id) {
 }
 
 ColumnPtr LazyMaterializationContext::get_column(SlotId slot_id) {
-    auto* entry = _materializer.get_slot_cache(slot_id);
+    auto* entry = _materializer->get_slot_cache(slot_id);
     if (entry != nullptr) {
         return entry->values;
     }
@@ -93,7 +93,7 @@ ColumnPtr LazyMaterializationContext::get_column(SlotId slot_id) {
         return nullptr;
     }
     // Physical lazy slot: result lands in slot_cache.
-    entry = _materializer.get_slot_cache(slot_id);
+    entry = _materializer->get_slot_cache(slot_id);
     if (entry != nullptr) {
         return entry->values;
     }

--- a/be/src/formats/parquet/lazy_materialization_context.h
+++ b/be/src/formats/parquet/lazy_materialization_context.h
@@ -14,40 +14,91 @@
 
 #pragma once
 
+#include <memory>
+#include <unordered_set>
+
+#include "column/chunk.h"
 #include "column/column.h"
+#include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "storage/primitive/range.h"
 
 namespace starrocks::parquet {
 
 class ColumnMaterializer;
+class VariantProjectionHandler;
 
-// Expression-facing facade over ColumnMaterializer.  Provides on-demand
-// single-slot materialization to the scanner-local predicate evaluator.
+// Expression-facing facade over ColumnMaterializer.  Scoped to a single
+// get_next() iteration: created before predicate evaluation, destroyed
+// before the scanner emits a Chunk.  Lazy state must not escape the scanner.
 //
-// Lifetime: created per get_next() range/batch, destroyed before the
-// scanner emits a fully materialized chunk.  No lazy state leaks out.
-class LazyMaterializationContext {
+// Implements MissingColumnProvider so it can be attached to active_chunk
+// during predicate evaluation.  When ColumnRef encounters a missing slot
+// it calls can_provide() / provide() on this context, which loads the
+// column on demand through ColumnMaterializer or VariantProjectionHandler.
+//
+// Column state invariant:
+//   provide() / materialize_slot() always calls finalize_lazy_state()
+//   after read_range().  The column returned to the caller is LOGICAL
+//   (e.g. LowCardDictColumn, BinaryColumn), never PHYSICAL (dict codes
+//   or intermediate raw values).  This guarantees expression evaluators
+//   always receive StarRocks-native logical columns.
+//
+//   Because materialize_slot() finalizes the column, the lazy column
+//   in _read_chunk is already LOGICAL when read_lazy_columns() moves it
+//   into active_chunk.  emit_physical_columns() must therefore bypass
+//   fill_dst_column() for these slots (see _logical_slot_ids in
+//   ColumnMaterializer).
+class LazyMaterializationContext : public MissingColumnProvider {
 public:
-    LazyMaterializationContext(ColumnMaterializer* materializer, const Range<uint64_t>& range, const Filter* filter)
-            : _materializer(materializer), _range(range), _filter(filter) {}
+    // variant may be nullptr when no variant columns are present.
+    LazyMaterializationContext(ColumnMaterializer& materializer, VariantProjectionHandler* variant,
+                               const Range<uint64_t>& range, const Filter* filter, ChunkPtr& active_chunk)
+            : _materializer(materializer),
+              _variant(variant),
+              _range(range),
+              _filter(filter),
+              _active_chunk(active_chunk) {}
 
-    bool has_slot(SlotId slot_id) const { return _materializer->get_slot_cache(slot_id) != nullptr; }
+    LazyMaterializationContext(const LazyMaterializationContext&) = delete;
+    LazyMaterializationContext& operator=(const LazyMaterializationContext&) = delete;
 
-    Status ensure_slot_materialized(SlotId slot_id) {
-        return _materializer->materialize_slot(slot_id, _range, _filter);
-    }
+    // Whether the slot is currently available (in active_chunk or cached).
+    bool has_slot(SlotId slot_id) const;
 
-    ColumnPtr get_column(SlotId slot_id) const {
-        auto* entry = _materializer->get_slot_cache(slot_id);
-        return entry ? entry->values : nullptr;
-    }
+    // Whether the context can materialize this slot on demand.
+    // Returns true for slots in the lazy column sets or variant hidden sources.
+    bool can_materialize(SlotId slot_id) const;
+
+    // Materialize a lazy slot, reading through its ColumnReader if needed.
+    // No-op if the slot is already cached.
+    Status materialize_slot(SlotId slot_id);
+
+    // Return the column for a slot, materializing it on demand first.
+    // Returns nullptr if the slot cannot be resolved.
+    ColumnPtr get_column(SlotId slot_id);
+
+    // MissingColumnProvider implementation: called by ColumnRef when a slot
+    // is absent from the active chunk during predicate evaluation.
+    bool can_provide(SlotId slot_id) const override { return can_materialize(slot_id); }
+    StatusOr<ColumnPtr> provide(SlotId slot_id) override;
+
+    const Range<uint64_t>& range() const { return _range; }
+    const Filter* filter() const { return _filter; }
+    ChunkPtr& active_chunk() { return _active_chunk; }
 
 private:
-    ColumnMaterializer* _materializer;
+    ColumnMaterializer& _materializer;
+    VariantProjectionHandler* _variant;
     Range<uint64_t> _range;
     const Filter* _filter;
+    ChunkPtr& _active_chunk;
+    // Tracks slots triggered for the first time this iteration, to avoid
+    // double-counting in parquet_lazy_slot_triggered.
+    // Cleared implicitly when the context is destroyed at end of get_next().
+    std::unordered_set<SlotId> _triggered_slots;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/lazy_materialization_context.h
+++ b/be/src/formats/parquet/lazy_materialization_context.h
@@ -54,7 +54,7 @@ class VariantProjectionHandler;
 class LazyMaterializationContext : public MissingColumnProvider {
 public:
     // variant may be nullptr when no variant columns are present.
-    LazyMaterializationContext(ColumnMaterializer& materializer, VariantProjectionHandler* variant,
+    LazyMaterializationContext(ColumnMaterializer* materializer, VariantProjectionHandler* variant,
                                const Range<uint64_t>& range, const Filter* filter, ChunkPtr& active_chunk)
             : _materializer(materializer),
               _variant(variant),
@@ -90,7 +90,7 @@ public:
     ChunkPtr& active_chunk() { return _active_chunk; }
 
 private:
-    ColumnMaterializer& _materializer;
+    ColumnMaterializer* _materializer;
     VariantProjectionHandler* _variant;
     Range<uint64_t> _range;
     const Filter* _filter;

--- a/be/src/formats/parquet/read_range_planner.cpp
+++ b/be/src/formats/parquet/read_range_planner.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/read_range_planner.h"
+
+#include <algorithm>
+
+#include "formats/parquet/column_reader.h"
+#include "formats/parquet/group_reader.h"
+
+namespace starrocks::parquet {
+
+ReadRangePlanner::ReadRangePlanner(const GroupReaderParam& param, ColumnReaderMap* column_readers)
+        : _param(param), _column_readers(column_readers) {}
+
+void ReadRangePlanner::collect_ranges(const std::vector<int>& column_indices, bool is_active, std::vector<IORange>* out,
+                                      int64_t* end_offset, ColumnIOTypeFlags types) {
+    for (const auto& index : column_indices) {
+        const auto& column = _param.read_cols[index];
+        (*_column_readers)[column.slot_id()]->collect_column_io_range(out, end_offset, types, is_active);
+    }
+}
+
+void ReadRangePlanner::deduplicate(std::vector<IORange>* ranges) {
+    if (ranges == nullptr || ranges->size() <= 1) {
+        return;
+    }
+    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.offset != rhs.offset) {
+            return lhs.offset < rhs.offset;
+        }
+        if (lhs.size != rhs.size) {
+            return lhs.size < rhs.size;
+        }
+        return lhs.is_active < rhs.is_active;
+    });
+    size_t write_idx = 0;
+    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
+        auto& current = (*ranges)[write_idx];
+        const auto& next = (*ranges)[read_idx];
+        if (current.offset == next.offset && current.size == next.size) {
+            current.is_active = current.is_active || next.is_active;
+            continue;
+        }
+        ++write_idx;
+        if (write_idx != read_idx) {
+            (*ranges)[write_idx] = next;
+        }
+    }
+    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
+}
+
+bool ReadRangePlanner::should_coalesce_active_lazy() const {
+    if (_param.lazy_column_coalesce_counter == nullptr) {
+        return true;
+    }
+    return _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed) >= 0;
+}
+
+void ReadRangePlanner::pre_plan_lazy_ranges(const std::vector<int>& lazy_column_indices, int64_t* end_offset,
+                                            ColumnIOTypeFlags types) {
+    _lazy_ranges.clear();
+    collect_ranges(lazy_column_indices, false, &_lazy_ranges, end_offset, types);
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/read_range_planner.h
+++ b/be/src/formats/parquet/read_range_planner.h
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "cache/scan/shared_buffered_input_stream.h"
+#include "common/global_types.h"
+#include "common/status.h"
+#include "formats/parquet/utils.h"
+
+namespace starrocks::parquet {
+
+struct GroupReaderParam;
+class ColumnReader;
+
+// Plans and coalesces IO ranges for Parquet column readers.
+//
+// Active ranges are planned and submitted during row-group prepare().
+// Lazy ranges are pre-computed but may be submitted on demand (currently
+// submitted together with active ranges during prepare; deferred lazy
+// submission will be enabled when SharedBufferedInputStream supports
+// incremental range addition).
+//
+// Used by ColumnMaterializer; not called directly by expression evaluation.
+class ReadRangePlanner {
+public:
+    using ColumnReaderMap = std::unordered_map<SlotId, std::unique_ptr<ColumnReader>>;
+    using IORange = SharedBufferedInputStream::IORange;
+
+    ReadRangePlanner(const GroupReaderParam& param, ColumnReaderMap* column_readers);
+
+    // Collect IO ranges for a set of column indices into `out`.  `types`
+    // controls whether PAGE_INDEX or PAGES ranges are collected.
+    // `is_active` tags the collected ranges.
+    void collect_ranges(const std::vector<int>& column_indices, bool is_active, std::vector<IORange>* out,
+                        int64_t* end_offset, ColumnIOTypeFlags types);
+
+    // Deduplicate exact-duplicate ranges; if two ranges share the same
+    // (offset, size), the active flag is OR-ed.
+    static void deduplicate(std::vector<IORange>* ranges);
+
+    // Whether active and lazy ranges should be coalesced into a unified
+    // stream set (adaptive counter >= 0 or config forces it).
+    bool should_coalesce_active_lazy() const;
+
+    // Plan active ranges now (called during prepare).
+    // Returns the planned active ranges.
+    const std::vector<IORange>& active_ranges() const { return _active_ranges; }
+
+    // Pre-compute lazy ranges (called during prepare).
+    // The ranges are stored; actual stream submission is deferred.
+    void pre_plan_lazy_ranges(const std::vector<int>& lazy_column_indices, int64_t* end_offset,
+                              ColumnIOTypeFlags types);
+
+    // Whether lazy ranges have been planned (non-empty set).
+    bool has_lazy_ranges() const { return !_lazy_ranges.empty(); }
+
+    // Retrieve pre-planned lazy ranges for on-demand submission.
+    const std::vector<IORange>& lazy_ranges() const { return _lazy_ranges; }
+
+private:
+    const GroupReaderParam& _param;
+    ColumnReaderMap* _column_readers = nullptr;
+
+    std::vector<IORange> _active_ranges;
+    std::vector<IORange> _lazy_ranges;
+};
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -595,6 +595,9 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
                     "Parquet lazy dictionary decode source column is not a dictionary code column");
         }
         if (_dict_filter_ctx != nullptr && !_dict_filter_ctx->is_decode_needed) {
+            // reset_column() guarantees a clean dst regardless of any prior
+            // set_num_rows / resize call (e.g. via append_side_columns_to_chunk).
+            dst->as_mutable_raw_ptr()->reset_column();
             dst->as_mutable_raw_ptr()->append_default(src->size());
             src->as_mutable_raw_ptr()->reset_column();
         } else {

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -449,22 +449,22 @@ StatusOr<bool> RawColumnReader::_row_group_bloom_filter(const std::vector<const 
     return filtered;
 }
 
-// If `column` still refers to one of the reader's temporary columns, a previous fill_dst_column()
-// was skipped (e.g. the whole range was filtered out and GroupReader::get_next() continued without
-// filling). Restore the caller-visible column to the original destination column so that no
-// temporary column can leak out of the reader. The set of temporary columns is reader-specific and
-// reported through the _is_tmp_column() override.
-Status RawColumnReader::_restore_tmp_column(ColumnPtr& column) {
-    if (!_is_tmp_column(column)) {
+// If `column` still refers to one of the reader's PHYSICAL columns, a previous
+// fill_dst_column() was skipped (e.g. the whole range was filtered out and
+// GroupReader::get_next() continued without filling).  _restore_physical_column
+// at the top of read_range() repairs this state.
+
+Status RawColumnReader::_restore_physical_column(ColumnPtr& column) {
+    if (!_is_physical_column(column)) {
         return Status::OK();
     }
-    if (UNLIKELY(_ori_column == nullptr)) {
-        return Status::InternalError("Parquet reader found a temporary column without an original destination column");
+    if (UNLIKELY(_logical_dst == nullptr)) {
+        return Status::InternalError("Parquet reader found a physical column without a saved logical destination");
     }
     column->as_mutable_raw_ptr()->reset_column();
-    _ori_column->as_mutable_raw_ptr()->reset_column();
-    column = _ori_column;
-    _ori_column = nullptr;
+    _logical_dst->as_mutable_raw_ptr()->reset_column();
+    column = _logical_dst;
+    _logical_dst = nullptr;
     return Status::OK();
 }
 
@@ -472,8 +472,8 @@ Status RawColumnReader::_restore_tmp_column(ColumnPtr& column) {
 
 Status ScalarColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    RETURN_IF_ERROR(_restore_tmp_column(dst));
-    const bool need_lazy_decode =
+    RETURN_IF_ERROR(_restore_physical_column(dst));
+    bool need_lazy_decode =
             _dict_filter_ctx != nullptr || (_can_lazy_dict_decode && filter != nullptr &&
                                             SIMD::count_nonzero(*filter) * 1.0 / filter->size() < FILTER_RATIO);
     ColumnContentType content_type = !need_lazy_decode ? ColumnContentType::VALUE : ColumnContentType::DICT_CODE;
@@ -512,30 +512,27 @@ bool ScalarColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decode
 }
 
 Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
-    // Dispatch on what the src column actually is rather than on flags like `_need_lazy_decode`:
-    // those flags are recomputed by every read_range() call, so when a fill is skipped (e.g. all
-    // rows of a range are filtered out) and a later read flips the flag, flag-based dispatch would
-    // hand the raw Int32 dictionary-code column to the upper layer as if it were the value column.
-    if (_is_dict_code_column(src)) {
+    // Dispatch on which temp column src actually is — the truth — not a recomputable flag.
+    if (_code_column != nullptr && src.get() == _code_column.get()) {
         return _fill_dst_column_impl<true, false>(dst, src);
-    }
-    if (_is_intermediate_column(src)) {
+    } else if (_tmp_intermediate_column != nullptr && src.get() == _tmp_intermediate_column.get()) {
         return _fill_dst_column_impl<false, true>(dst, src);
+    } else {
+        return _fill_dst_column_impl<false, false>(dst, src);
     }
-    return _fill_dst_column_impl<false, false>(dst, src);
 }
 
 template <bool LAZY_DICT_DECODE, bool LAZY_CONVERT>
 Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const Filter* filter,
                                             ColumnContentType content_type, ColumnPtr& dst) {
     if constexpr (LAZY_DICT_DECODE) {
-        if (_tmp_code_column == nullptr) {
-            _tmp_code_column = ColumnHelper::create_column(
+        if (_code_column == nullptr) {
+            _code_column = ColumnHelper::create_column(
                     TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
         }
-        _ori_column = dst;
-        _tmp_code_column->as_mutable_raw_ptr()->reset_column();
-        dst = _tmp_code_column;
+        _code_column->as_mutable_raw_ptr()->reset_column();
+        _logical_dst = dst;
+        dst = _code_column;
         dst->as_mutable_raw_ptr()->reserve(range.span_size());
         SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
         return _reader->read_range(range, filter, content_type, dst->as_mutable_raw_ptr());
@@ -562,7 +559,7 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
                 _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
                 return Status::OK();
             } else {
-                _ori_column = dst;
+                _logical_dst = dst;
                 dst = _tmp_intermediate_column;
                 return Status::OK();
             }
@@ -618,14 +615,12 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
                 }
                 _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
             } else {
+                dst->as_mutable_raw_ptr()->reset_column();
                 RETURN_IF_ERROR(_dict_decode(dst, src));
             }
         }
-        if (UNLIKELY(_ori_column == nullptr)) {
-            return Status::InternalError("Parquet lazy dictionary decode lost original destination column");
-        }
-        src = _ori_column;
-        _ori_column = nullptr;
+        src = _logical_dst;
+        _logical_dst = nullptr;
     } else {
         if constexpr (LAZY_CONVERT) {
             if (UNLIKELY(!_is_intermediate_column(src))) {
@@ -636,11 +631,8 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
                 RETURN_IF_ERROR(_converter->convert(src, dst->as_mutable_raw_ptr()));
             }
             src->as_mutable_raw_ptr()->reset_column();
-            if (UNLIKELY(_ori_column == nullptr)) {
-                return Status::InternalError("Parquet lazy conversion lost original destination column");
-            }
-            src = _ori_column;
-            _ori_column = nullptr;
+            src = _logical_dst;
+            _logical_dst = nullptr;
         } else {
             dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
         }
@@ -649,11 +641,45 @@ Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src)
 }
 
 bool ScalarColumnReader::_is_dict_code_column(const ColumnPtr& column) const {
-    return _tmp_code_column != nullptr && column.get() == _tmp_code_column.get();
+    return _code_column != nullptr && column.get() == _code_column.get();
 }
 
 bool ScalarColumnReader::_is_intermediate_column(const ColumnPtr& column) const {
     return _tmp_intermediate_column != nullptr && column.get() == _tmp_intermediate_column.get();
+}
+
+Status ScalarColumnReader::finalize_lazy_state(ColumnPtr& col) {
+    if (_logical_dst != nullptr) {
+        if (col.get() == _code_column.get()) {
+            auto saved = std::move(_logical_dst);
+            _logical_dst = nullptr;
+            if (_converter->need_convert) {
+                if (_tmp_intermediate_column == nullptr) {
+                    _tmp_intermediate_column = _converter->create_src_column();
+                }
+                _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
+                RETURN_IF_ERROR(_dict_decode(_tmp_intermediate_column, col));
+                {
+                    SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+                    RETURN_IF_ERROR(_converter->convert(_tmp_intermediate_column.get(), saved->as_mutable_raw_ptr()));
+                }
+                _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
+            } else {
+                RETURN_IF_ERROR(_dict_decode(saved, col));
+            }
+            col = std::move(saved);
+        } else if (col.get() == _tmp_intermediate_column.get()) {
+            auto saved = std::move(_logical_dst);
+            _logical_dst = nullptr;
+            {
+                SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+                RETURN_IF_ERROR(_converter->convert(col, saved->as_mutable_raw_ptr()));
+            }
+            col->as_mutable_raw_ptr()->reset_column();
+            col = std::move(saved);
+        }
+    }
+    return Status::OK();
 }
 
 void ScalarColumnReader::collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges,
@@ -675,16 +701,16 @@ void ScalarColumnReader::collect_column_io_range(std::vector<SharedBufferedInput
 
 Status LowCardColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    RETURN_IF_ERROR(_restore_tmp_column(dst));
+    RETURN_IF_ERROR(_restore_physical_column(dst));
     ColumnContentType content_type = ColumnContentType::DICT_CODE;
 
-    if (_dict_code == nullptr) {
-        _dict_code = ColumnHelper::create_column(
+    if (_code_column == nullptr) {
+        _code_column = ColumnHelper::create_column(
                 TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
     }
-    _ori_column = dst;
-    _dict_code->as_mutable_raw_ptr()->reset_column();
-    dst = _dict_code;
+    _code_column->as_mutable_raw_ptr()->reset_column();
+    _logical_dst = dst;
+    dst = _code_column;
     dst->as_mutable_raw_ptr()->reserve(range.span_size());
 
     {
@@ -715,7 +741,10 @@ bool LowCardColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decod
 
 Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     if (UNLIKELY(!_is_dict_code_column(src))) {
-        return Status::InternalError("Parquet low-cardinality source column is not a dictionary code column");
+        // src is already LOGICAL (e.g. finalized by compound conjuncts).
+        // Swap directly — no dict-code decoding needed.
+        dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
+        return Status::OK();
     }
     size_t num_rows = src->size();
     if (!_code_convert_map.has_value()) {
@@ -751,17 +780,24 @@ Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     }
 
     src->as_mutable_raw_ptr()->reset_column();
-    if (UNLIKELY(_ori_column == nullptr)) {
-        return Status::InternalError("Parquet low-cardinality reader lost original destination column");
-    }
-    src = _ori_column;
-    _ori_column = nullptr;
+    src = _logical_dst;
+    _logical_dst = nullptr;
 
     return Status::OK();
 }
 
+Status LowCardColumnReader::finalize_lazy_state(ColumnPtr& col) {
+    if (_logical_dst != nullptr && col.get() == _code_column.get()) {
+        auto saved = std::move(_logical_dst);
+        _logical_dst = nullptr;
+        RETURN_IF_ERROR(fill_dst_column(saved, col));
+        col = std::move(saved);
+    }
+    return Status::OK();
+}
+
 bool LowCardColumnReader::_is_dict_code_column(const ColumnPtr& column) const {
-    return _dict_code != nullptr && column.get() == _dict_code.get();
+    return _code_column != nullptr && column.get() == _code_column.get();
 }
 
 Status LowCardColumnReader::_check_current_dict() {
@@ -824,15 +860,15 @@ void LowCardColumnReader::collect_column_io_range(std::vector<SharedBufferedInpu
 
 Status LowRowsColumnReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     DCHECK(get_column_parquet_field()->is_nullable ? dst->is_nullable() : true);
-    RETURN_IF_ERROR(_restore_tmp_column(dst));
+    RETURN_IF_ERROR(_restore_physical_column(dst));
     ColumnContentType content_type = ColumnContentType::VALUE;
 
-    if (_tmp_column == nullptr) {
-        _tmp_column = ColumnHelper::create_column(TYPE_VARCHAR_DESC, true);
+    if (_raw_string_column == nullptr) {
+        _raw_string_column = ColumnHelper::create_column(TYPE_VARCHAR_DESC, true);
     }
-    _ori_column = dst;
-    _tmp_column->as_mutable_raw_ptr()->reset_column();
-    dst = _tmp_column;
+    _raw_string_column->as_mutable_raw_ptr()->reset_column();
+    _logical_dst = dst;
+    dst = _raw_string_column;
     dst->as_mutable_raw_ptr()->reserve(range.span_size());
 
     {
@@ -842,8 +878,10 @@ Status LowRowsColumnReader::read_range(const Range<uint64_t>& range, const Filte
 }
 
 Status LowRowsColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
-    if (UNLIKELY(!_is_tmp_column(src))) {
-        return Status::InternalError("Parquet low-rows source column is not a temporary string column");
+    if (UNLIKELY(!_is_physical_column(src))) {
+        // src is already LOGICAL — swap directly
+        dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
+        return Status::OK();
     }
     dst->as_mutable_raw_ptr()->resize(src->size());
 
@@ -873,17 +911,20 @@ Status LowRowsColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     }
 
     src->as_mutable_raw_ptr()->reset_column();
-    if (UNLIKELY(_ori_column == nullptr)) {
-        return Status::InternalError("Parquet low-rows reader lost original destination column");
-    }
-    src = _ori_column;
-    _ori_column = nullptr;
+    src = _logical_dst;
+    _logical_dst = nullptr;
 
     return Status::OK();
 }
 
-bool LowRowsColumnReader::_is_tmp_column(const ColumnPtr& column) const {
-    return _tmp_column != nullptr && column.get() == _tmp_column.get();
+Status LowRowsColumnReader::finalize_lazy_state(ColumnPtr& col) {
+    if (_logical_dst != nullptr && col.get() == _raw_string_column.get()) {
+        auto saved = std::move(_logical_dst);
+        _logical_dst = nullptr;
+        RETURN_IF_ERROR(fill_dst_column(saved, col));
+        col = std::move(saved);
+    }
+    return Status::OK();
 }
 
 void LowRowsColumnReader::collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges,

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -127,14 +127,26 @@ protected:
                                            CompoundNodeType pred_relation, const TypeDescriptor& col_type,
                                            const uint64_t rg_first_row, const uint64_t rg_num_rows) const;
 
-    // If `column` still refers to one of this reader's internal temporary columns, a previous
-    // fill_dst_column() was skipped (e.g. the whole range was filtered out and
-    // GroupReader::get_next() continued without filling). Restore the caller-visible column to the
-    // original destination column so that no temporary column can leak out of the reader.
-    Status _restore_tmp_column(ColumnPtr& column);
-    // Whether `column` is one of this reader's internal temporary columns. Overridden by readers
-    // that swap in a temporary column (dict-code / intermediate / low-rows string) during read.
-    virtual bool _is_tmp_column(const ColumnPtr& column) const { return false; }
+    // ── Physical ↔ Logical column swap machinery ──
+    //
+    // Convention: after read_range(), a slot holds a PHYSICAL column
+    // (_code_column / _raw_string_column / _tmp_intermediate_column).
+    // The caller's original LOGICAL destination is parked in _logical_dst.
+    //
+    // finalize_lazy_state() converts PHYSICAL → LOGICAL.
+    // fill_dst_column() consumes the PHYSICAL column and restores _logical_dst.
+    //
+    // If fill_dst_column() is skipped (e.g. the range was filtered out),
+    // _restore_physical_column() at the top of the next read_range() detects
+    // the leftover via _is_physical_column() and restores _logical_dst.
+
+    // If `column` is a PHYSICAL column owned by this reader, a previous fill
+    // was skipped.  Restore the slot to _logical_dst so the reader can install
+    // a fresh PHYSICAL column for the next range.
+    Status _restore_physical_column(ColumnPtr& column);
+    // Whether `column` is a PHYSICAL column owned by this reader
+    // (dict codes, intermediate, or raw strings — not yet LOGICAL).
+    virtual bool _is_physical_column(const ColumnPtr& column) const { return false; }
 
     const ColumnReaderOptions& _opts;
 
@@ -142,9 +154,11 @@ protected:
 
     const tparquet::ColumnChunk* _chunk_metadata = nullptr;
     std::unique_ptr<ColumnOffsetIndexCtx> _offset_index_ctx;
-    // Original destination column saved when a temporary column is swapped in during read_range();
-    // restored by _restore_tmp_column()/fill_dst_column() once the temporary column is consumed.
-    ColumnPtr _ori_column = nullptr;
+
+    // LOGICAL column saved when a PHYSICAL column is swapped into the slot
+    // during read_range().  Restored by _restore_physical_column() or at
+    // the end of a successful fill_dst_column().
+    ColumnPtr _logical_dst = nullptr;
 };
 
 class ScalarColumnReader final : public RawColumnReader {
@@ -157,9 +171,14 @@ public:
     Status prepare() override {
         RETURN_IF_ERROR(ColumnConverterFactory::create_converter(*get_column_parquet_field(), *_col_type,
                                                                  _opts.timezone, &_converter));
-        // Finalize lazy dict-decode eligibility now that _converter is known.
-        // Lazy dict decode is only valid when no value conversion is required, because the dict-decode
-        // path materialises values directly into dst and bypasses converters (e.g. UUID bytes -> string).
+        // Adaptive lazy dict-decode (_can_lazy_dict_decode) is disabled when a
+        // converter exists, because the automatic decode-on-first-touch path
+        // would materialise values directly into dst, bypassing conversion.
+        //
+        // Dict-filter forced dict-code reads (via _dict_filter_ctx) are NOT
+        // affected: finalize_lazy_state() / fill_dst_column() perform a
+        // two-step decode → intermediate → convert, so dict-code + converter
+        // pairs work correctly for filter-only scenarios.
         if (_can_lazy_dict_decode && _converter->need_convert) {
             _can_lazy_dict_decode = false;
         }
@@ -196,6 +215,8 @@ public:
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
+    Status finalize_lazy_state(ColumnPtr& col) override;
+
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                              CompoundNodeType pred_relation, const uint64_t rg_first_row,
                                              const uint64_t rg_num_rows) const override {
@@ -230,7 +251,7 @@ private:
 
     bool _is_dict_code_column(const ColumnPtr& column) const;
     bool _is_intermediate_column(const ColumnPtr& column) const;
-    bool _is_tmp_column(const ColumnPtr& column) const override {
+    bool _is_physical_column(const ColumnPtr& column) const override {
         return _is_dict_code_column(column) || _is_intermediate_column(column);
     }
 
@@ -239,13 +260,14 @@ private:
     std::unique_ptr<ColumnDictFilterContext> _dict_filter_ctx;
     const TypeDescriptor* _col_type = nullptr;
 
-    // _can_lazy_dict_decode means string type and all page dict code
     bool _can_lazy_dict_decode = false;
     bool _can_lazy_convert = false;
-    // we use lazy decode adaptively because of RLE && decoder may be better than filter && decoder
     static constexpr double FILTER_RATIO = 0.2;
-    // dict code
-    ColumnPtr _tmp_code_column = nullptr;
+    // PHYSICAL columns used during lazy-decode / lazy-convert paths.
+    // _code_column stores Parquet dict codes (Int32); _tmp_intermediate_column
+    // stores decoded-but-unconverted raw values.  At most one is installed
+    // in the caller slot at any time — dispatch is by col.get() pointer identity.
+    ColumnPtr _code_column = nullptr;
     ColumnPtr _tmp_intermediate_column = nullptr;
 };
 
@@ -272,6 +294,8 @@ public:
     }
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
+
+    Status finalize_lazy_state(ColumnPtr& col) override;
 
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                              CompoundNodeType pred_relation, const uint64_t rg_first_row,
@@ -300,7 +324,6 @@ public:
 private:
     Status _check_current_dict();
     bool _is_dict_code_column(const ColumnPtr& column) const;
-    bool _is_tmp_column(const ColumnPtr& column) const override { return _is_dict_code_column(column); }
 
     std::unique_ptr<ColumnDictFilterContext> _dict_filter_ctx;
 
@@ -309,7 +332,11 @@ private:
 
     std::optional<std::vector<int16_t>> _code_convert_map;
 
-    ColumnPtr _dict_code = nullptr;
+    bool _is_physical_column(const ColumnPtr& column) const override { return column.get() == _code_column.get(); }
+    // PHYSICAL column: Parquet dict codes (Int32).  read_range() swaps this
+    // into the slot; fill_dst_column() decodes it to global-dict IDs
+    // (LOGICAL LowCardDictColumn).
+    ColumnPtr _code_column = nullptr;
 };
 
 class LowRowsColumnReader final : public RawColumnReader {
@@ -320,6 +347,8 @@ public:
     Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override;
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
+
+    Status finalize_lazy_state(ColumnPtr& col) override;
 
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                              CompoundNodeType pred_relation, const uint64_t rg_first_row,
@@ -339,12 +368,14 @@ public:
                                  ColumnIOTypeFlags types, bool active) override;
 
 private:
-    bool _is_tmp_column(const ColumnPtr& column) const override;
-
     const GlobalDictMap* _dict = nullptr;
     const SlotId _slot_id;
 
-    ColumnPtr _tmp_column = nullptr;
+    bool _is_physical_column(const ColumnPtr& column) const override {
+        return _raw_string_column != nullptr && column.get() == _raw_string_column.get();
+    }
+    // PHYSICAL column: raw VARCHAR strings read from non-dict-encoded pages.
+    ColumnPtr _raw_string_column = nullptr;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -32,6 +32,8 @@
 #include "common/statusor.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/decimal_cast_expr.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
 #include "exprs/variant_path_reader.h"
 #include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
@@ -496,6 +498,15 @@ std::unordered_set<SlotId> VariantProjectionHandler::deferred_conjunct_physical_
             result.insert(src);
         }
     }
+    // Also force physical sources of virtual slots referenced in compound (multi-slot) conjuncts.
+    if (_param.scanner_ctx != nullptr) {
+        for (SlotId vsid : referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs)) {
+            auto proj_it = _projections.find(vsid);
+            if (proj_it != _projections.end() && proj_it->second.source_slot_id >= 0) {
+                result.insert(proj_it->second.source_slot_id);
+            }
+        }
+    }
     return result;
 }
 
@@ -740,15 +751,91 @@ void VariantProjectionHandler::init_read_chunk_slots() {
 
 // ── get_next() phases ────────────────────────────────────────────────────────
 
+std::unordered_set<SlotId> VariantProjectionHandler::referenced_variant_virtual_slot_ids(
+        const std::vector<ExprContext*>& conjunct_ctxs) const {
+    std::unordered_set<SlotId> result;
+    std::vector<SlotId> slot_ids;
+    for (ExprContext* ctx : conjunct_ctxs) {
+        if (ctx == nullptr) continue;
+        slot_ids.clear();
+        ctx->root()->get_slot_ids(&slot_ids);
+        for (SlotId id : slot_ids) {
+            if (is_virtual_slot(id)) {
+                result.insert(id);
+            }
+        }
+    }
+    return result;
+}
+
+Status VariantProjectionHandler::fetch_and_project_virtual_slots(const std::unordered_set<SlotId>& virtual_slot_ids,
+                                                                 const Range<uint64_t>& range, ChunkPtr& active_chunk,
+                                                                 const cctz::time_zone& zone) {
+    // 1. Collect hidden source slots that are needed but not yet fetched.
+    for (SlotId virtual_slot_id : virtual_slot_ids) {
+        auto proj_it = _projections.find(virtual_slot_id);
+        if (proj_it == _projections.end()) {
+            return Status::InternalError(
+                    fmt::format("variant virtual slot {} not found in projections", virtual_slot_id));
+        }
+        SlotId source_slot_id = proj_it->second.source_slot_id;
+        // Physical sources (slot_id >= 0) are already populated as active columns.
+        if (source_slot_id < 0 && !_fetched_hidden_slots.count(source_slot_id)) {
+            auto it = _hidden_slot_index.find(source_slot_id);
+            if (it == _hidden_slot_index.end()) {
+                return Status::InternalError(fmt::format("hidden source slot {} not found in index", source_slot_id));
+            }
+            // Read into the pre-created column (from init_read_chunk_slots) if it
+            // exists; otherwise create a new one.
+            if (active_chunk->is_slot_exist(source_slot_id)) {
+                auto& col = active_chunk->get_column_by_slot_id(source_slot_id);
+                RETURN_IF_ERROR(it->second->reader->read_range(range, nullptr, col));
+                RETURN_IF_ERROR(it->second->reader->finalize_lazy_state(col));
+            } else {
+                ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
+                RETURN_IF_ERROR(it->second->reader->read_range(range, nullptr, col));
+                RETURN_IF_ERROR(it->second->reader->finalize_lazy_state(col));
+                active_chunk->append_column(std::move(col), source_slot_id);
+            }
+            _fetched_hidden_slots.insert(source_slot_id);
+        }
+    }
+
+    // 2. Project each needed virtual slot from its source column.
+    //    active_chunk is rebuilt per range, so append_column is the
+    //    common case.  When called multiple times within the same
+    //    iteration update_column replaces a previously projected slot.
+    for (SlotId virtual_slot_id : virtual_slot_ids) {
+        auto proj_it = _projections.find(virtual_slot_id);
+        DCHECK(proj_it != _projections.end());
+        const auto& projection = proj_it->second;
+        DCHECK(active_chunk->is_slot_exist(projection.source_slot_id));
+        const ColumnPtr& source_col = active_chunk->get_column_by_slot_id(projection.source_slot_id);
+        ASSIGN_OR_RETURN(auto result_col,
+                         project_variant_leaf_column(source_col, projection.parsed_path, projection.target_type, zone));
+        if (active_chunk->is_slot_exist(virtual_slot_id)) {
+            active_chunk->update_column(std::move(result_col), virtual_slot_id);
+        } else {
+            active_chunk->append_column(std::move(result_col), virtual_slot_id);
+        }
+    }
+    return Status::OK();
+}
+
 void VariantProjectionHandler::reset_iteration_state() {
     _deferred_projected_chunk.reset();
+    _fetched_hidden_slots.clear();
 }
 
 Status VariantProjectionHandler::fetch_sources(const Range<uint64_t>& range, ChunkPtr& active_chunk) {
     for (SlotId slot_id : _active_hidden_slot_ids) {
+        // Skip columns that were already populated by an early fetch in Phase 2b.
+        if (_fetched_hidden_slots.count(slot_id)) continue;
         auto* hidden_src = _hidden_slot_index.at(slot_id);
         auto& hidden_col = active_chunk->get_column_by_slot_id(slot_id);
         RETURN_IF_ERROR(hidden_src->reader->read_range(range, nullptr, hidden_col));
+        RETURN_IF_ERROR(hidden_src->reader->finalize_lazy_state(hidden_col));
+        _fetched_hidden_slots.insert(slot_id);
     }
     return Status::OK();
 }
@@ -823,6 +910,11 @@ Status VariantProjectionHandler::backfill_sources(const Range<uint64_t>& full_ra
 
     auto lazy_hidden_chunk = std::make_shared<Chunk>();
     for (SlotId slot_id : _lazy_hidden_slot_ids) {
+        // Skip slots already populated this iteration via on-demand
+        // materialization (materialize_hidden_source) or early fetch
+        // (fetch_and_project_virtual_slots).
+        if (_fetched_hidden_slots.count(slot_id)) continue;
+
         auto* hidden_src = _hidden_slot_index.at(slot_id);
         ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
         if (has_filter) {
@@ -831,13 +923,44 @@ Status VariantProjectionHandler::backfill_sources(const Range<uint64_t>& full_ra
         } else {
             RETURN_IF_ERROR(hidden_src->reader->read_range(full_range, nullptr, col));
         }
+        RETURN_IF_ERROR(hidden_src->reader->finalize_lazy_state(col));
         lazy_hidden_chunk->append_column(std::move(col), slot_id);
+        _fetched_hidden_slots.insert(slot_id);
+    }
+    if (lazy_hidden_chunk->num_columns() == 0) {
+        return Status::OK();
     }
     if (lazy_hidden_chunk->num_rows() != active_chunk->num_rows()) {
         return Status::InternalError(fmt::format("Unmatched row count, active_rows={}, lazy_hidden_rows={}",
                                                  active_chunk->num_rows(), lazy_hidden_chunk->num_rows()));
     }
     active_chunk->merge(std::move(*lazy_hidden_chunk));
+    return Status::OK();
+}
+
+Status VariantProjectionHandler::materialize_hidden_source(SlotId slot_id, const Range<uint64_t>& range,
+                                                           const Filter* filter, ChunkPtr& active_chunk) {
+    // Check this is actually a lazy hidden source slot.
+    auto& lazy_ids = _lazy_hidden_slot_ids;
+    if (std::find(lazy_ids.begin(), lazy_ids.end(), slot_id) == lazy_ids.end()) {
+        return Status::OK();
+    }
+    // Already populated this iteration (by an earlier on-demand trigger).
+    if (_fetched_hidden_slots.count(slot_id)) {
+        return Status::OK();
+    }
+    auto it = _hidden_slot_index.find(slot_id);
+    if (it == _hidden_slot_index.end()) {
+        return Status::InternalError(
+                fmt::format("materialize_hidden_source: slot {} not in hidden_slot_index", slot_id));
+    }
+    // active_chunk is rebuilt per range, so the slot never exists from a
+    // prior iteration — always append.
+    ColumnPtr col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
+    RETURN_IF_ERROR(it->second->reader->read_range(range, filter, col));
+    RETURN_IF_ERROR(it->second->reader->finalize_lazy_state(col));
+    active_chunk->append_column(std::move(col), slot_id);
+    _fetched_hidden_slots.insert(slot_id);
     return Status::OK();
 }
 
@@ -855,6 +978,12 @@ Status VariantProjectionHandler::emit_projections(ChunkPtr& active_chunk, ChunkP
                                     slot_id, projected_col->size(), active_chunk->num_rows()));
             }
             (*dst)->get_column_by_slot_id(slot_id) = projected_col;
+            continue;
+        }
+        // Early-projected virtual slot (Phase 2b compound-conjunct prep) —
+        // already filtered and ready to move to dst.
+        if (active_chunk->is_slot_exist(slot_id)) {
+            (*dst)->get_column_by_slot_id(slot_id) = active_chunk->get_column_by_slot_id(slot_id);
             continue;
         }
         if (!active_chunk->is_slot_exist(projection.source_slot_id)) {

--- a/be/src/formats/parquet/variant_projection.h
+++ b/be/src/formats/parquet/variant_projection.h
@@ -131,8 +131,17 @@ public:
     Status align_after_combined_filter(const ChunkPtr& active_chunk, const Filter& filter, size_t pre_filter_rows);
 
     // 6. Backfill projection-only variant source columns.
+    // Slots already populated this iteration (tracked by _fetched_hidden_slots)
+    // are skipped to avoid double-reading.
     Status backfill_sources(const Range<uint64_t>& full_range, const Range<uint64_t>* post_filter_range,
                             const Filter* post_filter, bool has_filter, ChunkPtr& active_chunk);
+
+    // On-demand materialization of a single lazy hidden source slot into active_chunk.
+    // Called by LazyMaterializationContext when an expression triggers the slot.
+    // No-op if slot_id is not a lazy hidden source or was already populated this
+    // iteration (tracked by _fetched_hidden_slots).
+    Status materialize_hidden_source(SlotId slot_id, const Range<uint64_t>& range, const Filter* filter,
+                                     ChunkPtr& active_chunk);
 
     // 7. Emit variant virtual-column projections into the destination chunk.
     //    Consumes internally stored projected chunk (set by filter_subfields).
@@ -141,6 +150,20 @@ public:
     bool has_projections() const { return !_projections.empty(); }
     bool is_virtual_slot(SlotId slot_id) const { return _projections.count(slot_id) > 0; }
     std::unordered_set<SlotId> projection_slot_ids() const;
+
+    // Returns the subset of variant virtual slot ids that are referenced by
+    // the given conjuncts.  Used to decide which projections must be
+    // materialised before compound-conjunct evaluation (Phase 2b).
+    std::unordered_set<SlotId> referenced_variant_virtual_slot_ids(
+            const std::vector<ExprContext*>& conjunct_ctxs) const;
+
+    // Project only the requested variant virtual slots into active_chunk.
+    // Fetches only the hidden source columns that are needed for the given
+    // virtual slots (skipping ones already present in active_chunk).
+    // Returns the set of virtual slots that were successfully projected.
+    Status fetch_and_project_virtual_slots(const std::unordered_set<SlotId>& virtual_slot_ids,
+                                           const Range<uint64_t>& range, ChunkPtr& active_chunk,
+                                           const cctz::time_zone& zone);
 
     //    Reset per-iteration state (call at start of each get_next() call).
     void reset_iteration_state();
@@ -184,6 +207,12 @@ private:
 
     cctz::time_zone _timezone_obj = cctz::utc_time_zone();
     bool _timezone_resolved = false;
+
+    // Tracks hidden source slots that have already been populated with data
+    // during the current iteration: by fetch_sources(), by an early fetch in
+    // fetch_and_project_virtual_slots(), or by on-demand materialization in
+    // materialize_hidden_source().  Reset by reset_iteration_state().
+    std::unordered_set<SlotId> _fetched_hidden_slots;
 
     // Per-iteration state — set by filter_subfields, consumed by
     // align_after_combined_filter and emit_projections.

--- a/be/src/formats/scan_context.h
+++ b/be/src/formats/scan_context.h
@@ -43,6 +43,20 @@ struct FormatScannerStats {
     int64_t rows_read = 0;
     int64_t late_materialize_skip_rows = 0;
 
+    // Parquet lazy materialization: rows filtered before lazy columns were read.
+    int64_t parquet_lazy_col_skip_rows = 0;
+    // Parquet lazy materialization: number of lazy slots triggered via MissingColumnProvider.
+    int64_t parquet_lazy_slot_triggered = 0;
+    // Parquet lazy materialization: number of lazy column read operations.
+    int64_t parquet_lazy_read_count = 0;
+    // Parquet lazy materialization: time spent reading lazy columns.
+    int64_t parquet_lazy_read_ns = 0;
+    // Parquet dict-code predicate evaluation count.
+    int64_t parquet_dict_code_predicate_eval_count = 0;
+    // Parquet lazy materialization: row groups where every lazy slot was triggered
+    // on-demand (suggests active/lazy classification could be improved).
+    int64_t parquet_lazy_full_trigger_count = 0;
+
     int64_t io_ns = 0;
     int64_t io_count = 0;
     int64_t bytes_read = 0;

--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -1059,9 +1059,9 @@ TEST(ParquetComplexColumnReaderTest, VariantVirtualZoneMapReaderSkipsWhenSourceI
 
 // White-box coverage for the fail-fast invariants introduced by the dict-code-leak fix.
 //
-// In normal flow fill_dst_column()/_restore_tmp_column() are only reached right after read_range()
-// has swapped in the reader's internal temporary column, so the "source is not a temporary column"
-// and "lost original destination column" guards are unreachable end to end. The test target is built
+// In normal flow fill_dst_column()/_restore_physical_column() are only reached right after read_range()
+// has swapped in the reader's PHYSICAL column, so the "source is not a physical column"
+// and "lost logical destination" guards are unreachable end to end. The test target is built
 // with -fno-access-control, so construct the readers directly and reach into their internals.
 TEST(ParquetScalarColumnReaderGuardTest, FillAndRestoreRejectNonTemporarySource) {
     ColumnReaderOptions opts;
@@ -1071,35 +1071,35 @@ TEST(ParquetScalarColumnReaderGuardTest, FillAndRestoreRejectNonTemporarySource)
     GlobalDictMap dict;
     auto make_int_col = [] { return ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true); };
 
-    // LowCardColumnReader::fill_dst_column rejects a src that is not its dict-code column
-    // (_dict_code is null without a preceding read_range()).
+    // LowCardColumnReader::fill_dst_column: when src is not _code_column
+    // (PHYSICAL dict codes), it is treated as already LOGICAL → swap directly.
     {
         ScalarColumnReader base(&field, &chunk_meta, &varchar_type, opts);
         LowCardColumnReader reader(base, &dict, /*slot_id=*/1);
         ColumnPtr dst = make_int_col();
         ColumnPtr src = make_int_col();
-        EXPECT_FALSE(reader.fill_dst_column(dst, src).ok());
+        EXPECT_TRUE(reader.fill_dst_column(dst, src).ok());
     }
 
-    // LowRowsColumnReader::fill_dst_column rejects a src that is not its temporary string column.
+    // LowRowsColumnReader::fill_dst_column: same LOGICAL fallback.
     {
         ScalarColumnReader base(&field, &chunk_meta, &varchar_type, opts);
         LowRowsColumnReader reader(base, &dict, /*slot_id=*/1);
         ColumnPtr dst = make_int_col();
         ColumnPtr src = make_int_col();
-        EXPECT_FALSE(reader.fill_dst_column(dst, src).ok());
+        EXPECT_TRUE(reader.fill_dst_column(dst, src).ok());
     }
 
-    // RawColumnReader::_restore_tmp_column errors when a temporary column is still referenced as the
-    // caller-visible column but the original destination column was lost.
+    // RawColumnReader::_restore_physical_column errors when a PHYSICAL column
+    // is still the caller-visible column but _logical_dst was lost.
     {
         ScalarColumnReader base(&field, &chunk_meta, &varchar_type, opts);
         LowCardColumnReader reader(base, &dict, /*slot_id=*/1);
         ColumnPtr code = make_int_col();
-        reader._dict_code = code;
-        reader._ori_column = nullptr;
+        reader._code_column = code;
+        reader._logical_dst = nullptr;
         ColumnPtr col = code;
-        EXPECT_FALSE(reader._restore_tmp_column(col).ok());
+        EXPECT_FALSE(reader._restore_physical_column(col).ok());
     }
 }
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2834,6 +2834,79 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
     EXPECT_EQ(100, total_row_nums);
 }
 
+// Reproduce: when a chunk is fully filtered (hit_count==0), the ScalarColumnReader's
+// fill_dst_column() is skipped and the subfield slot is left pointing at the internal
+// Int32 dict-code column. The next chunk that does survive then reads/fills against
+// a wrong column type, causing a type-mismatch crash or corrupt output.
+// Using chunk_size=30 ensures the first chunk (rows 1-30, c0%100 in 1..30) has no
+// match for c_struct.c0='55', forcing the skipped-fill path before a matching chunk.
+TEST_F(FileReaderTest, TestStructSubfieldDictCodeNoLeakOnSkippedFill) {
+    const std::string struct_in_struct_file_path =
+            "./be/test/formats/parquet/test_data/test_parquet_struct_in_struct.parquet";
+    auto ctx = _create_file_struct_in_struct_read_context(struct_in_struct_file_path);
+
+    TypeDescriptor type_struct =
+            TypeDescriptor::create_struct_type({"c0", "c1"}, {TYPE_VARCHAR_DESC, TYPE_VARCHAR_DESC});
+    TypeDescriptor type_struct_in_struct =
+            TypeDescriptor::create_struct_type({"c0", "c_struct"}, {TYPE_VARCHAR_DESC, type_struct});
+
+    std::vector<std::string> subfield_path({"c_struct", "c0"});
+    _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "55",
+                                                    &ctx->conjunct_ctxs_by_slot[3]);
+
+    // Small chunk size: first chunk (rows 1-30) has no match for c_struct.c0='55',
+    // so hit_count==0 and fill is skipped — this is what triggers the bug.
+    auto file_reader = _create_file_reader(struct_in_struct_file_path, 30);
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(TYPE_INT_DESC, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(TYPE_INT_DESC, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_struct_in_struct, true), chunk->num_columns());
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+
+    // After a successful fill (get_next returns >0 rows), verify that the inner
+    // struct subfield c_struct.c0 in _read_chunk is still a binary column.
+    // Without the fix, gap B leaves _ori_column pointing at _tmp_code_column (Int32),
+    // so fill_dst_column "restores" c0 to Int32 instead of Binary — detectable here.
+    auto assert_read_chunk_c_struct_c0_is_binary = [&]() {
+        const auto& rg = file_reader->_row_group_readers[0];
+        const ChunkPtr& rc = rg->_column_materializer->read_chunk();
+        ASSERT_TRUE(rc != nullptr);
+        // Use as_mutable_raw_ptr() to navigate const ColumnPtr& without casts.
+        auto* outer_col = rc->get_column_by_slot_id(3)->as_mutable_raw_ptr();
+        auto* outer_nullable = down_cast<NullableColumn*>(outer_col);
+        auto* outer_struct = down_cast<StructColumn*>(outer_nullable->data_column_raw_ptr());
+        auto c_struct_r = outer_struct->field_column("c_struct");
+        ASSERT_TRUE(c_struct_r.ok());
+        auto* inner_nullable = down_cast<NullableColumn*>(c_struct_r.value()->as_mutable_raw_ptr());
+        auto* inner_struct = down_cast<StructColumn*>(inner_nullable->data_column_raw_ptr());
+        auto c0_r = inner_struct->field_column("c0");
+        ASSERT_TRUE(c0_r.ok());
+        // c0 is NullableColumn(BinaryColumn); unwrap to check the data column type.
+        Column* c0_data = ColumnHelper::get_data_column(c0_r.value()->as_mutable_raw_ptr());
+        ASSERT_TRUE(c0_data->is_binary())
+                << "Bug: c_struct.c0 in _read_chunk leaked as dict-code column: " << c0_r.value()->get_name();
+    };
+
+    size_t total_row_nums = 0;
+    while (!status.is_end_of_file()) {
+        chunk->reset();
+        status = file_reader->get_next(&chunk);
+        ASSERT_TRUE(status.ok() || status.is_end_of_file()) << status.message();
+        chunk->check_or_die();
+        total_row_nums += chunk->num_rows();
+        if (chunk->num_rows() != 0) {
+            ASSERT_EQ("{c0:'55',c_struct:{c0:'55',c1:'46'}}", chunk->get_column_by_slot_id(3)->debug_item(0));
+            // Verify internal state: c_struct.c0 must be binary, not a leaked Int32 dict-code column.
+            assert_read_chunk_c_struct_c0_is_binary();
+        }
+    }
+    EXPECT_EQ(100, total_row_nums);
+}
+
 TEST_F(FileReaderTest, TestStructSubfieldZonemap) {
     const std::string struct_in_struct_file_path =
             "./be/test/formats/parquet/test_data/test_parquet_struct_in_struct.parquet";

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -4480,7 +4480,8 @@ TEST_F(GroupReaderTest, ReadLazyColumnsSeparatesTriggeredFromUntriggered) {
     // Simulate: lazy_a was triggered during predicate eval → in slot_cache.
     // lazy_b was NOT triggered → not in slot_cache.
     group_reader->_column_materializer->reset_read_chunk();
-    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr,
+                                   active_chunk);
     ASSERT_OK(ctx.materialize_slot(lazy_a_slot->id()));
     EXPECT_NE(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_a_slot->id()));
     EXPECT_EQ(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_b_slot->id()));
@@ -4551,7 +4552,8 @@ TEST_F(GroupReaderTest, ReadLazyColumnsFiltersTriggeredColumnsWithChunkFilter) {
 
     // Trigger lazy_slot so it is in slot_cache with full_range data.
     group_reader->_column_materializer->reset_read_chunk();
-    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr,
+                                   active_chunk);
     ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
 
     // chunk_filter has 1s for all rows (row 0 and 1 survive).
@@ -4910,7 +4912,8 @@ TEST_F(GroupReaderTest, EmitPhysicalColumnsBypassesFillDstForLogicalSlots) {
     group_reader->_column_materializer->reset_read_chunk();
 
     // Compound predicate evaluation triggers on-demand lazy materialization.
-    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr,
+                                   active_chunk);
     ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
     EXPECT_TRUE(mock_lazy_ptr->_finalize_called)
             << "materialize_slot() must call finalize_lazy_state(), converting to LOGICAL";

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -5070,7 +5070,7 @@ TEST_F(GroupReaderTest, LateMaterializeSkipRowsCompoundConjunctFiltersAll) {
 //         scanner_ctxs when slot-by-slot conjuncts are absent.
 TEST_F(GroupReaderTest, EvaluateAllPredicatesWithScannerCtxs) {
     auto* scanner_ctx = _pool.add(new HdfsScannerContext());
-    scanner_ctx->stats = &g_hdfs_stats;
+    scanner_ctx->format_scan_context.stats = &g_hdfs_stats;
 
     // Create a BIGINT chunk with 2 rows: values [0, 1].
     auto chunk = std::make_shared<Chunk>();

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -32,6 +32,8 @@
 #include "formats/parquet/column_materializer.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/complex_column_reader.h"
+#include "formats/parquet/lazy_materialization_context.h"
+#include "formats/parquet/read_range_planner.h"
 #include "formats/parquet/utils.h"
 #include "formats/parquet/variant_projection.h"
 #include "formats/reserved_columns.h"
@@ -236,6 +238,48 @@ public:
 
 private:
     std::vector<SharedBufferedInputStream::IORange> _ranges;
+};
+
+class MockTempColumnReader : public ColumnReader {
+public:
+    explicit MockTempColumnReader() : ColumnReader(nullptr) {}
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter*, ColumnPtr& dst) override {
+        if (_temp_col == nullptr) {
+            _temp_col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        }
+        dst = _temp_col;
+        _temp_col->as_mutable_raw_ptr()->append_datum(Datum(int32_t(42)));
+        return Status::OK();
+    }
+
+    Status finalize_lazy_state(ColumnPtr& col) override {
+        if (col.get() == _temp_col.get()) {
+            _finalize_called = true;
+            size_t n = _temp_col->size();
+            auto dest = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARCHAR), true);
+            dest->append_default(n);
+            _temp_col->as_mutable_raw_ptr()->reset_column();
+            col = std::move(dest);
+        }
+        return Status::OK();
+    }
+
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override {
+        dst = src;
+        return Status::OK();
+    }
+
+    void set_need_parse_levels(bool) override {}
+    void get_levels(level_t**, level_t**, size_t*) override {}
+    void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>*, int64_t*, ColumnIOTypeFlags,
+                                 bool) override {}
+    void select_offset_index(const SparseRange<uint64_t>&, const uint64_t) override {}
+
+    ColumnPtr _temp_col = nullptr;
+    bool _finalize_called = false;
 };
 
 class GroupReaderTest : public ::testing::Test {
@@ -4134,6 +4178,916 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnOverflowBecomesN
     ASSERT_EQ(2, result->size());
     EXPECT_EQ(500, result->get(0).get_int32()); // 5 × 100 = 500
     EXPECT_TRUE(result->is_null(1));            // 21474837 × 100 overflows int32_t → NULL
+}
+
+// ── LazyMaterializationContext tests ─────────────────────────────────────────
+
+// Covers: LazyMaterializationContext::provides MissingColumnProvider
+//         interface for physical lazy slots.
+TEST_F(GroupReaderTest, LazyMaterializationContextCanMaterializeAndProvidePhysicalSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot = _pool.add(
+            new SlotDescriptor(200, "active_col", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(201, "lazy_col", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* unrelated_slot = _pool.add(
+            new SlotDescriptor(202, "other_col", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    // Wire mock readers: active slot has data, lazy slot has mock that records reads.
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    // Verify classification: active_slot in active, lazy_slot in lazy.
+    const auto& lazy_ids = group_reader->_column_materializer->lazy_slot_ids();
+    EXPECT_TRUE(std::find(lazy_ids.begin(), lazy_ids.end(), lazy_slot->id()) != lazy_ids.end());
+
+    // Init read_chunk so materialize_slot has a valid _read_chunk.
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 2);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // can_materialize: true for lazy slot, false for active and unrelated.
+    EXPECT_TRUE(ctx.can_materialize(lazy_slot->id()));
+    EXPECT_FALSE(ctx.can_materialize(active_slot->id()));
+    EXPECT_FALSE(ctx.can_materialize(unrelated_slot->id()));
+
+    // can_provide (MissingColumnProvider interface) mirrors can_materialize.
+    EXPECT_TRUE(ctx.can_provide(lazy_slot->id()));
+    EXPECT_FALSE(ctx.can_provide(unrelated_slot->id()));
+
+    // provide: materializes the lazy slot and returns its column.
+    auto result = ctx.provide(lazy_slot->id());
+    ASSERT_TRUE(result.ok());
+    auto col = result.value();
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(2u, col->size());
+
+    // Second provide is idempotent (slot already cached).
+    auto result2 = ctx.provide(lazy_slot->id());
+    ASSERT_TRUE(result2.ok());
+}
+
+// Covers: LazyMaterializationContext::has_slot for both
+//         slot_cache (physical) and active_chunk paths.
+TEST_F(GroupReaderTest, LazyMaterializationContextHasSlotReturnsTrueForCachedAndActiveChunkSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(210, "ac", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(211, "lz", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 1);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // has_slot: active_chunk has active_slot → true
+    EXPECT_TRUE(ctx.has_slot(active_slot->id()));
+    // has_slot: lazy_slot not in active_chunk or slot_cache → false
+    EXPECT_FALSE(ctx.has_slot(lazy_slot->id()));
+
+    // materialize the lazy slot → populates slot_cache
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_TRUE(ctx.has_slot(lazy_slot->id()));
+}
+
+// Covers: LazyMaterializationContext::materialize_slot dispatches to
+//         ColumnMaterializer for physical lazy slots (variant is nullptr).
+TEST_F(GroupReaderTest, LazyMaterializationContextMaterializeSlotDelegatesToColumnMaterializer) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(220, "aa", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(221, "bb", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 1);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // Trigger set starts empty.
+    EXPECT_EQ(0u, group_reader->_column_materializer->lazy_triggered_count());
+
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_EQ(1u, group_reader->_column_materializer->lazy_triggered_count());
+
+    // Idempotent: second materialize on same slot is a no-op.
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_EQ(1u, group_reader->_column_materializer->lazy_triggered_count());
+}
+
+// Covers: LazyMaterializationContext::get_column returns nullptr for
+//         slots that can't be materialized and returns valid column
+//         after materialize_slot (physical path).
+TEST_F(GroupReaderTest, LazyMaterializationContextGetColumnReturnsNullForUnknownSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(230, "x", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(231, "y", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* unknown_slot =
+            _pool.add(new SlotDescriptor(999, "zz", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 1);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    // Unknown slot → nullptr (not in lazy_slots, can't materialize).
+    EXPECT_EQ(nullptr, ctx.get_column(unknown_slot->id()));
+
+    // get_column materializes on demand and returns result.
+    auto col = ctx.get_column(lazy_slot->id());
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(1u, col->size());
+
+    // Active slot from active_chunk → returns existing column.
+    auto active_col = ctx.get_column(active_slot->id());
+    ASSERT_NE(nullptr, active_col);
+}
+
+// Covers: ColumnMaterializer::read_lazy_columns separates triggered
+//         (in slot_cache) from untriggered lazy columns.
+TEST_F(GroupReaderTest, ReadLazyColumnsSeparatesTriggeredFromUntriggered) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(240, "a", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_a_slot =
+            _pool.add(new SlotDescriptor(241, "la", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_b_slot =
+            _pool.add(new SlotDescriptor(242, "lb", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cla{};
+    cla.slot_desc = lazy_a_slot;
+    GroupReaderParam::Column clb{};
+    clb.slot_desc = lazy_b_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cla);
+    param->read_cols.emplace_back(clb);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_a_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_b_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    const auto& lazy_ids = group_reader->_column_materializer->lazy_slot_ids();
+    EXPECT_EQ(2u, lazy_ids.size());
+
+    // Build active_chunk manually with the active slot pre-filled to 2 rows.
+    size_t num_rows = 2;
+    Range<uint64_t> full_range(0, num_rows);
+    auto active_chunk = std::make_shared<Chunk>();
+    auto active_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    active_col->append_datum(Datum(int64_t(1)));
+    active_col->append_datum(Datum(int64_t(2)));
+    active_chunk->append_column(active_col, active_slot->id());
+
+    // Simulate: lazy_a was triggered during predicate eval → in slot_cache.
+    // lazy_b was NOT triggered → not in slot_cache.
+    group_reader->_column_materializer->reset_read_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    ASSERT_OK(ctx.materialize_slot(lazy_a_slot->id()));
+    EXPECT_NE(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_a_slot->id()));
+    EXPECT_EQ(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_b_slot->id()));
+
+    // read_lazy_columns should:
+    // - Move lazy_a (triggered) from _read_chunk → append → active_chunk
+    // - Read lazy_b (untriggered) via full_range → merge → active_chunk
+    Range<uint64_t> post_filter_range = full_range;
+    Filter empty_filter{};
+    Filter chunk_filter(num_rows, 1);
+    ASSERT_OK(group_reader->_column_materializer->read_lazy_columns(full_range, post_filter_range, empty_filter,
+                                                                    chunk_filter, false, active_chunk));
+
+    // Both lazy columns should now be in active_chunk (3 total: active + lazy_a + lazy_b).
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_a_slot->id()));
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_b_slot->id()));
+    EXPECT_EQ(3u, active_chunk->num_columns());
+}
+
+// Covers: ColumnMaterializer::read_lazy_columns filters triggered columns
+//         with chunk_filter when has_filter is true.
+TEST_F(GroupReaderTest, ReadLazyColumnsFiltersTriggeredColumnsWithChunkFilter) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(250, "act", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(251, "lz", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(10)));
+    bigint_col->append_datum(Datum(int64_t(20)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    size_t num_rows = 2;
+    Range<uint64_t> full_range(0, num_rows);
+
+    // Build active_chunk manually: 2 surviving rows for active_slot.
+    auto active_chunk = std::make_shared<Chunk>();
+    auto active_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    active_col->append_datum(Datum(int64_t(1)));
+    active_col->append_datum(Datum(int64_t(2)));
+    active_chunk->append_column(active_col, active_slot->id());
+
+    // Trigger lazy_slot so it is in slot_cache with full_range data.
+    group_reader->_column_materializer->reset_read_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+
+    // chunk_filter has 1s for all rows (row 0 and 1 survive).
+    Filter chunk_filter(num_rows, 1);
+    Range<uint64_t> post_filter_range = full_range;
+    Filter empty_filter{};
+    ASSERT_OK(group_reader->_column_materializer->read_lazy_columns(full_range, post_filter_range, empty_filter,
+                                                                    chunk_filter, true, active_chunk));
+
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_slot->id()));
+    auto& col = active_chunk->get_column_by_slot_id(lazy_slot->id());
+    EXPECT_EQ(num_rows, col->size());
+}
+
+// Covers: ReadRangePlanner::deduplicate merges duplicate IORanges.
+TEST_F(GroupReaderTest, ReadRangePlannerDeduplicateMergesIdenticalRanges) {
+    using IORange = SharedBufferedInputStream::IORange;
+    std::vector<IORange> ranges;
+    ranges.emplace_back(100, 50, true);
+    ranges.emplace_back(100, 50, false);
+    ranges.emplace_back(200, 30, true);
+    ranges.emplace_back(200, 30, true);
+
+    ReadRangePlanner::deduplicate(&ranges);
+
+    // Two duplicates: (100,50) merged → is_active = true, (200,30) merged → is_active = true.
+    ASSERT_EQ(2u, ranges.size());
+    EXPECT_EQ(100, ranges[0].offset);
+    EXPECT_EQ(50, ranges[0].size);
+    EXPECT_TRUE(ranges[0].is_active);
+    EXPECT_EQ(200, ranges[1].offset);
+    EXPECT_EQ(30, ranges[1].size);
+    EXPECT_TRUE(ranges[1].is_active);
+}
+
+// Covers: ReadRangePlanner::deduplicate sorts by size when offsets are equal.
+TEST_F(GroupReaderTest, ReadRangePlannerDeduplicateSortsBySizeWhenOffsetsEqual) {
+    using IORange = SharedBufferedInputStream::IORange;
+    std::vector<IORange> ranges;
+    // Same offset, different sizes → must be ordered by size.
+    ranges.emplace_back(100, 50, true);
+    ranges.emplace_back(100, 30, true);
+
+    ReadRangePlanner::deduplicate(&ranges);
+
+    ASSERT_EQ(2u, ranges.size());
+    EXPECT_EQ(100, ranges[0].offset);
+    EXPECT_EQ(30, ranges[0].size);
+    EXPECT_EQ(100, ranges[1].offset);
+    EXPECT_EQ(50, ranges[1].size);
+}
+
+// Covers: ReadRangePlanner::should_coalesce_active_lazy returns true
+//         when counter is nullptr (default).
+TEST_F(GroupReaderTest, ReadRangePlannerShouldCoalesceReturnsTrueWhenCounterIsNull) {
+    auto* param = _create_group_reader_param();
+    param->lazy_column_coalesce_counter = nullptr;
+
+    std::unordered_map<int32_t, std::unique_ptr<ColumnReader>> readers;
+    ReadRangePlanner planner(*param, &readers);
+
+    EXPECT_TRUE(planner.should_coalesce_active_lazy());
+}
+
+// Covers: ReadRangePlanner::should_coalesce_active_lazy reads
+//         the adaptive counter.
+TEST_F(GroupReaderTest, ReadRangePlannerShouldCoalesceReadsCounter) {
+    auto* param = _create_group_reader_param();
+    std::atomic<int32_t> counter = -1;
+    param->lazy_column_coalesce_counter = &counter;
+
+    std::unordered_map<int32_t, std::unique_ptr<ColumnReader>> readers;
+    ReadRangePlanner planner(*param, &readers);
+
+    EXPECT_FALSE(planner.should_coalesce_active_lazy());
+
+    counter.store(0, std::memory_order_relaxed);
+    EXPECT_TRUE(planner.should_coalesce_active_lazy());
+}
+
+// ── Temp Column Lifecycle Tests ──────────────────────────────────────────────
+
+// Covers: ColumnMaterializer::materialize_slot finalizes lazy state
+//         before caching, so _slot_cache always holds logical columns.
+TEST_F(GroupReaderTest, MaterializeSlotFinalizesLazyStateBeforeCaching) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(300, "a", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(301, "lz", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto mock_lazy = std::make_unique<MockTempColumnReader>();
+    auto* mock_lazy_ptr = mock_lazy.get();
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::move(mock_lazy));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    Range<uint64_t> range(0, 2);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+
+    EXPECT_TRUE(mock_lazy_ptr->_finalize_called) << "materialize_slot must call finalize_lazy_state before caching";
+
+    const auto* entry = group_reader->_column_materializer->get_slot_cache(lazy_slot->id());
+    ASSERT_NE(nullptr, entry);
+    auto col = entry->values;
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(1u, col->size());
+
+    auto result = ctx.provide(lazy_slot->id());
+    ASSERT_TRUE(result.ok());
+    auto provided = result.value();
+    ASSERT_NE(nullptr, provided);
+    EXPECT_EQ(1u, provided->size());
+    EXPECT_NE(mock_lazy_ptr->_temp_col.get(), provided.get()) << "provide() must return logical column, not raw temp";
+}
+
+// Contract test / mock reproducer: MockTempColumnReader's read_range() is
+// append-only (simulating StoredColumnReader).  Without reset, two consecutive
+// reads WITHOUT an intervening finalize accret stale data — this is the
+// production bug that reset_column() in ScalarColumnReader / LowCardColumnReader /
+// LowRowsColumnReader read_range() fixes.
+//
+// This is a contract test; production reset_column() coverage is indirect
+// (integration tests exercise the real reader path).
+TEST_F(GroupReaderTest, TempColumnAccretesStaleWithoutReset) {
+    MockTempColumnReader reader;
+
+    ColumnPtr col1 = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true);
+    ASSERT_OK(reader.read_range(Range<uint64_t>(0, 1), nullptr, col1));
+    EXPECT_EQ(1u, col1->size()) << "First read: 1 row";
+
+    // Simulate skipped fill: don't call finalize_lazy_state
+
+    ColumnPtr col2 = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true);
+    ASSERT_OK(reader.read_range(Range<uint64_t>(0, 1), nullptr, col2));
+    EXPECT_EQ(2u, col2->size()) << "Without reset, second read accretes stale data: 1 stale + 1 new = 2 rows";
+
+    // finalize_lazy_state produces n logical rows where n = temp size.
+    // With stale accretion: temp has 2 rows, so finalize yields 2 rows.
+    ASSERT_OK(reader.finalize_lazy_state(col2));
+    EXPECT_EQ(2u, col2->size()) << "Stale accretion propagates: 2 logical rows from 2 temp rows";
+    EXPECT_TRUE(reader._finalize_called);
+    EXPECT_EQ(0u, reader._temp_col->size()) << "Temp column is empty after finalize";
+}
+
+// Contract test: finalize_lazy_state resets the temp column so that a
+// subsequent read_range starts fresh — even when the mock itself does
+// not reset before appending.  Verifies the finalize → reset → no-accretion
+// lifecycle contract through the ColumnMaterializer pipeline.
+//
+// Production read_range() reset is exercised by integration tests.
+TEST_F(GroupReaderTest, FinalizeResetsTempPreventingStaleAccretion) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(310, "a", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(311, "lz", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto mock_lazy = std::make_unique<MockTempColumnReader>();
+    auto* mock_lazy_ptr = mock_lazy.get();
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::move(mock_lazy));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    // First materialize: read_range appends 1 row, finalize_lazy_state resets temp.
+    Range<uint64_t> range1(0, 1);
+    auto active_chunk1 = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx1(*group_reader->_column_materializer, nullptr, range1, nullptr, active_chunk1);
+    ASSERT_OK(ctx1.materialize_slot(lazy_slot->id()));
+    EXPECT_TRUE(mock_lazy_ptr->_finalize_called);
+
+    auto* entry1 = group_reader->_column_materializer->get_slot_cache(lazy_slot->id());
+    ASSERT_NE(nullptr, entry1);
+    EXPECT_EQ(1u, entry1->values->size());
+
+    // Reset between iterations.
+    group_reader->_column_materializer->reset_read_chunk();
+    mock_lazy_ptr->_finalize_called = false;
+
+    // Second materialize: because finalize reset _temp_col in range1,
+    // read_range starts fresh → 1 row, not 2.
+    Range<uint64_t> range2(0, 1);
+    auto active_chunk2 = group_reader->_column_materializer->create_active_chunk();
+    LazyMaterializationContext ctx2(*group_reader->_column_materializer, nullptr, range2, nullptr, active_chunk2);
+    ASSERT_OK(ctx2.materialize_slot(lazy_slot->id()));
+
+    auto* entry2 = group_reader->_column_materializer->get_slot_cache(lazy_slot->id());
+    ASSERT_NE(nullptr, entry2);
+    EXPECT_EQ(1u, entry2->values->size()) << "After finalize, temp is empty → no stale accretion across iterations";
+    EXPECT_TRUE(mock_lazy_ptr->_finalize_called);
+}
+
+// ── Logical-column bypass in emit_physical_columns ───────────────────────────
+
+// Mock reader that models LowCardColumnReader's PHYSICAL-vs-LOGICAL identity
+// dispatch in fill_dst_column().  When src is _code_column (PHYSICAL) it
+// decodes; when src is already LOGICAL it swaps directly.
+class MockGlobalDictColumnReader : public ColumnReader {
+public:
+    MockGlobalDictColumnReader() : ColumnReader(nullptr) {}
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter*, ColumnPtr& dst) override {
+        if (_code_column == nullptr) {
+            _code_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        }
+        _code_column->as_mutable_raw_ptr()->reset_column();
+        _code_column->as_mutable_raw_ptr()->append_datum(Datum(int32_t(100)));
+        _code_column->as_mutable_raw_ptr()->append_datum(Datum(int32_t(200)));
+        dst = _code_column;
+        return Status::OK();
+    }
+
+    Status finalize_lazy_state(ColumnPtr& col) override {
+        if (_finalize_called) return Status::OK();
+        if (col.get() == _code_column.get()) {
+            _finalize_called = true;
+            auto logical = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARCHAR), true);
+            logical->as_mutable_raw_ptr()->append_datum(Datum(Slice("hello")));
+            logical->as_mutable_raw_ptr()->append_datum(Datum(Slice("world")));
+            col = std::move(logical);
+        }
+        return Status::OK();
+    }
+
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override {
+        if (src.get() == _code_column.get()) {
+            auto logical = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARCHAR), true);
+            logical->as_mutable_raw_ptr()->append_datum(Datum(Slice("decoded_hello")));
+            logical->as_mutable_raw_ptr()->append_datum(Datum(Slice("decoded_world")));
+            dst->as_mutable_raw_ptr()->swap_column(*logical);
+            return Status::OK();
+        }
+        // src is already LOGICAL — swap directly (pointer identity fallback)
+        dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
+        return Status::OK();
+    }
+
+    void set_need_parse_levels(bool) override {}
+    void get_levels(level_t**, level_t**, size_t*) override {}
+    void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>*, int64_t*, ColumnIOTypeFlags,
+                                 bool) override {}
+    void select_offset_index(const SparseRange<uint64_t>&, const uint64_t) override {}
+
+    ColumnPtr _code_column = nullptr;
+    bool _finalize_called = false;
+};
+
+// Covers: global-dict lazy column triggered by compound predicate must bypass
+//         fill_dst_column() in emit_physical_columns() because
+//         materialize_slot() already finalized it to LOGICAL form.
+TEST_F(GroupReaderTest, EmitPhysicalColumnsBypassesFillDstForLogicalSlots) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* active_slot =
+            _pool.add(new SlotDescriptor(350, "act", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* lazy_slot =
+            _pool.add(new SlotDescriptor(351, "lzc", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = active_slot;
+    GroupReaderParam::Column cl{};
+    cl.slot_desc = lazy_slot;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cl);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, active_slot->id(), 42, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[active_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto bigint_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    bigint_col->append_datum(Datum(int64_t(42)));
+    bigint_col->append_datum(Datum(int64_t(99)));
+    auto mock_lazy = std::make_unique<MockGlobalDictColumnReader>();
+    auto* mock_lazy_ptr = mock_lazy.get();
+    group_reader->_column_readers.emplace(active_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(bigint_col));
+    group_reader->_column_readers.emplace(lazy_slot->id(), std::move(mock_lazy));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    ASSERT_TRUE(group_reader->_column_materializer->lazy_column_indices().size() > 0);
+
+    size_t num_rows = 2;
+    Range<uint64_t> full_range(0, num_rows);
+    auto active_chunk = std::make_shared<Chunk>();
+    auto active_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    active_col->append_datum(Datum(int64_t(1)));
+    active_col->append_datum(Datum(int64_t(2)));
+    active_chunk->append_column(active_col, active_slot->id());
+
+    group_reader->_column_materializer->reset_read_chunk();
+
+    // Compound predicate evaluation triggers on-demand lazy materialization.
+    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
+    EXPECT_TRUE(mock_lazy_ptr->_finalize_called)
+            << "materialize_slot() must call finalize_lazy_state(), converting to LOGICAL";
+    EXPECT_NE(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_slot->id()));
+
+    // read_lazy_columns: triggered lazy column must be in active_chunk AND
+    // recorded in _logical_slot_ids so emit_physical_columns can bypass fill_dst_column.
+    Range<uint64_t> post_filter_range = full_range;
+    Filter empty_filter{};
+    Filter chunk_filter(num_rows, 1);
+    ASSERT_OK(group_reader->_column_materializer->read_lazy_columns(full_range, post_filter_range, empty_filter,
+                                                                    chunk_filter, false, active_chunk));
+    EXPECT_TRUE(active_chunk->is_slot_exist(lazy_slot->id()));
+
+    // Build a destination chunk with the output schema.
+    std::vector<SlotDescriptor*> dst_slots{active_slot, lazy_slot};
+    auto dst_chunk = std::make_shared<Chunk>();
+    for (auto* s : dst_slots) {
+        auto col = ColumnHelper::create_column(s->type(), true);
+        dst_chunk->append_column(col, s->id());
+    }
+
+    // The key assertion: before the fix this would fail with InternalError
+    // because fill_dst_column() rejected the already-logical lazy column.
+    ASSERT_OK(group_reader->_column_materializer->emit_physical_columns(active_chunk, &dst_chunk));
+
+    EXPECT_TRUE(dst_chunk->is_slot_exist(lazy_slot->id()));
+    auto& dst_col = dst_chunk->get_column_by_slot_id(lazy_slot->id());
+    EXPECT_EQ(2u, dst_col->size()) << "LOGICAL lazy column must be emitted with correct row count";
+}
+
+// Covers: active global-dict columns finalized by compound conjunct path
+//         must be marked as logical so emit_physical_columns() bypasses
+//         fill_dst_column().  Without the mark, LowCardColumnReader rejects
+//         an already-finalized logical column in fill_dst_column().
+TEST_F(GroupReaderTest, ActiveGlobalDictEmitBypassesFillDstAfterCompoundFinalize) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    // Two active low-card-like slots, each with a single-slot conjunct.
+    auto* slot_a =
+            _pool.add(new SlotDescriptor(360, "dict_a", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+    auto* slot_b =
+            _pool.add(new SlotDescriptor(361, "dict_b", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+
+    GroupReaderParam::Column ca{};
+    ca.slot_desc = slot_a;
+    GroupReaderParam::Column cb{};
+    cb.slot_desc = slot_b;
+    param->read_cols.emplace_back(ca);
+    param->read_cols.emplace_back(cb);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> ctx_a, ctx_b;
+    ASSERT_OK(create_varchar_eq_conjunct_ctxs(&_pool, &runtime_state, slot_a->id(), "x", &ctx_a));
+    ASSERT_OK(create_varchar_eq_conjunct_ctxs(&_pool, &runtime_state, slot_b->id(), "y", &ctx_b));
+    param->conjunct_ctxs_by_slot[slot_a->id()] = ctx_a;
+    param->conjunct_ctxs_by_slot[slot_b->id()] = ctx_b;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto mock_a = std::make_unique<MockGlobalDictColumnReader>();
+    auto mock_b = std::make_unique<MockGlobalDictColumnReader>();
+    auto* mock_a_ptr = mock_a.get();
+    auto* mock_b_ptr = mock_b.get();
+    group_reader->_column_readers.emplace(slot_a->id(), std::move(mock_a));
+    group_reader->_column_readers.emplace(slot_b->id(), std::move(mock_b));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_OK(group_reader->_column_materializer->init_read_chunk());
+
+    ASSERT_TRUE(group_reader->_column_materializer->active_slot_ids().size() > 0);
+
+    size_t num_rows = 2;
+    Range<uint64_t> full_range(0, num_rows);
+    auto active_chunk = group_reader->_column_materializer->create_active_chunk();
+
+    group_reader->_column_materializer->reset_read_chunk();
+
+    // Simulate step 2a: read active columns → PHYSICAL (dict codes).
+    Filter filter(num_rows, 1);
+    ASSERT_OK(group_reader->_column_materializer->read_active_range(full_range, &filter, &active_chunk));
+
+    // Simulate step 2b compound-conjunct prep: finalize all active columns
+    // to LOGICAL.  fill_dst_column() handles already-logical columns via
+    // pointer identity fallback (swap), so no _logical_slot_ids mark needed.
+    for (int col_idx : group_reader->_column_materializer->active_column_indices()) {
+        SlotId slot_id = param->read_cols[col_idx].slot_id();
+        ASSERT_OK(group_reader->_column_materializer->finalize_active_slot(slot_id, active_chunk));
+    }
+    EXPECT_TRUE(mock_a_ptr->_finalize_called);
+    EXPECT_TRUE(mock_b_ptr->_finalize_called);
+
+    // Build output chunk and emit.  Before the fix, emit_physical_columns
+    // would call fill_dst_column() on the already-logical global-dict columns
+    // and fail with "not a dictionary code column".
+    std::vector<SlotDescriptor*> dst_slots{slot_a, slot_b};
+    auto dst_chunk = std::make_shared<Chunk>();
+    for (auto* s : dst_slots) {
+        auto col = ColumnHelper::create_column(s->type(), true);
+        dst_chunk->append_column(col, s->id());
+    }
+
+    ASSERT_OK(group_reader->_column_materializer->emit_physical_columns(active_chunk, &dst_chunk));
+
+    for (auto* s : dst_slots) {
+        EXPECT_TRUE(dst_chunk->is_slot_exist(s->id()));
+        EXPECT_EQ(2u, dst_chunk->get_column_by_slot_id(s->id())->size());
+    }
+}
+
+// Covers: GroupReader::get_next Phase 2b late_materialize_skip_rows
+//         when compound (scanner_ctxs) conjuncts filter all rows.
+TEST_F(GroupReaderTest, LateMaterializeSkipRowsCompoundConjunctFiltersAll) {
+    auto* file = _create_file();
+    auto* param = _create_group_reader_param();
+    param->chunk_size = config::vector_chunk_size;
+    param->file = file;
+
+    // Scanner conjunct on col0: INT32 = 999999 → all rows filtered.
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> scanner_ctxs;
+    ASSERT_OK(create_int_eq_conjunct_ctxs(&_pool, &runtime_state, param->read_cols[0].slot_id(), 999999,
+                                          &scanner_ctxs));
+    param->scanner_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSERT_OK(group_reader->init());
+    group_reader->prepare();
+    replace_column_readers(group_reader, param);
+    group_reader->_column_materializer->mutable_read_chunk() = _create_chunk(param);
+    prepare_row_range(group_reader);
+
+    auto chunk = _create_chunk(param);
+    size_t row_count = 8;
+    auto status = group_reader->get_next(&chunk, &row_count);
+    // All rows filtered by scanner_ctxs → get_next consumes all ranges and returns EOF.
+    ASSERT_TRUE(status.is_end_of_file());
+    // Skip count = first range (8) + second range (4).
+    EXPECT_EQ(12, param->stats->late_materialize_skip_rows);
+}
+
+// Covers: HdfsScannerContext::evaluate_all_predicates evaluates
+//         scanner_ctxs when slot-by-slot conjuncts are absent.
+TEST_F(GroupReaderTest, EvaluateAllPredicatesWithScannerCtxs) {
+    auto* scanner_ctx = _pool.add(new HdfsScannerContext());
+    scanner_ctx->stats = &g_hdfs_stats;
+
+    // Create a BIGINT chunk with 2 rows: values [0, 1].
+    auto chunk = std::make_shared<Chunk>();
+    auto col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+    col->append_datum(Datum(int64_t(0)));
+    col->append_datum(Datum(int64_t(1)));
+    SlotId slot_id = 600;
+    chunk->append_column(col, slot_id);
+
+    // Scanner conjunct: col = 0 → filters row 1, keeps row 0.
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> scanner_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, slot_id, 0, &scanner_ctxs));
+    scanner_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
+
+    ASSERT_OK(scanner_ctx->evaluate_all_predicates(&chunk));
+    EXPECT_EQ(1u, chunk->num_rows());
+    EXPECT_EQ(0, chunk->get_column_by_slot_id(slot_id)->get(0).get_int64());
+
+    ExprExecutor::close(scanner_ctxs, &runtime_state);
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -5037,8 +5037,8 @@ TEST_F(GroupReaderTest, LateMaterializeSkipRowsCompoundConjunctFiltersAll) {
     // Scanner conjunct on col0: INT32 = 999999 → all rows filtered.
     RuntimeState runtime_state{TQueryGlobals()};
     std::vector<ExprContext*> scanner_ctxs;
-    ASSERT_OK(create_int_eq_conjunct_ctxs(&_pool, &runtime_state, param->read_cols[0].slot_id(), 999999,
-                                          &scanner_ctxs));
+    ASSERT_OK(
+            create_int_eq_conjunct_ctxs(&_pool, &runtime_state, param->read_cols[0].slot_id(), 999999, &scanner_ctxs));
     param->scanner_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
 
     FileMetaData* file_meta;

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -4232,7 +4232,7 @@ TEST_F(GroupReaderTest, LazyMaterializationContextCanMaterializeAndProvidePhysic
 
     Range<uint64_t> range(0, 2);
     auto active_chunk = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, range, nullptr, active_chunk);
 
     // can_materialize: true for lazy slot, false for active and unrelated.
     EXPECT_TRUE(ctx.can_materialize(lazy_slot->id()));
@@ -4295,7 +4295,7 @@ TEST_F(GroupReaderTest, LazyMaterializationContextHasSlotReturnsTrueForCachedAnd
 
     Range<uint64_t> range(0, 1);
     auto active_chunk = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, range, nullptr, active_chunk);
 
     // has_slot: active_chunk has active_slot → true
     EXPECT_TRUE(ctx.has_slot(active_slot->id()));
@@ -4347,7 +4347,7 @@ TEST_F(GroupReaderTest, LazyMaterializationContextMaterializeSlotDelegatesToColu
 
     Range<uint64_t> range(0, 1);
     auto active_chunk = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, range, nullptr, active_chunk);
 
     // Trigger set starts empty.
     EXPECT_EQ(0u, group_reader->_column_materializer->lazy_triggered_count());
@@ -4403,7 +4403,7 @@ TEST_F(GroupReaderTest, LazyMaterializationContextGetColumnReturnsNullForUnknown
 
     Range<uint64_t> range(0, 1);
     auto active_chunk = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, range, nullptr, active_chunk);
 
     // Unknown slot → nullptr (not in lazy_slots, can't materialize).
     EXPECT_EQ(nullptr, ctx.get_column(unknown_slot->id()));
@@ -4480,7 +4480,7 @@ TEST_F(GroupReaderTest, ReadLazyColumnsSeparatesTriggeredFromUntriggered) {
     // Simulate: lazy_a was triggered during predicate eval → in slot_cache.
     // lazy_b was NOT triggered → not in slot_cache.
     group_reader->_column_materializer->reset_read_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr, active_chunk);
     ASSERT_OK(ctx.materialize_slot(lazy_a_slot->id()));
     EXPECT_NE(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_a_slot->id()));
     EXPECT_EQ(nullptr, group_reader->_column_materializer->get_slot_cache(lazy_b_slot->id()));
@@ -4551,7 +4551,7 @@ TEST_F(GroupReaderTest, ReadLazyColumnsFiltersTriggeredColumnsWithChunkFilter) {
 
     // Trigger lazy_slot so it is in slot_cache with full_range data.
     group_reader->_column_materializer->reset_read_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr, active_chunk);
     ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
 
     // chunk_filter has 1s for all rows (row 0 and 1 survive).
@@ -4677,7 +4677,7 @@ TEST_F(GroupReaderTest, MaterializeSlotFinalizesLazyStateBeforeCaching) {
 
     Range<uint64_t> range(0, 2);
     auto active_chunk = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, range, nullptr, active_chunk);
 
     ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
 
@@ -4774,7 +4774,7 @@ TEST_F(GroupReaderTest, FinalizeResetsTempPreventingStaleAccretion) {
     // First materialize: read_range appends 1 row, finalize_lazy_state resets temp.
     Range<uint64_t> range1(0, 1);
     auto active_chunk1 = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx1(*group_reader->_column_materializer, nullptr, range1, nullptr, active_chunk1);
+    LazyMaterializationContext ctx1(group_reader->_column_materializer.get(), nullptr, range1, nullptr, active_chunk1);
     ASSERT_OK(ctx1.materialize_slot(lazy_slot->id()));
     EXPECT_TRUE(mock_lazy_ptr->_finalize_called);
 
@@ -4790,7 +4790,7 @@ TEST_F(GroupReaderTest, FinalizeResetsTempPreventingStaleAccretion) {
     // read_range starts fresh → 1 row, not 2.
     Range<uint64_t> range2(0, 1);
     auto active_chunk2 = group_reader->_column_materializer->create_active_chunk();
-    LazyMaterializationContext ctx2(*group_reader->_column_materializer, nullptr, range2, nullptr, active_chunk2);
+    LazyMaterializationContext ctx2(group_reader->_column_materializer.get(), nullptr, range2, nullptr, active_chunk2);
     ASSERT_OK(ctx2.materialize_slot(lazy_slot->id()));
 
     auto* entry2 = group_reader->_column_materializer->get_slot_cache(lazy_slot->id());
@@ -4910,7 +4910,7 @@ TEST_F(GroupReaderTest, EmitPhysicalColumnsBypassesFillDstForLogicalSlots) {
     group_reader->_column_materializer->reset_read_chunk();
 
     // Compound predicate evaluation triggers on-demand lazy materialization.
-    LazyMaterializationContext ctx(*group_reader->_column_materializer, nullptr, full_range, nullptr, active_chunk);
+    LazyMaterializationContext ctx(group_reader->_column_materializer.get(), nullptr, full_range, nullptr, active_chunk);
     ASSERT_OK(ctx.materialize_slot(lazy_slot->id()));
     EXPECT_TRUE(mock_lazy_ptr->_finalize_called)
             << "materialize_slot() must call finalize_lazy_state(), converting to LOGICAL";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -4720,6 +4720,7 @@ public class PlanFragmentBuilder {
                     slotDescriptor.setColumn(columnRefOperatorColumnMap.get(columnRefOperator));
                     slotDescriptor.setIsMaterialized(true);
                     slotDescriptor.setIsNullable(columnRefOperator.isNullable());
+                    slotDescriptor.setIsOutputColumn(true);
                     context.getColRefToExpr().put(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDescriptor));
                 }
 
@@ -4730,6 +4731,7 @@ public class PlanFragmentBuilder {
                     slotDescriptor.setColumn(columnRefOperatorColumnMap.get(columnRefOperator));
                     slotDescriptor.setIsMaterialized(true);
                     slotDescriptor.setIsNullable(columnRefOperator.isNullable());
+                    slotDescriptor.setIsOutputColumn(true);
                     context.getColRefToExpr().put(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDescriptor));
                 }
                 List<ColumnRefOperator> fetchRefColumns = rowIdToFetchRefColumns.get(entry.getKey());

--- a/test/sql/test_iceberg/R/test_parquet_lazy_materialization
+++ b/test/sql/test_iceberg/R/test_parquet_lazy_materialization
@@ -1,0 +1,174 @@
+-- name: test_parquet_lazy_materialization
+create external catalog iceberg_lazy_test_${uuid0}
+PROPERTIES (
+    "type"="iceberg",
+    "iceberg.catalog.type"="hadoop",
+    "iceberg.catalog.warehouse"="oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/warehouse/"
+);
+-- result:
+-- !result
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/warehouse/zya > /dev/null
+-- result:
+0
+
+-- !result
+use iceberg_lazy_test_${uuid0}.zya;
+-- result:
+-- !result
+CREATE TABLE test_shredding (
+    data VARIANT,
+    id BIGINT,
+    age INT,
+    city VARCHAR
+) properties(
+  'format-version' = '3',
+  'iceberg.enableVariantShredding' = 'true'
+);
+-- result:
+-- !result
+shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_shredding.parquet oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/shredding.parquet > /dev/null
+-- result:
+0
+
+-- !result
+alter table test_shredding execute add_files(location='oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/shredding.parquet', file_format='parquet');
+-- result:
+-- !result
+CREATE TABLE test_noshredding (
+    data VARIANT,
+    id BIGINT,
+    age INT,
+    city VARCHAR
+) properties(
+  'format-version' = '3'
+);
+-- result:
+-- !result
+shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_noshredding.parquet oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/noshredding.parquet > /dev/null
+-- result:
+0
+
+-- !result
+alter table test_noshredding execute add_files(location='oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/noshredding.parquet', file_format='parquet');
+-- result:
+-- !result
+SELECT get_variant_int(data, '$.id') as vid
+FROM test_shredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+-- result:
+1001
+1002
+1003
+1004
+-- !result
+SELECT get_variant_int(data, '$.id') as vid,
+       get_variant_int(data, '$.age') as vage
+FROM test_shredding
+WHERE get_variant_int(data, '$.age') BETWEEN 20 AND 25
+ORDER BY vid;
+-- result:
+1000	20
+1001	21
+1002	22
+1003	23
+1004	24
+-- !result
+SELECT city,
+       get_variant_int(data, '$.profile.metrics.views') as views
+FROM test_shredding
+WHERE city IN ('city_1', 'city_2', 'city_3')
+  AND get_variant_int(data, '$.profile.metrics.views') > 100
+ORDER BY city;
+-- result:
+city_1	110
+city_2	120
+city_3	130
+-- !result
+SELECT get_variant_int(data, '$.id') as vid,
+       cast(variant_query(data, '$.score') as int) as score
+FROM test_shredding
+WHERE get_variant_int(data, '$.score') IS NOT NULL
+ORDER BY vid;
+-- result:
+1000	80
+1002	82
+1004	84
+-- !result
+SELECT get_variant_int(data, '$.id') as vid,
+       get_variant_string(data, '$.name') as vname,
+       get_variant_string(data, '$.email') as vemail
+FROM test_shredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+-- result:
+1001	name_1	user1@example.com
+1002	name_2	user2@example.com
+1003	name_3	user3@example.com
+1004	name_4	user4@example.com
+-- !result
+SELECT get_variant_int(data, '$.id') as vid,
+       get_variant_string(data, '$.events[0].type') as event_type,
+       get_variant_int(data, '$.groups[0].scores[0]') as group_score
+FROM test_shredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+-- result:
+1001	view	11
+1002	view	12
+1003	view	13
+1004	view	14
+-- !result
+set enable_profile=true;
+-- result:
+-- !result
+set enable_async_profile=false;
+-- result:
+-- !result
+SELECT id, age
+FROM test_shredding
+WHERE id > 1000 AND id > age
+ORDER BY id;
+-- result:
+1001	21
+1002	22
+1003	23
+1004	24
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%ParquetLazySlotTriggered%';
+-- result:
+               - ParquetLazySlotTriggered: 1
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%ParquetLazyReadCount%';
+-- result:
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%ParquetLazyReadTime%';
+-- result:
+-- !result
+SELECT get_variant_int(data, '$.id') as vid
+FROM test_noshredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+-- result:
+1001
+1002
+1003
+1004
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/ > /dev/null
+-- result:
+0
+
+-- !result
+drop table test_shredding force;
+-- result:
+-- !result
+drop table test_noshredding force;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_lazy_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_parquet_lazy_materialization
+++ b/test/sql/test_iceberg/T/test_parquet_lazy_materialization
@@ -1,0 +1,137 @@
+-- name: test_parquet_lazy_materialization
+
+create external catalog iceberg_lazy_test_${uuid0}
+PROPERTIES (
+    "type"="iceberg",
+    "iceberg.catalog.type"="hadoop",
+    "iceberg.catalog.warehouse"="oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/warehouse/"
+);
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/warehouse/zya > /dev/null
+
+use iceberg_lazy_test_${uuid0}.zya;
+
+-- ============================================================
+-- Setup: shredded variant table (typed shredded fields)
+-- ============================================================
+CREATE TABLE test_shredding (
+    data VARIANT,
+    id BIGINT,
+    age INT,
+    city VARCHAR
+) properties(
+  'format-version' = '3',
+  'iceberg.enableVariantShredding' = 'true'
+);
+
+shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_shredding.parquet oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/shredding.parquet > /dev/null
+alter table test_shredding execute add_files(location='oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/shredding.parquet', file_format='parquet');
+
+-- ============================================================
+-- Setup: no-shredding variant table (fallback path)
+-- ============================================================
+CREATE TABLE test_noshredding (
+    data VARIANT,
+    id BIGINT,
+    age INT,
+    city VARCHAR
+) properties(
+  'format-version' = '3'
+);
+
+shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_noshredding.parquet oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/noshredding.parquet > /dev/null
+alter table test_noshredding execute add_files(location='oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/data/noshredding.parquet', file_format='parquet');
+
+-- ============================================================
+-- Test 1: Simple predicate on variant virtual column triggers lazy load.
+-- $.id is a shredded typed field; predicate triggers materialization.
+-- ============================================================
+SELECT get_variant_int(data, '$.id') as vid
+FROM test_shredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+
+-- ============================================================
+-- Test 2: BETWEEN predicate on variant field.
+-- ============================================================
+SELECT get_variant_int(data, '$.id') as vid,
+       get_variant_int(data, '$.age') as vage
+FROM test_shredding
+WHERE get_variant_int(data, '$.age') BETWEEN 20 AND 25
+ORDER BY vid;
+
+-- ============================================================
+-- Test 3: Compound predicate with physical column + nested variant field.
+-- city = physical (active), $.profile.metrics.views = variant virtual (lazy).
+-- Two-column predicate triggers scanner_ctxs evaluation (Phase 2b).
+-- ============================================================
+SELECT city,
+       get_variant_int(data, '$.profile.metrics.views') as views
+FROM test_shredding
+WHERE city IN ('city_1', 'city_2', 'city_3')
+  AND get_variant_int(data, '$.profile.metrics.views') > 100
+ORDER BY city;
+
+-- ============================================================
+-- Test 4: IS NOT NULL on variant field.
+-- Some rows have NULL for $.score (shredded as a separate typed column).
+-- ============================================================
+SELECT get_variant_int(data, '$.id') as vid,
+       cast(variant_query(data, '$.score') as int) as score
+FROM test_shredding
+WHERE get_variant_int(data, '$.score') IS NOT NULL
+ORDER BY vid;
+
+-- ============================================================
+-- Test 5: Multiple lazy variant fields in SELECT, predicate only on one.
+-- $.name and $.email stay lazy until backfill phase; $.id triggered by predicate.
+-- ============================================================
+SELECT get_variant_int(data, '$.id') as vid,
+       get_variant_string(data, '$.name') as vname,
+       get_variant_string(data, '$.email') as vemail
+FROM test_shredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+
+-- ============================================================
+-- Test 6: Nested array/struct projection through variant.
+-- $.events[0].type and $.groups[0].scores[0] are shredded subfields.
+-- ============================================================
+SELECT get_variant_int(data, '$.id') as vid,
+       get_variant_string(data, '$.events[0].type') as event_type,
+       get_variant_int(data, '$.groups[0].scores[0]') as group_score
+FROM test_shredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+
+-- ============================================================
+-- Test 7: Profile verification — lazy materialization metrics.
+-- Single-column predicate on 'id' makes id active.  The compound
+-- conjunct 'id > age' goes to scanner_ctxs.  ColumnRef for 'age'
+-- triggers on-demand lazy load → ParquetLazySlotTriggered > 0.
+-- ============================================================
+set enable_profile=true;
+set enable_async_profile=false;
+SELECT id, age
+FROM test_shredding
+WHERE id > 1000 AND id > age
+ORDER BY id;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%ParquetLazySlotTriggered%';
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%ParquetLazyReadCount%';
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%ParquetLazyReadTime%';
+
+-- ============================================================
+-- Test 8: No-shredding variant — same predicate triggers lazy load
+-- through the fallback (non-shredded) path.
+-- ============================================================
+SELECT get_variant_int(data, '$.id') as vid
+FROM test_noshredding
+WHERE get_variant_int(data, '$.id') > 1000
+ORDER BY vid;
+
+-- Cleanup
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_lazy_materialization/${uuid0}/ > /dev/null
+drop table test_shredding force;
+drop table test_noshredding force;
+set catalog default_catalog;
+drop catalog iceberg_lazy_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

For multi-branch OR queries with `count(*)`, StarRocks reads far more IO than Trino:

```sql
SELECT count(*) FROM iceberg.zya.lineitem_latemat WHERE
   (l_shipdate BETWEEN '1998-01-01' AND '1998-01-31' AND (l_discount       > 0.09                 OR l_tax             > 0.07))
OR (l_shipdate BETWEEN '1997-11-01' AND '1997-11-30' AND (l_quantity       < 10                   OR l_extendedprice   > 90000))
OR (l_shipdate BETWEEN '1997-09-01' AND '1997-09-30' AND (l_returnflag     = 'R'                  OR l_linestatus      = 'O'))
OR (l_shipdate BETWEEN '1997-07-01' AND '1997-07-31' AND (l_shipmode       = 'AIR'                OR l_comment         LIKE '%URGENT%'))
OR (l_shipdate BETWEEN '1997-05-01' AND '1997-05-31' AND (l_shipinstruct   = 'DELIVER IN PERSON'  OR l_partkey         < 50000))
OR (l_shipdate BETWEEN '1997-03-01' AND '1997-03-31' AND (l_commitdate     > '1998-06-01'         OR l_receiptdate     > '1998-06-01'))
OR (l_shipdate BETWEEN '1997-01-01' AND '1997-01-31' AND (l_discount       < 0.02                 OR l_extendedprice   < 5000))
OR (l_shipdate BETWEEN '1996-11-01' AND '1996-11-30' AND (l_quantity       > 45                   OR l_suppkey         < 10000))
OR (l_shipdate BETWEEN '1996-09-01' AND '1996-09-30' AND (l_shipmode       = 'SHIP'               OR l_linestatus      = 'F'))
OR (l_shipdate BETWEEN '1996-07-01' AND '1996-07-31' AND (l_tax            < 0.01                 OR l_comment         LIKE '%SPECIAL%'));


CREATE TABLE iceberg.zya.lineitem_latemat
(
    l_orderkey      BIGINT,
    l_partkey       BIGINT,
    l_suppkey       BIGINT,
    l_linenumber    INT,
    l_quantity      DECIMAL(15,2),
    l_extendedprice DECIMAL(15,2),
    l_discount      DECIMAL(15,2),
    l_tax           DECIMAL(15,2),
    l_returnflag    STRING,
    l_linestatus    STRING,
    l_shipdate      DATE,
    l_commitdate    DATE,
    l_receiptdate   DATE,
    l_shipinstruct  STRING,
    l_shipmode      STRING,
    l_comment       STRING
)
USING iceberg
PARTITIONED BY (bucket(128, l_orderkey))
TBLPROPERTIES (
      'format-version' = '3',
    'write.parquet.compression-codec' = 'zstd',
    'write.target-file-size-bytes' = '134217728'
);

INSERT INTO iceberg.zya.lineitem_latemat
SELECT
    l_orderkey, l_partkey, l_suppkey, l_linenumber,
    l_quantity, l_extendedprice, l_discount, l_tax,
    l_returnflag, l_linestatus,
    l_shipdate, l_commitdate, l_receiptdate,
    l_shipinstruct, l_shipmode, l_comment
FROM iceberg.zz_iceberg_tpch_sf1000_iceberg_parquet_lz4.lineitem;

```

| Engine | BAD 10br narrow ScanBytes |
|--------|--------------------------|
| StarRocks (baseline) | 149.1 GB |
| Trino | 89.4 GB |
| StarRocks (this PR) | **78.1 GB** |

The root cause: compound conjuncts are evaluated at the scanner level **after** all lazy columns have been backfilled, so expression short-circuit never prevents IO. And predicate-only columns are forced into the output chunk schema, so `read_lazy_columns()` must backfill them regardless of whether expression evaluation ever reached them.

## What I'm doing:

Two changes:

### 1. Evaluate compound conjuncts inside GroupReader

Previously `scanner_ctxs` (multi-slot OR expressions) were evaluated at the scanner level after `GroupReader::get_next()` returned a fully-materialized chunk. Now they are evaluated inside `get_next()` while `LazyMaterializationContext` is still attached as `MissingColumnProvider`.

This allows `ColumnRef` to trigger `materialize_slot()` on-demand when the expression evaluator reaches a branch whose date-guard matches the current batch. Branches whose date-guard is all-false are short-circuited at the AND level — their payload columns are never loaded.

```
GroupReader::get_next():
  1. read active columns (l_shipdate)
  2. evaluate per-slot conjuncts (guard predicate) → filter
  2b. [NEW] evaluate scanner_ctxs (compound OR) with lazy_ctx attached
      → ColumnRef triggers materialize_slot() only for reached branches
  3. read_lazy_columns: backfill output columns, null-fill predicate-only columns
```

### 2. Skip physical IO for predicate-only untriggered columns

FE already distinguishes output columns from predicate columns via the `isOutputColumn` flag. In `read_lazy_columns()`, predicate-only columns that were never triggered during expression evaluation are null-filled instead of read from disk — they cost zero IO and their values are never accessed by downstream operators.

For `count(*)`, all lazy columns are predicate-only, so only the 1-2 branches per batch that are actually reached incur physical IO.

### 3. Separate active/lazy IO ranges when lazy loading is active

`SharedBufferedInputStream` supports two modes: merged (active+lazy ranges coalesced into one buffer) and separated (independent buffers). In merged mode, reading the active column would fetch the entire merged range — including all lazy column data — defeating the physical IO savings. This PR forces separated mode when `parquet_late_materialization_enable` is on and lazy columns exist, so that untriggered lazy columns' data is never physically fetched.

## Compromise

Predicate-only untriggered columns are null-filled rather than removed from the output chunk. The output chunk schema (`_tuple_desc`) includes all referenced columns, and `reorder_chunk()` downstream requires all slots to exist. The null-fill costs trivial memory but zero IO.

A follow-up PR will introduce an `output_tuple_desc` (filtered to `is_output_column()` slots) for output chunk creation, eliminating the null-fill entirely.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] No, this PR will not result in a change in behavior. Produces identical results; IO reduction only.
- [ ] Yes, this PR will result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5