### PR TITLE
[Enhancement] Avoid redundant consistent-hash ring walks in scan-range assignment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ConsistentHashRing.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ConsistentHashRing.java
@@ -32,6 +32,11 @@ public class ConsistentHashRing<K, N> implements HashRing<K, N> {
     HashFunction hashFunction;
 
     TreeMap<Long, VNode> hashRing = new TreeMap<>();
+    // Physical nodes currently on the ring. A node is spread across `virtualNumber`
+    // virtual nodes, so the ring can never hand back more distinct nodes than this set
+    // holds; `get` uses its size to stop walking instead of scanning for nodes that do
+    // not exist.
+    Set<N> physicalNodes = new HashSet<>();
     Funnel<K> keyFunnel;
     Funnel<N> nodeFunnel;
     int virtualNumber;
@@ -86,6 +91,7 @@ public class ConsistentHashRing<K, N> implements HashRing<K, N> {
 
     @Override
     public void addNode(N node) {
+        physicalNodes.add(node);
         for (int i = 0; i < virtualNumber; i++) {
             VNode vnode = new VNode(node, i);
             long hash = vnode.hashValue();
@@ -97,6 +103,7 @@ public class ConsistentHashRing<K, N> implements HashRing<K, N> {
 
     @Override
     public void removeNode(N node) {
+        physicalNodes.remove(node);
         for (int i = 0; i < virtualNumber; i++) {
             VNode vnode = new VNode(node, i);
             long hash = vnode.hashValue();
@@ -106,17 +113,15 @@ public class ConsistentHashRing<K, N> implements HashRing<K, N> {
         }
     }
 
-    private void collectNodes(SortedMap<Long, VNode> map, List<N> ans, int distinctNumber) {
-        Set<N> visited = new HashSet<>(ans);
+    private void collectNodes(SortedMap<Long, VNode> map, List<N> ans, Set<N> visited, int target) {
         for (Map.Entry<Long, VNode> entry : map.entrySet()) {
             VNode vnode = entry.getValue();
-            if (visited.contains(vnode.node)) {
+            if (!visited.add(vnode.node)) {
                 continue;
             }
-            visited.add(vnode.node);
             ans.add(vnode.node);
-            if (ans.size() == distinctNumber) {
-                break;
+            if (ans.size() == target) {
+                return;
             }
         }
     }
@@ -124,15 +129,23 @@ public class ConsistentHashRing<K, N> implements HashRing<K, N> {
     @Override
     public List<N> get(K key, int distinctNumber) {
         List<N> ans = new ArrayList<>();
+        // Never ask for more distinct nodes than the ring actually has: with a larger
+        // target the walk can never reach it and scans every virtual node in vain.
+        int target = Math.min(distinctNumber, physicalNodes.size());
+        if (target <= 0) {
+            return ans;
+        }
+
         Hasher hasher = hashFunction.newHasher();
         long hash = hasher.putObject(key, keyFunnel).hash().asLong();
 
-        // search from `hash` to end.
-        collectNodes(hashRing.tailMap(hash, true), ans, distinctNumber);
-        if (ans.size() < distinctNumber) {
-            // search from begin to end.
-            // so we walk this ring twice at most.
-            collectNodes(hashRing, ans, distinctNumber);
+        // Walk the ring clockwise once, wrapping around: [hash, end] then [begin, hash).
+        // `visited` is shared so the wrap-around segment does not re-scan the tail and a
+        // node selected in the first segment is not added twice.
+        Set<N> visited = new HashSet<>();
+        collectNodes(hashRing.tailMap(hash, true), ans, visited, target);
+        if (ans.size() < target) {
+            collectNodes(hashRing.headMap(hash, false), ans, visited, target);
         }
         return ans;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -358,10 +358,20 @@ public class HDFSBackendSelector implements BackendSelector {
         if (shuffleScanRange) {
             Collections.shuffle(remoteScanRangeLocations);
         }
+
+        // When re-balancing is skipped (data cache on and no forced re-balance), only the
+        // first ring node is ever used (both reBalanceScanRangeForComputeNode and the
+        // candidate selection take index 0). Asking the ring for kCandidateNumber distinct
+        // nodes then walks the ring for candidates that are thrown away, so request one.
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        boolean skipReBalance = !sessionVariable.getHdfsBackendSelectorForceRebalance()
+                && sessionVariable.isEnableScanDataCache();
+        int candidateNumber = skipReBalance ? 1 : kCandidateNumber;
+
         // assign scan ranges.
         for (int i = 0; i < remoteScanRangeLocations.size(); ++i) {
             TScanRangeLocations scanRangeLocations = remoteScanRangeLocations.get(i);
-            List<ComputeNode> backends = hashRing.get(scanRangeLocations, kCandidateNumber);
+            List<ComputeNode> backends = hashRing.get(scanRangeLocations, candidateNumber);
             ComputeNode node = reBalanceScanRangeForComputeNode(backends, avgNodeScanRangeBytes, scanRangeLocations);
             if (node == null) {
                 throw new StarRocksException("Failed to find backend to execute");
@@ -369,7 +379,7 @@ public class HDFSBackendSelector implements BackendSelector {
 
             ComputeNode candidateNode = null;
             if (candidateHashRing != null) {
-                List<ComputeNode> candidateBackends = candidateHashRing.get(scanRangeLocations, kCandidateNumber);
+                List<ComputeNode> candidateBackends = candidateHashRing.get(scanRangeLocations, candidateNumber);
                 // if data cache is enabled, skip re-balancing because it makes the cache position undefined.
                 candidateNode = candidateBackends.get(0);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/HashRingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/HashRingTest.java
@@ -22,12 +22,14 @@ import com.starrocks.common.util.ConsistentHashRing;
 import com.starrocks.common.util.HashRing;
 import com.starrocks.common.util.PlainHashRing;
 import com.starrocks.common.util.RendezvousHashRing;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -139,5 +141,38 @@ public class HashRingTest {
         List<String> nodes = generateNodes(kNodeSize);
         PlainHashRing hashRing = new PlainHashRing(Hashing.murmur3_128(), funnel, nodes);
         testWithHashRing(hashRing, nodes);
+    }
+
+    @Test
+    public void testConsistentHashRingFewerNodesThanRequested() {
+        // Requesting more distinct nodes than exist returns exactly the available nodes
+        // (deduplicated) and terminates, for any cluster size down to a single node.
+        for (int nodeSize = 1; nodeSize <= 3; nodeSize++) {
+            List<String> nodes = generateNodes(nodeSize);
+            ConsistentHashRing<String, String> hashRing =
+                    new ConsistentHashRing<>(Hashing.murmur3_128(), funnel, funnel, nodes, kVirtualNumber);
+            for (String key : generateKeys(kKeySize)) {
+                List<String> got = hashRing.get(key, nodeSize + 2);
+                Assertions.assertEquals(nodeSize, got.size());
+                Assertions.assertEquals(nodeSize, new HashSet<>(got).size());
+            }
+        }
+    }
+
+    @Test
+    public void testConsistentHashRingPrimaryStableAcrossCandidateCount() {
+        // The primary node must not depend on how many candidates are requested, so asking
+        // for a single candidate yields the same placement as asking for several.
+        List<String> nodes = generateNodes(kNodeSize);
+        ConsistentHashRing<String, String> hashRing =
+                new ConsistentHashRing<>(Hashing.murmur3_128(), funnel, funnel, nodes, kVirtualNumber);
+        for (String key : generateKeys(kKeySize)) {
+            List<String> one = hashRing.get(key, 1);
+            List<String> three = hashRing.get(key, 3);
+            Assertions.assertEquals(1, one.size());
+            Assertions.assertEquals(3, three.size());
+            Assertions.assertEquals(3, new HashSet<>(three).size());
+            Assertions.assertEquals(one.get(0), three.get(0));
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

While profiling FE-side planning for Iceberg queries with the metadata **caching catalog** enabled, I looked at where time goes once the manifest cache is warm (so `getScanFiles` is cheap). The remaining planning time was dominated by `computeScanRangeAssignment`: on one query (one compute node, ~1183 Iceberg splits) it took **~23 ms on the planning critical path**, plus ~16 ms more in incremental scan-range delivery.

Profiling that time pointed straight at `ConsistentHashRing` — `collectNodes`, `ComputeNode.hashCode`, `TreeMap` navigation. The cause: `get(key, distinctNumber)` is asked for `distinctNumber` **distinct** nodes (callers pass `kCandidateNumber = 3`). When the cluster has fewer physical nodes than that, `get()` can never reach the target, so it never breaks early — it walks the entire virtual ring (256 vnodes/node), and then walks it a **second time**, allocating a `HashSet` per call. One lookup per split makes this O(splits × ring_size) of pure waste.

This is **not just a single-node curiosity**. The scan data cache is **on by default**, and with it `HDFSBackendSelector` skips re-balancing and uses only the **first** ring node. So in the default production config we genuinely need *one* node but ask the ring for *three* — which is exactly what triggers the repeated full-ring walk on any warehouse running a small number of compute nodes.

## What I'm doing:

1. **`HDFSBackendSelector`** — when re-balancing is skipped (data cache on, no forced re-balance), ask the ring for a single candidate instead of `kCandidateNumber`, since only the first node is ever used.
2. **`ConsistentHashRing`** — make `get` robust regardless of caller: cap the target at `min(distinctNumber, nodeCount)` and walk the ring **at most once** (clockwise with wrap-around, shared `visited` set, early-stop). The returned node set and order are unchanged for the multi-node case.

Same query on one compute node: `computeScanRangeAssignment` **~23 ms → ~1 ms** on the critical path (and ~16 ms → ~2 ms in incremental delivery).

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

