### PR TITLE
[BugFix] Debounce autovacuum minActiveTxnId before txn-log deletion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -155,6 +155,11 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     private final AtomicLong lastSuccVacuumVersion = new AtomicLong(0);
 
+    // Purpose: the previous autovacuum round's computeMinActiveTxnId(), used to debounce a
+    //   transiently-too-high value (begin-vs-vacuum race) before allowing txn-log deletion.
+    // Persistence: in-memory only, NOT persisted (no @SerializedName); resets to 0 on restart/failover.
+    private volatile long lastMinActiveTxnId = 0;
+
     @SerializedName(value = "bucketNum")
     private int bucketNum = 0;
     
@@ -286,6 +291,14 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setLastSuccVacuumVersion(long lastSuccVacuumVersion) {
         this.lastSuccVacuumVersion.set(lastSuccVacuumVersion);
+    }
+
+    public long getLastMinActiveTxnId() {
+        return lastMinActiveTxnId;
+    }
+
+    public void setLastMinActiveTxnId(long lastMinActiveTxnId) {
+        this.lastMinActiveTxnId = lastMinActiveTxnId;
     }
 
     public long getExtraFileSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -178,6 +178,38 @@ public class AutovacuumDaemon extends FrontendDaemon {
         long minRetainVersion;
         long startTime = System.currentTimeMillis();
         long minActiveTxnId = computeMinActiveTxnId(db, table);
+
+        // Confirmed/lagged-watermark debounce, against a begin-transaction vs autovacuum race:
+        // beginTransaction() draws an id (advancing peekNextTransactionId()) BEFORE registering it in
+        // idToRunningTransactionState, so a probe landing in that gap can compute a minActiveTxnId one
+        // greater than an in-flight txn. Acting on it would let the BE delete that txn's still-needed
+        // combined log and permanently wedge publish on the partition. So we only act on a value confirmed
+        // by the PREVIOUS round (non-decreasing) and sweep txn logs with that older, confirmed value.
+        //
+        // When the current value is NOT confirmed -- first observation (also after FE restart/failover,
+        // since lastMinActiveTxnId is in-memory and resets to 0) or a regression -- we skip the ENTIRE
+        // round, not merely the txn-log delete. Skipping only the delete would still let the round advance
+        // lastSuccVacuumVersion; with lake_autovacuum_detect_vaccumed_version=true, shouldVacuum() then
+        // stops scheduling the partition once lastSuccVacuumVersion >= minRetainVersion, so for a partition
+        // that goes cold the confirming follow-up round (and its sweep) might never run, leaking txn logs.
+        // A full skip leaves lastSuccVacuumVersion untouched, so the partition stays schedulable and the
+        // next round runs with a confirmed watermark; the only cost is deferring this partition's
+        // metadata/data vacuum by one (rare) cycle. lastVacuumTime is set so naptime is still respected.
+        long lastMinActiveTxnId = partition.getLastMinActiveTxnId();
+        if (lastMinActiveTxnId <= 0 || minActiveTxnId < lastMinActiveTxnId) {
+            if (minActiveTxnId < lastMinActiveTxnId) {
+                LOG.warn("minActiveTxnId regressed {} -> {} for {}.{}.{}; skipping this vacuum round "
+                                + "(possible begin/vacuum race)",
+                        lastMinActiveTxnId, minActiveTxnId, db.getFullName(), table.getName(), partition.getId());
+            }
+            partition.setLastMinActiveTxnId(minActiveTxnId);
+            partition.setLastVacuumTime(startTime);
+            return;
+        }
+        // Confirmed non-decreasing: sweep txn logs with the previous (older, lower) value.
+        final long txnLogSweepWatermark = lastMinActiveTxnId;
+        partition.setLastMinActiveTxnId(minActiveTxnId);
+
         long preExtraFileSize = 0;
         // If shared file cleanup is enabled, vacuum runs on a single aggregator node.
         Map<ComputeNode, List<TabletInfoPB>> nodeToTablets = new HashMap<>();
@@ -313,7 +345,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
                     Math.max(clusterSnapshotMgr.getSafeDeletionTimeMs() / MILLISECONDS_PER_SECOND, 1));
             vacuumRequest.retainVersions = clusterSnapshotMgr.getVacuumRetainVersions(
                                            db.getId(), table.getId(), partition.getParentId(), partition.getId());
