### PR TITLE
[BugFix] Skip ConstColumn build key in AGG IN runtime filter

### DIFF
--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -93,9 +93,14 @@ RuntimeFilter* AggInRuntimeFilterBuilder::build(Aggregator* aggretator, ObjectPo
 }
 
 bool AggInRuntimeFilterMerger::merge(size_t seq, RuntimeFilterBuildDescriptor* desc, RuntimeFilter* in_rf) {
+    // A null builder result means this driver could not contribute its keys to the IN filter (e.g. a
+    // constant build column, see AggInRuntimeFilterBuilder). An IN filter is only correct if it
+    // contains every build-side key, so a single missing contribution forces the whole filter to
+    // always-true (no pruning). Return true so the caller observes the finished state and skips
+    // publishing via the always_true() check.
     if (in_rf == nullptr) {
         _always_true = true;
-        return false;
+        return true;
     }
     if (_always_true) {
         return false;
@@ -112,7 +117,7 @@ bool AggInRuntimeFilterMerger::merge(size_t seq, RuntimeFilterBuildDescriptor* d
         });
         if (total_size > config::max_pushdown_conditions_per_column) {
             _always_true = true;
-            return false;
+            return true;
         }
         for (size_t i = 1; i < _target_filters.size(); ++i) {
             _target_filters[0]->merge(_target_filters[i]);

--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -96,11 +96,10 @@ bool AggInRuntimeFilterMerger::merge(size_t seq, RuntimeFilterBuildDescriptor* d
     // A null builder result means this driver could not contribute its keys to the IN filter (e.g. a
     // constant build column, see AggInRuntimeFilterBuilder). An IN filter is only correct if it
     // contains every build-side key, so a single missing contribution forces the whole filter to
-    // always-true (no pruning). Return true so the caller observes the finished state and skips
-    // publishing via the always_true() check.
+    // always-true (no pruning); return false so it is never published.
     if (in_rf == nullptr) {
         _always_true = true;
-        return true;
+        return false;
     }
     if (_always_true) {
         return false;
@@ -117,7 +116,7 @@ bool AggInRuntimeFilterMerger::merge(size_t seq, RuntimeFilterBuildDescriptor* d
         });
         if (total_size > config::max_pushdown_conditions_per_column) {
             _always_true = true;
-            return true;
+            return false;
         }
         for (size_t i = 1; i < _target_filters.size(); ++i) {
             _target_filters[0]->merge(_target_filters[i]);

--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -70,9 +70,19 @@ MutableColumns extract_group_by_columns(Aggregator* aggregator) {
 struct AggInRuntimeFilterBuilderImpl {
     template <LogicalType ltype>
     RuntimeFilter* operator()(ObjectPool* pool, Aggregator* aggregator, size_t build_expr_order) {
-        auto runtime_filter = InRuntimeFilter<ltype>::create(pool);
         auto group_by_columns = extract_group_by_columns(aggregator);
-        runtime_filter->build(group_by_columns[build_expr_order].get());
+        Column* build_column = group_by_columns[build_expr_order].get();
+        // A constant build column carries a single value spread over column->size() logical rows but
+        // is backed by one physical row. InRuntimeFilter::build() down_casts to the typed/nullable
+        // column and iterates column->size() rows (its is_constant() check is only a DCHECK, compiled
+        // out in release builds), so a ConstColumn would be misinterpreted and overrun its backing
+        // storage. Returning nullptr leaves the merged filter always-true (conservative and correct),
+        // mirroring the ConstColumn handling in AggTopNRuntimeFilterBuilder::update().
+        if (build_column->is_constant()) {
+            return nullptr;
+        }
+        auto runtime_filter = InRuntimeFilter<ltype>::create(pool);
+        runtime_filter->build(build_column);
         return runtime_filter;
     }
 };

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -150,6 +150,12 @@ void AggregateBlockingSinkOperator::_build_in_runtime_filters(RuntimeState* stat
         auto* runtime_filter = _aggregator->build_in_filters(state, build_runtime_filters[i]);
         auto* merger = factory()->in_filter_merger(build_runtime_filters[i]->filter_id());
         if (merger->merge(_driver_sequence, desc, runtime_filter)) {
+            // The merged IN filter may have degraded to always-true (e.g. a constant build key, or the
+            // merged set exceeding the pushdown limit). In that case it prunes nothing, so skip
+            // publishing and let the probe side simply apply no filter.
+            if (merger->always_true()) {
+                continue;
+            }
             desc->set_runtime_filter(merger->merged_runtime_filter());
             merged_runtime_filters.emplace_back(desc);
         }

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -150,12 +150,6 @@ void AggregateBlockingSinkOperator::_build_in_runtime_filters(RuntimeState* stat
         auto* runtime_filter = _aggregator->build_in_filters(state, build_runtime_filters[i]);
         auto* merger = factory()->in_filter_merger(build_runtime_filters[i]->filter_id());
         if (merger->merge(_driver_sequence, desc, runtime_filter)) {
-            // The merged IN filter may have degraded to always-true (e.g. a constant build key, or the
-            // merged set exceeding the pushdown limit). In that case it prunes nothing, so skip
-            // publishing and let the probe side simply apply no filter.
-            if (merger->always_true()) {
-                continue;
-            }
             desc->set_runtime_filter(merger->merged_runtime_filter());
             merged_runtime_filters.emplace_back(desc);
         }


### PR DESCRIPTION
## Why I'm doing:

AggInRuntimeFilterBuilder fed the group-by build column straight to InRuntimeFilter::build(), which down_casts to the typed/nullable column and iterates column->size() rows. Its is_constant() guard is only a DCHECK, compiled out in release builds, so a ConstColumn build key was misinterpreted and overran its single backing row, crashing the BE.

This is the IN-filter sibling of the AGG TopN runtime filter crash fixed in #74809. Detect a constant build column and return nullptr; the AggInRuntimeFilterMerger already treats a null filter as always-true, so the merged filter stays conservative and correct.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

Claude-Session: https://claude.ai/code/session_01WYdtwv8AqKbdNfGxnWLpNk