### PR TITLE
[BugFix] Backquote COLUMNS/PARTITION identifiers in persisted routine load SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/RoutineLoadDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/RoutineLoadDesc.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load;
 
+import com.starrocks.common.util.ParseUtil;
 import com.starrocks.sql.ast.ColumnSeparator;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.ImportColumnsStmt;
@@ -144,7 +145,7 @@ public class RoutineLoadDesc {
     }
 
     private String pack(String str) {
-        return "`" + str + "`";
+        return ParseUtil.backquote(str);
     }
 
     private void castSlotRef(Expr expr) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/RoutineLoadDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/RoutineLoadDescTest.java
@@ -61,4 +61,28 @@ public class RoutineLoadDescTest {
                         "WHERE `a` = 1",
                 desc.toSql());
     }
+
+    @Test
+    public void testToSqlBackquotesSpecialIdentifiers() throws Exception {
+        // Column and partition names containing a backtick must have the embedded backtick
+        // doubled (a`b -> `a``b`); otherwise toSql() produces malformed SQL that fails to
+        // re-parse when the persisted CREATE ROUTINE LOAD statement is deserialized on FE
+        // restart, which would silently drop the routine load description.
+        RoutineLoadDesc originLoad = CreateRoutineLoadStmt.getLoadDesc(new OriginStatementInfo(
+                "CREATE ROUTINE LOAD job ON tbl " +
+                        "COLUMNS(`a``b`, `c`=1), " +
+                        "TEMPORARY PARTITION(`p``1`) " +
+                        "PROPERTIES (\"desired_concurrent_number\"=\"3\") " +
+                        "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", 0), null);
+
+        String sql = originLoad.toSql();
+        Assertions.assertEquals("COLUMNS(`a``b`, `c` = 1), TEMPORARY PARTITION(`p``1`)", sql);
+
+        // The rendered SQL must round-trip through the parser without losing the description.
+        RoutineLoadDesc reparsed = CreateRoutineLoadStmt.getLoadDesc(new OriginStatementInfo(
+                "CREATE ROUTINE LOAD job ON tbl " + sql +
+                        " PROPERTIES (\"desired_concurrent_number\"=\"3\")" +
+                        " FROM KAFKA (\"kafka_topic\" = \"my_topic\")", 0), null);
+        Assertions.assertEquals(sql, reparsed.toSql());
+    }
 }


### PR DESCRIPTION

RoutineLoadDesc.toSql() is interpolated into the persisted CREATE ROUTINE LOAD statement by RoutineLoadJob.mergeLoadDescToOriginStatement and re-parsed on FE restart. pack() wrapped column and partition names with naive backticks ("`" + name + "`") without escaping embedded backticks, so an identifier containing a backtick produced malformed SQL that failed to re-parse on restart, silently dropping the routine load description.

This is the same failure mode fixed for the job/table names in #74449; route the COLUMNS/PARTITION identifiers through ParseUtil.backquote so embedded backticks are doubled (a`b -> `a``b`). Output for ordinary identifiers is unchanged.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
