### PR TITLE
[BugFix] Support sub-1% sampling percent in TABLE SAMPLE and histogram analyze (backport #74551)

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -828,9 +828,11 @@ void OlapChunkSource::_update_counter() {
 
     // Data sampling
     if (_params.sample_options.enable_sampling) {
+        double sample_percent = _params.sample_options.__isset.probability_percent_v2
+                                        ? _params.sample_options.probability_percent_v2
+                                        : static_cast<double>(_params.sample_options.probability_percent);
         _runtime_profile->add_info_string("SampleMethod", to_string(_params.sample_options.sample_method));
-        _runtime_profile->add_info_string("SamplePercent",
-                                          std::to_string(_params.sample_options.probability_percent) + "%");
+        _runtime_profile->add_info_string("SamplePercent", std::to_string(sample_percent) + "%");
         COUNTER_UPDATE(ADD_CHILD_TIMER(_runtime_profile, "SampleTime", parent_name),
                        _reader->stats().sample_population_size);
         COUNTER_UPDATE(ADD_CHILD_TIMER(_runtime_profile, "SampleBuildHistogramTime", parent_name),

--- a/be/src/storage/rowset/data_sample.cpp
+++ b/be/src/storage/rowset/data_sample.cpp
@@ -27,14 +27,27 @@
 
 namespace starrocks {
 
+std::unique_ptr<BlockDataSample> DataSample::make_block_sample(double probability_percent, int64_t random_seed,
+                                                               size_t rows_per_block, size_t total_rows) {
+    return std::make_unique<BlockDataSample>(probability_percent, random_seed, rows_per_block, total_rows);
+}
+
+std::unique_ptr<PageDataSample> DataSample::make_page_sample(double probability_percent, int64_t random_seed,
+                                                             size_t num_pages, PageIndexer page_indexer) {
+    return std::make_unique<PageDataSample>(probability_percent, random_seed, num_pages, std::move(page_indexer));
+}
+
 StatusOr<RowIdSparseRange> BlockDataSample::sample(OlapReaderStatistics* stats) {
-    RETURN_IF(_probability_percent == 0 || _probability_percent == 100,
+    RETURN_IF(_probability_percent <= 0 || _probability_percent >= 100,
               Status::InvalidArgument("percent should be in (0, 100)"));
     std::mt19937 mt(_random_seed);
     std::bernoulli_distribution dist(_probability_percent / 100.0);
 
     size_t sampled_blocks = 0;
-    size_t total_blocks = _total_rows / _rows_per_block;
+    // Round up: a partial trailing block (or a table smaller than one block) still counts as one block,
+    // matching the loop below and the fallback. Floor division would undercount the population (0 for a
+    // sub-block table) and could even make sample_size exceed sample_population_size.
+    size_t total_blocks = (_total_rows + _rows_per_block - 1) / _rows_per_block;
     RowIdSparseRange sampled_ranges;
     for (size_t i = 0; i < _total_rows; i += _rows_per_block) {
         if (dist(mt)) {
@@ -43,11 +56,16 @@ StatusOr<RowIdSparseRange> BlockDataSample::sample(OlapReaderStatistics* stats) 
         }
     }
 
-    if (sampled_blocks == 0) {
-        std::uniform_int_distribution<size_t> uniform(0, total_blocks);
-        size_t block = uniform(mt);
+    if (sampled_blocks == 0 && _total_rows > 0) {
+        // No block was hit by the Bernoulli pass (very likely for a small percent, e.g. sub-1%). Pick one
+        // block uniformly so the sample is non-empty. The random value is a block *index* in
+        // [0, total_blocks - 1]; convert it to a row offset just like the main loop above. (The previous code
+        // used the block index directly as a row id, which biased the fallback sample to the head of the
+        // table, and used an inclusive upper bound that could point one block past the end.)
+        std::uniform_int_distribution<size_t> uniform(0, total_blocks - 1);
+        size_t start_row = uniform(mt) * _rows_per_block;
         sampled_blocks++;
-        sampled_ranges.add(RowIdRange(block, std::min(block + _rows_per_block, _total_rows)));
+        sampled_ranges.add(RowIdRange(start_row, std::min(start_row + _rows_per_block, _total_rows)));
     }
 
     stats->sample_size += sampled_blocks;
@@ -253,7 +271,7 @@ void SortableZoneMap::build_histogram(size_t buckets) {
 }
 
 StatusOr<RowIdSparseRange> PageDataSample::sample(OlapReaderStatistics* stats) {
-    RETURN_IF(_probability_percent == 0 || _probability_percent == 100,
+    RETURN_IF(_probability_percent <= 0 || _probability_percent >= 100,
               Status::InvalidArgument("percent should be in (0, 100)"));
     if (_zonemap) {
         _prepare_histogram(stats);
@@ -298,7 +316,7 @@ bool PageDataSample::_has_histogram() const {
 // Build a histogram based on zonemap to make the data sampling more even
 // Without histogram, page sampling may fall into local optimal but not global uniform
 void PageDataSample::_prepare_histogram(OlapReaderStatistics* stats) {
-    size_t expected_pages = _probability_percent * _num_pages / 100;
+    size_t expected_pages = static_cast<size_t>(_probability_percent * _num_pages / 100.0);
     if (expected_pages <= 1) {
         return;
     }
@@ -325,9 +343,10 @@ StatusOr<RowIdSparseRange> PageDataSample::_bernoulli_sample(OlapReaderStatistic
         }
     }
 
-    if (sampled_pages == 0) {
-        // provide at least one page
-        std::uniform_int_distribution<size_t> uniform(0, _num_pages);
+    if (sampled_pages == 0 && _num_pages > 0) {
+        // Provide at least one page. The page index must stay in [0, _num_pages - 1]; the previous
+        // inclusive upper bound could pass _num_pages to the indexer and read one page past the end.
+        std::uniform_int_distribution<size_t> uniform(0, _num_pages - 1);
         auto [first_ordinal, last_ordinal] = _page_indexer(uniform(mt));
         sampled_ranges.add(RowIdRange(first_ordinal, last_ordinal));
         sampled_pages++;

--- a/be/src/storage/rowset/data_sample.h
+++ b/be/src/storage/rowset/data_sample.h
@@ -38,29 +38,27 @@ class DataSample {
 public:
     virtual ~DataSample() = default;
 
-    DataSample(int64_t probability_percent, int64_t random_seed)
+    DataSample(double probability_percent, int64_t random_seed)
             : _probability_percent(probability_percent), _random_seed(random_seed) {}
 
-    static std::unique_ptr<BlockDataSample> make_block_sample(int64_t probability_percent, int64_t random_seed,
-                                                              size_t rows_per_block, size_t total_rows) {
-        return std::make_unique<BlockDataSample>(probability_percent, random_seed, rows_per_block, total_rows);
-    }
+    static std::unique_ptr<BlockDataSample> make_block_sample(double probability_percent, int64_t random_seed,
+                                                              size_t rows_per_block, size_t total_rows);
 
-    static std::unique_ptr<PageDataSample> make_page_sample(int64_t probability_percent, int64_t random_seed,
-                                                            size_t num_pages, PageIndexer page_indexer) {
-        return std::make_unique<PageDataSample>(probability_percent, random_seed, num_pages, std::move(page_indexer));
-    }
+    static std::unique_ptr<PageDataSample> make_page_sample(double probability_percent, int64_t random_seed,
+                                                            size_t num_pages, PageIndexer page_indexer);
 
     virtual StatusOr<RowIdSparseRange> sample(OlapReaderStatistics* stats) = 0;
 
 protected:
-    int64_t _probability_percent;
+    // Sampling probability as a percent in the open range (0, 100). Stored as double so that sub-1%
+    // ratios (e.g. 0.5) on very large tables are preserved instead of being truncated to 0.
+    double _probability_percent;
     int64_t _random_seed;
 };
 
 class BlockDataSample final : public DataSample {
 public:
-    BlockDataSample(int64_t probability_percent, int64_t random_seed, size_t rows_per_block, size_t total_rows)
+    BlockDataSample(double probability_percent, int64_t random_seed, size_t rows_per_block, size_t total_rows)
             : DataSample(probability_percent, random_seed), _rows_per_block(rows_per_block), _total_rows(total_rows) {}
 
     StatusOr<RowIdSparseRange> sample(OlapReaderStatistics* stats) override;
@@ -99,7 +97,7 @@ struct SortableZoneMap {
 
 class PageDataSample final : public DataSample {
 public:
-    PageDataSample(int64_t probability_percent, int64_t random_seed, size_t num_pages, PageIndexer page_indexer)
+    PageDataSample(double probability_percent, int64_t random_seed, size_t num_pages, PageIndexer page_indexer)
             : DataSample(probability_percent, random_seed),
               _num_pages(num_pages),
               _page_indexer(std::move(page_indexer)) {}

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2148,10 +2148,19 @@ static void erase_column_pred_from_pred_tree(PredicateTree& pred_tree,
     pred_tree = PredicateTree::create(std::move(new_root));
 }
 
+// Prefer the new double field (which can carry sub-1% values such as 0.5); fall back to the legacy
+// integer field for backward compatibility with an old FE that does not set probability_percent_v2.
+static double sample_probability_percent(const TTableSampleOptions& opts) {
+    if (opts.__isset.probability_percent_v2) {
+        return opts.probability_percent_v2;
+    }
+    return static_cast<double>(opts.probability_percent);
+}
+
 StatusOr<RowIdSparseRange> SegmentIterator::_sample_by_block() {
     size_t rows_per_block = _segment->num_rows_per_block();
     size_t total_rows = _segment->num_rows();
-    int64_t probability_percent = _opts.sample_options.probability_percent;
+    double probability_percent = sample_probability_percent(_opts.sample_options);
     int64_t random_seed = _opts.sample_options.random_seed;
 
     auto sampler = DataSample::make_block_sample(probability_percent, random_seed, rows_per_block, total_rows);
@@ -2168,7 +2177,7 @@ StatusOr<RowIdSparseRange> SegmentIterator::_sample_by_page() {
     int32_t num_data_pages = column_reader->num_data_pages();
     PageIndexer page_indexer = [&](size_t page_index) { return column_reader->get_page_range(page_index); };
 
-    int64_t probability_percent = _opts.sample_options.probability_percent;
+    double probability_percent = sample_probability_percent(_opts.sample_options);
     int64_t random_seed = _opts.sample_options.random_seed;
     auto sampler = DataSample::make_page_sample(probability_percent, random_seed, num_data_pages, page_indexer);
 
@@ -2186,9 +2195,10 @@ Status SegmentIterator::_apply_data_sampling() {
     RETURN_IF(!_opts.sample_options.enable_sampling, Status::OK());
     RETURN_IF(_scan_range.empty(), Status::OK());
     RETURN_IF_ERROR(_segment->load_index(_opts.lake_io_opts));
-    RETURN_IF(_opts.sample_options.probability_percent <= 0, Status::InvalidArgument("probability_percent must > 0"));
+    RETURN_IF(sample_probability_percent(_opts.sample_options) <= 0,
+              Status::InvalidArgument("probability_percent must > 0"));
 
-    DCHECK(_opts.sample_options.__isset.probability_percent);
+    DCHECK(_opts.sample_options.__isset.probability_percent || _opts.sample_options.__isset.probability_percent_v2);
     DCHECK(_opts.sample_options.__isset.random_seed);
     DCHECK(_opts.sample_options.__isset.sample_method);
 

--- a/be/test/storage/rowset/data_sample_test.cpp
+++ b/be/test/storage/rowset/data_sample_test.cpp
@@ -82,6 +82,136 @@ TEST(DataSampleTest, test_page_sample) {
     }
 }
 
+// Regression test for sub-1% sampling on large tables. Previously the probability percent was an
+// integer, so a ratio below 1% was truncated to 0 and rejected. It is now a double, so 0.5% must be
+// accepted and produce a small but non-empty sample.
+TEST(DataSampleTest, test_block_sample_sub_one_percent) {
+    int64_t random_seed = 123;
+    size_t rows_per_block = 1024;
+    size_t total_rows = 10'000'000;
+    double percentage = 0.5;
+
+    auto data_sample = DataSample::make_block_sample(percentage, random_seed, rows_per_block, total_rows);
+    ASSERT_NE(data_sample, nullptr);
+
+    OlapReaderStatistics stats;
+    auto sampled_ranges = data_sample->sample(&stats);
+    ASSERT_TRUE(sampled_ranges.ok());
+    EXPECT_GT(sampled_ranges.value().size(), 0);
+    // Sampled blocks should be well below the population and roughly bounded by the ratio (with slack).
+    size_t total_blocks = total_rows / rows_per_block;
+    EXPECT_LT(sampled_ranges.value().size(), total_blocks);
+    EXPECT_LE(stats.sample_size, (size_t)(percentage / 100.0 * total_blocks * 3 + 8));
+}
+
+TEST(DataSampleTest, test_page_sample_sub_one_percent) {
+    int64_t random_seed = 123;
+    size_t num_pages = 100'000;
+    double percentage = 0.5;
+    auto page_indexer = [](size_t page_index) { return std::make_pair(page_index * 1024, (page_index + 1) * 1024); };
+
+    auto data_sample = DataSample::make_page_sample(percentage, random_seed, num_pages, std::move(page_indexer));
+    ASSERT_NE(data_sample, nullptr);
+
+    OlapReaderStatistics stats;
+    auto sampled_ranges = data_sample->sample(&stats);
+    ASSERT_TRUE(sampled_ranges.ok());
+    EXPECT_GT(sampled_ranges.value().size(), 0);
+    EXPECT_LT(sampled_ranges.value().size(), num_pages);
+}
+
+// A non-positive percent (including a value that used to be produced by integer truncation) must still error.
+TEST(DataSampleTest, test_block_sample_zero_percent_rejected) {
+    int64_t random_seed = 123;
+    auto data_sample = DataSample::make_block_sample(0.0, random_seed, 1024, 100'000);
+    OlapReaderStatistics stats;
+    ASSERT_FALSE(data_sample->sample(&stats).ok());
+}
+
+// With an extremely small percent the Bernoulli pass almost never hits a block, so the "at least one block"
+// fallback runs. Each returned range must be block-aligned and stay in bounds. (Before the fix the fallback
+// used the random block index directly as a row id, biasing the sample to the head of the table, and used an
+// inclusive upper bound that could point one block past the end.)
+TEST(DataSampleTest, test_block_sample_fallback_block_aligned_in_bounds) {
+    size_t rows_per_block = 1024;
+    size_t total_rows = 10 * rows_per_block; // exactly divisible -> exercises the off-by-one upper bound
+    size_t total_blocks = total_rows / rows_per_block;
+    double percentage = 1e-6; // effectively forces the fallback path
+
+    for (int64_t seed = 0; seed < 500; seed++) {
+        auto data_sample = DataSample::make_block_sample(percentage, seed, rows_per_block, total_rows);
+        ASSERT_NE(data_sample, nullptr);
+        OlapReaderStatistics stats;
+        auto sampled_ranges = data_sample->sample(&stats);
+        ASSERT_TRUE(sampled_ranges.ok());
+        ASSERT_GE(sampled_ranges.value().size(), 1);
+        for (size_t i = 0; i < sampled_ranges.value().size(); i++) {
+            auto& range = sampled_ranges.value()[i];
+            EXPECT_EQ(range.begin() % rows_per_block, 0UL) << "begin not block-aligned, seed=" << seed;
+            EXPECT_LT(range.begin(), (rowid_t)total_rows) << "begin past end, seed=" << seed;
+            EXPECT_LE(range.end(), (rowid_t)total_rows) << "end past end, seed=" << seed;
+            EXPECT_LE(range.begin() / rows_per_block, total_blocks - 1) << "invalid block index, seed=" << seed;
+        }
+    }
+}
+
+// Same idea for page sampling: a tiny percent forces the fallback, which must only ever ask the indexer for a
+// page in [0, num_pages - 1]. (Before the fix the inclusive upper bound could pass num_pages to the indexer and
+// read one page past the end.)
+TEST(DataSampleTest, test_page_sample_fallback_index_in_bounds) {
+    size_t num_pages = 16;
+    double percentage = 1e-6; // effectively forces the fallback path
+
+    for (int64_t seed = 0; seed < 500; seed++) {
+        size_t max_index_seen = 0;
+        bool indexed = false;
+        auto page_indexer = [&](size_t page_index) {
+            indexed = true;
+            max_index_seen = std::max(max_index_seen, page_index);
+            return std::make_pair((int64_t)(page_index * 1024), (int64_t)((page_index + 1) * 1024));
+        };
+        auto data_sample = DataSample::make_page_sample(percentage, seed, num_pages, page_indexer);
+        ASSERT_NE(data_sample, nullptr);
+        OlapReaderStatistics stats;
+        auto sampled_ranges = data_sample->sample(&stats);
+        ASSERT_TRUE(sampled_ranges.ok());
+        ASSERT_GE(sampled_ranges.value().size(), 1);
+        ASSERT_TRUE(indexed);
+        EXPECT_LE(max_index_seen, num_pages - 1) << "page index out of range, seed=" << seed;
+    }
+}
+
+// Regression test for the block population accounting. The number of blocks must be rounded up: a table
+// smaller than one block still has one block, and a partial trailing block still counts. Floor division
+// previously undercounted the population (reporting 0 for a sub-block table, which is also less than the
+// always-1 sample_size) and disagreed with the ceil-based fallback in the same function.
+TEST(DataSampleTest, test_block_sample_population_size_rounds_up) {
+    int64_t random_seed = 123;
+    size_t rows_per_block = 1024;
+    double percentage = 50.0;
+
+    // Table smaller than a single block -> population is 1, not 0.
+    {
+        auto data_sample = DataSample::make_block_sample(percentage, random_seed, rows_per_block, 100);
+        OlapReaderStatistics stats;
+        auto sampled_ranges = data_sample->sample(&stats);
+        ASSERT_TRUE(sampled_ranges.ok());
+        EXPECT_EQ(stats.sample_population_size, 1);
+        EXPECT_GE(stats.sample_population_size, stats.sample_size);
+    }
+
+    // Partial trailing block (5 full blocks + 100 rows) -> population is 6, not 5.
+    {
+        size_t total_rows = 5 * rows_per_block + 100;
+        auto data_sample = DataSample::make_block_sample(percentage, random_seed, rows_per_block, total_rows);
+        OlapReaderStatistics stats;
+        auto sampled_ranges = data_sample->sample(&stats);
+        ASSERT_TRUE(sampled_ranges.ok());
+        EXPECT_EQ(stats.sample_population_size, 6);
+        EXPECT_GE(stats.sample_population_size, stats.sample_size);
+    }
+}
+
 class PageSampleTestSuite : public testing::Test {
 protected:
     void SetUp() override {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ParseUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ParseUtil.java
@@ -105,6 +105,14 @@ public class ParseUtil {
         }
     }
 
+    public static double analyzeDoubleValue(String value) throws AnalysisException {
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            throw new AnalysisException("invalid number: " + value);
+        }
+    }
+
     public static boolean parseBooleanValue(String value, String name) {
         if (value.equalsIgnoreCase("ON")
                 || value.equalsIgnoreCase("TRUE")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableSampleClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableSampleClause.java
@@ -23,6 +23,7 @@ import com.starrocks.thrift.TTableSampleOptions;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.util.Strings;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -41,13 +42,15 @@ public final class TableSampleClause implements ParseNode {
 
     // Default values for sampling
     private static final SampleMethod DEFAULT_SAMPLE_METHOD = SampleMethod.BY_BLOCK;
-    private static final long DEFAULT_RANDOM_PROBABILITY_PERCENT = 1;
+    private static final double DEFAULT_RANDOM_PROBABILITY_PERCENT = 1;
 
     private final NodePosition pos;
     private boolean useSampling = true;
     private SampleMethod sampleMethod = DEFAULT_SAMPLE_METHOD;
     private long randomSeed = ThreadLocalRandom.current().nextLong();
-    private long randomProbabilityPercent = DEFAULT_RANDOM_PROBABILITY_PERCENT;
+    // Sampling probability as a percent in the open range (0, 100). Allows fractional values such as 0.5
+    // so that very large tables can be sampled below 1% without being truncated to 0.
+    private double randomProbabilityPercent = DEFAULT_RANDOM_PROBABILITY_PERCENT;
 
     public TableSampleClause(NodePosition pos) {
         this.pos = pos;
@@ -70,7 +73,7 @@ public final class TableSampleClause implements ParseNode {
                     this.sampleMethod = SampleMethod.mustParse(value);
                     break;
                 case SAMPLE_PROPERTY_PERCENT:
-                    long percent = ParseUtil.analyzeLongValue(value);
+                    double percent = ParseUtil.analyzeDoubleValue(value);
                     if (!(0 < percent && percent < 100)) {
                         throw new AnalysisException("invalid " + entry.getKey() + " which should in (0, 100)");
                     }
@@ -87,7 +90,9 @@ public final class TableSampleClause implements ParseNode {
 
     public void toThrift(TTableSampleOptions msg) {
         msg.setEnable_sampling(true);
-        msg.setProbability_percent(randomProbabilityPercent);
+        // BE is always upgraded before FE, so a new FE only ever talks to a BE that already understands
+        // this field. The legacy integer probability_percent is intentionally left unset.
+        msg.setProbability_percent_v2(randomProbabilityPercent);
         msg.setSample_method(sampleMethod.toThrift());
         msg.setRandom_seed(randomSeed);
     }
@@ -102,12 +107,18 @@ public final class TableSampleClause implements ParseNode {
         return sb.toString();
     }
 
+    // Render the percent without a trailing ".0" for integral values (e.g. "1" instead of "1.0"), while
+    // keeping fractional values intact (e.g. "0.5") and avoiding scientific notation that the parser rejects.
+    private String percentToString() {
+        return BigDecimal.valueOf(randomProbabilityPercent).stripTrailingZeros().toPlainString();
+    }
+
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("SAMPLE(");
         sb.append("'method'=").append(Strings.quote(sampleMethod.toString())).append(",");
         sb.append("'seed'=").append(Strings.quote(String.valueOf(randomSeed))).append(",");
-        sb.append("'percent'=").append(Strings.quote(String.valueOf(randomProbabilityPercent)));
+        sb.append("'percent'=").append(Strings.quote(percentToString()));
         sb.append(")");
         return sb.toString();
     }
@@ -116,7 +127,7 @@ public final class TableSampleClause implements ParseNode {
         StringBuffer sb = new StringBuffer("SAMPLE: ");
         sb.append("method=").append(sampleMethod);
         sb.append(" seed=").append(randomSeed);
-        sb.append(" probability=").append(randomProbabilityPercent);
+        sb.append(" probability=").append(percentToString());
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -26,6 +27,7 @@ import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.thrift.TStatisticData;
 import org.apache.velocity.VelocityContext;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,6 +107,17 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         }
     }
 
+    // Convert a sample ratio in (0, 1) into a percent string in (0, 100) for the SAMPLE('percent'=...) clause.
+    // Uses BigDecimal to avoid both binary float noise (e.g. 0.49999999999999994) and truncation to 0 for
+    // sub-1% ratios on very large tables (which used to produce the illegal SAMPLE('percent'='0')).
+    @VisibleForTesting
+    static String formatSamplePercent(double sampleRatio) {
+        BigDecimal percent = BigDecimal.valueOf(sampleRatio).multiply(BigDecimal.valueOf(100));
+        // Drop trailing zeros so integral percents stay clean (e.g. "50" not "50.00"), and avoid
+        // scientific notation that the SQL parser cannot consume.
+        return percent.stripTrailingZeros().toPlainString();
+    }
+
     private String buildCollectMCV(Database database, Table table, Long topN, String columnName, double sampleRatio) {
         VelocityContext context = new VelocityContext();
         context.put("tableId", table.getId());
@@ -116,7 +129,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         context.put("topN", topN);
 
         if (sampleRatio > 0.0 && sampleRatio < 1.0) {
-            String sample = String.format("SAMPLE('percent'='%d')", (int) (sampleRatio * 100));
+            String sample = String.format("SAMPLE('percent'='%s')", formatSamplePercent(sampleRatio));
             context.put("sampleClause", sample);
         } else {
             context.put("sampleClause", "");
@@ -150,7 +163,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
 
         // TODO: use it by default and remove this switch
         if (Config.enable_use_table_sample_collect_statistics && sampleRatio > 0.0 && sampleRatio < 1.0) {
-            String sampleClause = String.format("SAMPLE('percent'='%d')", (int) (sampleRatio * 100));
+            String sampleClause = String.format("SAMPLE('percent'='%s')", formatSamplePercent(sampleRatio));
             context.put("sampleClause", sampleClause);
             context.put("randFilter", "TRUE");
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
@@ -202,7 +202,11 @@ public class HyperStatisticSQLs {
                             " ) %s",
                     table, tabletHint, ratio, alias);
         } else {
-            int percent = (int) (ratio * 100);
+            // Clamp into the open range (0, 100): the upper bound is 99 because the parser rejects 100, and the
+            // lower bound is 1 so floating-point noise in `ratio * 100` is never truncated to the illegal
+            // SAMPLE('percent'='0'). Matches the clamp in TableSampleClause.toThrift. The read ratios here are
+            // all >= 1%, so this clamp is purely defensive.
+            int percent = Math.max(1, Math.min(99, (int) (ratio * 100)));
             return String.format(" SELECT * FROM (SELECT * FROM %s TABLET(%s) SAMPLE('percent'='%d')) %s",
                     table, tabletHint, percent, alias);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/TableSampleClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/TableSampleClauseTest.java
@@ -36,4 +36,35 @@ public class TableSampleClauseTest extends PlanTestBase {
         starRocksAssert.query(sql).explainContains("SAMPLE");
     }
 
+    @Test
+    public void testFractionalPercent() throws Exception {
+        // Sub-1% percent must be accepted and preserved (not truncated to 0 or rounded to 1).
+        final String sql = "select * from t1 sample('method'='by_block', 'seed'='1', 'percent'='0.5')";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        Assertions.assertEquals("SELECT `test`.`t1`.`v4`, `test`.`t1`.`v5`, `test`.`t1`.`v6`\n" +
+                        "FROM `test`.`t1` SAMPLE('method'='BY_BLOCK','seed'='1','percent'='0.5')",
+                AstToSQLBuilder.toSQL(statementBase));
+    }
+
+    @Test
+    public void testIntegralPercentHasNoTrailingZero() throws Exception {
+        // An integral percent should still serialize without a trailing ".0".
+        final String sql = "select * from t1 sample('method'='by_block', 'seed'='1', 'percent'='10')";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        Assertions.assertEquals("SELECT `test`.`t1`.`v4`, `test`.`t1`.`v5`, `test`.`t1`.`v6`\n" +
+                        "FROM `test`.`t1` SAMPLE('method'='BY_BLOCK','seed'='1','percent'='10')",
+                AstToSQLBuilder.toSQL(statementBase));
+    }
+
+    @Test
+    public void testPercentOutOfRangeRejected() {
+        // 0 and 100 remain invalid; the lower bound is open so fractional values just above 0 are allowed.
+        Assertions.assertThrows(Exception.class, () -> UtFrameUtils.parseStmtWithNewParser(
+                "select * from t1 sample('percent'='0')", connectContext));
+        Assertions.assertThrows(Exception.class, () -> UtFrameUtils.parseStmtWithNewParser(
+                "select * from t1 sample('percent'='100')", connectContext));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -69,6 +69,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     private static long t0StatsTableId = 0;
 
+    @Test
+    public void testHistogramFormatSamplePercent() {
+        // Sub-1% ratios on large tables previously truncated to "0", producing the illegal SAMPLE('percent'='0').
+        // They must now be rendered as their true percent value.
+        Assertions.assertEquals("0.5", HistogramStatisticsCollectJob.formatSamplePercent(0.005));
+        Assertions.assertEquals("0.1", HistogramStatisticsCollectJob.formatSamplePercent(0.001));
+        // 10M / 2B = 0.005 -> 0.5%
+        Assertions.assertEquals("0.5",
+                HistogramStatisticsCollectJob.formatSamplePercent(10_000_000.0 / 2_000_000_000.0));
+        // Integral percents stay clean, no trailing zeros, no scientific notation.
+        Assertions.assertEquals("50", HistogramStatisticsCollectJob.formatSamplePercent(0.5));
+        Assertions.assertEquals("1", HistogramStatisticsCollectJob.formatSamplePercent(0.01));
+        // Very small ratios must remain a positive decimal, never "0".
+        String tiny = HistogramStatisticsCollectJob.formatSamplePercent(0.0000001);
+        Assertions.assertNotEquals("0", tiny);
+        Assertions.assertFalse(tiny.contains("E"));
+        Assertions.assertFalse(tiny.contains("e"));
+    }
+
     private static LocalDateTime t0UpdateTime = LocalDateTime.of(2022, 1, 1, 1, 1, 1);
 
     @TempDir

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -595,8 +595,8 @@ struct TTableSampleOptions {
   1: optional bool enable_sampling;
   2: optional SampleMethod sample_method;
   3: optional i64 random_seed;
-  4: optional i64 probability_percent;
-
+  4: optional i64 probability_percent;       // kept for backward compatibility with old BE/FE; integer percent in (0, 100)
+  5: optional double probability_percent_v2; // new field; can carry sub-1% values such as 0.5, takes precedence when set
 }
 
 // If you find yourself changing this struct, see also TLakeScanNode

--- a/test/sql/test_scan/R/test_table_sample
+++ b/test/sql/test_scan/R/test_table_sample
@@ -82,3 +82,44 @@ select count(k1), sum(k1), sum(k2) from pk_t1 sample('seed'='1', 'method'='by_bl
 -- result:
 49152	24024997888	24748888
 -- !result
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='0.5');
+-- result:
+1
+-- !result
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='0.01');
+-- result:
+1
+-- !result
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='0.001');
+-- result:
+1
+-- !result
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='1.5');
+-- result:
+1
+-- !result
+select count(k1) > 0 from pk_t1 sample('seed'='1', 'method'='by_block', 'percent'='0.5');
+-- result:
+1
+-- !result
+create table t1_page (k1 int) duplicate key(k1) distributed by hash(k1) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t1_page select s1 from table(generate_series(1, 655350)) s(s1);
+-- result:
+-- !result
+alter table t1_page compact;
+-- result:
+-- !result
+select count(k1) > 0 from t1_page sample('seed'='1', 'method'='by_page', 'percent'='0.5');
+-- result:
+1
+-- !result
+select count(k1) > 0 from t1_page sample('seed'='1', 'method'='by_page', 'percent'='0.01');
+-- result:
+1
+-- !result
+select count(k1) > 0 from t1_page sample('seed'='1', 'method'='by_page', 'percent'='1.5');
+-- result:
+1
+-- !result

--- a/test/sql/test_scan/T/test_table_sample
+++ b/test/sql/test_scan/T/test_table_sample
@@ -51,3 +51,18 @@ where k2 = 2;
 
 -- primary key
 select count(k1), sum(k1), sum(k2) from pk_t1 sample('seed'='1', 'method'='by_block', 'percent'='10');
+
+-- sub-1% / fractional percent must be accepted end-to-end (it used to be truncated to integer 0 and
+-- rejected as "invalid percent which should in (0, 100)"); the fallback keeps the sample non-empty (count > 0).
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='0.5');
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='0.01');
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='0.001');
+select count(k1) > 0 from t1 sample('seed'='1', 'method'='by_block', 'percent'='1.5');
+select count(k1) > 0 from pk_t1 sample('seed'='1', 'method'='by_block', 'percent'='0.5');
+-- by_page needs the scan to read a single column, so use a single-column table here.
+create table t1_page (k1 int) duplicate key(k1) distributed by hash(k1) buckets 1 properties("replication_num" = "1");
+insert into t1_page select s1 from table(generate_series(1, 655350)) s(s1);
+alter table t1_page compact;
+select count(k1) > 0 from t1_page sample('seed'='1', 'method'='by_page', 'percent'='0.5');
+select count(k1) > 0 from t1_page sample('seed'='1', 'method'='by_page', 'percent'='0.01');
+select count(k1) > 0 from t1_page sample('seed'='1', 'method'='by_page', 'percent'='1.5');


### PR DESCRIPTION

## Why I'm doing:

Backports the fix https://github.com/StarRocks/starrocks/pull/74551 that is merged to main as the fix will not be backported to older branches

## What I'm doing:
More details in the original PR https://github.com/StarRocks/starrocks/pull/74551#issue-4619285019

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

