### PR TITLE
[BugFix] Record audit stats for async materialized view refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1356,7 +1356,7 @@ public class StmtExecutor {
      * some statements may execute multiple statement which will also create multiple StmtExecutor, so here
      * we accumulate them into the ConnectContext instead of using the last one
      */
-    private void recordExecStatsIntoContext() {
+    public void recordExecStatsIntoContext() {
         PQueryStatistics execStats = getQueryStatisticsForAuditLog();
         context.getAuditEventBuilder().addCpuCostNs(execStats.getCpuCostNs() != null ? execStats.getCpuCostNs() : 0);
         context.getAuditEventBuilder()

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -371,6 +371,8 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
             throw e;
         } finally {
             logger.info("[QueryId:{}] finished to refresh mv in DML", ctx.getQueryId());
+            // the MV refresh uses its own fresh ConnectContext whose audit builder starts at the default value.
+            executor.recordExecStatsIntoContext();
             auditAfterExec(mvTaskRunContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
             executor.addFinishedQueryDetail();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVTaskRunProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVTaskRunProcessorTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.plugin.AuditEvent;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
@@ -151,6 +152,55 @@ public class MVTaskRunProcessorTest extends MVTestBase {
         Assertions.assertFalse(infoStrings.isEmpty(), "Runtime profile should contain trace information");
 
         starRocksAssert.dropMaterializedView("test_mv_plan_builder");
+    }
+
+    /**
+     * Regression test: async MV refresh runs the INSERT OVERWRITE through
+     * StmtExecutor.handleDMLStmtWithProfile() directly and bypasses StmtExecutor.execute(), where
+     * recordExecStatsIntoContext() is invoked. Before the fix the execution statistics were never
+     * flushed into the audit event builder, so the audit log lost CpuCostNs/MemCostBytes/ScanRows
+     * for every MV refresh (regression of #56257). This verifies they are recorded again.
+     */
+    @Test
+    public void testMVRefreshRecordsAuditStats() throws Exception {
+        // Insert data so the refresh issues a real INSERT OVERWRITE that produces exec statistics.
+        executeInsertSql(connectContext, "insert into test.tbl1 partition(p1) values('2022-01-02', 1, 10)");
+
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test_mv_audit_stats` " +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"" +
+                        ")\n" +
+                        "AS SELECT k1, k2, v1 FROM test.tbl1;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "test_mv_audit_stats"));
+        Assertions.assertNotNull(mv);
+
+        Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+        task.getProperties().put(TaskRun.IS_TEST, "true");
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        // The refresh uses its own ConnectContext; read the audit event built on that context.
+        ConnectContext runCtx = taskRun.getRunCtx();
+        Assertions.assertNotNull(runCtx, "MV refresh ConnectContext should be available");
+        AuditEvent auditEvent = runCtx.getAuditEventBuilder().build();
+
+        // Default value is -1 (dropped from the audit line by AuditLogBuilder). A non-default value
+        // proves the stats were flushed into the builder on the MV refresh path.
+        Assertions.assertNotEquals(-1L, auditEvent.cpuCostNs,
+                "MV refresh audit log should record CpuCostNs");
+        Assertions.assertNotEquals(-1L, auditEvent.memCostBytes,
+                "MV refresh audit log should record MemCostBytes");
+        Assertions.assertNotEquals(-1L, auditEvent.scanRows,
+                "MV refresh audit log should record ScanRows");
+
+        starRocksAssert.dropMaterializedView("test_mv_audit_stats");
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

  Close #74942

  Async materialized view refresh audit-log entries lost the `CpuCostNs` / `MemCostBytes` / `ScanBytes` / `ScanRows` fields. This is a regression introduced by #56257, which centralized audit-stats writing into `StmtExecutor.recordExecStatsIntoContext()` (only called from
  `execute()` / `executeStmtWithExecPlan()` / `executeStmtWithResultQueue()`) and removed the old fallback in `ConnectProcessor.auditAfterExec()`.

  MV refresh does not go through `execute()`: it calls `executor.handleDMLStmtWithProfile()` directly, so `recordExecStatsIntoContext()` is never invoked and the statistics never reach the audit-event builder, even though the data is available via
  `executor.getQueryStatisticsForAuditLog()`.

  ## What I'm doing:

  Flush exec statistics into the audit-event builder on the MV-refresh path before `auditAfterExec`, mirroring what `execute()` does in its `finally` block. `recordExecStatsIntoContext()` is made `public` (it lives in `qe`, the caller in `scheduler`).

  It is intentionally **not** placed inside `handleDMLStmtWithProfile()`: `execute()` also calls `handleDMLStmtWithProfile()` and then calls `recordExecStatsIntoContext()` in its own `finally`, so flushing inside `handleDMLStmtWithProfile()` would double-count for normal
  INSERTs (the builder uses accumulating `add*`). The MV-refresh path uses a fresh `ConnectContext` whose builder starts at the default `-1`, so a single explicit call is correct and not double-counted.

  ## What type of PR is this:
  - [x] BugFix
  - [ ] Feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  ## Does this PR entail a change in behavior?
  - [x] Yes, this PR will result in a change in behavior.
  - [ ] No, this PR will not result in a change in behavior.

  ## If yes, please specify the type of change:
  - [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [ ] Parameter changes: default values, similar parameters but with different default values
  - [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

  ## Checklist:
  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This PR needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
  - [ ] This is a backport PR

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the PR will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [x] 3.5
    - [ ] 3.4
    - [ ] 3.3
