### PR TITLE
[BugFix] Merge access groups in setUnnest to fix BE SIGSEGV with stacked UNNESTs on the same array column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -130,8 +130,21 @@ public class PruneComplexTypeUtil {
                 ColumnRefOperator output = operator.getFnResultColRefs().get(i);
                 ColumnRefOperator input = operator.getFnParamColumnRefs().get(i);
                 unnestColRefMap.put(output, input);
-                if (getVisitedAccessGroup(output) != null) {
-                    accessGroups.put(input, getVisitedAccessGroup(output));
+                ComplexTypeAccessGroup outputGroup = getVisitedAccessGroup(output);
+                if (outputGroup != null) {
+                    // Merge access paths into the input column's access group instead of overwriting.
+                    // Multiple UNNEST operators may share the same input array column (e.g. UNNEST(a), UNNEST(a)),
+                    // and each one's downstream consumers may need different subfields of the array element.
+                    // A hard put would drop access paths recorded by earlier UNNESTs and cause the scan to
+                    // prune subfields that are still needed, leading to BE crashes when reading missing fields.
+                    ComplexTypeAccessGroup existing = accessGroups.get(input);
+                    if (existing == null) {
+                        accessGroups.put(input, outputGroup);
+                    } else if (existing != outputGroup) {
+                        for (ComplexTypeAccessPaths paths : outputGroup.getAccessGroup()) {
+                            existing.addAccessPaths(paths);
+                        }
+                    }
                     if (operator.getProjection() == null && operator.getOutputColRefs().contains(output)) {
                         add(input, input);
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -320,6 +320,20 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = false;
     }
 
+    // Reproduces SIGSEGV scenario where two UNNESTs share the same input array column.
+    @Test
+    public void testTwoUnnestsOnSameArrayColumn() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select count(c1), sum(case when t2.c2_sub2 is not null then 1 else 0 end) " +
+                "from array_struct_nest, unnest(c2) as t(t1), unnest(c2) as tt(t2) " +
+                "where t1.c2_sub1 = 5";
+        String plan = getVerboseExplain(sql);
+        // After fix: both c2_sub1 (used by t1.c2_sub1 in WHERE) and c2_sub2 (used by t2.c2_sub2) must
+        // be retained in the pruned type, otherwise BE crashes when reading the missing field.
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
+        FeConstants.runningUnitTest = false;
+    }
+
     @Test
     public void testSubfieldNoCopy() throws Exception {
         String sql = "select c3.c.a, c3.c.b, c3.a, c3.b, c3.d, c2.a, c1.a, c1.b[1].a from test";

--- a/test/sql/test_unnest/R/test_unnest_stacked_same_array_join_crash
+++ b/test/sql/test_unnest/R/test_unnest_stacked_same_array_join_crash
@@ -1,0 +1,56 @@
+-- name: test_unnest_stacked_same_array_join_crash
+-- Repro for the stacked-UNNEST access-group overwrite (PR #75012, xhumanoid:fix-merge-unnest-planner).
+-- Two UNNESTs on the SAME array column need DIFFERENT subfields: a() reads .name, b() reads .value.
+-- Without merging access groups in setUnnest, the second UNNEST's hard put overwrites the first's
+-- access path, so the scan prunes a still-needed subfield. A shuffle JOIN then copies the array column
+-- whose slot type was narrowed (1 field) while the physical struct is full (2 fields), aborting in
+-- StructColumn::append (_fields.size() == fields().size(), 1 vs 2). Merging the access groups keeps both
+-- subfields so the scan stays full and the join copy is consistent.
+drop database if exists test_unnest_stacked_same_array_join_crash;
+-- result:
+-- !result
+create database test_unnest_stacked_same_array_join_crash;
+-- result:
+-- !result
+use test_unnest_stacked_same_array_join_crash;
+-- result:
+-- !result
+create table t_evt(
+  transaction_uuid varchar(64) null,
+  request_attributes array<struct<name varchar(32), value varchar(32)>> null,
+  ts datetime null
+) duplicate key(transaction_uuid)
+distributed by hash(transaction_uuid) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+create table t_dim(transaction_uuid varchar(64) null, dim int)
+  duplicate key(transaction_uuid) distributed by hash(dim) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t_evt
+select concat('u', generate_series % 300), [row('n1','v1'), row('n2','v2')], '2026-02-02 03:04:05'
+from table(generate_series(1, 3000));
+-- result:
+-- !result
+insert into t_dim
+select concat('u', generate_series % 300), generate_series from table(generate_series(1, 3000));
+-- result:
+-- !result
+set broadcast_row_limit = 0;
+-- result:
+-- !result
+set enable_prune_complex_types_in_unnest = true;
+-- result:
+-- !result
+select count(*)
+from t_evt e
+join t_dim d on e.transaction_uuid = d.transaction_uuid
+cross join unnest(e.request_attributes) as a(s)
+cross join unnest(e.request_attributes) as b(s2)
+where a.s.name = 'n1' and b.s2.value = 'v2';
+-- result:
+30000
+-- !result
+drop database test_unnest_stacked_same_array_join_crash;
+-- result:
+-- !result

--- a/test/sql/test_unnest/R/test_unnest_stacked_same_array_prune
+++ b/test/sql/test_unnest/R/test_unnest_stacked_same_array_prune
@@ -1,0 +1,55 @@
+-- name: test_unnest_stacked_same_array_prune
+-- Repro guard for the stacked-UNNEST access-group overwrite (PR #75012): two UNNESTs on the
+-- SAME array column whose downstream consumers need DIFFERENT subfields. setUnnest's hard put
+-- of the access group lets the second UNNEST drop the subfield the first one needs, so the scan
+-- prunes a still-needed field. This is a prune-ON vs prune-OFF differential: the prune must not
+-- change the result. (On an OLAP build that does not physically prune the array<struct> read the
+-- mis-prune is latent and both match; on a build that honors it, prune-ON would diverge or crash.)
+drop database if exists test_unnest_stacked_same_array_prune;
+-- result:
+-- !result
+create database test_unnest_stacked_same_array_prune;
+-- result:
+-- !result
+use test_unnest_stacked_same_array_prune;
+-- result:
+-- !result
+create table array_struct_nest(c1 int, c2 array<struct<c2_sub1 int, c2_sub2 int>>)
+  duplicate key(c1) distributed by hash(c1) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into array_struct_nest values
+  (1, [row(5,100),row(6,200)]),
+  (2, [row(5,300),row(7,400)]),
+  (3, [row(8,500)]);
+-- result:
+-- !result
+set enable_prune_complex_types_in_unnest = false;
+-- result:
+-- !result
+select count(t1.c2_sub1), sum(t2.c2_sub2) from array_struct_nest,
+  unnest(c2) as t(t1), unnest(c2) as tt(t2) where t1.c2_sub1 = 5;
+-- result:
+4	1000
+-- !result
+set enable_prune_complex_types_in_unnest = true;
+-- result:
+-- !result
+select count(t1.c2_sub1), sum(t2.c2_sub2) from array_struct_nest,
+  unnest(c2) as t(t1), unnest(c2) as tt(t2) where t1.c2_sub1 = 5;
+-- result:
+4	1000
+-- !result
+select sum(t1.c2_sub2), count(t2.c2_sub1) from array_struct_nest,
+  unnest(c2) as t(t1), unnest(c2) as tt(t2) where t2.c2_sub1 = 5;
+-- result:
+1000	4
+-- !result
+select count(c1), sum(case when t2.c2_sub2 is not null then 1 else 0 end)
+  from array_struct_nest, unnest(c2) as t(t1), unnest(c2) as tt(t2) where t1.c2_sub1 = 5;
+-- result:
+4	4
+-- !result
+drop database test_unnest_stacked_same_array_prune;
+-- result:
+-- !result

--- a/test/sql/test_unnest/T/test_unnest_stacked_same_array_join_crash
+++ b/test/sql/test_unnest/T/test_unnest_stacked_same_array_join_crash
@@ -1,0 +1,42 @@
+-- name: test_unnest_stacked_same_array_join_crash
+-- Repro for the stacked-UNNEST access-group overwrite (PR #75012, xhumanoid:fix-merge-unnest-planner).
+-- Two UNNESTs on the SAME array column need DIFFERENT subfields: a() reads .name, b() reads .value.
+-- Without merging access groups in setUnnest, the second UNNEST's hard put overwrites the first's
+-- access path, so the scan prunes a still-needed subfield. A shuffle JOIN then copies the array column
+-- whose slot type was narrowed (1 field) while the physical struct is full (2 fields), aborting in
+-- StructColumn::append (_fields.size() == fields().size(), 1 vs 2). Merging the access groups keeps both
+-- subfields so the scan stays full and the join copy is consistent.
+drop database if exists test_unnest_stacked_same_array_join_crash;
+create database test_unnest_stacked_same_array_join_crash;
+use test_unnest_stacked_same_array_join_crash;
+
+create table t_evt(
+  transaction_uuid varchar(64) null,
+  request_attributes array<struct<name varchar(32), value varchar(32)>> null,
+  ts datetime null
+) duplicate key(transaction_uuid)
+distributed by hash(transaction_uuid) buckets 3 properties("replication_num"="1");
+
+create table t_dim(transaction_uuid varchar(64) null, dim int)
+  duplicate key(transaction_uuid) distributed by hash(dim) buckets 3 properties("replication_num"="1");
+
+insert into t_evt
+select concat('u', generate_series % 300), [row('n1','v1'), row('n2','v2')], '2026-02-02 03:04:05'
+from table(generate_series(1, 3000));
+
+insert into t_dim
+select concat('u', generate_series % 300), generate_series from table(generate_series(1, 3000));
+
+set broadcast_row_limit = 0;
+set enable_prune_complex_types_in_unnest = true;
+
+-- a() needs request_attributes.name, b() needs request_attributes.value; the scan must keep BOTH.
+-- Before the fix this aborts the BE; after the fix it returns 30000.
+select count(*)
+from t_evt e
+join t_dim d on e.transaction_uuid = d.transaction_uuid
+cross join unnest(e.request_attributes) as a(s)
+cross join unnest(e.request_attributes) as b(s2)
+where a.s.name = 'n1' and b.s2.value = 'v2';
+
+drop database test_unnest_stacked_same_array_join_crash;

--- a/test/sql/test_unnest/T/test_unnest_stacked_same_array_prune
+++ b/test/sql/test_unnest/T/test_unnest_stacked_same_array_prune
@@ -1,0 +1,34 @@
+-- name: test_unnest_stacked_same_array_prune
+-- Repro guard for the stacked-UNNEST access-group overwrite (PR #75012): two UNNESTs on the
+-- SAME array column whose downstream consumers need DIFFERENT subfields. setUnnest's hard put
+-- of the access group lets the second UNNEST drop the subfield the first one needs, so the scan
+-- prunes a still-needed field. This is a prune-ON vs prune-OFF differential: the prune must not
+-- change the result. (On an OLAP build that does not physically prune the array<struct> read the
+-- mis-prune is latent and both match; on a build that honors it, prune-ON would diverge or crash.)
+drop database if exists test_unnest_stacked_same_array_prune;
+create database test_unnest_stacked_same_array_prune;
+use test_unnest_stacked_same_array_prune;
+
+create table array_struct_nest(c1 int, c2 array<struct<c2_sub1 int, c2_sub2 int>>)
+  duplicate key(c1) distributed by hash(c1) buckets 1 properties("replication_num"="1");
+insert into array_struct_nest values
+  (1, [row(5,100),row(6,200)]),
+  (2, [row(5,300),row(7,400)]),
+  (3, [row(8,500)]);
+
+-- Baseline: prune disabled.
+set enable_prune_complex_types_in_unnest = false;
+select count(t1.c2_sub1), sum(t2.c2_sub2) from array_struct_nest,
+  unnest(c2) as t(t1), unnest(c2) as tt(t2) where t1.c2_sub1 = 5;
+-- Prune enabled: t1 needs c2_sub1 (WHERE), t2 needs c2_sub2 (SUM). Must match the baseline.
+set enable_prune_complex_types_in_unnest = true;
+select count(t1.c2_sub1), sum(t2.c2_sub2) from array_struct_nest,
+  unnest(c2) as t(t1), unnest(c2) as tt(t2) where t1.c2_sub1 = 5;
+-- Reversed roles: t1 needs c2_sub2, t2 needs c2_sub1.
+select sum(t1.c2_sub2), count(t2.c2_sub1) from array_struct_nest,
+  unnest(c2) as t(t1), unnest(c2) as tt(t2) where t2.c2_sub1 = 5;
+-- PR #75012's exact reproducer query.
+select count(c1), sum(case when t2.c2_sub2 is not null then 1 else 0 end)
+  from array_struct_nest, unnest(c2) as t(t1), unnest(c2) as tt(t2) where t1.c2_sub1 = 5;
+
+drop database test_unnest_stacked_same_array_prune;


### PR DESCRIPTION


Merge access paths into the input column's access group instead of overwriting.

Multiple UNNEST operators may share the same input array column (e.g. UNNEST(a), UNNEST(a)), 
and each one's downstream consumers may need different subfields of the array element.

A hard put would drop access paths recorded by earlier UNNESTs and cause the scan to
prune subfields that are still needed, leading to BE crashes when reading missing fields.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
