### PR TITLE
[BugFix] Render DATETIME microseconds locale-independently

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
@@ -14,7 +14,10 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.common.util.DateUtils;
+
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * The value window the meta tier accepts for DATE/DATETIME sort-key boundaries:
@@ -32,9 +35,10 @@ import java.time.LocalDate;
  * </ul>
  *
  * <p>This lives in one place — rather than being duplicated per reader like the
- * integer-stat conversion — because the constraint is format-agnostic: it operates on
- * an already-decoded {@link LocalDate}, identical whether the value came from a Parquet
- * INT32/INT64 stat or an ORC day-of-epoch stat.
+ * integer-stat conversion — because both responsibilities are format-agnostic: the
+ * window check operates on an already-decoded {@link LocalDate}, and the microsecond
+ * datetime renderer on an already-decoded {@link LocalDateTime}, identical whether the
+ * value came from a Parquet INT32/INT64 stat or an ORC day-of-epoch / timestamp stat.
  */
 final class MetaTierTemporalWindow {
 
@@ -54,5 +58,20 @@ final class MetaTierTemporalWindow {
                     "DATE/DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
                             + date + " is outside that window");
         }
+    }
+
+    /**
+     * Render a decoded UTC {@link LocalDateTime} as StarRocks canonical datetime text
+     * ("yyyy-MM-dd HH:mm:ss[.ffffff]"): second precision unless there is a sub-second part,
+     * then 6-digit microseconds. {@link DateUtils#parseStrictDateTime} round-trips both, as
+     * does the BE {@code datum_from_string} parser. Shared by the Parquet and ORC footer
+     * readers (mirrors {@code DateVariant.getStringValue}).
+     */
+    static String renderDateTime(LocalDateTime dateTime) {
+        if (dateTime.getNano() == 0) {
+            return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
+        }
+        return dateTime.format(DateUtils.DATE_TIME_FORMATTER)
+                + "." + String.format("%06d", dateTime.getNano() / 1000);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
@@ -63,15 +63,21 @@ final class MetaTierTemporalWindow {
     /**
      * Render a decoded UTC {@link LocalDateTime} as StarRocks canonical datetime text
      * ("yyyy-MM-dd HH:mm:ss[.ffffff]"): second precision unless there is a sub-second part,
-     * then 6-digit microseconds. {@link DateUtils#parseStrictDateTime} round-trips both, as
-     * does the BE {@code datum_from_string} parser. Shared by the Parquet and ORC footer
+     * then a fixed 6-digit microsecond fraction. {@link DateUtils#parseStrictDateTime} and the
+     * BE {@code datum_from_string} parser round-trip both. Shared by the Parquet and ORC footer
      * readers (mirrors {@code DateVariant.getStringValue}).
+     *
+     * <p>Both branches use the {@code %Y}-based {@code *_UNIX} formatters (the same family
+     * {@code parseStrictDateTime} uses), not the deprecated {@code yyyy} ones: a
+     * {@link java.time.format.DateTimeFormatter} renders numeric fields as ASCII via
+     * DecimalStyle.STANDARD, so the output is locale-independent — unlike {@code String.format("%06d", …)},
+     * whose digits would follow the FE JVM's default locale and emit non-ASCII digits
+     * (Arabic/Persian), breaking {@code parseStrictDateTime} / BE boundary parsing.
      */
     static String renderDateTime(LocalDateTime dateTime) {
         if (dateTime.getNano() == 0) {
-            return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
+            return dateTime.format(DateUtils.DATE_TIME_FORMATTER_UNIX);
         }
-        return dateTime.format(DateUtils.DATE_TIME_FORMATTER)
-                + "." + String.format("%06d", dateTime.getNano() / 1000);
+        return dateTime.format(DateUtils.DATE_TIME_MS_FORMATTER_UNIX);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -325,8 +325,8 @@ public final class OrcStripeStatisticsReader {
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
             MetaTierTemporalWindow.rejectDateOutsideWindow(minDateTime.toLocalDate());
             MetaTierTemporalWindow.rejectDateOutsideWindow(maxDateTime.toLocalDate());
-            minVariant = Variant.of(location.starRocksColumn.getType(), renderDateTime(minDateTime));
-            maxVariant = Variant.of(location.starRocksColumn.getType(), renderDateTime(maxDateTime));
+            minVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(minDateTime));
+            maxVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(maxDateTime));
         } catch (RuntimeException conversionFailure) {
             throw new MetaTierUnavailableException(String.format(
                     "ORC timestamp stats value not representable for sort-key column \"%s\": %s",
@@ -342,16 +342,6 @@ public final class OrcStripeStatisticsReader {
         // part correct; ofEpochSecond combines them. The window gate rejects pre-1970 / post-9999.
         long epochSecond = Math.floorDiv(utcTimestamp.getTime(), 1000L);
         return LocalDateTime.ofEpochSecond(epochSecond, utcTimestamp.getNanos(), ZoneOffset.UTC);
-    }
-
-    private static String renderDateTime(LocalDateTime dateTime) {
-        // Mirrors DateVariant.getStringValue / the Parquet reader: second precision unless there is a
-        // sub-second part, then 6-digit microseconds. parseStrictDateTime round-trips both.
-        if (dateTime.getNano() == 0) {
-            return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
-        }
-        return dateTime.format(DateUtils.DATE_TIME_FORMATTER)
-                + "." + String.format("%06d", dateTime.getNano() / 1000);
     }
 
     private record SortKeyLocation(int columnId, Column starRocksColumn) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -260,8 +260,8 @@ public final class OrcStripeStatisticsReader {
             // uncaught exception that would skip pre-split entirely.
             MetaTierTemporalWindow.rejectDateOutsideWindow(minDate);
             MetaTierTemporalWindow.rejectDateOutsideWindow(maxDate);
-            minVariant = Variant.of(location.starRocksColumn.getType(), minDate.format(DateUtils.DATE_FORMATTER));
-            maxVariant = Variant.of(location.starRocksColumn.getType(), maxDate.format(DateUtils.DATE_FORMATTER));
+            minVariant = Variant.of(location.starRocksColumn.getType(), minDate.format(DateUtils.DATE_FORMATTER_UNIX));
+            maxVariant = Variant.of(location.starRocksColumn.getType(), maxDate.format(DateUtils.DATE_FORMATTER_UNIX));
         } catch (RuntimeException conversionFailure) {
             throw new MetaTierUnavailableException(String.format(
                     "ORC date stats value not representable for sort-key column \"%s\": %s",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -295,7 +295,7 @@ public final class ParquetRowGroupStatisticsReader {
             // INT32 days since 1970-01-01 → canonical "yyyy-MM-dd".
             LocalDate date = LocalDate.ofEpochDay(((Number) parquetValue).longValue());
             MetaTierTemporalWindow.rejectDateOutsideWindow(date);
-            return Variant.of(location.starRocksColumn.getType(), date.format(DateUtils.DATE_FORMATTER));
+            return Variant.of(location.starRocksColumn.getType(), date.format(DateUtils.DATE_FORMATTER_UNIX));
         }
         if (location.logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
             long ticks = ((Number) parquetValue).longValue();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -304,7 +304,7 @@ public final class ParquetRowGroupStatisticsReader {
             // rejected here, which also keeps the floorDiv/floorMod conversion above in the range
             // where it is provably identical to BE's signed division.
             MetaTierTemporalWindow.rejectDateOutsideWindow(dateTime.toLocalDate());
-            return Variant.of(location.starRocksColumn.getType(), renderDateTime(dateTime));
+            return Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(dateTime));
         }
         if (location.logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation) {
             // Reconstruct the signed unscaled integer at the source scale; the exact precision/scale
@@ -349,16 +349,6 @@ public final class ParquetRowGroupStatisticsReader {
         long epochSecond = Math.floorDiv(ticks, ticksPerSecond);
         long nanoOfSecond = Math.floorMod(ticks, ticksPerSecond) * nanosPerTick;
         return LocalDateTime.ofEpochSecond(epochSecond, (int) nanoOfSecond, ZoneOffset.UTC);
-    }
-
-    private static String renderDateTime(LocalDateTime dateTime) {
-        // Mirrors DateVariant.getStringValue: second precision unless there is a
-        // sub-second part, then 6-digit microseconds. parseStrictDateTime round-trips both.
-        if (dateTime.getNano() == 0) {
-            return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
-        }
-        return dateTime.format(DateUtils.DATE_TIME_FORMATTER)
-                + "." + String.format("%06d", dateTime.getNano() / 1000);
     }
 
     private static ColumnChunkMetaData findColumnChunk(BlockMetaData block, ColumnPath path) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
@@ -61,12 +61,16 @@ public class DateVariant extends Variant {
         LocalDateTime dateTime = LocalDateTime.ofEpochSecond(seconds, (int) nanos, ZoneOffset.UTC);
         switch (type.getPrimitiveType()) {
             case DATE:
-                return dateTime.format(DateUtils.DATE_FORMATTER);
+                return dateTime.format(DateUtils.DATE_FORMATTER_UNIX);
             case DATETIME:
+                // Render via the %Y-based *_UNIX DateTimeFormatters (the family parseStrictDateTime
+                // uses), whose digits are ASCII through DecimalStyle.STANDARD. String.format("%06d", ...)
+                // for the microsecond fraction would instead follow the JVM default locale and emit
+                // non-ASCII digits (Arabic/Persian), which datum_from_string then rejects.
                 if (nanos == 0) {
-                    return dateTime.format(DateUtils.DATE_TIME_FORMATTER);
+                    return dateTime.format(DateUtils.DATE_TIME_FORMATTER_UNIX);
                 }
-                return dateTime.format(DateUtils.DATE_TIME_FORMATTER) + "." + String.format("%06d", nanos / 1000);
+                return dateTime.format(DateUtils.DATE_TIME_MS_FORMATTER_UNIX);
             default:
                 return Instant.ofEpochSecond(seconds, nanos).toString();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+
+public class MetaTierTemporalWindowTest {
+
+    // A locale that pins the Arabic-Indic numbering system (-u-nu-arab) so locale-sensitive
+    // number formatting would emit non-ASCII digits regardless of the JDK locale provider's
+    // default for ar-SA. Proves the rendered microsecond fraction is ASCII no matter the JVM
+    // default locale.
+    private static final Locale ARABIC = Locale.forLanguageTag("ar-SA-u-nu-arab");
+
+    @Test
+    public void renderDateTimeUsesAsciiDigitsUnderNonAsciiLocale() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(ARABIC);
+            LocalDateTime withMicros = LocalDateTime.ofEpochSecond(1, 500123000, ZoneOffset.UTC);
+            Assertions.assertEquals("1970-01-01 00:00:01.500123",
+                    MetaTierTemporalWindow.renderDateTime(withMicros));
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
+    public void renderDateTimeKeepsFixedSixDigitFraction() {
+        // The fraction is always 6 digits and trailing zeros are NOT trimmed, matching the
+        // boundary text the BE load stores: 500000 us must render ".500000", not ".5".
+        LocalDateTime trailingZeros = LocalDateTime.ofEpochSecond(1, 500_000_000, ZoneOffset.UTC);
+        Assertions.assertEquals("1970-01-01 00:00:01.500000",
+                MetaTierTemporalWindow.renderDateTime(trailingZeros));
+    }
+
+    @Test
+    public void renderDateTimeOmitsFractionWhenNoSubSecond() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(ARABIC);
+            LocalDateTime wholeSecond = LocalDateTime.ofEpochSecond(1, 0, ZoneOffset.UTC);
+            Assertions.assertEquals("1970-01-01 00:00:01",
+                    MetaTierTemporalWindow.renderDateTime(wholeSecond));
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -45,6 +45,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class VariantTest {
 
@@ -425,6 +426,18 @@ public class VariantTest {
     public void testDateTimeStringValueKeepsMicros() {
         Variant v = new DateVariant(DateType.DATETIME, Instant.ofEpochSecond(0, 123456000));
         Assertions.assertEquals("1970-01-01 00:00:00.123456", v.getStringValue());
+    }
+
+    @Test
+    public void testDateTimeStringValueIsLocaleIndependent() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("ar-SA-u-nu-arab"));
+            Variant v = new DateVariant(DateType.DATETIME, Instant.ofEpochSecond(0, 123456000));
+            Assertions.assertEquals("1970-01-01 00:00:00.123456", v.getStringValue());
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The DATETIME canonical text renders its sub-second microsecond component with `String.format("%06d", micros)`, which honors the JVM default locale's digit set. On an FE JVM whose default locale uses non-ASCII digits (e.g. Arabic/Persian), the canonical text becomes e.g. `1970-01-01 00:00:01.٥٠٠١٢٣` instead of `1970-01-01 00:00:01.500123`. `DateUtils.parseStrictDateTime` and the BE `datum_from_string` parser then reject the value, so a date/datetime sort-key boundary fails to parse and the split is silently skipped. Under a normal ROOT/en default locale the output is byte-identical, so the defect is locale-latent.

The same locale-sensitive `String.format("%06d", ...)` appeared at three render sites: the canonical `DateVariant.getStringValue()` and a byte-identical private `renderDateTime` duplicated in both the Parquet and ORC footer readers.

## What I'm doing:

Two commits:

1. `[Refactor]` Extract the two footer readers' byte-identical private `renderDateTime(LocalDateTime)` into a single package-private `static MetaTierTemporalWindow.renderDateTime` (same `com.starrocks.alter.reshard.presplit` package; already the readers' shared temporal helper) and delegate. Pure move, zero behavior change.
2. `[BugFix]` Render the touched DATE/DATETIME boundary path via the `%Y`-based `*_UNIX` `DateTimeFormatter`s (`DATE_FORMATTER_UNIX`, `DATE_TIME_FORMATTER_UNIX`, `DATE_TIME_MS_FORMATTER_UNIX`) — the same family `parseStrictDateTime` already uses. Their numeric fields render as ASCII via `DecimalStyle.STANDARD`, so the output is locale-independent **without** any `String.format`.

### Why the `*_UNIX` formatters (not `Locale.ROOT` on `String.format`)

- A `java.time.format.DateTimeFormatter` renders numeric fields with `DecimalStyle.STANDARD` (ASCII digits) regardless of the JVM default locale — so moving the microsecond fraction onto `DATE_TIME_MS_FORMATTER_UNIX` removes the locale footgun at the root rather than patching each `String.format` with `Locale.ROOT`.
- It also reuses the existing canonical formatter (`ConstantOperator` / `FeExecuteCoordinator` already render datetime-with-micros this way) and keeps the two renderers independent across packages (no `catalog`↔`presplit` coupling) — they each call the shared `DateUtils` layer they already depend on.
- It additionally retires the deprecated `yyyy`-based `DATE_FORMATTER` / `DATE_TIME_FORMATTER` from these sites. Those are `@Deprecated` because the year-of-era `yyyy` mis-renders year 0000; the `%Y`-based `*_UNIX` formatters render the proleptic year (matching the parser).

Output is **byte-identical for all in-range values** (verified, including trailing-zero microseconds e.g. `.500000`, and the `nano == 0` no-fraction branch). The fixed 6-digit microsecond width is preserved (`%f` resolves to a fixed-width fraction in output mode).

`DateVariant`'s `DATE` and `DATETIME` branches both move to the `*_UNIX` family; the `TIME`/default branch (ISO `Instant.toString()`) is unchanged.

### Tests

- New `MetaTierTemporalWindowTest`: forces a non-ASCII-digit locale (`Locale.forLanguageTag("ar-SA-u-nu-arab")`, which pins the Arabic-Indic numbering system) and asserts `renderDateTime` returns ASCII `1970-01-01 00:00:01.500123`; also covers the fixed-6-digit fraction (`.500000`, not `.5`) and the `nano == 0` (no-fraction) branch. Restores the prior locale in `finally`.
- `VariantTest.testDateTimeStringValueIsLocaleIndependent`: same forced-locale assertion for the public canonical site `DateVariant.getStringValue()`.
- Existing footer-reader micro/timestamp/date tests and the existing `VariantTest` DATE/DATETIME tests serve as byte-equivalence regression guards (209 tests green across the touched classes).

No TSP/cluster e2e: the defect only manifests when the FE JVM default locale uses non-ASCII digits (ar/fa), which a TSP cluster cannot reproduce; the forced-locale unit tests are the authoritative verification.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5