### PR TITLE
[Enhancement] Accept ORC local TIMESTAMP at the tablet pre-split meta tier

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -318,6 +318,9 @@ public final class OrcStripeStatisticsReader {
             // wrong data or wrong results (and if a conversion ever yields min > max, the downstream
             // ParquetMetadataSampler treats the row group as fallback rather than emitting a boundary).
             // Modern writers (StarRocks unload, Spark, Hive, ORC >= 1.5) emit minimumUtc and are unaffected.
+            // rejectDateOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
+            // catch(RuntimeException) below (keeping its own message); getMinimumUTC/Variant.of
+            // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateStripe.
             LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
             MetaTierTemporalWindow.rejectDateOutsideWindow(minDateTime.toLocalDate());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -32,10 +32,14 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.StripeInformation;
 import org.apache.orc.StripeStatistics;
+import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -55,12 +59,18 @@ import java.util.Objects;
  *       rendering, pre-1582 proleptic/hybrid calendar ambiguity) fall back to data tier</li>
  *   <li>ORC DECIMAL → StarRocks DECIMAL of the SAME precision and scale (ORC orders decimal
  *       stats correctly, so footer min/max are usable). Non-matching precision/scale → data tier</li>
+ *   <li>ORC TIMESTAMP (local, no timezone) → StarRocks DATETIME, using the tz-independent UTC stat,
+ *       gated to {@code [1970-01-01, 9999-12-31]}. TIMESTAMP_INSTANT is deferred (the load applies a
+ *       session-tz offset this reader cannot reproduce).</li>
  * </ul>
  * Everything else — STRING/CHAR/VARCHAR (data-tier fallback anyway), BOOLEAN,
- * FLOAT/DOUBLE, TIMESTAMP/TIMESTAMP_INSTANT (reader-local-tz stats, deferred),
+ * FLOAT/DOUBLE, TIMESTAMP_INSTANT (load applies a session-tz offset this reader cannot reproduce),
  * non-matching-precision/scale DECIMAL, and any complex type — makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier. That is
  * NOT a load failure. Pure I/O failures surface as {@link StarRocksException}.
