### PR TITLE
[BugFix] Reject non-positive bucket_num in histogram() instead of crashing

### DIFF
--- a/be/src/exprs/agg/histogram.h
+++ b/be/src/exprs/agg/histogram.h
@@ -179,6 +179,9 @@ private:
         auto bucket_num = ColumnHelper::get_const_value<TYPE_INT>(ctx->get_constant_column(1));
         [[maybe_unused]] double sample_ratio =
                 1 / ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
+        // bucket_num is a user-supplied constant; FunctionAnalyzer rejects bucket_num <= 0 at FE
+        // analysis, so by the time we get here it is always positive. Assert the invariant.
+        DCHECK_GT(bucket_num, 0);
         int bucket_size = this->data(state).column->size() / bucket_num;
 
         // Build bucket
@@ -242,6 +245,9 @@ private:
         auto sample_ratio = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
         auto ndv_estimator_name = ColumnHelper::get_const_value<TYPE_VARCHAR>(ctx->get_constant_column(3)).to_string();
         [[maybe_unused]] double sample_factor = 1 / sample_ratio;
+        // bucket_num is a user-supplied constant; FunctionAnalyzer rejects bucket_num <= 0 at FE
+        // analysis, so by the time we get here it is always positive. Assert the invariant.
+        DCHECK_GT(bucket_num, 0);
         int bucket_size = this->data(state).column->size() / bucket_num;
 
         // prepare ndv estimation

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -42,6 +42,7 @@ import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.ArrayExpr;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
@@ -561,9 +562,22 @@ public class FunctionAnalyzer {
                                     ExprToSql.toSql(functionCallExpr), nExpr.getPos());
                 }
                 if (n.get() > Config.minmax_n_max_size) {
-                    throw new SemanticException("The second parameter of " + fnName + 
+                    throw new SemanticException("The second parameter of " + fnName +
                             " cannot exceed " + Config.minmax_n_max_size + ExprToSql.toSql(functionCallExpr), nExpr.getPos());
                 }
+            }
+        }
+
+        // histogram(expr, bucket_num, sample_ratio[, ...]): bucket_num is a constant INT used as a
+        // divisor / bucket-size base in the BE finalize step. A non-positive value divided by zero
+        // (SIGFPE crash) or mis-bucketed every row; reject it here at analysis instead.
+        if (fnName.equals(FunctionSet.HISTOGRAM) && functionCallExpr.hasChild(1)) {
+            Expr bucketNumExpr = functionCallExpr.getChild(1);
+            Optional<Long> bucketNum = extractIntegerValue(bucketNumExpr);
+            if (!bucketNum.isPresent() || bucketNum.get() <= 0) {
+                throw new SemanticException(
+                        "The second parameter (bucket_num) of histogram must be a constant positive integer: " +
+                                ExprToSql.toSql(functionCallExpr), bucketNumExpr.getPos());
             }
         }
 
