### PR TITLE
[BugFix] Fix three FE metadata-lock correctness races

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -381,10 +381,23 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
     @Override
     public Void visitDropPersistentIndexClause(DropPersistentIndexClause clause, ConnectContext context) {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        // This clause is dispatched via the unlocked else branch in visitAlterTableStatement, so take the
+        // table WRITE lock here (mirroring the other clause handlers): processLakeTableDropPersistentIndex
+        // walks the table's partition/index/tablet structures and runs a check-then-set on
+        // LakeTablet.rebuildPindexVersion, and that work must be serialized against concurrent alters.
+        // NOTE: this lock does NOT serialize with the lake publish path. That reader (Utils.processTablets)
+        // reads rebuildPindexVersion lock-free after publishPartition has released its own table lock, so
+        // cross-thread visibility relies solely on the field being volatile. A publish already in flight for
+        // the marked version can still miss the rebuild request -- that is a pre-existing version-matching
+        // TOCTOU in the publish/flag protocol, not something an FE-side lock can close.
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
             schemaChangeHandler.processLakeTableDropPersistentIndex(clause, db, (OlapTable) table);
         } catch (StarRocksException e) {
             throw new AlterJobException(e.getMessage(), e);
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1920,7 +1920,11 @@ public class RestoreJob extends AbstractJob {
             finishedTime = System.currentTimeMillis();
             persistStateChange(RestoreJobState.FINISHED);
 
-            locker.lockDatabase(db.getId(), LockType.READ);
+            // WRITE (not READ): the post-restore actions below structurally mutate metadata in this db --
+            // doAfterRestore rewrites MV baseTableInfos/version maps and the failure branch calls
+            // mv.dropPartition (mutating the plain idToPartition/nameToPartition maps). A shared READ lets
+            // concurrent planners observe a torn map, so the whole walk must hold the exclusive db lock.
+            locker.lockDatabase(db.getId(), LockType.WRITE);
             try {
                 for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
                     Table tbl = globalStateMgr.getLocalMetastore()
@@ -1989,7 +1993,7 @@ public class RestoreJob extends AbstractJob {
                 LOG.warn("Do post actions after restore success failed: ", e);
                 throw e;
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
+                locker.unLockDatabase(db.getId(), LockType.WRITE);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -62,7 +62,9 @@ public class LakeTablet extends Tablet {
 
     private volatile long minVersion = 0L;
 
-    public long rebuildPindexVersion = 0L;
+    // Written by the ALTER ... DROP PERSISTENT INDEX path and read lock-free by the lake publish
+    // thread (Utils.processTablets); must be volatile so the publish thread observes the update.
+    private volatile long rebuildPindexVersion = 0L;
 
     public LakeTablet() {
         super();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4669,7 +4669,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         if (shadowTable == null) {
             throw new DdlException("the DB " + dbName + " table: " + tableName + " doesn't exist");
         }
-        try (AutoCloseableLock ignore = new AutoCloseableLock(db.getId(), shadowTable.getId(), LockType.READ)) {
+        // WRITE (not READ): the edit-log callback mutates TableProperty.hasForbiddenGlobalDict, a plain
+        // non-volatile boolean that optimizer rules read under a table READ lock. The replay path
+        // (replayModifyTableProperty) already takes WRITE here, so match it to serialize the mutation.
+        try (AutoCloseableLock ignore = new AutoCloseableLock(db.getId(), shadowTable.getId(), LockType.WRITE)) {
             Table table = getTable(db.getFullName(), tableName);
             if (table == null) {
                 throw new DdlException("the DB " + dbName + " table: " + tableName + " doesn't exist");


### PR DESCRIPTION
DROP PERSISTENT INDEX: the clause is dispatched via the unlocked else branch in AlterJobExecutor, so processLakeTableDropPersistentIndex walked the partition/index/tablet structures and set LakeTablet.rebuildPindexVersion with no lock, while the lake publish thread reads that field lock-free. Make rebuildPindexVersion volatile and take a table WRITE lock around the handler.

RestoreJob post-restore: the post-restore walk held only DB READ while doAfterRestore rewrites MV baseTableInfos/version maps and the failure branch calls mv.dropPartition (mutating the plain idToPartition/nameToPartition maps); related MVs may live in other databases. Take DB WRITE for the walk and lock each related MV's own db/table inside OlapTable.doAfterRestore.

setHasForbiddenGlobalDict: the edit-log callback wrote the plain boolean TableProperty.hasForbiddenGlobalDict under a table READ lock while optimizer rules read it; the replay path already uses WRITE. Switch the online path to WRITE.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
