### PR TITLE
[Enhancement] Add hdfs_backend_selector_cache_replica_num variable 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -62,6 +62,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Hybrid backend selector for hive table.
@@ -94,6 +95,10 @@ public class HDFSBackendSelector implements BackendSelector {
     private final boolean shuffleScanRange;
     private final boolean useIncrementalScanRanges;
     private final int kCandidateNumber = 3;
+    // Number of top hash-candidate nodes a split may be cached/served on. Each scan range is routed to a
+    // uniformly random one of its top-N hash nodes, spreading a hot data object across N nodes instead of
+    // pinning it to its single hash home. 1 (default) preserves the original single-home placement behavior.
+    private final int cacheReplicaNum;
     // After testing, this value can ensure that the scan range size assigned to each BE is as uniform as possible,
     // and the largest scan data is not more than 1.1 times of the average value
     private final double kMaxImbalanceRatio = 1.1;
@@ -174,6 +179,7 @@ public class HDFSBackendSelector implements BackendSelector {
         this.hdfsScanRangeHasher = new HdfsScanRangeHasher();
         this.shuffleScanRange = shuffleScanRange;
         this.useIncrementalScanRanges = useIncrementalScanRanges;
+        this.cacheReplicaNum = connectContext.getSessionVariable().getHdfsBackendSelectorCacheReplicaNum();
         this.candidateWorkerProvider = initCandidateWorkerProvider();
     }
 
@@ -359,19 +365,46 @@ public class HDFSBackendSelector implements BackendSelector {
             Collections.shuffle(remoteScanRangeLocations);
         }
         // assign scan ranges.
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        // Only spread a split across its top-N hash candidates when cache locality is actually in play: the
+        // data cache is enabled and the user has not explicitly requested byte re-balancing. Otherwise fall
+        // back to the existing re-balance path so enable_scan_datacache=false and
+        // hdfs_backend_selector_force_rebalance=true keep their intended byte-balanced placement.
+        boolean useCacheReplicaSpread = cacheReplicaNum > 1
+                && sessionVariable.isEnableScanDataCache()
+                && !sessionVariable.getHdfsBackendSelectorForceRebalance();
+        int candidateCount = useCacheReplicaSpread ? Math.max(kCandidateNumber, cacheReplicaNum) : kCandidateNumber;
         for (int i = 0; i < remoteScanRangeLocations.size(); ++i) {
             TScanRangeLocations scanRangeLocations = remoteScanRangeLocations.get(i);
-            List<ComputeNode> backends = hashRing.get(scanRangeLocations, kCandidateNumber);
-            ComputeNode node = reBalanceScanRangeForComputeNode(backends, avgNodeScanRangeBytes, scanRangeLocations);
+            List<ComputeNode> backends = hashRing.get(scanRangeLocations, candidateCount);
+            ComputeNode node;
+            if (useCacheReplicaSpread && !backends.isEmpty()) {
+                // Route each split to a uniformly random one of its top-N hash candidates so a hot data
+                // object is served by N nodes instead of pinning to its single hash home. Stateless: the
+                // only per-call state is the random draw.
+                int replicaCount = Math.min(cacheReplicaNum, backends.size());
+                node = backends.get(ThreadLocalRandom.current().nextInt(replicaCount));
+            } else {
+                // An empty backends list also falls through here: reBalanceScanRangeForComputeNode returns
+                // null and the node == null check below raises the clear "Failed to find backend" error.
+                node = reBalanceScanRangeForComputeNode(backends, avgNodeScanRangeBytes, scanRangeLocations);
+            }
             if (node == null) {
                 throw new StarRocksException("Failed to find backend to execute");
             }
 
             ComputeNode candidateNode = null;
             if (candidateHashRing != null) {
-                List<ComputeNode> candidateBackends = candidateHashRing.get(scanRangeLocations, kCandidateNumber);
-                // if data cache is enabled, skip re-balancing because it makes the cache position undefined.
-                candidateNode = candidateBackends.get(0);
+                List<ComputeNode> candidateBackends = candidateHashRing.get(scanRangeLocations, candidateCount);
+                if (!candidateBackends.isEmpty()) {
+                    // Spread the peer datacache hint across the historical top-N as well when the execution
+                    // node is spread; otherwise all N execution replicas of a hot split would peer-read from
+                    // the single historical top-1 node, recreating the worker skew on the cache-read path.
+                    int candidateIndex = useCacheReplicaSpread
+                            ? ThreadLocalRandom.current().nextInt(Math.min(cacheReplicaNum, candidateBackends.size()))
+                            : 0;
+                    candidateNode = candidateBackends.get(candidateIndex);
+                }
             }
             recordScanRangeAssignment(node, candidateNode, backends, scanRangeLocations);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1015,6 +1015,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String HDFS_BACKEND_SELECTOR_FORCE_REBALANCE = "hdfs_backend_selector_force_rebalance";
 
+    public static final String HDFS_BACKEND_SELECTOR_CACHE_REPLICA_NUM = "hdfs_backend_selector_cache_replica_num";
+
     public static final String CONSISTENT_HASH_VIRTUAL_NUMBER = "consistent_hash_virtual_number";
 
     public static final String ENABLE_COLLECT_TABLE_LEVEL_SCAN_STATS = "enable_collect_table_level_scan_stats";
@@ -2207,6 +2209,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_FORCE_REBALANCE, flag = VariableMgr.INVISIBLE)
     private boolean hdfsBackendSelectorForceRebalance = false;
+
+    @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_CACHE_REPLICA_NUM)
+    private int hdfsBackendSelectorCacheReplicaNum = 1;
 
     @VariableMgr.VarAttr(name = CONSISTENT_HASH_VIRTUAL_NUMBER, flag = VariableMgr.INVISIBLE)
     private int consistentHashVirtualNodeNum = 256;