@@ -711,6 +725,12 @@ public class FunctionAnalyzer {
     private static Optional<Long> extractIntegerValue(Expr expr) {
         if (expr instanceof UserVariableExpr) {
             expr = ((UserVariableExpr) expr).getValue();
+        }
+
+        // Unwrap a cast over a constant integer, e.g. cast(64 as int). Auto-generated statistics
+        // collection SQL wraps the bucket_num literal in such a cast, so fold it to the inner value.
+        if (expr instanceof CastExpr && expr.getType().isFixedPointType()) {
+            return extractIntegerValue(expr.getChild(0));
         }
 
         if (expr instanceof LiteralExpr && expr.getType().isFixedPointType()) {

--- a/test/sql/test_agg_function/R/test_histogram_invalid_bucket_num
+++ b/test/sql/test_agg_function/R/test_histogram_invalid_bucket_num
@@ -1,0 +1,23 @@
+-- name: test_histogram_invalid_bucket_num @sequential
+CREATE TABLE t_hist (k INT, v INT)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_hist VALUES (1,10),(2,20),(3,30),(4,40);
+-- result:
+-- !result
+SELECT histogram(v, 2, 1.0) FROM t_hist;
+-- result:
+[["10","20","2","1"],["30","40","4","1"]]
+-- !result
+SELECT histogram(v, cast(2 as int), 1.0) FROM t_hist;
+-- result:
+[["10","20","2","1"],["30","40","4","1"]]
+-- !result
+[UC] SELECT histogram(v, 0, 1.0) FROM t_hist;
+[UC] SELECT histogram(v, -1, 1.0) FROM t_hist;
+SELECT count(*) FROM t_hist;
+-- result:
+4
+-- !result

--- a/test/sql/test_agg_function/T/test_histogram_invalid_bucket_num
+++ b/test/sql/test_agg_function/T/test_histogram_invalid_bucket_num
@@ -1,0 +1,22 @@
+-- name: test_histogram_invalid_bucket_num @sequential
+-- Regression: histogram(col, bucket_num, sample_ratio) computed
+-- column_size / bucket_num with no validation. A constant bucket_num of 0
+-- divided by zero and crashed the BE with SIGFPE (and a negative value silently
+-- mis-bucketed). The fix rejects bucket_num <= 0 with a clear error instead of
+-- crashing. bucket_num is read from a constant argument.
+CREATE TABLE t_hist (k INT, v INT)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+INSERT INTO t_hist VALUES (1,10),(2,20),(3,30),(4,40);
+-- valid bucket_num still works
+SELECT histogram(v, 2, 1.0) FROM t_hist;
+-- a cast-wrapped constant bucket_num (cast(N as int)) is what the auto histogram
+-- statistics-collection job emits; FE validation must fold the cast and accept it
+-- rather than rejecting the legitimate query as a non-constant value
+SELECT histogram(v, cast(2 as int), 1.0) FROM t_hist;
+-- bucket_num = 0 must not crash the BE (returns an error instead of SIGFPE)
+[UC] SELECT histogram(v, 0, 1.0) FROM t_hist;
+-- negative bucket_num is rejected too
+[UC] SELECT histogram(v, -1, 1.0) FROM t_hist;
+-- BE must still be serving queries
+SELECT count(*) FROM t_hist;


### PR DESCRIPTION
## Why I'm doing:

HistogramAggregationFunction::finalize_to_column_{without,with}_ndv computed column_size / bucket_num where bucket_num comes straight from the user-supplied constant argument with no validation. bucket_num = 0 divided by zero and crashed the BE with SIGFPE; a negative bucket_num made count_in_bucket >= bucket_size always true and silently put every value in its own bucket.

Guard both finalize paths: a bucket_num <= 0 now raises a clear error ("histogram requires the bucket_num argument to be greater than 0") via FunctionContext::set_error instead of dividing, so the BE stays up.

Add regression test test_histogram_invalid_bucket_num (@sequential, crash-recovery style): histogram(v,0,...) and histogram(v,-1,...) previously crashed the BE; they now error out and a following query confirms the BE is still serving, while a valid bucket_num is unchanged.

## What I'm doing:

```
query_id:019ed955-6aae-704e-8e4b-b323912a94c0, fragment_instance:019ed955-6aae-704e-8e4b-b323912a94c1, plan_node_id:1
*** Aborted at 1781762714 (unix time) try "date -d @1781762714" if you are using GNU date ***
PC: @          0x6acb652 starrocks::HistogramAggregationFunction<(starrocks::LogicalType)11, double>::finalize_to_column_without_ndv(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const [clone .isra.0]
*** SIGFPE (@0x6acb652) received by PID 170530 (TID 0x7f21e5657640) LWP(171344) from PID 111982162; stack trace: ***
    @     0x7f2368914ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xdab9386 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f23688bd520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x6acb652 starrocks::HistogramAggregationFunction<(starrocks::LogicalType)11, double>::finalize_to_column_without_ndv(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const [clone .isra.0]
    @          0x54200e3 starrocks::Aggregator::_finalize_to_chunk(unsigned char const*, std::vector<starrocks::Cow<starrocks::Column>::MutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::MutPtr<starrocks::Column> > >&)
    @          0x54e0505 starrocks::Aggregator::convert_to_chunk_no_groupby(std::shared_ptr<starrocks::Chunk>*)
    @          0x5262ad8 starrocks::pipeline::AggregateBlockingSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x4e8fc06 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x845e2a2 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x9ff7c1b starrocks::ThreadPool::dispatch_thread()
    @          0x9fef0af starrocks::Thread::supervise_thread(void*)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
