### PR TITLE
[Doc] Sync pre-split metric descriptions for the unified INSERT hook

### DIFF
--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -526,13 +526,13 @@ All transaction metrics share the following labels:
 
 - Unit: ms
 - Type: Histogram
-- Description: Wall-clock time the coordinator spent awaiting `FINISHED` on the admitted Sample-Based Tablet Pre-Split reshard job. Fires on both production paths — the INSERT-from-FILES hook (called from `StmtExecutor` before `StatementPlanner.plan` opens the load txn) and the Broker Load hook (called from `BrokerLoadJob.createLoadingTask` before `beginTxn` opens `T_load`) — and on the optional `runPreSplit` synchronous-await wrapper used by tests. In all cases the trigger load itself plans against the post-split layout.
+- Description: Wall-clock time the coordinator spent awaiting `FINISHED` on the admitted Sample-Based Tablet Pre-Split reshard job. Fires on all production load kinds — INSERT-from-FILES and INSERT-from-table (both via `InsertPreSplitHook`, called from `StmtExecutor` before `StatementPlanner.plan` opens the load txn) and Broker Load (via `BrokerLoadPreSplitHook`, called from `BrokerLoadJob.createLoadingTask` before `beginTxn` opens `T_load`), all sync-awaiting through the shared `PreSplitFlow` — and on the optional `runPreSplit` synchronous-await wrapper used by tests. In all cases the trigger load itself plans against the post-split layout.
 
 ## `starrocks_fe_tablet_pre_split_post_submit_hard_cap`
 
 - Unit: Count
 - Type: Cumulative
