### PR TITLE
[BugFix] Fix concurrent loads failing/losing data during online optimize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -315,10 +315,12 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
                     tbl.addDoubleWritePartition(p.getId(), temp.getId());
 
                     // Assign the watershed transaction id atomically with enabling the double-write mapping,
-                    // while still holding the table's write lock. This closes a race window: a load reads the
-                    // double-write mapping (OlapTableSink) under the table read lock, which conflicts with this
-                    // write lock, so any load that observed an *empty* mapping (and therefore only writes the
-                    // source partition) must have begun its transaction before this point and thus has a txn id
+                    // while still holding this database WRITE lock. This closes a race window: a load reads the
+                    // double-write mapping (OlapTableSink) after allocating its txn id at beginTransaction, and
+                    // reads it under a database INTENTION_SHARED + table READ lock that conflicts with this
+                    // database WRITE lock. So any load that observed an *empty* mapping (and therefore only
+                    // writes the source partition) must have read it before this critical section ran, hence
+                    // allocated its txn id before watershedTxnId (a single monotonic generator) -> txn id
                     // < watershedTxnId; isPreviousLoadFinished() below drains exactly those. Every load with a
                     // txn id >= watershedTxnId necessarily begins after the mapping is visible and will
                     // double-write into the temp partition. Previously the watershed was assigned after this

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -30,6 +30,7 @@ import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
@@ -654,7 +655,14 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
     // source partition identified by sourcePartitionName. Mirrors the visibility gate used by the offline
     // OptimizeJobV2, so the online job never replaces a partition that an unpublished load still references.
     protected boolean hasCommittedNotVisible(Database db, OlapTable tbl, String sourcePartitionName) {
-        long sourcePartitionId;
+        // Committed load metadata (TableCommitInfo's PartitionCommitInfo map) is keyed by PHYSICAL partition
+        // id, not the logical partition id (see TableCommitInfo.addPartitionCommitInfo). For normal partitions
+        // the logical Partition.getId() differs from the physical partition id, so resolve the source
+        // partition's physical partition(s) here: passing the logical id would make existCommittedTxns miss a
+        // committed-but-not-visible load and let the replacement proceed under an unpublished transaction,
+        // reopening the publish-failure window this gate is meant to close. The source partition has a single
+        // sub-partition (see enableDoubleWritePartition), but iterate defensively in case that changes.
+        List<Long> sourcePhysicalPartitionIds = Lists.newArrayList();
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(db.getId(), tbl.getId(), LockType.READ);
         try {
@@ -662,12 +670,19 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             if (partition == null) {
                 return false;
             }
-            sourcePartitionId = partition.getId();
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                sourcePhysicalPartitionIds.add(physicalPartition.getId());
+            }
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tbl.getId(), LockType.READ);
         }
-        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                    .existCommittedTxns(db.getId(), tbl.getId(), sourcePartitionId);
+        for (long physicalPartitionId : sourcePhysicalPartitionIds) {
+            if (GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .existCommittedTxns(db.getId(), tbl.getId(), physicalPartitionId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -384,7 +384,8 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             }
 
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.PENDING) {
-                // enableDoubleWritePartition assigns watershedTxnId atomically under the table write lock.
+                // enableDoubleWritePartition assigns watershedTxnId atomically under the database WRITE lock
+                // (the lock that conflicts with the load's mapping read in OlapTableSink.complete()).
                 enableDoubleWritePartition(db, tbl, rewriteTask.getPartitionName(), rewriteTask.getTempPartitionName());
                 rewriteTask.setOptimizeTaskState(Constants.TaskRunState.RUNNING);
             }
@@ -666,7 +667,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             locker.unLockTableWithIntensiveDbLock(db.getId(), tbl.getId(), LockType.READ);
         }
         return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                    .existCommittedTxns(dbId, tableId, sourcePartitionId);
+                    .existCommittedTxns(db.getId(), tbl.getId(), sourcePartitionId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -314,8 +314,22 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
                     Preconditions.checkState(p.getSubPartitions().size() == 1);
                     tbl.addDoubleWritePartition(p.getId(), temp.getId());
 
-                    LOG.info("job {} add double write partition: {}:{} -> {}:{}", jobId, sourcePartitionName,
-                                p.getId(), tempPartitionName, temp.getId());
+                    // Assign the watershed transaction id atomically with enabling the double-write mapping,
+                    // while still holding the table's write lock. This closes a race window: a load reads the
+                    // double-write mapping (OlapTableSink) under the table read lock, which conflicts with this
+                    // write lock, so any load that observed an *empty* mapping (and therefore only writes the
+                    // source partition) must have begun its transaction before this point and thus has a txn id
+                    // < watershedTxnId; isPreviousLoadFinished() below drains exactly those. Every load with a
+                    // txn id >= watershedTxnId necessarily begins after the mapping is visible and will
+                    // double-write into the temp partition. Previously the watershed was assigned after this
+                    // lock was released, leaving a gap where a source-only load could obtain a txn id
+                    // >= watershed, escape double-write, and then be dropped by the partition replacement
+                    // (silent data loss) or fail at publish against a force-deleted source tablet.
+                    this.watershedTxnId = GlobalStateMgr.getCurrentState()
+                                .getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+
+                    LOG.info("job {} add double write partition: {}:{} -> {}:{}, watershedTxnId {}", jobId,
+                                sourcePartitionName, p.getId(), tempPartitionName, temp.getId(), watershedTxnId);
                 } else {
                     LOG.warn("job {} add double partition {} does not exist", jobId, sourcePartitionName);
                 }
