### PR TITLE
[Refactor] Move chunk allocation from HiveDataSource into individual scanners

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -1004,7 +1004,7 @@ Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     }
 
     do {
-        RETURN_IF_ERROR(_init_chunk_if_needed(chunk, _runtime_state->chunk_size()));
+        RETURN_IF_ERROR(_init_chunk_if_needed(chunk, 0));
         Status st = _scanner->get_next(state, chunk);
         if (!st.ok()) {
             return _scanner->reinterpret_status(st);

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -977,13 +977,13 @@ Status VariantProjectionHandler::emit_projections(ChunkPtr& active_chunk, ChunkP
                         fmt::format("variant deferred projected column row count mismatch for slot {}: {} vs {}",
                                     slot_id, projected_col->size(), active_chunk->num_rows()));
             }
-            (*dst)->get_column_by_slot_id(slot_id) = projected_col;
+            (*dst)->append_or_update_column(ColumnPtr(projected_col), slot_id);
             continue;
         }
         // Early-projected virtual slot (Phase 2b compound-conjunct prep) —
         // already filtered and ready to move to dst.
         if (active_chunk->is_slot_exist(slot_id)) {
-            (*dst)->get_column_by_slot_id(slot_id) = active_chunk->get_column_by_slot_id(slot_id);
+            (*dst)->append_or_update_column(ColumnPtr(active_chunk->get_column_by_slot_id(slot_id)), slot_id);
             continue;
         }
         if (!active_chunk->is_slot_exist(projection.source_slot_id)) {
@@ -993,7 +993,7 @@ Status VariantProjectionHandler::emit_projections(ChunkPtr& active_chunk, ChunkP
         const ColumnPtr& source_column = active_chunk->get_column_by_slot_id(projection.source_slot_id);
         ASSIGN_OR_RETURN(auto result_column, project_variant_leaf_column(source_column, projection.parsed_path,
                                                                          projection.target_type, zone));
-        (*dst)->get_column_by_slot_id(slot_id) = std::move(result_column);
+        (*dst)->append_or_update_column(std::move(result_column), slot_id);
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Why I'm doing:

Previously, `HiveDataSource::_init_chunk_if_needed` pre-allocated a chunk with all `tuple_desc` columns before calling `scanner->get_next()`. This couples the caller to the scanner's column layout and forces every scanner to work with a pre-shaped chunk — even though different scanners (Parquet, ORC, Text, JSON, Avro, JNI) populate columns in very different ways.

Moving chunk allocation into each scanner makes ownership explicit: the scanner creates exactly the chunk it needs, and the caller only reorders columns afterward.

## What I'm doing:

**1. Each scanner allocates its own chunk in `do_get_next`**

Remove `HiveDataSource::_init_chunk_if_needed`. Each scanner now creates the chunk at the start of `do_get_next`:
- Parquet / ORC / Avro / count / min-max paths → `std::make_shared<Chunk>()` (empty chunk, columns added during read)
- Text / JSON / JNI → `RuntimeChunkHelper::new_chunk_checked(slot_descs, chunk_size)` (pre-shaped chunk these scanners expect)

**2. `emit_physical_columns` handles empty dst chunk**

Since the dst chunk is no longer pre-allocated with all columns, `emit_physical_columns` now creates missing slots on-the-fly before swap/fill:

```
Before:  dst has all columns pre-allocated
         dst[slot] ← swap/fill(active[slot])

After:   dst may start empty
         if dst[slot] missing → create + append_default(num_rows)
         dst[slot] ← swap/fill(active[slot])
```

`num_rows` is cached at function entry to avoid reading it after `fill_dst_column` may swap/reset columns in `active_chunk`.

**3. `variant_projection`: `append_or_update_column` replaces direct assignment**

`emit_projections` used `(*dst)->get_column_by_slot_id(slot_id) = col` which assumes the slot already exists. Changed to `append_or_update_column()` to handle both existing and missing slots.

**4. Rename `reorder_chunk` → `reorder_output_chunk`**

Consolidated two overloads into a single `reorder_output_chunk(TupleDescriptor, Chunk*)`. Logic unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
