### PR TITLE
[BugFix] Respect ALLOW_THROW_EXCEPTION in parse_json

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -291,6 +291,9 @@ StatusOr<ColumnPtr> JsonFunctions::parse_json(FunctionContext* context, const Co
 
         auto json = JsonValue::parse(slice);
         if (!json.ok()) {
+            if (context != nullptr && context->allow_throw_exception()) {
+                return json.status();
+            }
             result.append_null();
         } else {
             result.append(std::move(json.value()));

--- a/test/sql/test_json/R/test_parse_json_throw_exception
+++ b/test/sql/test_json/R/test_parse_json_throw_exception
@@ -10,18 +10,18 @@ insert into t_pj values (1, '{"a": 1}'), (2, '{'), (3, '[1,2,3]'), (4, '{"a":}')
 -- !result
 select id, get_json_string(s, '$.a') from t_pj order by id;
 -- result:
-[REGEX].*Expecting item.*
+[REGEX].*Expecting.*
 -- !result
 select id, parse_json(s) from t_pj order by id;
 -- result:
-[REGEX].*Expecting item.*
+[REGEX].*Expecting.*
 -- !result
 create table t_dst (id int, j json) properties('replication_num' = '1');
 -- result:
 -- !result
 insert into t_dst select id, parse_json(s) from t_pj;
 -- result:
-[REGEX].*Expecting item.*
+[REGEX].*Expecting.*
 -- !result
 select id, j from t_dst order by id;
 -- result:

--- a/test/sql/test_json/R/test_parse_json_throw_exception
+++ b/test/sql/test_json/R/test_parse_json_throw_exception
@@ -1,0 +1,44 @@
+-- name: test_parse_json_throw_exception
+set sql_mode = 'ALLOW_THROW_EXCEPTION';
+-- result:
+-- !result
+create table t_pj (id int, s varchar(100)) properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_pj values (1, '{"a": 1}'), (2, '{'), (3, '[1,2,3]'), (4, '{"a":}');
+-- result:
+-- !result
+select id, get_json_string(s, '$.a') from t_pj order by id;
+-- result:
+[REGEX].*Expecting item.*
+-- !result
+select id, parse_json(s) from t_pj order by id;
+-- result:
+[REGEX].*Expecting item.*
+-- !result
+create table t_dst (id int, j json) properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_dst select id, parse_json(s) from t_pj;
+-- result:
+[REGEX].*Expecting item.*
+-- !result
+select id, j from t_dst order by id;
+-- result:
+-- !result
+set sql_mode = '';
+-- result:
+-- !result
+select id, parse_json(s) from t_pj order by id;
+-- result:
+1	{"a": 1}
+2	None
+3	[1, 2, 3]
+4	None
+-- !result
+drop table if exists t_dst;
+-- result:
+-- !result
+drop table if exists t_pj;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_parse_json_throw_exception
+++ b/test/sql/test_json/T/test_parse_json_throw_exception
@@ -1,0 +1,28 @@
+-- name: test_parse_json_throw_exception
+-- Reproduces an unfixed sibling of PR #73199 (commit cb7d9b5e3ec,
+-- "[BugFix] Respect ALLOW_THROW_EXCEPTION in get_json_string").
+-- #73199 made get_json_string (via _string_json) raise the JSON parse error
+-- under sql_mode='ALLOW_THROW_EXCEPTION'. The user-facing parse_json()
+-- (JsonFunctions::parse_json) was NOT fixed: on a genuinely-malformed JSON it
+-- still silently appends NULL instead of raising.
+--
+-- NOTE: inputs must be genuinely malformed. A bare word like 'invalid json'
+-- parses as a JSON *string*, so it does NOT trigger the parse-failure path.
+-- Use '{' , '{"a":}' etc. Column values are used so the expression runs on
+-- the BE (constant args are folded on the FE and bypass the C++ code).
+set sql_mode = 'ALLOW_THROW_EXCEPTION';
+create table t_pj (id int, s varchar(100)) properties('replication_num' = '1');
+insert into t_pj values (1, '{"a": 1}'), (2, '{'), (3, '[1,2,3]'), (4, '{"a":}');
+-- CONTROL: get_json_string is FIXED -> raises on the malformed row.
+select id, get_json_string(s, '$.a') from t_pj order by id;
+-- BUG: parse_json should ALSO raise, but silently returns NULL rows.
+select id, parse_json(s) from t_pj order by id;
+-- BUG: INSERT..SELECT silently writes NULL for malformed rows instead of failing.
+create table t_dst (id int, j json) properties('replication_num' = '1');
+insert into t_dst select id, parse_json(s) from t_pj;
+select id, j from t_dst order by id;
+-- Without the mode, parse_json must keep returning NULL (no raise).
+set sql_mode = '';
+select id, parse_json(s) from t_pj order by id;
+drop table if exists t_dst;
+drop table if exists t_pj;


### PR DESCRIPTION
## Why I'm doing:

parse_json() swallowed JSON parse errors by appending NULL even when sql_mode='ALLOW_THROW_EXCEPTION', while get_json_string was fixed to raise in that mode by #73199. Mirror that fix in JsonFunctions::parse_json so malformed JSON fails the query (e.g. INSERT..SELECT) instead of silently producing NULL. Default (non-strict) behavior is unchanged.

Add test/sql/test_json SQL test covering parse_json vs get_json_string under ALLOW_THROW_EXCEPTION.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