-- Description: Total Sample-Based Tablet Pre-Split post-submit hard-cap events. Incremented when the admitted reshard job did not reach `FINISHED` within `tablet_pre_split_post_submit_wait_seconds`. Fires on the INSERT-from-FILES production path on timeout (the INSERT then proceeds without abort against the currently visible tablet layout — still the original layout if the daemon hasn't transitioned, or partially / fully post-split if the daemon raced past the wait. `tablet_pre_split_load_abort` is NOT incremented because the INSERT itself is not aborted) and on the `runPreSplit` synchronous-await wrapper. The Broker Load production path does not await and so does not update this counter.
+- Description: Total Sample-Based Tablet Pre-Split post-submit hard-cap events. Incremented when the admitted reshard job did not reach `FINISHED` within `tablet_pre_split_post_submit_wait_seconds`. Fires on every production load kind on timeout — INSERT-from-FILES, INSERT-from-table, and Broker Load (all sync-await through the shared `PreSplitFlow`) — as well as the `runPreSplit` synchronous-await wrapper. The load then proceeds without abort against the currently visible tablet layout (still the original layout if the daemon hasn't transitioned, or partially / fully post-split if the daemon raced past the wait); `tablet_pre_split_load_abort` is NOT incremented because the load itself is not aborted.
 
 ## `starrocks_fe_tablet_pre_split_load_abort`
 

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -522,13 +522,13 @@ description: "Alphabetical s"
 
 - 単位: ミリ秒
 - タイプ: ヒストグラム
-- 説明: 受理されたサンプリングベースのタブレット事前分割 reshard ジョブの `FINISHED` をコーディネーターが待機した壁時計時間。両方の本番経路で更新されます — INSERT-from-FILES の hook（`StmtExecutor` で `StatementPlanner.plan` が取り込みトランザクションを開く前に呼ばれる）と Broker Load の hook（`BrokerLoadJob.createLoadingTask` で `beginTxn` が `T_load` を開く前に呼ばれる）。テスト用の `runPreSplit` 同期待機ラッパーでも更新されます。いずれの経路でも、トリガーとなった取り込み自身が分割後のタブレットレイアウトに対してプランされます。
+- 説明: 受理されたサンプリングベースのタブレット事前分割 reshard ジョブの `FINISHED` をコーディネーターが待機した壁時計時間。すべての本番取り込み種別で更新されます — INSERT-from-FILES と INSERT-from-table（いずれも `InsertPreSplitHook` 経由、`StmtExecutor` で `StatementPlanner.plan` が取り込みトランザクションを開く前に呼ばれる）、および Broker Load（`BrokerLoadPreSplitHook` 経由、`BrokerLoadJob.createLoadingTask` で `beginTxn` が `T_load` を開く前に呼ばれる）で、いずれも共有の `PreSplitFlow` を通じて同期待機します。テスト用の `runPreSplit` 同期待機ラッパーでも更新されます。いずれの経路でも、トリガーとなった取り込み自身が分割後のタブレットレイアウトに対してプランされます。
 
 ## `starrocks_fe_tablet_pre_split_post_submit_hard_cap`
 
 - 単位: カウント
 - タイプ: 累積
-- 説明: サンプリングベースのタブレット事前分割で post-submit ハードキャップが発火した累計回数。受理された reshard ジョブが `tablet_pre_split_post_submit_wait_seconds` 以内に `FINISHED` に到達しなかったときにインクリメントされます。INSERT-from-FILES 本番経路でタイムアウト時に発火します（INSERT は**中止せずに継続実行**し、その時点で可視のタブレットレイアウトに対してプランされます — デーモンがまだ遷移していなければ元の単一タブレットレイアウト、待機放棄後にデーモンがレースで完了した場合は部分的／完全に分割後のレイアウトとなり得ます。INSERT 自体は中止されないため、`tablet_pre_split_load_abort` はインクリメントされません）。テスト用の `runPreSplit` 同期待機ラッパーでも発火します。Broker Load 本番経路は待機しないため、このカウンタは更新されません。
+- 説明: サンプリングベースのタブレット事前分割で post-submit ハードキャップが発火した累計回数。受理された reshard ジョブが `tablet_pre_split_post_submit_wait_seconds` 以内に `FINISHED` に到達しなかったときにインクリメントされます。すべての本番取り込み種別でタイムアウト時に発火します — INSERT-from-FILES、INSERT-from-table、および Broker Load（いずれも共有の `PreSplitFlow` を通じて同期待機）。テスト用の `runPreSplit` 同期待機ラッパーでも発火します。取り込みはこのとき**中止せずに継続実行**し、その時点で可視のタブレットレイアウトに対してプランされます（デーモンがまだ遷移していなければ元の単一タブレットレイアウト、待機放棄後にデーモンがレースで完了した場合は部分的／完全に分割後のレイアウト）。取り込み自体は中止されないため、`tablet_pre_split_load_abort` はインクリメントされません。
 
 ## `starrocks_fe_tablet_pre_split_load_abort`
 

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -548,13 +548,13 @@ description: "Alphabetical s"
 
 - 单位：毫秒
 - 类型：直方图
-- 描述：协调器等待已提交的预分裂 reshard 作业到达 `FINISHED` 状态所耗费的墙钟时间。在两条生产路径上均触发 —— INSERT-from-FILES 的 hook（在 `StmtExecutor` 中、`StatementPlanner.plan` 打开导入 txn 之前调用）与 Broker Load 的 hook（在 `BrokerLoadJob.createLoadingTask` 中、`beginTxn` 打开 `T_load` 之前调用）；测试用的 `runPreSplit` 同步包装路径也触发。两种路径下触发导入本身均按分裂后的 tablet 布局做计划。
+- 描述：协调器等待已提交的预分裂 reshard 作业到达 `FINISHED` 状态所耗费的墙钟时间。在所有生产导入类型上均触发 —— INSERT-from-FILES 与 INSERT-from-table（均经由 `InsertPreSplitHook`，在 `StmtExecutor` 中、`StatementPlanner.plan` 打开导入 txn 之前调用）以及 Broker Load（经由 `BrokerLoadPreSplitHook`，在 `BrokerLoadJob.createLoadingTask` 中、`beginTxn` 打开 `T_load` 之前调用），三者均通过共享的 `PreSplitFlow` 同步等待；测试用的 `runPreSplit` 同步包装路径也触发。所有路径下触发导入本身均按分裂后的 tablet 布局做计划。
 
 ## `starrocks_fe_tablet_pre_split_post_submit_hard_cap`
 
 - 单位：计数
 - 类型：累计
-- 描述：基于采样的 Tablet 预分裂触发提交后硬上限的事件总数。已提交的 reshard 作业未能在 `tablet_pre_split_post_submit_wait_seconds` 内到达 `FINISHED` 时递增。INSERT-from-FILES 生产路径超时后会触发（INSERT 此时**不中止地继续执行**，按当时可见的 Tablet 布局做计划 —— 守护线程还未推进则仍为原单 tablet 布局，若守护线程在我们放弃等待之后才完成则可能已部分／完全分裂；**不**递增 `tablet_pre_split_load_abort`，因为 INSERT 本身未被中止）；测试用的 `runPreSplit` 同步包装路径也会触发。Broker Load 生产路径不等待，因此不会更新此计数器。
+- 描述：基于采样的 Tablet 预分裂触发提交后硬上限的事件总数。已提交的 reshard 作业未能在 `tablet_pre_split_post_submit_wait_seconds` 内到达 `FINISHED` 时递增。所有生产导入类型超时后均会触发 —— INSERT-from-FILES、INSERT-from-table 与 Broker Load（三者均通过共享的 `PreSplitFlow` 同步等待）；测试用的 `runPreSplit` 同步包装路径也会触发。导入此时**不中止地继续执行**，按当时可见的 Tablet 布局做计划（守护线程还未推进则仍为原单 tablet 布局，若守护线程在放弃等待之后才完成则可能已部分／完全分裂）；**不**递增 `tablet_pre_split_load_abort`，因为导入本身未被中止。
 
 ## `starrocks_fe_tablet_pre_split_load_abort`
 


### PR DESCRIPTION
## Why I'm doing:

PR #74828 ("[Enhancement] Support Sample-Based Tablet Pre-Split for INSERT-from-table loads", merged as `69ea74f73da`) added **INSERT-from-table** as a third pre-split load kind and unified the three entry hooks onto a shared `PreSplitFlow` (`InsertPreSplitHook` for INSERT-from-FILES + INSERT-from-table, `BrokerLoadPreSplitHook` for Broker Load). The metrics reference `monitoring/metric_details/s.md` was not updated and is now stale:

- `tablet_pre_split_post_submit_wait_ms` / `tablet_pre_split_post_submit_hard_cap` describe pre-split as **two** production paths (INSERT-from-FILES + Broker Load) and name the old per-hook wording.
- The hard-cap description still says **"the Broker Load production path does not await and so does not update this counter"** — stale since Broker Load gained sync-await in #74048 (P2-b), and now INSERT-from-table awaits too. All three load kinds sync-await through the shared `PreSplitFlow`, so the hard-cap counter fires on every production path on timeout.

## What I'm doing:

Doc-only sync of the two metric descriptions in `docs/{en,zh,ja}/administration/management/monitoring/metric_details/s.md` to the three load kinds behind `InsertPreSplitHook` / `BrokerLoadPreSplitHook`, all sync-awaiting through `PreSplitFlow`. No metric semantics or code change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)