### PR TITLE
[BugFix] Pin QueryContext alive during fragment teardown to avoid spill UAF

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -127,6 +127,9 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
 
     const bool query_ctx_should_exist = t_desc_tbl.__isset.is_cached && t_desc_tbl.is_cached;
     ASSIGN_OR_RETURN(_query_ctx, _query_ctx_mgr->get_or_register(query_id, query_ctx_should_exist));
+    // Hold a strong reference so the QueryContext (and the query-scoped state that
+    // fragment operators point into, e.g. the spill manager) outlives `_fragment_ctx`.
+    _query_ctx_hold = _query_ctx->get_shared_ptr();
     _query_ctx->set_query_execution_services(&exec_env->query_execution_services());
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -155,6 +155,13 @@ private:
     int64_t _fragment_start_time = 0;
     QueryContextManager* _query_ctx_mgr = nullptr;
     QueryContext* _query_ctx = nullptr;
+    // Pin the QueryContext alive for at least as long as `_fragment_ctx`.
+    // Fragment operators cache raw pointers into query-scoped state (e.g.
+    // QueryContext::spill_manager()); if the QueryContext is reclaimed (its active
+    // fragment count reaches 0) while this executor still holds the last reference
+    // to `_fragment_ctx`, tearing the fragment down would deref freed memory.
+    // Declared before `_fragment_ctx` so it is destroyed AFTER it.
+    QueryContextPtr _query_ctx_hold = nullptr;
     FragmentContextPtr _fragment_ctx = nullptr;
     workgroup::WorkGroupPtr _wg = nullptr;
 };

--- a/be/test/compute_env/spill/operator_mem_resource_manager_test.cpp
+++ b/be/test/compute_env/spill/operator_mem_resource_manager_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <memory>
 
 #include "base/uid_util.h"
 #include "runtime/runtime_state.h"
@@ -86,6 +87,36 @@ TEST_F(OperatorMemoryResourceManagerTest, test_compute_available_memory_bytes_ma
                              _dummy_state.spill_operator_max_bytes());
 
     EXPECT_EQ(expected, OperatorMemoryResourceManager::compute_available_memory_bytes(_dummy_state));
+}
+
+
+// Regression for a heap-use-after-free during fragment teardown.
+//
+// OperatorMemoryResourceManager stores a RAW pointer to the QueryContext-owned
+// QuerySpillManager. When an operator is closed while its query is still alive
+// (the normal teardown ordering), close() must drop that raw pointer so the
+// manager's destructor -- which runs reset() again -- does not dereference the
+// spill manager after the QueryContext has been reclaimed. On branches where
+// close() does NOT drop the pointer, the destructor's reset() dereferences freed
+// memory (ASAN: heap-use-after-free in ResGuard::reset()).
+TEST_F(OperatorMemoryResourceManagerTest, test_close_drops_query_spill_manager_pointer) {
+    auto query_spill_manager = std::make_unique<QuerySpillManager>(dummy_query_id, &_global_mgr, &_dir_mgr);
+
+    OperatorMemoryResourceManager op_mem_res_mgr;
+    op_mem_res_mgr.prepare(query_spill_manager.get(), true, true, 128);
+    EXPECT_EQ(query_spill_manager.get(), op_mem_res_mgr.query_spill_manager());
+
+    // Operator closes while the query (and its spill manager) is still alive.
+    op_mem_res_mgr.close();
+    EXPECT_EQ(nullptr, op_mem_res_mgr.query_spill_manager());
+    EXPECT_EQ(_global_mgr.spillable_operators(), 0);
+    EXPECT_EQ(_global_mgr.spill_expected_reserved_bytes(), 0);
+
+    // Query teardown frees the spill manager that the operator pointed into.
+    query_spill_manager.reset();
+
+    // op_mem_res_mgr's destructor runs close()->reset() again at scope exit;
+    // because the raw pointer was dropped above, this is a no-op rather than a UAF.
 }
 
 } // namespace starrocks::spill

--- a/be/test/compute_env/spill/operator_mem_resource_manager_test.cpp
+++ b/be/test/compute_env/spill/operator_mem_resource_manager_test.cpp
@@ -89,7 +89,6 @@ TEST_F(OperatorMemoryResourceManagerTest, test_compute_available_memory_bytes_ma
     EXPECT_EQ(expected, OperatorMemoryResourceManager::compute_available_memory_bytes(_dummy_state));
 }
 
-
 // Regression for a heap-use-after-free during fragment teardown.
 //
 // OperatorMemoryResourceManager stores a RAW pointer to the QueryContext-owned


### PR DESCRIPTION
## Why I'm doing:

Fragment operators cache raw pointers into query-scoped state (e.g. QueryContext::spill_manager()). If the QueryContext was reclaimed (its active fragment count reaching 0) while FragmentExecutor still held the last reference to _fragment_ctx, tearing the fragment down dereferenced freed memory (ASAN: heap-use-after-free in ResGuard::reset()).

Hold a strong QueryContextPtr in FragmentExecutor, declared before _fragment_ctx so it is destroyed after it, keeping the QueryContext and its spill manager alive for at least as long as the fragment. Add a regression test verifying OperatorMemoryResourceManager::close() drops its raw QuerySpillManager pointer so the destructor's reset() is a no-op rather than a UAF.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
