### PR TITLE
[BugFix] fix Nested materialized view refresh Npe (backport #73644)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
 import static com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable;
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 
 /**
  * {@link MVTimelinessArbiter} is the base class of all materialized view timeliness arbiters which is used to determine the mv's
@@ -159,7 +160,7 @@ public abstract class MVTimelinessArbiter {
     /**
      * Collect ref base table's update partition infos
      * @param refBaseTableAndColumns ref base table and columns of mv
-     * @return ref base table's changed partition names
+     * @return ref base table's changed partition names, or null if the partial refresh info cannot be collected safely
      */
     protected Map<Table, Set<String>> collectBaseTableUpdatePartitionNames(Map<Table, Column> refBaseTableAndColumns,
                                                                            MvUpdateInfo mvUpdateInfo) {
@@ -168,6 +169,11 @@ public abstract class MVTimelinessArbiter {
             Table baseTable = e.getKey();
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
                     true, isQueryRewrite);
+            if (mvBaseTableUpdateInfo == null) {
+                logMVPrepare(mv, "Failed to collect update info for ref base table {}, fallback to full refresh",
+                        baseTable.getName());
+                return null;
+            }
             mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
             // If base table is a mv, its to-update partitions may not be created yet, skip it
             baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPartitionNames());
@@ -210,9 +216,9 @@ public abstract class MVTimelinessArbiter {
      * TODO: Optimize performance in loos/force_mv mode
      * TODO: in loose mode, ignore partition that both exists in baseTable and mv
      */
-    protected void collectBaseTableUpdatePartitionNamesInLoose(MvUpdateInfo mvUpdateInfo) {
+    protected boolean collectBaseTableUpdatePartitionNamesInLoose(MvUpdateInfo mvUpdateInfo) {
         Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
         // collect & update mv's to refresh partitions based on base table's partition changes
-        collectBaseTableUpdatePartitionNames(refBaseTableAndColumns, mvUpdateInfo);
+        return collectBaseTableUpdatePartitionNames(refBaseTableAndColumns, mvUpdateInfo) != null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -70,6 +70,9 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         MvUpdateInfo mvTimelinessInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL);
         Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTableAndColumns,
                 mvTimelinessInfo);
+        if (baseChangedPartitionNames == null) {
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
         Map<Table, Map<String, PListCell>> refBaseTablePartitionMap = Maps.newHashMap();
         Map<String, PListCell> allBasePartitionItems = Maps.newHashMap();
         Map<Table, List<Integer>> tableRefIdxes = Maps.newHashMap();
@@ -164,7 +167,9 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
             mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName);
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
-        collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
+        if (!collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo)) {
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
         collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, listPartitionDiff, tableRefIdxes, mvUpdateInfo);
         return mvUpdateInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -68,11 +68,12 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
             }
 
             // once mv's base table has updated, refresh the materialized view totally.
-            // once mv's base table has updated, refresh the materialized view totally.
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, isQueryRewrite);
-            // TODO: fixme if mvBaseTableUpdateInfo is null, should return full refresh?
-            if (mvBaseTableUpdateInfo != null &&
-                    CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames())) {
+            if (mvBaseTableUpdateInfo == null) {
+                logMVPrepare(mv, "Non-partitioned base table update info is unknown, need refresh totally.");
+                return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+            }
+            if (CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames())) {
                 logMVPrepare(mv, "Non-partitioned base table has updated, need refresh totally.");
                 return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -81,6 +81,9 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         // collect & update mv's to refresh partitions based on base table's partition changes
         Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTableAndColumns,
                 mvTimelinessInfo);
+        if (baseChangedPartitionNames == null) {
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
 
         // collect all ref base table's partition range map
         Map<Table, Map<String, Range<PartitionKey>>> basePartitionNameToRangeMap =
@@ -180,7 +183,9 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
             mvUpdateInfo.addMvToRefreshPartitionNames(mvPartitionName);
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
-        collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
+        if (!collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo)) {
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
         collectMVToBaseTablePartitionNames(rBTPartitionMap, rangePartitionDiff, mvUpdateInfo);
         return mvUpdateInfo;
     }


### PR DESCRIPTION
## Why I'm doing:

Backport of #73644 to `branch-3.3`.

A partitioned MV refresh can fail with an NPE when the MV depends on nested MVs. When the nested base MV's timeliness is FULL/UNKNOWN (e.g. a non-ref base table changed, partition diff cannot be computed, or partition-level update info is unavailable), `getMvBaseTableUpdateInfo()` returns `null`, and the parent MV dereferences it in `collectBaseTableUpdatePartitionNames()`:

```
Refresh mv xxx failed after 1 times, ... java.lang.NullPointerException
    at MVTimelinessArbiter.collectBaseTableUpdatePartitionNames(MVTimelinessArbiter.java:173)
    at MVTimelinessRangePartitionArbiter.getMVTimelinessUpdateInfoInChecked(...)
```

## What I'm doing:

Guard the `null` returned by `getMvBaseTableUpdateInfo()` in `collectBaseTableUpdatePartitionNames()` (return `null` to signal "incremental info cannot be collected safely"), and have each arbiter (Range/List/NonPartition, plus loose mode) fall back to a full refresh in that case. Clean backport of #73644 adapted to the `branch-3.3` API.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

