### PR TITLE
[BugFix] fix eliminiate sort column bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateSortColumnWithEqualityPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateSortColumnWithEqualityPredicateRule.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -62,9 +63,6 @@ public class EliminateSortColumnWithEqualityPredicateRule extends Transformation
         }
 
         if (reservedOrdering.isEmpty()) {
-            if (topn.hasLimit()) {
-                scan.setLimit(topn.getLimit());
-            }
             // if topn has projection, we should merge topn's projection into scan's projection
             if (topn.getProjection() != null) {
                 if (scan.getProjection() == null) {
@@ -80,6 +78,16 @@ public class EliminateSortColumnWithEqualityPredicateRule extends Transformation
                 }
             }
 
+            if (topn.hasLimit()) {
+                // Eliminating the sort removes the only operator that would force a global merge.
+                // This rule runs after the limit split/merge rules, so emitting an init-phase limit
+                // would never be split and would fail in the implementation phase. Emit a GLOBAL
+                // limit instead, which is enforced after the gather. Without it the bound would be
+                // applied independently per tablet and inflate downstream aggregates such as count(*).
+                scan.setLimit(topn.getLimit() + topn.getOffset());
+                LogicalLimitOperator global = LogicalLimitOperator.global(topn.getLimit(), topn.getOffset());
+                return Lists.newArrayList(OptExpression.create(global, input.getInputs()));
+            }
             return input.getInputs();
         } else {
             LogicalTopNOperator newTopn = LogicalTopNOperator.builder().withOperator(topn)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EliminateSortColumnWithEqualityPredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EliminateSortColumnWithEqualityPredicateTest.java
@@ -38,9 +38,12 @@ public class EliminateSortColumnWithEqualityPredicateTest extends PlanTestBase {
                 "ORDER BY v2 DESC \n" +
                 "LIMIT 30;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "RESULT SINK\n" +
-                "\n" +
-                "  0:OlapScanNode\n" +
+        // The pinned sort column is eliminated, but a GLOBAL limit (gather exchange) must remain so
+        // the limit is enforced after the merge instead of only per scan instance. Otherwise the
+        // limit applied independently per tablet would inflate downstream consumers (e.g. count(*)).
+        assertContains(plan, "  1:EXCHANGE\n" +
+                "     limit: 30");
+        assertContains(plan, "  0:OlapScanNode\n" +
                 "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 2: v2 = 111\n" +
@@ -49,8 +52,7 @@ public class EliminateSortColumnWithEqualityPredicateTest extends PlanTestBase {
                 "     tabletRatio=0/0\n" +
                 "     tabletList=\n" +
                 "     cardinality=1\n" +
-                "     avgRowSize=3.0\n" +
-                "     limit: 30");
+                "     avgRowSize=3.0");
 
         sql = "select v1, v2, v3  FROM t0 WHERE v2 = 111 and v3 > 0 \n" +
                 "ORDER BY v2, v3 DESC \n" +
@@ -85,5 +87,40 @@ public class EliminateSortColumnWithEqualityPredicateTest extends PlanTestBase {
                 "LIMIT 30;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 2> 2: v2 DESC");
+    }
+
+    @Test
+    public void testCountOverEliminatedSortKeepsGlobalLimit() throws Exception {
+        // Regression for the wrong-result bug: count(*) over a derived table whose only ORDER BY
+        // column is pinned by an equality predicate. The sort is eliminated; without a GLOBAL limit
+        // the limit becomes a per-tablet scan cap and the 2-phase count sums the per-instance counts
+        // (e.g. returns 100 instead of 50). The plan must keep a global limit feeding the aggregate.
+        String sql = "select count(*) from " +
+                "(select v1, v2, v3 from t0 where v2 = 111 order by v2 limit 30) t;";
+        String plan = getFragmentPlan(sql);
+        // count(*) runs after a global limit gather, not over a per-tablet scan-only limit.
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:EXCHANGE\n" +
+                "     limit: 30");
+        // the scan still feeds the global limit (no scan-local limit; the gather enforces the bound)
+        assertContains(plan, "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 2: v2 = 111");
+
+        // offset variant: the global limit must carry the offset; the gather enforces offset + limit.
+        sql = "select count(*) from " +
+                "(select v1, v2, v3 from t0 where v2 = 111 order by v2 limit 10, 30) t;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:EXCHANGE\n" +
+                "     offset: 10\n" +
+                "     limit: 30");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
```
1FE 2BE:
SELECT count(*) FROM (
      SELECT * FROM t WHERE givname = '振龙' ORDER BY givname LIMIT 50
  ) v;
This result it 100, but should be 50.

  Buggy plan (note: limit only on the scan, no global limit, 2-phase count):
  3:AGGREGATE (merge finalize)  count
  2:EXCHANGE
  1:AGGREGATE (update serialize) count(*)
  0:OlapScanNode  PREDICATES: givname='振龙'  limit: 50
```
EliminateSortColumnWithEqualityPredicateRule eliminate the topn operator, and set the limit to the scan.

But no global limit is set. Under concurrency, the result will be greater than the right answer.
## What I'm doing:

Substitute TOPN with GLOBAL limt.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
