### PR TITLE
[BugFix] Define out-of-range bit shift counts to return 0

### DIFF
--- a/be/src/exprs/arithmetic_operation.h
+++ b/be/src/exprs/arithmetic_operation.h
@@ -178,21 +178,35 @@ struct ArithmeticBinaryOperator {
         } else if constexpr (is_bitxor_op<Op>) {
             return l ^ r;
         } else if constexpr (is_bit_shift_left_op<Op>) {
-            return l << r;
+            // A shift count outside [0, bit width) is C++ undefined behavior; on x86 the
+            // hardware masks the count and silently returns a wrong value. Define such
+            // out-of-range counts to return 0. Kept branchless so the per-element loop still
+            // auto-vectorizes: mask the count into [0, width) to make the shift well-defined,
+            // then blend in 0 for out-of-range counts. A negative count wraps to a huge
+            // unsigned value and is caught by the same unsigned comparison. r is a BIGINT.
+            constexpr RType width = sizeof(LType) * 8;
+            LType v = l << (r & (width - 1));
+            return static_cast<uint64_t>(r) >= static_cast<uint64_t>(width) ? LType(0) : v;
         } else if constexpr (is_bit_shift_right_op<Op>) {
-            return l >> r;
+            constexpr RType width = sizeof(LType) * 8;
+            LType v = l >> (r & (width - 1));
+            return static_cast<uint64_t>(r) >= static_cast<uint64_t>(width) ? LType(0) : v;
         } else if constexpr (is_bit_shift_right_logical_op<Op>) {
+            constexpr RType width = sizeof(LType) * 8;
+            const RType shift = r & (width - 1);
+            LType v;
             if constexpr (std::is_same_v<LType, int8_t>) {
-                return uint8_t(l) >> r;
+                v = uint8_t(l) >> shift;
             } else if constexpr (std::is_same_v<LType, int16_t>) {
-                return uint16_t(l) >> r;
+                v = uint16_t(l) >> shift;
             } else if constexpr (std::is_same_v<LType, int32_t>) {
-                return uint32_t(l) >> r;
+                v = uint32_t(l) >> shift;
             } else if constexpr (std::is_same_v<LType, int64_t>) {
-                return uint64_t(l) >> r;
+                v = uint64_t(l) >> shift;
             } else if constexpr (std::is_same_v<LType, __int128_t>) {
-                return uint128_t(l) >> r;
+                v = uint128_t(l) >> shift;
             }
+            return static_cast<uint64_t>(r) >= static_cast<uint64_t>(width) ? LType(0) : v;
         } else {
             static_assert(is_binary_op<Op>, "Invalid binary operators");
         }
@@ -331,15 +345,37 @@ struct ArithmeticBinaryOperator {
         } else if constexpr (is_bitxor_op<Op>) {
             result.value = b.CreateXor(l, r);
         } else if constexpr (is_bit_shift_left_op<Op>) {
-            result.value = b.CreateShl(l, r);
+            // Mirror the scalar path: a shift count outside [0, bit width) is UB, define it to 0.
+            // r is a BIGINT (i64); adapt it to the operand width for the actual shift instruction.
+            auto* oob = b.CreateOr(b.CreateICmpSLT(r, llvm::ConstantInt::get(r->getType(), 0)),
+                                   b.CreateICmpSGE(r, llvm::ConstantInt::get(r->getType(), sizeof(LType) * 8)));
+            // Mask into [0, width) so the shift is never poison; the select below still
+            // forces 0 for out-of-range counts.
+            auto* amount = b.CreateAnd(b.CreateZExtOrTrunc(r, l->getType()),
+                                       llvm::ConstantInt::get(l->getType(), sizeof(LType) * 8 - 1));
+            result.value = b.CreateSelect(oob, llvm::ConstantInt::get(l->getType(), 0), b.CreateShl(l, amount));
         } else if constexpr (is_bit_shift_right_op<Op>) {
+            auto* oob = b.CreateOr(b.CreateICmpSLT(r, llvm::ConstantInt::get(r->getType(), 0)),
+                                   b.CreateICmpSGE(r, llvm::ConstantInt::get(r->getType(), sizeof(LType) * 8)));
+            // Mask into [0, width) so the shift is never poison; the select below still
+            // forces 0 for out-of-range counts.
+            auto* amount = b.CreateAnd(b.CreateZExtOrTrunc(r, l->getType()),
+                                       llvm::ConstantInt::get(l->getType(), sizeof(LType) * 8 - 1));
+            llvm::Value* shifted;
             if constexpr (lt_is_unsigned<Type>) {
-                result.value = b.CreateLShr(l, r);
+                shifted = b.CreateLShr(l, amount);
             } else {
-                result.value = b.CreateAShr(l, r);
+                shifted = b.CreateAShr(l, amount);
             }
+            result.value = b.CreateSelect(oob, llvm::ConstantInt::get(l->getType(), 0), shifted);
         } else if constexpr (is_bit_shift_right_logical_op<Op>) {
-            result.value = b.CreateLShr(l, r);
+            auto* oob = b.CreateOr(b.CreateICmpSLT(r, llvm::ConstantInt::get(r->getType(), 0)),
+                                   b.CreateICmpSGE(r, llvm::ConstantInt::get(r->getType(), sizeof(LType) * 8)));
+            // Mask into [0, width) so the shift is never poison; the select below still
+            // forces 0 for out-of-range counts.
+            auto* amount = b.CreateAnd(b.CreateZExtOrTrunc(r, l->getType()),
+                                       llvm::ConstantInt::get(l->getType(), sizeof(LType) * 8 - 1));
+            result.value = b.CreateSelect(oob, llvm::ConstantInt::get(l->getType(), 0), b.CreateLShr(l, amount));
         } else {
             static_assert(is_binary_op<Op>, "Invalid binary operators");
         }

