### PR TITLE
[BugFix] Fix nestloop join crash on const build/probe columns

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_build_operator.cpp
@@ -56,6 +56,14 @@ Status NLJoinBuildOperator::set_finishing(RuntimeState* state) {
 }
 
 Status NLJoinBuildOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    // The permute path on the probe side copies build columns through `Column::append`, which
+    // `down_cast` to the concrete column type and cannot handle a `ConstColumn`. Materialize const
+    // columns here so the build chunks kept in the cross-join context never carry one (otherwise the
+    // probe operator type-confuses a `ConstColumn` as the destination column type and crashes in release
+    // builds where `down_cast` is an unchecked `static_cast`).
+    if (chunk != nullptr && !chunk->is_empty()) {
+        chunk->unpack_and_duplicate_const_columns();
+    }
     return _cross_join_context->append_build_chunk(_driver_sequence, chunk);
 }
 

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -776,6 +776,14 @@ void NLJoinProbeOperator::_init_build_match() const {
 
 Status NLJoinProbeOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     _probe_chunk = chunk;
+    // The permute path (`_permute_probe_row`/`_permute_left_join`) copies probe columns through
+    // `Column::append`/`append_value_multiple_times`, which `down_cast` to the concrete column type and
+    // cannot handle a `ConstColumn`. Materialize const columns up front so the permute code never
+    // type-confuses a `ConstColumn` as the destination column type (which crashes in release builds where
+    // `down_cast` is an unchecked `static_cast`).
+    if (_probe_chunk != nullptr && !_probe_chunk->is_empty()) {
+        _probe_chunk->unpack_and_duplicate_const_columns();
+    }
     _probe_row_start = 0;
     _probe_row_current = 0;
     _probe_row_matched = false;


### PR DESCRIPTION
## Why I'm doing:

A BE crashes with `SIGSEGV` while running a nested-loop join. The PC is in
`BinaryColumnBase<uint32>::append(const Column&, size_t, size_t)` and the fault
address is near-null, e.g.:

```
*** SIGSEGV (@0x834) received ...
PC: starrocks::BinaryColumnBase<unsigned int>::append(...)
    starrocks::pipeline::NLJoinProbeOperator::_permute_probe_row(...)
    starrocks::pipeline::NLJoinProbeOperator::_permute_chunk_for_other_join(...)
    starrocks::pipeline::NLJoinProbeOperator::_pull_chunk_for_other_join(...)
    starrocks::pipeline::NLJoinProbeOperator::pull_chunk(...)
```

Root cause: the pipeline nestloop-join permute path
(`NLJoinProbeOperator::_permute_probe_row` / `_permute_left_join`) copies columns
through `Column::append` / `append_value_multiple_times`, which `down_cast` the
source to the concrete column type. In release builds `down_cast` is an unchecked
`static_cast`, so a `ConstColumn` that reaches the permute path is type-confused
as the destination column type (e.g. `BinaryColumn`). Its `_offsets` / `_bytes`
are then read from unrelated memory, producing a wild pointer and a SIGSEGV at a
near-null address.

This is reachable for degenerate nestloop plans where a constant inline view / CTE
feeds the build or probe side of a cross join (the equi-keys collapse to constant
predicate pushdown, so the join degrades to a nestloop join with a constant side).

The legacy non-pipeline `CrossJoinNode` guards every append with `is_constant()`
branches; the pipeline operator (introduced in #9430) never carried that protection
over, and there is no single chokepoint that guarantees const columns are
materialized before the join.

## What I'm doing:

Materialize const columns at the nestloop-join build and probe entry points
(`NLJoinBuildOperator::push_chunk` and `NLJoinProbeOperator::push_chunk`) via
`Chunk::unpack_and_duplicate_const_columns()`, so the permute code never sees a
`ConstColumn`. This mirrors the existing convention added at the local exchange
source operator (#43403) for the same class of bug.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Status

> [!WARNING]
> Draft. Pending validation on a build environment:
> - [ ] BE build
> - [ ] Reproduce the crash on the unfixed binary, confirm it is gone after the fix
> - [ ] Add a regression test (SQL test for the degenerate constant-CTE nestloop plan)

## Does this PR entail a change in behavior?

- [x] No, this PR will not change any behavior. (Const columns are semantically
      identical to their materialized form.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
