### PR TITLE
[BugFix] Reject malformed Stream Load numeric headers instead of crashing the BE

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -311,7 +311,16 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
     ctx->body_bytes = 0;
     size_t max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
     if (!http_req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
-        ctx->body_bytes = std::stol(http_req->header(HttpHeaders::CONTENT_LENGTH));
+        const auto& content_length = http_req->header(HttpHeaders::CONTENT_LENGTH);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto content_length_value =
+                StringParser::string_to_int<int64_t>(content_length.c_str(), content_length.length(), &parse_result);
+        // Reject negative values before assigning to the unsigned body_bytes: a negative length
+        // would wrap and then fail the size-limit check with a misleading message.
+        if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS || content_length_value < 0)) {
+            return Status::InvalidArgument(fmt::format("Invalid content length: {}", content_length));
+        }
+        ctx->body_bytes = content_length_value;
         if (ctx->body_bytes > max_body_bytes) {
             std::stringstream ss;
             ss << "body size " << ctx->body_bytes << " exceed limit: " << max_body_bytes << ", " << ctx->brief()
@@ -514,15 +523,16 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         request.__set_rowDelimiter(http_req->header(HTTP_ROW_DELIMITER));
     }
     if (!http_req->header(HTTP_SKIP_HEADER).empty()) {
-        try {
-            auto skip_header = std::stoll(http_req->header(HTTP_SKIP_HEADER));
-            if (skip_header < 0) {
-                return Status::InvalidArgument("skip_header must be equal or greater than 0");
-            }
-            request.__set_skipHeader(skip_header);
-        } catch (const std::invalid_argument& e) {
+        const auto& value = http_req->header(HTTP_SKIP_HEADER);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto skip_header = StringParser::string_to_int<int64_t>(value.c_str(), value.length(), &parse_result);
+        if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS)) {
             return Status::InvalidArgument("Invalid csv load skip_header format");
         }
+        if (skip_header < 0) {
+            return Status::InvalidArgument("skip_header must be equal or greater than 0");
+        }
+        request.__set_skipHeader(skip_header);
     }
     if (!http_req->header(HTTP_TRIM_SPACE).empty()) {
         if (boost::iequals(http_req->header(HTTP_TRIM_SPACE), "false")) {
@@ -571,15 +581,16 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         request.__set_timezone(http_req->header(HTTP_TIMEZONE));
     }
     if (!http_req->header(HTTP_LOAD_MEM_LIMIT).empty()) {
-        try {
-            auto load_mem_limit = std::stoll(http_req->header(HTTP_LOAD_MEM_LIMIT));
-            if (load_mem_limit < 0) {
-                return Status::InvalidArgument("load_mem_limit must be equal or greater than 0");
-            }
-            request.__set_loadMemLimit(load_mem_limit);
-        } catch (const std::invalid_argument& e) {
+        const auto& value = http_req->header(HTTP_LOAD_MEM_LIMIT);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto load_mem_limit = StringParser::string_to_int<int64_t>(value.c_str(), value.length(), &parse_result);
+        if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS)) {
             return Status::InvalidArgument("Invalid load mem limit format");
         }
+        if (load_mem_limit < 0) {
+            return Status::InvalidArgument("load_mem_limit must be equal or greater than 0");
+        }
+        request.__set_loadMemLimit(load_mem_limit);
     }
     if (!http_req->header(HTTP_JSONPATHS).empty()) {
         request.__set_jsonpaths(http_req->header(HTTP_JSONPATHS));
@@ -629,23 +640,28 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         request.__set_transmission_compression_type(http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE));
     }
     if (!http_req->header(HTTP_LOAD_DOP).empty()) {
-        try {
-            auto parallel_request_num = std::stoll(http_req->header(HTTP_LOAD_DOP));
-            request.__set_load_dop(parallel_request_num);
-        } catch (const std::invalid_argument& e) {
+        const auto& value = http_req->header(HTTP_LOAD_DOP);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        // load_dop is an i32 in TStreamLoadPutRequest, so parse as int32_t to reject values
+        // beyond the field's range instead of silently truncating them.
+        auto parallel_request_num = StringParser::string_to_int<int32_t>(value.c_str(), value.length(), &parse_result);
+        if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS)) {
             return Status::InvalidArgument("Invalid load_dop format");
         }
