### PR TITLE
[BugFix] guard against null driver_executor in `FragmentContext::set_final_status`

### DIFF
--- a/be/src/exec/runtime/fragment_context.cpp
+++ b/be/src/exec/runtime/fragment_context.cpp
@@ -303,7 +303,11 @@ void FragmentContext::set_final_status(const Status& status) {
                             ? workgroup()->executors()
                             : execution_services(_runtime_state.get()).workgroup_manager->shared_executors();
             auto* executor = executors->driver_executor();
-            iterate_drivers([executor](const DriverPtr& driver) { executor->cancel(driver.get()); });
+            if (executor == nullptr) {
+                LOG(WARNING) << "[Driver] driver_executor is null, skip cancel drivers, query_id=" << print_id(_query_id);
+            } else {
+                iterate_drivers([executor](const DriverPtr& driver) { executor->cancel(driver.get()); });
+            }
         }
 
         // cancel drivers in event scheduler

--- a/be/src/exec/runtime/fragment_context.cpp
+++ b/be/src/exec/runtime/fragment_context.cpp
@@ -304,7 +304,8 @@ void FragmentContext::set_final_status(const Status& status) {
                             : execution_services(_runtime_state.get()).workgroup_manager->shared_executors();
             auto* executor = executors->driver_executor();
             if (executor == nullptr) {
-                LOG(WARNING) << "[Driver] driver_executor is null, skip cancel drivers, query_id=" << print_id(_query_id);
+                LOG(WARNING) << "[Driver] driver_executor is null, skip cancel drivers, query_id="
+                             << print_id(_query_id);
             } else {
                 iterate_drivers([executor](const DriverPtr& driver) { executor->cancel(driver.get()); });
             }


### PR DESCRIPTION
## Why I'm doing:

When a `cancel_plan_fragment` RPC arrives before `PipelineExecutorSet::start()` is called,
`driver_executor()` returns null (default value of `unique_ptr`).
Calling `executor->cancel()` in this state attempts a pure virtual function call through
a null vtable pointer, causing **`SIGSEGV @0x0`** and immediately terminating the CN process.

## What I'm doing:

Add a null guard in the cancel path of `FragmentContext::set_final_status`.
When `driver_executor()` returns null, log a WARNING and skip `iterate_drivers`.
Skipping cancel is safe because no drivers can be submitted before `start()` is called.

Fixes #75029

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4