@@ -368,9 +382,8 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             }
 
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.PENDING) {
+                // enableDoubleWritePartition assigns watershedTxnId atomically under the table write lock.
                 enableDoubleWritePartition(db, tbl, rewriteTask.getPartitionName(), rewriteTask.getTempPartitionName());
-                this.watershedTxnId = GlobalStateMgr.getCurrentState()
-                            .getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
                 rewriteTask.setOptimizeTaskState(Constants.TaskRunState.RUNNING);
             }
 
@@ -386,13 +399,32 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
 
                 if (this.future != null) {
                     if (this.future.isDone()) {
+                        Constants.TaskRunState taskState;
                         try {
-                            rewriteTask.setOptimizeTaskState(future.get());
+                            taskState = future.get();
                         } catch (InterruptedException | ExecutionException e) {
                             LOG.warn("get rewrite task result failed", e);
-                            rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
+                            taskState = Constants.TaskRunState.FAILED;
                         }
 
+                        // Before allowing the partition replacement, make sure no load transaction has
+                        // committed to the source partition but is not yet visible (published). Such a load
+                        // has already been double-written into the temp partition (it begins after the
+                        // watershed and therefore observes the double-write mapping), but replacing the source
+                        // partition before it is published would drop the source partition out from under an
+                        // unpublished transaction that still references it -> publish failure. We do NOT abandon
+                        // the optimization here; we simply wait one scheduler round for the load to become
+                        // visible, preserving the "online" contract (loads neither fail nor lose data).
+                        // future stays set and done, so the rewrite SQL is not re-run on retry.
+                        if (taskState == Constants.TaskRunState.SUCCESS
+                                && hasCommittedNotVisible(db, tbl, rewriteTask.getPartitionName())) {
+                            LOG.info("optimize job {} task {} waiting for committed-not-visible loads on "
+                                    + "partition {} before replacing", jobId, rewriteTask.getName(),
+                                    rewriteTask.getPartitionName());
+                            return;
+                        }
+
+                        rewriteTask.setOptimizeTaskState(taskState);
                         if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED) {
                             this.allPartitionOptimized = false;
                         }
@@ -613,6 +645,26 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
     protected boolean isPreviousLoadFinished() throws AnalysisException {
         return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                     .isPreviousTransactionsFinished(watershedTxnId, dbId, Lists.newArrayList(tableId));
+    }
+
+    // Returns true if there exists a committed-but-not-visible (not yet published) load transaction on the
+    // source partition identified by sourcePartitionName. Mirrors the visibility gate used by the offline
+    // OptimizeJobV2, so the online job never replaces a partition that an unpublished load still references.
+    protected boolean hasCommittedNotVisible(Database db, OlapTable tbl, String sourcePartitionName) {
+        long sourcePartitionId;
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tbl.getId(), LockType.READ);
+        try {
+            Partition partition = tbl.getPartition(sourcePartitionName);
+            if (partition == null) {
+                return false;
+            }
+            sourcePartitionId = partition.getId();
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tbl.getId(), LockType.READ);
+        }
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                    .existCommittedTxns(dbId, tableId, sourcePartitionId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -299,7 +299,26 @@ public class StatisticsCollectionTrigger {
                 Map<Long, Long> tabletRows = partitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad();
 
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
-                Long partitionId = table.getPartition(physicalPartition.getParentId()).getId();
+                if (physicalPartition == null) {
+                    // The partition referenced by this commit info may have been replaced or dropped by a
+                    // concurrent online optimize (e.g. a double-write temp partition swapped in via
+                    // replacePartition + disableDoubleWritePartition) between the load txn becoming VISIBLE
+                    // and this post-commit, best-effort stats trigger running. Statistics collection on first
+                    // load must never fail an already-committed load, so skip the missing partition.
+                    LOG.debug("skip first-load statistics for physical partition {} of table {}: physical partition " +
+                            "no longer exists (likely replaced by a concurrent optimize)", physicalPartitionId, table.getId());
+                    continue;
+                }
+                Partition logicalPartition = table.getPartition(physicalPartition.getParentId());
+                if (logicalPartition == null) {
+                    // Parent logical partition was replaced/removed by a concurrent optimize after this physical
+                    // partition's commit; nothing to collect against. Skip rather than NPE and fail the load.
+                    LOG.debug("skip first-load statistics for physical partition {} of table {}: parent logical " +
+                            "partition {} no longer exists (likely replaced by a concurrent optimize)",
+                            physicalPartitionId, table.getId(), physicalPartition.getParentId());
+                    continue;
+                }
+                Long partitionId = logicalPartition.getId();
                 if (table.isNativeTableOrMaterializedView()) {
                     OlapTable olapTable = (OlapTable) table;
                     if (olapTable.isTempPartition(partitionId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -657,7 +657,12 @@ public class GlobalTransactionMgr implements MemoryTrackable {
             if (transactionState.getTableIdList().contains(tableId)) {
                 if (partitionId == null) {
                     return true;
-                } else if (transactionState.getTableCommitInfo(tableId).getPartitionCommitInfo(partitionId) != null) {
+                }
+                // getTableCommitInfo is @Nullable: a committed txn can list the table in its tableIdList
+                // before its TableCommitInfo is populated, so guard against NPE here (this method is called
+                // lock-free, e.g. by the online optimize visibility gate).
+                TableCommitInfo tableCommitInfo = transactionState.getTableCommitInfo(tableId);
+                if (tableCommitInfo != null && tableCommitInfo.getPartitionCommitInfo(partitionId) != null) {
                     return true;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -643,6 +643,12 @@ public class GlobalTransactionMgr implements MemoryTrackable {
 
     public boolean existCommittedTxns(Long dbId, Long tableId, Long partitionId) {
         DatabaseTransactionMgr dbTransactionMgr = dbIdToDatabaseTransactionMgrs.get(dbId);
+        if (dbTransactionMgr == null) {
+            // The database transaction manager may be absent if the database was dropped concurrently.
+            // Treat that as "no committed transactions" rather than throwing NPE, since callers invoke
+            // this lock-free (e.g. the online optimize visibility gate).
+            return false;
+        }
         if (tableId == null && partitionId == null) {
             return !dbTransactionMgr.getCommittedTxnList().isEmpty();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -305,6 +305,123 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
                 "replay must not null out defaultDistributionInfo when persisted job has null distributionInfo");
     }
 
+    @Test
+    public void testDoubleWriteEnableAssignsWatershedAndDisableClears() throws Exception {
+        // Window-A regression: enabling the double-write mapping and assigning the watershed txn id must
+        // happen together (atomically, under the table write lock). Otherwise a load can obtain a txn id
+        // >= watershed yet still observe an empty double-write mapping, write only the source partition,
+        // and then be dropped by the partition replacement (silent data loss) or fail at publish against a
+        // force-deleted source tablet. This asserts the enable+watershed timing rather than relying on the
+        // always-finished isPreviousLoadFinished() mock.
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+
+        schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
+        OnlineOptimizeJobV2 optimizeJob =
+                spyPreviousTxnFinished((OnlineOptimizeJobV2) alterJobsV2.values().stream().findAny().get());
+
+        optimizeJob.runPendingJob();
+        optimizeJob.runWaitingTxnJob();
+        Assertions.assertEquals(JobState.RUNNING, optimizeJob.getJobState());
+
+        OptimizeTask task = optimizeJob.getOptimizeTasks().get(0);
+
+        // Before any task is activated, the double-write mapping is empty.
+        Assertions.assertTrue(olapTable.getDoubleWritePartitions().isEmpty());
+
+        // Activate double-write for the task's source/temp partition pair (the path runRunningJob takes
+        // when a task transitions PENDING -> RUNNING).
+        java.lang.reflect.Method enable = OnlineOptimizeJobV2.class.getDeclaredMethod(
+                "enableDoubleWritePartition", Database.class, OlapTable.class, String.class, String.class);
+        enable.setAccessible(true);
+        enable.invoke(optimizeJob, db, olapTable, task.getPartitionName(), task.getTempPartitionName());
+
+        // The mapping is now visible AND the watershed has been assigned in the same critical section.
+        Assertions.assertFalse(olapTable.getDoubleWritePartitions().isEmpty(),
+                "double-write mapping must be enabled");
+        Assertions.assertTrue(optimizeJob.getTransactionId().isPresent(),
+                "watershed txn id must be assigned atomically when double-write is enabled");
+        Assertions.assertTrue(optimizeJob.getTransactionId().get() > 0);
+
+        // Disabling double-write clears the mapping (the replacement / cancel cleanup path).
+        java.lang.reflect.Method disable = OnlineOptimizeJobV2.class.getDeclaredMethod(
+                "disableDoubleWritePartition", Database.class, OlapTable.class);
+        disable.setAccessible(true);
+        disable.invoke(optimizeJob, db, olapTable);
+        Assertions.assertTrue(olapTable.getDoubleWritePartitions().isEmpty(),
+                "double-write mapping must be cleared after disable");
+    }
+
+    @Test
+    public void testHasCommittedNotVisibleFalseWhenNoCommittedTxns() throws Exception {
+        // The visibility gate must report "safe to replace" when there are no committed-but-unpublished
+        // loads on the source partition, so the optimization converges in the common case (we delay the
+        // replacement only while a committed load is still unpublished, we never abandon it).
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+
+        schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
+        OnlineOptimizeJobV2 optimizeJob =
+                spyPreviousTxnFinished((OnlineOptimizeJobV2) alterJobsV2.values().stream().findAny().get());
+        optimizeJob.runPendingJob();
+        optimizeJob.runWaitingTxnJob();
+
+        OptimizeTask task = optimizeJob.getOptimizeTasks().get(0);
+        java.lang.reflect.Method m = OnlineOptimizeJobV2.class.getDeclaredMethod(
+                "hasCommittedNotVisible", Database.class, OlapTable.class, String.class);
+        m.setAccessible(true);
+        boolean committedNotVisible = (boolean) m.invoke(optimizeJob, db, olapTable, task.getPartitionName());
+        Assertions.assertFalse(committedNotVisible);
+    }
+
+    @Test
+    public void testCommittedNotVisibleDefersReplacementWithoutRerunningRewrite() throws Exception {
+        // When the rewrite SQL has finished (future done = SUCCESS) but a load is committed-but-not-visible
+        // on the source partition, runRunningJob must DEFER the partition replacement: stay in RUNNING and
+        // leave the (completed) future in place so the rewrite INSERT is NOT resubmitted on the next round.
+        // This preserves the online contract (no abandon) while never replacing under an unpublished load.
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+
+        schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
+        OnlineOptimizeJobV2 optimizeJob =
+                spyPreviousTxnFinished((OnlineOptimizeJobV2) alterJobsV2.values().stream().findAny().get());
+        optimizeJob.runPendingJob();
+        optimizeJob.runWaitingTxnJob();
+        Assertions.assertEquals(JobState.RUNNING, optimizeJob.getJobState());
+
+        // Drive the first task straight into the "future done = SUCCESS" branch without running the real
+        // INSERT: mark it RUNNING and inject an already-completed future.
+        OptimizeTask task = optimizeJob.getOptimizeTasks().get(0);
+        task.setOptimizeTaskState(Constants.TaskRunState.RUNNING);
+        java.lang.reflect.Field futureField = OnlineOptimizeJobV2.class.getDeclaredField("future");
+        futureField.setAccessible(true);
+        futureField.set(optimizeJob,
+                java.util.concurrent.CompletableFuture.completedFuture(Constants.TaskRunState.SUCCESS));
+
+        // A committed-but-not-visible load exists on the source partition -> must defer.
+        Mockito.doReturn(true).when(optimizeJob)
+                .hasCommittedNotVisible(Mockito.any(), Mockito.any(), Mockito.anyString());
+
+        optimizeJob.runRunningJob();
+
+        // Deferred: still RUNNING, task still RUNNING, and the completed future is retained so the rewrite
+        // SQL is not resubmitted next round.
+        Assertions.assertEquals(JobState.RUNNING, optimizeJob.getJobState());
+        Assertions.assertEquals(Constants.TaskRunState.RUNNING, task.getOptimizeTaskState());
+        Assertions.assertNotNull(futureField.get(optimizeJob),
+                "completed future must be retained while deferring, so the rewrite INSERT is not re-run");
+    }
+
     private OnlineOptimizeJobV2 spyPreviousTxnFinished(OnlineOptimizeJobV2 job) throws AnalysisException {
         // Detach the job from schema change handler to prevent background scheduler from changing state
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -478,6 +478,35 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         }
     }
 
+    @Test
+    public void testExistCommittedTxnsFalseWhenTableCommitInfoNull() {
+        // Cover the @Nullable TableCommitInfo guard: a committed txn can list the table in its tableIdList
+        // before its TableCommitInfo is populated. With a non-null partitionId, existCommittedTxns must treat
+        // the null TableCommitInfo as "no committed txn for this partition" (the short-circuit false branch of
+        // `tableCommitInfo != null`) and fall through to return false rather than NPE -- this method is called
+        // lock-free by the online optimize visibility gate.
+        long dbId = 222333445L;
+        long tableId = 777L;
+        long partitionId = 888L;
+
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        Mockito.when(txnState.getTableIdList()).thenReturn(List.of(tableId));
+        Mockito.when(txnState.getTableCommitInfo(tableId)).thenReturn(null);
+        DatabaseTransactionMgr dbTransactionMgr = Mockito.mock(DatabaseTransactionMgr.class);
+        Mockito.when(dbTransactionMgr.getCommittedTxnList()).thenReturn(List.of(txnState));
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Map<Long, DatabaseTransactionMgr> dbMgrs = globalTransactionMgr.getAllDatabaseTransactionMgrs();
+        dbMgrs.put(dbId, dbTransactionMgr);
+        try {
+            Assertions.assertFalse(globalTransactionMgr.existCommittedTxns(dbId, tableId, partitionId),
+                    "existCommittedTxns must return false (not NPE) when the committed txn's TableCommitInfo "
+                            + "is not yet populated");
+        } finally {
+            dbMgrs.remove(dbId);
+        }
+    }
+
     private OnlineOptimizeJobV2 spyPreviousTxnFinished(OnlineOptimizeJobV2 job) throws AnalysisException {
         // Detach the job from schema change handler to prevent background scheduler from changing state
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -420,6 +420,28 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         Assertions.assertEquals(Constants.TaskRunState.RUNNING, task.getOptimizeTaskState());
         Assertions.assertNotNull(futureField.get(optimizeJob),
                 "completed future must be retained while deferring, so the rewrite INSERT is not re-run");
+
+        // Run a second scheduler round while still committed-not-visible: it must defer again and, crucially,
+        // must NOT resubmit the rewrite INSERT (the retained completed future short-circuits re-execution).
+        optimizeJob.runRunningJob();
+        Assertions.assertEquals(JobState.RUNNING, optimizeJob.getJobState());
+        Assertions.assertEquals(Constants.TaskRunState.RUNNING, task.getOptimizeTaskState());
+        Assertions.assertNotNull(futureField.get(optimizeJob));
+
+        // The rewrite SQL is never (re-)executed across the deferred rounds: the injected future stands in for
+        // the completed INSERT, and the defer branch returns before any resubmission path.
+        Mockito.verify(optimizeJob, Mockito.never()).executeSql(Mockito.anyString());
+    }
+
+    @Test
+    public void testExistCommittedTxnsReturnsFalseForDroppedDb() {
+        // The visibility gate calls existCommittedTxns lock-free; if the database was dropped concurrently
+        // its DatabaseTransactionMgr is absent. That must yield "no committed txns" (safe to proceed) rather
+        // than throwing NPE inside the optimize scheduler loop.
+        long missingDbId = 987654321L;
+        boolean exists = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .existCommittedTxns(missingDbId, 1L, 1L);
+        Assertions.assertFalse(exists, "existCommittedTxns must return false (not NPE) for an absent database");
     }
 
     private OnlineOptimizeJobV2 spyPreviousTxnFinished(OnlineOptimizeJobV2 job) throws AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -30,6 +30,11 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.transaction.DatabaseTransactionMgr;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.PartitionCommitInfo;
+import com.starrocks.transaction.TableCommitInfo;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.UtFrameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -442,6 +447,35 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         boolean exists = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                 .existCommittedTxns(missingDbId, 1L, 1L);
         Assertions.assertFalse(exists, "existCommittedTxns must return false (not NPE) for an absent database");
+    }
+
+    @Test
+    public void testExistCommittedTxnsTrueForCommittedPartition() {
+        // Cover the @Nullable-guarded TableCommitInfo branch: a registered db whose committed txn lists the
+        // table and has a populated TableCommitInfo/PartitionCommitInfo must report an existing committed txn
+        // (the dropped-db test only exercises the early null-DatabaseTransactionMgr short-circuit).
+        long dbId = 222333444L;
+        long tableId = 555L;
+        long partitionId = 666L;
+
+        TableCommitInfo tableCommitInfo = Mockito.mock(TableCommitInfo.class);
+        Mockito.when(tableCommitInfo.getPartitionCommitInfo(partitionId))
+                .thenReturn(Mockito.mock(PartitionCommitInfo.class));
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        Mockito.when(txnState.getTableIdList()).thenReturn(List.of(tableId));
+        Mockito.when(txnState.getTableCommitInfo(tableId)).thenReturn(tableCommitInfo);
+        DatabaseTransactionMgr dbTransactionMgr = Mockito.mock(DatabaseTransactionMgr.class);
+        Mockito.when(dbTransactionMgr.getCommittedTxnList()).thenReturn(List.of(txnState));
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Map<Long, DatabaseTransactionMgr> dbMgrs = globalTransactionMgr.getAllDatabaseTransactionMgrs();
+        dbMgrs.put(dbId, dbTransactionMgr);
+        try {
+            Assertions.assertTrue(globalTransactionMgr.existCommittedTxns(dbId, tableId, partitionId),
+                    "existCommittedTxns must report the committed txn whose TableCommitInfo is populated");
+        } finally {
+            dbMgrs.remove(dbId);
+        }
     }
 
     private OnlineOptimizeJobV2 spyPreviousTxnFinished(OnlineOptimizeJobV2 job) throws AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -30,11 +30,6 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.ast.AlterTableStmt;
-import com.starrocks.transaction.DatabaseTransactionMgr;
-import com.starrocks.transaction.GlobalTransactionMgr;
-import com.starrocks.transaction.PartitionCommitInfo;
-import com.starrocks.transaction.TableCommitInfo;
-import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.UtFrameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -436,75 +431,6 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         // The rewrite SQL is never (re-)executed across the deferred rounds: the injected future stands in for
         // the completed INSERT, and the defer branch returns before any resubmission path.
         Mockito.verify(optimizeJob, Mockito.never()).executeSql(Mockito.anyString());
-    }
-
-    @Test
-    public void testExistCommittedTxnsReturnsFalseForDroppedDb() {
-        // The visibility gate calls existCommittedTxns lock-free; if the database was dropped concurrently
-        // its DatabaseTransactionMgr is absent. That must yield "no committed txns" (safe to proceed) rather
-        // than throwing NPE inside the optimize scheduler loop.
-        long missingDbId = 987654321L;
-        boolean exists = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                .existCommittedTxns(missingDbId, 1L, 1L);
-        Assertions.assertFalse(exists, "existCommittedTxns must return false (not NPE) for an absent database");
-    }
-
-    @Test
-    public void testExistCommittedTxnsTrueForCommittedPartition() {
-        // Cover the @Nullable-guarded TableCommitInfo branch: a registered db whose committed txn lists the
-        // table and has a populated TableCommitInfo/PartitionCommitInfo must report an existing committed txn
-        // (the dropped-db test only exercises the early null-DatabaseTransactionMgr short-circuit).
-        long dbId = 222333444L;
-        long tableId = 555L;
-        long partitionId = 666L;
-
-        TableCommitInfo tableCommitInfo = Mockito.mock(TableCommitInfo.class);
-        Mockito.when(tableCommitInfo.getPartitionCommitInfo(partitionId))
-                .thenReturn(Mockito.mock(PartitionCommitInfo.class));
-        TransactionState txnState = Mockito.mock(TransactionState.class);
-        Mockito.when(txnState.getTableIdList()).thenReturn(List.of(tableId));
-        Mockito.when(txnState.getTableCommitInfo(tableId)).thenReturn(tableCommitInfo);
-        DatabaseTransactionMgr dbTransactionMgr = Mockito.mock(DatabaseTransactionMgr.class);
-        Mockito.when(dbTransactionMgr.getCommittedTxnList()).thenReturn(List.of(txnState));
-
-        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        Map<Long, DatabaseTransactionMgr> dbMgrs = globalTransactionMgr.getAllDatabaseTransactionMgrs();
-        dbMgrs.put(dbId, dbTransactionMgr);
-        try {
-            Assertions.assertTrue(globalTransactionMgr.existCommittedTxns(dbId, tableId, partitionId),
-                    "existCommittedTxns must report the committed txn whose TableCommitInfo is populated");
-        } finally {
-            dbMgrs.remove(dbId);
-        }
-    }
-
-    @Test
-    public void testExistCommittedTxnsFalseWhenTableCommitInfoNull() {
-        // Cover the @Nullable TableCommitInfo guard: a committed txn can list the table in its tableIdList
-        // before its TableCommitInfo is populated. With a non-null partitionId, existCommittedTxns must treat
-        // the null TableCommitInfo as "no committed txn for this partition" (the short-circuit false branch of
-        // `tableCommitInfo != null`) and fall through to return false rather than NPE -- this method is called
-        // lock-free by the online optimize visibility gate.
-        long dbId = 222333445L;
-        long tableId = 777L;
-        long partitionId = 888L;
-
-        TransactionState txnState = Mockito.mock(TransactionState.class);
-        Mockito.when(txnState.getTableIdList()).thenReturn(List.of(tableId));
-        Mockito.when(txnState.getTableCommitInfo(tableId)).thenReturn(null);
-        DatabaseTransactionMgr dbTransactionMgr = Mockito.mock(DatabaseTransactionMgr.class);
-        Mockito.when(dbTransactionMgr.getCommittedTxnList()).thenReturn(List.of(txnState));
-
-        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        Map<Long, DatabaseTransactionMgr> dbMgrs = globalTransactionMgr.getAllDatabaseTransactionMgrs();
-        dbMgrs.put(dbId, dbTransactionMgr);
-        try {
-            Assertions.assertFalse(globalTransactionMgr.existCommittedTxns(dbId, tableId, partitionId),
-                    "existCommittedTxns must return false (not NPE) when the committed txn's TableCommitInfo "
-                            + "is not yet populated");
-        } finally {
-            dbMgrs.remove(dbId);
-        }
     }
 
     private OnlineOptimizeJobV2 spyPreviousTxnFinished(OnlineOptimizeJobV2 job) throws AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
@@ -17,6 +17,7 @@ package com.starrocks.statistic;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.qe.DmlType;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -101,6 +103,92 @@ public class StatisticsCollectionTriggerTest extends PlanTestBase {
                     StatisticsCollectionTrigger.triggerOnFirstLoad(transactionState, db, table, true, true,
                             DmlType.INSERT_INTO);
             Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, trigger.getAnalyzeType());
+        }
+    }
+
+    @Test
+    public void triggerOnLoadSkipsPartitionRemovedByConcurrentOptimize() throws Exception {
+        // Regression: during online optimize, a load txn becomes VISIBLE and its post-commit, best-effort
+        // first-load stats trigger iterates the txn's PartitionCommitInfo. A concurrent OnlineOptimizeJobV2 can
+        // replacePartition + disableDoubleWritePartition in between, so the committed partition id no longer
+        // resolves on the table. Previously prepareAnalyzeJobForLoad dereferenced it unguarded and NPE'd,
+        // surfacing an already-committed load to the client as FAILED. The trigger must skip the missing
+        // partition (and still process the surviving ones) instead.
+        final String dbName = "test_statistics";
+        final String tableName = "t_load_optimize_race";
+        starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+        starRocksAssert.withTable("create table " + tableName + " (" +
+                "c1 int not null," +
+                "c2 int not null" +
+                ") " +
+                "partition by (c1)\n" +
+                "properties('replication_num'='1')");
+        starRocksAssert.ddl("alter table " + tableName + " add partition p1 values in ('1')");
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = db.getTable(tableName);
+
+        // Case 1 (guard #1, physicalPartition == null): a commit info whose physical partition was swapped out
+        // by a concurrent optimize -> use an id that is not assigned to any partition of the table.
+        // Must not throw (pre-fix this NPE'd at getParentId()); with nothing resolvable there is nothing to collect.
+        {
+            long vanishedPhysicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+            TransactionState transactionState = new TransactionState();
+            TableCommitInfo commitInfo = new TableCommitInfo(table.getId());
+            commitInfo.addPartitionCommitInfo(new PartitionCommitInfo(vanishedPhysicalPartitionId, 2, 1));
+            transactionState.putIdToTableCommitInfo(table.getId(), commitInfo);
+            transactionState.setTxnCommitAttachment(new InsertTxnCommitAttachment(1000, 5));
+
+            StatisticsCollectionTrigger trigger = Assertions.assertDoesNotThrow(() ->
+                    StatisticsCollectionTrigger.triggerOnFirstLoad(transactionState, db, table, true, true,
+                            DmlType.INSERT_INTO));
+            Assertions.assertNull(trigger.getAnalyzeType());
+        }
+
+        // Case 2 (pin `continue` semantics): a vanished partition alongside a still-valid one. The vanished entry
+        // must be skipped while the valid partition is still collected -> proves we `continue` rather than abort
+        // the whole loop on the first miss.
+        {
+            Partition valid = table.getPartition("p1");
+            setPartitionStatistics((OlapTable) table, "p1", 1000);
+            TransactionState transactionState = new TransactionState();
+            TableCommitInfo commitInfo = new TableCommitInfo(table.getId());
+            commitInfo.addPartitionCommitInfo(
+                    new PartitionCommitInfo(GlobalStateMgr.getCurrentState().getNextId(), 2, 1)); // vanished
+            commitInfo.addPartitionCommitInfo(
+                    new PartitionCommitInfo(valid.getDefaultPhysicalPartition().getId(), 2, 1));  // survives
+            transactionState.putIdToTableCommitInfo(table.getId(), commitInfo);
+            transactionState.setTxnCommitAttachment(new InsertTxnCommitAttachment(1000, 5));
+
+            StatisticsCollectionTrigger trigger = Assertions.assertDoesNotThrow(() ->
+                    StatisticsCollectionTrigger.triggerOnFirstLoad(transactionState, db, table, true, true,
+                            DmlType.INSERT_INTO));
+            // Valid partition was still picked up -> collection proceeds (FULL for a 1000-row first load).
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, trigger.getAnalyzeType());
+        }
+
+        // Case 3 (guard #2, physicalPartition != null but parent logical partition == null): the physical
+        // partition still resolves but its parent logical partition was removed by the concurrent optimize.
+        // Use a spy so getPhysicalPartition returns a stub whose parentId points at a non-existent logical id.
+        {
+            OlapTable spyTable = Mockito.spy((OlapTable) table);
+            long orphanPhysicalId = GlobalStateMgr.getCurrentState().getNextId();
+            long missingParentLogicalId = GlobalStateMgr.getCurrentState().getNextId();
+            PhysicalPartition orphan = Mockito.mock(PhysicalPartition.class);
+            Mockito.when(orphan.getParentId()).thenReturn(missingParentLogicalId);
+            Mockito.doReturn(orphan).when(spyTable).getPhysicalPartition(orphanPhysicalId);
+            // real getPartition(missingParentLogicalId) returns null since that id is unassigned -> hits guard #2.
+
+            TransactionState transactionState = new TransactionState();
+            TableCommitInfo commitInfo = new TableCommitInfo(spyTable.getId());
+            commitInfo.addPartitionCommitInfo(new PartitionCommitInfo(orphanPhysicalId, 2, 1));
+            transactionState.putIdToTableCommitInfo(spyTable.getId(), commitInfo);
+            transactionState.setTxnCommitAttachment(new InsertTxnCommitAttachment(1000, 5));
+
+            StatisticsCollectionTrigger trigger = Assertions.assertDoesNotThrow(() ->
+                    StatisticsCollectionTrigger.triggerOnFirstLoad(transactionState, db, spyTable, true, true,
+                            DmlType.INSERT_INTO));
+            Assertions.assertNull(trigger.getAnalyzeType());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -90,6 +90,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -1438,6 +1439,69 @@ public class GlobalTransactionMgrTest {
                     "error must mention shared-data/lake requirement, got: " + ex.getMessage());
         } finally {
             Config.enable_admin_skip_committed_txn = original;
+        }
+    }
+
+    @Test
+    public void testExistCommittedTxnsReturnsFalseForAbsentDb() {
+        // existCommittedTxns is invoked lock-free by the online optimize visibility gate. When the database
+        // was dropped concurrently its DatabaseTransactionMgr is absent; the method must short-circuit to
+        // "no committed txns" (return false) instead of NPEing on the missing manager.
+        long absentDbId = 987654321L;
+        Assertions.assertFalse(masterTransMgr.existCommittedTxns(absentDbId, 1L, 1L),
+                "existCommittedTxns must return false (not NPE) for an absent DatabaseTransactionMgr");
+    }
+
+    @Test
+    public void testExistCommittedTxnsTrueForPopulatedPartitionCommitInfo() {
+        // A registered db whose committed txn lists the table and has a populated TableCommitInfo with the
+        // queried PartitionCommitInfo must report an existing committed txn.
+        long dbId = 222333444L;
+        long tableId = 555L;
+        long partitionId = 666L;
+
+        TableCommitInfo tableCommitInfo = Mockito.mock(TableCommitInfo.class);
+        Mockito.when(tableCommitInfo.getPartitionCommitInfo(partitionId))
+                .thenReturn(Mockito.mock(PartitionCommitInfo.class));
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        Mockito.when(txnState.getTableIdList()).thenReturn(List.of(tableId));
+        Mockito.when(txnState.getTableCommitInfo(tableId)).thenReturn(tableCommitInfo);
+        DatabaseTransactionMgr dbTransactionMgr = Mockito.mock(DatabaseTransactionMgr.class);
+        Mockito.when(dbTransactionMgr.getCommittedTxnList()).thenReturn(List.of(txnState));
+
+        Map<Long, DatabaseTransactionMgr> dbMgrs = masterTransMgr.getAllDatabaseTransactionMgrs();
+        dbMgrs.put(dbId, dbTransactionMgr);
+        try {
+            Assertions.assertTrue(masterTransMgr.existCommittedTxns(dbId, tableId, partitionId),
+                    "existCommittedTxns must report the committed txn whose TableCommitInfo is populated");
+        } finally {
+            dbMgrs.remove(dbId);
+        }
+    }
+
+    @Test
+    public void testExistCommittedTxnsFalseWhenTableCommitInfoNull() {
+        // A committed txn can list the table in its tableIdList before its TableCommitInfo is populated.
+        // With a non-null partitionId, the `tableCommitInfo != null` guard must short-circuit and the method
+        // must fall through to return false rather than NPE (it is called lock-free by the optimize gate).
+        long dbId = 222333445L;
+        long tableId = 777L;
+        long partitionId = 888L;
+
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        Mockito.when(txnState.getTableIdList()).thenReturn(List.of(tableId));
+        Mockito.when(txnState.getTableCommitInfo(tableId)).thenReturn(null);
+        DatabaseTransactionMgr dbTransactionMgr = Mockito.mock(DatabaseTransactionMgr.class);
+        Mockito.when(dbTransactionMgr.getCommittedTxnList()).thenReturn(List.of(txnState));
+
+        Map<Long, DatabaseTransactionMgr> dbMgrs = masterTransMgr.getAllDatabaseTransactionMgrs();
+        dbMgrs.put(dbId, dbTransactionMgr);
+        try {
+            Assertions.assertFalse(masterTransMgr.existCommittedTxns(dbId, tableId, partitionId),
+                    "existCommittedTxns must return false (not NPE) when the committed txn's TableCommitInfo "
+                            + "is not yet populated");
+        } finally {
+            dbMgrs.remove(dbId);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When `ALTER TABLE ... OPTIMIZE` runs online (`OnlineOptimizeJobV2`, `enable_online_optimize_table=true`)
concurrently with data loads, loads could fail or silently lose rows around the partition-replacement window.

Online optimize keeps loads "online" via a per-source-partition **double-write** mapping: while a partition is
being rewritten into a temp partition, concurrent loads write to *both* the source and the temp partition, so the
final atomic replacement loses nothing. Two timing gaps broke that contract:

1. **Source-only load window (silent data loss / publish failure).** The watershed transaction id was generated in
   `runRunningJob` *after* `enableDoubleWritePartition` released the table write lock. A load reads the double-write
   mapping in `OlapTableSink.complete()` under a table READ lock (which conflicts with that write lock). Because the
   watershed was assigned outside the lock, a load could obtain a txn id `>= watershed`, yet have planned its sink
   against the still-empty mapping, and therefore write **only** the source partition. `isPreviousLoadFinished()`
   only drains txns `< watershed`, so the rewrite snapshot excluded it; the subsequent replacement then dropped the
   source partition (and force-deleted its tablets), discarding that load's rows or failing it at publish.

2. **Committed-but-not-visible load.** A load that committed (and double-wrote into the temp partition) but had not
   yet published could have the source partition replaced out from under it, failing its publish.

## What I'm doing:

FE-only change in `OnlineOptimizeJobV2`:

1. **Assign `watershedTxnId` atomically with enabling the double-write mapping**, inside the same table write lock in
   `enableDoubleWritePartition`. Since a load allocates its txn id at `beginTransaction` *before* planning, and reads
   the mapping under a READ lock that conflicts with this WRITE lock, any load that observes an empty mapping
   provably began before the watershed and is therefore drained by `isPreviousLoadFinished()`. Every load with a txn
   id `>= watershed` necessarily observes the populated mapping and double-writes. This closes window (1).

2. **Visibility gate before replacement.** After the rewrite finishes, `runRunningJob` now defers the partition
   replacement while a load is committed-but-not-visible on the source partition (`existCommittedTxns`). It **delays**
   (one scheduler round, retaining the completed rewrite future so the INSERT is not re-run) rather than abandoning —
   preserving the online contract. The deferral is bounded by the alter job timeout, which cancels cleanly (drops temp
   partitions, restores `NORMAL` state) with no data change. This addresses window (2).

3. **Null-guard `GlobalTransactionMgr.existCommittedTxns`** against a concurrently-dropped database (the gate calls it
   lock-free), returning `false` instead of throwing NPE — consistent with sibling accessors.

FE change in `StatisticsCollectionTrigger` (post-commit statistics path):

4. **Skip partitions removed by a concurrent optimize in the first-load statistics trigger.** A load that becomes
   VISIBLE during an online optimize fires a post-commit, best-effort first-load statistics collection that iterates
   the txn's `PartitionCommitInfo` and resolves each committed partition on the live table. A concurrent optimize can
   `replacePartition` + `disableDoubleWritePartition` in between, so `table.getPhysicalPartition(id)` returns null (and
   the parent logical partition may be gone too). `prepareAnalyzeJobForLoad` dereferenced both unguarded and threw NPE,
   which — on the INSERT/DML path there is no surrounding try/catch around the listener — bubbled through
   `StmtExecutor.execute` and reported an **already-committed, VISIBLE load to the client as FAILED**. The lookups are
   now null-guarded and the missing partition is skipped (`continue`), so surviving partitions in the same txn are
   still collected. First-load statistics are best-effort and must never fail a committed load.

Tests: `OnlineOptimizeJobV2Test` asserts the double-write enable/disable + watershed-in-lock timing, the visibility
gate's defer-without-rerunning-rewrite control flow, and the gate's safe-to-proceed case. `StatisticsCollectionTriggerTest`
adds a regression case for the stats trigger: a vanished physical partition, a vanished partition alongside a surviving
one (pinning the skip-only-the-missing-one semantics), and an orphaned physical partition whose parent logical partition
is gone.

Scope note: this closes the source-only silent-loss window, the committed-not-visible publish window, and the
post-commit statistics NPE that surfaced a committed load as failed. A residual narrow window remains for an in-flight
(not-yet-committed) double-writing load that commits in the same instant the replacement runs; fully closing it requires
BE publish-time handling and is tracked separately. Note the statistics trigger's stream/broker-load path runs without a
table lock, so the null-guard handles the logical replace/drop race gracefully but does not by itself make every
unsynchronized partition-map read memory-safe — that pre-existing concern is orthogonal to this fix. End-to-end
zero-error / zero-loss is validated on a shared-nothing cluster under concurrent high-ingest + repeated optimize.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
