### PR TITLE
[BugFix] Fix planner crash on empty range in join predicate derivation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/property/RangeExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/property/RangeExtractor.java
@@ -364,7 +364,12 @@ public class RangeExtractor {
 
         @Override
         public Range<ConstantOperator> toRange() {
-            Preconditions.checkState(!values.isEmpty());
+            // An empty value set means the source predicate is contradictory (e.g. col > X AND col < X),
+            // so there is no derivable range. Return Range.all() so callers (e.g. generateBound) derive
+            // no extra bound instead of failing the !values.isEmpty() precondition.
+            if (values.isEmpty()) {
+                return Range.all();
+            }
             ConstantOperator min = values.stream().min(ConstantOperator::compareTo).get();
             ConstantOperator max = values.stream().max(ConstantOperator::compareTo).get();
             return Range.closed(min, max);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
@@ -13,9 +13,36 @@
 // limitations under the License.
 package com.starrocks.sql.plan;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PredicatePushDownTest extends PlanTestBase {
+
+    @Test
+    public void testRangeExtractEmptyRange() throws Exception {
+        // Reproduces: a contradictory range predicate (col > X AND col < X) yields an empty value
+        // set for the column. When the same column is referenced by a column-to-column relation
+        // predicate (e.g. v5 < v1) during join predicate range-relation derivation, the empty
+        // MultiValuesDescriptor.toRange() must not throw IllegalStateException.
+        {
+            // strict both sides: intersection of disconnected ranges -> empty MultiValuesDescriptor
+            String sql = "select * from t0 join t1 where (v1 > 3 and v1 < 3) and v5 < v1";
+            String plan = getFragmentPlan(sql);
+            Assertions.assertTrue(plan != null && !plan.isEmpty());
+        }
+        {
+            // closed/open: intersection produces an empty range -> empty MultiValuesDescriptor
+            String sql = "select * from t0 join t1 where (v1 >= 3 and v1 < 3) and v5 < v1";
+            String plan = getFragmentPlan(sql);
+            Assertions.assertTrue(plan != null && !plan.isEmpty());
+        }
+        {
+            // relation predicate referencing the empty-range column on the other side (v1 > v5)
+            String sql = "select * from t0 join t1 where (v1 > 3 and v1 < 3) and v1 > v5";
+            String plan = getFragmentPlan(sql);
+            Assertions.assertTrue(plan != null && !plan.isEmpty());
+        }
+    }
 
     @Test
     public void testCoalescePushDown() throws Exception {


### PR DESCRIPTION
A contradictory range predicate (e.g. col > X AND col < X) collapses to an empty MultiValuesDescriptor in RangeExtractor. When that column is also referenced by a column-to-column predicate during join predicate range-relation derivation, generateBound() calls
MultiValuesDescriptor.toRange(), which asserted !values.isEmpty() and threw IllegalStateException, aborting query planning (including EXPLAIN). Return Range.all() for an empty value set so callers derive no extra bound; the original contradictory predicate is preserved, keeping results correct.
- Handle empty values in MultiValuesDescriptor.toRange()
- Add regression test PredicatePushDownTest#testRangeExtractEmptyRange

tested on 4.0, as our prod
can have similar issue in 3.5, we didn't check it yet

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
