### PR TITLE
[BugFix] Forbid pushing down aggregate over CASE with non-null constant ELSE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
@@ -210,6 +210,15 @@ public class PushDownAggregateCollector extends OptExpressionVisitor<Void, Aggre
                     newWhenThen.add(caseWhen.getThenClause(i));
                 }
 
+                if (caseWhen.hasElse() && caseWhen.getElseClause().isConstant()
+                        && !caseWhen.getElseClause().isConstantNull()) {
+                    // forbid push down: a non-null constant ELSE cannot be pushed below the join.
+                    // PushDownAggregateRewriter.rewriteProject asserts a constant ELSE is NULL, so
+                    // letting it through would trip that checkState (IllegalStateException). Mirror
+                    // the THEN-clause guard above and the IF path's else-branch check.
+                    return visit(optExpression, context);
+                }
+
                 // mock just value case when
                 CaseWhenOperator newCaseWhen = new CaseWhenOperator(caseWhen.getType(), null,
                         caseWhen.hasElse() ? caseWhen.getElseClause() : null, newWhenThen);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownWithCostTest.java
@@ -413,4 +413,17 @@ public class AggregatePushDownWithCostTest extends PlanWithCostTestBase {
                 "     * [v10, v11]-->[ndv=100000]");
         connectContext.getSessionVariable().setCboPushDownAggregateOnBroadcastJoin(true);
     }
+
+    @Test
+    public void testPushDownAggCaseWhenWithNonNullConstElseDoesNotCrash() throws Exception {
+        // A multi-WHEN CASE with non-constant THENs and a non-null constant ELSE used to trip a
+        // Preconditions.checkState in PushDownAggregateRewriter.rewriteProject (IllegalStateException)
+        // when the aggregate was pushed below a broadcast join (large probe t0, small build t1). The
+        // collector only validated THEN clauses; the non-null ELSE must also forbid push-down.
+        String sql = "select t0.v1, " +
+                "sum(case when t0.v3 > 0 then t0.v2 when t0.v3 < 0 then t0.v2 + 1 else 5 end) " +
+                "from t0 join [broadcast] t1 on t0.v1 = t1.v4 group by t0.v1";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("t0"), plan);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

PushDownAggregateCollector decides whether a CASE-WHEN-wrapped aggregate may be pushed below a join. Its loop only rejects a non-null constant in the THEN clauses and never validates the ELSE clause, but PushDownAggregateRewriter then asserts a constant ELSE must be NULL (Preconditions.checkState). A multi-WHEN CASE with non-constant THENs and a non-null constant ELSE (which stays a CASE, unlike a two-branch CASE that is normalized to if) therefore tripped that assertion and aborted planning with IllegalStateException once the rule fired (large probe side, small broadcast build side).

Mirror the THEN check (and the IF path's else-branch check) for the ELSE clause so a non-null constant ELSE forbids push-down before the rewriter is reached.

## What I'm doing:
```sql
CREATE TABLE pda_t0 (v1 INT, v2 INT, v3 INT) DUPLICATE KEY(v1)
  DISTRIBUTED BY HASH(v1) BUCKETS 4 PROPERTIES("replication_num"="1");
CREATE TABLE pda_t1 (v1 INT) DUPLICATE KEY(v1)
  DISTRIBUTED BY HASH(v1) BUCKETS 4 PROPERTIES("replication_num"="1");
-- large probe side so push-down is cost-beneficial:
INSERT INTO pda_t0
  SELECT generate_series % 1000, generate_series, generate_series % 3 - 1
  FROM TABLE(generate_series(1, 200000));
INSERT INTO pda_t1 VALUES (1),(2);
ANALYZE TABLE pda_t0; ANALYZE TABLE pda_t1;

SELECT t0.v1,
       SUM(CASE WHEN t0.v3 > 0 THEN t0.v2 WHEN t0.v3 < 0 THEN t0.v2+1 ELSE 5 END)
FROM pda_t0 t0 JOIN [broadcast] pda_t1 t1 ON t0.v1 = t1.v1
GROUP BY t0.v1;
```
**Observed:** client → `ERROR 1064 (HY000): Unknown error`. FE log:
```
err=IllegalStateException ... sql=...SUM(CASE WHEN ... ELSE 5 END)... JOIN [broadcast] ...
java.lang.IllegalStateException: null
    at com.google.common.base.Preconditions.checkState(Preconditions.java:496)
    at ...pdagg.PushDownAggregateRewriter.rewriteProject(PushDownAggregateRewriter.java:216)
    at ...pdagg.PushDownAggregateRule.rewrite(PushDownAggregateRule.java:36)
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