+ * Note: a legacy ORC file lacking modern UTC stats (pre-1.5-era footer) decodes through the JVM
+ * default timezone, which may bias or reorder cut points — the load still routes every row by its
+ * actual value, so this only mis-places the split, never loses or corrupts data.
  */
 public final class OrcStripeStatisticsReader {
 
@@ -140,9 +150,10 @@ public final class OrcStripeStatisticsReader {
      * Reject ORC/StarRocks type pairings outside meta tier's supported window
      * eagerly, before iterating stripes. Anything outside the window means "fall
      * back to data tier", not "fail the load". The supported window is the unannotated
-     * integer categories, ORC DATE → StarRocks DATE, and ORC DECIMAL → a same-precision/scale
-     * StarRocks DECIMAL. String, boolean, floating-point, TIMESTAMP/TIMESTAMP_INSTANT,
-     * non-matching DECIMAL, and complex types are deferred (fall back to data tier).
+     * integer categories, ORC DATE → StarRocks DATE, ORC DECIMAL → a same-precision/scale
+     * StarRocks DECIMAL, and ORC TIMESTAMP → StarRocks DATETIME. String, boolean,
+     * floating-point, TIMESTAMP_INSTANT, non-matching DECIMAL, and complex types are deferred
+     * (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             TypeDescription fieldType, Column sortKeyColumn) throws MetaTierUnavailableException {
@@ -155,6 +166,9 @@ public final class OrcStripeStatisticsReader {
             // ORC orders decimal stats correctly (no Parquet unsigned-byte trap), so footer
             // min/max are usable; require an exact precision/scale match with the StarRocks column.
             case DECIMAL -> decimalMatchesExactly(fieldType, sortKeyColumn);
+            // Plain ORC TIMESTAMP is local (no timezone); the BE load stores its UTC wall clock
+            // verbatim (no session-tz offset, unlike TIMESTAMP_INSTANT) → StarRocks DATETIME.
+            case TIMESTAMP -> starRocksPrimitive == PrimitiveType.DATETIME;
             default -> false;
         };
         if (!compatible) {
@@ -197,6 +211,10 @@ public final class OrcStripeStatisticsReader {
         if (sortKeyStatistics instanceof DecimalColumnStatistics decimalStatistics
                 && decimalStatistics.getNumberOfValues() > 0) {
             return convertDecimalStripe(decimalStatistics, rowCount, location);
+        }
+        if (sortKeyStatistics instanceof TimestampColumnStatistics timestampStatistics
+                && timestampStatistics.getNumberOfValues() > 0) {
+            return convertTimestampStripe(timestampStatistics, rowCount, location);
         }
         // Absent / all-null stats (no presence flag on ORC numeric/date stats, so an
         // empty stripe is detected via getNumberOfValues() == 0) → missing min/max.
@@ -278,6 +296,59 @@ public final class OrcStripeStatisticsReader {
         }
         return new RowGroupStatistics(
                 new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+    }
+
+    private static RowGroupStatistics convertTimestampStripe(
+            TimestampColumnStatistics timestampStatistics, long rowCount, SortKeyLocation location)
+            throws MetaTierUnavailableException {
+        Variant minVariant;
+        Variant maxVariant;
+        try {
+            // getMinimumUTC()/getMaximumUTC() return the tz-independent UTC wall clock (raw UTC
+            // millis, NOT the TimeZone.getDefault()-shifted getMinimum()). This matches what the BE
+            // load stores for a plain (non-instant) TIMESTAMP: the wall clock verbatim, no session-tz
+            // offset. getNanos() carries the full sub-second nanos (millis fraction + sub-millisecond),
+            // which BE also keeps for a plain TIMESTAMP; renderDateTime truncates to microseconds
+            // (StarRocks DATETIME precision), mirroring the Parquet reader.
+            // NOTE: a legacy ORC file carrying only pre-1.5-era stats (no minimumUtc) decodes through
+            // TimeZone.getDefault(), so getMinimumUTC() may be tz-shifted (and under DST, shifted
+            // non-uniformly so individual values can reorder); the high-level stats API exposes no flag
+            // to detect this. BoundaryPlanner still emits a SORTED boundary set and BE routes every row
+            // by its actual value, so the only effect is a possibly mis-placed / uneven split — never
+            // wrong data or wrong results (and if a conversion ever yields min > max, the downstream
+            // ParquetMetadataSampler treats the row group as fallback rather than emitting a boundary).
+            // Modern writers (StarRocks unload, Spark, Hive, ORC >= 1.5) emit minimumUtc and are unaffected.
+            LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
+            LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
+            MetaTierTemporalWindow.rejectDateOutsideWindow(minDateTime.toLocalDate());
+            MetaTierTemporalWindow.rejectDateOutsideWindow(maxDateTime.toLocalDate());
+            minVariant = Variant.of(location.starRocksColumn.getType(), renderDateTime(minDateTime));
+            maxVariant = Variant.of(location.starRocksColumn.getType(), renderDateTime(maxDateTime));
+        } catch (RuntimeException conversionFailure) {
+            throw new MetaTierUnavailableException(String.format(
+                    "ORC timestamp stats value not representable for sort-key column \"%s\": %s",
+                    location.starRocksColumn.getName(), conversionFailure.getMessage()));
+        }
+        return new RowGroupStatistics(
+                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+    }
+
+    private static LocalDateTime utcTimestampToDateTime(Timestamp utcTimestamp) {
+        // getTime() is UTC epoch millis (no TimeZone.getDefault() shift, unlike getMinimum());
+        // getNanos() is the full sub-second nanos (0..999_999_999). floorDiv keeps the whole-second
+        // part correct; ofEpochSecond combines them. The window gate rejects pre-1970 / post-9999.
+        long epochSecond = Math.floorDiv(utcTimestamp.getTime(), 1000L);
+        return LocalDateTime.ofEpochSecond(epochSecond, utcTimestamp.getNanos(), ZoneOffset.UTC);
+    }
+
+    private static String renderDateTime(LocalDateTime dateTime) {
+        // Mirrors DateVariant.getStringValue / the Parquet reader: second precision unless there is a
+        // sub-second part, then 6-digit microseconds. parseStrictDateTime round-trips both.
+        if (dateTime.getNano() == 0) {
+            return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
+        }
+        return dateTime.format(DateUtils.DATE_TIME_FORMATTER)
+                + "." + String.format("%06d", dateTime.getNano() / 1000);
     }
 
     private record SortKeyLocation(int columnId, Column starRocksColumn) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -330,15 +330,74 @@ class OrcStripeStatisticsReaderTest {
     }
 
     @Test
-    void timestampColumnStillFallsBackToDataTier() throws Exception {
-        // ORC TIMESTAMP stats carry reader-local-tz semantics that need separate
-        // alignment work; deferred. Falls back to data tier (NOT a load failure).
+    void readsTimestampStatistics() throws Exception {
+        // Plain ORC TIMESTAMP → StarRocks DATETIME. setIsUTC(true): time[] is UTC epoch millis, so
+        // minimumUtc == the written millis. 1000 ms = 1970-01-01 00:00:01 UTC; +1000 ms per row.
         Path orcPath = writeOrc(
                 "struct<event_ts:timestamp>",
+                /*rowCount=*/ 3,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = (rowIndex + 1) * 1000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        for (RowGroupStatistics stripe : stats) {
+            Assertions.assertFalse(stripe.isTruncated());
+            String minValue = stripe.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = stripe.getMaxTuple().getValues().get(0).getStringValue();
+            Assertions.assertTrue(minValue.compareTo(maxValue) <= 0);
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals("1970-01-01 00:00:01", globalMin);
+        // Whole-second max; assert the second prefix to stay robust to a sub-millisecond stats
+        // ceiling if the ORC writer leaves maxNanos at its sentinel for a 0-nanos value.
+        Assertions.assertTrue(globalMax.startsWith("1970-01-01 00:00:03"), "unexpected max " + globalMax);
+    }
+
+    @Test
+    void readsTimestampStatisticsWithMicroseconds() throws Exception {
+        // Sub-second precision must survive: BE keeps microseconds for a plain TIMESTAMP, so the
+        // boundary must too. 1.500123 s: time=1000 ms (second 1), nanos=500123000 (full sub-second).
+        // (Hive TimestampColumnVector contract: nanos[] is the full sub-second; if this ORC version
+        // instead treats nanos[] as the sub-millisecond remainder, write time=1500, nanos=123000 — the
+        // expected rendered value is the same; confirm by running.)
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = 1000L;
+                    vector.nanos[batchRow] = 500_123_000;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals("1970-01-01 00:00:01.500123",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void timestampInstantFallsBackToDataTier() throws Exception {
+        // TIMESTAMP_INSTANT (timestamp with local time zone) gets a session-tz offset at load time
+        // that this reader cannot reproduce → defer to data tier.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp with local time zone>",
                 /*rowCount=*/ 2,
                 (batch, batchRow, rowIndex) -> {
                     TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
-                    vector.time[batchRow] = rowIndex * 1000L;
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = (rowIndex + 1) * 1000L;
                     vector.nanos[batchRow] = 0;
                 });
 
@@ -346,6 +405,85 @@ class OrcStripeStatisticsReaderTest {
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME)));
+    }
+
+    @Test
+    void timestampIntoNonDatetimeSortKeyFallsBackToDataTier() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = (rowIndex + 1) * 1000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", IntegerType.BIGINT)));
+    }
+
+    @Test
+    void pre1970TimestampFallsBackToDataTier() throws Exception {
+        // -1000 ms = 1969-12-31 23:59:59 < 1970-01-01: outside the safe window → data tier.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = -1000L - rowIndex;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME)));
+    }
+
+    @Test
+    void postYear9999TimestampFallsBackToDataTier() throws Exception {
+        // 253402300800000 ms = 10000-01-01 00:00:00 UTC, year > 9999 → above the safe window.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = 253402300800000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME)));
+    }
+
+    @Test
+    void allNullTimestampStripeReportsAbsentStatistics() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 3,
+                (batch, batchRow, rowIndex) -> {
+                    batch.cols[0].noNulls = false;
+                    batch.cols[0].isNull[batchRow] = true;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertFalse(stats.isEmpty());
+        long totalRowCount = 0L;
+        for (RowGroupStatistics stripe : stats) {
+            Assertions.assertNull(stripe.getMinTuple());
+            Assertions.assertNull(stripe.getMaxTuple());
+            totalRowCount += stripe.getRowCount();
+        }
+        Assertions.assertEquals(3L, totalRowCount);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -366,10 +366,9 @@ class OrcStripeStatisticsReaderTest {
     @Test
     void readsTimestampStatisticsWithMicroseconds() throws Exception {
         // Sub-second precision must survive: BE keeps microseconds for a plain TIMESTAMP, so the
-        // boundary must too. 1.500123 s: time=1000 ms (second 1), nanos=500123000 (full sub-second).
-        // (Hive TimestampColumnVector contract: nanos[] is the full sub-second; if this ORC version
-        // instead treats nanos[] as the sub-millisecond remainder, write time=1500, nanos=123000 — the
-        // expected rendered value is the same; confirm by running.)
+        // boundary must too. 1.500123 s = time=1000 ms (second 1) + nanos=500123000: a Hive
+        // TimestampColumnVector adds nanos[] (the full sub-second, confirmed for orc-core 1.9.1) onto
+        // the whole second of time[].
         Path orcPath = writeOrc(
                 "struct<event_ts:timestamp>",
                 /*rowCount=*/ 1,


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split has a cheap **meta tier** (read Parquet/ORC footer statistics, no data scan) and a fallback **data tier** (a SELECT sampling sub-query). Two footer readers project a sort-key column's per-stripe/per-row-group min/max into a StarRocks boundary. Prior work extended them to DATE/DATETIME (#74710) and DECIMAL (#74739/#74792/#74902). A plain ORC `TIMESTAMP` sort key still always paid a data-tier sub-query — this closes that gap.

## What I'm doing:

Extended only `OrcStripeStatisticsReader` (everything below it — sampler, `BoundaryPlanner`, `Variant`, providers — is already type-agnostic and untouched). Accept a plain ORC `TIMESTAMP` (local, no timezone) → StarRocks `DATETIME` using the timezone-independent `getMinimumUTC()/getMaximumUTC()` (a plain TIMESTAMP is loaded by the BE into DATETIME with **no** session-tz offset — verified in `be/src/formats/orc`), at microsecond precision, gated to the `[1970-01-01, 9999-12-31]` window. `TIMESTAMP_INSTANT` stays rejected because the load applies a session-tz offset this reader cannot reproduce (mirrors the UTC-adjusted Parquet rejection). Anything outside the supported window keeps falling back to the data tier — never a load failure. FE-only.

Scope: exactly `OrcStripeStatisticsReader.java` + its test.

> **Note on the dropped Parquet UNSIGNED-int path.** An earlier revision of this PR also accepted Parquet `UINT_8/16/32`. It was removed after a Codex review finding (verified against the BE): StarRocks BE loads a Parquet UINT_32 into a BIGINT by **sign-extending** the underlying `int32` (`be/src/formats/parquet/column_converter.cpp` selects `NumericToNumericConverter<int32_t,int64_t>` on the physical type without inspecting `isSigned`), so a source value above `2^31-1` is stored as a negative BIGINT. The footer min/max are unsigned-ordered while the loaded values are signed-ordered, so a meta-tier boundary cannot be aligned with the loaded data for high-bit values. Unsigned-int sort keys therefore continue to use the data tier (which samples the actually-loaded values and is consistent). This is left to a separate effort if/when the BE gains true unsigned-load support.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5