### PR TITLE
[BugFix] race between FE EOS-cancel and BE stage-2 deploy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -763,6 +763,12 @@ public class DefaultCoordinator extends Coordinator {
 
     private void handleErrorExecution(Status status, FragmentInstanceExecState execution, Throwable failure)
             throws StarRocksException, RpcException {
+        if (returnedAllResults && status.isCancelled()) {
+            // Receiver already got EOS; any in-flight deploy that races with our QUERY_FINISHED cancel
+            // returns Cancelled("QueryFinished") or Cancelled("Query terminates prematurely") on the BE.
+            // These are not real errors.
+            return;
+        }
         switch (Objects.requireNonNull(status.getErrorCode())) {
             case TIMEOUT:
                 cancelInternal(PPlanFragmentCancelReason.TIMEOUT);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -225,6 +225,48 @@ public class CoordinatorTest extends PlanTestBase {
         Assertions.assertFalse(ex.getMessage().contains("'" + SessionVariable.QUERY_TIMEOUT + "'"));
     }
 
+    private static java.lang.reflect.Method handleErrorExecutionMethod() throws NoSuchMethodException {
+        java.lang.reflect.Method m = DefaultCoordinator.class.getDeclaredMethod(
+                "handleErrorExecution", Status.class,
+                com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.class, Throwable.class);
+        m.setAccessible(true);
+        return m;
+    }
+
+    @Test
+    public void testHandleErrorExecutionSuppressesCancelAfterEos() throws Exception {
+        // After the receiver got EOS (returnedAllResults=true), an in-flight stage-2 deploy that races
+        // with our QUERY_FINISHED cancel returns CANCELLED on the BE. Those are not real errors and must
+        // not surface as "[reason=INTERNAL_ERROR] [msg=null]" to the client.
+        // Covers DefaultCoordinator.handleErrorExecution guard at line ~766.
+        Deencapsulation.setField(coordinator, "returnedAllResults", true);
+        java.lang.reflect.Method handle = handleErrorExecutionMethod();
+
+        for (String beMsg : new String[] {"Query terminates prematurely", "QueryFinished", "Cancelled"}) {
+            ctx.getState().reset();
+            Status cancelled = new Status(TStatusCode.CANCELLED, beMsg);
+            Assertions.assertDoesNotThrow(
+                    () -> handle.invoke(coordinator, cancelled, null, null),
+                    "handleErrorExecution must swallow post-EOS cancel: " + beMsg);
+            Assertions.assertTrue(
+                    ctx.getState().getErrorMessage() == null || ctx.getState().getErrorMessage().isEmpty(),
+                    "post-EOS cancel must not set client error, msg was: " + ctx.getState().getErrorMessage());
+        }
+    }
+
+    @Test
+    public void testHandleErrorExecutionStillThrowsBeforeEos() throws Exception {
+        // Sanity: when EOS has not been delivered, a non-internal CANCELLED still falls through to the
+        // default branch and surfaces — i.e. the new guard must not swallow real pre-EOS errors.
+        Deencapsulation.setField(coordinator, "returnedAllResults", false);
+        java.lang.reflect.Method handle = handleErrorExecutionMethod();
+        Status cancelled = new Status(TStatusCode.CANCELLED, "some real cancel reason");
+        java.lang.reflect.InvocationTargetException ite = Assertions.assertThrows(
+                java.lang.reflect.InvocationTargetException.class,
+                () -> handle.invoke(coordinator, cancelled, null, null));
+        Assertions.assertInstanceOf(StarRocksException.class, ite.getCause());
+    }
+
     @Test
     public void testClearExternalResourcesOnlyOnce() {
         AtomicInteger clearCount = new AtomicInteger();


### PR DESCRIPTION
## Why I'm doing:

some query marked as canceled after finished fully successful

## What I'm doing:

add additional checks to proper handling on late events from BE

not sure about 3.5, because we are on 4.0 now

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
