### PR TITLE
[BugFix] Don't fail LIST-partitioned queries when a partition value can't be cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -338,7 +338,12 @@ public class OptOlapPartitionPruner {
             } else {
                 return prune;
             }
-        } catch (AnalysisException e) {
+        } catch (Exception e) {
+            // Pruning is best-effort. A non-numeric LIST partition value that fails to cast (or any
+            // other pruning failure) must not abort the query: fall back to the unpruned candidate set
+            // (all partitions when no explicit PARTITION hint was given), and let the scan apply the
+            // predicate. StarRocksConnectorException (a RuntimeException) used to escape the old
+            // AnalysisException-only catch and fail valid queries.
             LOG.warn("PartitionPrune Failed. ", e);
         }
         return specifyPartitionIds;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -781,4 +781,24 @@ public class PartitionPruneTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
 
     }
+
+    @Test
+    public void testListPartitionCastPredicateDoesNotFailQuery() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t_lp_cast (id INT, region VARCHAR(32)) " +
+                "PARTITION BY LIST(region) (" +
+                "  PARTITION p_num  VALUES IN ('100','200')," +
+                "  PARTITION p_text VALUES IN ('east','west')" +
+                ") DISTRIBUTED BY HASH(id) PROPERTIES('replication_num'='1')");
+        try {
+            // 'east'/'west' cannot cast to INT; the per-partition cast in the LIST pruner used to throw
+            // StarRocksConnectorException and abort the whole (valid) query. Pruning is best-effort, so
+            // these must still plan.
+            String plan = getFragmentPlan("select * from t_lp_cast where cast(region as int) = 100");
+            Assertions.assertTrue(plan.contains("t_lp_cast"), plan);
+            plan = getFragmentPlan("select * from t_lp_cast where cast(region as int) in (100, 200)");
+            Assertions.assertTrue(plan.contains("t_lp_cast"), plan);
+        } finally {
+            starRocksAssert.dropTable("t_lp_cast");
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

OptOlapPartitionPruner.listPartitionPrune only caught AnalysisException, but the LIST pruner casts every partition value to the predicate's target type via ListPartitionPruner.castLiteralExpr, which rethrows any failure as StarRocksConnectorException (a RuntimeException). A non-numeric partition value (e.g. 'east') under a CAST(col AS INT) = / IN / range predicate therefore made the exception escape pruning and fail an otherwise-valid query with "can not cast literal value ... to target type int".

Partition pruning is best-effort, so widen the catch to fall back to the unpruned candidate set (all partitions when no PARTITION hint is given) on any exception, letting the scan apply the predicate normally.

## What I'm doing:

Fixes #issue

reproduce case:
```sql
CREATE TABLE t_lp (id INT, region VARCHAR(32))
PARTITION BY LIST(region) (
  PARTITION p_num  VALUES IN ("100","200"),
  PARTITION p_text VALUES IN ("east","west")
)
DISTRIBUTED BY HASH(id) PROPERTIES("replication_num"="1");
INSERT INTO t_lp VALUES (1,"100"),(2,"east");

SELECT * FROM t_lp WHERE CAST(region AS INT) = 100;        -- FAILS
SELECT * FROM t_lp WHERE CAST(region AS INT) IN (100,200); -- FAILS
```
**Observed:** `ERROR 1064 (HY000): can not cast literal value east to target type int(11)`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
