### PR TITLE
[Enhancement] Optimize segment dictionary lookup for large IN predicate rewriting

### DIFF
--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -214,11 +214,7 @@ StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewri
     if (PredicateType::kInList == pred->type()) {
         std::vector<Datum> values = pred->values();
         std::vector<int> codewords;
-        for (const auto& value : values) {
-            if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
-                codewords.emplace_back(code);
-            }
-        }
+        _column_iterators[cid]->dict_lookup_batch(values, &codewords);
         if (codewords.empty()) {
             return RewriteStatus::ALWAYS_FALSE;
         }
@@ -234,11 +230,7 @@ StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewri
     if (PredicateType::kNotInList == pred->type()) {
         std::vector<Datum> values = pred->values();
         std::vector<int> codewords;
-        for (const auto& value : values) {
-            if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
-                codewords.emplace_back(code);
-            }
-        }
+        _column_iterators[cid]->dict_lookup_batch(values, &codewords);
         if (codewords.empty()) {
             if (!field->is_nullable()) {
                 return RewriteStatus::ALWAYS_TRUE;

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -56,6 +56,7 @@ class IndexDeltaGroupLoader;
 class Column;
 class ColumnAccessPath;
 class ColumnPredicate;
+class Datum;
 
 class ColumnReader;
 class RandomAccessFile;
@@ -206,6 +207,11 @@ public:
     // otherwise -1 is returned.
     // NOTE: this method can be invoked only if `all_page_dict_encoded` returns true.
     virtual int dict_lookup(const Slice& word) { return -1; }
+
+    // Batch variant of dict_lookup: for each word in |words|, append its dictionary code to
+    // |codes| if found. Codes for missing words are silently omitted.
+    // NOTE: this method can be invoked only if `all_page_dict_encoded` returns true.
+    virtual void dict_lookup_batch(const std::vector<Datum>& words, std::vector<int>* codes) {}
 
     // like `next_batch` but instead of return a batch of column values, this method returns a
     // batch of dictionary codes for dictionary encoded values.

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -34,8 +34,13 @@
 
 #include "storage/rowset/scalar_column_iterator.h"
 
+#include <algorithm>
+
 #include "base/bit/bitmap.h"
+#include "base/hash/hash.h"
+#include "base/phmap/phmap.h"
 #include "cache/mem_cache/page_handle_fwd.h"
+#include "column/column_hash.h"
 #include "common/config_rowset_fwd.h"
 #include "common/config_scan_io_fwd.h"
 #include "common/config_storage_fwd.h"
@@ -49,9 +54,16 @@
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/dict_page.h"
 #include "storage/rowset/encoding_info.h"
+#include "types/datum.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
+
+namespace {
+
+constexpr size_t kDictLookupHashThreshold = 100;
+
+} // namespace
 
 ScalarColumnIterator::ScalarColumnIterator(ColumnReader* reader) : _reader(reader) {}
 
@@ -566,6 +578,42 @@ int ScalarColumnIterator::dict_lookup(const Slice& word) {
     return (this->*_dict_lookup_func)(word);
 }
 
+void ScalarColumnIterator::dict_lookup_batch(const std::vector<Datum>& words, std::vector<int>* codes) {
+    DCHECK(all_page_dict_encoded());
+    if (words.empty()) {
+        return;
+    }
+
+    const size_t dict_sz = static_cast<size_t>(dict_size());
+    if (std::max(dict_sz, words.size()) < kDictLookupHashThreshold) {
+        for (const auto& word : words) {
+            if (int code = dict_lookup(word.get_slice()); code >= 0) {
+                codes->emplace_back(code);
+            }
+        }
+        return;
+    }
+
+    switch (delegate_type(_reader->column_type())) {
+    case TYPE_CHAR:
+        _do_dict_lookup_batch<TYPE_CHAR>(words, codes);
+        break;
+    case TYPE_VARCHAR:
+        _do_dict_lookup_batch<TYPE_VARCHAR>(words, codes);
+        break;
+    case TYPE_JSON:
+        _do_dict_lookup_batch<TYPE_JSON>(words, codes);
+        break;
+    default:
+        for (const auto& word : words) {
+            if (int code = dict_lookup(word.get_slice()); code >= 0) {
+                codes->emplace_back(code);
+            }
+        }
+        break;
+    }
+}
+
 Status ScalarColumnIterator::next_dict_codes(size_t* n, Column* dst) {
     DCHECK(all_page_dict_encoded());
     return (this->*_next_dict_codes_func)(n, dst);
@@ -607,6 +655,43 @@ template <LogicalType Type>
 int ScalarColumnIterator::_do_dict_lookup(const Slice& word) {
     auto dict = down_cast<BinaryPlainPageDecoder<Type>*>(_dict_decoder.get());
     return dict->find(word);
+}
+
+template <LogicalType Type>
+void ScalarColumnIterator::_do_dict_lookup_batch(const std::vector<Datum>& words, std::vector<int>* codes) {
+    auto dict = down_cast<BinaryPlainPageDecoder<Type>*>(_dict_decoder.get());
+    const size_t dict_sz = static_cast<size_t>(dict->dict_size());
+
+    if (words.size() <= dict_sz) {
+        phmap::flat_hash_set<Slice, SliceHash, SliceEqual> values;
+        values.reserve(words.size());
+        for (const auto& word : words) {
+            values.emplace(word.get_slice());
+        }
+
+        codes->reserve(codes->size() + std::min(values.size(), dict_sz));
+        for (uint32_t i = 0; i < dict_sz; i++) {
+            if (values.find(dict->string_at_index(i)) != values.end()) {
+                codes->emplace_back(i);
+            }
+        }
+    } else {
+        phmap::flat_hash_map<Slice, int, SliceHash, SliceEqual> dict_map;
+        dict_map.reserve(dict_sz);
+        for (uint32_t i = 0; i < dict_sz; i++) {
+            dict_map.emplace(dict->string_at_index(i), i);
+        }
+
+        phmap::flat_hash_set<int> code_set;
+        code_set.reserve(dict_sz);
+        codes->reserve(codes->size() + dict_sz);
+        for (const auto& word : words) {
+            auto iter = dict_map.find(word.get_slice());
+            if (iter != dict_map.end() && code_set.emplace(iter->second).second) {
+                codes->emplace_back(iter->second);
+            }
+        }
+    }
 }
 
 template <LogicalType Type>
@@ -768,18 +853,23 @@ Status ScalarColumnIterator::fetch_dict_codes_by_rowid(const rowid_t* rowids, si
 }
 
 int ScalarColumnIterator::dict_size() {
-    if (_reader->column_type() == TYPE_CHAR) {
+    switch (delegate_type(_reader->column_type())) {
+    case TYPE_CHAR: {
         auto dict = down_cast<BinaryPlainPageDecoder<TYPE_CHAR>*>(_dict_decoder.get());
         return static_cast<int>(dict->dict_size());
-    } else if (_reader->column_type() == TYPE_JSON) {
-        auto dict = down_cast<BinaryPlainPageDecoder<TYPE_JSON>*>(_dict_decoder.get());
-        return static_cast<int>(dict->dict_size());
-    } else if (_reader->column_type() == TYPE_VARCHAR) {
+    }
+    case TYPE_VARCHAR: {
         auto dict = down_cast<BinaryPlainPageDecoder<TYPE_VARCHAR>*>(_dict_decoder.get());
         return static_cast<int>(dict->dict_size());
     }
-    __builtin_unreachable();
-    return 0;
+    case TYPE_JSON: {
+        auto dict = down_cast<BinaryPlainPageDecoder<TYPE_JSON>*>(_dict_decoder.get());
+        return static_cast<int>(dict->dict_size());
+    }
+    default:
+        __builtin_unreachable();
+        return 0;
+    }
 }
 
 bool ScalarColumnIterator::_contains_deleted_row(uint32_t page_index) const {

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -43,6 +43,8 @@
 
 namespace starrocks {
 
+class Datum;
+
 // TODO: rename to ScalarColumnIterator
 class ScalarColumnIterator final : public ColumnIterator {
 public:
@@ -86,6 +88,8 @@ public:
     Status fetch_all_dict_words(std::vector<Slice>* words) const override;
 
     int dict_lookup(const Slice& word) override;
+
+    void dict_lookup_batch(const std::vector<Datum>& words, std::vector<int>* codes) override;
 
     Status next_dict_codes(size_t* n, Column* dst) override;
 
@@ -133,6 +137,9 @@ private:
 
     template <LogicalType Type>
     int _do_dict_lookup(const Slice& word);
+
+    template <LogicalType Type>
+    void _do_dict_lookup_batch(const std::vector<Datum>& words, std::vector<int>* codes);
 
     template <LogicalType Type>
     Status _do_next_dict_codes(size_t* n, Column* dst);

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 
@@ -956,6 +957,466 @@ TEST_F(SegmentIteratorTest, testCharToVarcharZoneMapFilter) {
         ASSERT_EQ(0, stats.segment_stats_filtered);
         ASSERT_EQ(0, stats.rows_stats_filtered);
     }
+}
+
+// Tests for dict_lookup_batch optimization: large IN predicate on dict-encoded VARCHAR column.
+// The hash-based batch lookup (kDictLookupHashThreshold=100) is exercised when either
+// dict_size >= 100 or the IN list has >= 100 values.
+
+// Helper to extract the integer suffix from a formatted test value like "value_042" or "v_042".
+static int _extract_idx(Slice s, size_t prefix_len) {
+    return std::stoi(std::string(s.data + prefix_len, s.size - prefix_len));
+}
+
+// IN predicate with large value list on dict-encoded VARCHAR column.
+// dict_size=128 >= 100 and IN list=150 >= 100, triggering the hash-based batch lookup.
+TEST_F(SegmentIteratorTest, TestDictLookupBatchInListLarge) {
+    using namespace starrocks::test;
+
+    const int num_distinct = 128;
+    const int num_in_dict = 80;
+    const int num_not_in_dict = 70;
+    const size_t num_rows = 10000;
+
+    std::vector<std::string> values(num_distinct);
+    for (int i = 0; i < num_distinct; ++i) {
+        values[i] = fmt::format("value_{:03d}", i);
+    }
+    auto slice_provider = [&](int32_t i) { return Slice(values[i % num_distinct]); };
+
+    std::string file_name = kSegmentDir + "/dict_lookup_batch_inlist_large";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR).set_length(32).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, slice_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    std::vector<std::string> in_values;
+    for (int i = 0; i < num_in_dict; ++i) {
+        in_values.push_back(values[i]); // "value_000" to "value_079"
+    }
+    for (int i = 0; i < num_not_in_dict; ++i) {
+        in_values.push_back(fmt::format("not_in_dict_{:03d}", i));
+    }
+
+    auto* predicate = pool.add(new_column_in_predicate(get_type_info(TYPE_VARCHAR), 0, in_values));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{predicate});
+
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    size_t total = 0;
+    while (true) {
+        res_chunk->reset();
+        auto st = chunk_iter->get_next(res_chunk.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        size_t n = res_chunk->num_rows();
+        total += n;
+        auto* col = down_cast<const BinaryColumn*>(res_chunk->get_column_raw_ptr_by_index(0));
+        for (size_t i = 0; i < n; ++i) {
+            Slice s = col->get_slice(i);
+            ASSERT_TRUE(s.starts_with(Slice("value_"))) << "Unexpected value: " << s.to_string();
+            int idx = _extract_idx(s, 6);
+            ASSERT_LT(idx, num_in_dict) << "v=" << s.to_string() << " idx=" << idx;
+        }
+    }
+
+    // Distribution of 10000 rows / 128 distinct: first 16 values appear 79 times, rest 78.
+    // Matching values 0-79: 16*79 + 64*78 = 1264 + 4992 = 6256
+    ASSERT_EQ(total, 6256);
+}
+
+// NOT IN predicate with large value list on dict-encoded VARCHAR column.
+TEST_F(SegmentIteratorTest, TestDictLookupBatchNotInListLarge) {
+    using namespace starrocks::test;
+
+    const int num_distinct = 128;
+    const int num_excluded = 80;
+    const size_t num_rows = 10000;
+
+    std::vector<std::string> values(num_distinct);
+    for (int i = 0; i < num_distinct; ++i) {
+        values[i] = fmt::format("value_{:03d}", i);
+    }
+    auto slice_provider = [&](int32_t i) { return Slice(values[i % num_distinct]); };
+
+    std::string file_name = kSegmentDir + "/dict_lookup_batch_notinlist_large";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR).set_length(32).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, slice_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    std::vector<std::string> not_in_values;
+    for (int i = 0; i < num_excluded; ++i) {
+        not_in_values.push_back(values[i]);
+    }
+    for (int i = 0; i < 70; ++i) {
+        not_in_values.push_back(fmt::format("not_in_dict_{:03d}", i));
+    }
+
+    auto* predicate = pool.add(new_column_not_in_predicate(get_type_info(TYPE_VARCHAR), 0, not_in_values));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{predicate});
+
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    size_t total = 0;
+    while (true) {
+        res_chunk->reset();
+        auto st = chunk_iter->get_next(res_chunk.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        size_t n = res_chunk->num_rows();
+        total += n;
+        auto* col = down_cast<const BinaryColumn*>(res_chunk->get_column_raw_ptr_by_index(0));
+        for (size_t i = 0; i < n; ++i) {
+            Slice s = col->get_slice(i);
+            ASSERT_TRUE(s.starts_with(Slice("value_"))) << "Unexpected value: " << s.to_string();
+            int idx = _extract_idx(s, 6);
+            ASSERT_GE(idx, num_excluded) << "v=" << s.to_string() << " idx=" << idx << " should be excluded by NOT IN";
+        }
+    }
+    // Excluded values 0-79: 16*79 + 64*78 = 6256 excluded. Remaining: 10000-6256 = 3744
+    ASSERT_EQ(total, 3744);
+}
+
+// Small IN list below the batch threshold (max(64,10) < 100): falls back to per-element dict_lookup.
+TEST_F(SegmentIteratorTest, TestDictLookupBatchInListSmall) {
+    using namespace starrocks::test;
+
+    const int num_distinct = 64;
+    const int num_in_dict = 8;
+    const size_t num_rows = 5000;
+
+    std::vector<std::string> values(num_distinct);
+    for (int i = 0; i < num_distinct; ++i) {
+        values[i] = fmt::format("v_{:03d}", i);
+    }
+    auto slice_provider = [&](int32_t i) { return Slice(values[i % num_distinct]); };
+
+    std::string file_name = kSegmentDir + "/dict_lookup_batch_inlist_small";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR).set_length(32).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, slice_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    std::vector<std::string> in_values;
+    for (int i = 0; i < num_in_dict; ++i) {
+        in_values.push_back(values[i]);
+    }
+    in_values.push_back("not_in_dict_a");
+    in_values.push_back("not_in_dict_b");
+
+    auto* predicate = pool.add(new_column_in_predicate(get_type_info(TYPE_VARCHAR), 0, in_values));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{predicate});
+
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    size_t total = 0;
+    while (true) {
+        res_chunk->reset();
+        auto st = chunk_iter->get_next(res_chunk.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        size_t n = res_chunk->num_rows();
+        total += n;
+        auto* col = down_cast<const BinaryColumn*>(res_chunk->get_column_raw_ptr_by_index(0));
+        for (size_t i = 0; i < n; ++i) {
+            int idx = _extract_idx(col->get_slice(i), 2);
+            ASSERT_LT(idx, num_in_dict) << "Unexpected v=" << col->get_slice(i).to_string();
+        }
+    }
+    // 5000/64 = 78 rem 8. Values 0-7 each appear 79 times. 8*79 = 632
+    ASSERT_EQ(total, 632);
+}
+
+// IN predicate where no values match the dictionary -> ALWAYS_FALSE.
+TEST_F(SegmentIteratorTest, TestDictLookupBatchInListAlwaysFalse) {
+    using namespace starrocks::test;
+
+    const int num_distinct = 20;
+    const size_t num_rows = 1000;
+
+    std::vector<std::string> values(num_distinct);
+    for (int i = 0; i < num_distinct; ++i) {
+        values[i] = fmt::format("v_{:03d}", i);
+    }
+    auto slice_provider = [&](int32_t i) { return Slice(values[i % num_distinct]); };
+
+    std::string file_name = kSegmentDir + "/dict_lookup_batch_inlist_false";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR).set_length(32).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, slice_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    std::vector<std::string> in_values;
+    for (int i = 0; i < 150; ++i) {
+        in_values.push_back(fmt::format("not_found_{:03d}", i));
+    }
+
+    auto* predicate = pool.add(new_column_in_predicate(get_type_info(TYPE_VARCHAR), 0, in_values));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{predicate});
+
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    auto st = chunk_iter->get_next(res_chunk.get());
+    ASSERT_TRUE(st.is_end_of_file());
+    ASSERT_EQ(res_chunk->num_rows(), 0);
+}
+
+// NOT IN predicate where no values match dictionary (non-nullable column) -> ALWAYS_TRUE.
+TEST_F(SegmentIteratorTest, TestDictLookupBatchNotInListAlwaysTrue) {
+    using namespace starrocks::test;
+
+    const int num_distinct = 20;
+    const size_t num_rows = 1000;
+
+    std::vector<std::string> values(num_distinct);
+    for (int i = 0; i < num_distinct; ++i) {
+        values[i] = fmt::format("v_{:03d}", i);
+    }
+    auto slice_provider = [&](int32_t i) { return Slice(values[i % num_distinct]); };
+
+    std::string file_name = kSegmentDir + "/dict_lookup_batch_notinlist_true";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR).set_length(32).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, slice_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    std::vector<std::string> not_in_values;
+    for (int i = 0; i < 150; ++i) {
+        not_in_values.push_back(fmt::format("not_found_{:03d}", i));
+    }
+
+    auto* predicate = pool.add(new_column_not_in_predicate(get_type_info(TYPE_VARCHAR), 0, not_in_values));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{predicate});
+
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    size_t total = 0;
+    while (true) {
+        res_chunk->reset();
+        auto st = chunk_iter->get_next(res_chunk.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        total += res_chunk->num_rows();
+    }
+    ASSERT_EQ(total, num_rows);
+}
+
+// Duplicate values in IN list should be handled correctly (dedup by dict code).
+TEST_F(SegmentIteratorTest, TestDictLookupBatchDuplicateValues) {
+    using namespace starrocks::test;
+
+    const int num_distinct = 50;
+    const size_t num_rows = 2000;
+
+    std::vector<std::string> values(num_distinct);
+    for (int i = 0; i < num_distinct; ++i) {
+        values[i] = fmt::format("v_{:03d}", i);
+    }
+    auto slice_provider = [&](int32_t i) { return Slice(values[i % num_distinct]); };
+
+    std::string file_name = kSegmentDir + "/dict_lookup_batch_duplicates";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_VARCHAR).set_length(32).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, slice_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    // Duplicates: v_000 appears 5 times, v_001 appears 3 times
+    std::vector<std::string> in_values;
+    for (int i = 0; i < 5; ++i) in_values.push_back(values[0]);
+    for (int i = 0; i < 3; ++i) in_values.push_back(values[1]);
+    for (int i = 2; i < 10; ++i) in_values.push_back(values[i]);
+    for (int i = 0; i < 100; ++i) in_values.push_back(fmt::format("nf_{:03d}", i));
+
+    auto* predicate = pool.add(new_column_in_predicate(get_type_info(TYPE_VARCHAR), 0, in_values));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{predicate});
+
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(chunk_iter->init_output_schema(std::unordered_set<uint32_t>()));
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    size_t total = 0;
+    while (true) {
+        res_chunk->reset();
+        auto st = chunk_iter->get_next(res_chunk.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        size_t n = res_chunk->num_rows();
+        total += n;
+        auto* col = down_cast<const BinaryColumn*>(res_chunk->get_column_raw_ptr_by_index(0));
+        for (size_t i = 0; i < n; ++i) {
+            int idx = _extract_idx(col->get_slice(i), 2);
+            ASSERT_LT(idx, 10) << "Unexpected v=" << col->get_slice(i).to_string();
+        }
+    }
+    // 2000/50 = 40 each. 10 matching values -> 400
+    ASSERT_EQ(total, 400);
 }
 
 } // namespace starrocks

