### PR TITLE
[Tool] ci: add rocky9 to thirdparty build pipelines and dev-env image

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -96,6 +96,11 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER centos7
 
+      - name: update image - rocky9
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER rocky9
+
       - name: Clean ENV
         if: always()
         run: |

--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -255,7 +255,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linux: [centos7, ubuntu]
+        linux: [centos7, ubuntu, rocky9]
     steps:
       - name: clean
         run: |

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -305,7 +305,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linux: [centos7, ubuntu]
+        linux: [centos7, ubuntu, rocky9]
     env:
       PR_NUMBER: ${{ github.event.number }}
       BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/image-rebuild-three-digit.yml
+++ b/.github/workflows/image-rebuild-three-digit.yml
@@ -93,6 +93,11 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER centos7
 
+      - name: update image - rocky9
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER rocky9
+
       - name: Clean ENV
         if: always()
         run: |

--- a/docker/dockerfiles/dev-env/README.md
+++ b/docker/dockerfiles/dev-env/README.md
@@ -22,7 +22,15 @@ E.g.:
 ```shell
 DOCKER_BUILDKIT=1 docker build --rm=true --build-arg distro=centos7 -f dev-env.Dockerfile -t ghcr.io/starrocks/starrocks/dev-env-centos7:main ../../..
 ```
-### 1.3 Build ubuntu dev env image with a Github token
+### 1.3 Build rocky9 dev env image
+```
+DOCKER_BUILDKIT=1 docker build --rm=true --build-arg distro=rocky9 -f dev-env.Dockerfile -t ghcr.io/OWNER/starrocks/dev-env-rocky9:<tag> ../../..
+```
+E.g.:
+```shell
+DOCKER_BUILDKIT=1 docker build --rm=true --build-arg distro=rocky9 -f dev-env.Dockerfile -t ghcr.io/starrocks/starrocks/dev-env-rocky9:main ../../..
+```
+### 1.4 Build ubuntu dev env image with a Github token
 ```
 DOCKER_BUILDKIT=1 docker build --rm=true --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -f dev-env.Dockerfile -t ghcr.io/OWNER/starrocks/dev-env-ubuntu:<tag> ../../..
 ```

--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -8,8 +8,10 @@
 #  `distro` argument can be specified to build for a different linux distribution other than default `ubuntu`.
 #  For example, build centos7 dev-env with following commands
 #    DOCKER_BUILDKIT=1 docker build --rm=true --build-arg distro=centos7 --build-arg starlet_tag=$STARLET_ARTIFACTS_TAG -f docker/dockerfiles/dev-env/dev-env.Dockerfile -t dev-env-centos7:latest .
+#  Or build rocky9 dev-env with following commands
+#    DOCKER_BUILDKIT=1 docker build --rm=true --build-arg distro=rocky9 --build-arg starlet_tag=$STARLET_ARTIFACTS_TAG -f docker/dockerfiles/dev-env/dev-env.Dockerfile -t dev-env-rocky9:latest .
 #
-#  Supported linux distribution are: centos7, ubuntu
+#  Supported linux distribution are: centos7, ubuntu, rocky9
 
 # whether prebuild starrocks maven project and cache the maven artifacts
 # value: true | false
@@ -23,14 +25,14 @@ ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-mai
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
 ARG starlet_tag=v4.2-rc2
-# build for which linux distro: centos7|ubuntu
+# build for which linux distro: centos7|ubuntu|rocky9
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.
 ARG GITHUB_TOKEN
 # the root directory to build the project
 ARG BUILD_ROOT=/build
 
-FROM starrocks/toolchains-${distro}:main-20251029 as base
+FROM starrocks/toolchains-${distro}:main-20260616 as base
 ENV STARROCKS_THIRDPARTY=/var/local/thirdparty
 
 WORKDIR /
@@ -71,6 +73,9 @@ FROM build_prebuild_mvn_${prebuild_maven} as build_stage2
 
 FROM starrocks/starlet-artifacts-ubuntu22:${starlet_tag} as starlet-ubuntu
 FROM starrocks/starlet-artifacts-centos7:${starlet_tag} as starlet-centos7
+# rocky9 (glibc 2.34) reuses the centos7 artifacts (glibc 2.17, forward-compatible);
+# the ubuntu22 artifacts (glibc 2.35) are too new to run on rocky9.
+FROM starrocks/starlet-artifacts-centos7:${starlet_tag} as starlet-rocky9
 # determine which artifacts to use
 FROM starlet-${distro} as starlet
 ARG BUILD_ROOT


### PR DESCRIPTION
Wire Rocky Linux 9 into the build infrastructure:
- dev-env image: add the rocky9 distro arg value, docs, and a starlet-rocky9 stage that reuses the centos7 starlet artifacts (glibc 2.17, forward-compatible with rocky9's 2.34)
- add rocky9 to the thirdparty-update matrix in ci-pipeline.yml and ci-pipeline-branch.yml
- add a rocky9 update-image step to image-rebuild-three-digit.yml

## Why I'm doing:

## What I'm doing:

Refs #74517

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
