### PR TITLE
[Enhancement] Add global materialized view count and query metrics

### DIFF
--- a/docs/en/administration/management/monitoring/metrics-materialized_view.md
+++ b/docs/en/administration/management/monitoring/metrics-materialized_view.md
@@ -113,3 +113,18 @@ scrape_configs:
 
 - Type: Histogram
 - Description: Wall-clock duration of refresh jobs, in milliseconds. For multi-batch jobs, measured from the first task run start to the final task run completion.
+
+### mv_global_count
+
+- Type: Gauge
+- Description: Current number of asynchronous materialized views in the cluster, with labels `refresh_mode` (the materialized view's refresh mode) and `status` (`ACTIVE` or `INACTIVE`). This metric is always emitted, regardless of the per-materialized-view metrics privilege.
+
+### mv_global_query_rewrite_queries_total
+
+- Type: Counter
+- Description: Number of queries grouped by materialized view rewrite outcome, with label `state`: `HIT` (the query was rewritten to use a materialized view), `NO_HIT` (rewrite was enabled but no materialized view was used), or `DISABLED` (materialized view rewrite was disabled by the session variable or the FE configuration). Counted once per query.
+
+### mv_global_query_mv_usage_total
+
+- Type: Counter
+- Description: Number of times materialized views are used by queries, with labels `usage_type` (`REWRITE` if a query was rewritten to use the materialized view, or `DIRECT` if a query reads the materialized view directly) and `refresh_mode`.

--- a/docs/ja/administration/management/monitoring/metrics-materialized_view.md
+++ b/docs/ja/administration/management/monitoring/metrics-materialized_view.md
@@ -113,3 +113,18 @@ scrape_configs:
 
 - Type: Histogram
 - Description: リフレッシュジョブの実時間（ミリ秒）。マルチバッチジョブの場合、最初の Task Run 開始から最後の Task Run 完了までを計測する。
+
+### mv_global_count
+
+- Type: Gauge
+- Description: クラスター内の非同期マテリアライズドビューの現在の数。ラベル `refresh_mode`（マテリアライズドビューのリフレッシュモード）と `status`（`ACTIVE` または `INACTIVE`）を持ちます。このメトリクスは、マテリアライズドビューごとのメトリクス権限に関係なく常に出力されます。
+
+### mv_global_query_rewrite_queries_total
+
+- Type: Counter
+- Description: マテリアライズドビューの書き換え結果でグループ化されたクエリ数。ラベル `state`：`HIT`（クエリがマテリアライズドビューを使用するように書き換えられた）、`NO_HIT`（書き換えは有効だがマテリアライズドビューが使用されなかった）、`DISABLED`（セッション変数または FE 設定でマテリアライズドビューの書き換えが無効化されている）。クエリごとに 1 回カウントされます。
+
+### mv_global_query_mv_usage_total
+
+- Type: Counter
+- Description: クエリによってマテリアライズドビューが使用された回数。ラベル `usage_type`（`REWRITE` はクエリがマテリアライズドビューを使用するように書き換えられた場合、`DIRECT` はマテリアライズドビューを直接クエリする場合）と `refresh_mode` を持ちます。

--- a/docs/zh/administration/management/monitoring/metrics-materialized_view.md
+++ b/docs/zh/administration/management/monitoring/metrics-materialized_view.md
@@ -113,3 +113,18 @@ scrape_configs:
 
 - 类型：Histogram
 - 描述：刷新作业的挂钟时长，单位为毫秒。对于多批次作业，从第一个 Task Run 开始到最后一个 Task Run 完成为止计算。
+
+### mv_global_count
+
+- 类型：Gauge
+- 描述：集群中异步物化视图的当前数量，包含标签 `refresh_mode`（物化视图的刷新模式）和 `status`（`ACTIVE` 或 `INACTIVE`）。该指标始终输出，不受单个物化视图指标权限的限制。
+
+### mv_global_query_rewrite_queries_total
+
+- 类型：Counter
+- 描述：按物化视图改写结果分组的查询数量，标签 `state` 取值：`HIT`（查询被改写为使用物化视图）、`NO_HIT`（已启用改写但未使用任何物化视图）或 `DISABLED`（会话变量或 FE 配置关闭了物化视图改写）。每个查询计一次。
+
+### mv_global_query_mv_usage_total
+
+- 类型：Counter
+- 描述：物化视图被查询使用的次数，包含标签 `usage_type`（`REWRITE` 表示查询被改写为使用物化视图，`DIRECT` 表示直接查询物化视图）和 `refresh_mode`。

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -16,11 +16,16 @@ package com.starrocks.metric;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,6 +42,10 @@ public class MaterializedViewMetricsRegistry {
     private final ScheduledThreadPoolExecutor timer;
     private static final MaterializedViewMetricsRegistry INSTANCE = new MaterializedViewMetricsRegistry();
     private static final IMaterializedViewMetricsEntity BLACK_HOLE_ENTITY = new MaterializedViewMetricsBlackHoleEntity();
+
+    // mv_global_query_mv_usage_total is keyed by (usage_type, refresh_mode); MetricWithLabelGroup only
+    // supports a single label, so the two-dimensional counters are tracked here.
+    private static final Map<String, LongCounterMetric> MV_USAGE_COUNTERS = Maps.newConcurrentMap();
 
     private MaterializedViewMetricsRegistry() {
         idToMVMetrics = Maps.newHashMap();
@@ -134,5 +143,55 @@ public class MaterializedViewMetricsRegistry {
                 visitor.visitHistogram(e.getKey(), e.getValue());
             }
         }
+    }
+
+    // Enumerate all async materialized views at scrape time, bucketed by refresh mode x active status.
+    // Lock-free like MetricRepo.collectTableMetrics (reads only immutable-ish fields); db.getMaterializedViews()
+    // covers async MVs only (not sync/rollup MVs).
+    public static void collectGlobalMvCount(MetricVisitor visitor) {
+        Map<String, Long> countByModeStatus = Maps.newHashMap();
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        for (String dbName : globalStateMgr.getLocalMetastore().listDbNames(new ConnectContext())) {
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
+            if (db == null) {
+                continue;
+            }
+            for (MaterializedView mv : db.getMaterializedViews()) {
+                String mode = mv.getRefreshMode() == null ? "UNKNOWN" : mv.getRefreshMode().name();
+                String status = mv.isActive() ? "ACTIVE" : "INACTIVE";
+                countByModeStatus.merge(mode + "|" + status, 1L, Long::sum);
+            }
+        }
+        for (Map.Entry<String, Long> entry : countByModeStatus.entrySet()) {
+            String[] parts = entry.getKey().split("\\|", 2);
+            GaugeMetricImpl<Long> gauge = new GaugeMetricImpl<>("mv_global_count", Metric.MetricUnit.NOUNIT,
+                    "current number of materialized views by refresh mode and active status");
+            gauge.addLabel(new MetricLabel("refresh_mode", parts[0]));
+            gauge.addLabel(new MetricLabel("status", parts[1]));
+            gauge.setValue(entry.getValue());
+            visitor.visit(gauge);
+        }
+    }
+
+    public static void increaseMvUsage(String usageType, String refreshMode) {
+        String mode = refreshMode == null ? "UNKNOWN" : refreshMode;
+        MV_USAGE_COUNTERS.computeIfAbsent(usageType + "|" + mode, key -> {
+            LongCounterMetric metric = new LongCounterMetric("mv_global_query_mv_usage_total",
+                    Metric.MetricUnit.REQUESTS, "materialized view usage by access type and refresh mode");
+            metric.addLabel(new MetricLabel("usage_type", usageType));
+            metric.addLabel(new MetricLabel("refresh_mode", mode));
+            MetricRepo.addMetric(metric);
+            return metric;
+        }).increase(1L);
+    }
+
+    @VisibleForTesting
+    public static long getMvUsageCount(String usageType, String refreshMode) {
+        LongCounterMetric metric = MV_USAGE_COUNTERS.get(usageType + "|" + refreshMode);
+        return metric == null ? 0L : metric.getValue();
+    }
+
+    public static void increaseGlobalQueryRewrite(String state) {
+        MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric(state).increase(1L);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -160,6 +160,10 @@ public final class MetricRepo {
             new MetricWithLabelGroup<>("result",
                     () -> new LongCounterMetric(SPM_REWRITE_TOTAL_METRIC_NAME, MetricUnit.REQUESTS,
                             "total SPM rewrite attempts by result"));
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_MV_GLOBAL_QUERY_REWRITE =
+            new MetricWithLabelGroup<>("state",
+                    () -> new LongCounterMetric("mv_global_query_rewrite_queries_total", MetricUnit.REQUESTS,
+                            "queries by materialized view rewrite outcome (HIT/NO_HIT/DISABLED)"));
     public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_SPM_CAPTURE_CANDIDATE_TOTAL =
             new MetricWithLabelGroup<>("result",
                     () -> new LongCounterMetric(SPM_CAPTURE_CANDIDATE_TOTAL_METRIC_NAME, MetricUnit.REQUESTS,
@@ -1427,6 +1431,9 @@ public final class MetricRepo {
         if (requestParams.isCollectMVMetrics()) {
             MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, requestParams.isMinifyMVMetrics());
         }
+
+        // global MV count: low-cardinality, always emitted (not gated by the per-MV metrics auth above)
+        MaterializedViewMetricsRegistry.collectGlobalMvCount(visitor);
 
         // histogram
         SortedMap<String, Histogram> histograms = METRIC_REGISTER.getHistograms();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -150,6 +150,27 @@ public class MVRewriteValidator {
             taskContext.getOptimizerContext().getQueryTables().addAll(diffMVs);
         }
 
+        // Record global MV usage and rewrite outcome once per non-explain query, regardless of whether
+        // rewrite is enabled — a direct MV read still counts as usage in a rewrite-disabled session.
+        if (connectContext.getExplainLevel() == null) {
+            for (MaterializedView mv : mvs) {
+                String refreshMode = mv.getRefreshMode() == null ? "UNKNOWN" : mv.getRefreshMode().name();
+                String usageType = beforeTableIds.contains(mv.getId()) ? "DIRECT" : "REWRITE";
+                MaterializedViewMetricsRegistry.increaseMvUsage(usageType, refreshMode);
+            }
+            String rewriteState;
+            if (!connectContext.getSessionVariable().isEnableMaterializedViewRewrite()
+                    || connectContext.getSessionVariable().isDisableMaterializedViewRewrite()
+                    || !Config.enable_materialized_view) {
+                rewriteState = "DISABLED";
+            } else if (!diffMVs.isEmpty()) {
+                rewriteState = "HIT";
+            } else {
+                rewriteState = "NO_HIT";
+            }
+            MaterializedViewMetricsRegistry.increaseGlobalQueryRewrite(rewriteState);
+        }
+
         if (diffMVs.isEmpty()) {
             boolean hasRewriteSuccess = Tracers.getAllVars().stream()
                     .anyMatch(var -> StringUtils.contains(var.getValue().toString(),

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MaterializedViewGlobalMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MaterializedViewGlobalMetricsTest.java
@@ -1,0 +1,200 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.codahale.metrics.Histogram;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.monitor.jvm.JvmStats;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.starrocks.sql.plan.PlanTestNoneDBBase.assertContains;
+
+/**
+ * Verifies the global materialized view metrics: mv_global_count, mv_global_query_mv_usage_total,
+ * and mv_global_query_rewrite_queries_total.
+ */
+public class MaterializedViewGlobalMetricsTest extends MVTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+        starRocksAssert.withTable(cluster, "depts");
+    }
+
+    private static String refreshMode(MaterializedView mv) {
+        return mv.getRefreshMode() == null ? "UNKNOWN" : mv.getRefreshMode().name();
+    }
+
+    @Test
+    public void globalMvCountEmittedByModeAndStatus() {
+        String mvName = "pm_cnt_mv";
+        String sql = String.format("CREATE MATERIALIZED VIEW %s REFRESH DEFERRED MANUAL " +
+                "AS SELECT * FROM depts where deptno > 10", mvName);
+        starRocksAssert.withMaterializedView(sql, () -> {
+            MaterializedView mv = (MaterializedView) getTable(DB_NAME, mvName);
+            String mode = refreshMode(mv);
+
+            RecordingMetricVisitor visitor = new RecordingMetricVisitor();
+            MaterializedViewMetricsRegistry.collectGlobalMvCount(visitor);
+
+            Assertions.assertTrue(visitor.hasSeries("mv_global_count", "refresh_mode", mode, "status", "ACTIVE"),
+                    "expected mv_global_count{refresh_mode=" + mode + ", status=ACTIVE}");
+        });
+    }
+
+    @Test
+    public void mvUsageRewriteAndDirectCounted() {
+        String mvName = "pm_usage_mv";
+        String sql = String.format("CREATE MATERIALIZED VIEW %s REFRESH DEFERRED MANUAL " +
+                "AS SELECT * FROM depts where deptno > 10", mvName);
+        starRocksAssert.withMaterializedView(sql, () -> {
+            refreshMaterializedView(DB_NAME, mvName);
+            String mode = refreshMode((MaterializedView) getTable(DB_NAME, mvName));
+
+            long rewriteBefore = MaterializedViewMetricsRegistry.getMvUsageCount("REWRITE", mode);
+            assertContains(getFragmentPlan("select * from depts where deptno > 20"), mvName);
+            Assertions.assertEquals(rewriteBefore + 1,
+                    MaterializedViewMetricsRegistry.getMvUsageCount("REWRITE", mode));
+
+            long directBefore = MaterializedViewMetricsRegistry.getMvUsageCount("DIRECT", mode);
+            assertContains(getFragmentPlan("select * from " + mvName), mvName);
+            Assertions.assertEquals(directBefore + 1,
+                    MaterializedViewMetricsRegistry.getMvUsageCount("DIRECT", mode));
+        });
+    }
+
+    @Test
+    public void queryRewriteOutcomeCounted() {
+        String mvName = "pm_hit_mv";
+        String sql = String.format("CREATE MATERIALIZED VIEW %s REFRESH DEFERRED MANUAL " +
+                "AS SELECT * FROM depts where deptno > 10", mvName);
+        starRocksAssert.withMaterializedView(sql, () -> {
+            refreshMaterializedView(DB_NAME, mvName);
+
+            long hitBefore = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("HIT").getValue();
+            assertContains(getFragmentPlan("select * from depts where deptno > 20"), mvName);
+            long hitAfter = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("HIT").getValue();
+            Assertions.assertEquals(hitBefore + 1, hitAfter);
+
+            long missBefore = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("NO_HIT").getValue();
+            PlanTestBase.assertNotContains(getFragmentPlan("select * from depts where deptno < 20"), mvName);
+            long missAfter = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("NO_HIT").getValue();
+            Assertions.assertEquals(missBefore + 1, missAfter);
+        });
+    }
+
+    @Test
+    public void queryRewriteDisabledCounted() throws Exception {
+        boolean original = connectContext.getSessionVariable().isEnableMaterializedViewRewrite();
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
+        try {
+            long disabledBefore = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("DISABLED").getValue();
+            getFragmentPlan("select * from depts where deptno > 20");
+            long disabledAfter = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("DISABLED").getValue();
+            Assertions.assertEquals(disabledBefore + 1, disabledAfter);
+        } finally {
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(original);
+        }
+    }
+
+    @Test
+    public void directMvUsageCountedWhenRewriteDisabled() {
+        String mvName = "pm_direct_mv";
+        String sql = String.format("CREATE MATERIALIZED VIEW %s REFRESH DEFERRED MANUAL " +
+                "AS SELECT * FROM depts where deptno > 10", mvName);
+        starRocksAssert.withMaterializedView(sql, () -> {
+            refreshMaterializedView(DB_NAME, mvName);
+            String mode = refreshMode((MaterializedView) getTable(DB_NAME, mvName));
+
+            boolean original = connectContext.getSessionVariable().isEnableMaterializedViewRewrite();
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
+            try {
+                long directBefore = MaterializedViewMetricsRegistry.getMvUsageCount("DIRECT", mode);
+                assertContains(getFragmentPlan("select * from " + mvName), mvName);
+                Assertions.assertEquals(directBefore + 1,
+                        MaterializedViewMetricsRegistry.getMvUsageCount("DIRECT", mode),
+                        "a direct MV read must count as DIRECT usage even when rewrite is disabled");
+            } finally {
+                connectContext.getSessionVariable().setEnableMaterializedViewRewrite(original);
+            }
+        });
+    }
+
+    @Test
+    public void rewriteModeDisableCountedAsDisabled() throws Exception {
+        String originalMode = connectContext.getSessionVariable().getMaterializedViewRewriteMode();
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("disable");
+        try {
+            long disabledBefore = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("DISABLED").getValue();
+            getFragmentPlan("select * from depts where deptno > 20");
+            long disabledAfter = MetricRepo.COUNTER_MV_GLOBAL_QUERY_REWRITE.getMetric("DISABLED").getValue();
+            Assertions.assertEquals(disabledBefore + 1, disabledAfter,
+                    "materialized_view_rewrite_mode=disable must count as DISABLED, not NO_HIT");
+        } finally {
+            connectContext.getSessionVariable().setMaterializedViewRewriteMode(originalMode);
+        }
+    }
+
+    private static final class RecordingMetricVisitor extends MetricVisitor {
+        private final List<Metric> visited = Lists.newArrayList();
+
+        private RecordingMetricVisitor() {
+            super("");
+        }
+
+        @Override
+        public void visit(Metric metric) {
+            visited.add(metric);
+        }
+
+        private boolean hasSeries(String name, String k1, String v1, String k2, String v2) {
+            return visited.stream().anyMatch(m -> name.equals(m.getName())
+                    && hasLabel(m, k1, v1) && hasLabel(m, k2, v2));
+        }
+
+        private static boolean hasLabel(Metric metric, String key, String value) {
+            List<MetricLabel> labels = metric.getLabels();
+            return labels.stream().anyMatch(l -> key.equals(l.getKey()) && value.equals(l.getValue()));
+        }
+
+        @Override
+        public void visitJvm(JvmStats jvmStats) {
+        }
+
+        @Override
+        public void visitHistogram(String name, Histogram histogram) {
+        }
+
+        @Override
+        public void visitHistogram(HistogramMetric histogram) {
+        }
+
+        @Override
+        public void getNodeInfo() {
+        }
+
+        @Override
+        public String build() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The materialized view metrics today are per-MV (refresh counters/duration, per-query hit/considered counts). There are no FE-native, low-cardinality cluster-wide (global) metrics — how many materialized views exist by refresh mode and active status, how often query rewrite hits, and how materialized views are used (rewrite vs direct). This PR adds those.

This is PR3 of a series derived from the MV Metrics PRD; it is independent of the per-MV job-granularity PR (#74907) and the global-refresh PR.

## What I'm doing:

Add three additive, FE-aggregated global materialized view metrics (no behavior change):

- `mv_global_count{refresh_mode, status}` — gauge enumerating async materialized views at scrape time, by refresh mode and `ACTIVE`/`INACTIVE`. Collected unconditionally in `MetricRepo.getMetric` (not gated by the per-MV metrics privilege), lock-free like `collectTableMetrics`.
- `mv_global_query_mv_usage_total{usage_type, refresh_mode}` — counter of materialized view usage: `REWRITE` (query rewritten to use the MV) vs `DIRECT` (query reads the MV directly), bumped per used materialized view in `MVRewriteValidator`.
- `mv_global_query_rewrite_queries_total{state}` — counter of per-query rewrite outcome: `HIT` / `NO_HIT` / `DISABLED`, counted once per non-explain query in `MVRewriteValidator.validateMV`.

Docs (en/zh/ja) and unit tests added.

Fixes #issue: N/A — internal observability enhancement from the MV Metrics PRD; no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)