--- a/be/src/exprs/bit_functions.cpp
+++ b/be/src/exprs/bit_functions.cpp
@@ -25,12 +25,30 @@ namespace starrocks {
 VECTORIZED_BIT_BINARY_IMPL(bitAnd, &);
 VECTORIZED_BIT_BINARY_IMPL(bitOr, |);
 VECTORIZED_BIT_BINARY_IMPL(bitXor, ^);
-VECTORIZED_BIT_BINARY_IMPL(bitShiftLeft, <<);
-VECTORIZED_BIT_BINARY_IMPL(bitShiftRight, >>);
 
 #undef VECTORIZED_BIT_BINARY_IMPL
 
+// The shift count must be in [0, bitwidth(operand)). A negative count or one >= the
+// operand's bit width is undefined behavior in C++; on x86 the hardware shift masks
+// the count to the operand width and silently returns a wrong result instead of 0.
+// Define such out-of-range shifts to return 0. The shift count is a BIGINT (int64_t).
+#define VECTORIZED_BIT_SHIFT_IMPL(NAME, OP)                          \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(NAME##Impl, l, r) {             \
+        if (r < 0 || r >= static_cast<int64_t>(sizeof(LType) * 8)) { \
+            return 0;                                                \
+        }                                                            \
+        return l OP r;                                               \
+    }
+
+VECTORIZED_BIT_SHIFT_IMPL(bitShiftLeft, <<);
+VECTORIZED_BIT_SHIFT_IMPL(bitShiftRight, >>);
+
+#undef VECTORIZED_BIT_SHIFT_IMPL
+
 DEFINE_BINARY_FUNCTION_WITH_IMPL(bitShiftRightLogicalImpl, v, shift) {
+    if (shift < 0 || shift >= static_cast<int64_t>(sizeof(LType) * 8)) {
+        return 0;
+    }
     if constexpr (std::is_same_v<LType, int8_t>) {
         return uint8_t(v) >> shift;
     } else if constexpr (std::is_same_v<LType, int16_t>) {

--- a/test/sql/test_function/R/test_bit_shift_out_of_range
+++ b/test/sql/test_function/R/test_bit_shift_out_of_range
@@ -1,0 +1,54 @@
+-- name: test_bit_shift_out_of_range
+CREATE TABLE t_bit_shift (
+  k INT,
+  v_tiny TINYINT, v_small SMALLINT, v_int INT, v_big BIGINT,
+  nv_int INT, nv_big BIGINT,
+  s BIGINT
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_bit_shift VALUES
+ (1, 1, 1, 1, 1, -1024, -1024,  -1),
+ (2, 1, 1, 1, 1, -1024, -1024,   0),
+ (3, 1, 1, 1, 1, -1024, -1024,   1),
+ (4, 1, 1, 1, 1, -1024, -1024,   8),
+ (5, 1, 1, 1, 1, -1024, -1024,  16),
+ (6, 1, 1, 1, 1, -1024, -1024,  32),
+ (7, 1, 1, 1, 1, -1024, -1024,  64),
+ (8, 1, 1, 1, 1, -1024, -1024, 100);
+-- result:
+-- !result
+SELECT k, bit_shift_left(v_tiny, s), bit_shift_left(v_small, s), bit_shift_left(v_int, s), bit_shift_left(v_big, s) FROM t_bit_shift ORDER BY k;
+-- result:
+1	0	0	0	0
+2	1	1	1	1
+3	2	2	2	2
+4	0	256	256	256
+5	0	0	65536	65536
+6	0	0	0	4294967296
+7	0	0	0	0
+8	0	0	0	0
+-- !result
+SELECT k, bit_shift_right(nv_int, s), bit_shift_right(nv_big, s) FROM t_bit_shift ORDER BY k;
+-- result:
+1	0	0
+2	-1024	-1024
+3	-512	-512
+4	-4	-4
+5	-1	-1
+6	0	-1
+7	0	0
+8	0	0
+-- !result
+SELECT k, bit_shift_right_logical(nv_int, s), bit_shift_right_logical(nv_big, s) FROM t_bit_shift ORDER BY k;
+-- result:
+1	0	0
+2	-1024	-1024
+3	2147483136	9223372036854775296
+4	16777212	72057594037927932
+5	65535	281474976710655
+6	0	4294967295
+7	0	0
+8	0	0
+-- !result

--- a/test/sql/test_function/T/test_bit_shift_out_of_range
+++ b/test/sql/test_function/T/test_bit_shift_out_of_range
@@ -1,0 +1,28 @@
+-- name: test_bit_shift_out_of_range
+-- Regression: bit_shift_left / bit_shift_right / bit_shift_right_logical with a
+-- shift count that is negative or >= the operand bit width was C++ undefined
+-- behavior; on x86 the hardware masks the count to the operand width and returned
+-- a wrong value instead of 0. The fix defines such out-of-range shifts to return 0.
+-- Operands are read from columns so the FE cannot constant-fold them away.
+CREATE TABLE t_bit_shift (
+  k INT,
+  v_tiny TINYINT, v_small SMALLINT, v_int INT, v_big BIGINT,
+  nv_int INT, nv_big BIGINT,
+  s BIGINT
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO t_bit_shift VALUES
+ (1, 1, 1, 1, 1, -1024, -1024,  -1),
+ (2, 1, 1, 1, 1, -1024, -1024,   0),
+ (3, 1, 1, 1, 1, -1024, -1024,   1),
+ (4, 1, 1, 1, 1, -1024, -1024,   8),
+ (5, 1, 1, 1, 1, -1024, -1024,  16),
+ (6, 1, 1, 1, 1, -1024, -1024,  32),
+ (7, 1, 1, 1, 1, -1024, -1024,  64),
+ (8, 1, 1, 1, 1, -1024, -1024, 100);
+-- left shift: out-of-range count (s<0 or s>=bitwidth) must yield 0, in-range is normal
+SELECT k, bit_shift_left(v_tiny, s), bit_shift_left(v_small, s), bit_shift_left(v_int, s), bit_shift_left(v_big, s) FROM t_bit_shift ORDER BY k;
+-- arithmetic right shift of a negative value
+SELECT k, bit_shift_right(nv_int, s), bit_shift_right(nv_big, s) FROM t_bit_shift ORDER BY k;
+-- logical right shift of a negative value
+SELECT k, bit_shift_right_logical(nv_int, s), bit_shift_right_logical(nv_big, s) FROM t_bit_shift ORDER BY k;


### PR DESCRIPTION
## Why I'm doing:

bit_shift_left / bit_shift_right / bit_shift_right_logical computed l << r / l >> r directly. When the shift count is negative or >= the operand bit width, this is C++ undefined behavior; on x86 the hardware masks the count to the operand width and silently returns a wrong (and non-deterministic) value instead of 0.

These SQL functions are registered as ArithmeticExpr operators, so they are evaluated through ArithmeticBinaryOperator in arithmetic_operation.h, not through BitFunctions in bit_functions.cpp. Guard the shift in both the scalar apply() and the JIT generate_ir() paths so an out-of-range count yields 0. The JIT path additionally adapts the i64 BIGINT shift count to the operand width (CreateZExtOrTrunc) to match the shift-instruction operand type. The defensive guard in bit_functions.cpp is kept for the (shadowed) builtin path.

Add regression test test_bit_shift_out_of_range covering all three functions across TINYINT/SMALLINT/INT/BIGINT with negative, == bit width and > bit width shift counts, with operands read from columns so the FE cannot constant-fold them away.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
