### PR TITLE
[Enhancement] Make materialized_views.LAST_REFRESH_DURATION wall-clock

### DIFF
--- a/docs/en/sql-reference/information_schema/materialized_views.md
+++ b/docs/en/sql-reference/information_schema/materialized_views.md
@@ -22,7 +22,7 @@ The following fields are provided in `materialized_views`:
 | TASK_NAME                            | Name of the task responsible for refreshing the materialized view. |
 | LAST_REFRESH_START_TIME              | Start time of the most recent refresh task.                  |
 | LAST_REFRESH_FINISHED_TIME           | End time of the most recent refresh task.                    |
-| LAST_REFRESH_DURATION                | Duration of the most recent refresh task.                    |
+| LAST_REFRESH_DURATION                | Wall-clock duration of the most recent refresh, in seconds (the last task run's finish time minus the first task run's process-start time). Matches `materialized_view_refresh_jobs.DURATION_TIME` for that job. |
 | LAST_REFRESH_STATE                   | State of the most recent refresh task.                       |
 | LAST_REFRESH_FORCE_REFRESH           | Indicates whether the most recent refresh task was a force refresh. |
 | LAST_REFRESH_START_PARTITION         | Starting partition for the most recent refresh task.         |

--- a/docs/ja/sql-reference/information_schema/materialized_views.md
+++ b/docs/ja/sql-reference/information_schema/materialized_views.md
@@ -22,7 +22,7 @@ description: "materialized_viewsはすべてのマテリアライズドビュー
 | TASK_NAME                            | マテリアライズドビューをリフレッシュするタスクの名前。       |
 | LAST_REFRESH_START_TIME              | 最新のリフレッシュタスクの開始時間。                         |
 | LAST_REFRESH_FINISHED_TIME           | 最新のリフレッシュタスクの終了時間。                         |
-| LAST_REFRESH_DURATION                | 最新のリフレッシュタスクの期間。                             |
+| LAST_REFRESH_DURATION                | 最新のリフレッシュの実時間（秒）。最後のタスク実行の終了時刻から最初のタスク実行の処理開始時刻を引いた値。そのジョブの `materialized_view_refresh_jobs.DURATION_TIME` と一致します。 |
 | LAST_REFRESH_STATE                   | 最新のリフレッシュタスクの状態。                             |
 | LAST_REFRESH_FORCE_REFRESH           | 最新のリフレッシュタスクが強制リフレッシュであったかどうかを示します。 |
 | LAST_REFRESH_START_PARTITION         | 最新のリフレッシュタスクの開始パーティション。               |

--- a/docs/zh/sql-reference/information_schema/materialized_views.md
+++ b/docs/zh/sql-reference/information_schema/materialized_views.md
@@ -22,7 +22,7 @@ description: "materialized_views 提供所有物化视图的信息。"
 | TASK_NAME                            | 物化视图刷新任务的名称。                         |
 | LAST_REFRESH_START_TIME              | 最近一次刷新任务的开始时间。                     |
 | LAST_REFRESH_FINISHED_TIME           | 最近一次刷新任务的结束时间。                     |
