### PR TITLE
[BugFix] Fix stack-buffer overflow in jodatime_format minute specifier

### DIFF
--- a/be/src/types/datetime_value.cpp
+++ b/be/src/types/datetime_value.cpp
@@ -1397,7 +1397,10 @@ bool DateTimeValue::to_joda_format_string(const char* format, int len, char* to)
             pos = int_to_str(_minute, buf);
             buf_size = pos - buf;
             actual_size = std::max(buf_size, same_ch_size);
-            if (write_size + 2 >= buffer_size) return false;
+            // Joda 'm' may repeat (e.g. repeat('m',200)) so actual_size can exceed 2; the
+            // sibling numeric specifiers guard with actual_size. The constant 2 here let a long
+            // run overflow the caller's 128-byte stack buffer. Mirror the siblings.
+            if (write_size + actual_size >= buffer_size) return false;
             to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
             break;
         case 's':

--- a/test/sql/test_time_fn/R/test_jodatime_format_m_overflow
+++ b/test/sql/test_time_fn/R/test_jodatime_format_m_overflow
@@ -1,0 +1,18 @@
+-- name: test_jodatime_format_m_overflow @sequential
+CREATE TABLE t_joda_m (k INT, dt DATETIME, fmt VARCHAR(500))
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_joda_m VALUES (1, "2023-05-15 10:20:30", repeat("m", 200));
+-- result:
+-- !result
+SELECT jodatime_format(dt, "yyyy-MM-dd HH:mm:ss") FROM t_joda_m;
+-- result:
+2023-05-15 10:20:30
+-- !result
+[UC] SELECT jodatime_format(dt, fmt) FROM t_joda_m;
+SELECT count(*) FROM t_joda_m;
+-- result:
+1
+-- !result

--- a/test/sql/test_time_fn/T/test_jodatime_format_m_overflow
+++ b/test/sql/test_time_fn/T/test_jodatime_format_m_overflow
@@ -1,0 +1,18 @@
+-- name: test_jodatime_format_m_overflow @sequential
+-- Regression: the Joda minute specifier 'm' in to_joda_format_string guarded the
+-- output with write_size + 2 (constant) but append_with_prefix writes actual_size
+-- bytes, where actual_size grows with the run length of 'm' in the format. A long
+-- run such as repeat('m',200) overflowed the caller's 128-byte stack buffer and
+-- crashed the BE (SIGSEGV in DateTimeValue::to_joda_format_string). The fix guards
+-- with actual_size like the sibling numeric specifiers, so an over-long format
+-- returns NULL instead. The format is read from a column so the FE cannot fold it.
+CREATE TABLE t_joda_m (k INT, dt DATETIME, fmt VARCHAR(500))
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+INSERT INTO t_joda_m VALUES (1, "2023-05-15 10:20:30", repeat("m", 200));
+-- normal format still works
+SELECT jodatime_format(dt, "yyyy-MM-dd HH:mm:ss") FROM t_joda_m;
+-- over-long run must not crash the BE; with the fix it returns NULL
+[UC] SELECT jodatime_format(dt, fmt) FROM t_joda_m;
+-- BE must still be serving queries after the over-long format
+SELECT count(*) FROM t_joda_m;


### PR DESCRIPTION
## Why I'm doing:

DateTimeValue::to_joda_format_string handles the Joda minute specifier 'm' by writing actual_size bytes via append_with_prefix, where actual_size grows with the run length of 'm' in the format string (e.g. repeat('m',200) -> 200). The bounds check only tested write_size + 2 (a constant), so a long run of 'm' overflowed the caller's 128-byte stack buffer and crashed the BE with SIGSEGV. Every sibling numeric specifier (k/h/H/s/K/...) already guards with actual_size.

Guard the 'm' case with actual_size like its siblings, so an over-long format returns NULL instead of overflowing.

Add regression test test_jodatime_format_m_overflow (@sequential, crash-recovery style): a column-driven repeat('m',200) format that previously crashed the BE now returns NULL, and a following query confirms the BE is still serving.

## What I'm doing:

```
*** Aborted at 1781773621 (unix time) try "date -d @1781773621" if you are using GNU date ***
PC: @          0x9ab4bbd void starrocks::common_joda_format_process<(starrocks::LogicalType)51>(starrocks::ColumnViewer<(starrocks::LogicalType)51>*, starrocks::ColumnViewer<(starrocks::LogicalType)17>*, starrocks::ColumnBuilder<(starrocks::LogicalType)17>*, int)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
