### PR TITLE
[Enhancement][metrics] Add FE metric for max committed txn pending-publish time

### DIFF
--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -552,6 +552,12 @@ All transaction metrics share the following labels:
 - Type: Instantaneous
 - Description: Indicates the number of tablets on each BE node.
 
+## `starrocks_fe_txn_max_committed_pending_publish_ms`
+
+- Unit: ms
+- Type: Instantaneous
+- Description: The longest time, in milliseconds, that a transaction is currently sitting in the `COMMITTED` status pending publish to `VISIBLE`, that is, the age of the oldest committed-but-not-yet-published transaction. Unlike `starrocks_fe_txn_publish_*` metrics, which are summaries recorded after a transaction finishes, this is a live gauge of the worst-case in-flight wait. The value is reported per database via the `db` label and only by the Leader FE node (`is_leader="true"`). It returns `0` when no committed transaction is pending publish. A high or continuously growing value indicates that version publishing is stuck or lagging behind commits.
+
 ## `starrocks_fe_txn_publish_ack_latency_ms`
 
 - Unit: ms

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -548,6 +548,12 @@ description: "Alphabetical s"
 - タイプ: 瞬間的
 - 説明: 各BEノード上のタブレット数を示します。
 
+## `starrocks_fe_txn_max_committed_pending_publish_ms`
+
+- 単位: ms
+- タイプ: 瞬間的
+- 説明: 現在 `COMMITTED` 状態にあり `VISIBLE` への発行を待っているトランザクションのうち、最も長く滞留しているものの待機時間（ミリ秒）。つまり、コミット済みでまだ発行されていない最も古いトランザクションの経過時間です。トランザクション完了後に記録される概要（summary）メトリックである `starrocks_fe_txn_publish_*` とは異なり、これは現在の最悪ケースの待機時間をリアルタイムに示すゲージ（gauge）です。この値は `db` ラベルによってデータベースごとに、かつ Leader FE ノード（`is_leader="true"`）のみが報告します。発行待ちのコミット済みトランザクションがない場合は `0` を返します。値が高い、または継続的に増加している場合、バージョンの発行が停止しているか、コミットに遅れていることを示します。
+
 ## `starrocks_fe_txn_publish_ack_latency_ms`
 
 - 単位: ms

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -574,6 +574,12 @@ description: "Alphabetical s"
 - 类型：瞬时
 - 描述：表示每个BE节点上的tablet数量。
 
+## `starrocks_fe_txn_max_committed_pending_publish_ms`
+
+- 单位：毫秒
+- 类型：瞬时
+- 描述：当前处于 `COMMITTED` 状态、等待发布为 `VISIBLE` 的事务中，停留时间最长者已等待的时长（毫秒），即最早提交但尚未发布的事务的存在时长。与 `starrocks_fe_txn_publish_*` 这类在事务完成后记录的汇总（summary）指标不同，该指标是实时反映当前最坏情况等待时间的瞬时值（gauge）。该值按数据库通过 `db` 标签上报，且仅由 Leader FE 节点上报（`is_leader="true"`）。当没有等待发布的已提交事务时返回 `0`。该值较高或持续增长，表示版本发布卡住或落后于提交。
+
 ## `starrocks_fe_txn_publish_ack_latency_ms`
 
 - 单位：毫秒

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -1664,6 +1664,18 @@ public final class MetricRepo {
             };
             txnNum.addLabel(new MetricLabel("db", db.getFullName()));
             visitor.visit(txnNum);
+
+            LeaderAwareGaugeMetric<Long> maxCommittedPendingPublish = new LeaderAwareGaugeMetricLong(
+                    "txn_max_committed_pending_publish_ms", MetricUnit.MILLISECONDS,
+                    "max time in milliseconds that a transaction has been sitting in committed status "
+                            + "pending publish to visible") {
+                @Override
+                public Long getValueLeader() {
+                    return mgr.getMaxCommittedTxnPendingPublishMs(System.currentTimeMillis());
+                }
+            };
+            maxCommittedPendingPublish.addLabel(new MetricLabel("db", db.getFullName()));
+            visitor.visit(maxCommittedPendingPublish);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -913,6 +913,24 @@ public class DatabaseTransactionMgr {
         }
     }
 
