### PR TITLE
[BugFix] Fix LIKE escaping mismatch with MySQL in constant folding (backport #74814)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -43,13 +43,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
-import com.starrocks.type.ArrayType;
-import com.starrocks.type.BooleanType;
-import com.starrocks.type.NullType;
-import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
-import com.starrocks.type.Type;
-import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -538,7 +531,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
     public ScalarOperator visitLikePredicateOperator(LikePredicateOperator predicate,
                                                      ScalarOperatorRewriteContext context) {
         if (hasNull(predicate.getChildren())) {
-            return ConstantOperator.createNull(BooleanType.BOOLEAN);
+            return ConstantOperator.createNull(Type.BOOLEAN);
         }
         if (notAllConstant(predicate.getChildren()) || predicate.getLikeType() != LikePredicateOperator.LikeType.LIKE) {
             return predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -43,6 +43,13 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.NullType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -52,6 +59,8 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -529,9 +538,54 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
     public ScalarOperator visitLikePredicateOperator(LikePredicateOperator predicate,
                                                      ScalarOperatorRewriteContext context) {
         if (hasNull(predicate.getChildren())) {
-            return ConstantOperator.createNull(Type.BOOLEAN);
+            return ConstantOperator.createNull(BooleanType.BOOLEAN);
+        }
+        if (notAllConstant(predicate.getChildren()) || predicate.getLikeType() != LikePredicateOperator.LikeType.LIKE) {
+            return predicate;
+        }
+
+        String text = ((ConstantOperator) predicate.getChild(0)).getVarchar();
+        String pattern = ((ConstantOperator) predicate.getChild(1)).getVarchar();
+
+        // Group 1 captures the literal body; %-wildcards are matched outside the group so an
+        // escaped \% inside the body is never mistaken for a trailing/leading wildcard.
+        Matcher equals = LIKE_EQUALS.matcher(pattern);
+        if (equals.matches()) {
+            return ConstantOperator.createBoolean(text.equals(removeLikeEscape(equals.group(1))));
+        }
+        Matcher endsWith = LIKE_ENDS_WITH.matcher(pattern);
+        if (endsWith.matches()) {
+            return ConstantOperator.createBoolean(text.endsWith(removeLikeEscape(endsWith.group(1))));
+        }
+        Matcher startsWith = LIKE_STARTS_WITH.matcher(pattern);
+        if (startsWith.matches()) {
+            return ConstantOperator.createBoolean(text.startsWith(removeLikeEscape(startsWith.group(1))));
+        }
+        Matcher substring = LIKE_SUBSTRING.matcher(pattern);
+        if (substring.matches()) {
+            return ConstantOperator.createBoolean(text.contains(removeLikeEscape(substring.group(1))));
         }
         return predicate;
+    }
+
+    // LIKE body token = an escaped sequence \x (atomic) or a plain char that is not %, _ or \
+    private static final String LIKE_BODY = "((?:\\\\.|[^%_\\\\])+)";
+    private static final Pattern LIKE_EQUALS = Pattern.compile("^" + LIKE_BODY + "$");
+    private static final Pattern LIKE_ENDS_WITH = Pattern.compile("^%+" + LIKE_BODY + "$");
+    private static final Pattern LIKE_STARTS_WITH = Pattern.compile("^" + LIKE_BODY + "%+$");
+    private static final Pattern LIKE_SUBSTRING = Pattern.compile("^%+" + LIKE_BODY + "%+$");
+
+    // Strips LIKE-layer escape sequences: \\ -> \, \% -> %, \_ -> _, \x -> x
+    private static String removeLikeEscape(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == '\\' && i + 1 < s.length()) {
+                sb.append(s.charAt(++i));
+            } else {
+                sb.append(s.charAt(i));
+            }
+        }
+        return sb.toString();
     }
 
     private boolean notAllConstant(List<ScalarOperator> operators) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
@@ -260,7 +260,7 @@ public class FoldConstantsRuleTest {
         // Non-constant text: not folded, returned as-is
         LikePredicateOperator nonConst = new LikePredicateOperator(
                 LikePredicateOperator.LikeType.LIKE,
-                new ColumnRefOperator(1, VarcharType.VARCHAR, "col", true),
+                new ColumnRefOperator(1, Type.VARCHAR, "col", true),
                 ConstantOperator.createVarchar("a\\\\b"));
         assertEquals(nonConst, rule.apply(nonConst, null));
 
@@ -385,7 +385,7 @@ public class FoldConstantsRuleTest {
         // NULL operand → NULL
         assertEquals(OB_NULL, rule.apply(new LikePredicateOperator(
                 LikePredicateOperator.LikeType.LIKE,
-                ConstantOperator.createNull(VarcharType.VARCHAR),
+                ConstantOperator.createNull(Type.VARCHAR),
                 ConstantOperator.createVarchar("abc")), null));
 
         // LIKE folding is case-sensitive (binary collation): 'ABC' LIKE 'abc' → 0

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import mockit.Expectations;
@@ -202,5 +203,195 @@ public class FoldConstantsRuleTest {
                 ConstantOperator.createInt(1), ConstantOperator.createInt(1));
         assertEquals(OB_FALSE, rule.apply(bpo10, null));
 
+    }
+
+    @Test
+    public void applyLikeFolding() {
+        // Values below are what the FE Parser produces after the first layer of string-literal
+        // escaping (AstBuilder.escapeBackSlash). Java string mapping:
+        //   SQL 'a\\b'   → Java "a\\b"  (3 chars: a, \, b)
+        //   SQL 'a\\\\b' → Java "a\\\\b" (4 chars: a, \, \, b)
+        //   SQL '100\\%' → Java "100\\%" (5 chars: 1,0,0,\,%) — Parser keeps \% intact
+        //   SQL 'a\\_b'  → Java "a\\_b"  (4 chars: a,\,_,b)   — Parser keeps \_ intact
+
+        // Bug regression: 'a\\b' LIKE 'a\\\\b' must return 1 (MySQL), was 0 before fix
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("a\\b"),
+                ConstantOperator.createVarchar("a\\\\b")), null));
+
+        // Bug regression: 'a\\b' LIKE 'a\\b' must return 0 (MySQL), was 1 before fix
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("a\\b"),
+                ConstantOperator.createVarchar("a\\b")), null));
+
+        // Escaped % as literal: '100%' LIKE '100\%' → 1 (\% matches the literal % in text)
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("100%"),
+                ConstantOperator.createVarchar("100\\%")), null));
+
+        // Escaped % must NOT act as wildcard: '100abc' LIKE '100\%' → 0
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("100abc"),
+                ConstantOperator.createVarchar("100\\%")), null));
+
+        // Plain equals (no backslash) — existing behavior preserved
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("hello"),
+                ConstantOperator.createVarchar("hello")), null));
+
+        // Plain startsWith — existing behavior preserved
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("abcdef"),
+                ConstantOperator.createVarchar("abc%")), null));
+
+        // Pattern with _ wildcard: not a fast-path pattern, returned to BE as-is
+        LikePredicateOperator withUnderscore = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("abc"),
+                ConstantOperator.createVarchar("a_c"));
+        assertEquals(withUnderscore, rule.apply(withUnderscore, null));
+
+        // Non-constant text: not folded, returned as-is
+        LikePredicateOperator nonConst = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                new ColumnRefOperator(1, VarcharType.VARCHAR, "col", true),
+                ConstantOperator.createVarchar("a\\\\b"));
+        assertEquals(nonConst, rule.apply(nonConst, null));
+
+        // endsWith path: 'xyzabc' LIKE '%abc' → 1
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("xyzabc"),
+                ConstantOperator.createVarchar("%abc")), null));
+
+        // contains path: 'xyzabcdef' LIKE '%abc%' → 1
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("xyzabcdef"),
+                ConstantOperator.createVarchar("%abc%")), null));
+
+        // Trailing lone backslash — invalid LIKE escape, not folded → return predicate
+        LikePredicateOperator trailingSlash = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("a\\"),
+                ConstantOperator.createVarchar("a\\"));
+        assertEquals(trailingSlash, rule.apply(trailingSlash, null));
+
+        // startsWith with escaped % in body: text must start with literal "a%xy"
+        // SQL pattern 'a\%xy%': Parser keeps \% → Java "a\\%xy%"; trailing % is the real wildcard
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("a%xyz"),
+                ConstantOperator.createVarchar("a\\%xy%")), null));
+
+        // \% in body is NOT a wildcard: "aXxyz" does not start with "a%xy"
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("aXxyz"),
+                ConstantOperator.createVarchar("a\\%xy%")), null));
+
+        // --- Escaped wildcard directly adjacent to a real wildcard (regression for the
+        //     stripStart/stripEnd over-strip bug; only passes with the capture-group fix) ---
+
+        // startsWith: SQL 'abc\%%' → Java "abc\\%%": literal "abc%" + trailing wildcard %.
+        // Must match text starting with "abc%".
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("abc%xyz"),
+                ConstantOperator.createVarchar("abc\\%%")), null));
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("abcXyz"),
+                ConstantOperator.createVarchar("abc\\%%")), null));
+
+        // endsWith: SQL '%\%abc' → Java "%\\%abc": leading wildcard % + literal "%abc".
+        // Must match text ending with "%abc".
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("xyz%abc"),
+                ConstantOperator.createVarchar("%\\%abc")), null));
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("xyzabc"),
+                ConstantOperator.createVarchar("%\\%abc")), null));
+
+        // contains: SQL '%a\%b%' → Java "%a\\%b%": wildcards on both ends, literal "a%b" inside.
+        // Must match text containing "a%b".
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("xa%by"),
+                ConstantOperator.createVarchar("%a\\%b%")), null));
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("xaXby"),
+                ConstantOperator.createVarchar("%a\\%b%")), null));
+
+        // --- Other escape forms ---
+
+        // Double backslash + wildcard: SQL 'a\\%' → Java "a\\\\%": literal "a\" + wildcard %.
+        // Must match text starting with "a\".
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("a\\xyz"),
+                ConstantOperator.createVarchar("a\\\\%")), null));
+
+        // Trailing escaped backslash (EQUALS): SQL 'abc\\' → Java "abc\\\\": literal "abc\".
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("abc\\"),
+                ConstantOperator.createVarchar("abc\\\\")), null));
+
+        // Escaped underscore as a literal: SQL 'a\_b' → Java "a\\_b": literal "a_b".
+        assertEquals(OB_TRUE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("a_b"),
+                ConstantOperator.createVarchar("a\\_b")), null));
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("aXb"),
+                ConstantOperator.createVarchar("a\\_b")), null));
+
+        // --- Cases that are intentionally NOT folded (returned to BE) ---
+
+        // Pure wildcards have no literal body → not folded
+        LikePredicateOperator pureWildcard = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("anything"),
+                ConstantOperator.createVarchar("%"));
+        assertEquals(pureWildcard, rule.apply(pureWildcard, null));
+
+        // Empty pattern → not folded
+        LikePredicateOperator emptyPattern = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("x"),
+                ConstantOperator.createVarchar(""));
+        assertEquals(emptyPattern, rule.apply(emptyPattern, null));
+
+        // REGEXP (not LIKE) type → not folded by this rule
+        LikePredicateOperator regexp = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.REGEXP,
+                ConstantOperator.createVarchar("abc"),
+                ConstantOperator.createVarchar("abc"));
+        assertEquals(regexp, rule.apply(regexp, null));
+
+        // --- Other correctness checks ---
+
+        // NULL operand → NULL
+        assertEquals(OB_NULL, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createNull(VarcharType.VARCHAR),
+                ConstantOperator.createVarchar("abc")), null));
+
+        // LIKE folding is case-sensitive (binary collation): 'ABC' LIKE 'abc' → 0
+        assertEquals(OB_FALSE, rule.apply(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE,
+                ConstantOperator.createVarchar("ABC"),
+                ConstantOperator.createVarchar("abc")), null));
     }
 }

