### PR TITLE
[BugFix] Avoid BE crash (SIGFPE) in mod()/pmod() on TYPE_MIN % -1

### DIFF
--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -567,6 +567,13 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(RValueCheckZeroDecimalv2Impl, a, b) {
 
 // pmod
 DEFINE_BINARY_FUNCTION_WITH_IMPL(pmodImpl, a, b) {
+    // Guard against SIGFPE: on x86 the idiv instruction raises #DE when computing
+    // TYPE_MIN % -1 (the quotient overflows the result width). pmod(a, -1) == 0 for
+    // every a, so short-circuit before the hardware divide. The operator path in
+    // arithmetic_operation.h already carries this guard; mirror it for the function.
+    if (b == -1) {
+        return ResultType(0);
+    }
     return ((a % (b + (b == 0))) + b) % (b + (b == 0));
 }
 
@@ -579,6 +586,10 @@ DEFINE_BINARY_FUNCTION(fmodImpl, fmod);
 
 // mod
 DEFINE_BINARY_FUNCTION_WITH_IMPL(modImpl, a, b) {
+    // See pmodImpl: avoid SIGFPE on TYPE_MIN % -1. a % -1 == 0 for every a.
+    if (b == -1) {
+        return ResultType(0);
+    }
     return (a % (b + (b == 0)));
 }
 

--- a/test/sql/test_function/R/test_mod_pmod_int_min_overflow
+++ b/test/sql/test_function/R/test_mod_pmod_int_min_overflow
@@ -1,0 +1,28 @@
+-- name: test_mod_pmod_int_min_overflow
+-- Regression: mod()/pmod() of TYPE_MIN % -1 used to abort the BE with SIGFPE
+-- (x86 idiv #DE: the quotient TYPE_MIN / -1 overflows the result width).
+-- Operands are read from columns so the FE cannot constant-fold them away.
+CREATE TABLE t_mod_min (
+  k INT,
+  c_tiny TINYINT, c_small SMALLINT, c_int INT, c_big BIGINT, c_large LARGEINT,
+  d_tiny TINYINT, d_small SMALLINT, d_int INT, d_big BIGINT, d_large LARGEINT
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_mod_min VALUES
+ (1, -128, -32768, -2147483648, -9223372036854775808, -170141183460469231731687303715884105728, -1, -1, -1, -1, -1);
+-- result:
+-- !result
+SELECT mod(c_tiny, d_tiny), mod(c_small, d_small), mod(c_int, d_int), mod(c_big, d_big), mod(c_large, d_large) FROM t_mod_min;
+-- result:
+0	0	0	0	0
+-- !result
+SELECT pmod(c_int, d_int), pmod(c_big, d_big) FROM t_mod_min;
+-- result:
+0	0
+-- !result
+SELECT c_int % d_int, c_big % d_big FROM t_mod_min;
+-- result:
+0	0
+-- !result

--- a/test/sql/test_function/T/test_mod_pmod_int_min_overflow
+++ b/test/sql/test_function/T/test_mod_pmod_int_min_overflow
@@ -1,0 +1,15 @@
+-- name: test_mod_pmod_int_min_overflow
+-- Regression: mod()/pmod() of TYPE_MIN % -1 used to abort the BE with SIGFPE
+-- (x86 idiv #DE: the quotient TYPE_MIN / -1 overflows the result width).
+-- Operands are read from columns so the FE cannot constant-fold them away.
+CREATE TABLE t_mod_min (
+  k INT,
+  c_tiny TINYINT, c_small SMALLINT, c_int INT, c_big BIGINT, c_large LARGEINT,
+  d_tiny TINYINT, d_small SMALLINT, d_int INT, d_big BIGINT, d_large LARGEINT
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO t_mod_min VALUES
+ (1, -128, -32768, -2147483648, -9223372036854775808, -170141183460469231731687303715884105728, -1, -1, -1, -1, -1);
+SELECT mod(c_tiny, d_tiny), mod(c_small, d_small), mod(c_int, d_int), mod(c_big, d_big), mod(c_large, d_large) FROM t_mod_min;
+SELECT pmod(c_int, d_int), pmod(c_big, d_big) FROM t_mod_min;
+SELECT c_int % d_int, c_big % d_big FROM t_mod_min;


### PR DESCRIPTION
## Why I'm doing:

On x86 the idiv instruction raises #DE (SIGFPE) when computing TYPE_MIN % -1: the quotient TYPE_MIN / -1 overflows the result width. The mod() and pmod() scalar functions divided without guarding this case, so a query such as SELECT mod(c_int, d_int) with c_int = -2147483648 and d_int = -1 aborted the BE.

Short-circuit b == -1 to return 0 (a % -1 == 0 and pmod(a, -1) == 0 for every a) before the hardware divide. This mirrors the guard already present on the operator path in arithmetic_operation.h.

Add a regression test (test_mod_pmod_int_min_overflow) covering TINYINT/SMALLINT/INT/BIGINT/LARGEINT, with operands read from columns so the FE cannot constant-fold them away.

## What I'm doing:

Fixes #issue

```
query_id:019ed692-e87c-738a-bf8d-87b2ecef80bf, fragment_instance:019ed692-e87c-738a-bf8d-87b2ecef80c1, plan_node_id:0
*** Aborted at 1781716412 (unix time) try "date -d @1781716412" if you are using GNU date ***
PC: @          0x9a5be86 starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnpackConstColumnBinaryFunction<starrocks::pmodImpl>::evaluate<(starrocks::LogicalType)7, (starrocks::LogicalType)7
, (starrocks::LogicalType)7>(starrocks::Cow<starrocks::Column>::Imm@
*** SIGFPE (@0x9a5be86) received by PID 129645 (TID 0x7f9c263b1640) LWP(130474) from PID 161857158; stack trace: ***
    @     0x7f9dae880ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xdab93c6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f9dae829520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x9a5be86 starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnpackConstColumnBinaryFunction<starrocks::pmodImpl>::evaluate<(starrocks::LogicalType)7, (starrocks::LogicalType)7
, (starrocks::LogicalType)7>(starrocks::Cow<starrocks::Column>::Imm@
    @          0x9a5c05f starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::ProduceNullableColumnBinaryFunction<starrocks::UnpackConstColumnBinaryFunction<starrocks::RValueCheckZeroImpl>, sta
rrocks::UnpackConstColumnBinaryFunction<starrocks::pmodImpl> >::eva@
    @          0x9a5c31c starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::MathFunctions::pmod<(starrocks::LogicalType)7>(starrocks::FunctionContext*, std::vector<starr
ocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::all@
    @          0x6cf518a std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::Immu
tPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::C@
    @          0x6ee5738 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x8a46173 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x8a46e5b starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x51a5862 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x4e90857 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x845e2a2 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x9ff7c5b starrocks::ThreadPool::dispatch_thread()
    @          0x9fef0ef starrocks::Thread::supervise_thread(void*)
    @     0x7f9dae87bac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
