### PR TITLE
[BugFix] Guard against cyclic view definitions to avoid StackOverflowError

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -238,6 +238,12 @@ public class ConnectContext {
 
     private boolean relationAliasCaseInsensitive = false;
 
+    // Keys of the views currently being expanded on the analysis path, used to detect cyclic view
+    // definitions. It lives on the session (not on a single QueryAnalyzer.Visitor) so the path is
+    // shared across the fresh QueryAnalyzer instances spawned for scalar/IN/EXISTS subqueries; a
+    // cycle routed through a subquery would otherwise reset the per-Visitor set on every hop.
+    private final Set<String> viewExpansionPath = Sets.newHashSet();
+
     private final Map<String, PrepareStmtContext> preparedStmtCtxs = Maps.newHashMap();
 
     // Control whether to read Iceberg caches without populating/updating them for the current execution.
@@ -1273,6 +1279,10 @@ public class ConnectContext {
 
     public boolean isRelationAliasCaseInsensitive() {
         return relationAliasCaseInsensitive;
+    }
+
+    public Set<String> getViewExpansionPath() {
+        return viewExpansionPath;
     }
 
     public void setForwardTimes(int forwardTimes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CyclicViewException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CyclicViewException.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+/**
+ * Raised when view expansion re-enters a view already on the resolution path, i.e. the view
+ * definitions form a cycle. It is a distinct type so that the enclosing {@code visitView} catch
+ * block can let it propagate unchanged instead of re-wrapping it as a generic "references invalid
+ * table(s)/column(s)" error, which would bury the real (cyclic) reason behind a misleading prefix.
+ */
+public class CyclicViewException extends SemanticException {
+    public CyclicViewException(String detailMsg) {
+        super(detailMsg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1575,7 +1575,7 @@ public class QueryAnalyzer {
             // here to avoid unbounded recursion -> StackOverflowError during analysis.
             String viewKey = viewExpansionKey(node);
             if (!viewExpansionStack.add(viewKey)) {
-                throw new SemanticException(
+                throw new CyclicViewException(
                         "View " + node.getName() + " contains a cycle in its definition");
             }
             boolean isRelationAliasCaseInSensitive = false;
@@ -1589,6 +1589,10 @@ public class QueryAnalyzer {
             Scope queryOutputScope;
             try {
                 queryOutputScope = process(node.getQueryStatement(), scope);
+            } catch (CyclicViewException e) {
+                // Let the cycle error surface as-is; re-wrapping it at every enclosing view would
+                // bury the real reason behind a misleading "references invalid table(s)" prefix.
+                throw e;
             } catch (SemanticException e) {
                 throw new SemanticException("View " + node.getName() + " references invalid table(s) or column(s) or " +
                         "function(s) or definer/invoker of view lack rights to use them: " + e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -428,10 +428,19 @@ public class QueryAnalyzer {
     private class Visitor implements AstVisitorExtendInterface<Scope, Scope> {
         // for recursive cte analyze
         private String currentRecursiveCTE = null;
-        // for cyclic view detection: stable keys of views currently being expanded on the resolution path
-        private final Set<String> viewExpansionStack = new HashSet<>();
+        // Fallback for cyclic view detection when there is no session; the shared path lives on the
+        // session (see viewExpansionStack()) so it survives the fresh QueryAnalyzer that each
+        // scalar/IN/EXISTS subquery spawns.
+        private final Set<String> localViewExpansionStack = new HashSet<>();
 
         public Visitor() {
+        }
+
+        // Stable keys of the views currently being expanded on the resolution path. Shared via the
+        // session so a cycle routed through a subquery (which gets its own QueryAnalyzer/Visitor) is
+        // still observed; only when session is null do we fall back to the per-Visitor set.
+        private Set<String> viewExpansionStack() {
+            return session != null ? session.getViewExpansionPath() : localViewExpansionStack;
         }
 
         public Scope process(ParseNode node, Scope scope) {
@@ -1574,6 +1583,7 @@ public class QueryAnalyzer {
             // Views have no CREATE-time cycle check (ALTER VIEW can close a cycle), so guard
             // here to avoid unbounded recursion -> StackOverflowError during analysis.
             String viewKey = viewExpansionKey(node);
+            Set<String> viewExpansionStack = viewExpansionStack();
             if (!viewExpansionStack.add(viewKey)) {
                 throw new CyclicViewException(
                         "View " + node.getName() + " contains a cycle in its definition");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -428,8 +428,8 @@ public class QueryAnalyzer {
     private class Visitor implements AstVisitorExtendInterface<Scope, Scope> {
         // for recursive cte analyze
         private String currentRecursiveCTE = null;
-        // for cyclic view detection: ids of views currently being expanded on the resolution path
-        private final Set<Long> viewExpansionStack = new HashSet<>();
+        // for cyclic view detection: stable keys of views currently being expanded on the resolution path
+        private final Set<String> viewExpansionStack = new HashSet<>();
 
         public Visitor() {
         }
@@ -1573,7 +1573,8 @@ public class QueryAnalyzer {
         public Scope visitView(ViewRelation node, Scope scope) {
             // Views have no CREATE-time cycle check (ALTER VIEW can close a cycle), so guard
             // here to avoid unbounded recursion -> StackOverflowError during analysis.
-            if (!viewExpansionStack.add(node.getView().getId())) {
+            String viewKey = viewExpansionKey(node);
+            if (!viewExpansionStack.add(viewKey)) {
                 throw new SemanticException(
                         "View " + node.getName() + " contains a cycle in its definition");
             }
@@ -1592,7 +1593,7 @@ public class QueryAnalyzer {
                 throw new SemanticException("View " + node.getName() + " references invalid table(s) or column(s) or " +
                         "function(s) or definer/invoker of view lack rights to use them: " + e.getMessage(), e);
             } finally {
-                viewExpansionStack.remove(node.getView().getId());
+                viewExpansionStack.remove(viewKey);
                 if (ConnectContext.get() != null && node.getView().isHiveView()) {
                     ConnectContext.get().setRelationAliasCaseInSensitive(isRelationAliasCaseInSensitive);
                 }
@@ -1628,6 +1629,21 @@ public class QueryAnalyzer {
             collector.process(node, viewScope);
 
             return viewScope;
+        }
+
+        // Returns a key that is stable across re-resolutions of the same logical view, for cycle
+        // detection. Internal (olap) views carry a persistent catalog id, so the id is used.
+        // Connector views (hive/iceberg/paimon) are rebuilt with a freshly generated id on every
+        // metadata lookup (see IcebergApiConverter.toView), so their id changes on each expansion
+        // and cannot detect re-entry; their fully-qualified name is stable instead, because
+        // connector view bodies qualify their table references (ConnectorView.formatRelations).
+        private String viewExpansionKey(ViewRelation node) {
+            View view = node.getView();
+            if (view.isOlapView()) {
+                return "id:" + view.getId();
+            }
+            TableName name = node.getName();
+            return "name:" + (name == null ? view.getName() : name.toString());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -428,6 +428,8 @@ public class QueryAnalyzer {
     private class Visitor implements AstVisitorExtendInterface<Scope, Scope> {
         // for recursive cte analyze
         private String currentRecursiveCTE = null;
+        // for cyclic view detection: ids of views currently being expanded on the resolution path
+        private final Set<Long> viewExpansionStack = new HashSet<>();
 
         public Visitor() {
         }
@@ -1569,6 +1571,12 @@ public class QueryAnalyzer {
 
         @Override
         public Scope visitView(ViewRelation node, Scope scope) {
+            // Views have no CREATE-time cycle check (ALTER VIEW can close a cycle), so guard
+            // here to avoid unbounded recursion -> StackOverflowError during analysis.
+            if (!viewExpansionStack.add(node.getView().getId())) {
+                throw new SemanticException(
+                        "View " + node.getName() + " contains a cycle in its definition");
+            }
             boolean isRelationAliasCaseInSensitive = false;
             if (ConnectContext.get() != null) {
                 isRelationAliasCaseInSensitive = ConnectContext.get().isRelationAliasCaseInsensitive();
@@ -1584,6 +1592,7 @@ public class QueryAnalyzer {
                 throw new SemanticException("View " + node.getName() + " references invalid table(s) or column(s) or " +
                         "function(s) or definer/invoker of view lack rights to use them: " + e.getMessage(), e);
             } finally {
+                viewExpansionStack.remove(node.getView().getId());
                 if (ConnectContext.get() != null && node.getView().isHiveView()) {
                     ConnectContext.get().setRelationAliasCaseInSensitive(isRelationAliasCaseInSensitive);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -766,6 +766,18 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                     "SELECT 1 as id, 'data' as data, CAST('2024-01-01' as DATE) as date", MOCKED_ICEBERG_CATALOG_NAME, dbName,
                     "view_location", Maps.newHashMap());
         }
+        // A pair of mutually-referencing views (cyc_a -> cyc_b -> cyc_a) used to verify cyclic
+        // connector-view detection. Each lookup mints a *fresh* id, mirroring
+        // IcebergApiConverter.toView (CONNECTOR_ID_GENERATOR.getNextId()), so the id can never be
+        // used to detect re-entry.
+        if (dbName.equalsIgnoreCase("view_db")
+                && (viewName.equalsIgnoreCase("cyc_a") || viewName.equalsIgnoreCase("cyc_b"))) {
+            List<Column> schema = Lists.newArrayList(new Column("id", IntegerType.INT));
+            String other = viewName.equalsIgnoreCase("cyc_a") ? "cyc_b" : "cyc_a";
+            String def = "SELECT id FROM " + MOCKED_ICEBERG_CATALOG_NAME + ".view_db." + other;
+            return new IcebergView(idGen.getAndIncrement(), MOCKED_ICEBERG_CATALOG_NAME, dbName, viewName, schema,
+                    def, MOCKED_ICEBERG_CATALOG_NAME, dbName, "view_location", Maps.newHashMap());
+        }
         return null;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCyclicViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCyclicViewTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+/**
+ * Verifies that a cycle through Iceberg connector views (cyc_a -> cyc_b -> cyc_a) is detected and
+ * reported as a graceful SemanticException instead of recursing forever into a StackOverflowError.
+ *
+ * <p>Connector views are rebuilt with a freshly generated id on every metadata lookup (see
+ * IcebergApiConverter.toView), so keying cycle detection on the view id never observes the same id
+ * twice and the guard would never fire. The fix keys connector views by their stable, fully
+ * qualified name; this test would StackOverflow without it.
+ */
+public class IcebergCyclicViewTest extends ConnectorPlanTestBase {
+    @TempDir
+    public static File temp;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.doInit(newFolder(temp, "junit").toURI().toString());
+    }
+
+    @Test
+    public void testCyclicIcebergViewRaisesSemanticErrorNotStackOverflow() {
+        Throwable t = Assertions.assertThrows(Throwable.class,
+                () -> getFragmentPlan("select * from iceberg0.view_db.cyc_a"));
+        Assertions.assertFalse(t instanceof StackOverflowError,
+                "cyclic connector view must not overflow the stack");
+        Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+                "expected a graceful cycle semantic error, but got: " + t);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCyclicViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCyclicViewTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.sql.analyzer.CyclicViewException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,12 @@ public class IcebergCyclicViewTest extends ConnectorPlanTestBase {
                 () -> getFragmentPlan("select * from iceberg0.view_db.cyc_a"));
         Assertions.assertFalse(t instanceof StackOverflowError,
                 "cyclic connector view must not overflow the stack");
-        Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+        Assertions.assertInstanceOf(CyclicViewException.class, t,
                 "expected a graceful cycle semantic error, but got: " + t);
+        Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+                "expected the cycle to be reported, but got: " + t);
+        // The cycle reason must surface directly, not be masked behind the generic outer wrapper.
+        Assertions.assertFalse(t.getMessage().contains("references invalid table"),
+                "cycle error must not be re-wrapped as a generic 'invalid table' error: " + t);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1830,4 +1830,35 @@ public class ViewPlanTest extends PlanTestBase {
             starRocksAssert.dropTable("cyc_base");
         }
     }
+
+    @Test
+    public void testCyclicViewThroughSubqueryRaisesSemanticErrorNotStackOverflow() throws Exception {
+        starRocksAssert.withTable("create table cyc_sub_base (a int) duplicate key(a) " +
+                "distributed by hash(a) buckets 1 properties('replication_num'='1')");
+        starRocksAssert.withView("create view cyc_sub_v1 as select a from cyc_sub_base");
+        starRocksAssert.withView("create view cyc_sub_v2 as " +
+                "select a from cyc_sub_base where a in (select a from cyc_sub_v1)");
+
+        // Close the cycle through an IN subquery: cyc_sub_v1 -> (subquery) cyc_sub_v2 -> (subquery)
+        // cyc_sub_v1. Each subquery is analyzed by a *fresh* QueryAnalyzer, so the guard only fires
+        // if the expansion path is shared across those analyzers (via the session).
+        String alterView = "alter view cyc_sub_v1 as select a from cyc_sub_base where a in (select a from cyc_sub_v2)";
+        AlterViewStmt alterViewStmt = (AlterViewStmt) UtFrameUtils.parseStmtWithNewParser(alterView, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterView(connectContext, alterViewStmt);
+
+        try {
+            Throwable t = Assertions.assertThrows(Throwable.class,
+                    () -> getFragmentPlan("select * from cyc_sub_v1"));
+            Assertions.assertFalse(t instanceof StackOverflowError,
+                    "cyclic view through a subquery must not overflow the stack");
+            Assertions.assertInstanceOf(CyclicViewException.class, t,
+                    "expected a graceful cycle semantic error, but got: " + t);
+            Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+                    "expected the cycle to be reported, but got: " + t);
+        } finally {
+            starRocksAssert.dropView("cyc_sub_v1");
+            starRocksAssert.dropView("cyc_sub_v2");
+            starRocksAssert.dropTable("cyc_sub_base");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.CyclicViewException;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -1816,8 +1817,13 @@ public class ViewPlanTest extends PlanTestBase {
                     () -> getFragmentPlan("select * from cyc_v1"));
             Assertions.assertFalse(t instanceof StackOverflowError,
                     "cyclic view must not overflow the stack");
-            Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+            Assertions.assertInstanceOf(CyclicViewException.class, t,
                     "expected a graceful cycle semantic error, but got: " + t);
+            Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+                    "expected the cycle to be reported, but got: " + t);
+            // The cycle reason must surface directly, not be masked behind the generic outer wrapper.
+            Assertions.assertFalse(t.getMessage().contains("references invalid table"),
+                    "cycle error must not be re-wrapped as a generic 'invalid table' error: " + t);
         } finally {
             starRocksAssert.dropView("cyc_v1");
             starRocksAssert.dropView("cyc_v2");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1795,4 +1795,33 @@ public class ViewPlanTest extends PlanTestBase {
         starRocksAssert.dropView("v_r");
         starRocksAssert.getCtx().getSessionVariable().setEnableViewBasedMvRewrite(false);
     }
+
+    @Test
+    public void testCyclicViewRaisesSemanticErrorNotStackOverflow() throws Exception {
+        starRocksAssert.withTable("create table cyc_base (a int) duplicate key(a) " +
+                "distributed by hash(a) buckets 1 properties('replication_num'='1')");
+        starRocksAssert.withView("create view cyc_v1 as select a from cyc_base");
+        starRocksAssert.withView("create view cyc_v2 as select a from cyc_v1");
+
+        // ALTER VIEW is analyzed against the *current* catalog (cyc_v1 still reads cyc_base), so it
+        // passes analysis and commits the cycle cyc_v1 -> cyc_v2 -> cyc_v1.
+        String alterView = "alter view cyc_v1 as select a from cyc_v2";
+        AlterViewStmt alterViewStmt = (AlterViewStmt) UtFrameUtils.parseStmtWithNewParser(alterView, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterView(connectContext, alterViewStmt);
+
+        try {
+            // Selecting through the cycle must raise a graceful SemanticException, never a
+            // StackOverflowError escaping to the top-level handler.
+            Throwable t = Assertions.assertThrows(Throwable.class,
+                    () -> getFragmentPlan("select * from cyc_v1"));
+            Assertions.assertFalse(t instanceof StackOverflowError,
+                    "cyclic view must not overflow the stack");
+            Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("cycle"),
+                    "expected a graceful cycle semantic error, but got: " + t);
+        } finally {
+            starRocksAssert.dropView("cyc_v1");
+            starRocksAssert.dropView("cyc_v2");
+            starRocksAssert.dropTable("cyc_base");
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

QueryAnalyzer.visitView re-resolves a view body recursively with no visited-set or depth guard. A view cannot reference itself at CREATE time, but ALTER VIEW analyzes the new body against the current catalog, so an ALTER that closes a cycle (v1 -> v2 -> v1) passes analysis and commits the cycle. A later SELECT then recurses forever and throws StackOverflowError, which is an Error and escapes the catch (SemanticException), aborting the query with an opaque "Unknown error".

Track the ids of views currently being expanded on the resolution path and raise a SemanticException when a view re-enters its own expansion, mirroring the currentRecursiveCTE guard used for recursive CTEs. Diamond view references (the same view in sibling subtrees) are unaffected because the id is popped when its subtree finishes.

## What I'm doing:
reproduce case:
```
CREATE TABLE vt (a INT) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1
  PROPERTIES("replication_num"="1");
CREATE VIEW cyc_v1 AS SELECT a FROM vt;
CREATE VIEW cyc_v2 AS SELECT a FROM cyc_v1;
ALTER VIEW cyc_v1 AS SELECT a FROM cyc_v2;   -- analyzes vs. old v1 → OK, commits the cycle
SELECT * FROM cyc_v1 LIMIT 1;                -- StackOverflowError
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