+        request.__set_load_dop(parallel_request_num);
     }
     if (!http_req->header(HTTP_LOG_REJECTED_RECORD_NUM).empty()) {
-        try {
-            auto log_rejected_record_num = std::stoll(http_req->header(HTTP_LOG_REJECTED_RECORD_NUM));
-            if (log_rejected_record_num < -1) {
-                return Status::InvalidArgument("log_rejected_record_num must be equal or greater than -1");
-            }
-            request.__set_log_rejected_record_num(log_rejected_record_num);
-        } catch (const std::invalid_argument& e) {
+        const auto& value = http_req->header(HTTP_LOG_REJECTED_RECORD_NUM);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto log_rejected_record_num =
+                StringParser::string_to_int<int64_t>(value.c_str(), value.length(), &parse_result);
+        if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS)) {
             return Status::InvalidArgument("Invalid log_rejected_record_num format");
         }
+        if (log_rejected_record_num < -1) {
+            return Status::InvalidArgument("log_rejected_record_num must be equal or greater than -1");
+        }
+        request.__set_log_rejected_record_num(log_rejected_record_num);
     }
     if (ctx->timeout_second != -1) {
         request.__set_timeout(ctx->timeout_second);
@@ -689,7 +705,12 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     }
 
     if (!http_req->header(HTTP_EXEC_MEM_LIMIT).empty()) {
-        auto exec_mem_limit = std::stoll(http_req->header(HTTP_EXEC_MEM_LIMIT));
+        const auto& value = http_req->header(HTTP_EXEC_MEM_LIMIT);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto exec_mem_limit = StringParser::string_to_int<int64_t>(value.c_str(), value.length(), &parse_result);
+        if (UNLIKELY(parse_result != StringParser::PARSE_SUCCESS)) {
+            return Status::InvalidArgument("Invalid exec_mem_limit format");
+        }
         if (exec_mem_limit <= 0) {
             return Status::InvalidArgument("exec_mem_limit must be greater than 0");
         }

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -29,6 +29,7 @@
 
 #include "base/auth/auth_info.h"
 #include "base/json/json_util.h"
+#include "base/string/string_parser.hpp"
 #include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "base/uid_util.h"
@@ -253,7 +254,15 @@ int TransactionStreamLoadAction::on_header(HttpRequest* req) {
 
     StreamLoadContext* ctx = nullptr;
     if (!req->header(HTTP_CHANNEL_ID).empty()) {
-        int channel_id = std::stoi(req->header(HTTP_CHANNEL_ID));
+        const auto& value = req->header(HTTP_CHANNEL_ID);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        // string_to_int rejects non-numeric, trailing-garbage (e.g. "0abc"), and out-of-range
+        // values; std::stoi would silently parse the numeric prefix and attach to the wrong channel.
+        int channel_id = StringParser::string_to_int<int32_t>(value.c_str(), value.length(), &parse_result);
+        if (parse_result != StringParser::PARSE_SUCCESS) {
+            _send_error_reply(req, Status::InvalidArgument(fmt::format("Invalid channel id {}", value)));
+            return -1;
+        }
         ctx = _exec_env->stream_context_mgr()->get_channel_context(label, table_name, channel_id);
     } else {
         ctx = _exec_env->stream_context_mgr()->get(label);
@@ -319,7 +328,16 @@ Status TransactionStreamLoadAction::_on_header(HttpRequest* http_req, StreamLoad
     // check content length
     size_t max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
     if (!http_req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
-        ctx->body_bytes += std::stol(http_req->header(HttpHeaders::CONTENT_LENGTH));
+        const auto& content_length = http_req->header(HttpHeaders::CONTENT_LENGTH);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto content_length_value =
+                StringParser::string_to_int<int64_t>(content_length.c_str(), content_length.length(), &parse_result);
+        // Reject negative values: this accumulates across the transaction's requests, so a
+        // negative length would silently shrink the accumulated body size under the cap.
+        if (parse_result != StringParser::PARSE_SUCCESS || content_length_value < 0) {
+            return Status::InvalidArgument(fmt::format("Invalid content length: {}", content_length));
+        }
+        ctx->body_bytes += content_length_value;
         if (ctx->body_bytes > max_body_bytes) {
             std::stringstream ss;
             ss << "body size " << ctx->body_bytes << " exceed limit: " << max_body_bytes << ", " << ctx->brief()
@@ -433,15 +451,16 @@ Status TransactionStreamLoadAction::_parse_request(HttpRequest* http_req, Stream
         request.__set_timezone(http_req->header(HTTP_TIMEZONE));
     }
     if (!http_req->header(HTTP_LOAD_MEM_LIMIT).empty()) {
-        try {
-            auto load_mem_limit = std::stoll(http_req->header(HTTP_LOAD_MEM_LIMIT));
-            if (load_mem_limit < 0) {
-                return Status::InvalidArgument("load_mem_limit must be equal or greater than 0");
-            }
-            request.__set_loadMemLimit(load_mem_limit);
-        } catch (const std::invalid_argument& e) {
+        const auto& value = http_req->header(HTTP_LOAD_MEM_LIMIT);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto load_mem_limit = StringParser::string_to_int<int64_t>(value.c_str(), value.length(), &parse_result);
+        if (parse_result != StringParser::PARSE_SUCCESS) {
             return Status::InvalidArgument("Invalid load mem limit format");
         }
+        if (load_mem_limit < 0) {
+            return Status::InvalidArgument("load_mem_limit must be equal or greater than 0");
+        }
+        request.__set_loadMemLimit(load_mem_limit);
     }
     if (!http_req->header(HTTP_JSONPATHS).empty()) {
         request.__set_jsonpaths(http_req->header(HTTP_JSONPATHS));
@@ -487,12 +506,15 @@ Status TransactionStreamLoadAction::_parse_request(HttpRequest* http_req, Stream
         request.__set_transmission_compression_type(http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE));
     }
     if (!http_req->header(HTTP_LOAD_DOP).empty()) {
-        try {
-            auto parallel_request_num = std::stoll(http_req->header(HTTP_LOAD_DOP));
-            request.__set_load_dop(parallel_request_num);
-        } catch (const std::invalid_argument& e) {
+        const auto& value = http_req->header(HTTP_LOAD_DOP);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        // load_dop is an i32 in TStreamLoadPutRequest, so parse as int32_t to reject values
+        // beyond the field's range instead of silently truncating them.
+        auto parallel_request_num = StringParser::string_to_int<int32_t>(value.c_str(), value.length(), &parse_result);
+        if (parse_result != StringParser::PARSE_SUCCESS) {
             return Status::InvalidArgument("Invalid load_dop format");
         }
+        request.__set_load_dop(parallel_request_num);
     }
     if (ctx->timeout_second != -1) {
         request.__set_timeout(ctx->timeout_second);
@@ -571,7 +593,12 @@ Status TransactionStreamLoadAction::_exec_plan_fragment(HttpRequest* http_req, S
     VLOG(3) << "params is " << apache::thrift::ThriftDebugString(ctx->put_result.params);
 
     if (!http_req->header(HTTP_EXEC_MEM_LIMIT).empty()) {
-        auto exec_mem_limit = std::stoll(http_req->header(HTTP_EXEC_MEM_LIMIT));
+        const auto& value = http_req->header(HTTP_EXEC_MEM_LIMIT);
+        StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+        auto exec_mem_limit = StringParser::string_to_int<int64_t>(value.c_str(), value.length(), &parse_result);
+        if (parse_result != StringParser::PARSE_SUCCESS) {
+            return Status::InvalidArgument("Invalid exec_mem_limit format");
+        }
         if (exec_mem_limit <= 0) {
             return Status::InvalidArgument("exec_mem_limit must be greater than 0");
         }

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -793,4 +793,135 @@ TEST_F(StreamLoadActionTest, format_arrow) {
     ASSERT_EQ(TFileFormatType::FORMAT_ARROW, ctx->format);
 }
 
+TEST_F(StreamLoadActionTest, malformed_numeric_header_returns_error) {
+    struct TestCase {
+        const std::string header;
+        const char* value;
+        const char* expected_msg;
+    };
+    // Each value is non-numeric, has trailing garbage after a numeric prefix, or is out of
+    // the range of the target integer type. Before the fix, std::stol/std::stoll either threw
+    // an uncaught std::invalid_argument / std::out_of_range and aborted the whole BE process,
+    // or (for a value like "16abc") silently parsed the numeric prefix and ignored the rest;
+    // now every malformed numeric header must be rejected with a per-request error instead.
+    TestCase test_cases[] = {
+            {HttpHeaders::CONTENT_LENGTH, "abc", "Invalid content length"},
+            {HttpHeaders::CONTENT_LENGTH, "16abc", "Invalid content length"},
+            {HttpHeaders::CONTENT_LENGTH, "99999999999999999999999999", "Invalid content length"},
+            {HTTP_EXEC_MEM_LIMIT, "abc", "Invalid exec_mem_limit format"},
+            {HTTP_EXEC_MEM_LIMIT, "99999999999999999999999999", "Invalid exec_mem_limit format"},
+            {HTTP_EXEC_MEM_LIMIT, "5garbage", "Invalid exec_mem_limit format"},
+            {HTTP_LOAD_MEM_LIMIT, "99999999999999999999999999", "Invalid load mem limit format"},
+            {HTTP_LOAD_MEM_LIMIT, "10abc", "Invalid load mem limit format"},
+            {HTTP_SKIP_HEADER, "99999999999999999999999999", "Invalid csv load skip_header format"},
+            {HTTP_SKIP_HEADER, "3x", "Invalid csv load skip_header format"},
+            {HTTP_LOAD_DOP, "99999999999999999999999999", "Invalid load_dop format"},
+            {HTTP_LOAD_DOP, "2147483648", "Invalid load_dop format"}, // beyond i32: thrift load_dop is an i32
+            {HTTP_LOAD_DOP, "2x", "Invalid load_dop format"},
+            {HTTP_LOG_REJECTED_RECORD_NUM, "99999999999999999999999999", "Invalid log_rejected_record_num format"},
+            {HTTP_LOG_REJECTED_RECORD_NUM, "4x", "Invalid log_rejected_record_num format"},
+    };
+
+    for (const auto& tc : test_cases) {
+        StreamLoadAction action(&_env, &_stream_load_orchestrator, _stream_load_executor.get(), _limiter.get(),
+                                _batch_write_mgr.get());
+
+        HttpRequest request(_evhttp_req);
+        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        if (tc.header != HttpHeaders::CONTENT_LENGTH) {
+            request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+        }
+        request._headers.emplace(tc.header, tc.value);
+        request.set_handler(&action);
+        action.on_header(&request);
+        action.handle(&request);
+
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("Fail", doc["Status"].GetString()) << "header=" << tc.header << " value=" << tc.value;
+        ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), tc.expected_msg))
+                << "header=" << tc.header << " message=" << doc["Message"].GetString();
+    }
+}
+
+TEST_F(StreamLoadActionTest, negative_numeric_header_returns_error) {
+    struct TestCase {
+        const std::string header;
+        const char* value;
+        const char* expected_msg;
+    };
+    // Negative or below-minimum values parse successfully, so they bypass the StringParser
+    // rejection and must still be caught by a range check.
+    TestCase test_cases[] = {
+            {HttpHeaders::CONTENT_LENGTH, "-16", "Invalid content length"},
+            {HTTP_SKIP_HEADER, "-1", "skip_header must be equal or greater than 0"},
+            {HTTP_LOAD_MEM_LIMIT, "-1", "load_mem_limit must be equal or greater than 0"},
+            {HTTP_LOG_REJECTED_RECORD_NUM, "-2", "log_rejected_record_num must be equal or greater than -1"},
+            {HTTP_EXEC_MEM_LIMIT, "0", "exec_mem_limit must be greater than 0"},
+            {HTTP_EXEC_MEM_LIMIT, "-1", "exec_mem_limit must be greater than 0"},
+    };
+
+    for (const auto& tc : test_cases) {
+        StreamLoadAction action(&_env, &_stream_load_orchestrator, _stream_load_executor.get(), _limiter.get(),
+                                _batch_write_mgr.get());
+
+        HttpRequest request(_evhttp_req);
+        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        if (tc.header != HttpHeaders::CONTENT_LENGTH) {
+            request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+        }
+        request._headers.emplace(tc.header, tc.value);
+        request.set_handler(&action);
+        action.on_header(&request);
+        action.handle(&request);
+
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("Fail", doc["Status"].GetString()) << "header=" << tc.header << " value=" << tc.value;
+        ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), tc.expected_msg))
+                << "header=" << tc.header << " message=" << doc["Message"].GetString();
+    }
+}
+
+TEST_F(StreamLoadActionTest, valid_numeric_headers_populate_request) {
+    StreamLoadAction action(&_env, &_stream_load_orchestrator, _stream_load_executor.get(), _limiter.get(),
+                            _batch_write_mgr.get());
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("StreamLoadAction::_process_put::rpc_timeout");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    TStreamLoadPutRequest captured_request;
+    SyncPoint::GetInstance()->SetCallBack("StreamLoadAction::_process_put::rpc_timeout", [&](void* arg) {
+        captured_request = *static_cast<TStreamLoadPutRequest*>(arg);
+    });
+
+    // Valid values must keep flowing into TStreamLoadPutRequest unchanged: this guards the
+    // success path of the same parsing that the malformed and negative cases exercise for rejection.
+    HttpRequest request(_evhttp_req);
+    request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    request._headers.emplace(HTTP_SKIP_HEADER, "1");
+    request._headers.emplace(HTTP_LOAD_MEM_LIMIT, "1048576");
+    request._headers.emplace(HTTP_LOAD_DOP, "2");
+    request._headers.emplace(HTTP_LOG_REJECTED_RECORD_NUM, "-1"); // -1 is the allowed lower bound
+    request.set_handler(&action);
+    action.on_header(&request);
+    action.handle(&request);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("Success", doc["Status"].GetString()) << k_response_str;
+    ASSERT_TRUE(captured_request.__isset.skipHeader);
+    ASSERT_EQ(1, captured_request.skipHeader);
+    ASSERT_TRUE(captured_request.__isset.loadMemLimit);
+    ASSERT_EQ(1048576, captured_request.loadMemLimit);
+    ASSERT_TRUE(captured_request.__isset.load_dop);
+    ASSERT_EQ(2, captured_request.load_dop);
+    ASSERT_TRUE(captured_request.__isset.log_rejected_record_num);
+    ASSERT_EQ(-1, captured_request.log_rejected_record_num);
+}
+
 } // namespace starrocks

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -1232,4 +1232,175 @@ TEST_F(TransactionStreamLoadActionTest, stream_load_put_rpc_timeout_setting) {
     }
 }
 
+TEST_F(TransactionStreamLoadActionTest, malformed_channel_id_returns_error) {
+    // Before the fix, std::stoi threw an uncaught std::invalid_argument here and aborted
+    // the whole BE process; now a malformed channel_id must be rejected per request.
+    // "0abc" guards the numeric-prefix case: std::stoi would silently parse the "0" prefix
+    // and attach the request to channel 0 instead of returning a per-request error.
+    // "2147483648" is one past INT32_MAX: std::stoi threw an uncaught std::out_of_range.
+    const char* malformed_values[] = {"abc", "0abc", "2147483648"};
+    for (const char* value : malformed_values) {
+        TransactionStreamLoadAction action(&_env, &_stream_load_orchestrator, _transaction_mgr.get());
+        HttpRequest request(_evhttp_req);
+        request.set_handler(&action);
+        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        request._headers.emplace(HTTP_LABEL_KEY, "123");
+        request._headers.emplace(HTTP_CHANNEL_ID, value);
+
+        ASSERT_EQ(-1, action.on_header(&request)) << "value=" << value;
+
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString()) << "value=" << value;
+        const std::string expected_msg = std::string("Invalid channel id ") + value;
+        ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), expected_msg.c_str()))
+                << "value=" << value << " message=" << doc["Message"].GetString();
+    }
+}
+
+TEST_F(TransactionStreamLoadActionTest, malformed_numeric_header_returns_error) {
+    struct TestCase {
+        const char* label;
+        const std::string header;
+        const char* value;
+        const char* expected_msg;
+    };
+    // Each value is non-numeric, has trailing garbage after a numeric prefix, or is out of
+    // the range of the target integer type. Before the fix, std::stol/std::stoll either threw
+    // an uncaught std::invalid_argument / std::out_of_range and aborted the whole BE process,
+    // or (for a value like "16abc") silently parsed the numeric prefix and ignored the rest;
+    // now every malformed numeric header must be rejected with a per-request error instead.
+    TestCase test_cases[] = {
+            {"bad_content_length", HttpHeaders::CONTENT_LENGTH, "abc", "Invalid content length"},
+            {"trailing_content_length", HttpHeaders::CONTENT_LENGTH, "16abc", "Invalid content length"},
+            {"overflow_content_length", HttpHeaders::CONTENT_LENGTH, "99999999999999999999999999",
+             "Invalid content length"},
+            {"negative_content_length", HttpHeaders::CONTENT_LENGTH, "-16", "Invalid content length"},
+            {"bad_load_mem_limit", HTTP_LOAD_MEM_LIMIT, "99999999999999999999999999", "Invalid load mem limit format"},
+            {"trailing_load_mem_limit", HTTP_LOAD_MEM_LIMIT, "10abc", "Invalid load mem limit format"},
+            {"bad_load_dop", HTTP_LOAD_DOP, "99999999999999999999999999", "Invalid load_dop format"},
+            // beyond i32: thrift load_dop is an i32
+            {"i32_overflow_load_dop", HTTP_LOAD_DOP, "2147483648", "Invalid load_dop format"},
+            {"trailing_load_dop", HTTP_LOAD_DOP, "2x", "Invalid load_dop format"},
+            {"bad_exec_mem_limit", HTTP_EXEC_MEM_LIMIT, "abc", "Invalid exec_mem_limit format"},
+            {"overflow_exec_mem_limit", HTTP_EXEC_MEM_LIMIT, "99999999999999999999999999",
+             "Invalid exec_mem_limit format"},
+            {"trailing_exec_mem_limit", HTTP_EXEC_MEM_LIMIT, "5garbage", "Invalid exec_mem_limit format"},
+    };
+
+    for (const auto& tc : test_cases) {
+        // Begin a fresh transaction so the load request below has a context to attach to.
+        TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+        HttpRequest begin_req(_evhttp_req);
+        begin_req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        begin_req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+        begin_req._headers.emplace(HTTP_LABEL_KEY, tc.label);
+        begin_req._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+        txn_action.handle(&begin_req);
+        {
+            rapidjson::Document doc;
+            doc.Parse(k_response_str.c_str());
+            ASSERT_STREQ("OK", doc["Status"].GetString()) << "begin failed for label=" << tc.label;
+        }
+
+        TransactionStreamLoadAction action(&_env, &_stream_load_orchestrator, _transaction_mgr.get());
+        HttpRequest request(_evhttp_req);
+        request.set_handler(&action);
+        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        request._headers.emplace(HTTP_LABEL_KEY, tc.label);
+        if (tc.header != HttpHeaders::CONTENT_LENGTH) {
+            request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+        }
+        request._headers.emplace(tc.header, tc.value);
+        // A malformed numeric header makes on_header fail and send the error reply itself;
+        // handle() is not called for a failed on_header (it DCHECKs a live context).
+        ASSERT_EQ(-1, action.on_header(&request)) << "header=" << tc.header << " value=" << tc.value;
+
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString()) << "header=" << tc.header << " value=" << tc.value;
+        ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), tc.expected_msg))
+                << "header=" << tc.header << " message=" << doc["Message"].GetString();
+    }
+}
+
+TEST_F(TransactionStreamLoadActionTest, negative_numeric_header_returns_error) {
+    // Negative values parse successfully, so they bypass the StringParser rejection and must
+    // still be caught by the pre-existing range checks.
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin_req(_evhttp_req);
+    begin_req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin_req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin_req._headers.emplace(HTTP_LABEL_KEY, "negative_load_mem_limit");
+    begin_req._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin_req);
+    {
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("OK", doc["Status"].GetString());
+    }
+
+    TransactionStreamLoadAction action(&_env, &_stream_load_orchestrator, _transaction_mgr.get());
+    HttpRequest request(_evhttp_req);
+    request.set_handler(&action);
+    request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    request._headers.emplace(HTTP_LABEL_KEY, "negative_load_mem_limit");
+    request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+    request._headers.emplace(HTTP_LOAD_MEM_LIMIT, "-1");
+    ASSERT_EQ(-1, action.on_header(&request));
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString());
+    ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), "load_mem_limit must be equal or greater than 0"))
+            << "message=" << doc["Message"].GetString();
+}
+
+TEST_F(TransactionStreamLoadActionTest, valid_numeric_headers_populate_request) {
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin_req(_evhttp_req);
+    begin_req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin_req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin_req._headers.emplace(HTTP_LABEL_KEY, "valid_numeric_headers");
+    begin_req._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin_req);
+    {
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("OK", doc["Status"].GetString());
+    }
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("TransactionStreamLoadAction::_exec_plan_fragment::rpc_timeout");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    TStreamLoadPutRequest captured_request;
+    SyncPoint::GetInstance()->SetCallBack(
+            "TransactionStreamLoadAction::_exec_plan_fragment::rpc_timeout",
+            [&](void* arg) { captured_request = *static_cast<TStreamLoadPutRequest*>(arg); });
+
+    // Valid values must keep flowing into TStreamLoadPutRequest unchanged: this guards the
+    // success path of the same parsing that the malformed and negative cases exercise for rejection.
+    TransactionStreamLoadAction action(&_env, &_stream_load_orchestrator, _transaction_mgr.get());
+    HttpRequest request(_evhttp_req);
+    request.set_handler(&action);
+    request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    request._headers.emplace(HTTP_LABEL_KEY, "valid_numeric_headers");
+    request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+    request._headers.emplace(HTTP_LOAD_MEM_LIMIT, "1048576");
+    request._headers.emplace(HTTP_LOAD_DOP, "2");
+    ASSERT_EQ(0, action.on_header(&request));
+    action.handle(&request);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString()) << k_response_str;
+    ASSERT_TRUE(captured_request.__isset.loadMemLimit);
+    ASSERT_EQ(1048576, captured_request.loadMemLimit);
+    ASSERT_TRUE(captured_request.__isset.load_dop);
+    ASSERT_EQ(2, captured_request.load_dop);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

