### PR TITLE
[Enhancement] Plan cached Iceberg manifests on the consumer thread (avoid ParallelIterable poll wait)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -42,7 +42,6 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.ScanMetricsUtil;
-import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.SerializationUtil;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.logging.log4j.LogManager;
@@ -305,7 +304,10 @@ public class StarRocksIcebergTableScan
         Iterable<CloseableIterable<FileScanTask>> tasks =
                 CloseableIterable.transform(CloseableIterable.withNoopClose(dataManifestWithCache), this::filterDataFiles);
 
-        CloseableIterable<FileScanTask> tasksWithCache = new ParallelIterable<>(tasks, planExecutor());
+        // Cached manifests are fully in memory; their scan tasks are assembled lazily on the
+        // consumer thread, since there is no IO here for a worker pool to overlap. Routing them
+        // through ParallelIterable would only add executor hand-off and its poll-based wait.
+        CloseableIterable<FileScanTask> tasksWithCache = CloseableIterable.concat(tasks);
         if (dataManifestWithoutCache.isEmpty()) {
             return tasksWithCache;
         } else {


### PR DESCRIPTION
## Why I'm doing:

Continuing to profile warm FE-side Iceberg planning with the metadata caching catalog: even once the manifest cache is warm, `getScanFiles` still cost **~17 ms**. Profiling showed this isn't CPU — the coordinator thread sits in `futex_wait`, waiting on the planning worker pool.

The culprit is upstream `ParallelIterable` (Apache Iceberg 1.10.0). Its consumer `hasNext()` polls the queue and, when it's momentarily empty while tasks run, does `Thread.sleep(10)`. On the cache-hit planning path the per-manifest work is purely in-memory (microseconds), and the whole result fits far under `DEFAULT_MAX_QUEUE_SIZE` (30k) so producers never yield — yet the consumer still sleeps a 10 ms quantum before it notices the queue filled. With no IO to overlap, that sleep *is* the latency rather than being hidden by it.

In `StarRocksIcebergTableScan.planTaskWithCache`, data manifests are already split into cache hits (fully in memory) and cache misses (need IO). The cache-hit branch was assembled through `ParallelIterable` — paying the executor hand-off and the 10 ms poll for zero benefit.

## What I'm doing:

`planTaskWithCache`: assemble the cache-hit scan tasks with a sequential `CloseableIterable.concat`, evaluated lazily on the consumer thread (no executor, no poll-sleep). Cache-**miss** manifests keep parallel planning via `planFileTasks`, where real IO genuinely benefits from it.

No new unit test: the change is behavior-equivalent — same set of `FileScanTask`, only the iteration over already-in-memory cached data changes from parallel to sequential. Existing `IcebergMetadataTest` (`planFiles` -> file-scan-task assertions) covers the planning output.

Same query, warm cache: `getScanFiles` **~17 ms -> ~6 ms**, and the inner `hasMoreOutput` (where the sleep lived) **~16 ms -> ~2 ms**.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
