### PR TITLE
[Enhancement] Trigger tablet split/merge in real time from publish version response

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -49,6 +49,7 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_metadata.h"
 #include "storage/lake/tablet_reshard.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
@@ -420,6 +421,19 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                     if (res.ok()) {
                         auto metadata = std::move(res).value();
                         auto score = compaction_score(_tablet_mgr, metadata);
+                        // Per-tablet stats returned to FE: for range-distribution tablets (every
+                        // publish) to drive real-time split/merge, and on first import (base_version==1)
+                        // for any tablet so FE can collect first-load statistics. Supersedes the
+                        // deprecated tablet_row_nums field; note num_rows here is the live-row count
+                        // (PK tablets subtract deletes) rather than that field's raw rowset row sum,
+                        // so a first load with intra-batch duplicate keys or deletes reports fewer
+                        // rows. Summed without delvec I/O (publish hot path).
+                        const bool emit_stats = metadata->has_range() || request->base_version() == 1;
+                        int64_t stats_num_rows = 0;
+                        int64_t stats_data_size = 0;
+                        if (emit_stats) {
+                            compute_tablet_stats(*metadata, &stats_num_rows, &stats_data_size);
+                        }
                         // Copy metadata out of the lock(response_mtx), to let it execute in parallel.
                         TabletMetadataPB local_metadata;
                         if (skip_write_tablet_metadata) {
@@ -428,12 +442,18 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                         {
                             std::lock_guard l(response_mtx);
                             response->mutable_compaction_scores()->insert({metadata->id(), score});
-                            if (request->base_version() == 1) {
-                                int64_t row_nums = std::accumulate(
-                                        metadata->rowsets().begin(), metadata->rowsets().end(), 0,
-                                        [](int64_t sum, const auto& rowset) { return sum + rowset.num_rows(); });
-                                // Used to collect statistics when the partition is first imported
-                                response->mutable_tablet_row_nums()->insert({metadata->id(), row_nums});
+                            if (emit_stats) {
+                                auto* stat = &(*response->mutable_tablet_stats())[metadata->id()];
+                                stat->set_num_rows(stats_num_rows);
+                                stat->set_data_size(stats_data_size);
+                                // Compat shim: also mirror the first-load row count into the legacy
+                                // field so an old FE (BE-before-FE rolling upgrade) still collects
+                                // first-load statistics from ordinal 4; a new FE reads tablet_stats.
+                                // Nested here because base_version==1 implies emit_stats, so
+                                // stats_num_rows is the freshly computed value.
+                                if (request->base_version() == 1) {
+                                    (*response->mutable_deprecated_tablet_row_nums())[metadata->id()] = stats_num_rows;
+                                }
                             }
                             if (skip_write_tablet_metadata) {
                                 (*response->mutable_tablet_metas())[metadata->id()].Swap(&local_metadata);
@@ -650,8 +670,11 @@ struct AggregatePublishContext {
         for (const auto& [tid, score] : resp->compaction_scores()) {
             (*response->mutable_compaction_scores())[tid] = score;
         }
-        for (const auto& [tid, row_num] : resp->tablet_row_nums()) {
-            (*response->mutable_tablet_row_nums())[tid] = row_num;
+        for (const auto& [tid, stat] : resp->tablet_stats()) {
+            (*response->mutable_tablet_stats())[tid] = stat;
+        }
+        for (const auto& [tid, row_num] : resp->deprecated_tablet_row_nums()) {
+            (*response->mutable_deprecated_tablet_row_nums())[tid] = row_num;
         }
         for (auto& [tid, meta] : *resp->mutable_tablet_metas()) {
             // Use swap to avoid copy

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -26,4 +26,26 @@ using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 using BundleTabletMetadataPtr = std::shared_ptr<BundleTabletMetadataPB>;
 using TabletMetadataPtrs = std::vector<TabletMetadataPtr>;
 
+// Sum a tablet's aggregate stats from rowset metadata WITHOUT any delvec I/O.
+// For PK tablets, subtracts the stored (approximate) num_dels; never reads delete
+// vectors (unlike get_tablet_stats's accurate/old-metadata fallback branches).
+// Used on the publish hot path where extra I/O is unacceptable; the periodic
+// TabletStatMgr scan remains responsible for accurate live-row counts.
+inline void compute_tablet_stats(const TabletMetadataPB& metadata, int64_t* num_rows, int64_t* data_size) {
+    const bool is_pk = metadata.schema().keys_type() == PRIMARY_KEYS;
+    int64_t rows = 0;
+    int64_t size = 0;
+    for (const auto& rowset : metadata.rowsets()) {
+        const int64_t num_deletes = (is_pk && rowset.has_num_dels()) ? rowset.num_dels() : 0;
+        const int64_t live_rows = rowset.num_rows() - num_deletes;
+        rows += (live_rows > 0 ? live_rows : 0);
+        size += rowset.data_size();
+    }
+    for (const auto& [_, file] : metadata.delvec_meta().version_to_file()) {
+        size += file.size();
+    }
+    *num_rows = rows;
+    *data_size = size;
+}
+
 } // namespace starrocks

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -6013,4 +6013,123 @@ TEST_F(LakeServiceTest, test_build_vector_index_request_built_version_floor) {
     EXPECT_EQ(1, response.new_built_version());
 }
 
+TEST_F(LakeServiceTest, test_compute_tablet_stats) {
+    TabletMetadataPB meta;
+    meta.mutable_schema()->set_keys_type(PRIMARY_KEYS);
+    auto* r1 = meta.add_rowsets();
+    r1->set_num_rows(100);
+    r1->set_data_size(1000);
+    r1->set_num_dels(30);
+    // Old PK rowset without num_dels: must NOT read delvec, dels treated as 0.
+    auto* r2 = meta.add_rowsets();
+    r2->set_num_rows(50);
+    r2->set_data_size(500);
+    // delvec file sizes add to data_size.
+    (*meta.mutable_delvec_meta()->mutable_version_to_file())[1].set_size(7);
+
+    int64_t num_rows = -1;
+    int64_t data_size = -1;
+    starrocks::compute_tablet_stats(meta, &num_rows, &data_size);
+    EXPECT_EQ(num_rows, (100 - 30) + 50); // 120 live rows
+    EXPECT_EQ(data_size, 1000 + 500 + 7); // 1507
+}
+
+// Verifies the has_range() gate for tablet_stats in publish_version response:
+// - A non-range tablet produces no tablet_stats entry.
+// - A range-distribution tablet (metadata has_range() == true) produces a
+//   tablet_stats entry with data_size > 0.
+TEST_F(LakeServiceTest, test_publish_returns_tablet_stats) {
+    // --- First load (base_version==1) of a non-range tablet: stats are reported via tablet_stats,
+    //     and the live-row count is also mirrored into deprecated_tablet_row_nums for old-FE compat. ---
+    {
+        TxnLog log = generate_write_txn_log(2, 101, 4096);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(log.txn_id());
+
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+
+        ASSERT_EQ(0, response.failed_tablets_size()) << response.status().error_msgs(0);
+        auto it = response.tablet_stats().find(_tablet_id);
+        ASSERT_NE(it, response.tablet_stats().end()) << "first-load tablet must report stats via tablet_stats";
+        EXPECT_EQ(101, it->second.num_rows()) << "first-load row count must flow through tablet_stats";
+        // Mirrored into the legacy field (same live-row count) so an old FE during a BE-before-FE
+        // rolling upgrade still collects first-load statistics.
+        ASSERT_EQ(1, response.deprecated_tablet_row_nums().count(_tablet_id))
+                << "first-load row count must be mirrored into deprecated_tablet_row_nums for old FEs";
+        EXPECT_EQ(101, response.deprecated_tablet_row_nums().at(_tablet_id));
+    }
+
+    // --- Non-first-load (base_version>1) of a non-range tablet: must NOT appear in tablet_stats. ---
+    {
+        TxnLog log = generate_write_txn_log(1, 50, 2048);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+        PublishVersionRequest request;
+        request.set_base_version(2);
+        request.set_new_version(3);
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(log.txn_id());
+
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+
+        ASSERT_EQ(0, response.failed_tablets_size()) << response.status().error_msgs(0);
+        EXPECT_EQ(0, response.tablet_stats().count(_tablet_id))
+                << "non-range, non-first-load tablet must not appear in tablet_stats";
+    }
+
+    // --- Positive: range-distribution tablet MUST appear in tablet_stats ---
+    // Create a new tablet whose metadata has a range set.
+    int64_t range_tablet_id = next_id();
+    create_tablet_metadata_with_range(range_tablet_id, /*version=*/1, /*lower=*/0, /*upper=*/100);
+
+    // Write a segment file for this tablet so publish has data to work with.
+    auto seg_name = lake::gen_segment_filename(next_id());
+    auto seg_path = _tablet_mgr->segment_location(range_tablet_id, seg_name);
+    {
+        ASSIGN_OR_ABORT(auto f, fs::new_writable_file(seg_path));
+        CHECK_OK(f->append("dummy"));
+        CHECK_OK(f->close());
+    }
+
+    // The metadata created by create_tablet_metadata_with_range already has a rowset
+    // with data_size=100, so we can publish directly without a txn log by using
+    // the idempotent-republish path: publish same version (already version 1, publish
+    // base=1->new=1 is not valid), so instead we inject a simple txn log on top.
+    {
+        auto txn_id = next_id();
+        TxnLog log;
+        log.set_tablet_id(range_tablet_id);
+        log.set_partition_id(_partition_id);
+        log.set_txn_id(txn_id);
+        auto* segment_meta = log.mutable_op_write()->mutable_rowset()->add_segment_metas();
+        segment_meta->set_filename(seg_name);
+        segment_meta->set_size(512);
+        segment_meta->set_num_rows(10);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(512);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(10);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(range_tablet_id);
+        request.add_txn_ids(txn_id);
+
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+
+        ASSERT_EQ(0, response.failed_tablets_size()) << response.status().error_msgs(0);
+        auto it = response.tablet_stats().find(range_tablet_id);
+        ASSERT_NE(it, response.tablet_stats().end()) << "range tablet must have a tablet_stats entry";
+        EXPECT_GT(it->second.data_size(), 0) << "data_size must be positive for range tablet";
+    }
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -14,11 +14,13 @@
 
 package com.starrocks.alter.reshard;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
@@ -40,7 +42,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(TabletReshardJobMgr.class);
@@ -56,6 +60,39 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
     // ({@code tablet_reshard_job_scheduler_interval_ms}) and self-gates on shared-data-mode,
     // leader status, and empty unstable-groups before doing any real work.
     private final ColocateChecker colocateChecker = new ColocateChecker();
+
+    // Coalescible reshard candidate for one table, marked by both the publish path and the periodic
+    // TabletStatMgr scan: the largest tablet (split) and the smallest adjacent fresh-pair sum (merge).
+    // Long.MAX_VALUE is the "no merge" identity, so a split-only publish mark and a split+merge periodic
+    // mark compose by (max, min) regardless of arrival order. Self-contained (carries db/table id) so
+    // the drain needs no side key. Transient (not persisted): leader failover falls back to the scan.
+    private record ReshardCandidate(long dbId, long tableId,
+                                    long maxTabletSize, long minAdjacentTabletPairSize) {
+    }
+
+    // tableId (globally unique) -> coalesced reshard candidate awaiting a drain evaluation.
+    private final Map<Long, ReshardCandidate> reshardCandidates = new ConcurrentHashMap<>();
+
+    // Enqueue a table for a reshard evaluation, carrying the signals its caller already computed so the
+    // drain triggers without re-walking the table. Both the write-locked publish path (split-only:
+    // minAdjacentTabletPairSize = Long.MAX_VALUE) and the periodic scan (split+merge) mark here;
+    // concurrent marks for the same table coalesce by (max, min) before the next drain. Callers need
+    // only supply the signals (and gate on leader/eligibility for their own reasons); the split/merge
+    // actionability decision lives here, so non-actionable signals are dropped and never queued.
+    public void addReshardCandidate(long dbId, long tableId, long maxTabletSize, long minAdjacentTabletPairSize) {
+        if (!isLeaderAdmissionOpen()) {
+            return;
+        }
+        // Keep the queue empty in the common (no-reshard) case; the drain re-checks authoritatively.
+        if (!TabletReshardUtils.needSplit(maxTabletSize) && !TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
+            return;
+        }
+        reshardCandidates.merge(tableId,
+                new ReshardCandidate(dbId, tableId, maxTabletSize, minAdjacentTabletPairSize),
+                (existing, incoming) -> new ReshardCandidate(existing.dbId(), existing.tableId(),
+                        Math.max(existing.maxTabletSize(), incoming.maxTabletSize()),
+                        Math.min(existing.minAdjacentTabletPairSize(), incoming.minAdjacentTabletPairSize())));
+    }
 
     public TabletReshardJobMgr() {
         super("tablet-reshard-job-mgr", Config.tablet_reshard_job_scheduler_interval_ms);
@@ -96,6 +133,47 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         }
         TabletReshardJob job = new MergeTabletJobFactory(db, table, mergeTabletClause).createTabletReshardJob();
         addTabletReshardJob(job);
+    }
+
+    /**
+     * Reshard-trigger decision. The sole caller is {@link #drainReshardCandidates()}, which feeds the
+     * signals that both the publish path and the periodic TabletStatMgr scan supplied via
+     * {@link #addReshardCandidate}. Self-gates on leader/admission, cloud-native range distribution,
+     * and NORMAL table state; the authoritative NORMAL re-check happens in the job factory under its
+     * own lock.
+     */
+    private void triggerTabletReshard(Database db, OlapTable table,
+                                      long maxTabletSize, long minAdjacentTabletPairSize) {
+        if (!isLeaderAdmissionOpen()) {
+            return;
+        }
+        if (!table.isCloudNativeTableOrMaterializedView() || !table.isRangeDistribution()) {
+            return;
+        }
+        if (table.getState() != OlapTable.OlapTableState.NORMAL) {
+            return;
+        }
+        try {
+            if (TabletReshardUtils.needSplit(maxTabletSize)) {
+                createTabletReshardJob(db, table, new SplitTabletClause());
+                LOG.info("Auto triggered split tablet job for table {}.{}, maxTabletSize {}",
+                        db.getFullName(), table.getName(), maxTabletSize);
+                return;
+            }
+            if (TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
+                createTabletReshardJob(db, table, new MergeTabletClause());
+                LOG.info("Auto triggered merge tablet job for table {}.{}, minAdjacentTabletPairSize {}",
+                        db.getFullName(), table.getName(), minAdjacentTabletPairSize);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to create tablet reshard job for table {}.{}.",
+                    db.getFullName(), table.getName(), e);
+        }
+    }
+
+    private boolean isLeaderAdmissionOpen() {
+        return GlobalStateMgr.getCurrentState().isLeader()
+                && GlobalStateMgr.getCurrentState().isLeaderWorkAdmissionOpen();
     }
 
     public void addTabletReshardJob(TabletReshardJob tabletReshardJob) throws StarRocksException {
@@ -176,8 +254,53 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
 
     @Override
     protected void runAfterCatalogReady() {
+        // Hard-gate the whole reshard tick: this is a FrontendDaemon (not stopped on demotion),
+        // and neither runTabletReshardJobs() nor ColocateChecker.runOneCycle() self-gates on
+        // leader/admission. Both create reshard jobs that journal via the non-throwing logJsonObject
+        // path, so a demoted node must not run them.
+        if (!isLeaderAdmissionOpen()) {
+            reshardCandidates.clear();
+            return;
+        }
         colocateChecker.runOneCycle();
+        drainReshardCandidates();
         runTabletReshardJobs();
+    }
+
+    @VisibleForTesting
+    void runAfterCatalogReadyForTest() {
+        runAfterCatalogReady();
+    }
+
+    @VisibleForTesting
+    int getReshardCandidateCount() {
+        return reshardCandidates.size();
+    }
+
+    private void drainReshardCandidates() {
+        if (reshardCandidates.isEmpty()) {
+            return;
+        }
+        // Snapshot the keys; remove each atomically so a concurrent re-mark is re-evaluated next tick.
+        for (Long tableId : new ArrayList<>(reshardCandidates.keySet())) {
+            ReshardCandidate candidate = reshardCandidates.remove(tableId);
+            if (candidate == null) {
+                continue;
+            }
+            // db and table lookups are not atomic; the null guards are conservative — a dropped db/table
+            // is simply skipped this cycle.
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(candidate.dbId());
+            if (db == null) {
+                continue;
+            }
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(candidate.dbId(), candidate.tableId());
+            if (!(table instanceof OlapTable)) {
+                continue;
+            }
+            triggerTabletReshard(db, (OlapTable) table,
+                    candidate.maxTabletSize(), candidate.minAdjacentTabletPairSize());
+        }
     }
 
     private void checkTabletReshardJob(TabletReshardJob tabletReshardJob) throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -18,8 +18,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.common.Config;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TabletReshardUtils {
+    private static final Logger LOG = LogManager.getLogger(TabletReshardUtils.class);
 
     // Reshard size invariants — DO NOT change individually.
     //
@@ -156,5 +159,17 @@ public class TabletReshardUtils {
         ComputeResource computeResource =
                 GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
         return parallelismFloor(computeNodeCount(computeResource), Config.tablet_reshard_max_split_count);
+    }
+
+    // Parallelism floor for merge eligibility; returns 0 (ungated) when warehouse state is unavailable.
+    // computeParallelismFloor resolves warehouse compute-node count via StarMgr, so call it off hot,
+    // lock-held paths (e.g. the periodic scan), not per-publish.
+    public static int safeComputeParallelismFloor(long tableId) {
+        try {
+            return computeParallelismFloor(tableId);
+        } catch (RuntimeException e) {
+            LOG.warn("Parallelism floor unavailable for table {}; auto-merge will not be floor-gated.", tableId, e);
+            return 0;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -57,8 +57,6 @@ import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
-import com.starrocks.sql.ast.MergeTabletClause;
-import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
@@ -141,7 +139,14 @@ public class TabletStatMgr extends FrontendDaemon {
                 Map<Pair<Long, Long>, Long> indexRowCountMap = Maps.newHashMap();
                 // NOTE: calculate the row first with read lock, then update the stats with write lock
                 OlapTable olapTable = (OlapTable) table;
-                int parallelismFloor = resolveMergeParallelismFloor(db, olapTable);
+                // Reshard is leader-only (TabletStatMgr runs on all FEs), and only for cloud-native
+                // range-distribution tables. This gates the parallelism-floor lookup (a StarMgr RPC),
+                // the adjacency walk, and the reshard trigger — none of which should run on followers.
+                boolean reshardEligible = GlobalStateMgr.getCurrentState().isLeader()
+                        && olapTable.isCloudNativeTableOrMaterializedView()
+                        && olapTable.isRangeDistribution();
+                int parallelismFloor = reshardEligible
+                        ? TabletReshardUtils.safeComputeParallelismFloor(table.getId()) : 0;
                 locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
                 try {
                     for (Partition partition : olapTable.getAllPartitions()) {
@@ -210,62 +215,19 @@ public class TabletStatMgr extends FrontendDaemon {
                     locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.WRITE);
                 }
 
-                // Trigger tablet reshard
-                if (GlobalStateMgr.getCurrentState().isLeader()) {
-                    triggerTabletReshard(db, olapTable, maxTabletSize, minAdjacentTabletPairSize);
+                // Emit a reshard candidate with the signals computed above; addReshardCandidate drops
+                // non-actionable signals and the TabletReshardJobMgr drain owns job creation. This
+                // periodic scan is the fallback for the publish-driven path, so unlike publish it
+                // carries the merge signal too.
+                if (reshardEligible) {
+                    GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addReshardCandidate(
+                            db.getId(), olapTable.getId(), maxTabletSize, minAdjacentTabletPairSize);
                 }
             }
         }
         LOG.info("finished to update index row num of all databases. cost: {} ms",
                 (System.currentTimeMillis() - start));
         lastWorkTimestamp = LocalDateTime.now();
-    }
-
-    /**
-     * Minimum tablet count auto-merge must keep per index for {@code table}. Returns 0 ("not
-     * floor-gated") for tables that never auto-merge (non-cloud-native or non-range-distribution),
-     * and also on lookup failure so a single table's warehouse error cannot abort the daemon cycle.
-     * Called before the table lock since it resolves warehouse/compute-node state.
-     */
-    private static int resolveMergeParallelismFloor(Database db, OlapTable table) {
-        if (!table.isCloudNativeTableOrMaterializedView() || !table.isRangeDistribution()) {
-            return 0;
-        }
-        try {
-            return TabletReshardUtils.computeParallelismFloor(table.getId());
-        } catch (RuntimeException e) {
-            LOG.warn("Parallelism floor unavailable for table {}.{}; "
-                            + "auto-merge will not be floor-gated for this table.",
-                    db.getFullName(), table.getName(), e);
-            return 0;
-        }
-    }
-
-    private static void triggerTabletReshard(Database db, OlapTable table,
-                                             long maxTabletSize, long minAdjacentTabletPairSize) {
-        if (!table.isCloudNativeTableOrMaterializedView() || !table.isRangeDistribution()) {
-            return;
-        }
-
-        try {
-            if (TabletReshardUtils.needSplit(maxTabletSize)) {
-                GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().createTabletReshardJob(
-                        db, table, new SplitTabletClause());
-                LOG.info("Auto triggered split tablet job for table {}.{}, maxTabletSize {}",
-                        db.getFullName(), table.getName(), maxTabletSize);
-                return;
-            }
-
-            if (TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
-                GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().createTabletReshardJob(
-                        db, table, new MergeTabletClause());
-                LOG.info("Auto triggered merge tablet job for table {}.{}, minAdjacentTabletPairSize {}",
-                        db.getFullName(), table.getName(), minAdjacentTabletPairSize);
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to create tablet reshard job for table {}.{}.",
-                    db.getFullName(), table.getName(), e);
-        }
     }
 
     private void updateLocalTabletStat() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -34,6 +34,7 @@ import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
 import com.starrocks.proto.TabletRangePB;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
@@ -183,11 +184,11 @@ public class Utils {
                                            Map<Long, Double> compactionScores,
                                            Map<ComputeNode, List<Long>> nodeToTablets,
                                            ComputeResource computeResource,
-                                           Map<Long, Long> tabletRowNum,
+                                           Map<Long, TabletStatPB> tabletStats,
                                            List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         publishVersionBatch(tablets, txnInfos, baseVersion, newVersion, compactionScores, null, nodeToTablets,
-                computeResource, tabletRowNum, vectorIndexBuildInfos);
+                computeResource, tabletStats, vectorIndexBuildInfos);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
@@ -196,7 +197,7 @@ public class Utils {
                                            Map<Long, TabletRange> tabletRanges,
                                            Map<ComputeNode, List<Long>> nodeToTablets,
                                            ComputeResource computeResource,
-                                           Map<Long, Long> tabletRowNum,
+                                           Map<Long, TabletStatPB> tabletStats,
                                            List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
@@ -253,8 +254,8 @@ public class Utils {
                         tabletRanges.put(entry.getKey(), TabletRange.fromProto(entry.getValue()));
                     }
                 }
-                if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
-                    tabletRowNum.putAll(response.tabletRowNums);
+                if (tabletStats != null && response != null && response.tabletStats != null) {
+                    tabletStats.putAll(response.tabletStats);
                 }
                 if (vectorIndexBuildInfos != null && response != null
                         && response.vectorIndexBuildInfos != null) {
@@ -275,28 +276,29 @@ public class Utils {
 
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, Map<Long, Double> compactionScores,
-                                      ComputeResource computeResource, Map<Long, Long> tabletRowNums,
-                                      boolean useAggregatePublish,
+                                      ComputeResource computeResource,
+                                      Map<Long, TabletStatPB> tabletStats, boolean useAggregatePublish,
                                       List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         publishVersion(tablets, txnInfo, baseVersion, newVersion, compactionScores,
-                null, computeResource, tabletRowNums, useAggregatePublish, vectorIndexBuildInfos);
+                null, computeResource, tabletStats, useAggregatePublish, vectorIndexBuildInfos);
     }
 
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, Map<Long, Double> compactionScores,
                                       Map<Long, TabletRange> tabletRanges, ComputeResource computeResource,
-                                      Map<Long, Long> tabletRowNums, boolean useAggregatePublish,
+                                      Map<Long, TabletStatPB> tabletStats,
+                                      boolean useAggregatePublish,
                                       List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         List<TxnInfoPB> txnInfos = Lists.newArrayList(txnInfo);
         if (!useAggregatePublish) {
             publishVersionBatch(tablets, txnInfos, baseVersion, newVersion,
-                    compactionScores, tabletRanges, null, computeResource, tabletRowNums,
+                    compactionScores, tabletRanges, null, computeResource, tabletStats,
                     vectorIndexBuildInfos);
         } else {
             aggregatePublishVersion(tablets, txnInfos, baseVersion, newVersion, compactionScores,
-                    tabletRanges, null, computeResource, tabletRowNums, vectorIndexBuildInfos);
+                    tabletRanges, null, computeResource, tabletStats, vectorIndexBuildInfos);
         }
     }
 
@@ -421,18 +423,18 @@ public class Utils {
     public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                                                           long baseVersion, ComputeResource computeResource,
                                                           Map<Long, Double> compactionScores,
-                                                          Map<Long, Long> tabletRowNum,
+                                                          Map<Long, TabletStatPB> tabletStats,
                                                           List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores, null,
-                tabletRowNum, vectorIndexBuildInfos);
+                tabletStats, vectorIndexBuildInfos);
     }
 
     public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                                                           long baseVersion, ComputeResource computeResource,
                                                           Map<Long, Double> compactionScores,
                                                           Map<Long, TabletRange> tabletRanges,
-                                                          Map<Long, Long> tabletRowNum,
+                                                          Map<Long, TabletStatPB> tabletStats,
                                                           List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
@@ -478,8 +480,8 @@ public class Utils {
                     tabletRanges.put(entry.getKey(), TabletRange.fromProto(entry.getValue()));
                 }
             }
-            if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
-                tabletRowNum.putAll(response.tabletRowNums);
+            if (tabletStats != null && response != null && response.tabletStats != null) {
+                tabletStats.putAll(response.tabletStats);
             }
             if (vectorIndexBuildInfos != null && response != null
                     && response.vectorIndexBuildInfos != null) {
@@ -516,11 +518,11 @@ public class Utils {
                                                Map<Long, Double> compactionScores,
                                                Map<ComputeNode, List<Long>> nodeToTablets,
                                                ComputeResource computeResource,
-                                               Map<Long, Long> tabletRowNum,
+                                               Map<Long, TabletStatPB> tabletStats,
                                                List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         aggregatePublishVersion(tablets, txnInfos, baseVersion, newVersion, compactionScores,
-                null, nodeToTablets, computeResource, tabletRowNum, vectorIndexBuildInfos);
+                null, nodeToTablets, computeResource, tabletStats, vectorIndexBuildInfos);
     }
 
     public static void aggregatePublishVersion(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
@@ -529,7 +531,7 @@ public class Utils {
                                                Map<Long, TabletRange> tabletRanges,
                                                Map<ComputeNode, List<Long>> nodeToTablets,
                                                ComputeResource computeResource,
-                                               Map<Long, Long> tabletRowNum,
+                                               Map<Long, TabletStatPB> tabletStats,
                                                List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
@@ -537,7 +539,7 @@ public class Utils {
             createSubRequestForAggregatePublish(tablets, txnInfos, baseVersion, newVersion,
                                                 nodeToTablets, computeResource, request);
             sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores,
-                                               tabletRanges, tabletRowNum, vectorIndexBuildInfos);
+                                               tabletRanges, tabletStats, vectorIndexBuildInfos);
         } catch (Exception e) {
             throw e;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -84,6 +84,7 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.DeleteJob;
 import com.starrocks.load.OlapDeleteJob;
 import com.starrocks.load.loadv2.SparkLoadJob;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -717,10 +718,11 @@ public class LeaderImpl {
                     long partitionId = tabletInfo.getPartition_id();
                     PartitionCommitInfo commitInfo = idToPartitionCommitInfo.get(partitionId);
                     if (commitInfo != null && commitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
-                        long rowCount = tabletInfo.getRow_count();
                         long tabletId = tabletInfo.getTablet_id();
-                        Map<Long, Long> tableIdToRowCount = commitInfo.getTabletIdToRowCountForPartitionFirstLoad();
-                        tableIdToRowCount.put(tabletId, rowCount);
+                        TabletStatPB stat = new TabletStatPB();
+                        stat.numRows = tabletInfo.getRow_count();
+                        stat.dataSize = tabletInfo.getData_size();
+                        commitInfo.getTabletStats().put(tabletId, stat);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -35,6 +35,7 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.InsertOverwriteStateChangeInfo;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
@@ -733,16 +734,19 @@ public class InsertOverwriteJobRunner {
                         for (var entry : tableCommitInfo.getIdToPartitionCommitInfo().entrySet()) {
                             long physicalPartitionId = entry.getKey();
                             PartitionCommitInfo partitionCommitInfo = entry.getValue();
-                            Map<Long, Long> tabletRows = partitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad();
+                            Map<Long, TabletStatPB> tabletStats = partitionCommitInfo.getTabletStats();
 
                             PhysicalPartition physicalPartition = targetTable.getPhysicalPartition(physicalPartitionId);
                             if (physicalPartition != null) {
                                 Partition partition = targetTable.getPartition(physicalPartition.getParentId());
-                                if (partition != null && !tabletRows.isEmpty() &&
+                                if (partition != null && !tabletStats.isEmpty() &&
                                         stats.getTargetPartitionIds().contains(partition.getId())) {
                                     long partitionId = partition.getId();
-                                    tabletRows.forEach((tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId,
-                                            tabletId, rowCount));
+                                    tabletStats.forEach((tabletId, stat) -> {
+                                        if (stat != null && stat.numRows != null) {
+                                            partitionTabletRowCounts.put(partitionId, tabletId, stat.numRows);
+                                        }
+                                    });
                                 }
                             }
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -29,6 +29,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.EtlStatus;
 import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.streamload.StreamLoadTxnCommitAttachment;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DmlType;
 import com.starrocks.server.GlobalStateMgr;
@@ -296,7 +297,7 @@ public class StatisticsCollectionTrigger {
                 // statistic collect granularity is logical partition.
                 long physicalPartitionId = entry.getKey();
                 PartitionCommitInfo partitionCommitInfo = entry.getValue();
-                Map<Long, Long> tabletRows = partitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad();
+                Map<Long, TabletStatPB> tabletStats = partitionCommitInfo.getTabletStats();
 
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                 Long partitionId = table.getPartition(physicalPartition.getParentId()).getId();
@@ -310,14 +311,12 @@ public class StatisticsCollectionTrigger {
                 if (dmlType == DmlType.UPDATE) {
                     // For UPDATE, collect on touched partitions regardless of version.
                     partitionIds.add(partitionId);
-                    tabletRows.forEach(
-                            (tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId, tabletId, rowCount));
+                    putTabletRowCounts(partitionTabletRowCounts, partitionId, tabletStats);
                 } else if (dmlType == DmlType.INSERT_INTO) {
                     // For INSERT, only consider the first load of a partition
                     if (partitionCommitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
                         partitionIds.add(partitionId);
-                        tabletRows.forEach(
-                                (tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId, tabletId, rowCount));
+                        putTabletRowCounts(partitionTabletRowCounts, partitionId, tabletStats);
                     }
                 } else {
                     // TODO: support DELETE
@@ -338,6 +337,15 @@ public class StatisticsCollectionTrigger {
         if (analyzeType != SAMPLE) {
             partitionTabletRowCounts.clear();
         }
+    }
+
+    private static void putTabletRowCounts(com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts,
+                                           long partitionId, Map<Long, TabletStatPB> tabletStats) {
+        tabletStats.forEach((tabletId, stat) -> {
+            if (stat != null && stat.numRows != null) {
+                partitionTabletRowCounts.put(partitionId, tabletId, stat.numRows);
+            }
+        });
     }
 
     private void prepareAnalyzeForOverwrite() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -18,12 +18,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.compaction.CompactionTxnCommitAttachment;
 import com.starrocks.lake.compaction.PartitionIdentifier;
 import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -31,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 public class LakeTableTxnLogApplier implements TransactionLogApplier {
     private static final Logger LOG = LogManager.getLogger(LakeTableTxnLogApplier.class);
@@ -120,6 +126,14 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             if (!partitionCommitInfo.getDictCollectedVersions().isEmpty()) {
                 dictCollectedVersions = partitionCommitInfo.getDictCollectedVersions();
             }
+            // Publish-driven real-time reshard triggering + transient stat refresh. Leader-only; on
+            // followers / replay / checkpoint the transient tabletStats map is empty, so skip there.
+            if (GlobalStateMgr.getCurrentState().isLeader() && !GlobalStateMgr.isCheckpointThread()) {
+                Map<Long, TabletStatPB> tabletStats = partitionCommitInfo.getTabletStats();
+                if (tabletStats != null && !tabletStats.isEmpty()) {
+                    refreshTabletStatsAndMarkReshardCandidate(partition, tabletStats, db, versionTime);
+                }
+            }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
         }
 
@@ -136,6 +150,56 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                         .updateGlobalDict(table, columnName, collectedVersion, maxPartitionVersionTime);
             }
         }
+    }
+
+    /**
+     * Leader-only post-publish bookkeeping for one lake partition: refresh each LakeTablet's data size
+     * and row count from the BE-reported {@code tabletStats}, then mark the table a reshard candidate
+     * with the largest just-published tablet size ({@code addReshardCandidate} applies the split threshold).
+     *
+     * <p>The candidate carries only the split signal (merge = Long.MAX_VALUE): split is the publish
+     * path's real-time benefit and is never gated by the merge parallelism floor, so this stays a pure
+     * in-memory max with no StarMgr RPC on the write-locked publish path. maxTabletSize is taken over
+     * only the just-published tablets (those in {@code tabletStats}); a tablet only grows when written,
+     * so this is the real-time signal, and the periodic TabletStatMgr scan is the backstop for any
+     * already-oversized tablet this publish did not touch. It is also monotone (table-wide &gt;= this
+     * partition's), so a per-partition crossing is decision-safe. Merge is left to the periodic scan,
+     * whose adjacency signal requires every neighbor to be fresh — a single publish rarely satisfies that.
+     *
+     * <p>{@code tabletStats} is transient transport: it is consumed here and cleared to bound FE heap,
+     * since the LakeTablet row counts set above persist independently and the post-visible first-load
+     * statistics collector samples from LakeTablet.getFuzzyRowCount(), not from this map.
+     */
+    private void refreshTabletStatsAndMarkReshardCandidate(PhysicalPartition partition,
+            Map<Long, TabletStatPB> tabletStats, Database db, long versionTime) {
+        List<MaterializedIndex> indexes = partition.getLatestMaterializedIndices(IndexExtState.VISIBLE);
+        long maxTabletSize = 0L;
+        // Walk only the tablets this publish actually reported, not every tablet in the partition: this
+        // runs under the table write lock, so resolve each reported id directly (O(1) per index).
+        for (Map.Entry<Long, TabletStatPB> entry : tabletStats.entrySet()) {
+            Tablet tablet = null;
+            for (MaterializedIndex index : indexes) {
+                tablet = index.getTablet(entry.getKey());
+                if (tablet != null) {
+                    break;
+                }
+            }
+            if (!(tablet instanceof LakeTablet)) {
+                continue;
+            }
+            LakeTablet lakeTablet = (LakeTablet) tablet;
+            TabletStatPB tabletStat = entry.getValue();
+            long dataSize = tabletStat.dataSize != null ? tabletStat.dataSize : 0L;
+            lakeTablet.setDataSize(dataSize);
+            lakeTablet.setRowCount(tabletStat.numRows != null ? tabletStat.numRows : 0L);
+            lakeTablet.setDataSizeUpdateTime(versionTime);
+            maxTabletSize = Math.max(maxTabletSize, dataSize);
+        }
+        if (maxTabletSize > 0 && table.isRangeDistribution()) {
+            GlobalStateMgr.getCurrentState().getTabletReshardJobMgr()
+                    .addReshardCandidate(db.getId(), table.getId(), maxTabletSize, Long.MAX_VALUE);
+        }
+        tabletStats.clear();
     }
 
     public void applyVisibleLogBatch(TransactionStateBatch txnStateBatch, Database db) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -39,6 +39,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.io.Writable;
 import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.proto.TabletStatPB;
 
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +84,11 @@ public class PartitionCommitInfo implements Writable {
     @SerializedName(value = "compactionScore")
     private Quantiles compactionScore;
 
-    private final Map<Long, Long> tabletIdToRowCountForPartitionFirstLoad = new HashMap<>();
+    // Per-tablet stats collected during publish: for lake tables from the publish RPC response
+    // (range-distribution tablets, and any tablet on first import), for shared-nothing tables
+    // from TTabletInfo on first import. Transient (not serialized), leader-only. Consumed for
+    // first-load statistics collection and (lake only) real-time reshard triggering.
+    private final Map<Long, TabletStatPB> tabletStats = new HashMap<>();
 
     private boolean isDoubleWrite = false;
 
@@ -129,7 +134,7 @@ public class PartitionCommitInfo implements Writable {
         this.compactionScore = partitionCommitInfo.compactionScore == null
                 ? null
                 : new Quantiles(partitionCommitInfo.compactionScore);
-        this.tabletIdToRowCountForPartitionFirstLoad.putAll(partitionCommitInfo.tabletIdToRowCountForPartitionFirstLoad);
+        this.tabletStats.putAll(partitionCommitInfo.tabletStats);
         this.isDoubleWrite = partitionCommitInfo.isDoubleWrite;
     }
 
@@ -193,8 +198,8 @@ public class PartitionCommitInfo implements Writable {
         this.compactionScore = compactionScore;
     }
 
-    public Map<Long, Long> getTabletIdToRowCountForPartitionFirstLoad() {
-        return tabletIdToRowCountForPartitionFirstLoad;
+    public Map<Long, TabletStatPB> getTabletStats() {
+        return tabletStats;
     }
 
     @Nullable

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -58,6 +58,7 @@ import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.rpc.BrpcProxy;
@@ -702,14 +703,16 @@ public class PublishVersionDaemon extends LeaderDaemon {
 
                 // used to delete txnLog when publish success
                 Map<ComputeNode, List<Long>> nodeToTablets = new HashMap<>();
+                // Per-tablet stats for real-time reshard triggering (range-distribution tablets only).
+                Map<Long, TabletStatPB> tabletStats = new HashMap<>();
                 List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                 if (!useAggregatePublish) {
                     Utils.publishVersionBatch(publishTablets, txnInfos,
                             startVersion - 1, endVersion, compactionScores, nodeToTablets,
-                            computeResource, null, vectorIndexBuildInfos);
+                            computeResource, tabletStats, vectorIndexBuildInfos);
                 } else {
                     Utils.aggregatePublishVersion(publishTablets, txnInfos, startVersion - 1, endVersion,
-                            compactionScores, nodeToTablets, computeResource, null, vectorIndexBuildInfos);
+                            compactionScores, nodeToTablets, computeResource, tabletStats, vectorIndexBuildInfos);
                 }
 
                 // Mixed batches (rare) fall back to false so the load-tail delay protects
@@ -719,6 +722,9 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, allFromCompaction);
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 stateBatch.setCompactionScore(tableId, partitionId, quantiles);
+                if (!tabletStats.isEmpty()) {
+                    stateBatch.setTabletStats(tableId, partitionId, tabletStats);
+                }
                 stateBatch.putBeTablets(partitionId, nodeToTablets);
             }
         } catch (Exception e) {
@@ -1103,17 +1109,18 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
             if (CollectionUtils.isNotEmpty(normalTablets)) {
                 Map<Long, Double> compactionScores = new HashMap<>();
-                // Used to collect statistics when the partition is first imported
-                Map<Long, Long> tabletRowNums = new HashMap<>();
+                // Per-tablet stats from the publish response: first-load row counts for statistics
+                // collection, and range-distribution tablet sizes for real-time reshard triggering.
+                Map<Long, TabletStatPB> tabletStats = new HashMap<>();
                 List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                 Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
-                        computeResource, tabletRowNums, useAggregatePublish, vectorIndexBuildInfos);
+                        computeResource, tabletStats, useAggregatePublish, vectorIndexBuildInfos);
 
                 VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, txnState.isFromLakeCompaction());
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);
-                if (!tabletRowNums.isEmpty()) {
-                    partitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad().putAll(tabletRowNums);
+                if (!tabletStats.isEmpty()) {
+                    partitionCommitInfo.getTabletStats().putAll(tabletStats);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import org.apache.logging.log4j.LogManager;
@@ -67,6 +68,19 @@ public class TransactionStateBatch implements Writable {
                 .map(transactionState -> transactionState.getTableCommitInfo(tableId))
                 .filter(commitInfo -> commitInfo.getPartitionCommitInfo(partitionId) != null)
                 .forEach(commitInfo -> commitInfo.getPartitionCommitInfo(partitionId).setCompactionScore(quantiles));
+    }
+
+    // Fan per-tablet stats onto each batched txn's PartitionCommitInfo for this partition.
+    // Mirrors setCompactionScore; applied (idempotently) in LakeTableTxnLogApplier.applyVisibleLog.
+    public void setTabletStats(long tableId, long partitionId, Map<Long, TabletStatPB> tabletStats) {
+        if (tabletStats == null || tabletStats.isEmpty()) {
+            return;
+        }
+        this.transactionStates.stream()
+                .map(transactionState -> transactionState.getTableCommitInfo(tableId))
+                .filter(commitInfo -> commitInfo != null && commitInfo.getPartitionCommitInfo(partitionId) != null)
+                .forEach(commitInfo ->
+                        commitInfo.getPartitionCommitInfo(partitionId).getTabletStats().putAll(tabletStats));
     }
 
     public void putBeTablets(long partitionId, Map<ComputeNode, List<Long>> nodeToTablets)  {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -298,7 +298,7 @@ public class LakeRollupJobTest {
             public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                     long baseVersion, ComputeResource computeResource,
                     Map<Long, Double> compactionScores,
-                    Map<Long, Long> tabletRowNum,
+                    Map<Long, com.starrocks.proto.TabletStatPB> tabletStats,
                     java.util.List<com.starrocks.proto.VectorIndexBuildInfoPB> vectorIndexBuildInfos)
                     throws NoAliveBackendException, RpcException {
                 // Do nothing, just return successfully

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
@@ -16,7 +16,6 @@ package com.starrocks.alter.reshard;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.TabletStatMgr;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -30,6 +29,7 @@ import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AutomaticTabletReshardTest {
@@ -56,6 +56,23 @@ public class AutomaticTabletReshardTest {
                 .getTable(db.getFullName(), "test_table");
     }
 
+    @BeforeEach
+    public void setUp() {
+        // triggerTabletReshard is leader-admission gated; open the gate so each test exercises
+        // the split/merge decision instead of short-circuiting.
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+
+            @Mock
+            public boolean isLeaderWorkAdmissionOpen() {
+                return true;
+            }
+        };
+    }
+
     @Test
     void testTriggerTabletReshardFailed() {
         new MockUp<TabletReshardJobMgr>() {
@@ -66,7 +83,8 @@ public class AutomaticTabletReshardTest {
             }
         };
 
-        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        Deencapsulation.invoke(mgr, "triggerTabletReshard", db, table,
                 Config.tablet_reshard_target_size * 4, Long.MAX_VALUE);
     }
 
@@ -80,7 +98,8 @@ public class AutomaticTabletReshardTest {
             }
         };
 
-        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        Deencapsulation.invoke(mgr, "triggerTabletReshard", db, table,
                 Config.tablet_reshard_target_size * 4, Long.MAX_VALUE);
     }
 
@@ -98,7 +117,8 @@ public class AutomaticTabletReshardTest {
         // pair sum strictly below mergePairThreshold = ceil(0.8 * target) → triggers merge
         long t = Config.tablet_reshard_target_size;
         long pairSumBelowThreshold = TabletReshardUtils.mergePairThreshold(t) - 1;
-        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        Deencapsulation.invoke(mgr, "triggerTabletReshard", db, table,
                 0L, pairSumBelowThreshold);
         org.junit.jupiter.api.Assertions.assertTrue(mergeCalled[0],
                 "merge job should be created when minAdjacentPair < mergePairThreshold");
@@ -118,7 +138,8 @@ public class AutomaticTabletReshardTest {
         // pair sum exactly at mergePairThreshold → strict-less-than means NOT triggered
         long t = Config.tablet_reshard_target_size;
         long atThreshold = TabletReshardUtils.mergePairThreshold(t);
-        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        Deencapsulation.invoke(mgr, "triggerTabletReshard", db, table,
                 0L, atThreshold);
         org.junit.jupiter.api.Assertions.assertFalse(mergeCalled[0],
                 "merge must not trigger at the exact threshold (strict <)");
@@ -138,7 +159,8 @@ public class AutomaticTabletReshardTest {
         // maxTabletSize one byte below splitThreshold = ceil(1.5 * target) → NOT triggered
         long t = Config.tablet_reshard_target_size;
         long justBelow = TabletReshardUtils.splitThreshold(t) - 1;
-        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        Deencapsulation.invoke(mgr, "triggerTabletReshard", db, table,
                 justBelow, Long.MAX_VALUE);
         org.junit.jupiter.api.Assertions.assertFalse(splitCalled[0],
                 "split must not trigger one byte below splitThreshold");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -445,7 +445,7 @@ public class MergeTabletJobTest {
                                        long baseVersion, long newVersion, Map<Long, Double> compactionScores,
                                        Map<Long, TabletRange> tabletRanges,
                                        ComputeResource computeResource,
-                                       Map<Long, Long> tabletRowNums,
+                                       Map<Long, com.starrocks.proto.TabletStatPB> tabletStats,
                                        boolean useAggregatePublish,
                                        List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) throws Exception {
                 throw new RuntimeException("mock");
@@ -479,7 +479,7 @@ public class MergeTabletJobTest {
                                        long baseVersion, long newVersion, Map<Long, Double> compactionScores,
                                        Map<Long, TabletRange> tabletRanges,
                                        ComputeResource computeResource,
-                                       Map<Long, Long> tabletRowNums,
+                                       Map<Long, com.starrocks.proto.TabletStatPB> tabletStats,
                                        boolean useAggregatePublish,
                                        List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) {
                 actualResource.set(computeResource);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -303,7 +303,8 @@ public class SplitTabletJobTest {
             public void publishVersion(List<Tablet> tablets, TxnInfoPB txnInfo,
                                        long baseVersion, long newVersion, Map<Long, Double> compactionScores,
                                        Map<Long, TabletRange> tabletRanges, ComputeResource computeResource,
-                                       Map<Long, Long> tabletRowNums, boolean useAggregatePublish,
+                                       Map<Long, com.starrocks.proto.TabletStatPB> tabletStats,
+                                       boolean useAggregatePublish,
                                        List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) {
                 actualResource.set(computeResource);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -14,15 +14,24 @@
 
 package com.starrocks.alter.reshard;
 
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.thrift.TTabletReshardJobsItem;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TabletReshardJobMgrTest {
@@ -151,12 +160,43 @@ public class TabletReshardJobMgrTest {
 
     protected static ConnectContext connectContext;
     protected static StarRocksAssert starRocksAssert;
+    private static Database reshardDb;
+    private static OlapTable reshardTable;
+    private static LakeTablet oversizedTablet;
+
+    @BeforeEach
+    public void clearSharedMgr() {
+        // Tests that use the singleton TabletReshardJobMgr share its state. Clear it before each
+        // test so a job created in one test does not block table-reservation checks in the next.
+        GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().tabletReshardJobs.clear();
+        // Reset the table state: a split job created by a previous test transitions the table to
+        // TABLET_RESHARD via init(), and triggerTabletReshard short-circuits on non-NORMAL.
+        if (reshardTable != null) {
+            reshardTable.setState(OlapTable.OlapTableState.NORMAL);
+        }
+    }
 
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("reshard_test_db").useDatabase("reshard_test_db");
+        reshardDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("reshard_test_db");
+
+        String sql = "create table reshard_trigger_table (key1 int, key2 varchar(10))\n" +
+                "order by(key1)\n" +
+                "properties('replication_num' = '1');";
+        starRocksAssert.withTable(sql);
+        reshardTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(reshardDb.getFullName(), "reshard_trigger_table");
+
+        // Grab the single tablet from the default partition.
+        Tablet t = reshardTable.getPartitions().iterator().next()
+                .getDefaultPhysicalPartition().getLatestBaseIndex().getTablets().get(0);
+        oversizedTablet = (LakeTablet) t;
     }
 
     @Test
@@ -222,5 +262,126 @@ public class TabletReshardJobMgrTest {
         jobMgr.addTabletReshardJob(job2);
 
         Assertions.assertEquals(2, jobMgr.getAllJobsInfo().getItems().size());
+    }
+
+    private void mockLeaderAdmissionOpen() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+
+            @Mock
+            public boolean isLeaderWorkAdmissionOpen() {
+                return true;
+            }
+        };
+    }
+
+    private void mockLeaderAdmissionClosed() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+
+            @Mock
+            public boolean isLeaderWorkAdmissionOpen() {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    public void testAddAndDrainReshardCandidate() throws Exception {
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+
+        mockLeaderAdmissionOpen();
+
+        Assertions.assertTrue(reshardTable.isRangeDistribution(),
+                "test table must be range-distributed; update DDL or Config if this fires");
+
+        int before = mgr.getTabletReshardJobs().size();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertEquals(before + 1, mgr.getTabletReshardJobs().size());
+    }
+
+    @Test
+    public void testTickSkippedWhenAdmissionClosed() throws Exception {
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+
+        // Phase 1: admission open — pre-seed one candidate so the set is non-empty.
+        mockLeaderAdmissionOpen();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        Assertions.assertEquals(1, mgr.getReshardCandidateCount(),
+                "pre-seeded candidate should be present while admission is open");
+
+        // Phase 2: flip admission closed — runAfterCatalogReady must clear the candidate set
+        // without creating any new reshard job.
+        mockLeaderAdmissionClosed();
+        int before = mgr.getTabletReshardJobs().size();
+        mgr.runAfterCatalogReadyForTest();                                    // gated: drain + jobs skipped, candidates cleared
+        Assertions.assertEquals(before, mgr.getTabletReshardJobs().size(),
+                "no new reshard job should be created when admission is closed");
+        Assertions.assertEquals(0, mgr.getReshardCandidateCount(),
+                "candidate set must be cleared when admission is closed");
+    }
+
+    @Test
+    public void testAddReshardCandidateDropsNonActionableSignal() throws Exception {
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        mockLeaderAdmissionOpen();
+        // A tablet below the split threshold with no merge signal is not actionable: even with
+        // admission open, addReshardCandidate must drop it rather than queue a no-op candidate.
+        long belowSplit = TabletReshardUtils.splitThreshold(Config.tablet_reshard_target_size) - 1;
+        int before = mgr.getReshardCandidateCount();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), belowSplit, Long.MAX_VALUE);
+        Assertions.assertEquals(before, mgr.getReshardCandidateCount(),
+                "non-actionable signal (below split threshold, no merge) must not be queued");
+    }
+
+    @Test
+    public void testAddReshardCandidateCoalescesPerTable() throws Exception {
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        mockLeaderAdmissionOpen();
+        long target = Config.tablet_reshard_target_size;
+        // First actionable mark seeds the table's candidate.
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), target * 2, Long.MAX_VALUE);
+        int afterFirst = mgr.getReshardCandidateCount();
+        // A second mark for the same table must coalesce (exercise the merge remap), not add a new entry.
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), target * 4, Long.MAX_VALUE);
+        Assertions.assertEquals(afterFirst, mgr.getReshardCandidateCount(),
+                "repeated marks for one table coalesce into a single candidate");
+    }
+
+    @Test
+    public void testAddAndDrainMergeCandidate() throws Exception {
+        // The unified candidate queue carries the merge signal too: a sub-threshold adjacent-pair sum
+        // (no split signal) marked via addReshardCandidate must be routed to a merge job by the drain.
+        boolean[] mergeCalled = {false};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause clause) {
+                mergeCalled[0] = true;
+            }
+        };
+
+        mockLeaderAdmissionOpen();
+        Assertions.assertTrue(reshardTable.isRangeDistribution(),
+                "test table must be range-distributed; update DDL or Config if this fires");
+
+        // pair sum strictly below mergePairThreshold = ceil(0.8 * target) -> needMerge, needSplit(0) false
+        long mergePairBelowThreshold =
+                TabletReshardUtils.mergePairThreshold(Config.tablet_reshard_target_size) - 1;
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), 0L, mergePairBelowThreshold);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertTrue(mergeCalled[0],
+                "drain must route a sub-threshold merge candidate to a merge job");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.alter.reshard;
 
 import com.starrocks.common.Config;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -188,6 +190,20 @@ public class TabletReshardUtilsTest {
         long data = (Long.MAX_VALUE / t) * t;
         // expected to cap at max_split_count
         assertEquals(Config.tablet_reshard_max_split_count, TabletReshardUtils.calcSplitCount(data, t));
+    }
+
+    @Test
+    public void safeComputeParallelismFloor_returnsZeroWhenComputeFails() {
+        // computeParallelismFloor resolves warehouse / compute-node state via StarMgr and can throw
+        // (e.g. the warehouse no longer exists). safeComputeParallelismFloor must swallow that and
+        // fall back to "no floor" (0) so a single table's warehouse error cannot abort the scan.
+        new MockUp<TabletReshardUtils>() {
+            @Mock
+            public static int computeParallelismFloor(long tableId) {
+                throw new RuntimeException("warehouse unavailable");
+            }
+        };
+        assertEquals(0, TabletReshardUtils.safeComputeParallelismFloor(123L));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
@@ -14,10 +14,26 @@
 
 package com.starrocks.transaction;
 
+import com.starrocks.alter.reshard.TabletReshardJobMgr;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.RangeDistributionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.compaction.CompactionTxnCommitAttachment;
+import com.starrocks.proto.TabletStatPB;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class LakeTableTxnLogApplierTest extends LakeTableTestHelper {
     @Test
@@ -68,6 +84,138 @@ public class LakeTableTxnLogApplierTest extends LakeTableTestHelper {
         Assertions.assertEquals(partitionCommitInfo.getVersionTime(),
                 table.getPartition(partitionId).getDefaultPhysicalPartition()
                         .getVisibleVersionTime());
+    }
+
+    @Test
+    public void testApplyVisibleLogUpdatesLakeTabletAndEnqueues() {
+        // Build a table with two tablets in the index: one WITH a matching stat entry, one WITHOUT.
+        MaterializedIndex index = new MaterializedIndex(indexId);
+        LakeTablet lakeTablet = new LakeTablet(tabletId[0]);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId[0], tabletMeta);
+        index.addTablet(lakeTablet, tabletMeta);
+
+        // Second tablet has no entry in tabletStats — verifies per-tablet selectivity.
+        LakeTablet noStatTablet = new LakeTablet(tabletId[1]);
+        TabletMeta noStatMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId[1], noStatMeta);
+        index.addTablet(noStatTablet, noStatMeta);
+
+        LakeTable table = buildLakeTableWithIndex(index);
+        // Range distribution is required for the publish-driven reshard path to evaluate the table.
+        table.setDefaultDistributionInfo(new RangeDistributionInfo());
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        TransactionState state = newTransactionState();
+        state.setTransactionStatus(TransactionStatus.COMMITTED);
+
+        PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(physicalPartitionId, 2, 0);
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(tableId);
+        tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
+        applier.applyCommitLog(state, tableCommitInfo);
+
+        state.setTransactionStatus(TransactionStatus.VISIBLE);
+        long versionTime = System.currentTimeMillis();
+        partitionCommitInfo.setVersionTime(versionTime);
+
+        // Populate tabletStats for tabletId[0] only — tabletId[1] is intentionally absent.
+        // Oversize tabletId[0] so the precomputed split signal crosses the threshold and the
+        // table is enqueued as a reshard candidate.
+        long oversize = Config.tablet_reshard_target_size * 2;
+        TabletStatPB stat = new TabletStatPB();
+        stat.numRows = 5L;
+        stat.dataSize = oversize;
+        Map<Long, TabletStatPB> stats = new HashMap<>();
+        stats.put(tabletId[0], stat);
+        partitionCommitInfo.getTabletStats().putAll(stats);
+
+        // Mock leader=true, checkpoint=false; intercept addReshardCandidate to count calls
+        AtomicInteger addCandidateCalls = new AtomicInteger(0);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+
+            @Mock
+            public static boolean isCheckpointThread() {
+                return false;
+            }
+        };
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void addReshardCandidate(long dbId, long tableId, long maxTabletSize, long minAdjacentTabletPairSize) {
+                addCandidateCalls.incrementAndGet();
+            }
+        };
+
+        Database db = new Database(dbId, "test_db");
+        applier.applyVisibleLog(state, tableCommitInfo, db);
+
+        // Tablet with a stat entry: fields must be updated.
+        Assertions.assertEquals(oversize, lakeTablet.getDataSize(true));
+        Assertions.assertEquals(5L, lakeTablet.getRowCount(0));
+        Assertions.assertEquals(versionTime, lakeTablet.getDataSizeUpdateTime());
+        Assertions.assertEquals(1, addCandidateCalls.get(), "addReshardCandidate should be called once");
+
+        // Tablet WITHOUT a stat entry: must remain at default values (per-tablet selectivity).
+        Assertions.assertEquals(0L, noStatTablet.getDataSizeUpdateTime(),
+                "tablet absent from tabletStats must not have its update-time modified");
+        Assertions.assertEquals(0L, noStatTablet.getDataSize(true),
+                "tablet absent from tabletStats must not have its data-size modified");
+    }
+
+    @Test
+    public void testApplyVisibleLogSkippedOnNonLeader() {
+        // Use indexId+100 to avoid any ID collision with the positive test's index (indexId).
+        long negativeIndexId = indexId + 100;
+        MaterializedIndex index = new MaterializedIndex(negativeIndexId);
+        LakeTablet lakeTablet = new LakeTablet(tabletId[1]);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId[1], tabletMeta);
+        index.addTablet(lakeTablet, tabletMeta);
+
+        LakeTable table = buildLakeTableWithIndex(index);
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        TransactionState state = newTransactionState();
+        state.setTransactionStatus(TransactionStatus.COMMITTED);
+
+        PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(physicalPartitionId, 2, 0);
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(tableId);
+        tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
+        applier.applyCommitLog(state, tableCommitInfo);
+
+        state.setTransactionStatus(TransactionStatus.VISIBLE);
+        partitionCommitInfo.setVersionTime(System.currentTimeMillis());
+
+        TabletStatPB stat = new TabletStatPB();
+        stat.numRows = 10L;
+        stat.dataSize = 888L;
+        partitionCommitInfo.getTabletStats().put(tabletId[1], stat);
+
+        // Mock leader=false; intercept addReshardCandidate to prove it is never called.
+        AtomicInteger addCandidateCalls = new AtomicInteger(0);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+        };
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void addReshardCandidate(long dbId, long tableId, long maxTabletSize, long minAdjacentTabletPairSize) {
+                addCandidateCalls.incrementAndGet();
+            }
+        };
+
+        long beforeUpdateTime = lakeTablet.getDataSizeUpdateTime();
+        applier.applyVisibleLog(state, tableCommitInfo, /*unused*/null);
+
+        // LakeTablet fields must be unchanged on a non-leader node.
+        Assertions.assertEquals(beforeUpdateTime, lakeTablet.getDataSizeUpdateTime());
+        Assertions.assertEquals(0L, lakeTablet.getDataSize(true));
+        // addReshardCandidate must not have been invoked at all.
+        Assertions.assertEquals(0, addCandidateCalls.get(),
+                "addReshardCandidate must not be called on a non-leader node");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PartitionCommitInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PartitionCommitInfoTest.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.starrocks.proto.TabletStatPB;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PartitionCommitInfoTest {
+    @Test
+    public void testTabletStatsCopiedByCopyConstructor() {
+        PartitionCommitInfo src = new PartitionCommitInfo(1L, 2L, 3L);
+        TabletStatPB stat = new TabletStatPB();
+        stat.numRows = 10L;
+        stat.dataSize = 100L;
+        src.getTabletStats().put(7L, stat);
+
+        PartitionCommitInfo copy = new PartitionCommitInfo(src);
+        Assertions.assertEquals(1, copy.getTabletStats().size());
+        Assertions.assertEquals(100L, copy.getTabletStats().get(7L).dataSize);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
@@ -16,6 +16,7 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.system.ComputeNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -73,6 +74,53 @@ public class TransactionStateBatchTest {
 
         stateBatch.putBeTablets(partitionId2, nodeToTablets2);
         Assertions.assertEquals(2, stateBatch.getPartitionToTablets().size());
+    }
+
+    @Test
+    public void testSetTabletStats() {
+        long dbId = 1000L;
+        long tableId = 20000L;
+        long partitionId = 7L;
+        TransactionState[] txns = new TransactionState[] {
+                new TransactionState(dbId, Lists.newArrayList(tableId), 3000, "label1", UUIDUtil.genTUniqueId(),
+                        TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                        new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
+                        60 * 1000L),
+                new TransactionState(dbId, Lists.newArrayList(tableId), 3001, "label2", UUIDUtil.genTUniqueId(),
+                        TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                        new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
+                        60 * 1000L),
+        };
+        for (TransactionState txn : txns) {
+            TableCommitInfo tableCommitInfo = new TableCommitInfo(tableId);
+            tableCommitInfo.addPartitionCommitInfo(new PartitionCommitInfo(partitionId, 2L, 100L));
+            txn.putIdToTableCommitInfo(tableId, tableCommitInfo);
+        }
+        TransactionStateBatch stateBatch = new TransactionStateBatch(Lists.newArrayList(txns));
+
+        // null / empty -> no-op
+        stateBatch.setTabletStats(tableId, partitionId, null);
+        stateBatch.setTabletStats(tableId, partitionId, new HashMap<>());
+        Assertions.assertTrue(txns[0].getTableCommitInfo(tableId).getPartitionCommitInfo(partitionId)
+                .getTabletStats().isEmpty());
+
+        // populated -> fanned onto every batched txn's PartitionCommitInfo
+        Map<Long, TabletStatPB> stats = new HashMap<>();
+        TabletStatPB stat = new TabletStatPB();
+        stat.numRows = 11L;
+        stat.dataSize = 222L;
+        stats.put(5L, stat);
+        stateBatch.setTabletStats(tableId, partitionId, stats);
+        for (TransactionState txn : txns) {
+            Map<Long, TabletStatPB> got =
+                    txn.getTableCommitInfo(tableId).getPartitionCommitInfo(partitionId).getTabletStats();
+            Assertions.assertEquals(1, got.size());
+            Assertions.assertEquals(222L, (long) got.get(5L).dataSize);
+            Assertions.assertEquals(11L, (long) got.get(5L).numRows);
+        }
+
+        // partition absent from the commit info -> filtered out, no NPE
+        stateBatch.setTabletStats(tableId, 999L, stats);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -31,6 +31,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.proto.TxnFinishStatePB;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
@@ -92,7 +93,9 @@ public class TransactionStateTest {
         partitionCommitInfo.setDataVersion(11L);
         partitionCommitInfo.setVersionEpoch(12L);
         partitionCommitInfo.setIsDoubleWrite(true);
-        partitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad().put(40000L, 123L);
+        TabletStatPB stat = new TabletStatPB();
+        stat.numRows = 123L;
+        partitionCommitInfo.getTabletStats().put(40000L, stat);
         tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
         original.putIdToTableCommitInfo(20000L, tableCommitInfo);
 
@@ -115,7 +118,7 @@ public class TransactionStateTest {
 
         partitionCommitInfo.setVersion(20L);
         assertEquals(10L, copiedPartitionCommitInfo.getVersion());
-        assertEquals(Long.valueOf(123L), copiedPartitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad().get(40000L));
+        assertEquals(Long.valueOf(123L), copiedPartitionCommitInfo.getTabletStats().get(40000L).numRows);
     }
 
     @Test

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -50,19 +50,37 @@ message PublishVersionRequest {
     map<int64, int64> tablet_built_versions = 11;
 }
 
+// Per-tablet stats returned by the lake publish RPC. The FE also reuses this as a plain in-process
+// {num_rows, data_size} holder on the shared-nothing first-load path (built from TTabletInfo in
+// LeaderImpl), so first-load statistics collection is unified across both architectures.
+message TabletStatPB {
+    optional int64 num_rows = 1;
+    optional int64 data_size = 2;
+}
+
 message PublishVersionResponse {
     repeated int64 failed_tablets = 1;
     // Mapping from tablet id to compaction score.
     map<int64, double> compaction_scores = 2;
     optional StatusPB status = 3;
-    // Mapping from tablet id to row_nums when the partition is first imported
-    map<int64, int64> tablet_row_nums = 4;
+    // Legacy first-import row counts. A new FE derives first-load statistics from |tablet_stats|
+    // (field 8) and ignores this field. BE still populates it for base_version == 1 so that an OLD
+    // FE during a BE-before-FE rolling upgrade keeps collecting first-load statistics: the old FE
+    // reads ordinal 4 (original json_name "tablet_row_nums"). Once all FEs are upgraded this field
+    // is dead. Do not reuse ordinal 4.
+    map<int64, int64> deprecated_tablet_row_nums = 4 [json_name = "tablet_row_nums"];
     map<int64, TabletMetadataPB> tablet_metas = 5;
     // New tablet ranges for tablet splitting
     map<int64, TabletRangePB> tablet_ranges = 6;
     // Tablets that have async vector indexes and were published in this batch.
     // FE uses this to register new pending build tasks.
     repeated VectorIndexBuildInfoPB vector_index_build_infos = 7;
+    // Per-tablet aggregate stats. Returned for range-distribution tablets on every
+    // publish so FE can trigger split/merge in real time, and for any tablet on first
+    // import (base_version == 1) so FE can collect first-load statistics (supersedes the
+    // deprecated_tablet_row_nums field). No entry is emitted for non-range tablets after
+    // their first import.
+    map<int64, TabletStatPB> tablet_stats = 8;
 }
 
 message VectorIndexBuildInfoPB {


### PR DESCRIPTION
## Why I'm doing:

For shared-data range-distribution tables, automatic tablet split/merge is driven by `TabletStatMgr`, which collects per-tablet stats from CNs on a periodic cycle (`tablet_stat_update_interval_second`, default 300s) and only then evaluates `needSplit`/`needMerge`. Triggering therefore lags a load by up to that interval — a tablet can sit oversized for minutes before it splits, holding back parallelism.

BE already has the freshly-applied `TabletMetadata` in hand during `publish_version`. Returning per-tablet stats in the publish response lets the FE react at publish time and trigger reshard in near-real-time, while keeping the periodic `TabletStatMgr` scan as the authoritative fallback (leader failover, non-publish size changes, stat correction).

## What I'm doing:

**Proto** (`gensrc/proto/lake_service.proto`)
- Add `TabletStatPB { num_rows, data_size }` and `map<int64, TabletStatPB> tablet_stats = 8` to `PublishVersionResponse`.
- Rename the redundant `tablet_row_nums` field to `deprecated_tablet_row_nums = 4` (`json_name = "tablet_row_nums"`, ordinal retained and never reused). A new FE derives first-load row counts from `tablet_stats`; BE still populates this legacy field for `base_version == 1` so an old FE keeps collecting first-load statistics during a BE-before-FE rolling upgrade. The field is intentionally **not** marked `[deprecated]`, since BE actively writes it.

**BE**
- Add `compute_tablet_stats` (in `tablet_metadata.h`): sums `data_size` / live `num_rows` from rowset metadata with **zero delvec I/O** (the signature takes only `const TabletMetadataPB&`, so it structurally cannot do I/O); for PK it subtracts the stored `num_dels`.
- `LakeServiceImpl::publish_version`: populate `tablet_stats` for range-distribution tablets (`metadata->has_range()`, every publish) and for any tablet on first import (`base_version == 1`), computed outside `response_mtx`; merge them in the aggregate-publish path. For `base_version == 1` it also mirrors the live-row count into `deprecated_tablet_row_nums` for old-FE rolling-upgrade compatibility. For PK tablets the first-load `num_rows` is now the live-row count (`num_rows - num_dels`) rather than the deprecated field's raw rowset sum — more accurate, and self-healed by the periodic `TabletStatMgr` scan.

**FE**
- Thread the stats through `Utils` publish overloads → `PartitionCommitInfo`/`TransactionStateBatch` (transient) → `LakeTableTxnLogApplier.applyVisibleLog`, which refreshes the in-memory `LakeTablet` stats (setting `dataSizeUpdateTime` to the visible version time) for the just-published tablets.
- Unify reshard triggering behind a single candidate queue in `TabletReshardJobMgr`: both the publish path and the periodic `TabletStatMgr` scan call `addReshardCandidate(dbId, tableId, maxTabletSize, minAdjacentTabletPairSize)`, keyed by globally-unique tableId and coalesced by (max for split, min for merge). `addReshardCandidate` applies the `needSplit`/`needMerge` actionability check, and a leader/admission-gated tick drains candidates and is the sole creator of split/merge jobs. Signals are computed where the tablets are already walked — no separate locked full-table re-walk — and the parallelism-floor StarMgr RPC stays on the periodic, leader-only scan, off the write-locked publish path. The publish path is split-only (its partition-local max is monotone, so a per-partition crossing is decision-safe); the periodic scan carries both signals and remains the authoritative fallback.
- Consolidate first-load per-tablet row counts onto `tablet_stats` (`PartitionCommitInfo.tabletStats`): the shared-nothing publish path (`LeaderImpl`) builds `TabletStatPB` from `TTabletInfo`, the old `tabletIdToRowCountForPartitionFirstLoad` map and the `Utils` `tabletRowNum` parameter are removed, and `StatisticsCollectionTrigger` / `InsertOverwriteJobRunner` read `tabletStats[id].numRows`.

Split gets the real-time benefit (a single publish freshens the just-grown tablet); merge stays largely fallback-bound because its adjacency signal requires both neighbors to be fresh. No new config; always-on (the periodic fallback makes it safe).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