-| LAST_REFRESH_DURATION                | 最近一次刷新任务的持续时间。                     |
+| LAST_REFRESH_DURATION                | 最近一次刷新的墙钟耗时（秒）：最后一个 task run 的完成时间减去第一个 task run 的开始执行时间。与该 job 在 `materialized_view_refresh_jobs.DURATION_TIME` 中的值一致。 |
 | LAST_REFRESH_STATE                   | 最近一次刷新任务的状态。                         |
 | LAST_REFRESH_FORCE_REFRESH           | 最近一次刷新任务是否强制刷新。                   |
 | LAST_REFRESH_START_PARTITION         | 最近一次刷新任务的开始分区。                     |

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewRefreshJobsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewRefreshJobsSystemTable.java
@@ -190,10 +190,7 @@ public class MaterializedViewRefreshJobsSystemTable extends SystemTable {
 
             if (rjs.isRefreshFinished()) {
                 info.setFinish_time(TimeUtils.longToTimeString(rjs.getMvRefreshEndTime()));
-                // Wall-clock span of the whole job, not the per-run totalProcessDuration sum.
-                long startBasis = rjs.getMvRefreshProcessTime() > 0
-                        ? rjs.getMvRefreshProcessTime() : rjs.getMvRefreshStartTime();
-                long wallMs = rjs.getMvRefreshEndTime() - startBasis;
+                long wallMs = ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(rjs);
                 // Locale.ROOT so the BE's std::stod always receives a '.' decimal regardless of FE JVM locale.
                 info.setDuration_time(String.format(Locale.ROOT, "%.3f", wallMs / 1000D));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -99,7 +99,6 @@ public class ShowMaterializedViewStatus {
         private long mvRefreshStartTime;
         private long mvRefreshProcessTime;
         private long mvRefreshEndTime;
-        private long totalProcessDuration;
         private boolean isForce;
         private List<String> refreshedPartitionStarts;
         private List<String> refreshedPartitionEnds;
@@ -135,14 +134,6 @@ public class ShowMaterializedViewStatus {
 
         public void setMvRefreshEndTime(long mvRefreshEndTime) {
             this.mvRefreshEndTime = mvRefreshEndTime;
-        }
-
-        public long getTotalProcessDuration() {
-            return totalProcessDuration;
-        }
-
-        public void setTotalProcessDuration(long totalProcessDuration) {
-            this.totalProcessDuration = totalProcessDuration;
         }
 
         public boolean isForce() {
@@ -247,8 +238,8 @@ public class ShowMaterializedViewStatus {
                     "taskOwner='" + taskOwner + '\'' +
                     ", refreshState=" + refreshState +
                     ", mvRefreshStartTime=" + mvRefreshStartTime +
+                    ", mvRefreshProcessTime=" + mvRefreshProcessTime +
                     ", mvRefreshEndTime=" + mvRefreshEndTime +
-                    ", totalProcessDuration=" + totalProcessDuration +
                     ", isForce=" + isForce +
                     ", refreshedPartitionStarts=" + refreshedPartitionStarts +
                     ", refreshedPartitionEnds=" + refreshedPartitionEnds +
@@ -705,14 +696,24 @@ public class ShowMaterializedViewStatus {
             long mvRefreshFinishTime = lastTaskRunStatus.getFinishTime();
             status.setMvRefreshEndTime(mvRefreshFinishTime);
 
-            long totalProcessDuration = sorted.stream()
-                    .map(TaskRunStatus::calculateRefreshProcessDuration)
-                    .collect(Collectors.summingLong(Long::longValue));
-            status.setTotalProcessDuration(totalProcessDuration);
             status.setErrorCode(String.valueOf(lastTaskRunStatus.getErrorCode()));
             status.setErrorMsg(Strings.nullToEmpty(lastTaskRunStatus.getErrorMessage()));
         }
         return status;
+    }
+
+    /**
+     * Wall-clock duration (ms) of a refresh job: the last run's finish minus the first run's process start,
+     * falling back to the submit time when the process start is unknown (0), clamped to 0 to tolerate clock skew.
+     * Shared with materialized_view_refresh_jobs.DURATION_TIME so both surfaces report the same elapsed time.
+     */
+    public static long getRefreshJobWallClockDurationMs(RefreshJobStatus job) {
+        if (!job.isRefreshFinished()) {
+            return 0L;
+        }
+        long startBasis = job.getMvRefreshProcessTime() > 0
+                ? job.getMvRefreshProcessTime() : job.getMvRefreshStartTime();
+        return Math.max(0L, job.getMvRefreshEndTime() - startBasis);
     }
 
     public String getQueryRewriteStatus() {
@@ -765,7 +766,7 @@ public class ShowMaterializedViewStatus {
         // only updated when refresh is finished
         if (refreshJobStatus.isRefreshFinished()) {
             status.setLast_refresh_finished_time(TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshEndTime()));
-            status.setLast_refresh_duration(formatDuration(refreshJobStatus.getTotalProcessDuration()));
+            status.setLast_refresh_duration(formatDuration(getRefreshJobWallClockDurationMs(refreshJobStatus)));
             status.setLast_refresh_error_code(refreshJobStatus.getErrorCode());
             status.setLast_refresh_error_message(refreshJobStatus.getErrorMsg());
         }
@@ -833,7 +834,7 @@ public class ShowMaterializedViewStatus {
         // process finish time
         addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshEndTime()));
         // process duration
-        addField(resultRow, formatDuration(refreshJobStatus.getTotalProcessDuration()));
+        addField(resultRow, formatDuration(getRefreshJobWallClockDurationMs(refreshJobStatus)));
         // last refresh state
         addField(resultRow, refreshJobStatus.getRefreshState());
         // whether it's force refresh

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -693,7 +693,11 @@ public class ShowMaterializedViewStatus {
         if (lastTaskRunStatus.isRefreshFinished()) {
             status.setRefreshFinished(true);
 
-            long mvRefreshFinishTime = lastTaskRunStatus.getFinishTime();
+            // A pending follow-up run aborted by clearUnfinishedTaskRun() is marked FAILED without a finishTime,
+            // so the tail run's finishTime can be 0; take the max across the batch to keep the real job end.
+            long mvRefreshFinishTime = sorted.stream()
+                    .mapToLong(TaskRunStatus::getFinishTime)
+                    .max().orElse(lastTaskRunStatus.getFinishTime());
             status.setMvRefreshEndTime(mvRefreshFinishTime);
 
             status.setErrorCode(String.valueOf(lastTaskRunStatus.getErrorCode()));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -693,11 +693,13 @@ public class ShowMaterializedViewStatus {
         if (lastTaskRunStatus.isRefreshFinished()) {
             status.setRefreshFinished(true);
 
-            // A pending follow-up run aborted by clearUnfinishedTaskRun() is marked FAILED without a finishTime,
-            // so the tail run's finishTime can be 0; take the max across the batch to keep the real job end.
-            long mvRefreshFinishTime = sorted.stream()
-                    .mapToLong(TaskRunStatus::getFinishTime)
-                    .max().orElse(lastTaskRunStatus.getFinishTime());
+            // Normally the tail run's finishTime is the job end. But a pending follow-up aborted by
+            // clearUnfinishedTaskRun() is marked FAILED without a finishTime (0); only then fall back to the
+            // batch's max finish so the completed sub-runs' elapsed work is not lost.
+            long tailFinishTime = lastTaskRunStatus.getFinishTime();
+            long mvRefreshFinishTime = tailFinishTime > 0
+                    ? tailFinishTime
+                    : sorted.stream().mapToLong(TaskRunStatus::getFinishTime).max().orElse(tailFinishTime);
             status.setMvRefreshEndTime(mvRefreshFinishTime);
 
             status.setErrorCode(String.valueOf(lastTaskRunStatus.getErrorCode()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -433,21 +433,6 @@ public class TaskRunStatus implements Writable {
         }
     }
 
-    public long calculateRefreshProcessDuration() {
-        if (finishTime > processStartTime) {
-            // NOTE:
-            // It's mostly because of tech debt, before this pr, the processStartTime can be persisted as 0 .
-            // In this case to avoid return a weird duration we choose the createTime as startTime
-            if (processStartTime > 0) {
-                return finishTime - processStartTime;
-            } else {
-                return finishTime - createTime;
-            }
-        } else {
-            return 0L;
-        }
-    }
-
     public boolean matchByTaskName(String dbName, Set<String> taskNames) {
         if (dbName != null && !dbName.equals(getDbName())) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -239,6 +239,22 @@ public class ShowMaterializedViewStatusTest {
     }
 
     @Test
+    public void wallClockUsesMaxFinishWhenPendingTailAbortedWithoutFinishTime() {
+        // A completed first sub-run plus a follow-up aborted while PENDING: clearUnfinishedTaskRun marks the tail
+        // FAILED without a finishTime (0). The job end must be the last real finish, not the aborted tail's 0,
+        // so the elapsed work of the completed sub-run is not lost.
+        TaskRunStatus firstRun = mvTaskRun("job-a", "run-1", 1000L, 1000L, 1500L, Constants.TaskRunState.SUCCESS);
+        TaskRunStatus abortedTail = mvTaskRun("job-a", "run-2", 2000L, 0L, 0L, Constants.TaskRunState.FAILED);
+
+        ShowMaterializedViewStatus.RefreshJobStatus status =
+                ShowMaterializedViewStatus.fromTaskRuns(Arrays.asList(abortedTail, firstRun));
+
+        Assertions.assertTrue(status.isRefreshFinished());
+        Assertions.assertEquals(1500L, status.getMvRefreshEndTime());
+        Assertions.assertEquals(500L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(status));
+    }
+
+    @Test
     public void toThriftIncludesLastRefreshTimeWhenPresent() {
         ShowMaterializedViewStatus viewStatus = new ShowMaterializedViewStatus(1L, "testDb", "testView");
         viewStatus.setLastRefreshTime(1735697100000L);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -91,8 +91,9 @@ public class ShowMaterializedViewStatusTest {
 
         Assertions.assertTrue(status.isRefreshFinished());
         Assertions.assertEquals(5900L, status.getMvRefreshEndTime());
-        long expectedDuration = (1500L - 1000L) + (3700L - 3000L) + (5900L - 5000L);
-        Assertions.assertEquals(expectedDuration, status.getTotalProcessDuration());
+        // Wall-clock span of the whole job: last run finish (5900) minus first run process start (1000),
+        // not the per-run execution sum (which would be 2100).
+        Assertions.assertEquals(4900L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(status));
     }
 
     @Test
@@ -128,6 +129,7 @@ public class ShowMaterializedViewStatusTest {
         Assertions.assertNotNull(empty);
         Assertions.assertFalse(empty.isRefreshFinished());
         Assertions.assertNull(empty.getJobId());
+        Assertions.assertEquals(0L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(empty));
 
         ShowMaterializedViewStatus.RefreshJobStatus fromNull = ShowMaterializedViewStatus.fromTaskRuns(null);
         Assertions.assertNotNull(fromNull);
@@ -147,7 +149,7 @@ public class ShowMaterializedViewStatusTest {
         Assertions.assertEquals("job-3", status.getJobId());
         Assertions.assertTrue(status.isRefreshFinished());
         Assertions.assertEquals(2600L, status.getMvRefreshEndTime());
-        Assertions.assertEquals(600L, status.getTotalProcessDuration());
+        Assertions.assertEquals(600L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(status));
     }
 
     @Test
@@ -212,6 +214,28 @@ public class ShowMaterializedViewStatusTest {
         Assertions.assertEquals("", resultSet.get(31)); // refresh policy
         Assertions.assertEquals("", resultSet.get(32)); // resource group
         Assertions.assertEquals("", resultSet.get(33)); // query rewrite status reason
+    }
+
+    @Test
+    public void wallClockDurationFallsBackToSubmitTimeWhenProcessStartUnknown() {
+        // A finished run whose processStartTime was never persisted (0): the wall-clock start basis falls back
+        // to the submit (create) time so the duration stays meaningful instead of jumping to the epoch.
+        TaskRunStatus run = mvTaskRun("job-f", "run-1", 1000L, 0L, 1500L, Constants.TaskRunState.SUCCESS);
+        ShowMaterializedViewStatus.RefreshJobStatus status =
+                ShowMaterializedViewStatus.fromTaskRuns(Collections.singletonList(run));
+
+        Assertions.assertEquals(0L, status.getMvRefreshProcessTime());
+        Assertions.assertEquals(500L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(status));
+    }
+
+    @Test
+    public void wallClockDurationClampsNegativeToZeroOnClockSkew() {
+        // Clock skew can persist a finish time earlier than the process start; the duration must not go negative.
+        TaskRunStatus run = mvTaskRun("job-skew", "run-1", 5000L, 5000L, 4000L, Constants.TaskRunState.SUCCESS);
+        ShowMaterializedViewStatus.RefreshJobStatus status =
+                ShowMaterializedViewStatus.fromTaskRuns(Collections.singletonList(run));
+
+        Assertions.assertEquals(0L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(status));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -255,6 +255,20 @@ public class ShowMaterializedViewStatusTest {
     }
 
     @Test
+    public void wallClockPrefersRecordedTailFinishOverEarlierRun() {
+        // The tail run has a recorded (positive) finish earlier than a prior run's (FE clock skew during the tail
+        // run); the job end must stay the recorded tail finish, not the larger earlier finish.
+        TaskRunStatus firstRun = mvTaskRun("job-s", "run-1", 1000L, 1000L, 1500L, Constants.TaskRunState.SUCCESS);
+        TaskRunStatus tailRun = mvTaskRun("job-s", "run-2", 2000L, 1300L, 1400L, Constants.TaskRunState.SUCCESS);
+
+        ShowMaterializedViewStatus.RefreshJobStatus status =
+                ShowMaterializedViewStatus.fromTaskRuns(Arrays.asList(firstRun, tailRun));
+
+        Assertions.assertEquals(1400L, status.getMvRefreshEndTime());
+        Assertions.assertEquals(400L, ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(status));
+    }
+
+    @Test
     public void toThriftIncludesLastRefreshTimeWhenPresent() {
         ShowMaterializedViewStatus viewStatus = new ShowMaterializedViewStatus(1L, "testDb", "testView");
         viewStatus.setLastRefreshTime(1735697100000L);


### PR DESCRIPTION
## Why I'm doing:

`information_schema.materialized_views.LAST_REFRESH_DURATION` reports the **sum** of each task run's process time (`finishTime - processStartTime`) across a refresh job. A single logical refresh can fan out into multiple task runs (PCT / IVM batching), so the sum drops the gaps between runs and **understates** the real elapsed time. It also disagrees with the newer `information_schema.materialized_view_refresh_jobs.DURATION_TIME`, which already reports the **wall-clock** span of the same job — so the two surfaces give different durations for the same refresh.

## What I'm doing:

Make `LAST_REFRESH_DURATION` report wall-clock duration, matching `materialized_view_refresh_jobs.DURATION_TIME`:

- Add a shared helper `ShowMaterializedViewStatus.getRefreshJobWallClockDurationMs(RefreshJobStatus)` = last run's finish − first run's process start (submit time as fallback when process start is unknown, clamped to 0 for clock skew).
- Both `LAST_REFRESH_DURATION` (system table + `SHOW MATERIALIZED VIEWS`) and `materialized_view_refresh_jobs.DURATION_TIME` now call this single helper, so they stay identical by construction.
- Remove the now-unused accumulated `RefreshJobStatus.totalProcessDuration` field/getter/setter and the orphaned `TaskRunStatus.calculateRefreshProcessDuration()`.
- Update docs (en/zh/ja) and FE unit tests (wall-clock value, process-start fallback, clock-skew clamp).

Fixes #issue: N/A — aligns the semantics of an existing observability column; no separate tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The displayed value of `LAST_REFRESH_DURATION` changes for multi-run refresh jobs (it now includes the inter-run gaps); single-run jobs are unaffected. Column name, position, and type are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5