### PR TITLE
[Refactor] Decouple TypeConverter from MemPool

### DIFF
--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -39,6 +39,7 @@
 #include "formats/parquet/scalar_column_reader.h"
 #include "runtime/mem_pool.h"
 #include "storage/convert_helper.h"
+#include "storage/type_info_allocator_adapter.h"
 #include "types/type_info.h"
 
 namespace starrocks::parquet {
@@ -135,8 +136,9 @@ StatusOr<ColumnPtr> cast_decimal_projection_column(const ColumnPtr& source_colum
 
     auto result = ColumnHelper::create_column(target_type, true);
     MemPool mem_pool;
+    TypeInfoAllocator type_info_allocator = make_type_info_allocator(&mem_pool);
     RETURN_IF_ERROR(converter->convert_column(source_type_info.get(), *source_column, target_type_info.get(),
-                                              result.get(), &mem_pool));
+                                              result.get(), &type_info_allocator));
     return result;
 }
 

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -25,7 +25,6 @@
 #include "column/nullable_column.h"
 #include "column/schema.h"
 #include "gutil/strings/substitute.h"
-#include "runtime/mem_pool.h"
 #include "storage/chunk_helper.h"
 #include "storage/tablet_schema.h"
 #include "types/bitmap_value.h"
@@ -99,11 +98,11 @@ Status to_decimal(const SrcType* src, DstType* dst, int src_precision, int src_s
 };
 
 Status TypeConverter::convert_column(TypeInfo* src_type, const Column& src, TypeInfo* dst_type, Column* dst,
-                                     MemPool* mem_pool) const {
+                                     const TypeInfoAllocator* allocator) const {
     for (size_t i = 0; i < src.size(); i++) {
         Datum old_datum = src.get(i);
         Datum new_datum;
-        RETURN_IF_ERROR(convert_datum(src_type, old_datum, dst_type, &new_datum, mem_pool));
+        RETURN_IF_ERROR(convert_datum(src_type, old_datum, dst_type, &new_datum, allocator));
         dst->append_datum(new_datum);
     }
     return Status::OK();
@@ -115,12 +114,12 @@ public:
     DatetimeToDateTypeConverter() = default;
     ~DatetimeToDateTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -141,12 +140,12 @@ public:
     TimestampToDateTypeConverter() = default;
     ~TimestampToDateTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -164,12 +163,12 @@ public:
     IntToDateTypeConverter() = default;
     ~IntToDateTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -192,12 +191,12 @@ public:
     DateV2ToDateTypeConverter() = default;
     ~DateV2ToDateTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -213,13 +212,13 @@ public:
     TimestampToDateV2TypeConverter() = default;
     ~TimestampToDateV2TypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         unaligned_store<DateValue>(dst, unaligned_load<TimestampValue>(src));
         return Status::OK();
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -239,7 +238,7 @@ public:
     DatetimeToDateV2TypeConverter() = default;
     ~DatetimeToDateV2TypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         TimestampValue timestamp{0};
         timestamp.from_timestamp_literal(unaligned_load<int64_t>(src));
         unaligned_store<DateValue>(dst, timestamp);
@@ -247,7 +246,7 @@ public:
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -269,12 +268,12 @@ public:
     DateToDateV2TypeConverter() = default;
     ~DateToDateV2TypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -291,12 +290,12 @@ public:
     DateToDatetimeFieldConveter() = default;
     ~DateToDatetimeFieldConveter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -315,12 +314,12 @@ public:
     DateV2ToDatetimeFieldConveter() = default;
     ~DateV2ToDatetimeFieldConveter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -338,12 +337,12 @@ public:
     TimestampToDatetimeTypeConverter() = default;
     ~TimestampToDatetimeTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -358,7 +357,7 @@ public:
     DateToTimestampTypeConverter() = default;
     ~DateToTimestampTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         uint32_t src_value = unaligned_load<uint24_t>(src);
         int day = implicit_cast<int>(src_value & 31u);
         int month = implicit_cast<int>((src_value >> 5u) & 15u);
@@ -368,7 +367,7 @@ public:
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -387,7 +386,7 @@ public:
     DateV2ToTimestampTypeConverter() = default;
     ~DateV2ToTimestampTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         auto src_value = unaligned_load<DateValue>(src);
         int year = 0;
         int month = 0;
@@ -398,7 +397,7 @@ public:
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -418,12 +417,12 @@ public:
     DatetimeToTimestampTypeConverter() = default;
     ~DatetimeToTimestampTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -440,12 +439,12 @@ public:
     FloatToDoubleTypeConverter() = default;
     ~FloatToDoubleTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -463,12 +462,12 @@ public:
     DecimalToDecimal12TypeConverter() = default;
     ~DecimalToDecimal12TypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -484,12 +483,12 @@ public:
     Decimal12ToDecimalTypeConverter() = default;
     ~Decimal12ToDecimalTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -509,7 +508,7 @@ public:
     IntegerToDateV2TypeConverter() = default;
     ~IntegerToDateV2TypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         auto src_value = unaligned_load<CppType>(src);
         DateValue dst_val;
         if (dst_val.from_date_literal_with_check(src_value)) {
@@ -520,7 +519,7 @@ public:
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -545,12 +544,12 @@ public:
     DecimalTypeConverter() = default;
     ~DecimalTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -572,12 +571,12 @@ public:
     DecimalV3TypeConverter() = default;
     ~DecimalV3TypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -600,12 +599,12 @@ public:
     StringToOtherTypeConverter() = default;
     ~StringToOtherTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -629,12 +628,12 @@ public:
     StringToOtherTypeConverter() = default;
     ~StringToOtherTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("not supported");
     }
 
     Status convert_column(TypeInfo* src_type, const Column& src, TypeInfo* dst_type, Column* dst,
-                          MemPool* mem_pool) const override {
+                          const TypeInfoAllocator* allocator) const override {
         for (size_t i = 0; i < src.size(); i++) {
             Datum src_datum = src.get(i);
             if (src_datum.is_null()) {
@@ -650,7 +649,7 @@ public:
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         CHECK(false) << "unreachable";
         return Status::NotSupported("");
     }
@@ -664,12 +663,12 @@ public:
     OtherToStringTypeConverter() = default;
     ~OtherToStringTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         if (src.is_null()) {
             dst->set_null();
             return Status::OK();
@@ -678,11 +677,11 @@ public:
         std::string source = src_typeinfo->to_string(&value);
         Slice slice;
         slice.size = source.size();
-        if (mem_pool == nullptr) {
+        if (allocator == nullptr) {
             LOG(WARNING) << "no guarantee of memory security";
             slice.data = (char*)source.data();
         } else {
-            slice.data = reinterpret_cast<char*>(mem_pool->allocate(slice.size));
+            slice.data = reinterpret_cast<char*>(allocator->allocate(slice.size));
             if (UNLIKELY(slice.data == nullptr)) {
                 return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
             }
@@ -701,12 +700,12 @@ public:
     OtherToStringTypeConverter() = default;
     ~OtherToStringTypeConverter() override = default;
 
-    Status convert(void* dst, const void* src, MemPool* memPool) const override {
+    Status convert(void* dst, const void* src, const TypeInfoAllocator* allocator) const override {
         return Status::InternalError("not supported");
     }
 
     Status convert_column(TypeInfo* src_type, const Column& src, TypeInfo* dst_type, Column* dst,
-                          MemPool* mem_pool) const override {
+                          const TypeInfoAllocator* allocator) const override {
         for (size_t i = 0; i < src.size(); i++) {
             Datum src_datum = src.get(i);
             if (src_datum.is_null()) {
@@ -715,8 +714,9 @@ public:
                 const JsonValue* json = src_datum.get_json();
                 std::string json_str = json->to_string_uncheck();
                 Slice dst_slice = json_str;
-                dst_slice.data = reinterpret_cast<char*>(mem_pool->allocate(dst_slice.size));
-                RETURN_IF_UNLIKELY_NULL(dst_slice.data, Status::MemoryAllocFailed("mempool exceeded"));
+                RETURN_IF_UNLIKELY_NULL(allocator, Status::MemoryAllocFailed("missing type info allocator"));
+                dst_slice.data = reinterpret_cast<char*>(allocator->allocate(dst_slice.size));
+                RETURN_IF_UNLIKELY_NULL(dst_slice.data, Status::MemoryAllocFailed("type info allocator exceeded"));
                 memcpy(dst_slice.data, json_str.data(), dst_slice.size);
                 dst->append_datum(Datum(dst_slice));
             }
@@ -725,7 +725,7 @@ public:
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src_datum, TypeInfo* dst_typeinfo, Datum* dst,
-                         MemPool* mem_pool) const override {
+                         const TypeInfoAllocator* allocator) const override {
         CHECK(false) << "unreachable";
     }
 };

--- a/be/src/storage/convert_helper.h
+++ b/be/src/storage/convert_helper.h
@@ -22,6 +22,7 @@
 #include "storage/olap_common.h"
 #include "types/datum.h"
 #include "types/logical_type.h"
+#include "types/type_info_allocator.h"
 
 namespace starrocks {
 class TabletSchema;
@@ -36,16 +37,16 @@ public:
     TypeConverter() = default;
     virtual ~TypeConverter() = default;
 
-    virtual Status convert(void* dest, const void* src, MemPool* memPool) const = 0;
+    virtual Status convert(void* dest, const void* src, const TypeInfoAllocator* allocator) const = 0;
 
     virtual Status convert_column(TypeInfo* src_type, const Column& src, TypeInfo* dst_type, Column* dst,
-                                  MemPool* mem_pool) const;
+                                  const TypeInfoAllocator* allocator) const;
 
 private:
     friend class SchemaChangeTest;
 
     virtual Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum* dst,
-                                 MemPool* mem_pool) const = 0;
+                                 const TypeInfoAllocator* allocator) const = 0;
 };
 
 const TypeConverter* get_type_converter(LogicalType from_type, LogicalType to_type);

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -23,6 +23,7 @@
 #include "runtime/mem_pool.h"
 #include "runtime/runtime_state.h"
 #include "storage/chunk_helper.h"
+#include "storage/type_info_allocator_adapter.h"
 #include "types/bitmap_value.h"
 #include "types/hll.h"
 #include "types/percentile_value.h"
@@ -239,6 +240,13 @@ StatusOr<Buffer<uint8_t>> ChunkChanger::_execute_where_expr(ChunkPtr& chunk) {
 
 bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const Schema& base_schema,
                                    const Schema& new_schema, MemPool* mem_pool) {
+    TypeInfoAllocator type_info_allocator;
+    const TypeInfoAllocator* allocator = nullptr;
+    if (mem_pool != nullptr) {
+        type_info_allocator = make_type_info_allocator(mem_pool);
+        allocator = &type_info_allocator;
+    }
+
     if (new_chunk->num_columns() != _schema_mapping.size()) {
         LOG(WARNING) << "new chunk does not match with schema mapping rules. "
                      << "chunk_schema_size=" << new_chunk->num_columns()
@@ -337,7 +345,7 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                     return false;
                 }
                 Status st = converter->convert_column(ref_type_info.get(), *base_col, new_type_info.get(),
-                                                      new_col->as_mutable_raw_ptr(), mem_pool);
+                                                      new_col->as_mutable_raw_ptr(), allocator);
                 if (!st.ok()) {
                     LOG(WARNING) << "failed to convert " << logical_type_to_string(ref_type) << " to "
                                  << logical_type_to_string(new_type);

--- a/be/test/storage/convert_helper_test.cpp
+++ b/be/test/storage/convert_helper_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -23,6 +24,7 @@
 #include "column/chunk_factory.h"
 #include "runtime/mem_pool.h"
 #include "storage/chunk_helper.h"
+#include "storage/type_info_allocator_adapter.h"
 #include "storage/types.h"
 #include "types/decimalv3.h"
 #include "types/json_value.h"
@@ -37,6 +39,22 @@ static std::string trim_trailing_zeros(const std::string& s) {
     l = (l > 0 && s[l - 1] == '.') ? l - 1 : l;
     return s.substr(0, l);
 }
+
+class LocalTypeInfoAllocator {
+public:
+    TypeInfoAllocator make_allocator() { return TypeInfoAllocator{this, allocate}; }
+
+private:
+    static uint8_t* allocate(void* ctx, size_t size) {
+        auto* self = static_cast<LocalTypeInfoAllocator*>(ctx);
+        auto buffer = std::make_unique<uint8_t[]>(size);
+        uint8_t* result = buffer.get();
+        self->_buffers.emplace_back(std::move(buffer));
+        return result;
+    }
+
+    std::vector<std::unique_ptr<uint8_t[]>> _buffers;
+};
 
 PARALLEL_TEST(ConvertHelperTest, testVoidPtr) {
     std::vector<std::string> test_cases = {
@@ -548,6 +566,7 @@ PARALLEL_TEST(ConvertHelperTest, testValidSchema) {
 
 PARALLEL_TEST(ConvertHelperTest, testNullableIntConvertString) {
     std::unique_ptr<MemPool> mem_pool(new MemPool());
+    TypeInfoAllocator allocator = make_type_info_allocator(mem_pool.get());
     auto conv = get_type_converter(TYPE_INT, TYPE_VARCHAR);
     auto c0 = ChunkFactory::column_from_field_type(TYPE_INT, true);
     auto c1 = ChunkFactory::column_from_field_type(TYPE_VARCHAR, true);
@@ -556,8 +575,7 @@ PARALLEL_TEST(ConvertHelperTest, testNullableIntConvertString) {
 
     c0->append_datum({1});
     c0->append_nulls(1);
-    auto status =
-            conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), mem_pool.get());
+    auto status = conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), &allocator);
 
     EXPECT_EQ("1", c1->get(0).get_slice());
     ASSERT_TRUE(c1->get(1).is_null());
@@ -565,6 +583,7 @@ PARALLEL_TEST(ConvertHelperTest, testNullableIntConvertString) {
 
 PARALLEL_TEST(ConvertHelperTest, testNullableStringConvertInt) {
     std::unique_ptr<MemPool> mem_pool(new MemPool());
+    TypeInfoAllocator allocator = make_type_info_allocator(mem_pool.get());
     auto conv = get_type_converter(TYPE_VARCHAR, TYPE_INT);
     auto c0 = ChunkFactory::column_from_field_type(TYPE_VARCHAR, true);
     auto c1 = ChunkFactory::column_from_field_type(TYPE_INT, true);
@@ -573,8 +592,7 @@ PARALLEL_TEST(ConvertHelperTest, testNullableStringConvertInt) {
 
     c0->append_datum({"1"});
     c0->append_nulls(1);
-    auto status =
-            conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), mem_pool.get());
+    auto status = conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), &allocator);
 
     EXPECT_EQ(1, c1->get(0).get_int32());
     ASSERT_TRUE(c1->get(1).is_null());
@@ -582,6 +600,7 @@ PARALLEL_TEST(ConvertHelperTest, testNullableStringConvertInt) {
 
 PARALLEL_TEST(ConvertHelperTest, testNullableStringConvertJson) {
     std::unique_ptr<MemPool> mem_pool(new MemPool());
+    TypeInfoAllocator allocator = make_type_info_allocator(mem_pool.get());
     auto conv = get_type_converter(TYPE_VARCHAR, TYPE_JSON);
     auto c0 = ChunkFactory::column_from_field_type(TYPE_VARCHAR, true);
     auto c1 = ChunkFactory::column_from_field_type(TYPE_JSON, true);
@@ -590,10 +609,25 @@ PARALLEL_TEST(ConvertHelperTest, testNullableStringConvertJson) {
 
     c0->append_datum({"{}"});
     c0->append_nulls(1);
-    auto status =
-            conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), mem_pool.get());
+    auto status = conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), &allocator);
 
     EXPECT_EQ("{}", c1->get(0).get_json()->to_string_uncheck());
     ASSERT_TRUE(c1->get(1).is_null());
+}
+
+PARALLEL_TEST(ConvertHelperTest, testConvertColumnUsesTypeInfoAllocator) {
+    LocalTypeInfoAllocator allocator_holder;
+    TypeInfoAllocator allocator = allocator_holder.make_allocator();
+    auto conv = get_type_converter(TYPE_INT, TYPE_VARCHAR);
+    auto c0 = ChunkFactory::column_from_field_type(TYPE_INT, false);
+    auto c1 = ChunkFactory::column_from_field_type(TYPE_VARCHAR, false);
+    auto t0 = get_scalar_type_info(TYPE_INT);
+    auto t1 = get_scalar_type_info(TYPE_VARCHAR);
+
+    c0->append_datum({123});
+    auto status = conv->convert_column(const_cast<TypeInfo*>(t0), *c0, const_cast<TypeInfo*>(t1), c1.get(), &allocator);
+
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ("123", c1->get(0).get_slice().to_string());
 }
 } // namespace starrocks

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -34,6 +34,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/txn_manager.h"
+#include "storage/type_info_allocator_adapter.h"
 #include "testutil/column_test_helper.h"
 #include "testutil/schema_test_helper.h"
 #include "testutil/tablet_test_helper.h"
@@ -76,6 +77,7 @@ protected:
     TabletManager* _tablet_mgr;
     TxnManager* _txn_mgr;
     MemPool _mem_pool;
+    TypeInfoAllocator _type_info_allocator = make_type_info_allocator(&_mem_pool);
     std::vector<SlotDescriptor> _slots;
     MemTracker _mem_tracker;
     OlapReaderStatistics _stats;
@@ -206,7 +208,7 @@ void SchemaChangeTest::test_convert_to_varchar(LogicalType type, int type_size, 
     Datum dst_datum;
 
     auto converter = get_type_converter(type, TYPE_VARCHAR);
-    ASSERT_OK(converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool));
+    ASSERT_OK(converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator));
     EXPECT_EQ(expect_val, dst_datum.get_slice().to_string());
 }
 
