### PR TITLE
[Enhancement] Count per-MV refresh metrics at job granularity

### DIFF
--- a/docs/en/administration/management/monitoring/metrics-materialized_view.md
+++ b/docs/en/administration/management/monitoring/metrics-materialized_view.md
@@ -37,17 +37,17 @@ scrape_configs:
 ### mv_refresh_jobs
 
 - Type: Counter
-- Description: Total number of refresh jobs of the materialized view.
+- Description: Total number of refresh jobs triggered for the materialized view. A refresh job corresponds to one user-initiated or scheduled refresh; a single job may execute multiple task runs internally. Each job is counted once when it reaches a terminal state. MERGED task runs (sub-tasks merged into a later batch) are not counted.
 
 ### mv_refresh_total_success_jobs
 
 - Type: Counter
-- Description: Number of successful refresh jobs of the materialized view.
+- Description: Number of refresh jobs that completed successfully. Counted once per job.
 
 ### mv_refresh_total_failed_jobs
 
 - Type: Counter
-- Description: Number of failed refresh jobs of the materialized view.
+- Description: Number of refresh jobs that failed. Counted once per job.
 
 ### mv_refresh_total_empty_jobs
 
@@ -112,4 +112,4 @@ scrape_configs:
 ### mv_refresh_duration
 
 - Type: Histogram
-- Description: Duration of the successful materialized view refresh jobs.
+- Description: Wall-clock duration of refresh jobs, in milliseconds. For multi-batch jobs, measured from the first task run start to the final task run completion.

--- a/docs/ja/administration/management/monitoring/metrics-materialized_view.md
+++ b/docs/ja/administration/management/monitoring/metrics-materialized_view.md
@@ -37,17 +37,17 @@ scrape_configs:
 ### mv_refresh_jobs
 
 - Type: Counter
-- Description: マテリアライズドビューのリフレッシュジョブの総数。
+- Description: マテリアライズドビューに対してトリガーされたリフレッシュジョブの総数。1つのリフレッシュジョブはユーザー起動またはスケジュールによる1回のリフレッシュに対応し、内部で複数の Task Run が実行される場合がある。各ジョブは終了状態に達した時点で1回カウントされる。MERGED 状態の Task Run（後のバッチにマージされたサブタスク）はカウントされない。
 
 ### mv_refresh_total_success_jobs
 
 - Type: Counter
-- Description: マテリアライズドビューの成功したリフレッシュジョブの数。
+- Description: 正常完了したリフレッシュジョブの数。ジョブ成功時に1回カウントされる。
 
 ### mv_refresh_total_failed_jobs
 
 - Type: Counter
-- Description: マテリアライズドビューの失敗したリフレッシュジョブの数。
+- Description: 失敗したリフレッシュジョブの数。ジョブ失敗時に1回カウントされる。
 
 ### mv_refresh_total_empty_jobs
 
@@ -112,4 +112,4 @@ scrape_configs:
 ### mv_refresh_duration
 
 - Type: Histogram
-- Description: 成功したマテリアライズドビューのリフレッシュジョブの期間。
+- Description: リフレッシュジョブの実時間（ミリ秒）。マルチバッチジョブの場合、最初の Task Run 開始から最後の Task Run 完了までを計測する。

--- a/docs/zh/administration/management/monitoring/metrics-materialized_view.md
+++ b/docs/zh/administration/management/monitoring/metrics-materialized_view.md
@@ -37,17 +37,17 @@ scrape_configs:
 ### mv_refresh_jobs
 
 - 类型：Counter
-- 描述：物化视图刷新作业的总数。
+- 描述：物化视图触发的刷新作业总数。一个刷新作业对应一次用户发起或调度的刷新；单个作业内部可能执行多个 Task Run。每个作业在达到终止状态时计数一次。MERGED 状态的 Task Run（被合并到后续批次的子任务）不计入。
 
 ### mv_refresh_total_success_jobs
 
 - 类型：Counter
