### PR TITLE
[BugFix] Honor CREATE DATABASE IF NOT EXISTS on Iceberg REST catalogs (backport #75017)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -225,7 +225,11 @@ public class IcebergMetadata implements ConnectorMetadata {
             throw new AlreadyExistsException("Database Already Exists");
         }
 
-        icebergCatalog.createDB(dbName, properties);
+        try {
+            icebergCatalog.createDB(dbName, properties);
+        } catch (org.apache.iceberg.exceptions.AlreadyExistsException e) {
+            throw new AlreadyExistsException("Database Already Exists: " + dbName);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -351,6 +351,29 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testCreateDbTranslatesConnectorAlreadyExists(@Mocked IcebergHiveCatalog icebergHiveCatalog) {
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        new Expectations() {
+            {
+                icebergHiveCatalog.listAllDatabases();
+                result = Lists.newArrayList();
+                minTimes = 0;
+
+                icebergHiveCatalog.createDB("TEST_PROBE", (Map<String, String>) any);
+                result = new org.apache.iceberg.exceptions.AlreadyExistsException(
+                        "Namespace already exists: TEST_PROBE");
+                times = 1;
+            }
+        };
+
+        AlreadyExistsException e = assertThrows(AlreadyExistsException.class,
+                () -> metadata.createDb("TEST_PROBE", new HashMap<>()));
+        Assertions.assertTrue(e.getMessage().contains("TEST_PROBE"),
+                "translated message should carry the database name, but was: " + e.getMessage());
+    }
+
+    @Test
     public void testCreateDbWithErrorConfig() {
         assertThrows(IllegalArgumentException.class, () -> {
             IcebergHiveCatalog hiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), new HashMap<>());


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #75017 to `branch-3.5`. The auto cherry-pick does not apply cleanly because `IcebergMetadata.createDb()` / `IcebergCatalog.createDB()` have a different signature on 3.5 (no `ConnectContext` parameter), so this change is adapted to the 3.5 API.

On Iceberg REST catalogs, `CREATE DATABASE IF NOT EXISTS <db>` failed with an error when the database already existed, instead of being silently ignored as the `IF NOT EXISTS` clause promises.

The root cause is an exception-type mismatch at the StarRocks ↔ Iceberg boundary. `IcebergMetadata.createDb()` only relies on StarRocks' `com.starrocks.common.AlreadyExistsException` to drive the `IF NOT EXISTS` handling in the upper layer. However, the Iceberg client (notably the REST catalog) throws its own `org.apache.iceberg.exceptions.AlreadyExistsException`, which is an unrelated class. That connector-level exception leaked through unchanged, so the upper layer never recognized it as "already exists" and the statement errored out.

## What I'm doing:

Translate the connector-level `org.apache.iceberg.exceptions.AlreadyExistsException` thrown by `icebergCatalog.createDB()` into StarRocks' `com.starrocks.common.AlreadyExistsException`, carrying the database name in the message. This lets the existing `IF NOT EXISTS` logic recognize the condition and behave correctly.

- `IcebergMetadata.createDb()`: wrap the `createDB` call in a try/catch and rethrow as StarRocks `AlreadyExistsException`.
- Added a unit test `testCreateDbTranslatesConnectorAlreadyExists` that mocks the catalog to throw the Iceberg exception and asserts the translated StarRocks exception (type + message) is raised.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

