### PR TITLE
[BugFix] Fix Iceberg scan task cleanup on planning cancel

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -75,6 +75,7 @@ import com.starrocks.metric.ConnectorMetricsMgr;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -1238,9 +1239,17 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                        Expression icebergPredicate,
                                                        TvrVersionRange tvrVersionRange,
                                                        GetRemoteFilesParams params) {
+        ConnectContext connectContext = ConnectContext.get();
         CloseableIterator<FileScanTask> iterator =
-                buildFileScanTaskIterator(table, icebergPredicate, tvrVersionRange, ConnectContext.get(),
+                buildFileScanTaskIterator(table, icebergPredicate, tvrVersionRange, connectContext,
                         params.isEnableColumnStats(), params.getFieldNames());
+        AtomicBoolean closed = new AtomicBoolean(false);
+        AutoCloseable closeIterator = () -> {
+            if (closed.compareAndSet(false, true)) {
+                iterator.close();
+            }
+        };
+        AutoCloseable unregister = registerCancellablePlanningResource(connectContext, closeIterator);
         return new RemoteFileInfoSource() {
             @Override
             public RemoteFileInfo getOutput() {
@@ -1257,11 +1266,26 @@ public class IcebergMetadata implements ConnectorMetadata {
             @Override
             public void close() {
                 try {
-                    iterator.close();
+                    closeIterator.close();
                 } catch (Exception ignore) {
+                } finally {
+                    try {
+                        unregister.close();
+                    } catch (Exception ignore) {
+                    }
                 }
             }
         };
+    }
+
+    private AutoCloseable registerCancellablePlanningResource(ConnectContext connectContext, AutoCloseable resource) {
+        if (connectContext == null || connectContext.getExecutor() == null) {
+            return () -> {
+            };
+        }
+
+        StmtExecutor executor = connectContext.getExecutor();
+        return executor.registerCancellablePlanningResource(resource);
     }
 
     private RemoteFileInfoSource buildRemoteInfoSource(List<FileScanTask> tasks, GetRemoteFilesParams params) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -74,6 +74,7 @@ import com.starrocks.common.QueryDumpLog;
 import com.starrocks.common.SqlBlacklistedException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.common.Version;
 import com.starrocks.common.profile.RawScopedTimer;
@@ -315,8 +316,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -336,6 +339,8 @@ public class StmtExecutor {
     private static final Gson GSON = new Gson();
 
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
+    private static final ExecutorService PLANNING_RESOURCE_CLEANUP_EXECUTOR =
+            ThreadPoolManager.newDaemonCacheThreadPool(32, 1024, "planning-resource-cleanup", false);
 
     private final ConnectContext context;
     private final MysqlSerializer serializer;
@@ -368,6 +373,9 @@ public class StmtExecutor {
 
     // Catalog types involved in this query (e.g., "default", "hive", "iceberg")
     private Set<String> catalogTypesInvolved = Collections.emptySet();
+    private final Set<AutoCloseable> cancellablePlanningResources = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean cancellablePlanningResourcesCleanupScheduled = new AtomicBoolean(false);
+    private final AtomicBoolean cancellablePlanningResourcesCleared = new AtomicBoolean(false);
 
     private final CompletableFuture<ArrowFlightSqlResultDescriptor> deploymentFinished;
 
@@ -1316,6 +1324,7 @@ public class StmtExecutor {
             if (coord != null) {
                 coord.clearExternalResources();
             }
+            clearCancellablePlanningResourcesAsync();
 
             if (parsedStmt != null && parsedStmt.isExistQueryScopeHint()) {
                 clearQueryScopeHintContext();
@@ -1702,6 +1711,7 @@ public class StmtExecutor {
 
     // Because this is called by other thread
     public void cancel(String cancelledMessage) {
+        clearCancellablePlanningResourcesAsync();
         if (parsedStmt instanceof DeleteStmt && ((DeleteStmt) parsedStmt).shouldHandledByDeleteHandler()) {
             DeleteStmt deleteStmt = (DeleteStmt) parsedStmt;
             long jobId = deleteStmt.getJobId();
@@ -1718,6 +1728,70 @@ public class StmtExecutor {
             if (coordRef != null) {
                 coordRef.cancel(cancelledMessage);
             }
+        }
+    }
+
+    public AutoCloseable registerCancellablePlanningResource(AutoCloseable resource) {
+        if (resource == null) {
+            return () -> {
+            };
+        }
+
+        if (cancellablePlanningResourcesCleared.get()) {
+            closeCancellablePlanningResourceAsync(resource);
+            return () -> {
+            };
+        }
+
+        cancellablePlanningResources.add(resource);
+        if (cancellablePlanningResourcesCleared.get() && cancellablePlanningResources.remove(resource)) {
+            closeCancellablePlanningResourceAsync(resource);
+        }
+        return () -> cancellablePlanningResources.remove(resource);
+    }
+
+    private void clearCancellablePlanningResourcesAsync() {
+        if (cancellablePlanningResourcesCleared.get() ||
+                !cancellablePlanningResourcesCleanupScheduled.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            PLANNING_RESOURCE_CLEANUP_EXECUTOR.execute(this::clearCancellablePlanningResources);
+        } catch (RejectedExecutionException e) {
+            cancellablePlanningResourcesCleanupScheduled.set(false);
+            LOG.warn("submit cancellable planning resource cleanup task failed, query id: {}",
+                    context != null ? context.getQueryId() : null, e);
+        }
+    }
+
+    private void clearCancellablePlanningResources() {
+        if (!cancellablePlanningResourcesCleared.compareAndSet(false, true)) {
+            return;
+        }
+
+        for (AutoCloseable resource : new ArrayList<>(cancellablePlanningResources)) {
+            if (cancellablePlanningResources.remove(resource)) {
+                closeCancellablePlanningResource(resource);
+            }
+        }
+    }
+
+    private void closeCancellablePlanningResourceAsync(AutoCloseable resource) {
+        try {
+            PLANNING_RESOURCE_CLEANUP_EXECUTOR.execute(() -> closeCancellablePlanningResource(resource));
+        } catch (RejectedExecutionException e) {
+            LOG.warn("submit cancellable planning resource close task failed, query id: {}",
+                    context != null ? context.getQueryId() : null, e);
+        }
+    }
+
+    private void closeCancellablePlanningResource(AutoCloseable resource) {
+        try {
+            resource.close();
+        } catch (Exception e) {
+            LOG.warn("close cancellable planning resource failed, query id: {}",
+                    context != null ? context.getQueryId() : null, e);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -46,6 +46,10 @@ import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.OriginStatement;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.type.IntegerType;
@@ -86,8 +90,10 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -365,6 +371,92 @@ public class ExternalResourceCleanupTest {
     }
 
     @Test
+    public void testStmtExecutorCancelClosesCancellablePlanningResource() throws Exception {
+        ConnectContext context = new ConnectContext();
+        StmtExecutor executor = newStmtExecutor(context);
+        context.setExecutor(executor);
+
+        CountDownLatch closed = new CountDownLatch(1);
+        AtomicInteger closeCount = new AtomicInteger();
+        executor.registerCancellablePlanningResource(() -> {
+            closeCount.incrementAndGet();
+            closed.countDown();
+        });
+
+        executor.cancel("cancelled");
+
+        Assertions.assertTrue(closed.await(5, TimeUnit.SECONDS));
+        Assertions.assertEquals(1, closeCount.get());
+    }
+
+    @Test
+    public void testIcebergRemoteInfoSourceClosesPlanningIteratorOnCancel() throws Exception {
+        ConnectContext context = new ConnectContext();
+        StmtExecutor executor = newStmtExecutor(context);
+        context.setExecutor(executor);
+
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
+        IcebergMetricsReporter reporter = new IcebergMetricsReporter();
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(nativeTbl.properties()).thenReturn(Map.of());
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getIcebergMetricsReporter()).thenReturn(reporter);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+
+        StarRocksIcebergTableScan tableScan = Mockito.mock(StarRocksIcebergTableScan.class);
+        Mockito.when(icebergCatalog.getTableScan(Mockito.eq(nativeTbl), Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.useSnapshot(Mockito.anyLong())).thenReturn(tableScan);
+        Mockito.when(tableScan.metricsReporter(Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.planWith(Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.targetSplitSize()).thenReturn(128L);
+        Mockito.when(tableScan.getMetricsReporter()).thenReturn(reporter);
+
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        Mockito.when(task.deletes()).thenReturn(List.of());
+        CountingFileScanTaskIterable plannedTasks = new CountingFileScanTaskIterable(task);
+        Mockito.when(tableScan.planFiles()).thenReturn(plannedTasks);
+
+        IcebergGetRemoteFilesParams.Builder builder = IcebergGetRemoteFilesParams.newBuilder();
+        builder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        builder.setPredicate(ConstantOperator.TRUE);
+        builder.setAllParams(IcebergTableMORParams.EMPTY);
+        builder.setParams(IcebergMORParams.EMPTY);
+        IcebergGetRemoteFilesParams params = (IcebergGetRemoteFilesParams) builder.build();
+
+        Method sourceMethod = IcebergMetadata.class.getDeclaredMethod(
+                "buildRemoteInfoSource", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
+                TvrVersionRange.class, GetRemoteFilesParams.class);
+        sourceMethod.setAccessible(true);
+
+        try (MockedStatic<TableScanUtil> tableScanUtilMock = Mockito.mockStatic(TableScanUtil.class);
+                ConnectContext.ScopeGuard ignored = context.bindScope()) {
+            tableScanUtilMock.when(() -> TableScanUtil.splitFiles(Mockito.any(), Mockito.anyLong()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            RemoteFileInfoSource source = (RemoteFileInfoSource) sourceMethod.invoke(
+                    metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
+                    TvrTableSnapshot.of(Optional.of(1L)), params);
+
+            Assertions.assertTrue(source.hasMoreOutput());
+            executor.cancel("cancelled");
+
+            Assertions.assertTrue(plannedTasks.closed.await(5, TimeUnit.SECONDS));
+            Assertions.assertTrue(plannedTasks.closeCount.get() >= 1);
+            source.close();
+        }
+    }
+
+    @Test
     public void testDeltaLakeMetadataIteratorAndCollect() throws Exception {
         // Prepare metadata with mocked delta ops and statistic provider.
         DeltaMetastoreOperations deltaOps = Mockito.mock(DeltaMetastoreOperations.class);
@@ -618,6 +710,54 @@ public class ExternalResourceCleanupTest {
         Mockito.when(icebergCatalog.getTableScan(Mockito.eq(nativeTbl), Mockito.any())).thenReturn(scan);
 
         Assertions.assertTrue(metadata.getDeleteFiles(table, 1L, ConstantOperator.TRUE, FileContent.EQUALITY_DELETES).isEmpty());
+    }
+
+    private static StmtExecutor newStmtExecutor(ConnectContext context) {
+        StatementBase stmt = Mockito.mock(StatementBase.class);
+        Mockito.when(stmt.getOrigStmt()).thenReturn(new OriginStatement("select 1", 0));
+        return new StmtExecutor(context, stmt);
+    }
+
+    private static class CountingFileScanTaskIterable implements CloseableIterable<FileScanTask> {
+        private final FileScanTask task;
+        private final AtomicInteger closeCount = new AtomicInteger();
+        private final CountDownLatch closed = new CountDownLatch(1);
+
+        CountingFileScanTaskIterable(FileScanTask task) {
+            this.task = task;
+        }
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+            closed.countDown();
+        }
+
+        @Override
+        public org.apache.iceberg.io.CloseableIterator<FileScanTask> iterator() {
+            return new org.apache.iceberg.io.CloseableIterator<>() {
+                private boolean used = false;
+
+                @Override
+                public void close() {
+                    // no-op
+                }
+
+                @Override
+                public boolean hasNext() {
+                    return !used;
+                }
+
+                @Override
+                public FileScanTask next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
+                    used = true;
+                    return task;
+                }
+            };
+        }
     }
 
     private static class CountingRemoteFileInfoSource implements RemoteFileInfoSource {


### PR DESCRIPTION
## Why I'm doing:

Fixes #74616.

When an Iceberg REST scan is cancelled or times out during FE planning, the live Iceberg `ScanTaskIterable` can be abandoned before a coordinator exists. Its producer workers may remain blocked in `offerWithTimeout()`, exhausting the catalog planning pool and causing later Iceberg planning to hang.

## What I'm doing:

- Register statement-scoped cancellable planning resources in `StmtExecutor`, and close them when `query_timeout` / `KILL QUERY` reaches the executor before coordinator cleanup is available.
- Register the live Iceberg file scan iterator with that cleanup path, while keeping normal iterator close idempotent.
- Add regression tests for statement cancellation cleanup and Iceberg iterator cleanup.

Fixes #74616

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Tests

- `git diff --check`
- `./gradlew :fe-core:checkstyleTest -x generateThriftSources`
- `./gradlew :fe-core:checkstyleMain -x generateThriftSources`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew :fe-core:test --tests com.starrocks.connector.ExternalResourceCleanupTest -Pfe_ut_parallel=1`