-- 描述：执行成功的物化视图刷新作业的数量。
+- 描述：执行成功的物化视图刷新作业的数量。每个作业成功时计数一次。
 
 ### mv_refresh_total_failed_jobs
 
 - 类型：Counter
-- 描述：执行失败的物化视图刷新作业的数量。
+- 描述：执行失败的物化视图刷新作业的数量。每个作业失败时计数一次。
 
 ### mv_refresh_total_empty_jobs
 
@@ -112,4 +112,4 @@ scrape_configs:
 ### mv_refresh_duration
 
 - 类型：Histogram
-- 描述：执行成功的物化视图刷新作业的持续时间。
+- 描述：刷新作业的挂钟时长，单位为毫秒。对于多批次作业，从第一个 Task Run 开始到最后一个 Task Run 完成为止计算。

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -44,7 +44,7 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
     private final List<Metric> metrics = Lists.newArrayList();
 
     // refresh
-    // increased once the materialized view's refresh job is triggered.
+    // increased once per refresh job, when it reaches a terminal state.
     public LongCounterMetric counterRefreshJobTotal;
     // increased only if the materialized view's refresh job is success refreshed.
     public LongCounterMetric counterRefreshJobSuccessTotal;
@@ -85,7 +85,7 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
     public GaugeMetric<Integer> counterPartitionCount;
 
     // histogram(ms)
-    // record the materialized view's refresh job duration only if it's refreshed successfully.
+    // records the refresh job's wall-clock duration, once per job on its terminal run.
     public Histogram histRefreshJobDuration;
 
     public Optional<String> dbNameOpt = Optional.empty();
@@ -369,6 +369,7 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
         if (status == null || !status.isFinishState()) {
             return;
         }
+        // Counted once per refresh job, on its terminal task run.
         this.counterRefreshJobTotal.increase(1L);
         switch (status) {
             case MERGED:

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -17,6 +17,8 @@ package com.starrocks.scheduler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -34,6 +36,7 @@ import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryState;
+import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshProcessor;
@@ -55,6 +58,9 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -194,22 +200,33 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
                 Preconditions.checkState(mv != null);
                 mvMetricsEntity = MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
                 this.taskRunState = retryProcessTaskRun(context);
+                boolean spawnedNext = false;
                 if (this.taskRunState == Constants.TaskRunState.SUCCESS) {
                     logger.info("Refresh materialized view {} finished successfully.", mv.getName());
                     // advance LAST_FRESHNESS_CONFIRMED_AT even when the refresh changed no version
                     mvRefreshProcessor.confirmFreshness();
-                    // if success, try to generate next task run
-                    mvRefreshProcessor.generateNextTaskRunIfNeeded();
+                    spawnedNext = mvRefreshProcessor.generateNextTaskRunIfNeeded();
+                    if (!spawnedNext && mvRefreshProcessor.hasNextBatchRun()) {
+                        // A pending next batch could not be enqueued (e.g. the task-run queue is full): the
+                        // refresh is incomplete, so fail it through the normal failure path below, keeping the
+                        // metric, task history and materialized_view_refresh_jobs consistent on FAILED.
+                        throw new DmlException("Materialized view %s refresh incomplete: " +
+                                "a pending batch could not be scheduled", mv.getName());
+                    }
                 } else {
                     logger.info("Refresh materialized view {} failed with state: {}.", mv.getName(), taskRunState);
                 }
-                // update metrics
-                mvMetricsEntity.increaseRefreshJobStatus(taskRunState);
+                // Count the job once on its terminal run; intermediate successful batches are not counted.
+                if (!spawnedNext) {
+                    mvMetricsEntity.increaseRefreshJobStatus(this.taskRunState);
+                    recordRefreshJobDuration(mvMetricsEntity);
+                }
                 connectContext.getState().setOk();
             }
         } catch (Exception e) {
             if (mvMetricsEntity != null) {
                 mvMetricsEntity.increaseRefreshJobStatus(Constants.TaskRunState.FAILED);
+                recordRefreshJobDuration(mvMetricsEntity);
             }
             connectContext.getState().setError(e.getMessage());
             throw e;
@@ -320,8 +337,6 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         final MVRefreshProcessor.ProcessExecPlan processExecPlan = mvRefreshProcessor.getProcessExecPlan(taskRunContext);
         if (processExecPlan.state() == Constants.TaskRunState.SKIPPED) {
             logger.info("MV {} refresh task skipped, no partitions to refresh", mv.getName());
-            long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
-            mvMetricsEntity.updateRefreshDuration(elapsed);
             return Constants.TaskRunState.SKIPPED;
         }
 
@@ -329,7 +344,6 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         Constants.TaskRunState result = mvRefreshProcessor.execProcessExecPlan(taskRunContext, processExecPlan, executor);
         long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
         logger.info("refresh mv success, cost time(ms): {}", DebugUtil.DECIMAL_FORMAT_SCALE_3.format(elapsed));
-        mvMetricsEntity.updateRefreshDuration(elapsed);
         return result;
     }
 
