### PR TITLE
[BugFix] Don't rewrite null-safe-equal join OR-disjuncts to UNION ALL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitJoinORToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitJoinORToUnionRule.java
@@ -183,6 +183,14 @@ public class SplitJoinORToUnionRule extends TransformationRule {
             return false;
         }
 
+        // The per-branch dedup predicate built in transform() is the negation of plain '=', which
+        // is NOT a correct negation of the null-safe '<=>' (EQ_FOR_NULL): for NULL operands both
+        // the join condition and the dedup predicate are true, so the row is emitted by both
+        // UNION ALL branches (duplicate rows). Refuse to rewrite null-safe-equal disjuncts.
+        if (equalPredicates.stream().anyMatch(p -> p.getBinaryType() == BinaryType.EQ_FOR_NULL)) {
+            return false;
+        }
+
         return true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
@@ -264,4 +264,22 @@ public class JoinPredicatePushdownTest extends PlanTestBase {
             connectContext.getSessionVariable().setEnabledRewriteOrToUnionAllJoin(false);
         }
     }
+
+    @Test
+    public void testSplitJoinORToUnionRuleRejectsNullSafeEqual() throws Exception {
+        connectContext.getSessionVariable().setEnabledRewriteOrToUnionAllJoin(true);
+        try {
+            // Null-safe '<=>' disjuncts must NOT be rewritten into a UNION ALL of joins: the dedup
+            // predicate added to the second branch is the negation of plain '=', which is wrong for
+            // '<=>' and would emit duplicate rows for NULL-matching tuples. The rule must keep the
+            // original OR condition on a single join instead of splitting it.
+            String sql = "select * from t0 join t1 on t0.v1 <=> t1.v4 or t0.v2 <=> t1.v5";
+            String plan = getFragmentPlan(sql);
+            PlanTestBase.assertContains(plan, "<=>");
+            // the '!=' dedup predicate only appears when the rule splits the OR; it must be absent.
+            PlanTestBase.assertNotContains(plan, "!=");
+        } finally {
+            connectContext.getSessionVariable().setEnabledRewriteOrToUnionAllJoin(false);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

SplitJoinORToUnionRule rewrites JOIN ON p1 OR p2 into a UNION ALL of two joins, adding a dedup predicate to the second branch so a row matching both disjuncts is not emitted twice. check() admits a disjunct as equi via JoinHelper.getEqualsPredicate, whose isEquivalence() is true for both EQ and EQ_FOR_NULL (<=>), but the dedup predicate is the negation of plain '=': (a != b) OR a IS NULL OR b IS NULL. For NULL operands a <=> b is TRUE (matched the first branch) and the dedup predicate is also TRUE, so the row is emitted by both branches -> duplicate rows.

Reject EQ_FOR_NULL disjuncts in check() so null-safe-equal ORs are left as a single join (the codebase already knows <=> has no simple negation).

## What I'm doing:

```sql
CREATE TABLE jl(k1 INT) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES("replication_num"="1");
CREATE TABLE jr(v1 INT, v2 INT) DUPLICATE KEY(v1) DISTRIBUTED BY HASH(v1) BUCKETS 1 PROPERTIES("replication_num"="1");
INSERT INTO jl VALUES (NULL);
INSERT INTO jr VALUES (NULL, NULL);

-- default (rule off): correct
SELECT * FROM jl JOIN jr ON jl.k1 <=> jr.v1 OR jl.k1 <=> jr.v2;   -- 1 row (NULL,NULL,NULL)

SET enable_rewrite_or_to_union_all_join = true;                   -- default false
SELECT * FROM jl JOIN jr ON jl.k1 <=> jr.v1 OR jl.k1 <=> jr.v2;   -- BUG: 2 identical rows
```
**Observed:** rule off → 1 row; rule on → **2 duplicate rows**. Plain `=` disjuncts are correct; only `<=>` is broken.



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
