### PR TITLE
[Enhancement] Fix unstable ds_hll_count_distinct cardinality estimate from order-dependent HIP estimator

### DIFF
--- a/be/src/exprs/agg/data_sketch/ds_hll.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_hll.cpp
@@ -113,6 +113,26 @@ int64_t DataSketchesHll::estimate_cardinality() const {
     if (_sketch_union == nullptr) {
         return 0;
     }
+    // Use the composite (non-HIP) estimator instead of get_estimate().
+    //
+    // get_estimate() returns the HIP (Historic Inverse Probability) estimate while the union's
+    // internal gadget still has its out-of-order flag unset. The HIP accumulator is updated
+    // incrementally using the running kxq value at the moment each register changes, so its final
+    // value depends on the order in which coupons/sketches were merged. In distributed/parallel
+    // aggregation the merge order is non-deterministic, which makes the HIP estimate fluctuate
+    // across runs over the same data. This happens whenever each partial sketch stays in coupon
+    // (LIST/SET) mode while the unioned cardinality crosses the SET->HLL promotion threshold: the
+    // gadget is promoted to HLL via coupon replay but never sets the out-of-order flag, so it keeps
+    // using the order-dependent HIP estimate.
+    //
+    // get_composite_estimate() is computed purely from the final register state, so it is
+    // independent of merge order and reproducible. The trade-off is a slightly higher relative
+    // standard error (non-HIP RSE factor 1.039 vs HIP 0.833, ~1.25x), which is acceptable here
+    // since this object is fundamentally a merge accumulator where the HIP estimate is not valid.
+    //
+    // There is no meaningful performance concern: estimate_cardinality() is only called from the
+    // finalize/output stage (once per group), never on the hot update/merge path. The extra cost
+    // of the composite estimator over reading the cached HIP accumulator is O(1) and negligible.
     return _sketch_union->get_composite_estimate();
 }
 