@@ -450,5 +464,44 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
     @VisibleForTesting
     public RuntimeProfile getRuntimeProfile() {
         return runtimeProfile;
+    }
+
+    // Records the job's wall-clock duration once, on the terminal run, reusing the exact roll-up the
+    // materialized_view_refresh_jobs system table uses so the metric and the table never diverge.
+    private void recordRefreshJobDuration(IMaterializedViewMetricsEntity metricsEntity) {
+        try {
+            if (mvTaskRunContext == null || mvTaskRunContext.getStatus() == null) {
+                return;
+            }
+            String jobId = mvTaskRunContext.getStatus().getStartTaskRunId();
+            if (Strings.isNullOrEmpty(jobId)) {
+                return;
+            }
+            List<TaskRunStatus> batch = Lists.newArrayList();
+            // Include archived runs: a long multi-batch refresh may have had early batches archived out of
+            // in-memory history before this terminal run, and the system table's roll-up also reads archived history.
+            String dbName = db == null ? null : db.getFullName();
+            if (dbName != null) {
+                String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
+                for (TaskRunStatus s : GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunHistory()
+                        .lookupLastJobOfTasks(dbName, Collections.singleton(mvTaskName))) {
+                    if (jobId.equals(s.getStartTaskRunId()) && s.getState() != Constants.TaskRunState.MERGED) {
+                        batch.add(s);
+                    }
+                }
+            }
+            batch.add(mvTaskRunContext.getStatus());
+            // fromTaskRuns picks first/last by createTime — sort the same way.
+            batch.sort(Comparator.comparingLong(TaskRunStatus::getCreateTime));
+            ShowMaterializedViewStatus.RefreshJobStatus rjs = ShowMaterializedViewStatus.fromTaskRuns(batch);
+            long startBasis = rjs.getMvRefreshProcessTime() > 0
+                    ? rjs.getMvRefreshProcessTime() : rjs.getMvRefreshStartTime();
+            // The terminal run's finishTime may not be persisted yet; fall back to now().
+            long endMs = rjs.getMvRefreshEndTime() > 0 ? rjs.getMvRefreshEndTime() : System.currentTimeMillis();
+            long wallMs = Math.max(0L, endMs - startBasis);
+            metricsEntity.updateRefreshDuration(wallMs);
+        } catch (Exception e) {
+            logger.warn("skip refresh job duration metric for mv {}", mv.getName(), e);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -202,8 +202,9 @@ public abstract class MVRefreshProcessor {
 
     /**
      * Generate the next task run to be processed and set it to the nextTaskRun field.
+     * Returns true iff this call enqueued a successor task run, false otherwise.
      */
-    public abstract void generateNextTaskRunIfNeeded();
+    public abstract boolean generateNextTaskRunIfNeeded();
 
     /**
      * Whether this refresh will spawn another batch task run after the current one.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridRefreshProcessor.java
@@ -146,8 +146,8 @@ public final class MVHybridRefreshProcessor extends MVRefreshProcessor {
     }
 
     @Override
-    public void generateNextTaskRunIfNeeded() {
-        getCurrentProcessor().generateNextTaskRunIfNeeded();
+    public boolean generateNextTaskRunIfNeeded() {
+        return getCurrentProcessor().generateNextTaskRunIfNeeded();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -43,6 +43,7 @@ import com.starrocks.qe.QueryDetail;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.SubmitResult;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
@@ -469,9 +470,9 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     }
 
     @Override
-    public void generateNextTaskRunIfNeeded() {
+    public boolean generateNextTaskRunIfNeeded() {
         if (!hasNextTaskRun || mvContext.getTaskRun().isKilled()) {
-            return;
+            return false;
         }
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         Map<String, String> properties = mvContext.getProperties();
@@ -522,9 +523,11 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                     .setExecuteOption(option)
                     .build();
             nextTaskRun = taskRun;
-        } else {
-            taskManager.executeTask(taskName, option);
+            return true;
         }
+        // Report the job as continued only if the successor run was accepted; a rejected submit (e.g. queue
+        // full) means no successor runs, so the current run stays the job's terminal run.
+        return taskManager.executeTask(taskName, option).getStatus() == SubmitResult.SubmitStatus.SUBMITTED;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -37,6 +37,7 @@ import com.starrocks.qe.QueryDetail;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.SubmitResult;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
@@ -295,9 +296,9 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
     }
 
     @Override
-    public void generateNextTaskRunIfNeeded() {
+    public boolean generateNextTaskRunIfNeeded() {
         if (!mvContext.hasNextBatchPartition() || mvContext.getTaskRun().isKilled()) {
-            return;
+            return false;
         }
 
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
@@ -370,9 +371,11 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
                     .setExecuteOption(option)
                     .build();
             nextTaskRun = taskRun;
-        } else {
-            taskManager.executeTask(taskName, option);
+            return true;
         }
+        // Report the job as continued only if the successor run was accepted; a rejected submit (e.g. queue
+        // full) means no successor runs, so the current run stays the job's terminal run.
+        return taskManager.executeTask(taskName, option).getStatus() == SubmitResult.SubmitStatus.SUBMITTED;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MaterializedViewMetricsJobLevelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MaterializedViewMetricsJobLevelTest.java
@@ -1,0 +1,266 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies MV refresh metrics are counted once per refresh job (on the terminal task run), not once per task run.
+ */
+public class MaterializedViewMetricsJobLevelTest extends MVTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+        starRocksAssert.withTable(cluster, "depts");
+    }
+
+    /**
+     * Single-run refresh: the one run IS the terminal run, so counters must still equal 1.
+     * This guards against regressions where the terminal-run gate accidentally suppresses
+     * single-batch refreshes.
+     */
+    @Test
+    public void testSingleBatchRefreshCountsOnce() throws Exception {
+        String partitionTable = "CREATE TABLE mjl_single_t1 (dt date, v int)\n" +
+                "PARTITION BY date_trunc('day', dt)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("mjl_single_t1", "p1", "2024-01-01", "2024-01-02");
+
+        String mvSql = "CREATE MATERIALIZED VIEW mjl_single_mv1 " +
+                "PARTITION BY date_trunc('day', dt) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\"partition_refresh_number\"=\"-1\") " +
+                "AS SELECT dt, sum(v) FROM mjl_single_t1 GROUP BY dt";
+        starRocksAssert.withMaterializedView(mvSql);
+
+        // Insert data after MV creation so the base table has a newer version than the MV's snapshot.
+        executeInsertSql("insert into mjl_single_t1 partition(p1) values('2024-01-01', 1)");
+
+        try {
+            MaterializedView mv = getMv("test", "mjl_single_mv1");
+
+            TaskRun taskRun = buildMVTaskRun(mv, "test");
+            initAndExecuteTaskRun(taskRun);
+
+            IMaterializedViewMetricsEntity iEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+            Assertions.assertInstanceOf(MaterializedViewMetricsEntity.class, iEntity);
+            MaterializedViewMetricsEntity metrics = (MaterializedViewMetricsEntity) iEntity;
+
+            Assertions.assertEquals(1, metrics.counterRefreshJobTotal.getValue(),
+                    "single-batch job should count as 1 job");
+            Assertions.assertEquals(1, metrics.counterRefreshJobSuccessTotal.getValue(),
+                    "single-batch job should count as 1 success");
+            Assertions.assertEquals(1, metrics.histRefreshJobDuration.getCount(),
+                    "single-batch job should record exactly 1 duration sample");
+        } finally {
+            starRocksAssert.dropMaterializedView("mjl_single_mv1");
+            starRocksAssert.dropTable("mjl_single_t1");
+        }
+    }
+
+    /**
+     * A second refresh on an already-up-to-date MV is SKIPPED: it is counted once as a job (in the
+     * empty bucket), not as a success or failure.
+     */
+    @Test
+    public void skippedRefreshCountedOncePerJob() throws Exception {
+        String mvSql = "CREATE MATERIALIZED VIEW mjl_skipped_mv1 " +
+                "REFRESH DEFERRED MANUAL " +
+                "AS SELECT * FROM depts WHERE deptno > 10";
+        starRocksAssert.withMaterializedView(mvSql);
+
+        try {
+            MaterializedView mv = getMv("test", "mjl_skipped_mv1");
+
+            refreshMaterializedView(DB_NAME, "mjl_skipped_mv1");
+
+            IMaterializedViewMetricsEntity iEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+            Assertions.assertInstanceOf(MaterializedViewMetricsEntity.class, iEntity);
+            MaterializedViewMetricsEntity entity = (MaterializedViewMetricsEntity) iEntity;
+
+            assertEquals(1L, entity.counterRefreshJobTotal.getValue());
+            assertEquals(1L, entity.counterRefreshJobSuccessTotal.getValue());
+            assertEquals(0L, entity.counterRefreshJobFailedTotal.getValue());
+            assertEquals(0L, entity.counterRefreshJobEmptyTotal.getValue());
+
+            // Second refresh: base table unchanged → SKIPPED (counts once as an empty job).
+            refreshMaterializedView(DB_NAME, "mjl_skipped_mv1");
+
+            assertEquals(2L, entity.counterRefreshJobTotal.getValue());
+            assertEquals(1L, entity.counterRefreshJobSuccessTotal.getValue());
+            assertEquals(0L, entity.counterRefreshJobFailedTotal.getValue());
+            assertEquals(1L, entity.counterRefreshJobEmptyTotal.getValue());
+        } finally {
+            starRocksAssert.dropMaterializedView("mjl_skipped_mv1");
+        }
+    }
+
+    /**
+     * Multi-batch refresh (partition_refresh_number=1 with 2 stale partitions):
+     * - The first task run calls generateNextTaskRunIfNeeded() which returns true (spawned a successor).
+     *   => it is NOT terminal; counters must NOT be bumped.
+     * - The second task run has no successor => it IS terminal; counters must be bumped exactly once.
+     *
+     * So after the full job: total=1, success=1, duration-samples=1 (not 2).
+     */
+    @Test
+    public void testMultiBatchRefreshCountsOnce() throws Exception {
+        String partitionTable = "CREATE TABLE mjl_multi_t1 (dt date, v int)\n" +
+                "PARTITION BY date_trunc('day', dt)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("mjl_multi_t1", "p1", "2024-02-01", "2024-02-02");
+        addRangePartition("mjl_multi_t1", "p2", "2024-02-02", "2024-02-03");
+
+        String mvSql = "CREATE MATERIALIZED VIEW mjl_multi_mv1 " +
+                "PARTITION BY date_trunc('day', dt) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\"partition_refresh_number\"=\"1\") " +
+                "AS SELECT dt, sum(v) FROM mjl_multi_t1 GROUP BY dt";
+        starRocksAssert.withMaterializedView(mvSql);
+
+        // Insert into both partitions AFTER MV creation so both are stale and need refreshing.
+        executeInsertSql("insert into mjl_multi_t1 partition(p1) values('2024-02-01', 1)");
+        executeInsertSql("insert into mjl_multi_t1 partition(p2) values('2024-02-02', 2)");
+
+        try {
+            MaterializedView mv = getMv("test", "mjl_multi_mv1");
+
+            // Batch 1: IS_TEST=true so the spawned next-run is stored in nextTaskRun, not submitted.
+            TaskRun taskRun1 = buildMVTaskRun(mv, "test");
+            initAndExecuteTaskRun(taskRun1);
+
+            MVPCTRefreshProcessor processor1 = getPartitionBasedRefreshProcessor(taskRun1);
+            TaskRun taskRun2 = processor1.getNextTaskRun();
+
+            Assertions.assertNotNull(taskRun2,
+                    "expected a second batch task run for 2-partition MV with partition_refresh_number=1");
+
+            IMaterializedViewMetricsEntity iEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+            Assertions.assertInstanceOf(MaterializedViewMetricsEntity.class, iEntity);
+            MaterializedViewMetricsEntity metrics = (MaterializedViewMetricsEntity) iEntity;
+
+            Assertions.assertEquals(0, metrics.counterRefreshJobTotal.getValue(),
+                    "job counter must not be bumped after an intermediate batch");
+            Assertions.assertEquals(0, metrics.histRefreshJobDuration.getCount(),
+                    "duration must not be sampled after an intermediate batch");
+
+            // Mirror production: the scheduler always adds batch N to history before dispatching batch N+1.
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunHistory().addHistory(taskRun1.getStatus());
+
+            // Regression: Database.getFullName() is unqualified while a stored TaskRunStatus keeps the
+            // "default_cluster:" prefix; matchByTaskName compares against the stripped getDbName(), so the
+            // roll-up must still find earlier in-memory batches (not only archived ones) via the plain db name.
+            String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
+            boolean foundEarlierBatch = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunHistory()
+                    .lookupLastJobOfTasks(DB_NAME, Collections.singleton(mvTaskName))
+                    .stream().anyMatch(s -> taskRun1.getStatus().getQueryId().equals(s.getQueryId()));
+            Assertions.assertTrue(foundEarlierBatch,
+                    "duration roll-up must find the earlier in-memory batch via the unqualified db name");
+
+            // Batch 2: terminal run (no more partitions left).
+            initAndExecuteTaskRun(taskRun2);
+
+            MVPCTRefreshProcessor processor2 = getPartitionBasedRefreshProcessor(taskRun2);
+            Assertions.assertNull(processor2.getNextTaskRun(),
+                    "no third batch expected");
+
+            Assertions.assertEquals(1, metrics.counterRefreshJobTotal.getValue(),
+                    "multi-batch job must be counted exactly once");
+            Assertions.assertEquals(1, metrics.counterRefreshJobSuccessTotal.getValue(),
+                    "multi-batch job must record exactly one success");
+            Assertions.assertEquals(1, metrics.histRefreshJobDuration.getCount(),
+                    "multi-batch job must record exactly one duration sample");
+        } finally {
+            starRocksAssert.dropMaterializedView("mjl_multi_mv1");
+            starRocksAssert.dropTable("mjl_multi_t1");
+        }
+    }
+
+    /**
+     * A successful batch whose pending next batch cannot be enqueued (rejected submit / queue full)
+     * leaves the refresh incomplete. The run must be failed so the metric agrees with task history and
+     * materialized_view_refresh_jobs, which would otherwise record this terminal run as a success.
+     */
+    @Test
+    public void incompleteRefreshWhenSuccessorRejectedCountsAsFailed() throws Exception {
+        String partitionTable = "CREATE TABLE mjl_reject_t1 (dt date, v int)\n" +
+                "PARTITION BY date_trunc('day', dt)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("mjl_reject_t1", "p1", "2024-03-01", "2024-03-02");
+        addRangePartition("mjl_reject_t1", "p2", "2024-03-02", "2024-03-03");
+
+        String mvSql = "CREATE MATERIALIZED VIEW mjl_reject_mv1 " +
+                "PARTITION BY date_trunc('day', dt) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\"partition_refresh_number\"=\"1\") " +
+                "AS SELECT dt, sum(v) FROM mjl_reject_t1 GROUP BY dt";
+        starRocksAssert.withMaterializedView(mvSql);
+
+        executeInsertSql("insert into mjl_reject_t1 partition(p1) values('2024-03-01', 1)");
+        executeInsertSql("insert into mjl_reject_t1 partition(p2) values('2024-03-02', 2)");
+
+        // Simulate a rejected successor submit: the first batch succeeds but cannot enqueue its next
+        // batch, while hasNextBatchRun() stays genuinely true (p2 is still pending).
+        new MockUp<MVPCTRefreshProcessor>() {
+            @Mock
+            public boolean generateNextTaskRunIfNeeded() {
+                return false;
+            }
+        };
+
+        try {
+            MaterializedView mv = getMv("test", "mjl_reject_mv1");
+            TaskRun taskRun = buildMVTaskRun(mv, "test");
+
+            Assertions.assertThrows(Exception.class, () -> initAndExecuteTaskRun(taskRun),
+                    "an incomplete refresh (successor rejected) must fail the run");
+
+            IMaterializedViewMetricsEntity iEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+            Assertions.assertInstanceOf(MaterializedViewMetricsEntity.class, iEntity);
+            MaterializedViewMetricsEntity metrics = (MaterializedViewMetricsEntity) iEntity;
+
+            Assertions.assertEquals(1, metrics.counterRefreshJobTotal.getValue(),
+                    "incomplete refresh must be counted exactly once");
+            Assertions.assertEquals(1, metrics.counterRefreshJobFailedTotal.getValue(),
+                    "incomplete refresh must count as a failed job");
+            Assertions.assertEquals(0, metrics.counterRefreshJobSuccessTotal.getValue(),
+                    "incomplete refresh must not count as a success");
+            Assertions.assertEquals(1, metrics.histRefreshJobDuration.getCount(),
+                    "incomplete refresh must record exactly one duration sample");
+        } finally {
+            starRocksAssert.dropMaterializedView("mjl_reject_mv1");
+            starRocksAssert.dropTable("mjl_reject_t1");
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The per-MV refresh Prometheus metrics (`mv_refresh_jobs`, `mv_refresh_total_success_jobs`, `mv_refresh_total_failed_jobs`, `mv_refresh_duration`) were incremented once per **task run**. A single refresh **job** can execute several task runs (batched PCT refresh, IVM follow-up chains), so the metrics over-counted relative to a user's notion of a "refresh job" and did not match the new `information_schema.materialized_view_refresh_jobs` system table (#74769), which is job-granular.

## What I'm doing:

Migrate the per-MV refresh metrics to **job granularity**, consistent with `materialized_view_refresh_jobs`:

- `generateNextTaskRunIfNeeded()` now returns whether it enqueued a successor batch. The refresh job is counted **once, on its terminal task run** (the run that enqueues no successor). `MERGED` runs are excluded.
- A successful batch that **cannot enqueue its pending next batch** (e.g. the task-run queue is full) leaves the refresh incomplete; the run is **failed** through the normal failure path, so it is recorded as a failed job consistently across the metric, task history, and `materialized_view_refresh_jobs`.
- `mv_refresh_duration`: now the **per-job wall-clock** duration (ms), computed by reusing `ShowMaterializedViewStatus.fromTaskRuns(...)` over the job's task runs (including archived ones), so it equals the system table's `DURATION_TIME`.
- Docs (en/zh/ja) and unit tests updated.

`mv_refresh_total_empty_jobs` is **left unchanged** in this PR (its deprecation is deferred to a later PR).

This is PR1 of a series; global (`mv_global_refresh_*`) and PM-usage metrics follow in separate PRs.

Fixes #issue: N/A — internal observability enhancement from the MV Metrics PRD; no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

> Note: existing dashboards/alerts built on the old per-task-run values will see lower job/success/failed counts for batched or IVM refreshes, and `mv_refresh_duration` as per-job wall-clock, after upgrade.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)