-            vacuumRequest.minActiveTxnId = minActiveTxnId;
+            vacuumRequest.minActiveTxnId = txnLogSweepWatermark;
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;
             vacuumRequest.enableFileBundling = fileBundling;
@@ -397,10 +429,11 @@ public class AutovacuumDaemon extends FrontendDaemon {
         MetricRepo.COUNTER_VACUUM_FILES_NUMBER.increase(vacuumedFiles);
         MetricRepo.COUNTER_VACUUM_FILES_BYTES.increase(vacuumedFileSize);
         LOG.info("Vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
-                        "visibleVersion={} minRetainVersion={} minActiveTxnId={} vacuumVersion={} extraFileSize={} cost={}ms",
+                        "visibleVersion={} minRetainVersion={} minActiveTxnId={} txnLogSweepWatermark={} " +
+                        "vacuumVersion={} extraFileSize={} cost={}ms",
                 db.getFullName(), table.getName(), partition.getId(), hasError, vacuumedFiles, vacuumedFileSize,
-                visibleVersion, minRetainVersion, minActiveTxnId, vacuumedVersion, extraFileSize, 
-                System.currentTimeMillis() - startTime);
+                visibleVersion, minRetainVersion, minActiveTxnId, txnLogSweepWatermark,
+                vacuumedVersion, extraFileSize, System.currentTimeMillis() - startTime);
     }
 
     private static long computeMinActiveTxnId(Database db, Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -162,6 +162,7 @@ public class VacuumTest {
         partition.setMinRetainVersion(10L);
         partition.setMetadataSwitchVersion(5L);
         partition.setLastSuccVacuumVersion(4L);
+        partition.setLastMinActiveTxnId(1L);  // confirmed predecessor so the round runs (Option A debounce)
 
         AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
 
@@ -201,6 +202,7 @@ public class VacuumTest {
         partition.setVisibleVersion(10L, System.currentTimeMillis());
         partition.setMinRetainVersion(10L);
         partition.setLastSuccVacuumVersion(4L);
+        partition.setLastMinActiveTxnId(1L);  // confirmed predecessor so the round runs (Option A debounce)
 
         AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
 
@@ -233,12 +235,76 @@ public class VacuumTest {
     }
 
     @Test
+    public void testTxnLogSweepDebounce() throws Exception {
+        // Option A (complete-round skip): an unconfirmed minActiveTxnId never drives a vacuum round; only a
+        // value confirmed by the previous round (non-decreasing) is acted on, sweeping with that older value.
+        partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+        Assertions.assertNotNull(partition);
+        partition.setVisibleVersion(10L, System.currentTimeMillis());
+        partition.setMinRetainVersion(10L);
+        partition.setLastSuccVacuumVersion(4L);
+
+        // Round 1: no confirmed predecessor (lastMinActiveTxnId == 0) -> the whole round is skipped.
+        partition.setLastMinActiveTxnId(0L);
+        List<VacuumRequest> round1 = runVacuumCaptureRequests();
+        Assertions.assertTrue(round1.isEmpty(), "first round must be skipped entirely");
+        long cur = partition.getLastMinActiveTxnId();   // seeded with the observed computeMinActiveTxnId()
+        Assertions.assertTrue(cur > 0);
+
+        // Round 2: confirmed non-decreasing -> run, sweeping with the PREVIOUS (older, lower) value, not cur.
+        long former = Math.max(1L, cur - 1);
+        partition.setLastMinActiveTxnId(former);
+        List<VacuumRequest> round2 = runVacuumCaptureRequests();
+        Assertions.assertFalse(round2.isEmpty(), "confirmed round must run");
+        boolean swept = false;
+        for (VacuumRequest req : round2) {
+            Assertions.assertEquals(former, (long) req.minActiveTxnId,
+                    "must act on the confirmed previous-round watermark, not the current observation");
+            if (Boolean.TRUE.equals(req.deleteTxnLog)) {
+                swept = true;
+            }
+        }
+        Assertions.assertTrue(swept, "confirmed round must sweep txn logs on one node");
+
+        // Round 3: regression (former set far above any real txn id) -> the whole round is skipped.
+        partition.setLastMinActiveTxnId(Long.MAX_VALUE);
+        List<VacuumRequest> round3 = runVacuumCaptureRequests();
+        Assertions.assertTrue(round3.isEmpty(), "regression round must be skipped entirely");
+    }
+
+    private List<VacuumRequest> runVacuumCaptureRequests() throws Exception {
+        VacuumResponse mockResponse = new VacuumResponse();
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = 0;
+        mockResponse.vacuumedFiles = 0L;
+        mockResponse.vacuumedFileSize = 0L;
+        mockResponse.vacuumedVersion = 0L;
+        mockResponse.extraFileSize = 0L;
+        mockResponse.tabletInfos = new ArrayList<>();
+
+        Future<VacuumResponse> mockFuture = mock(Future.class);
+        when(mockFuture.get()).thenReturn(mockResponse);
+
+        LakeService svc = mock(LakeService.class);
+        ArgumentCaptor<VacuumRequest> captor = ArgumentCaptor.forClass(VacuumRequest.class);
+        when(svc.vacuum(captor.capture())).thenReturn(mockFuture);
+
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        try (MockedStatic<BrpcProxy> mockBrpc = mockStatic(BrpcProxy.class)) {
+            mockBrpc.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(svc);
+            daemon.testVacuumPartitionImpl(db, olapTable, partition);
+        }
+        return captor.getAllValues();
+    }
+
+    @Test
     public void testAggregateVacuum() throws Exception {
         GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
         partition = olapTable2.getPhysicalPartitions().stream().findFirst().orElse(null);
         partition.setVisibleVersion(10L, System.currentTimeMillis());
         partition.setMinRetainVersion(10L);
         partition.setLastSuccVacuumVersion(4L);
+        partition.setLastMinActiveTxnId(1L);  // confirmed predecessor so the round runs (Option A debounce)
 
         AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
 
@@ -279,6 +345,7 @@ public class VacuumTest {
         partition.setMinRetainVersion(0L);
         partition.setLastSuccVacuumVersion(4L);
         partition.setMetadataSwitchVersion(6L);
+        partition.setLastMinActiveTxnId(1L);  // confirmed predecessor so the round runs (Option A debounce)
 
         AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
 
@@ -575,6 +642,7 @@ public class VacuumTest {
         partition.setMinRetainVersion(10L);
         partition.setLastSuccVacuumVersion(4L);
         partition.setMetadataSwitchVersion(5L);
+        partition.setLastMinActiveTxnId(1L);  // confirmed predecessor so the round runs (Option A debounce)
         AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
 
         VacuumResponse mockResponse = new VacuumResponse();


### PR DESCRIPTION
A begin-transaction vs autovacuum race could make computeMinActiveTxnId()
momentarily one greater than an in-flight transaction: beginTransaction() draws
an id (advancing the global generator / peekNextTransactionId()) before
registering it into idToRunningTransactionState, and an autovacuum probe landing
in that gap falls back to the peek seed. The resulting min_active_txn_id is sent
to the BE, whose vacuum_txn_log then deletes that transaction's still-needed
combined txn log. Its publish can never proceed afterwards ("Both txn_log and
corresponding tablet_meta missing"), permanently wedging the partition.

Defend in AutovacuumDaemon by never acting on a single, unconfirmed watermark:
keep a per-partition lastMinActiveTxnId and, on a round whose minActiveTxnId is
confirmed by the previous round (non-decreasing), sweep txn logs using that
older, confirmed value. When the value is unconfirmed -- first observation
(including after an FE restart/failover, since lastMinActiveTxnId is in-memory
and resets to 0) or a regression (logged at WARN) -- skip the ENTIRE vacuum round
rather than only the txn-log delete. Skipping only the delete would still let the
round advance lastSuccVacuumVersion, and with
lake_autovacuum_detect_vaccumed_version=true shouldVacuum() would then stop
scheduling the partition, so the confirming follow-up round (and its sweep) might
never run for a partition that goes cold. A full skip leaves lastSuccVacuumVersion
untouched, so the partition stays schedulable and the next round runs with a
confirmed watermark; the only cost is deferring that partition's metadata/data
vacuum by one (rare) cycle.

PhysicalPartition.lastMinActiveTxnId is in-memory runtime state only (no
@SerializedName, so excluded from the image and edit log); it resets to 0 on
restart/failover, which conservatively triggers the first-round skip.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
