### PR TITLE
[BugFix] Zero-extend unsigned INT32 parquet values on load

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <memory>
 #include <sstream>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -126,15 +127,21 @@ private:
     int64_t _scale_to_nano_factor = 0;
 };
 
-template <typename SourceType, typename DestType>
+template <typename SourceType, typename DestType, bool kSourceUnsigned = false>
 void convert_int_to_int(const SourceType* __restrict__ src, DestType* __restrict__ dst, size_t size) {
     for (size_t i = 0; i < size; i++) {
-        dst[i] = DestType(src[i]);
+        if constexpr (kSourceUnsigned && std::is_integral_v<SourceType>) {
+            // Reinterpret the source through its unsigned bit pattern before widening so a
+            // high-bit unsigned value is zero-extended instead of sign-extended.
+            dst[i] = DestType(static_cast<std::make_unsigned_t<SourceType>>(src[i]));
+        } else {
+            dst[i] = DestType(src[i]);
+        }
     }
 }
 
 // Support int => int and float => double
-template <typename SourceType, typename DestType>
+template <typename SourceType, typename DestType, bool kSourceUnsigned = false>
 class NumericToNumericConverter final : public ColumnConverter {
 public:
     NumericToNumericConverter() = default;
@@ -159,13 +166,13 @@ public:
 
         size_t size = dst_null_data.size();
         memcpy(dst_null_data.data(), src_null_data.data(), size);
-        convert_int_to_int<SourceType, DestType>(src_data.data(), dst_data.data(), size);
+        convert_int_to_int<SourceType, DestType, kSourceUnsigned>(src_data.data(), dst_data.data(), size);
         dst_nullable_column->set_has_null(src_nullable_column->has_null());
         return Status::OK();
     }
 };
 
-template <typename SourceType, LogicalType DestType>
+template <typename SourceType, LogicalType DestType, bool kSourceUnsigned = false>
 class PrimitiveToDecimalConverter final : public ColumnConverter {
 public:
     using DestDecimalType = typename RunTimeTypeTraits<DestType>::CppType;
@@ -206,7 +213,14 @@ public:
                 has_null = true;
                 continue;
             }
-            DestPrimitiveType value = src_data[i];
+            DestPrimitiveType value;
+            if constexpr (kSourceUnsigned && std::is_integral_v<SourceType>) {
+                // Reinterpret the source through its unsigned bit pattern so a high-bit
+                // unsigned value is zero-extended instead of sign-extended.
+                value = static_cast<std::make_unsigned_t<SourceType>>(src_data[i]);
+            } else {
+                value = src_data[i];
+            }
             if (_scale_type == DecimalScaleType::kScaleUp) {
                 value *= _scale_factor;
             } else if (_scale_type == DecimalScaleType::kScaleDown) {
@@ -428,6 +442,23 @@ Status FixedLenByteArrayToUUIDConverter::convert(const Column* src, Column* dst)
     return Status::OK();
 }
 
