### PR TITLE
[BugFix] Fix TopN RANK boundary bug in chunks_sorter_topn

### DIFF
--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -750,7 +750,7 @@ void ChunksSorterTopn::_rank_pruning() {
 
     const auto& merged_runs = _merged_runs;
     for (int i = 0; i < merged_runs.num_chunks(); ++i) {
-        if (target_index > merged_runs.at(i).num_rows()) {
+        if (target_index >= merged_runs.at(i).num_rows()) {
             target_index -= merged_runs.at(i).num_rows();
         } else {
             index_in_runs = i;

--- a/test/sql/test_sort/R/test_rank_topn_chunk_boundary
+++ b/test/sql/test_sort/R/test_rank_topn_chunk_boundary
@@ -1,0 +1,54 @@
+-- name: test_rank_topn_chunk_boundary
+CREATE TABLE rk (id INT, v VARCHAR(32))
+DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO rk SELECT generate_series, lpad(cast(generate_series AS varchar), 10, '0')
+FROM TABLE(generate_series(1, 100000));
+-- result:
+-- !result
+set chunk_size = 128;
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set full_sort_max_buffered_bytes = 1024;
+-- result:
+-- !result
+set full_sort_max_buffered_rows = 200;
+-- result:
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 128;
+-- result:
+128
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 129;
+-- result:
+129
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 130;
+-- result:
+130
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 256;
+-- result:
+256
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 257;
+-- result:
+257
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 384;
+-- result:
+384
+-- !result
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 385;
+-- result:
+385
+-- !result
+select max(rk) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 129;
+-- result:
+129
+-- !result

--- a/test/sql/test_sort/T/test_rank_topn_chunk_boundary
+++ b/test/sql/test_sort/T/test_rank_topn_chunk_boundary
@@ -1,0 +1,38 @@
+-- name: test_rank_topn_chunk_boundary
+-- Regression for an off-by-one in ChunksSorterTopn::_rank_pruning()
+-- (be/src/exec/chunks_sorter_topn.cpp). The loop that locates which merged-run
+-- chunk holds the rank boundary row used a strict `>` where the sibling
+-- _get_run_by_row_id() uses `>=`. When the boundary row index (rank_limit - 1)
+-- exactly equals the cumulative row count of the leading merged chunk(s), the
+-- wrong branch is taken and the peer-group end is computed against an
+-- out-of-bounds / wrong row, silently dropping one row from a RANK TopN result.
+--
+-- The bug only manifests when _merged_runs spans multiple chunks. We force that
+-- deterministically by shrinking the partial-sort buffer (full_sort_max_buffered_*)
+-- and the chunk_size, so merged runs are chunked at chunk_size=128 rows. The
+-- boundary is hit when rank_limit == k*chunk_size + 1.
+CREATE TABLE rk (id INT, v VARCHAR(32))
+DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num"="1");
+
+INSERT INTO rk SELECT generate_series, lpad(cast(generate_series AS varchar), 10, '0')
+FROM TABLE(generate_series(1, 100000));
+
+set chunk_size = 128;
+set pipeline_dop = 1;
+set full_sort_max_buffered_bytes = 1024;
+set full_sort_max_buffered_rows = 200;
+
+-- All v are distinct, so rank() == row position and `rk <= N` must return
+-- exactly N rows. Boundary cases (N = 129, 257, 385 = k*128+1) returned N-1
+-- before the fix.
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 128;
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 129;
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 130;
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 256;
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 257;
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 384;
+select count(*) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 385;
+-- Verify the actual boundary row is present (id ordering follows v here).
+select max(rk) from (select id, v, rank() over (order by v) rk from rk) s where rk <= 129;
+


### PR DESCRIPTION




## Why I'm doing:

Fix an off-by-one bug in be/src/exec/chunks_sorter_topn.cpp::_rank_pruning that caused RANK TopN to drop one row when the rank boundary lies exactly at a chunk boundary (i.e. rank_limit == k * chunk_size + 1). The issue manifested only when merged runs spanned multiple chunks. Root cause

The loop that locates which merged-run chunk contains the rank boundary used a strict > comparison, while the helper _get_run_by_row_id() uses >=. When the boundary index fell exactly at the end of a run/chunk, the wrong run was selected and the peer-group end was computed against an out-of-bounds/wrong row, silently dropping one row from the result. 

Change the comparison in _rank_pruning to match the semantics of _get_run_by_row_id() (use >= / equivalently compare cumulative >= boundary_idx + 1). This ensures the correct run is chosen when the boundary is exactly at a chunk end.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