--- a/be/src/exprs/agg/data_sketch/ds_hll.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_hll.cpp
@@ -113,7 +113,7 @@ int64_t DataSketchesHll::estimate_cardinality() const {
     if (_sketch_union == nullptr) {
         return 0;
     }
-    return _sketch_union->get_estimate();
+    return _sketch_union->get_composite_estimate();
 }
 
 std::string DataSketchesHll::to_string() const {

--- a/test/sql/test_agg_function/R/test_ndv_with_varbinary_type
+++ b/test/sql/test_agg_function/R/test_ndv_with_varbinary_type
@@ -47,7 +47,7 @@ SELECT ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test;
 -- !result
 SELECT ds_hll_count_distinct(data, 10) AS ds_hll_result_with_logk FROM tbinary_ndv_test;
 -- result:
-100
+102
 -- !result
 SELECT category, ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
 -- result:

--- a/test/sql/test_agg_state/R/test_ds_hll_count_distinct_estimate_stable.sql
+++ b/test/sql/test_agg_state/R/test_ds_hll_count_distinct_estimate_stable.sql
@@ -1,0 +1,60 @@
+-- name: test_ds_hll_count_distinct_estimate_stable
+
+-- Regression test for the order-dependent (unstable) HLL cardinality estimate.
+--
+-- Both tables hold the SAME 16000 distinct values, but split into a different number
+-- of per-key (coupon-mode) partial sketches: 16 partials vs 1. The total cardinality
+-- crosses the SET->HLL promotion threshold (lg_k=17, threshold = 3/4 * 2^(17-3) = 12288),
+-- so the union gadget is promoted to HLL via coupon replay WITHOUT setting the
+-- out-of-order flag. The old estimate_cardinality() then used the HIP estimator, whose
+-- value depends on the merge/replay order, so the two tables produced different (and
+-- run-to-run unstable) results. The composite estimator depends only on the final
+-- register state, which is identical regardless of how the values were partitioned, so
+-- the two estimates must agree (allowing 1 for double->int64 truncation) and stay close
+-- to the true cardinality.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t_hll_16 (
+  k    int NULL,
+  cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
+) ENGINE=OLAP
+AGGREGATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 16;
+
+CREATE TABLE t_hll_1 (
+  k    int NULL,
+  cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
+) ENGINE=OLAP
+AGGREGATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 16;
+
+-- 16 keys * 1000 distinct values each = 16000 distinct in total.
+insert into t_hll_16
+select generate_series % 16, ds_hll_count_distinct_state(cast(generate_series as varchar), 17, 'HLL_6')
+from table(generate_series(1, 16000));
+
+-- The same 16000 distinct values accumulated under a single key.
+insert into t_hll_1
+select 0, ds_hll_count_distinct_state(cast(generate_series as varchar), 17, 'HLL_6')
+from table(generate_series(1, 16000));
+
+-- Partition-independent: the two estimates must match (modulo double->int64 truncation).
+select abs(
+  (select ds_hll_count_distinct_merge(s) from (select ds_hll_count_distinct_union(cnt) s from t_hll_16) a)
+  -
+  (select ds_hll_count_distinct_merge(s) from (select ds_hll_count_distinct_union(cnt) s from t_hll_1) b)
+) <= 1;
+-- result:
+1
+-- !result
+
+-- Accuracy: the estimate stays within ~3% of the true cardinality (16000).
+select ds_hll_count_distinct_merge(s) between 15500 and 16500
+from (select ds_hll_count_distinct_union(cnt) s from t_hll_16) a;
+-- result:
+1
+-- !result
+
+drop database db_${uuid0};

--- a/test/sql/test_agg_state/R/test_ds_hll_count_distinct_estimate_stable.sql
+++ b/test/sql/test_agg_state/R/test_ds_hll_count_distinct_estimate_stable.sql
@@ -21,14 +21,16 @@ CREATE TABLE t_hll_16 (
   cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
 ) ENGINE=OLAP
 AGGREGATE KEY(k)
-DISTRIBUTED BY HASH(k) BUCKETS 16;
+DISTRIBUTED BY HASH(k) BUCKETS 16
+PROPERTIES ("replication_num" = "1");
 
 CREATE TABLE t_hll_1 (
   k    int NULL,
   cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
 ) ENGINE=OLAP
 AGGREGATE KEY(k)
-DISTRIBUTED BY HASH(k) BUCKETS 16;
+DISTRIBUTED BY HASH(k) BUCKETS 16
+PROPERTIES ("replication_num" = "1");
 
 -- 16 keys * 1000 distinct values each = 16000 distinct in total.
 insert into t_hll_16

--- a/test/sql/test_agg_state/T/test_ds_hll_count_distinct_estimate_stable.sql
+++ b/test/sql/test_agg_state/T/test_ds_hll_count_distinct_estimate_stable.sql
@@ -1,0 +1,54 @@
+-- name: test_ds_hll_count_distinct_estimate_stable
+
+-- Regression test for the order-dependent (unstable) HLL cardinality estimate.
+--
+-- Both tables hold the SAME 16000 distinct values, but split into a different number
+-- of per-key (coupon-mode) partial sketches: 16 partials vs 1. The total cardinality
+-- crosses the SET->HLL promotion threshold (lg_k=17, threshold = 3/4 * 2^(17-3) = 12288),
+-- so the union gadget is promoted to HLL via coupon replay WITHOUT setting the
+-- out-of-order flag. The old estimate_cardinality() then used the HIP estimator, whose
+-- value depends on the merge/replay order, so the two tables produced different (and
+-- run-to-run unstable) results. The composite estimator depends only on the final
+-- register state, which is identical regardless of how the values were partitioned, so
+-- the two estimates must agree (allowing 1 for double->int64 truncation) and stay close
+-- to the true cardinality.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t_hll_16 (
+  k    int NULL,
+  cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
+) ENGINE=OLAP
+AGGREGATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 16;
+
+CREATE TABLE t_hll_1 (
+  k    int NULL,
+  cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
+) ENGINE=OLAP
+AGGREGATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 16;
+
+-- 16 keys * 1000 distinct values each = 16000 distinct in total.
+insert into t_hll_16
+select generate_series % 16, ds_hll_count_distinct_state(cast(generate_series as varchar), 17, 'HLL_6')
+from table(generate_series(1, 16000));
+
+-- The same 16000 distinct values accumulated under a single key.
+insert into t_hll_1
+select 0, ds_hll_count_distinct_state(cast(generate_series as varchar), 17, 'HLL_6')
+from table(generate_series(1, 16000));
+
+-- Partition-independent: the two estimates must match (modulo double->int64 truncation).
+select abs(
+  (select ds_hll_count_distinct_merge(s) from (select ds_hll_count_distinct_union(cnt) s from t_hll_16) a)
+  -
+  (select ds_hll_count_distinct_merge(s) from (select ds_hll_count_distinct_union(cnt) s from t_hll_1) b)
+) <= 1;
+
+-- Accuracy: the estimate stays within ~3% of the true cardinality (16000).
+select ds_hll_count_distinct_merge(s) between 15500 and 16500
+from (select ds_hll_count_distinct_union(cnt) s from t_hll_16) a;
+
+drop database db_${uuid0};

--- a/test/sql/test_agg_state/T/test_ds_hll_count_distinct_estimate_stable.sql
+++ b/test/sql/test_agg_state/T/test_ds_hll_count_distinct_estimate_stable.sql
@@ -21,14 +21,16 @@ CREATE TABLE t_hll_16 (
   cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
 ) ENGINE=OLAP
 AGGREGATE KEY(k)
-DISTRIBUTED BY HASH(k) BUCKETS 16;
+DISTRIBUTED BY HASH(k) BUCKETS 16
+PROPERTIES ("replication_num" = "1");
 
 CREATE TABLE t_hll_1 (
   k    int NULL,
   cnt  ds_hll_count_distinct(varchar, int, varchar) NULL
 ) ENGINE=OLAP
 AGGREGATE KEY(k)
-DISTRIBUTED BY HASH(k) BUCKETS 16;
+DISTRIBUTED BY HASH(k) BUCKETS 16
+PROPERTIES ("replication_num" = "1");
 
 -- 16 keys * 1000 distinct values each = 16000 distinct in total.
 insert into t_hll_16


### PR DESCRIPTION
## Why I'm doing:

`ds_hll_count_distinct` (and the underlying `DataSketchesHll`) can return an **unstable cardinality estimate** for the exact same dataset: repeated executions of the same union/merge query yield slightly different results.

Root cause is in `DataSketchesHll::estimate_cardinality()`, which called `hll_union::get_estimate()`. That returns the **HIP (Historic Inverse Probability)** estimate while the union's internal gadget still has its out-of-order flag unset. The HIP accumulator is updated incrementally using the running `kxq` value at the moment each register changes, so its final value is **order-dependent**.

The out-of-order flag is only forced on the HLL×HLL merge path in `hll_union::union_impl`. When each partial sketch stays in coupon (LIST/SET) mode and the unioned cardinality crosses the SET→HLL promotion threshold (`3/4 * 2^(lg_k-3)`), the gadget is promoted to HLL via **coupon replay** and never sets the out-of-order flag — so it keeps using the order-dependent HIP estimate. In distributed/parallel aggregation the merge order is non-deterministic, hence the run-to-run fluctuation.

## What I'm doing:

Use the order-independent **composite (non-HIP) estimator** in `estimate_cardinality()`:

```cpp
return _sketch_union->get_composite_estimate();
```

The composite estimate is computed purely from the final register state, which is independent of merge order, so the result is reproducible. The trade-off is a slightly higher relative standard error (non-HIP RSE factor 1.039 vs HIP 0.833), which is the correct choice here: this object is fundamentally a merge accumulator, where HIP's assumptions do not hold. There is no performance concern — `estimate_cardinality()` is only called on the finalize/output path (once per group), never on the hot update/merge path.

Added a SQL-tester regression test that builds the same value set under two different partitionings (16 coupon-mode partials vs 1) and asserts the two estimates agree (composite is partition/order independent) and stay within ~3% of the true cardinality.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