+template <typename DestType>
+static std::unique_ptr<ColumnConverter> make_int32_numeric_converter(bool src_unsigned) {
+    if (src_unsigned) {
+        return std::make_unique<NumericToNumericConverter<int32_t, DestType, true>>();
+    }
+    return std::make_unique<NumericToNumericConverter<int32_t, DestType, false>>();
+}
+
+template <LogicalType DestType>
+static std::unique_ptr<ColumnConverter> make_int32_decimal_converter(bool src_unsigned, int32_t src_scale,
+                                                                     int32_t dst_scale) {
+    if (src_unsigned) {
+        return std::make_unique<PrimitiveToDecimalConverter<int32_t, DestType, true>>(src_scale, dst_scale);
+    }
+    return std::make_unique<PrimitiveToDecimalConverter<int32_t, DestType, false>>(src_scale, dst_scale);
+}
+
 Status ColumnConverterFactory::create_converter(const ParquetField& field, const TypeDescriptor& typeDescriptor,
                                                 const std::string& timezone,
                                                 std::unique_ptr<ColumnConverter>* converter) {
@@ -448,21 +479,22 @@ Status ColumnConverterFactory::create_converter(const ParquetField& field, const
         break;
     }
     case tparquet::Type::type::INT32: {
+        const bool src_unsigned = is_unsigned_integer(schema_element);
         if (col_type != LogicalType::TYPE_INT) {
             need_convert = true;
         }
         switch (col_type) {
         case LogicalType::TYPE_TINYINT:
-            *converter = std::make_unique<NumericToNumericConverter<int32_t, int8_t>>();
+            *converter = make_int32_numeric_converter<int8_t>(src_unsigned);
             break;
         case LogicalType::TYPE_SMALLINT:
-            *converter = std::make_unique<NumericToNumericConverter<int32_t, int16_t>>();
+            *converter = make_int32_numeric_converter<int16_t>(src_unsigned);
             break;
         case LogicalType::TYPE_BIGINT:
-            *converter = std::make_unique<NumericToNumericConverter<int32_t, int64_t>>();
+            *converter = make_int32_numeric_converter<int64_t>(src_unsigned);
             break;
         case LogicalType::TYPE_DOUBLE:
-            *converter = std::make_unique<NumericToNumericConverter<int32_t, double>>();
+            *converter = make_int32_numeric_converter<double>(src_unsigned);
             break;
         case LogicalType::TYPE_TIME:
             *converter = std::make_unique<Int32ToTimeConverter>();
@@ -478,19 +510,16 @@ Status ColumnConverterFactory::create_converter(const ParquetField& field, const
             // rejection
         case LogicalType::TYPE_DECIMALV2:
             // All DecimalV2 use scale 9 as scale
-            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMALV2>>(field.scale, 9);
+            *converter = make_int32_decimal_converter<TYPE_DECIMALV2>(src_unsigned, field.scale, 9);
             break;
         case LogicalType::TYPE_DECIMAL32:
-            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL32>>(field.scale,
-                                                                                                typeDescriptor.scale);
+            *converter = make_int32_decimal_converter<TYPE_DECIMAL32>(src_unsigned, field.scale, typeDescriptor.scale);
             break;
         case LogicalType::TYPE_DECIMAL64:
-            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL64>>(field.scale,
-                                                                                                typeDescriptor.scale);
+            *converter = make_int32_decimal_converter<TYPE_DECIMAL64>(src_unsigned, field.scale, typeDescriptor.scale);
             break;
         case LogicalType::TYPE_DECIMAL128:
-            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL128>>(field.scale,
-                                                                                                 typeDescriptor.scale);
+            *converter = make_int32_decimal_converter<TYPE_DECIMAL128>(src_unsigned, field.scale, typeDescriptor.scale);
             break;
         default:
             break;

--- a/be/src/formats/parquet/statistics_helper.cpp
+++ b/be/src/formats/parquet/statistics_helper.cpp
@@ -175,6 +175,13 @@ Status StatisticsHelper::get_min_max_value(const FileMetaData* file_metadata, co
 
     DCHECK_EQ(field->physical_type, column_meta->type);
     auto sort_order = sort_order_of_logical_type(type.type);
+    // A Parquet unsigned integer is compared with unsigned ordering, but its StarRocks
+    // destination type (e.g. BIGINT) is signed. Derive the order from the Parquet
+    // annotation so legacy footer stats written with signed ordering are rejected
+    // instead of being trusted and decoded as unsigned (which could invert min/max).
+    if (is_unsigned_integer(field->schema_element)) {
+        sort_order = SortOrder::UNSIGNED;
+    }
 
     if (!has_correct_min_max_stats(file_metadata, *column_meta, sort_order)) {
         return Status::Aborted("The file has incorrect order");

--- a/be/src/formats/parquet/utils.cpp
+++ b/be/src/formats/parquet/utils.cpp
@@ -411,4 +411,26 @@ TypeDescriptor variant_typed_desc_from_parquet_field(const ParquetField* field) 
     return k_variant_type;
 }
 
+bool is_unsigned_integer(const tparquet::SchemaElement& schema_element) {
+    // The modern logical type is authoritative when present, and only the INTEGER
+    // logical type carries signedness; any other logical type is therefore not an
+    // unsigned integer. Only fall back to the legacy converted type when no logical
+    // type is set, so a contradictory UINT_* converted type cannot override it.
+    if (schema_element.__isset.logicalType) {
+        return schema_element.logicalType.__isset.INTEGER && !schema_element.logicalType.INTEGER.isSigned;
+    }
+    if (schema_element.__isset.converted_type) {
+        switch (schema_element.converted_type) {
+        case tparquet::ConvertedType::UINT_8:
+        case tparquet::ConvertedType::UINT_16:
+        case tparquet::ConvertedType::UINT_32:
+        case tparquet::ConvertedType::UINT_64:
+            return true;
+        default:
+            return false;
+        }
+    }
+    return false;
+}
+
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/utils.h
+++ b/be/src/formats/parquet/utils.h
@@ -77,6 +77,12 @@ private:
 // This function always returns a concrete descriptor and never TYPE_UNKNOWN.
 TypeDescriptor variant_typed_desc_from_parquet_field(const ParquetField* field);
 
+// Returns true when the Parquet schema annotates this column as an unsigned integer:
+// a modern logical INTEGER with isSigned=false, or a legacy UINT_* converted type.
+// Used both to zero-extend unsigned INT32 values on load and to derive the unsigned
+// statistics sort order so signed-ordered legacy footer stats are not trusted.
+bool is_unsigned_integer(const tparquet::SchemaElement& schema_element);
+
 struct NullInfos {
     // The number of nulls contained in the null vector.
     size_t num_nulls{};

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -19,11 +19,15 @@
 #include <filesystem>
 
 #include "column/binary_column.h"
+#include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
 #include "common/config_exec_fwd.h"
 #include "formats/parquet/encoding_dict.h"
 #include "formats/parquet/encoding_plain.h"
 #include "formats/parquet/file_reader.h"
+#include "formats/parquet/metadata.h"
+#include "formats/parquet/statistics_helper.h"
 #include "fs/fs.h"
 #include "parquet_test_util/util.h"
 #include "runtime/descriptor_helper.h"
@@ -586,6 +590,161 @@ TEST_F(ColumnConverterTest, BooleanTest) {
             check(file_path, col_type, col_name, "[1]", expected_rows, true);
         }
     }
+}
+
+// Regression test for unsigned 32-bit integers physically stored as parquet INT32.
+// A UINT_32 column (logical INTEGER bitWidth=32 isSigned=false, or the legacy
+// UINT_32 converted type) must be loaded into a wider StarRocks column by
+// ZERO-extending the raw 32 bits, not sign-extending. Before the fix the high-bit
+// value 3000000000 (0xB2D05E00) was sign-extended to -1294967296 -> silent
+// data corruption.
+TEST_F(ColumnConverterTest, UnsignedInt32ZeroExtend) {
+    // 3000000000 has bit 31 set; its int32 reinterpretation is negative.
+    const int32_t kHighBits = static_cast<int32_t>(3000000000u); // == -1294967296
+    const int64_t kExpectedUnsigned = 3000000000LL;
+
+    auto make_src = [](int32_t bits) {
+        auto data = FixedLengthColumn<int32_t>::create();
+        data->get_data().push_back(bits);
+        auto nulls = NullColumn::create();
+        nulls->get_data().push_back(0);
+        return NullableColumn::create(std::move(data), std::move(nulls));
+    };
+
+    // use_logical_type selects logicalType.INTEGER vs the legacy converted_type encoding.
+    auto make_field = [](bool use_logical_type, bool is_signed) {
+        ParquetField field;
+        field.scale = 0;
+        field.precision = 0;
+        field.physical_type = tparquet::Type::INT32;
+        if (use_logical_type) {
+            field.schema_element.__isset.logicalType = true;
+            field.schema_element.logicalType.__isset.INTEGER = true;
+            field.schema_element.logicalType.INTEGER.bitWidth = 32;
+            field.schema_element.logicalType.INTEGER.isSigned = is_signed;
+        } else {
+            field.schema_element.__isset.converted_type = true;
+            field.schema_element.converted_type =
+                    is_signed ? tparquet::ConvertedType::INT_32 : tparquet::ConvertedType::UINT_32;
+        }
+        return field;
+    };
+
+    auto run_bigint = [&](const ParquetField& field) -> int64_t {
+        const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
+        std::unique_ptr<ColumnConverter> converter;
+        Status st = ColumnConverterFactory::create_converter(field, col_type, "UTC", &converter);
+        EXPECT_TRUE(st.ok()) << st.message();
+        auto src = make_src(kHighBits);
+        auto dst = ColumnHelper::create_column(col_type, true);
+        st = converter->convert(src.get(), dst.get());
+        EXPECT_TRUE(st.ok()) << st.message();
+        auto* dst_nullable = down_cast<NullableColumn*>(dst.get());
+        auto* dst_data = down_cast<FixedLengthColumn<int64_t>*>(dst_nullable->data_column_raw_ptr());
+        return dst_data->get_data()[0];
+    };
+
+    // UINT_32 via modern logical type -> BIGINT must zero-extend.
+    EXPECT_EQ(kExpectedUnsigned, run_bigint(make_field(/*use_logical_type=*/true, /*is_signed=*/false)));
+    // UINT_32 via legacy converted type -> BIGINT must zero-extend.
+    EXPECT_EQ(kExpectedUnsigned, run_bigint(make_field(/*use_logical_type=*/false, /*is_signed=*/false)));
+    // Signed INT_32 with the same bits must still sign-extend (no regression).
+    EXPECT_EQ(static_cast<int64_t>(kHighBits), run_bigint(make_field(/*use_logical_type=*/true, /*is_signed=*/true)));
+
+    // A present-but-non-INTEGER logical type takes precedence over a contradictory
+    // legacy UINT_32 converted type: the column must NOT be treated as unsigned.
+    {
+        ParquetField field;
+        field.scale = 0;
+        field.precision = 0;
+        field.physical_type = tparquet::Type::INT32;
+        field.schema_element.__isset.logicalType = true; // present, but INTEGER not set
+        field.schema_element.__isset.converted_type = true;
+        field.schema_element.converted_type = tparquet::ConvertedType::UINT_32;
+        EXPECT_EQ(static_cast<int64_t>(kHighBits), run_bigint(field));
+    }
+
+    // UINT_32 -> DOUBLE must also widen via the unsigned value.
+    {
+        const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DOUBLE);
+        ParquetField field = make_field(/*use_logical_type=*/false, /*is_signed=*/false);
+        std::unique_ptr<ColumnConverter> converter;
+        Status st = ColumnConverterFactory::create_converter(field, col_type, "UTC", &converter);
+        EXPECT_TRUE(st.ok()) << st.message();
+        auto src = make_src(kHighBits);
+        auto dst = ColumnHelper::create_column(col_type, true);
+        st = converter->convert(src.get(), dst.get());
+        EXPECT_TRUE(st.ok()) << st.message();
+        auto* dst_nullable = down_cast<NullableColumn*>(dst.get());
+        auto* dst_data = down_cast<FixedLengthColumn<double>*>(dst_nullable->data_column_raw_ptr());
+        EXPECT_DOUBLE_EQ(static_cast<double>(kExpectedUnsigned), dst_data->get_data()[0]);
+    }
+
+    // UINT_32 -> DECIMAL128(38,0) must zero-extend the unscaled value.
+    {
+        const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DECIMAL128, -1, 38, 0);
+        ParquetField field = make_field(/*use_logical_type=*/false, /*is_signed=*/false);
+        field.precision = 38;
+        std::unique_ptr<ColumnConverter> converter;
+        Status st = ColumnConverterFactory::create_converter(field, col_type, "UTC", &converter);
+        EXPECT_TRUE(st.ok()) << st.message();
+        auto src = make_src(kHighBits);
+        auto dst = ColumnHelper::create_column(col_type, true);
+        st = converter->convert(src.get(), dst.get());
+        EXPECT_TRUE(st.ok()) << st.message();
+        auto* dst_nullable = down_cast<NullableColumn*>(dst.get());
+        auto* dst_data = down_cast<Decimal128Column*>(dst_nullable->data_column_raw_ptr());
+        EXPECT_EQ(kExpectedUnsigned, static_cast<int64_t>(dst_data->get_data()[0]));
+    }
+}
+
+// Footer-statistics counterpart of the zero-extension fix. The converter is shared
+// with statistics decoding, so an unsigned INT32 column's min/max must be validated
+// with UNSIGNED Parquet sort order. Pre-1.10 parquet-mr writers stored the deprecated
+// min/max with SIGNED ordering, which would invert once decoded as unsigned, so those
+// legacy stats must be rejected for an unsigned column instead of trusted.
+TEST_F(ColumnConverterTest, UnsignedInt32StatsRejectsLegacySignedOrder) {
+    // Old parquet-mr writer (< 1.10.0): deprecated min/max are signed-ordered.
+    tparquet::FileMetaData t_meta;
+    t_meta.__set_version(1);
+    t_meta.__set_num_rows(2);
+    t_meta.__set_created_by("parquet-mr version 1.0.0 (build test)");
+    tparquet::SchemaElement root_sch;
+    root_sch.__set_name("schema");
+    root_sch.__set_num_children(1);
+    tparquet::SchemaElement leaf_sch;
+    leaf_sch.__set_name("u");
+    leaf_sch.__set_type(tparquet::Type::INT32);
+    t_meta.__set_schema({root_sch, leaf_sch});
+    FileMetaData file_meta;
+    ASSERT_TRUE(file_meta.init(t_meta, false).ok());
+
+    // Deprecated min/max present and differing (raw little-endian int32 bytes 1 and 2).
+    tparquet::ColumnMetaData column_meta;
+    column_meta.__set_type(tparquet::Type::INT32);
+    tparquet::Statistics stats;
+    stats.__set_min(std::string("\x01\x00\x00\x00", 4));
+    stats.__set_max(std::string("\x02\x00\x00\x00", 4));
+    column_meta.__set_statistics(stats);
+
+    const TypeDescriptor bigint = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
+
+    auto eval = [&](bool is_signed) {
+        ParquetField field;
+        field.physical_type = tparquet::Type::INT32;
+        field.schema_element.__isset.logicalType = true;
+        field.schema_element.logicalType.__isset.INTEGER = true;
+        field.schema_element.logicalType.INTEGER.bitWidth = 32;
+        field.schema_element.logicalType.INTEGER.isSigned = is_signed;
+        std::vector<std::string> mins;
+        std::vector<std::string> maxs;
+        return StatisticsHelper::get_min_max_value(&file_meta, bigint, &column_meta, &field, mins, maxs);
+    };
+
+    // Unsigned column -> UNSIGNED sort order -> legacy signed-ordered stats are rejected.
+    EXPECT_FALSE(eval(/*is_signed=*/false).ok());
+    // Signed column -> SIGNED sort order -> legacy stats are accepted (no regression).
+    EXPECT_TRUE(eval(/*is_signed=*/true).ok());
 }
 
 TEST_F(ColumnConverterTest, Int64_2_Timestamp) {


### PR DESCRIPTION
## Why I'm doing:

When the BE loads a Parquet column physically stored as `INT32` but annotated as an **unsigned** integer (`UINT_32` / logical `INTEGER` `bitWidth=32 isSigned=false`), it widened the value into a wider StarRocks column by **sign-extending** the signed `int32` source. A high-bit value such as `3000000000` (`0xB2D05E00`) was therefore silently stored as the negative value `-1294967296` — silent data corruption.

`be/src/formats/parquet/utils.cpp` already infers the correct destination type (UINT_32 → `BIGINT`, which can hold the full unsigned range); the bug was purely in value conversion. The converter selection in `ColumnConverterFactory::create_converter` branched only on the physical type (`INT32`) and destination type, never on the unsigned annotation, and `convert_int_to_int` widened with `DestType(src[i])` (i.e. `int64_t(int32_t)`), which sign-extends.

This is a long-standing bug, present since the converter was introduced; it affects `main`, 4.1, 4.0 and 3.5.

## What I'm doing:

For an **unsigned** `INT32` source, reinterpret each element through its unsigned bit pattern before widening — `static_cast<DestType>(static_cast<std::make_unsigned_t<SourceType>>(src[i]))` — so `3000000000` loads as `3000000000` instead of `-1294967296`. The source column stays materialized as the signed `FixedLengthColumn<int32_t>`; only the widening step changes.

- The unsigned decision is read from the Parquet schema element already available in `create_converter`, so the factory signature is unchanged. The predicate `is_unsigned_integer()` (logical `INTEGER.isSigned` when a logical type is present, else legacy `UINT_*` converted type) is promoted to a shared helper in `formats/parquet/utils.{h,cpp}`.
- Zero-extension is applied via a defaulted `kSourceUnsigned` template parameter on the two converters that widen an `INT32` source: `NumericToNumericConverter` (TINYINT/SMALLINT/BIGINT/DOUBLE) and `PrimitiveToDecimalConverter` (DECIMALV2/32/64/128). The branch is `if constexpr`, so there is no per-row runtime cost; signed sources, the `INT64` branch and the `FLOAT`→`DOUBLE` path are unchanged.
- The same converter is used by `StatisticsHelper` to decode footer min/max. To keep statistics consistent with the corrected decode, `get_min_max_value` now derives the statistics sort order from the Parquet annotation (`SortOrder::UNSIGNED` for unsigned integers) instead of the signed StarRocks destination type. This makes legacy (pre-1.10 parquet-mr) signed-ordered deprecated `min`/`max` be **rejected** for unsigned columns rather than trusted and zero-extended into inverted bounds; modern unsigned-ordered `min_value`/`max_value` are accepted and decoded correctly. (Incidentally, footer min/max for unsigned INT32 columns now decode correctly.)

**Behavior change:** This corrects a wrong result (high-bit `UINT_32` values were a bug), so behavior change is marked **No** per the project rubric. Reviewers should be aware that high-bit `UINT_32` values now load as the correct positive value instead of the previous (buggy) negative value.

**Scope / limitations (existing semantics, unchanged):**
- `UINT_64` (and `INTEGER bitWidth=64 isSigned=false`) is out of scope — it maps to a `VARIANT` fallback for schema inference and is not loaded as a plain integer; the `INT64` branch is untouched.
- User-declared narrower destinations (e.g. `UINT_32` → `INT`/`TINYINT`) keep existing overflow/narrowing semantics — this fix only guarantees correct *unsigned decode*; a value that cannot be represented in a too-narrow declared type still overflows as before.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

> Note for maintainers: this is an old bug present on 4.0 and 3.5 as well. I set 4.1 to match the related work line; please advise if you want it also backported to 4.0/3.5.

Tested with BE unit tests (`ColumnConverterTest.UnsignedInt32ZeroExtend` covers BIGINT/DOUBLE/DECIMAL zero-extension across both the logical-type and legacy converted-type encodings, signed non-regression, and logical-type precedence; `ColumnConverterTest.UnsignedInt32StatsRejectsLegacySignedOrder` covers the statistics sort-order rejection) plus a broader parquet reader/stats/metadata regression (208 tests pass).
