### PR TITLE
[BugFix] Keep segment-iterator vector positionally aligned in lake PK index rebuild

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -480,8 +480,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         RETURN_IF_ERROR(load_segments(&segments, false));
     }
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
-    std::vector<ChunkIteratorPtr> seg_iterators;
-    seg_iterators.reserve(segments.size());
+    // Size the result up front so each iterator is written to its segment's position. The returned
+    // vector must stay positionally aligned with `segments`: callers index it by segment position to
+    // derive the rssid (rowset id + segment idx), skip null entries, and assert the size equals the
+    // segment count. A segment that produces no iterator (e.g. fully pruned by zonemap predicate
+    // filtering) is left as the default null, never compacting away its slot.
+    std::vector<ChunkIteratorPtr> seg_iterators(segments.size());
     SegmentReadOptions seg_options;
     ASSIGN_OR_RETURN(seg_options.fs, FileSystemFactory::CreateSharedFromString(root_loc));
     seg_options.stats = stats;
@@ -518,12 +522,13 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
+            // Leave seg_iterators[i] as the default null placeholder, preserving alignment.
             continue;
         }
         if (!res.ok()) {
             return res.status();
         }
-        seg_iterators.push_back(std::move(res).value());
+        seg_iterators[i] = std::move(res).value();
     }
     return seg_iterators;
 }


### PR DESCRIPTION
## Why I'm doing:

`Rowset::get_each_segment_iterator_with_delvec` is used to rebuild the lake primary-key
persistent index. Both of its callers — the serial rebuild in `LakePrimaryIndex::load_from_lake_tablet`
and the parallel rebuild scan planner (`build_one_rowset_scan` / `build_rebuild_scan_units`) — treat the
returned iterator vector as **positionally aligned with the rowset's segments**:

- they derive each row's `rssid` as `rowset->id() + get_segment_idx(metadata, i)` where `i` is the index
  into the returned vector;
- they skip `nullptr` entries (`if (itr == nullptr) continue;`);
- they assert `itrs.size() == rowset->num_segments()`.

But the function did `continue` (compacting the vector) when a segment's `new_iterator` returned
`EndOfFile`. If that ever fired for a non-last segment, every later segment would shift one position,
so `get_segment_idx` would compute the **wrong rssid** for those segments' rows, or — more likely — the
`itrs.size() == num_segments` assertion would fail (returns error on the serial path, `CHECK`-crash on
the parallel path).

This is currently **latent**: the rebuild path sets no predicates, and the only `EndOfFile` source in
`Segment::_new_iterator` is zonemap predicate pruning, which therefore never fires here. A fully-deleted
segment (`num_rows == num_dels`) does **not** return `EndOfFile` from `new_iterator`; it returns a valid
iterator that yields EOF at `get_next` time, which is handled correctly and does not shift positions. The
fix hardens the function so it cannot silently corrupt the derived rssid if that invariant ever changes.

## What I'm doing:

In `get_each_segment_iterator_with_delvec`, push a `nullptr` placeholder on `EndOfFile` instead of
`continue`, keeping the returned vector positionally aligned with `segments`. This matches the callers'
existing null-handling contract and the `size == num_segments` assertion.

Scope notes:
- The general scan path `get_segment_iterator` (which unions non-overlapped iterators) is intentionally
  left unchanged — it has no positional `base + i` dependency, so compacting is correct there.
- The non-delvec `get_each_segment_iterator` documents the same `base + i` dependency, but its
  `DCHECK(seg_options.pred_tree_for_zone_map.empty())` makes the `EndOfFile` branch unreachable, so its
  `continue` is dead-defensive and is left as-is.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