@@ -223,7 +225,7 @@ void SchemaChangeTest::test_convert_from_varchar(LogicalType type, int type_size
     Datum dst_datum;
 
     auto converter = get_type_converter(TYPE_VARCHAR, type);
-    ASSERT_OK(converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool));
+    ASSERT_OK(converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator));
     EXPECT_EQ(expect_val, dst_datum.get<T>());
 }
 
@@ -325,7 +327,8 @@ TEST_F(SchemaChangeTest, convert_float_to_double) {
     Datum dst_datum;
 
     auto converter = get_type_converter(TYPE_FLOAT, TYPE_DOUBLE);
-    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
+    Status st =
+            converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator);
 
     ASSERT_TRUE(st.ok());
     EXPECT_EQ(1.2345, dst_datum.get_double());
@@ -349,7 +352,8 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_DATETIME_V1, TYPE_DATE_V1);
 
-    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
+    Status st =
+            converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator);
     ASSERT_TRUE(st.ok());
 
     int dst_value = (time_tm.tm_year + 1900) * 16 * 32 + (time_tm.tm_mon + 1) * 32 + time_tm.tm_mday;
@@ -372,7 +376,8 @@ TEST_F(SchemaChangeTest, convert_date_to_datetime) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_DATE_V1, TYPE_DATETIME_V1);
 
