### PR TITLE
[BugFix] Fix SIGFPE crash in iceberg truncate/bucket transforms on zero width

### DIFF
--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -362,6 +362,18 @@ DEFINE_MATH_BINARY_FN_WITH_NAN_CHECK(truncate, TYPE_DOUBLE, TYPE_INT, TYPE_DOUBL
 DEFINE_MATH_BINARY_FN(round_up_to, TYPE_DOUBLE, TYPE_INT, TYPE_DOUBLE);
 DEFINE_MATH_BINARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(atan2, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, std::atan2);
 
+// Iceberg truncate/bucket transforms use the second argument (truncate width /
+// number of buckets) directly as a modulo divisor. Iceberg requires it to be a
+// positive number; reject width <= 0 here so a width of 0 returns a normal error
+// instead of raising SIGFPE on the integer idiv.
+static Status check_iceberg_transform_width(int64_t width) {
+    if (width <= 0) {
+        return Status::InvalidArgument(
+                fmt::format("The width/num_buckets of iceberg transform must be greater than 0, but got: {}", width));
+    }
+    return Status::OK();
+}
+
 template <LogicalType Type>
 StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* context, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
@@ -369,6 +381,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* con
     const int size = columns[0]->size();
     ColumnViewer<Type> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     const int32_t original_scale = viewer.column()->scale();
     const int32_t original_precision = viewer.column()->precision();
@@ -410,6 +423,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_int(FunctionContext* context
     const int size = columns[0]->size();
     ColumnViewer<Type> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
 #define haveDifferentSigns(x, y) (((x) ^ (y)) < 0)
     ColumnBuilder<Type> builder(size);
@@ -441,6 +455,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_int(FunctionContext* context, 
     const int size = columns[0]->size();
     ColumnViewer<Type> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     ColumnBuilder<TYPE_INT> builder(size);
     for (int i = 0; i < size; i++) {
@@ -465,6 +480,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_string(FunctionContext* contex
     const int size = columns[0]->size();
     ColumnViewer<TYPE_VARCHAR> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     ColumnBuilder<TYPE_INT> builder(size);
     for (int i = 0; i < size; i++) {
@@ -486,6 +502,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_date(FunctionContext* context,
     const int size = columns[0]->size();
     ColumnViewer<TYPE_DATE> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     ColumnBuilder<TYPE_INT> builder(size);
     for (int i = 0; i < size; i++) {
@@ -507,6 +524,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_datetime(FunctionContext* cont
     const int size = columns[0]->size();
     ColumnViewer<TYPE_DATETIME> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     ColumnBuilder<TYPE_INT> builder(size);
     for (int i = 0; i < size; i++) {
@@ -529,6 +547,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_timestamptz_datetime(FunctionC
     const int size = columns[0]->size();
     ColumnViewer<TYPE_DATETIME> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     ColumnBuilder<TYPE_INT> builder(size);
     for (int i = 0; i < size; i++) {
@@ -577,6 +596,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_decimal(FunctionContext* conte
     const int size = columns[0]->size();
     ColumnViewer<Type> viewer(columns[0]);
     int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+    RETURN_IF_ERROR(check_iceberg_transform_width(width));
 
     ColumnBuilder<TYPE_INT> builder(size);
     for (int i = 0; i < size; i++) {

--- a/test/sql/test_function/R/test_iceberg_transform_zero_width
+++ b/test/sql/test_function/R/test_iceberg_transform_zero_width
@@ -1,0 +1,38 @@
+-- name: test_iceberg_transform_zero_width
+create table t0 (
+  i32 int not null,
+  i64 bigint not null,
+  d32 decimal(9,2) not null,
+  s   varchar(20) not null,
+  dt  date not null,
+  ts  datetime not null
+) PROPERTIES ("replication_num"="1");
+-- result:
+-- !result
+insert into t0 values (5, 5, 10.65, 'abc', '2024-01-01', '2024-01-01 12:00:00');
+-- result:
+-- !result
+[UC] select __iceberg_transform_truncate(i32, 0) from t0;
+[UC] select __iceberg_transform_truncate(i64, 0) from t0;
+[UC] select __iceberg_transform_truncate(d32, 0) from t0;
+[UC] select __iceberg_transform_bucket(i32, 0) from t0;
+[UC] select __iceberg_transform_bucket(i64, 0) from t0;
+[UC] select __iceberg_transform_bucket(d32, 0) from t0;
+[UC] select __iceberg_transform_bucket(s, 0) from t0;
+[UC] select __iceberg_transform_bucket(dt, 0) from t0;
+[UC] select __iceberg_transform_bucket(ts, 0) from t0;
+select count(*) from t0;
+-- result:
+1
+-- !result
+select __iceberg_transform_truncate(i32, 10) from t0;
+-- result:
+0
+-- !result
+select __iceberg_transform_bucket(i32, 8) from t0;
+-- result:
+7
+-- !result
+drop table t0;
+-- result:
+-- !result

--- a/test/sql/test_function/R/test_iceberg_transform_zero_width
+++ b/test/sql/test_function/R/test_iceberg_transform_zero_width
@@ -13,14 +13,32 @@ insert into t0 values (5, 5, 10.65, 'abc', '2024-01-01', '2024-01-01 12:00:00');
 -- result:
 -- !result
 [UC] select __iceberg_transform_truncate(i32, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_truncate(i64, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_truncate(d32, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_bucket(i32, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_bucket(i64, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_bucket(d32, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_bucket(s, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_bucket(dt, 0) from t0;
+-- result:
+-- !result
 [UC] select __iceberg_transform_bucket(ts, 0) from t0;
+-- result:
+-- !result
 select count(*) from t0;
 -- result:
 1

--- a/test/sql/test_function/T/test_iceberg_transform_zero_width
+++ b/test/sql/test_function/T/test_iceberg_transform_zero_width
@@ -1,0 +1,43 @@
+-- name: test_iceberg_transform_zero_width
+
+-- Regression for SIGFPE crash in MathFunctions::iceberg_truncate_int / iceberg_bucket_*.
+-- The second argument (truncate width / bucket count) was read once and used directly
+-- as a modulo divisor: `val % width` (truncate) and `(hash & INT_MAX) % width` (bucket),
+-- with no width != 0 guard. A width of 0 made the integer idiv raise SIGFPE and crash BE
+-- (be/src/exprs/math_functions.cpp). The fix validates width > 0 and returns a normal
+-- InvalidArgument error instead of dividing by zero.
+--
+-- This case fires width=0 against every transform variant (each of which used to kill
+-- BE), then asserts BE is still serving queries -- mirroring test_flat_json_write_fail.
+
+create table t0 (
+  i32 int not null,
+  i64 bigint not null,
+  d32 decimal(9,2) not null,
+  s   varchar(20) not null,
+  dt  date not null,
+  ts  datetime not null
+) PROPERTIES ("replication_num"="1");
+
+insert into t0 values (5, 5, 10.65, 'abc', '2024-01-01', '2024-01-01 12:00:00');
+
+-- Each of these used to SIGFPE the BE. The result is unchecked (the exact error is not
+-- asserted); the regression is that BE must NOT crash on width=0.
+[UC] select __iceberg_transform_truncate(i32, 0) from t0;
+[UC] select __iceberg_transform_truncate(i64, 0) from t0;
+[UC] select __iceberg_transform_truncate(d32, 0) from t0;
+[UC] select __iceberg_transform_bucket(i32, 0) from t0;
+[UC] select __iceberg_transform_bucket(i64, 0) from t0;
+[UC] select __iceberg_transform_bucket(d32, 0) from t0;
+[UC] select __iceberg_transform_bucket(s, 0) from t0;
+[UC] select __iceberg_transform_bucket(dt, 0) from t0;
+[UC] select __iceberg_transform_bucket(ts, 0) from t0;
+
+-- BE must still be alive and serving queries after the (now graceful) failures.
+select count(*) from t0;
+
+-- A valid positive width must still produce correct results.
+select __iceberg_transform_truncate(i32, 10) from t0;
+select __iceberg_transform_bucket(i32, 8) from t0;
+
+drop table t0;


### PR DESCRIPTION
## Why I'm doing:

    The __iceberg_transform_truncate / __iceberg_transform_bucket builtins read
    their second argument (truncate width / number of buckets) and used it directly
    as a modulo divisor -- `val % width` for truncate and `(hash & INT_MAX) % width`
    for bucket -- with no guard that width != 0. A width of 0 makes the integer idiv
    raise SIGFPE and crash the BE, for example:

        select __iceberg_transform_truncate(i32, 0) from t;

    Unlike %, mod, pmod and integer DIV (which all guard the divisor), these
    FE-registered builtins had no divide-by-zero protection and are directly
    callable from SQL, so a constant 0 in the second argument takes down the BE.

    Validate width > 0 once before the row loop -- Iceberg requires a positive
    truncate width / bucket count -- and return a normal InvalidArgument error
    instead of dividing by zero. The guard covers every entry point:
    truncate(int/bigint/decimal) and
    bucket(int/bigint/decimal/string/date/datetime/timestamptz).

    Add SQL regression test test_iceberg_transform_zero_width which fires width=0
    against every transform variant and then asserts the BE is still serving
    queries, following the test_flat_json_write_fail crash-recovery pattern.

## What I'm doing:

Fixes #issue

```
I20260617 17:17:34.739881 140299027137344 starrocks_main.cpp:208] file system provider registry init successfully
Built on a system without sched_getcpu() support. Performance may be impacted.pr-74693 RELEASE (build 5fb4cc4 distro ubuntu arch x86_64)
query_id:019ed8ce-d9ce-710d-9770-4d7327998ea3, fragment_instance:019ed8ce-d9ce-710d-9770-4d7327998ea4, plan_node_id:0
*** Aborted at 1781753895 (unix time) try "date -d @1781753895" if you are using GNU date ***
PC: @          0x9a222dc starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::MathFunctions::iceberg_truncate_int<(starrocks::LogicalType)5>(starrocks:
:FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::C@
*** SIGFPE (@0x9a222dc) received by PID 144957 (TID 0x7f9851bf8640) LWP(145803) from PID 161620700; stack trace: ***
    @     0x7f99e9db5ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xdab9386 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f99e9d5e520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x9a222dc starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::MathFunctions::iceberg_truncate_int<(starrocks::LogicalType)5>(starrocks:
:FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::C@
    @          0x6cf518a std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<star
rocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::C@
    @          0x6ee5738 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x8a46173 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x8a46e5b starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x51a5862 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x4e90857 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x845e2a2 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x9ff7c1b starrocks::ThreadPool::dispatch_thread()
    @          0x9fef0af starrocks::Thread::supervise_thread(void*)
    @     0x7f99e9db0ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