@@ -4096,6 +4101,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setConsistentHashVirtualNodeNum(int consistentHashVirtualNodeNum) {
         this.consistentHashVirtualNodeNum = consistentHashVirtualNodeNum;
+    }
+
+    public int getHdfsBackendSelectorCacheReplicaNum() {
+        return Math.max(1, hdfsBackendSelectorCacheReplicaNum);
+    }
+
+    public void setHdfsBackendSelectorCacheReplicaNum(int hdfsBackendSelectorCacheReplicaNum) {
+        this.hdfsBackendSelectorCacheReplicaNum = hdfsBackendSelectorCacheReplicaNum;
     }
 
     public void setBigQueryProfileThreshold(String bigQueryProfileThreshold) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -42,8 +42,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class HDFSBackendSelectorTest {
     @Mocked
@@ -451,5 +453,224 @@ public class HDFSBackendSelectorTest {
             }
         }
         Assertions.assertEquals(scanRanges, scanRangeNumber);
+    }
+
+    @Test
+    public void testCacheReplicaNumDefaultDoesNotSpread() throws Exception {
+        // With the default (hdfs_backend_selector_cache_replica_num = 1) a given split always lands on its
+        // single hash home; no spreading is introduced when the feature is off.
+        SessionVariable sessionVariable = new SessionVariable();
+        new Expectations() {
+            {
+                hdfsScanNode.getId();
+                result = scanNodeId;
+                hdfsScanNode.getTableName();
+                result = "hive_tbl";
+                hiveTable.getTableLocation();
+                result = "hdfs://dfs00/dataset/";
+                context.getSessionVariable();
+                result = sessionVariable;
+            }
+        };
+
+        int hostNumber = 10;
+        ImmutableMap<Long, ComputeNode> computeNodes = createComputeNodes(hostNumber);
+        List<TScanRangeLocations> hotSplit = createScanRanges(1, 10000);
+
+        Set<Long> chosen = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
+                    ImmutableMap.of(), computeNodes, ImmutableMap.of(), computeNodes,
+                    true, WarehouseManager.DEFAULT_RESOURCE);
+            HDFSBackendSelector selector =
+                    new HDFSBackendSelector(hdfsScanNode, hotSplit, assignment, workerProvider,
+                            false, false, false, context);
+            selector.computeScanRangeAssignment();
+            chosen.addAll(computeWorkerIdToReadBytes(assignment, scanNodeId).keySet());
+        }
+        Assertions.assertEquals(1, chosen.size());
+    }
+
+    @Test
+    public void testCacheReplicaNumSpreadsHotSplit() throws Exception {
+        // With cache_replica_num = N a hot split (same path, read by many queries) spreads uniformly across
+        // exactly its top-N hash candidates instead of pinning to its single hash home.
+        int replicaNum = 5;
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setHdfsBackendSelectorCacheReplicaNum(replicaNum);
+        sessionVariable.setEnableScanDataCache(true);
+        new Expectations() {
+            {
+                hdfsScanNode.getId();
+                result = scanNodeId;
+                hdfsScanNode.getTableName();
+                result = "hive_tbl";
+                hiveTable.getTableLocation();
+                result = "hdfs://dfs00/dataset/";
+                context.getSessionVariable();
+                result = sessionVariable;
+            }
+        };
+
+        int hostNumber = 10;
+        ImmutableMap<Long, ComputeNode> computeNodes = createComputeNodes(hostNumber);
+        List<TScanRangeLocations> hotSplit = createScanRanges(1, 10000);
+
+        // Expected spread targets: the top-N hash candidates for this split.
+        DefaultWorkerProvider probeProvider = new DefaultWorkerProvider(
+                ImmutableMap.of(), computeNodes, ImmutableMap.of(), computeNodes,
+                true, WarehouseManager.DEFAULT_RESOURCE);
+        HDFSBackendSelector probe = new HDFSBackendSelector(hdfsScanNode, hotSplit,
+                new FragmentScanRangeAssignment(), probeProvider, false, false, false, context);
+        HashRing hashRing = probe.makeHashRing(computeNodes.values());
+        List<ComputeNode> topNodes = hashRing.get(hotSplit.get(0), replicaNum);
+        Set<Long> expectedTopN = new HashSet<>();
+        for (ComputeNode node : topNodes) {
+            expectedTopN.add(node.getId());
+        }
+        Assertions.assertEquals(replicaNum, expectedTopN.size());
+
+        int iterations = 1000;
+        Map<Long, Integer> histogram = new HashMap<>();
+        for (int i = 0; i < iterations; i++) {
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
+                    ImmutableMap.of(), computeNodes, ImmutableMap.of(), computeNodes,
+                    true, WarehouseManager.DEFAULT_RESOURCE);
+            HDFSBackendSelector selector =
+                    new HDFSBackendSelector(hdfsScanNode, hotSplit, assignment, workerProvider,
+                            false, false, false, context);
+            selector.computeScanRangeAssignment();
+            for (Long id : computeWorkerIdToReadBytes(assignment, scanNodeId).keySet()) {
+                histogram.merge(id, 1, Integer::sum);
+            }
+        }
+
+        // All chosen nodes are within the top-N, and all N are exercised (uniform random over N).
+        Assertions.assertEquals(expectedTopN, histogram.keySet());
+        int expectedPerNode = iterations / replicaNum;
+        for (Map.Entry<Long, Integer> entry : histogram.entrySet()) {
+            System.out.printf("%s -> %d hits\n", entry.getKey(), entry.getValue());
+            Assertions.assertTrue(entry.getValue() > expectedPerNode / 2,
+                    "node " + entry.getKey() + " got too few hits: " + entry.getValue());
+            Assertions.assertTrue(entry.getValue() < expectedPerNode * 2,
+                    "node " + entry.getKey() + " got too many hits: " + entry.getValue());
+        }
+    }
+
+    @Test
+    public void testCacheReplicaNumClampedAndCappedByCluster() throws Exception {
+        SessionVariable sessionVariable = new SessionVariable();
+        new Expectations() {
+            {
+                hdfsScanNode.getId();
+                result = scanNodeId;
+                hdfsScanNode.getTableName();
+                result = "hive_tbl";
+                hiveTable.getTableLocation();
+                result = "hdfs://dfs00/dataset/";
+                context.getSessionVariable();
+                result = sessionVariable;
+            }
+        };
+
+        // A non-positive value clamps to 1 (single-home, no spread).
+        sessionVariable.setHdfsBackendSelectorCacheReplicaNum(0);
+        Assertions.assertEquals(1, sessionVariable.getHdfsBackendSelectorCacheReplicaNum());
+
+        // A replica count larger than the cluster spreads across all nodes without error.
+        int hostNumber = 3;
+        sessionVariable.setHdfsBackendSelectorCacheReplicaNum(100);
+        sessionVariable.setEnableScanDataCache(true);
+        ImmutableMap<Long, ComputeNode> computeNodes = createComputeNodes(hostNumber);
+        List<TScanRangeLocations> hotSplit = createScanRanges(1, 10000);
+
+        Set<Long> chosen = new HashSet<>();
+        for (int i = 0; i < 500; i++) {
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
+                    ImmutableMap.of(), computeNodes, ImmutableMap.of(), computeNodes,
+                    true, WarehouseManager.DEFAULT_RESOURCE);
+            HDFSBackendSelector selector =
+                    new HDFSBackendSelector(hdfsScanNode, hotSplit, assignment, workerProvider,
+                            false, false, false, context);
+            selector.computeScanRangeAssignment();
+            chosen.addAll(computeWorkerIdToReadBytes(assignment, scanNodeId).keySet());
+        }
+        Assertions.assertEquals(hostNumber, chosen.size());
+    }
+
+    @Test
+    public void testCacheReplicaNumGatedOffWhenDataCacheDisabled() throws Exception {
+        // The spread only applies when the data cache is on. With it disabled, cache_replica_num is ignored
+        // and placement falls back to the byte-rebalance path (a single range stays on its single home).
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setHdfsBackendSelectorCacheReplicaNum(5);
+        sessionVariable.setEnableScanDataCache(false);
+        new Expectations() {
+            {
+                hdfsScanNode.getId();
+                result = scanNodeId;
+                hdfsScanNode.getTableName();
+                result = "hive_tbl";
+                hiveTable.getTableLocation();
+                result = "hdfs://dfs00/dataset/";
+                context.getSessionVariable();
+                result = sessionVariable;
+            }
+        };
+
+        int hostNumber = 10;
+        ImmutableMap<Long, ComputeNode> computeNodes = createComputeNodes(hostNumber);
+        List<TScanRangeLocations> hotSplit = createScanRanges(1, 10000);
+
+        Set<Long> chosen = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
+                    ImmutableMap.of(), computeNodes, ImmutableMap.of(), computeNodes,
+                    true, WarehouseManager.DEFAULT_RESOURCE);
+            HDFSBackendSelector selector =
+                    new HDFSBackendSelector(hdfsScanNode, hotSplit, assignment, workerProvider,
+                            false, false, false, context);
+            selector.computeScanRangeAssignment();
+            chosen.addAll(computeWorkerIdToReadBytes(assignment, scanNodeId).keySet());
+        }
+        Assertions.assertEquals(1, chosen.size());
+    }
+
+    @Test
+    public void testCacheReplicaNumEmptyWorkersThrowsClearError() throws Exception {
+        // With cache_replica_num > 1 and no available workers, the random draw must not throw
+        // IllegalArgumentException; it must surface the clear "Failed to find backend to execute" error.
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setHdfsBackendSelectorCacheReplicaNum(5);
+        sessionVariable.setEnableScanDataCache(true);
+        // The assignment fails before any scan range is placed, so only the constructor path runs.
+        // Stub just what it touches (getId()/getTableName() are never reached here).
+        new Expectations() {
+            {
+                hiveTable.getTableLocation();
+                result = "hdfs://dfs00/dataset/";
+                context.getSessionVariable();
+                result = sessionVariable;
+            }
+        };
+
+        List<TScanRangeLocations> locations = createScanRanges(1, 10000);
+        FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+        DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
+                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(),
+                true, WarehouseManager.DEFAULT_RESOURCE);
+        HDFSBackendSelector selector =
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider,
+                        false, false, false, context);
+        try {
+            selector.computeScanRangeAssignment();
+            Assertions.fail("expected StarRocksException for an empty worker set");
+        } catch (Exception e) {
+            Assertions.assertEquals("Failed to find backend to execute", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION

## Why I'm doing:
In some cases when running highly concurrent queries against data lake tables the cache affinity of the HDFS backend selector creates worker skew where one or two workers will be overloaded while the rest of the cluster sits with minimal load

## What I'm doing:

Adding hdfs_backend_selector_cache_replica_num to allow configuring the number of CN nodes that get assigned particular data cache files. This more evenly distributes the load at the cost of caching files on additional nodes. The default is 1 which preserves the current behavior.

Fixes #75022

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
