### PR TITLE
[BugFix] Avoid date-bound overflow in ReduceCastRule aborting planning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -201,6 +201,14 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
         LocalDateTime originalDateTime = child2.getDatetime();
         LocalDateTime bottomDateTime = child2.getDatetime().truncatedTo(ChronoUnit.DAYS);
 
+        // A boundary literal (within a day of [0000-01-01, 9999-12-31]) would make plusDays(+/-1)
+        // overflow the supported range and throw from ConstantOperator.createDate/createDatetime,
+        // aborting planning. Skip the reduction and keep the original predicate in that case.
+        if (bottomDateTime.plusDays(1).isAfter(ConstantOperator.MAX_DATETIME)
+                || bottomDateTime.minusDays(1).isBefore(ConstantOperator.MIN_DATETIME)) {
+            return operator;
+        }
+
         LocalDateTime targetDateTime;
         BinaryType binaryType = operator.getBinaryType();
         int offset;
@@ -269,6 +277,11 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
         }
 
         LocalDateTime originalDate = child2.getDate().truncatedTo(ChronoUnit.DAYS);
+        // See reduceDateToDatetimeCast: avoid plusDays(+/-1) overflowing the supported date range.
+        if (originalDate.plusDays(1).isAfter(ConstantOperator.MAX_DATETIME)
+                || originalDate.minusDays(1).isBefore(ConstantOperator.MIN_DATETIME)) {
+            return operator;
+        }
         LocalDateTime targetDate;
         BinaryType binaryType = operator.getBinaryType();
         int offset;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -2062,4 +2062,28 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "<slot 2> : TRUE");
     }
+
+    @Test
+    public void testReduceCastBoundaryDateDoesNotAbortPlanning() throws Exception {
+        starRocksAssert.withTable("create table rc_t (id int, dt datetime) duplicate key(id) " +
+                "distributed by hash(id) buckets 1 properties('replication_num'='1')");
+        starRocksAssert.withTable("create table rc_t2 (id int, d date) duplicate key(id) " +
+                "distributed by hash(id) buckets 1 properties('replication_num'='1')");
+        try {
+            // Boundary date literals used to make ReduceCastRule shift past [0000-01-01, 9999-12-31]
+            // via plusDays(+/-1) and throw "Invalid date value", aborting planning of valid queries.
+            for (String sql : new String[] {
+                    "select * from rc_t where cast(dt as date) <= '9999-12-31'",
+                    "select * from rc_t where cast(dt as date) > '9999-12-31'",
+                    "select * from rc_t where cast(dt as date) = '9999-12-31'",
+                    "select * from rc_t2 where cast(d as datetime) < '0000-01-01 00:00:00'",
+                    "select * from rc_t2 where cast(d as datetime) > '9999-12-31 12:00:00'"}) {
+                String plan = getFragmentPlan(sql);
+                Assertions.assertTrue(plan.contains("rc_t"), sql + " => " + plan);
+            }
+        } finally {
+            starRocksAssert.dropTable("rc_t");
+            starRocksAssert.dropTable("rc_t2");
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

ReduceCastRule rewrites cast(datetime as date) / cast(date as datetime) comparisons by shifting the literal with plusDays(+/-1) and rebuilding it via the non-OrNull ConstantOperator.createDate/createDatetime, which call requiredValid() and throw SemanticException when the result leaves [0000-01-01, 9999-12-31 23:59:59]. A boundary literal (e.g. cast(dt as date) <= '9999-12-31') therefore aborted planning of a satisfiable predicate, since ScalarOperatorRewriter does not wrap rule application in try/catch.

Skip the reduction (keep the original predicate) when the day-shift would leave the supported range, guarding both reduce paths with a single bounds check.

## What I'm doing:

Fixes #issue

```sql
CREATE TABLE rc_t  (id INT, dt DATETIME) DUPLICATE KEY(id)
  DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
CREATE TABLE rc_t2 (id INT, d  DATE)     DUPLICATE KEY(id)
  DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
INSERT INTO rc_t  VALUES (1,"2020-01-01 00:00:00");
INSERT INTO rc_t2 VALUES (1,"2020-01-01");

SELECT * FROM rc_t  WHERE cast(dt AS date)     <= "9999-12-31";            -- ERROR
SELECT * FROM rc_t  WHERE cast(dt AS date)     >  "9999-12-31";            -- ERROR
SELECT * FROM rc_t  WHERE cast(dt AS date)     =  "9999-12-31";            -- ERROR
SELECT * FROM rc_t2 WHERE cast(d  AS datetime) <  "0000-01-01 00:00:00";   -- ERROR
SELECT * FROM rc_t2 WHERE cast(d  AS datetime) >  "9999-12-31 12:00:00";   -- ERROR
```
**Observed:** `ERROR 1064 (HY000): Getting analyzing error. Detail message: Invalid date value: +10000-01-01T00:00.` (upper bound) / `... -0001-12-31T00:00.` (lower bound).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
