### PR TITLE
[BugFix] Handle only-null argument in encode_fingerprint_sha256 without OOB

### DIFF
--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -907,7 +907,17 @@ StatusOr<ColumnPtr> EncryptionFunctions::encode_fingerprint_sha256(FunctionConte
     // Process each column using template dispatch
     for (size_t col_idx = 0; col_idx < columns.size(); col_idx++) {
         const ColumnPtr& col = columns[col_idx];
-        const Column* data_col = col->only_null() ? nullptr : ColumnHelper::get_data_column(col.get());
+        if (col->only_null()) {
+            // An all-NULL column contributes a Null marker for every row. Its const null
+            // column holds a single element, so the per-row encode path would read it out of
+            // bounds (and the data column is absent, risking a null deref). Handle it here.
+            const uint8_t null_marker = static_cast<uint8_t>(RowFingerprintValueType::Null);
+            for (size_t row = 0; row < chunk_size; row++) {
+                digests[row].update(&null_marker, 1);
+            }
+            continue;
+        }
+        const Column* data_col = ColumnHelper::get_data_column(col.get());
         const NullColumn* null_col = ColumnHelper::get_null_column(col.get());
 
         // Get logical type from FunctionContext

--- a/test/sql/test_function/R/test_encode_fingerprint_sha256_null
+++ b/test/sql/test_function/R/test_encode_fingerprint_sha256_null
@@ -1,0 +1,18 @@
+-- name: test_encode_fingerprint_sha256_null @sequential
+CREATE TABLE t_fp (k INT, v INT)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_fp SELECT generate_series, generate_series FROM TABLE(generate_series(1, 5000));
+-- result:
+-- !result
+[UC] SELECT count(encode_fingerprint_sha256(v, CAST(NULL AS INT))) FROM t_fp;
+SELECT length(encode_fingerprint_sha256(7, 11));
+-- result:
+32
+-- !result
+SELECT count(*) FROM t_fp;
+-- result:
+5000
+-- !result

--- a/test/sql/test_function/T/test_encode_fingerprint_sha256_null
+++ b/test/sql/test_function/T/test_encode_fingerprint_sha256_null
@@ -1,0 +1,16 @@
+-- name: test_encode_fingerprint_sha256_null @sequential
+-- Regression: encode_fingerprint_sha256 read the per-row null bitmap of each argument
+-- column. For an all-NULL (only_null) argument the const null column has a single
+-- element and the data column is absent, so iterating null_data[row] over a multi-row
+-- chunk read out of bounds and could dereference the missing data column, crashing the
+-- BE (SIGSEGV in SHA256_Update). The fix handles an only_null column as all-NULL.
+CREATE TABLE t_fp (k INT, v INT)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+INSERT INTO t_fp SELECT generate_series, generate_series FROM TABLE(generate_series(1, 5000));
+-- all-NULL argument over a multi-row chunk must not crash the BE
+[UC] SELECT count(encode_fingerprint_sha256(v, CAST(NULL AS INT))) FROM t_fp;
+-- a normal single-row call still produces a 32-byte digest
+SELECT length(encode_fingerprint_sha256(7, 11));
+-- BE must still be serving queries
+SELECT count(*) FROM t_fp;


### PR DESCRIPTION
## Why I'm doing:

encode_fingerprint_sha256 fingerprints each argument column by iterating the per-row null bitmap over the whole chunk. For an all-NULL (only_null) argument the data column is absent and the const null column holds a single element, so indexing null_data[row] across a multi-row chunk read out of bounds; when an out-of-bounds byte read as non-null the code took the value branch and dereferenced the missing data column, crashing the BE with SIGSEGV in SHA256_Update. encode_fingerprint_sha256 is in notAlwaysNullResultWithNullParam functions, so an only-null column really reaches the BE.

Detect an only_null argument up front and contribute a Null marker for every row directly, without touching the single-element null column or the absent data column.

Add regression test test_encode_fingerprint_sha256_null (`@sequential`, crash-recovery style): encode_fingerprint_sha256(v, CAST(NULL AS INT)) over a 5000-row chunk previously crashed the BE; it now completes, a normal call still yields a 32-byte digest, and a following query confirms the BE is still serving.


## What I'm doing:

```
query_id:019ed973-a6ea-758a-b736-b92116d08d24, fragment_instance:019ed973-a6ea-758a-b736-b92116d08d25, plan_node_id:1
*** Aborted at 1781764695 (unix time) try "date -d @1781764695" if you are using GNU date ***
PC: @     0x7f537a190e74 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1aee73)
*** SIGSEGV (@0x4) received by PID 179747 (TID 0x7f520b1ff640) LWP(180522) from PID 4; stack trace: ***
    @     0x7f537a07bee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xdab9386 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f537a024520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f537a190e74 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1aee73)
    @          0xe14db98 SHA256_Update
    @          0x995c3cd starrocks::EncryptionFunctions::encode_fingerprint_sha256(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)
    @          0x6cf518a std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::C@
    @          0x6ee5e36 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x8a46173 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x6ee5567 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x8a46173 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x8a46e5b starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x542a6cb starrocks::Aggregator::evaluate_agg_input_column(starrocks::Chunk*, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> >&, int)
    @          0x5502e8a starrocks::Aggregator::compute_single_agg_state(starrocks::Chunk*, unsigned long)
    @          0x5268556 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x4e90857 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x845e2a2 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x9ff7c1b starrocks::ThreadPool::dispatch_thread()
    @          0x9fef0af starrocks::Thread::supervise_thread(void*)
    @     0x7f537a076ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