-    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
+    Status st =
+            converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator);
     ASSERT_TRUE(st.ok());
 
     int64_t dst_value = ((time_tm.tm_year + 1900) * 10000L + (time_tm.tm_mon + 1) * 100L + time_tm.tm_mday) * 1000000L;
@@ -394,7 +399,8 @@ TEST_F(SchemaChangeTest, convert_int_to_date_v2) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_INT, TYPE_DATE);
 
-    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
+    Status st =
+            converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator);
     ASSERT_TRUE(st.ok());
 
     EXPECT_EQ("2021-09-28", dst_datum.get_date().to_string());
@@ -415,7 +421,8 @@ TEST_F(SchemaChangeTest, convert_int_to_date) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_INT, TYPE_DATE_V1);
 
-    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
+    Status st =
+            converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_type_info_allocator);
     ASSERT_TRUE(st.ok());
 
     int dst_value = (time_tm.tm_year + 1900) * 16 * 32 + (time_tm.tm_mon + 1) * 32 + time_tm.tm_mday;
@@ -645,7 +652,7 @@ TEST_F(SchemaChangeTest, convert_varchar_to_json) {
 
         auto converter = get_type_converter(TYPE_VARCHAR, TYPE_JSON);
         Status st = converter->convert_column(_varchar_type.get(), *src_column, _json_type.get(), dst_column.get(),
-                                              &_mem_pool);
+                                              &_type_info_allocator);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(*dst_column->get_object(0), expected);
     }
@@ -659,8 +666,8 @@ TEST_F(SchemaChangeTest, convert_json_to_varchar) {
     src_column->append(&json);
 
     auto converter = get_type_converter(TYPE_JSON, TYPE_VARCHAR);
-    Status st =
-            converter->convert_column(_json_type.get(), *src_column, _varchar_type.get(), dst_column.get(), &_mem_pool);
+    Status st = converter->convert_column(_json_type.get(), *src_column, _varchar_type.get(), dst_column.get(),
+                                          &_type_info_allocator);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(dst_column->get_slice(0), json_str);
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