+    // Return the time in milliseconds that the oldest committed-but-not-yet-visible transaction has been
+    // pending publish, i.e. (currentTimeMs - oldest commit time). Returns 0 when there is no committed
+    // transaction. A continuously growing value indicates that version publishing is stuck or lagging
+    // behind commits.
+    public long getMaxCommittedTxnPendingPublishMs(long currentTimeMs) {
+        readLock();
+        try {
+            long oldestCommitTime = idToRunningTransactionState.values().stream()
+                    .filter(transactionState -> transactionState.getTransactionStatus() == TransactionStatus.COMMITTED)
+                    .mapToLong(TransactionState::getCommitTime)
+                    .min()
+                    .orElse(0L);
+            return oldestCommitTime <= 0 ? 0L : Math.max(0L, currentTimeMs - oldestCommitTime);
+        } finally {
+            readUnlock();
+        }
+    }
+
     public Map<Long, Long> getLakeCompactionActiveTxnMap() {
         readLock();
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -508,6 +508,31 @@ public class DatabaseTransactionMgrTest {
         masterDbTransMgr.finishTransaction(txnId, null, 0);
         assertEquals(TransactionStatus.VISIBLE, masterDbTransMgr.getTxnState(txnId).getStatus());
     }
+
+    @Test
+    public void getMaxCommittedTxnPendingPublishMsTest() throws StarRocksException {
+        DatabaseTransactionMgr masterDbTransMgr =
+                masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+
+        // setUp() seeds several committed transactions; the metric reports the pending-publish time of the oldest one.
+        // getCommittedTxnList() is sorted ascending by commit time, so the first entry is the oldest.
+        List<TransactionState> committedTxns = masterDbTransMgr.getCommittedTxnList();
+        Assertions.assertFalse(committedTxns.isEmpty());
+        long oldestCommitTime = committedTxns.get(0).getCommitTime();
+
+        // pending-publish time is measured from the oldest commit time; use a fixed "now" for a deterministic assertion
+        assertEquals(5000L, masterDbTransMgr.getMaxCommittedTxnPendingPublishMs(oldestCommitTime + 5000L));
+        // a "now" earlier than the commit time must be clamped to 0, never negative
+        assertEquals(0L, masterDbTransMgr.getMaxCommittedTxnPendingPublishMs(oldestCommitTime - 1000L));
+
+        // once every committed transaction becomes visible, nothing is sitting in committed status
+        for (TransactionState txn : committedTxns) {
+            masterDbTransMgr.finishTransaction(txn.getTransactionId(), null, 0);
+        }
+        Assertions.assertTrue(masterDbTransMgr.getCommittedTxnList().isEmpty());
+        assertEquals(0L, masterDbTransMgr.getMaxCommittedTxnPendingPublishMs(System.currentTimeMillis()));
+    }
+
     @Test
     public void testAbortTransactionWithNotFoundException() throws StarRocksException {
         DatabaseTransactionMgr masterDbTransMgr =


### PR DESCRIPTION
Add a per-database, leader-aware gauge txn_max_committed_pending_publish_ms that reports the longest time a transaction is currently sitting in COMMITTED status pending publish to VISIBLE (the age of the oldest committed-but-not-yet- published txn). A high or continuously growing value signals that version publishing is stuck or lagging behind commits.

- DatabaseTransactionMgr: add getMaxCommittedTxnPendingPublishMs(), an O(N) read-lock scan over running txns with no per-txn locking.
- MetricRepo: emit the gauge next to txn_running in collectDbRunningTxnMetrics.
- Document the metric in the monitoring reference (en/zh/ja q-z.md).
- Add a unit test covering the pending-publish math, clamp-to-zero, and the empty (no committed txn) case.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
