### PR TITLE
[BugFix] Fix crash in peer cache read when peer node is unreachable

### DIFF
--- a/be/src/cache/peer_cache_engine.cpp
+++ b/be/src/cache/peer_cache_engine.cpp
@@ -39,6 +39,13 @@ Status PeerCacheEngine::read(const std::string& key, size_t off, size_t size, IO
 
     std::shared_ptr<PInternalService_RecoverableStub> stub =
             _stub_cache->get_stub(options->remote_host, options->remote_port);
+    // The stub can be null when the peer host is temporarily unresolvable (e.g. a peer node is
+    // restarting during a rolling upgrade and its hostname no longer resolves). Returning an error
+    // here lets the caller fall back to remote storage instead of dereferencing a null stub.
+    if (stub == nullptr) {
+        return Status::InternalError("failed to get brpc stub for peer cache node " + options->remote_host + ":" +
+                                     std::to_string(options->remote_port));
+    }
     PFetchDataCacheRequest request;
     PFetchDataCacheResponse response;
     request.set_request_id(butil::monotonic_time_ns());

--- a/be/test/cache/peer_cache_test.cpp
+++ b/be/test/cache/peer_cache_test.cpp
@@ -18,6 +18,8 @@
 #include "cache/disk_cache/io_buffer.h"
 #include "cache/disk_cache/local_disk_cache_engine.h"
 #include "cache/peer_cache_engine.h"
+#include "common/brpc/brpc_stub_cache.h"
+#include "common/bthread_timer.h"
 #include "common/statusor.h"
 
 namespace starrocks {
@@ -55,6 +57,34 @@ TEST_F(PeerCacheTest, io_adaptor) {
     IOBuffer buf;
     st = peer_cache.read("test_key", 0, 100, &buf, &read_options);
     ASSERT_TRUE(st.is_resource_busy());
+}
+
+// When the peer node's host cannot be resolved (e.g. it is restarting during a rolling upgrade),
+// BrpcStubCache::get_stub() returns nullptr. PeerCacheEngine::read must return an error instead of
+// dereferencing the null stub, so the caller can fall back to remote storage. Before the guard was
+// added this path crashed with SIGSEGV.
+TEST_F(PeerCacheTest, read_returns_error_when_peer_stub_unavailable) {
+    BthreadTimer timer;
+    ASSERT_TRUE(timer.start().ok());
+    BrpcStubCache stub_cache(&timer);
+
+    PeerCacheEngine peer_cache;
+    RemoteCacheOptions options;
+    options.skip_read_factor = 1.0;
+    ASSERT_TRUE(peer_cache.init(options).ok());
+    // Inject the stub cache into the engine under test so read() exercises the get_stub()-returns-null
+    // guard rather than the early-out for a missing stub cache.
+    peer_cache.set_stub_cache(&stub_cache);
+
+    DiskCacheReadOptions read_options;
+    read_options.use_adaptor = false;
+    // An unresolvable host makes BrpcStubCache::get_stub() return nullptr.
+    read_options.remote_host = "invalid.cm.invalid";
+    read_options.remote_port = 8060;
+
+    IOBuffer buf;
+    Status st = peer_cache.read("test_key", 0, 100, &buf, &read_options);
+    ASSERT_TRUE(st.is_internal_error());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
segfault during rolling cluster update

reproduced on 3.5 and 4.0 (what we have in prod)
but code in main branch the same

## What I'm doing:

add null pointer check

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