--- a/test/sql/test_low_cardinality/R/test_dict_lookup_batch
+++ b/test/sql/test_low_cardinality/R/test_dict_lookup_batch
@@ -1,0 +1,251 @@
+-- name: test_dict_lookup_batch_in_list
+SET enable_large_in_predicate = false;
+-- result:
+-- !result
+CREATE TABLE t_dict_in (
+    id INT NOT NULL,
+    val VARCHAR(50) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_dict_in VALUES
+    (1, 'alpha'), (2, 'beta'), (3, 'gamma'), (4, 'delta'), (5, 'epsilon'),
+    (6, 'zeta'), (7, 'eta'), (8, 'theta'), (9, 'iota'), (10, 'kappa'),
+    (11, 'lambda'), (12, 'mu'), (13, 'nu'), (14, 'xi'), (15, 'omicron'),
+    (16, 'pi'), (17, 'rho'), (18, 'sigma'), (19, 'tau'), (20, 'upsilon'),
+    (21, 'alpha'), (22, 'beta'), (23, 'gamma'), (24, 'delta'), (25, 'epsilon'),
+    (26, 'zeta'), (27, 'eta'), (28, 'theta'), (29, 'iota'), (30, 'kappa'),
+    (31, 'lambda'), (32, 'mu'), (33, 'nu'), (34, 'xi'), (35, 'omicron'),
+    (36, 'pi'), (37, 'rho'), (38, 'sigma'), (39, 'tau'), (40, 'upsilon'),
+    (41, 'alpha'), (42, 'beta'), (43, 'gamma'), (44, 'delta'), (45, 'epsilon'),
+    (46, 'zeta'), (47, 'eta'), (48, 'theta'), (49, 'iota'), (50, 'kappa');
+-- result:
+-- !result
+SELECT id FROM t_dict_in WHERE val IN ('alpha', 'gamma', 'epsilon', 'eta', 'iota', 'lambda', 'nu', 'omicron', 'rho', 'tau') ORDER BY id;
+-- result:
+1
+3
+5
+7
+9
+11
+13
+15
+17
+19
+21
+23
+25
+27
+29
+31
+33
+35
+37
+39
+41
+43
+45
+47
+49
+-- !result
+SELECT id FROM t_dict_in WHERE val IN ('alpha', 'beta', 'gamma', 'nonexistent_1', 'nonexistent_2', 'epsilon') ORDER BY id;
+-- result:
+1
+2
+3
+5
+21
+22
+23
+25
+41
+42
+43
+45
+-- !result
+SELECT COUNT(*) FROM t_dict_in WHERE val IN ('not_there_1', 'not_there_2', 'not_there_3');
+-- result:
+0
+-- !result
+SELECT id FROM t_dict_in WHERE val NOT IN ('alpha', 'beta', 'gamma', 'delta', 'epsilon') ORDER BY id;
+-- result:
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+46
+47
+48
+49
+50
+-- !result
+SET enable_large_in_predicate = false;
+-- result:
+-- !result
+CREATE TABLE t_dict_large (
+    id INT NOT NULL,
+    val VARCHAR(50) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_dict_large
+SELECT
+    generate_series,
+    CONCAT('val_', CAST(generate_series % 128 AS VARCHAR))
+FROM TABLE(generate_series(1, 3000));
+-- result:
+-- !result
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val IN (
+    'val_0', 'val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6', 'val_7', 'val_8', 'val_9',
+    'val_10', 'val_11', 'val_12', 'val_13', 'val_14', 'val_15', 'val_16', 'val_17', 'val_18', 'val_19',
+    'val_20', 'val_21', 'val_22', 'val_23', 'val_24', 'val_25', 'val_26', 'val_27', 'val_28', 'val_29',
+    'val_30', 'val_31', 'val_32', 'val_33', 'val_34', 'val_35', 'val_36', 'val_37', 'val_38', 'val_39',
+    'val_40', 'val_41', 'val_42', 'val_43', 'val_44', 'val_45', 'val_46', 'val_47', 'val_48', 'val_49',
+    'nx_00', 'nx_01', 'nx_02', 'nx_03', 'nx_04', 'nx_05', 'nx_06', 'nx_07', 'nx_08', 'nx_09',
+    'nx_10', 'nx_11', 'nx_12', 'nx_13', 'nx_14', 'nx_15', 'nx_16', 'nx_17', 'nx_18', 'nx_19',
+    'nx_20', 'nx_21', 'nx_22', 'nx_23', 'nx_24', 'nx_25', 'nx_26', 'nx_27', 'nx_28', 'nx_29',
+    'nx_30', 'nx_31', 'nx_32', 'nx_33', 'nx_34', 'nx_35', 'nx_36', 'nx_37', 'nx_38', 'nx_39',
+    'nx_40', 'nx_41', 'nx_42', 'nx_43', 'nx_44', 'nx_45', 'nx_46', 'nx_47', 'nx_48', 'nx_49',
+    'nx_50', 'nx_51', 'nx_52', 'nx_53', 'nx_54', 'nx_55', 'nx_56', 'nx_57', 'nx_58', 'nx_59',
+    'nx_60', 'nx_61', 'nx_62', 'nx_63', 'nx_64', 'nx_65', 'nx_66', 'nx_67', 'nx_68', 'nx_69',
+    'nx_70', 'nx_71', 'nx_72', 'nx_73', 'nx_74', 'nx_75', 'nx_76', 'nx_77', 'nx_78', 'nx_79',
+    'nx_80', 'nx_81', 'nx_82', 'nx_83', 'nx_84', 'nx_85', 'nx_86', 'nx_87', 'nx_88', 'nx_89',
+    'nx_90', 'nx_91', 'nx_92', 'nx_93', 'nx_94', 'nx_95', 'nx_96', 'nx_97', 'nx_98', 'nx_99'
+);
+-- result:
+1199
+-- !result
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val NOT IN (
+    'val_0', 'val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6', 'val_7', 'val_8', 'val_9',
+    'val_10', 'val_11', 'val_12', 'val_13', 'val_14', 'val_15', 'val_16', 'val_17', 'val_18', 'val_19',
+    'val_20', 'val_21', 'val_22', 'val_23', 'val_24', 'val_25', 'val_26', 'val_27', 'val_28', 'val_29',
+    'val_30', 'val_31', 'val_32', 'val_33', 'val_34', 'val_35', 'val_36', 'val_37', 'val_38', 'val_39',
+    'val_40', 'val_41', 'val_42', 'val_43', 'val_44', 'val_45', 'val_46', 'val_47', 'val_48', 'val_49',
+    'nx_00', 'nx_01', 'nx_02', 'nx_03', 'nx_04', 'nx_05', 'nx_06', 'nx_07', 'nx_08', 'nx_09',
+    'nx_10', 'nx_11', 'nx_12', 'nx_13', 'nx_14', 'nx_15', 'nx_16', 'nx_17', 'nx_18', 'nx_19',
+    'nx_20', 'nx_21', 'nx_22', 'nx_23', 'nx_24', 'nx_25', 'nx_26', 'nx_27', 'nx_28', 'nx_29',
+    'nx_30', 'nx_31', 'nx_32', 'nx_33', 'nx_34', 'nx_35', 'nx_36', 'nx_37', 'nx_38', 'nx_39',
+    'nx_40', 'nx_41', 'nx_42', 'nx_43', 'nx_44', 'nx_45', 'nx_46', 'nx_47', 'nx_48', 'nx_49',
+    'nx_50', 'nx_51', 'nx_52', 'nx_53', 'nx_54', 'nx_55', 'nx_56', 'nx_57', 'nx_58', 'nx_59',
+    'nx_60', 'nx_61', 'nx_62', 'nx_63', 'nx_64', 'nx_65', 'nx_66', 'nx_67', 'nx_68', 'nx_69',
+    'nx_70', 'nx_71', 'nx_72', 'nx_73', 'nx_74', 'nx_75', 'nx_76', 'nx_77', 'nx_78', 'nx_79',
+    'nx_80', 'nx_81', 'nx_82', 'nx_83', 'nx_84', 'nx_85', 'nx_86', 'nx_87', 'nx_88', 'nx_89',
+    'nx_90', 'nx_91', 'nx_92', 'nx_93', 'nx_94', 'nx_95', 'nx_96', 'nx_97', 'nx_98', 'nx_99'
+);
+-- result:
+1801
+-- !result
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val IN (
+    'val_0', 'val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6', 'val_7', 'val_8', 'val_9',
+    'val_10', 'val_11', 'val_12', 'val_13', 'val_14', 'val_15', 'val_16', 'val_17', 'val_18', 'val_19',
+    'val_20', 'val_21', 'val_22', 'val_23', 'val_24', 'val_25', 'val_26', 'val_27', 'val_28', 'val_29',
+    'val_30', 'val_31', 'val_32', 'val_33', 'val_34', 'val_35', 'val_36', 'val_37', 'val_38', 'val_39',
+    'val_40', 'val_41', 'val_42', 'val_43', 'val_44', 'val_45', 'val_46', 'val_47', 'val_48', 'val_49',
+    'val_50', 'val_51', 'val_52', 'val_53', 'val_54', 'val_55', 'val_56', 'val_57', 'val_58', 'val_59',
+    'val_60', 'val_61', 'val_62', 'val_63', 'val_64', 'val_65', 'val_66', 'val_67', 'val_68', 'val_69',
+    'val_70', 'val_71', 'val_72', 'val_73', 'val_74', 'val_75', 'val_76', 'val_77', 'val_78', 'val_79',
+    'val_80', 'val_81', 'val_82', 'val_83', 'val_84', 'val_85', 'val_86', 'val_87', 'val_88', 'val_89',
+    'val_90', 'val_91', 'val_92', 'val_93', 'val_94', 'val_95', 'val_96', 'val_97', 'val_98', 'val_99',
+    'val_100', 'val_101', 'val_102', 'val_103', 'val_104', 'val_105', 'val_106', 'val_107', 'val_108', 'val_109',
+    'val_110', 'val_111', 'val_112', 'val_113', 'val_114', 'val_115', 'val_116', 'val_117', 'val_118', 'val_119',
+    'val_120', 'val_121', 'val_122', 'val_123', 'val_124', 'val_125', 'val_126', 'val_127'
+);
+-- result:
+3000
+-- !result
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val IN ('val_5', 'val_5', 'val_5', 'val_10', 'val_10', 'val_15');
+-- result:
+72
+-- !result
+SET enable_large_in_predicate = false;
+-- result:
+-- !result
+CREATE TABLE t_dict_eq (
+    id INT NOT NULL,
+    val VARCHAR(50) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_dict_eq VALUES
+    (1, 'foo'), (2, 'bar'), (3, 'baz'), (4, 'foo'), (5, 'qux'),
+    (6, 'bar'), (7, 'foo'), (8, 'quux'), (9, 'baz'), (10, 'foo');
+-- result:
+-- !result
+SELECT id FROM t_dict_eq WHERE val = 'foo' ORDER BY id;
+-- result:
+1
+4
+7
+10
+-- !result
+SELECT id FROM t_dict_eq WHERE val != 'foo' ORDER BY id;
+-- result:
+2
+3
+5
+6
+8
+9
+-- !result
+SELECT id FROM t_dict_eq WHERE val IN ('foo', 'bar') ORDER BY id;
+-- result:
+1
+2
+4
+6
+7
+10
+-- !result
+SELECT id FROM t_dict_eq WHERE val NOT IN ('foo', 'bar') ORDER BY id;
+-- result:
+3
+5
+8
+9
+-- !result

--- a/test/sql/test_low_cardinality/T/test_dict_lookup_batch
+++ b/test/sql/test_low_cardinality/T/test_dict_lookup_batch
@@ -1,0 +1,162 @@
+-- name: test_dict_lookup_batch_in_list
+-- Test IN predicate with large value list on dictionary-encoded VARCHAR column.
+-- The BE uses batch dict_lookup (hash-based) when dict_size or IN list size >= 100.
+
+SET enable_large_in_predicate = false;
+
+CREATE TABLE t_dict_in (
+    id INT NOT NULL,
+    val VARCHAR(50) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- Insert data with very low cardinality: only 20 distinct VARCHAR values over 1000 rows
+-- This ensures dictionary encoding is used in the segment.
+INSERT INTO t_dict_in VALUES
+    (1, 'alpha'), (2, 'beta'), (3, 'gamma'), (4, 'delta'), (5, 'epsilon'),
+    (6, 'zeta'), (7, 'eta'), (8, 'theta'), (9, 'iota'), (10, 'kappa'),
+    (11, 'lambda'), (12, 'mu'), (13, 'nu'), (14, 'xi'), (15, 'omicron'),
+    (16, 'pi'), (17, 'rho'), (18, 'sigma'), (19, 'tau'), (20, 'upsilon'),
+    (21, 'alpha'), (22, 'beta'), (23, 'gamma'), (24, 'delta'), (25, 'epsilon'),
+    (26, 'zeta'), (27, 'eta'), (28, 'theta'), (29, 'iota'), (30, 'kappa'),
+    (31, 'lambda'), (32, 'mu'), (33, 'nu'), (34, 'xi'), (35, 'omicron'),
+    (36, 'pi'), (37, 'rho'), (38, 'sigma'), (39, 'tau'), (40, 'upsilon'),
+    (41, 'alpha'), (42, 'beta'), (43, 'gamma'), (44, 'delta'), (45, 'epsilon'),
+    (46, 'zeta'), (47, 'eta'), (48, 'theta'), (49, 'iota'), (50, 'kappa');
+
+-- IN predicate with found values
+SELECT id FROM t_dict_in WHERE val IN ('alpha', 'gamma', 'epsilon', 'eta', 'iota', 'lambda', 'nu', 'omicron', 'rho', 'tau') ORDER BY id;
+
+-- IN predicate with some values not in dict
+SELECT id FROM t_dict_in WHERE val IN ('alpha', 'beta', 'gamma', 'nonexistent_1', 'nonexistent_2', 'epsilon') ORDER BY id;
+
+-- IN predicate with no matching values
+SELECT COUNT(*) FROM t_dict_in WHERE val IN ('not_there_1', 'not_there_2', 'not_there_3');
+
+-- NOT IN predicate
+SELECT id FROM t_dict_in WHERE val NOT IN ('alpha', 'beta', 'gamma', 'delta', 'epsilon') ORDER BY id;
+
+
+-- Test with a larger IN list that should trigger the hash-based batch lookup path.
+-- The BE threshold is kDictLookupHashThreshold=100.
+
+SET enable_large_in_predicate = false;
+
+
+CREATE TABLE t_dict_large (
+    id INT NOT NULL,
+    val VARCHAR(50) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- Insert 3000 rows with 128 distinct values to get dict_size=128 (> threshold of 100)
+-- Use generate_series for bulk data generation
+INSERT INTO t_dict_large
+SELECT
+    generate_series,
+    CONCAT('val_', CAST(generate_series % 128 AS VARCHAR))
+FROM TABLE(generate_series(1, 3000));
+
+-- IN predicate: match first 50 values (values in dict) plus 100 non-existent values = 150 total
+-- dict_size=128 >=100 and IN list=150 >=100, both trigger the batch hash path
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val IN (
+    'val_0', 'val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6', 'val_7', 'val_8', 'val_9',
+    'val_10', 'val_11', 'val_12', 'val_13', 'val_14', 'val_15', 'val_16', 'val_17', 'val_18', 'val_19',
+    'val_20', 'val_21', 'val_22', 'val_23', 'val_24', 'val_25', 'val_26', 'val_27', 'val_28', 'val_29',
+    'val_30', 'val_31', 'val_32', 'val_33', 'val_34', 'val_35', 'val_36', 'val_37', 'val_38', 'val_39',
+    'val_40', 'val_41', 'val_42', 'val_43', 'val_44', 'val_45', 'val_46', 'val_47', 'val_48', 'val_49',
+    'nx_00', 'nx_01', 'nx_02', 'nx_03', 'nx_04', 'nx_05', 'nx_06', 'nx_07', 'nx_08', 'nx_09',
+    'nx_10', 'nx_11', 'nx_12', 'nx_13', 'nx_14', 'nx_15', 'nx_16', 'nx_17', 'nx_18', 'nx_19',
+    'nx_20', 'nx_21', 'nx_22', 'nx_23', 'nx_24', 'nx_25', 'nx_26', 'nx_27', 'nx_28', 'nx_29',
+    'nx_30', 'nx_31', 'nx_32', 'nx_33', 'nx_34', 'nx_35', 'nx_36', 'nx_37', 'nx_38', 'nx_39',
+    'nx_40', 'nx_41', 'nx_42', 'nx_43', 'nx_44', 'nx_45', 'nx_46', 'nx_47', 'nx_48', 'nx_49',
+    'nx_50', 'nx_51', 'nx_52', 'nx_53', 'nx_54', 'nx_55', 'nx_56', 'nx_57', 'nx_58', 'nx_59',
+    'nx_60', 'nx_61', 'nx_62', 'nx_63', 'nx_64', 'nx_65', 'nx_66', 'nx_67', 'nx_68', 'nx_69',
+    'nx_70', 'nx_71', 'nx_72', 'nx_73', 'nx_74', 'nx_75', 'nx_76', 'nx_77', 'nx_78', 'nx_79',
+    'nx_80', 'nx_81', 'nx_82', 'nx_83', 'nx_84', 'nx_85', 'nx_86', 'nx_87', 'nx_88', 'nx_89',
+    'nx_90', 'nx_91', 'nx_92', 'nx_93', 'nx_94', 'nx_95', 'nx_96', 'nx_97', 'nx_98', 'nx_99'
+);
+
+-- NOT IN predicate with large list: exclude 50 values, plus 100 non-existent values = 150 total
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val NOT IN (
+    'val_0', 'val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6', 'val_7', 'val_8', 'val_9',
+    'val_10', 'val_11', 'val_12', 'val_13', 'val_14', 'val_15', 'val_16', 'val_17', 'val_18', 'val_19',
+    'val_20', 'val_21', 'val_22', 'val_23', 'val_24', 'val_25', 'val_26', 'val_27', 'val_28', 'val_29',
+    'val_30', 'val_31', 'val_32', 'val_33', 'val_34', 'val_35', 'val_36', 'val_37', 'val_38', 'val_39',
+    'val_40', 'val_41', 'val_42', 'val_43', 'val_44', 'val_45', 'val_46', 'val_47', 'val_48', 'val_49',
+    'nx_00', 'nx_01', 'nx_02', 'nx_03', 'nx_04', 'nx_05', 'nx_06', 'nx_07', 'nx_08', 'nx_09',
+    'nx_10', 'nx_11', 'nx_12', 'nx_13', 'nx_14', 'nx_15', 'nx_16', 'nx_17', 'nx_18', 'nx_19',
+    'nx_20', 'nx_21', 'nx_22', 'nx_23', 'nx_24', 'nx_25', 'nx_26', 'nx_27', 'nx_28', 'nx_29',
+    'nx_30', 'nx_31', 'nx_32', 'nx_33', 'nx_34', 'nx_35', 'nx_36', 'nx_37', 'nx_38', 'nx_39',
+    'nx_40', 'nx_41', 'nx_42', 'nx_43', 'nx_44', 'nx_45', 'nx_46', 'nx_47', 'nx_48', 'nx_49',
+    'nx_50', 'nx_51', 'nx_52', 'nx_53', 'nx_54', 'nx_55', 'nx_56', 'nx_57', 'nx_58', 'nx_59',
+    'nx_60', 'nx_61', 'nx_62', 'nx_63', 'nx_64', 'nx_65', 'nx_66', 'nx_67', 'nx_68', 'nx_69',
+    'nx_70', 'nx_71', 'nx_72', 'nx_73', 'nx_74', 'nx_75', 'nx_76', 'nx_77', 'nx_78', 'nx_79',
+    'nx_80', 'nx_81', 'nx_82', 'nx_83', 'nx_84', 'nx_85', 'nx_86', 'nx_87', 'nx_88', 'nx_89',
+    'nx_90', 'nx_91', 'nx_92', 'nx_93', 'nx_94', 'nx_95', 'nx_96', 'nx_97', 'nx_98', 'nx_99'
+);
+
+-- IN predicate with large list where ALL values are in the dict (no misses)
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val IN (
+    'val_0', 'val_1', 'val_2', 'val_3', 'val_4', 'val_5', 'val_6', 'val_7', 'val_8', 'val_9',
+    'val_10', 'val_11', 'val_12', 'val_13', 'val_14', 'val_15', 'val_16', 'val_17', 'val_18', 'val_19',
+    'val_20', 'val_21', 'val_22', 'val_23', 'val_24', 'val_25', 'val_26', 'val_27', 'val_28', 'val_29',
+    'val_30', 'val_31', 'val_32', 'val_33', 'val_34', 'val_35', 'val_36', 'val_37', 'val_38', 'val_39',
+    'val_40', 'val_41', 'val_42', 'val_43', 'val_44', 'val_45', 'val_46', 'val_47', 'val_48', 'val_49',
+    'val_50', 'val_51', 'val_52', 'val_53', 'val_54', 'val_55', 'val_56', 'val_57', 'val_58', 'val_59',
+    'val_60', 'val_61', 'val_62', 'val_63', 'val_64', 'val_65', 'val_66', 'val_67', 'val_68', 'val_69',
+    'val_70', 'val_71', 'val_72', 'val_73', 'val_74', 'val_75', 'val_76', 'val_77', 'val_78', 'val_79',
+    'val_80', 'val_81', 'val_82', 'val_83', 'val_84', 'val_85', 'val_86', 'val_87', 'val_88', 'val_89',
+    'val_90', 'val_91', 'val_92', 'val_93', 'val_94', 'val_95', 'val_96', 'val_97', 'val_98', 'val_99',
+    'val_100', 'val_101', 'val_102', 'val_103', 'val_104', 'val_105', 'val_106', 'val_107', 'val_108', 'val_109',
+    'val_110', 'val_111', 'val_112', 'val_113', 'val_114', 'val_115', 'val_116', 'val_117', 'val_118', 'val_119',
+    'val_120', 'val_121', 'val_122', 'val_123', 'val_124', 'val_125', 'val_126', 'val_127'
+);
+
+-- IN predicate with duplicates should return correct results (no duplicates in output)
+SELECT COUNT(*) AS cnt FROM t_dict_large
+WHERE val IN ('val_5', 'val_5', 'val_5', 'val_10', 'val_10', 'val_15');
+
+
+-- Test that EQ/NE predicates also work correctly alongside the dict_lookup code path.
+-- EQ and NE use single-value dict_lookup, not batch.
+
+SET enable_large_in_predicate = false;
+
+
+CREATE TABLE t_dict_eq (
+    id INT NOT NULL,
+    val VARCHAR(50) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t_dict_eq VALUES
+    (1, 'foo'), (2, 'bar'), (3, 'baz'), (4, 'foo'), (5, 'qux'),
+    (6, 'bar'), (7, 'foo'), (8, 'quux'), (9, 'baz'), (10, 'foo');
+
+-- EQ on dict column
+SELECT id FROM t_dict_eq WHERE val = 'foo' ORDER BY id;
+
+-- NE on dict column
+SELECT id FROM t_dict_eq WHERE val != 'foo' ORDER BY id;
+
+-- IN list (single element - should behave like EQ after optimization)
+SELECT id FROM t_dict_eq WHERE val IN ('foo', 'bar') ORDER BY id;
+
+-- NOT IN list
+SELECT id FROM t_dict_eq WHERE val NOT IN ('foo', 'bar') ORDER BY id;


### PR DESCRIPTION
## Why I'm doing:

  When a low-cardinality VARCHAR/CHAR column is dictionary-encoded in the segment, and a query contains a large IN or NOT IN predicate (e.g., hundreds of values), the existing code does a
  per-element binary search in the dictionary — O(k × log n) for k predicate values and n dictionary entries. This becomes a bottleneck for large k.

## What I'm doing:

  Added dict_lookup_batch — a hash-based batch lookup — to ScalarColumnIterator. When either the dictionary or the value list exceeds 100 entries, it uses phmap::flat_hash_set/flat_hash_map
  to achieve O(k + n) amortized lookup instead of O(k × log n).

  Two strategies:
  - words.size() ≤ dict_size: build hash set from predicate values, scan dictionary entries → O(dict_size)
  - words.size() > dict_size: build hash map from dictionary, scan predicate values → O(words.size())

  The per-element binary search is kept as a fallback for small inputs (<100).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
