### PR TITLE
[Enhancement] Support byte-array DECIMAL in meta-tier tablet pre-split

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -226,15 +226,9 @@ public final class ParquetRowGroupStatisticsReader {
                 if (logicalAnnotation instanceof StringLogicalTypeAnnotation) {
                     yield starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR;
                 }
-                // BINARY-backed DECIMAL is big-endian two's-complement; accept only with an exact
-                // precision/scale match AND a footer-declared TypeDefinedOrder (signed min/max).
-                yield logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
-                        && decimalMatchesExactly(decimalAnnotation, sortKeyColumn)
-                        && signedByteArrayOrder;
+                yield isSignedByteArrayDecimal(logicalAnnotation, sortKeyColumn, signedByteArrayOrder);
             }
-            case FIXED_LEN_BYTE_ARRAY -> logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
-                    && decimalMatchesExactly(decimalAnnotation, sortKeyColumn)
-                    && signedByteArrayOrder;
+            case FIXED_LEN_BYTE_ARRAY -> isSignedByteArrayDecimal(logicalAnnotation, sortKeyColumn, signedByteArrayOrder);
             default -> false;
         };
         if (!compatible) {
@@ -391,6 +385,18 @@ public final class ParquetRowGroupStatisticsReader {
         ScalarType scalarType = (ScalarType) starRocksType;
         return annotation.getPrecision() == scalarType.getScalarPrecision()
                 && annotation.getScale() == scalarType.getScalarScale();
+    }
+
+    /**
+     * A byte-array (FIXED_LEN_BYTE_ARRAY/BINARY) DECIMAL is accepted only with an exact
+     * precision/scale match AND a footer-declared TypeDefinedOrder — then its big-endian
+     * two's-complement footer min/max are signed-ordered (see {@link #declaresSignedByteArrayOrder}).
+     */
+    private static boolean isSignedByteArrayDecimal(
+            LogicalTypeAnnotation logicalAnnotation, Column sortKeyColumn, boolean signedByteArrayOrder) {
+        return logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
+                && decimalMatchesExactly(decimalAnnotation, sortKeyColumn)
+                && signedByteArrayOrder;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.google.common.io.ByteStreams;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
@@ -44,7 +45,6 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnot
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -449,11 +449,13 @@ public final class ParquetRowGroupStatisticsReader {
             if (footerLength < 0 || footerStart < PLAINTEXT_FOOTER_MAGIC.length) {
                 return null; // corrupt footer length
             }
-            byte[] footerBytes = new byte[footerLength];
             input.seek(footerStart);
-            input.readFully(footerBytes);
+            // footerLength comes from the (untrusted) trailer, so do NOT materialize a
+            // new byte[footerLength] — a corrupt/huge value could raise OutOfMemoryError, an Error
+            // that escapes the IOException|RuntimeException fail-safe below. Cap Thrift to the
+            // footer's own bytes with a length-bounded view instead.
             org.apache.parquet.format.FileMetaData footer =
-                    Util.readFileMetaData(new ByteArrayInputStream(footerBytes));
+                    Util.readFileMetaData(ByteStreams.limit(input, footerLength));
             return footer.isSetColumn_orders() ? footer.getColumn_orders() : null;
         } catch (IOException | RuntimeException failure) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -25,6 +25,7 @@ import com.starrocks.type.Type;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.format.ColumnOrder;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -342,6 +343,25 @@ public final class ParquetRowGroupStatisticsReader {
         ScalarType scalarType = (ScalarType) starRocksType;
         return annotation.getPrecision() == scalarType.getScalarPrecision()
                 && annotation.getScale() == scalarType.getScalarScale();
+    }
+
+    /**
+     * True only when the file's raw footer positively declares a {@code TypeDefinedOrder} column
+     * order for this leaf. For a DECIMAL logical type that guarantees parquet ordered the byte-array
+     * min/max as signed two's-complement (parquet-mr's {@code BINARY_AS_SIGNED_INTEGER_COMPARATOR}).
+     *
+     * <p>A null/short {@code column_orders} list (legacy file that omitted it) or an unset entry
+     * (UNDEFINED order) is treated as unknown → data tier. We must read the RAW footer for this:
+     * parquet-mr's converted {@code PrimitiveType.columnOrder()} defaults a missing {@code column_orders}
+     * to {@code TYPE_DEFINED_ORDER}, so it cannot distinguish a legacy file. Package-private so the
+     * predicate is unit-testable (parquet-mr's high-level writer cannot produce a file without
+     * {@code column_orders}).
+     */
+    static boolean declaresSignedByteArrayOrder(List<ColumnOrder> columnOrders, int leafIndex) {
+        return columnOrders != null
+                && leafIndex >= 0
+                && leafIndex < columnOrders.size()
+                && columnOrders.get(leafIndex).isSetTYPE_ORDER();
     }
 
     private record SortKeyLocation(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -74,16 +74,19 @@ import java.util.Objects;
  *   <li>Parquet BINARY with UTF8 (string) annotation → StarRocks CHAR/VARCHAR
  *       (always marked truncated → forces data-tier fallback for string sort keys)</li>
  *   <li>Parquet INT32/INT64 with DECIMAL annotation → StarRocks DECIMAL of the SAME
- *       precision and scale (the unscaled integer's signed order equals the decimal
- *       order). FIXED_LEN_BYTE_ARRAY/BINARY-backed decimals are deferred (their footer
- *       min/max may use unsigned byte ordering, wrong for negatives) → data tier.</li>
+ *       precision and scale (the unscaled integer's signed order equals the decimal order).</li>
+ *   <li>Parquet FIXED_LEN_BYTE_ARRAY/BINARY with DECIMAL annotation → StarRocks DECIMAL of the
+ *       SAME precision and scale, but ONLY when the file's raw footer declares a TypeDefinedOrder
+ *       column order for that leaf (then the big-endian two's-complement footer min/max are
+ *       signed-ordered). A file with no/UNDEFINED column order is deferred → data tier.</li>
  * </ul>
  * <p>DATE/DATETIME values are additionally gated to {@code [1970-01-01, 9999-12-31]}; values
  * outside that window (year &le; 0 mis-renders through the {@code yyyy} formatters, pre-1970
  * has unverified FE/BE timestamp-division parity, pre-1582 has calendar-parity questions)
  * fall back to data tier.
  * Anything else (UINT_*, UTC-adjusted/INT96 timestamps, JSON, BSON, UUID, FLOAT, DOUBLE,
- * FIXED_LEN_BYTE_ARRAY/BINARY-backed DECIMAL, raw BINARY for VARBINARY) makes the reader throw
+ * byte-array DECIMAL without a footer-declared TypeDefinedOrder, raw BINARY for VARBINARY) makes
+ * the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier — not a
  * load failure. Pure I/O failures surface as {@link StarRocksException}.
  */
@@ -173,9 +176,11 @@ public final class ParquetRowGroupStatisticsReader {
      * the unannotated integer/boolean subset, the UTF8 string annotation for character
      * columns, INT32 with the DATE annotation → StarRocks DATE, INT64 with a non-UTC
      * TIMESTAMP annotation → StarRocks DATETIME, and INT32/INT64 with a DECIMAL annotation
-     * → a same-precision/scale StarRocks DECIMAL. FIXED_LEN_BYTE_ARRAY/BINARY-backed DECIMAL
-     * and other annotations (UINT_*, UTC-adjusted TIMESTAMP, JSON, BSON, UUID, ...) are
-     * deferred (fall back to data tier).
+     * → a same-precision/scale StarRocks DECIMAL. FIXED_LEN_BYTE_ARRAY/BINARY-backed DECIMAL is
+     * accepted on the same exact-precision/scale match but only when the caller resolved a
+     * footer-declared TypeDefinedOrder ({@code signedByteArrayOrder}); a file with no/UNDEFINED
+     * column order and other annotations (UINT_*, UTC-adjusted TIMESTAMP, JSON, BSON, UUID, ...)
+     * are deferred (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             PrimitiveTypeName parquetTypeName,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -26,12 +26,15 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.format.ColumnOrder;
+import org.apache.parquet.format.Util;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
@@ -41,8 +44,10 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnot
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -84,6 +89,9 @@ import java.util.Objects;
  */
 public final class ParquetRowGroupStatisticsReader {
 
+    // Parquet plaintext-footer trailing magic. "PARE" marks an encrypted footer (unreadable here).
+    private static final byte[] PLAINTEXT_FOOTER_MAGIC = {'P', 'A', 'R', '1'};
+
     private ParquetRowGroupStatisticsReader() {
     }
 
@@ -93,17 +101,19 @@ public final class ParquetRowGroupStatisticsReader {
         Objects.requireNonNull(hadoopConfig, "hadoopConfig");
         Objects.requireNonNull(sortKeyColumn, "sortKeyColumn");
 
-        try (ParquetFileReader reader = ParquetFileReader.open(
-                HadoopInputFile.fromStatus(fileStatus, hadoopConfig))) {
-            ParquetMetadata metadata = reader.getFooter();
-            SortKeyLocation location = locateSortKeyColumn(
-                    metadata.getFileMetaData().getSchema(), sortKeyColumn);
-            List<BlockMetaData> blocks = metadata.getBlocks();
-            List<RowGroupStatistics> rowGroupStatistics = new ArrayList<>(blocks.size());
-            for (BlockMetaData block : blocks) {
-                rowGroupStatistics.add(convertBlock(block, location));
+        try {
+            HadoopInputFile inputFile = HadoopInputFile.fromStatus(fileStatus, hadoopConfig);
+            try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
+                ParquetMetadata metadata = reader.getFooter();
+                SortKeyLocation location = locateSortKeyColumn(
+                        metadata.getFileMetaData().getSchema(), inputFile, sortKeyColumn);
+                List<BlockMetaData> blocks = metadata.getBlocks();
+                List<RowGroupStatistics> rowGroupStatistics = new ArrayList<>(blocks.size());
+                for (BlockMetaData block : blocks) {
+                    rowGroupStatistics.add(convertBlock(block, location));
+                }
+                return rowGroupStatistics;
             }
-            return rowGroupStatistics;
         } catch (IOException ioException) {
             throw new StarRocksException(
                     "failed to read Parquet footer for " + fileStatus.getPath() + ": " + ioException.getMessage(),
@@ -111,7 +121,7 @@ public final class ParquetRowGroupStatisticsReader {
         }
     }
 
-    private static SortKeyLocation locateSortKeyColumn(MessageType schema, Column sortKeyColumn)
+    private static SortKeyLocation locateSortKeyColumn(MessageType schema, InputFile inputFile, Column sortKeyColumn)
             throws MetaTierUnavailableException {
         String columnName = sortKeyColumn.getName();
         int fieldIndex = -1;
@@ -140,10 +150,20 @@ public final class ParquetRowGroupStatisticsReader {
         }
         PrimitiveTypeName parquetTypeName = fieldType.asPrimitiveType().getPrimitiveTypeName();
         LogicalTypeAnnotation logicalAnnotation = fieldType.getLogicalTypeAnnotation();
-        rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, sortKeyColumn);
-        return new SortKeyLocation(
-                ColumnPath.get(schema.getFieldName(fieldIndex)),
-                parquetTypeName, logicalAnnotation, sortKeyColumn);
+        ColumnPath path = ColumnPath.get(schema.getFieldName(fieldIndex));
+        // Footer min/max for a byte-array (FLBA/BINARY) decimal are only signed-ordered when the
+        // file's raw column_orders entry for this leaf is TypeDefinedOrder. parquet-mr's converted
+        // PrimitiveType.columnOrder() defaults a missing column_orders to TYPE_DEFINED_ORDER, so we
+        // inspect the raw footer instead. Only a byte-array decimal pays this extra footer read.
+        boolean signedByteArrayOrder = false;
+        if ((parquetTypeName == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
+                || parquetTypeName == PrimitiveTypeName.BINARY)
+                && logicalAnnotation instanceof DecimalLogicalTypeAnnotation) {
+            signedByteArrayOrder = declaresSignedByteArrayOrder(
+                    readColumnOrders(inputFile), leafColumnIndex(schema, path));
+        }
+        rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, signedByteArrayOrder, sortKeyColumn);
+        return new SortKeyLocation(path, parquetTypeName, logicalAnnotation, sortKeyColumn);
     }
 
     /**
@@ -160,6 +180,7 @@ public final class ParquetRowGroupStatisticsReader {
     private static void rejectIncompatibleTypeMapping(
             PrimitiveTypeName parquetTypeName,
             LogicalTypeAnnotation logicalAnnotation,
+            boolean signedByteArrayOrder,
             Column sortKeyColumn) throws MetaTierUnavailableException {
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (parquetTypeName) {
@@ -198,6 +219,9 @@ public final class ParquetRowGroupStatisticsReader {
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
             case BINARY -> logicalAnnotation instanceof StringLogicalTypeAnnotation
                     && (starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR);
+            case FIXED_LEN_BYTE_ARRAY -> logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
+                    && decimalMatchesExactly(decimalAnnotation, sortKeyColumn)
+                    && signedByteArrayOrder;
             default -> false;
         };
         if (!compatible) {
@@ -272,11 +296,18 @@ public final class ParquetRowGroupStatisticsReader {
             return Variant.of(location.starRocksColumn.getType(), renderDateTime(dateTime));
         }
         if (location.logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation) {
-            // Only INT32/INT64-backed decimals reach here — the gate rejects FIXED_LEN/BINARY —
-            // so the stat is the signed unscaled integer. Reconstruct at the source scale; the
-            // exact precision/scale gate guarantees it equals the StarRocks column scale.
-            long unscaled = ((Number) parquetValue).longValue();
-            BigDecimal decoded = BigDecimal.valueOf(unscaled, decimalAnnotation.getScale());
+            // Reconstruct the signed unscaled integer at the source scale; the exact precision/scale
+            // gate guarantees it equals the StarRocks column scale.
+            BigInteger unscaled;
+            if (location.parquetTypeName == PrimitiveTypeName.INT32
+                    || location.parquetTypeName == PrimitiveTypeName.INT64) {
+                unscaled = BigInteger.valueOf(((Number) parquetValue).longValue());
+            } else {
+                // FIXED_LEN_BYTE_ARRAY / BINARY: big-endian two's-complement bytes. The gate accepted
+                // these only when the footer declared TypeDefinedOrder, so the min/max are signed.
+                unscaled = new BigInteger(((Binary) parquetValue).getBytes());
+            }
+            BigDecimal decoded = new BigDecimal(unscaled, decimalAnnotation.getScale());
             return Variant.of(location.starRocksColumn.getType(), decoded.toPlainString());
         }
         String rendered = location.parquetTypeName == PrimitiveTypeName.BINARY
@@ -362,6 +393,62 @@ public final class ParquetRowGroupStatisticsReader {
                 && leafIndex >= 0
                 && leafIndex < columnOrders.size()
                 && columnOrders.get(leafIndex).isSetTYPE_ORDER();
+    }
+
+    /**
+     * Read the raw Thrift footer's {@code column_orders} list, or {@code null} if it cannot be
+     * obtained — an encrypted footer ({@code PARE} magic), a too-short file, a corrupt footer
+     * length, an absent list, or any IO/parse failure. Any failure is non-fatal: the caller
+     * treats {@code null} as "column order unknown" and falls back to the data tier. We read the
+     * raw footer (not the converted schema) because parquet-mr defaults a missing column order to
+     * TYPE_DEFINED_ORDER, which would not distinguish a legacy file.
+     */
+    private static List<ColumnOrder> readColumnOrders(InputFile inputFile) {
+        try (SeekableInputStream input = inputFile.newStream()) {
+            long length = inputFile.getLength();
+            int trailerLength = 8; // [footerLength:4 little-endian][magic:4]
+            if (length < PLAINTEXT_FOOTER_MAGIC.length + trailerLength) {
+                return null;
+            }
+            byte[] trailer = new byte[trailerLength];
+            input.seek(length - trailerLength);
+            input.readFully(trailer);
+            for (int i = 0; i < PLAINTEXT_FOOTER_MAGIC.length; i++) {
+                if (trailer[4 + i] != PLAINTEXT_FOOTER_MAGIC[i]) {
+                    return null; // encrypted ("PARE") or non-parquet footer — cannot confirm order
+                }
+            }
+            int footerLength = (trailer[0] & 0xff)
+                    | ((trailer[1] & 0xff) << 8)
+                    | ((trailer[2] & 0xff) << 16)
+                    | ((trailer[3] & 0xff) << 24);
+            long footerStart = length - trailerLength - footerLength;
+            if (footerLength < 0 || footerStart < PLAINTEXT_FOOTER_MAGIC.length) {
+                return null; // corrupt footer length
+            }
+            byte[] footerBytes = new byte[footerLength];
+            input.seek(footerStart);
+            input.readFully(footerBytes);
+            org.apache.parquet.format.FileMetaData footer =
+                    Util.readFileMetaData(new ByteArrayInputStream(footerBytes));
+            return footer.isSetColumn_orders() ? footer.getColumn_orders() : null;
+        } catch (IOException | RuntimeException failure) {
+            return null;
+        }
+    }
+
+    /**
+     * Leaf index of {@code path} among the schema's leaf columns. The footer's {@code column_orders}
+     * list is parallel to {@link MessageType#getPaths()} (leaf order). Returns -1 if not found.
+     */
+    private static int leafColumnIndex(MessageType schema, ColumnPath path) {
+        List<String[]> paths = schema.getPaths();
+        for (int i = 0; i < paths.size(); i++) {
+            if (ColumnPath.get(paths.get(i)).equals(path)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private record SortKeyLocation(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -217,8 +217,16 @@ public final class ParquetRowGroupStatisticsReader {
                         && decimalMatchesExactly(decimalAnnotation, sortKeyColumn);
             }
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
-            case BINARY -> logicalAnnotation instanceof StringLogicalTypeAnnotation
-                    && (starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR);
+            case BINARY -> {
+                if (logicalAnnotation instanceof StringLogicalTypeAnnotation) {
+                    yield starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR;
+                }
+                // BINARY-backed DECIMAL is big-endian two's-complement; accept only with an exact
+                // precision/scale match AND a footer-declared TypeDefinedOrder (signed min/max).
+                yield logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
+                        && decimalMatchesExactly(decimalAnnotation, sortKeyColumn)
+                        && signedByteArrayOrder;
+            }
             case FIXED_LEN_BYTE_ARRAY -> logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
                     && decimalMatchesExactly(decimalAnnotation, sortKeyColumn)
                     && signedByteArrayOrder;
@@ -270,7 +278,11 @@ public final class ParquetRowGroupStatisticsReader {
         // truncated unconditionally so the pipeline falls back to data tier for string
         // sort keys until column-index exactness flags are read explicitly. Numeric
         // and boolean stats are always exact and stay false.
-        boolean truncated = location.parquetTypeName == PrimitiveTypeName.BINARY;
+        // Only string-annotated BINARY is truncation-prone (parquet-mr truncates long binary
+        // min/max at 64 bytes). Numeric stats — including BINARY-backed and FLBA-backed DECIMAL —
+        // are exact; marking a decimal truncated would force a needless data-tier fallback.
+        boolean truncated = location.parquetTypeName == PrimitiveTypeName.BINARY
+                && location.logicalAnnotation instanceof StringLogicalTypeAnnotation;
         return new RowGroupStatistics(
                 new Tuple(List.of(minVariant)),
                 new Tuple(List.of(maxVariant)),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 
 class ParquetRowGroupStatisticsReaderTest {
@@ -534,21 +535,37 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
-    void fixedLenByteArrayDecimalFallsBackToDataTier() throws Exception {
-        // Even with an EXACT precision/scale match, a FIXED_LEN_BYTE_ARRAY-backed decimal is
-        // rejected: parquet-mr footer min/max for byte-array decimals can use unsigned byte
-        // ordering (wrong for negatives) unless a typed sort order was set — which we do not
-        // inspect. Conservative gate → data tier. (The gate rejects at schema inspection before
-        // any row group is read, so all-zero bytes are fine.)
+    void readsFixedLenByteArrayDecimalStatistics() throws Exception {
+        // FLBA(8)-backed DECIMAL(18,2) spanning negative→positive: -2.00, -1.00, 0.00, 1.00.
+        // parquet-mr writes column_orders=TypeDefinedOrder, so the byte-array min/max are ordered by
+        // the signed BINARY_AS_SIGNED_INTEGER_COMPARATOR — the gate accepts and decodes them. The
+        // negative span proves signed (not unsigned) ordering end-to-end, including the raw-footer read.
         Path parquetPath = writeParquet(
                 "message schema { required fixed_len_byte_array(8) d (DECIMAL(18,2)); }",
-                /*rowCount=*/ 1,
-                (group, rowIndex) -> group.append("d", Binary.fromConstantByteArray(new byte[8])));
+                /*rowCount=*/ 4,
+                (group, rowIndex) -> group.append("d", flbaDecimal(BigInteger.valueOf((rowIndex - 2) * 100L), 8)));
 
-        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
-                ParquetRowGroupStatisticsReader.read(
-                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))));
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
+        Assertions.assertEquals("-2.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("1.00", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    /**
+     * Encode {@code unscaled} as a fixed-length, big-endian two's-complement byte array of
+     * {@code byteLen} bytes (sign-extended) — the FIXED_LEN_BYTE_ARRAY layout parquet uses for
+     * DECIMAL. parquet-mr computes the footer min/max with its signed byte-array comparator.
+     */
+    private static Binary flbaDecimal(BigInteger unscaled, int byteLen) {
+        byte[] full = new byte[byteLen];
+        java.util.Arrays.fill(full, (byte) (unscaled.signum() < 0 ? 0xFF : 0x00));
+        byte[] minimal = unscaled.toByteArray();
+        System.arraycopy(minimal, 0, full, byteLen - minimal.length, minimal.length);
+        return Binary.fromConstantByteArray(full);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -23,6 +23,8 @@ import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.format.ColumnOrder;
+import org.apache.parquet.format.TypeDefinedOrder;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -562,6 +564,25 @@ class ParquetRowGroupStatisticsReaderTest {
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2))));
+    }
+
+    @Test
+    void declaresSignedByteArrayOrderRequiresTypeOrderEntry() {
+        // parquet-mr's high-level writer always emits column_orders, so the "no column_orders /
+        // unknown order → data tier" rejection is verified at the raw-footer-mapping predicate level.
+        ColumnOrder typeOrder = ColumnOrder.TYPE_ORDER(new TypeDefinedOrder());
+        // Footer positively declares TypeDefinedOrder for the leaf → signed order confirmed.
+        Assertions.assertTrue(
+                ParquetRowGroupStatisticsReader.declaresSignedByteArrayOrder(List.of(typeOrder), 0));
+        // Legacy file with no column_orders → not confirmed.
+        Assertions.assertFalse(
+                ParquetRowGroupStatisticsReader.declaresSignedByteArrayOrder(null, 0));
+        // Entry present but no TypeDefinedOrder set (UNDEFINED order) → not confirmed.
+        Assertions.assertFalse(
+                ParquetRowGroupStatisticsReader.declaresSignedByteArrayOrder(List.of(new ColumnOrder()), 0));
+        // Leaf index past the end of the list → not confirmed.
+        Assertions.assertFalse(
+                ParquetRowGroupStatisticsReader.declaresSignedByteArrayOrder(List.of(typeOrder), 5));
     }
 
     private Path writeParquet(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -601,6 +601,45 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
+    void readsFixedLenByteArrayDecimal128Statistics() throws Exception {
+        // Mirrors StarRocks' own unload: BE encodes DECIMAL128 as FLBA(16). DECIMAL(38,2) with a
+        // 38-digit unscaled value exercises the full 16-byte signed decode — the case that fell to
+        // the data tier before this phase.
+        BigInteger small = BigInteger.valueOf(100L);                                       // 1.00
+        BigInteger large = new BigInteger("99999999999999999999999999999999999999");       // 38-digit unscaled
+        Path parquetPath = writeParquet(
+                "message schema { required fixed_len_byte_array(16) d (DECIMAL(38,2)); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("d", flbaDecimal(rowIndex == 0 ? small : large, 16)));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 2)));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
+        Assertions.assertEquals("1.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        // Assert the max by VALUE (the unscaled `large` at scale 2), not a hand-counted digit string.
+        Assertions.assertEquals(0, new BigDecimal(large, 2).compareTo(
+                new BigDecimal(stats.get(0).getMaxTuple().getValues().get(0).getStringValue())));
+    }
+
+    @Test
+    void fixedLenByteArrayDecimalScaleMismatchFallsBackToDataTier() throws Exception {
+        // A byte-array decimal still requires an EXACT precision/scale match, independent of the
+        // (TypeDefinedOrder) column order: source DECIMAL(18,2) into a StarRocks DECIMAL64(18,4).
+        Path parquetPath = writeParquet(
+                "message schema { required fixed_len_byte_array(8) d (DECIMAL(18,2)); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("d", flbaDecimal(BigInteger.valueOf((rowIndex + 1) * 100L), 8)));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))));
+    }
+
+    @Test
     void declaresSignedByteArrayOrderRequiresTypeOrderEntry() {
         // parquet-mr's high-level writer always emits column_orders, so the "no column_orders /
         // unknown order → data tier" rejection is verified at the raw-footer-mapping predicate level.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 
@@ -569,18 +570,34 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
-    void binaryBackedDecimalFallsBackToDataTier() throws Exception {
-        // BINARY-backed decimal: same unsigned-byte-order trap as FIXED_LEN → reject (the BINARY
-        // arm only admits the UTF8 string annotation). DECIMAL128(20,2) exactly matches precision/scale.
+    void readsBinaryBackedDecimalStatistics() throws Exception {
+        // BINARY-backed DECIMAL128(20,2) spanning negative→positive: a negative value and a 20-digit
+        // unscaled value (> 64-bit) exercise the variable-length signed decode, the 128-bit path, and
+        // signed (not unsigned) ordering. parquet-mr's column_orders=TypeDefinedOrder makes the
+        // byte-array min/max signed; a decimal stat must NOT be marked truncated (reserved for strings).
+        BigInteger negative = BigInteger.valueOf(-100L);             // -1.00
+        BigInteger large = new BigInteger("99999999999999999999");   // 20-digit unscaled
         Path parquetPath = writeParquet(
                 "message schema { required binary d (DECIMAL(20,2)); }",
-                /*rowCount=*/ 1,
-                (group, rowIndex) -> group.append("d", Binary.fromConstantByteArray(new byte[] {0})));
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("d", binaryDecimal(rowIndex == 0 ? negative : large)));
 
-        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
-                ParquetRowGroupStatisticsReader.read(
-                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2))));
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
+        // min is the negative value (proves signed order); max asserted by VALUE (unscaled `large`).
+        Assertions.assertEquals("-1.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals(0, new BigDecimal(large, 2).compareTo(
+                new BigDecimal(stats.get(0).getMaxTuple().getValues().get(0).getStringValue())));
+    }
+
+    /** Encode {@code unscaled} as a minimal big-endian two's-complement byte array (variable-length
+     * BINARY DECIMAL layout). parquet-mr computes the footer min/max with its signed comparator. */
+    private static Binary binaryDecimal(BigInteger unscaled) {
+        return Binary.fromConstantByteArray(unscaled.toByteArray());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split's **meta tier** reads a Parquet file's footer min/max to plan tablet split boundaries cheaply (avoiding a data-tier reservoir-sampling sub-query). The previous phase decoded INT32/INT64-backed DECIMAL footer stats but **conservatively rejected** FIXED_LEN_BYTE_ARRAY (FLBA) and BINARY-backed DECIMAL, because parquet footer min/max for byte-array decimals can use *unsigned* byte ordering (wrong for negatives) unless the writer recorded a signed sort order.

This rejection had a concrete cost: **StarRocks' own BE Parquet writer encodes DECIMAL128 (precision 19–38) as FLBA** (`be/src/formats/parquet/level_builder.cpp`; the `use_legacy_decimal_encoding` flag, default false, also forces DECIMAL32/64 to FLBA), and third-party writers commonly use FLBA for all decimals. So a `DECIMAL(38,2)` `ORDER BY` load from StarRocks-unloaded Parquet missed the meta tier entirely and fell to the data tier.

## What I'm doing:

Extend only `ParquetRowGroupStatisticsReader` to accept FLBA/BINARY-backed DECIMAL **— but only when the file's raw footer positively declares a `TypeDefinedOrder` column order for that leaf**, which for a DECIMAL logical type guarantees the byte-array min/max were ordered as signed two's-complement (parquet-mr's `BINARY_AS_SIGNED_INTEGER_COMPARATOR`).

- The gate reads the **raw Thrift footer** (`org.apache.parquet.format.Util.readFileMetaData`) and checks the leaf's `column_orders` entry `isSetTYPE_ORDER()`. The converted `PrimitiveType.columnOrder()` cannot be used because parquet-mr defaults a missing `column_orders` to `TYPE_DEFINED_ORDER` (so it would not distinguish a legacy file). A null/short list, an unset entry, an encrypted footer, or any parse/IO failure is treated as unknown → data tier (never a load failure).
- The extra raw-footer read is bounded (`ByteStreams.limit`, no untrusted-length allocation) and is taken **only** for a byte-array column carrying a DECIMAL annotation; integers/dates/strings/INT-decimals are unaffected.
- `toVariant` decodes byte-array decimals as `new BigInteger(bytes)` (signed big-endian) at the source scale; INT32/INT64 decoding is unchanged.
- The `truncated` flag is tightened to string-annotated BINARY only, so a BINARY-backed DECIMAL (exact numeric stat) is no longer spuriously marked truncated.
- Exact precision/scale match is still required; ORC, the sampler, `BoundaryPlanner`, `Variant`/`DecimalVariant`, and BE are unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)