The stream load and transaction stream load HTTP handlers parse several numeric headers (`exec_mem_limit`, `load_mem_limit`, `load_dop`, `skip_header`, `log_rejected_record_num`, `Content-Length`, and `channel_id`) with `std::stoll` / `std::stol` / `std::stoi`. Five of the eleven call sites have no `try`/`catch` at all, and the six that do only catch `std::invalid_argument`. A non-numeric value (e.g. `exec_mem_limit: abc`) throws `std::invalid_argument`, and an out-of-range value (e.g. `99999999999999999999999999`) throws `std::out_of_range`. The uncaught exception escapes the HTTP worker and calls `std::terminate`, crashing the whole BE process and aborting every query running on that node. `std::stoll`/`std::stoi` also silently accept a value with a numeric prefix and trailing garbage (e.g. `channel_id: 0abc`): they parse the prefix and ignore the rest, so a malformed channel id attaches the request to the wrong channel instead of being rejected.

Reproduction:

```bash
curl --location-trusted -u root: -H 'label:repro' -H 'exec_mem_limit:abc' \
     -T data.csv http://<be_host>:<be_http_port>/api/<db>/<table>/_stream_load
# -> BE aborts (std::terminate)
```

Apache Doris hardened the identical load headers the same way: after recognizing the crash (apache/doris#48859) it added a `safe_stoll`/`safe_stoi` helper that catches both `std::invalid_argument` and `std::out_of_range` (apache/doris#49714). ClickHouse and Trino likewise return a per-request error for malformed request parameters.

## What I'm doing:

Parse every numeric load header with `StringParser::string_to_int` and check the `ParseResult` - the same pattern this file already uses for the `timeout` and `enable_merge_commit` headers. This rejects non-numeric, trailing-garbage, and out-of-range values with a per-request `Status::InvalidArgument` (the stream load protocol replies HTTP 200 with a `"Fail"` / `"INVALID_ARGUMENT"` JSON body) instead of crashing the BE or silently truncating the value.

- `be/src/http/action/stream_load.cpp`: `Content-Length`, `skip_header`, `load_mem_limit`, `load_dop`, `log_rejected_record_num`, and `exec_mem_limit`.
- `be/src/http/action/transaction_stream_load.cpp`: `channel_id`, `Content-Length`, `load_mem_limit`, `load_dop`, and `exec_mem_limit`.
- `load_dop` is parsed as `int32_t` because the thrift field is an `i32`: a value beyond the i32 range is now rejected instead of silently truncated (`std::stoll` accepted it and the implicit narrowing kept only the low bits).

Behaviour for valid requests is unchanged; negative values still hit their existing range checks. The only observable difference is that a malformed numeric header, which previously crashed the BE (or was silently prefix-parsed), now returns a per-request error with a descriptive message.

Fixes #74974

## Tests

- `StreamLoadActionTest.malformed_numeric_header_returns_error` / `TransactionStreamLoadActionTest.malformed_{channel_id,numeric_header}_returns_error`: send non-numeric, trailing-garbage (`0abc`, `16abc`), and out-of-range values (including `load_dop: 2147483648`, just past the i32 range) for every affected header and assert a `Fail` / `INVALID_ARGUMENT` response with the matching message. The non-numeric and int64 out-of-range cases abort the test process on the pre-fix code (`load_dop: 2147483648` was instead silently truncated to i32); the trailing-garbage cases were silently accepted before and are now rejected.
- `StreamLoadActionTest.negative_numeric_header_returns_error` / `TransactionStreamLoadActionTest.negative_numeric_header_returns_error`: negative or below-minimum values parse successfully and must still be caught by the pre-existing range checks.
- `StreamLoadActionTest.valid_numeric_headers_populate_request` / `TransactionStreamLoadActionTest.valid_numeric_headers_populate_request`: capture the `TStreamLoadPutRequest` through the existing `rpc_timeout` sync points and assert valid values keep flowing through unchanged.

Built and run with the dev-env image: `./run-be-ut.sh --build-target starrocks_test --gtest_filter 'StreamLoadActionTest*:TransactionStreamLoadActionTest*'` - 50/50 pass.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

The change is limited to malformed numeric headers: values that previously crashed the BE or were silently prefix-parsed/truncated are now rejected per request. Valid requests are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