--- a/test/sql/test_like_escape_backslash/R/test_like_escape_backslash
+++ b/test/sql/test_like_escape_backslash/R/test_like_escape_backslash
@@ -2,7 +2,6 @@
 DROP TABLE IF EXISTS t_like_escape;
 -- result:
 -- !result
-
 CREATE TABLE IF NOT EXISTS t_like_escape (
     c0 INT NOT NULL,
     c1 VARCHAR(200) NOT NULL
@@ -12,7 +11,6 @@ DISTRIBUTED BY HASH(c0) BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
-
 INSERT INTO t_like_escape (c0, c1) VALUES
 (1, 'abc'),
 (2, 'abc\\def'),
@@ -25,7 +23,6 @@ INSERT INTO t_like_escape (c0, c1) VALUES
 (9, 'abc_def');
 -- result:
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' ORDER BY c0;
 -- result:
 2	abc\def
@@ -34,29 +31,24 @@ SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' ORDER BY c0;
 7	test\asdf
 8	star\test
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\asdf' ORDER BY c0;
 -- result:
 6	\asdf
 7	test\asdf
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\%' ORDER BY c0;
 -- result:
 3	star\
 8	star\test
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\' ORDER BY c0;
 -- result:
 3	star\
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\%' ORDER BY c0;
 -- result:
 4	star%
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE like(c1, '%\\\\%') ORDER BY c0;
 -- result:
 2	abc\def
@@ -65,12 +57,10 @@ SELECT c0, c1 FROM t_like_escape WHERE like(c1, '%\\\\%') ORDER BY c0;
 7	test\asdf
 8	star\test
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE like(c1, 'star\\\\') ORDER BY c0;
 -- result:
 3	star\
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER BY c0;
 -- result:
 2	abc\def
@@ -81,12 +71,171 @@ SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER
 7	test\asdf
 8	star\test
 -- !result
-
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'abc\\_def' ORDER BY c0;
 -- result:
 9	abc_def
 -- !result
-
 DROP TABLE t_like_escape;
+-- result:
+-- !result
+SELECT 'a\\b' LIKE 'a\\\\b';
+-- result:
+1
+-- !result
+SELECT 'a\\b' LIKE 'a\\b';
+-- result:
+0
+-- !result
+SELECT '100%' LIKE '100\\%';
+-- result:
+1
+-- !result
+SELECT '100abc' LIKE '100\\%';
+-- result:
+0
+-- !result
+SELECT 'a_b' LIKE 'a\\_b';
+-- result:
+1
+-- !result
+SELECT 'aXb' LIKE 'a\\_b';
+-- result:
+0
+-- !result
+SELECT 'abc%xyz' LIKE 'abc\\%%';
+-- result:
+1
+-- !result
+SELECT 'abcXyz' LIKE 'abc\\%%';
+-- result:
+0
+-- !result
+SELECT 'xyz%abc' LIKE '%\\%abc';
+-- result:
+1
+-- !result
+SELECT 'xa%by' LIKE '%a\\%b%';
+-- result:
+1
+-- !result
+SELECT 'xaXby' LIKE '%a\\%b%';
+-- result:
+0
+-- !result
+SELECT 'a\\xyz' LIKE 'a\\\\%';
+-- result:
+1
+-- !result
+SELECT 'abc\\' LIKE 'abc\\\\';
+-- result:
+1
+-- !result
+SELECT 'abcdef' LIKE 'abc%';
+-- result:
+1
+-- !result
+SELECT 'xyzabc' LIKE '%abc';
+-- result:
+1
+-- !result
+SELECT 'xyzabcdef' LIKE '%abc%';
+-- result:
+1
+-- !result
+DROP TABLE IF EXISTS t_like_cmp;
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS t_like_cmp (
+    id INT NOT NULL,
+    txt VARCHAR(64) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_like_cmp (id, txt) VALUES
+(1,  'a\\b'),
+(2,  '100%'),
+(3,  '100abc'),
+(4,  'a_b'),
+(5,  'aXb'),
+(6,  'abc%xyz'),
+(7,  'abcXyz'),
+(8,  'xyz%abc'),
+(9,  'xa%by'),
+(10, 'xaXby'),
+(11, 'a\\xyz'),
+(12, 'abc\\'),
+(13, 'abcdef'),
+(14, 'xyzabc'),
+(15, 'xyzabcdef');
+-- result:
+-- !result
+SELECT ('a\\b' LIKE 'a\\\\b') AS fe_fold, (txt LIKE 'a\\\\b') AS be_exec FROM t_like_cmp WHERE id = 1;
+-- result:
+1	1
+-- !result
+SELECT ('a\\b' LIKE 'a\\b')   AS fe_fold, (txt LIKE 'a\\b')   AS be_exec FROM t_like_cmp WHERE id = 1;
+-- result:
+0	0
+-- !result
+SELECT ('100%' LIKE '100\\%')   AS fe_fold, (txt LIKE '100\\%') AS be_exec FROM t_like_cmp WHERE id = 2;
+-- result:
+1	1
+-- !result
+SELECT ('100abc' LIKE '100\\%') AS fe_fold, (txt LIKE '100\\%') AS be_exec FROM t_like_cmp WHERE id = 3;
+-- result:
+0	0
+-- !result
+SELECT ('a_b' LIKE 'a\\_b')     AS fe_fold, (txt LIKE 'a\\_b')  AS be_exec FROM t_like_cmp WHERE id = 4;
+-- result:
+1	1
+-- !result
+SELECT ('aXb' LIKE 'a\\_b')     AS fe_fold, (txt LIKE 'a\\_b')  AS be_exec FROM t_like_cmp WHERE id = 5;
+-- result:
+0	0
+-- !result
+SELECT ('abc%xyz' LIKE 'abc\\%%') AS fe_fold, (txt LIKE 'abc\\%%') AS be_exec FROM t_like_cmp WHERE id = 6;
+-- result:
+1	1
+-- !result
+SELECT ('abcXyz' LIKE 'abc\\%%')  AS fe_fold, (txt LIKE 'abc\\%%') AS be_exec FROM t_like_cmp WHERE id = 7;
+-- result:
+0	0
+-- !result
+SELECT ('xyz%abc' LIKE '%\\%abc') AS fe_fold, (txt LIKE '%\\%abc') AS be_exec FROM t_like_cmp WHERE id = 8;
+-- result:
+1	1
+-- !result
+SELECT ('xa%by' LIKE '%a\\%b%')   AS fe_fold, (txt LIKE '%a\\%b%') AS be_exec FROM t_like_cmp WHERE id = 9;
+-- result:
+1	1
+-- !result
+SELECT ('xaXby' LIKE '%a\\%b%')   AS fe_fold, (txt LIKE '%a\\%b%') AS be_exec FROM t_like_cmp WHERE id = 10;
+-- result:
+0	0
+-- !result
+SELECT ('a\\xyz' LIKE 'a\\\\%') AS fe_fold, (txt LIKE 'a\\\\%')  AS be_exec FROM t_like_cmp WHERE id = 11;
+-- result:
+1	1
+-- !result
+SELECT ('abc\\' LIKE 'abc\\\\') AS fe_fold, (txt LIKE 'abc\\\\') AS be_exec FROM t_like_cmp WHERE id = 12;
+-- result:
+1	1
+-- !result
+SELECT ('abcdef' LIKE 'abc%')    AS fe_fold, (txt LIKE 'abc%')   AS be_exec FROM t_like_cmp WHERE id = 13;
+-- result:
+1	1
+-- !result
+SELECT ('xyzabc' LIKE '%abc')    AS fe_fold, (txt LIKE '%abc')   AS be_exec FROM t_like_cmp WHERE id = 14;
+-- result:
+1	1
+-- !result
+SELECT ('xyzabcdef' LIKE '%abc%') AS fe_fold, (txt LIKE '%abc%') AS be_exec FROM t_like_cmp WHERE id = 15;
+-- result:
+1	1
+-- !result
+DROP TABLE t_like_cmp;
 -- result:
 -- !result

--- a/test/sql/test_like_escape_backslash/T/test_like_escape_backslash
+++ b/test/sql/test_like_escape_backslash/T/test_like_escape_backslash
@@ -49,3 +49,97 @@ SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'abc\\_def' ORDER BY c0;
 
 DROP TABLE t_like_escape;
+
+-- ============================================================================
+-- Constant LIKE constant: both sides literal -> folded in FE (FoldConstantsRule).
+-- These exercise the FE constant-folding path (the buggy path), unlike the column
+-- cases above which run on BE. Results must match MySQL.
+-- ============================================================================
+
+-- C1: two-layer escaping regression ('a\b' LIKE 'a\\b' -> 1 ; 'a\b' LIKE 'a\b' -> 0)
+SELECT 'a\\b' LIKE 'a\\\\b';
+SELECT 'a\\b' LIKE 'a\\b';
+
+-- C2: escaped wildcard treated as literal
+SELECT '100%' LIKE '100\\%';
+SELECT '100abc' LIKE '100\\%';
+SELECT 'a_b' LIKE 'a\\_b';
+SELECT 'aXb' LIKE 'a\\_b';
+
+-- C3: escaped wildcard directly adjacent to a real wildcard (stripEnd boundary bug)
+SELECT 'abc%xyz' LIKE 'abc\\%%';
+SELECT 'abcXyz' LIKE 'abc\\%%';
+SELECT 'xyz%abc' LIKE '%\\%abc';
+SELECT 'xa%by' LIKE '%a\\%b%';
+SELECT 'xaXby' LIKE '%a\\%b%';
+
+-- C4: double backslash + wildcard / trailing escaped backslash
+SELECT 'a\\xyz' LIKE 'a\\\\%';
+SELECT 'abc\\' LIKE 'abc\\\\';
+
+-- C5: plain prefix/suffix/substring wildcards (no escape) still fold correctly
+SELECT 'abcdef' LIKE 'abc%';
+SELECT 'xyzabc' LIKE '%abc';
+SELECT 'xyzabcdef' LIKE '%abc%';
+
+-- ============================================================================
+-- FE-vs-BE consistency: each row stores the text in a column. For every case we
+-- run the constant LIKE (folded in FE) side by side with the column LIKE (executed
+-- on BE). fe_fold and be_exec MUST be equal -- that is exactly the invariant this
+-- bug broke. The pattern stays a literal so the constant side is still folded.
+-- ============================================================================
+
+DROP TABLE IF EXISTS t_like_cmp;
+
+CREATE TABLE IF NOT EXISTS t_like_cmp (
+    id INT NOT NULL,
+    txt VARCHAR(64) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_like_cmp (id, txt) VALUES
+(1,  'a\\b'),
+(2,  '100%'),
+(3,  '100abc'),
+(4,  'a_b'),
+(5,  'aXb'),
+(6,  'abc%xyz'),
+(7,  'abcXyz'),
+(8,  'xyz%abc'),
+(9,  'xa%by'),
+(10, 'xaXby'),
+(11, 'a\\xyz'),
+(12, 'abc\\'),
+(13, 'abcdef'),
+(14, 'xyzabc'),
+(15, 'xyzabcdef');
+
+-- D1: two-layer escaping
+SELECT ('a\\b' LIKE 'a\\\\b') AS fe_fold, (txt LIKE 'a\\\\b') AS be_exec FROM t_like_cmp WHERE id = 1;
+SELECT ('a\\b' LIKE 'a\\b')   AS fe_fold, (txt LIKE 'a\\b')   AS be_exec FROM t_like_cmp WHERE id = 1;
+
+-- D2: escaped wildcard as literal
+SELECT ('100%' LIKE '100\\%')   AS fe_fold, (txt LIKE '100\\%') AS be_exec FROM t_like_cmp WHERE id = 2;
+SELECT ('100abc' LIKE '100\\%') AS fe_fold, (txt LIKE '100\\%') AS be_exec FROM t_like_cmp WHERE id = 3;
+SELECT ('a_b' LIKE 'a\\_b')     AS fe_fold, (txt LIKE 'a\\_b')  AS be_exec FROM t_like_cmp WHERE id = 4;
+SELECT ('aXb' LIKE 'a\\_b')     AS fe_fold, (txt LIKE 'a\\_b')  AS be_exec FROM t_like_cmp WHERE id = 5;
+
+-- D3: escaped wildcard adjacent to a real wildcard (the boundary bug)
+SELECT ('abc%xyz' LIKE 'abc\\%%') AS fe_fold, (txt LIKE 'abc\\%%') AS be_exec FROM t_like_cmp WHERE id = 6;
+SELECT ('abcXyz' LIKE 'abc\\%%')  AS fe_fold, (txt LIKE 'abc\\%%') AS be_exec FROM t_like_cmp WHERE id = 7;
+SELECT ('xyz%abc' LIKE '%\\%abc') AS fe_fold, (txt LIKE '%\\%abc') AS be_exec FROM t_like_cmp WHERE id = 8;
+SELECT ('xa%by' LIKE '%a\\%b%')   AS fe_fold, (txt LIKE '%a\\%b%') AS be_exec FROM t_like_cmp WHERE id = 9;
+SELECT ('xaXby' LIKE '%a\\%b%')   AS fe_fold, (txt LIKE '%a\\%b%') AS be_exec FROM t_like_cmp WHERE id = 10;
+
+-- D4: double backslash + wildcard / trailing escaped backslash
+SELECT ('a\\xyz' LIKE 'a\\\\%') AS fe_fold, (txt LIKE 'a\\\\%')  AS be_exec FROM t_like_cmp WHERE id = 11;
+SELECT ('abc\\' LIKE 'abc\\\\') AS fe_fold, (txt LIKE 'abc\\\\') AS be_exec FROM t_like_cmp WHERE id = 12;
+
+-- D5: plain wildcards
+SELECT ('abcdef' LIKE 'abc%')    AS fe_fold, (txt LIKE 'abc%')   AS be_exec FROM t_like_cmp WHERE id = 13;
+SELECT ('xyzabc' LIKE '%abc')    AS fe_fold, (txt LIKE '%abc')   AS be_exec FROM t_like_cmp WHERE id = 14;
+SELECT ('xyzabcdef' LIKE '%abc%') AS fe_fold, (txt LIKE '%abc%') AS be_exec FROM t_like_cmp WHERE id = 15;
+
+DROP TABLE t_like_cmp;


### PR DESCRIPTION
## Why I'm doing:

StarRocks is compatible with MySQL 8, but WHERE-LIKE with constant items produces different results.   
```
select 'a\\b' like 'a\\\\b';
MySQL: 1
StarRocks: 0

select 'a\\b' like 'a\\b';
MySQL: 0
StarRocks: 1
```

## What I'm doing:

Add the 2nd-layer escape operator when FE handle the WHERE-LIKE with constant items.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
