### PR TITLE
[Enhancement] Exclude null fractions in row count estimation for predicates  <, > and != in column to constant comparison cases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -226,9 +226,9 @@ public class BinaryPredicateStatisticCalculator {
                     orElseGet(() -> statistics.withOutputRowCount(rowCount));
         } else {
             ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
-            double rowCount = statistics.getOutputRowCount() -
-                    estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics)
-                            .getOutputRowCount();
+            double rowCount = Math.max(0.0, statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
+                    - estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics)
+                            .getOutputRowCount());
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
                             .setOutputRowCount(rowCount).addColumnStatistic(operator, estimatedColumnStatistic).build())
@@ -261,7 +261,7 @@ public class BinaryPredicateStatisticCalculator {
             Histogram estimatedHistogram = hist.get();
 
             long rowCountInHistogram = estimatedHistogram.getTotalRows();
-            double rowCount = statistics.getOutputRowCount()
+            double rowCount = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
                     * ((double) rowCountInHistogram / (double) columnStatistic.getHistogram().getTotalRows());
 
             ColumnStatistic newEstimateColumnStatistics =
@@ -301,7 +301,7 @@ public class BinaryPredicateStatisticCalculator {
         } else {
             Histogram estimatedHistogram = hist.get();
             long rowCountInHistogram = estimatedHistogram.getTotalRows();
-            double rowCount = statistics.getOutputRowCount()
+            double rowCount = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
                     * ((double) rowCountInHistogram / (double) columnStatistic.getHistogram().getTotalRows());
 
             ColumnStatistic newEstimateColumnStatistics =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -141,6 +141,46 @@ public class HistogramStatisticsTest {
         between(columnRefOperator, "GE", 1, "LE", 1000, statistics, 1000);
     }
 
+    @Test
+    public void testColumnToConstantExcludesNullFraction() {
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, IntegerType.BIGINT, "v1", true);
+
+        List<Bucket> bucketList = new ArrayList<>();
+        bucketList.add(new Bucket(1D, 10D, 100L, 20L));
+        bucketList.add(new Bucket(15D, 20D, 200L, 20L));
+        bucketList.add(new Bucket(21D, 36D, 300L, 20L));
+        bucketList.add(new Bucket(40D, 45D, 400L, 20L));
+        bucketList.add(new Bucket(46D, 46D, 500L, 100L));
+        bucketList.add(new Bucket(47D, 47D, 600L, 100L));
+        bucketList.add(new Bucket(48D, 60D, 700L, 20L));
+        bucketList.add(new Bucket(61D, 65D, 800L, 20L));
+        bucketList.add(new Bucket(66D, 99D, 900L, 20L));
+        bucketList.add(new Bucket(100D, 100D, 1000L, 100L));
+        Histogram histogram = new Histogram(bucketList, Maps.newHashMap());
+
+        double nullsFraction = 0.2;
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(1000);
+        builder.addColumnStatistic(columnRefOperator, ColumnStatistic.builder()
+                .setMinValue(1)
+                .setMaxValue(100)
+                .setNullsFraction(nullsFraction)
+                .setAverageRowSize(20)
+                .setDistinctValuesCount(20)
+                .setHistogram(histogram)
+                .build());
+        Statistics statistics = builder.build();
+
+        check(columnRefOperator, "GT", 10, statistics, 720);
+        check(columnRefOperator, "GT", 20, statistics, 640);
+        check(columnRefOperator, "GT", 99, statistics, 80);
+        check(columnRefOperator, "GE", 10, statistics, 736);
+        check(columnRefOperator, "LT", 10, statistics, 64);
+        check(columnRefOperator, "LT", 20, statistics, 144);
+        check(columnRefOperator, "LE", 10, statistics, 80);
+        check(columnRefOperator, "LE", 20, statistics, 160);
+    }
+
     void check(ColumnRefOperator columnRefOperator, String type, int constant, Statistics statistics, int rowCount) {
         BinaryPredicateOperator binaryPredicateOperator
                 = new BinaryPredicateOperator(BinaryType.valueOf(type),
@@ -422,6 +462,30 @@ public class HistogramStatisticsTest {
 
         Assertions.assertFalse(Double.isNaN(estimated.getOutputRowCount()));
         Assertions.assertEquals(3L, estimated.getOutputRowCount(), 0.001);
+    }
+
+    @Test
+    public void testColumnNotEqualToConstantExcludesNullRows() {
+        Map<String, Long> mcv = Maps.newHashMap();
+        mcv.put("10", 236L);
+        Histogram histogram = new Histogram(new ArrayList<>(), mcv);
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, IntegerType.BIGINT, "v1", true);
+        ColumnStatistic columnStatistic = new ColumnStatistic(1, 1000, 0.2, 8, 62,
+                histogram, ColumnStatistic.StatisticType.ESTIMATE);
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRefOperator, columnStatistic)
+                .build();
+
+        BinaryPredicateOperator ne = new BinaryPredicateOperator(
+                BinaryType.NE, columnRefOperator, ConstantOperator.createBigint(10));
+        Statistics estimated = BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(
+                Optional.of(columnRefOperator), columnStatistic, ne,
+                Optional.of(ConstantOperator.createBigint(10)), statistics);
+
+        Assertions.assertEquals(564L, estimated.getOutputRowCount(), 0.001);
+        Assertions.assertEquals(0.0, estimated.getColumnStatistic(columnRefOperator).getNullsFraction(), 0.001);
     }
 
 


### PR DESCRIPTION
## Why I'm doing:
In estimateColumnEqualToConstant null fractions are not excluded from row count calculation, this has the effect that we overestimate the number of output rows by the null fractions.

This is missing in estimateColumnNotEqualToConstant, estimateColumnLessThanConstant and estimateColumnGreaterThanConstant. 

## What I'm doing:
Factor out null fractions from output rows in the missing branches

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
