### PR TITLE
[BugFix] Exclude vulnerable jline from hadoop-yarn-client in FE

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -965,6 +965,13 @@ under the License.
                         <groupId>ch.qos.reload4j</groupId>
                         <artifactId>reload4j</artifactId>
                     </exclusion>
+                    <!-- jline (via hadoop-yarn-client) is only used by YARN's interactive
+                         shell, which FE never invokes. Exclude it to drop the vulnerable
+                         jline-remote-telnet bundle (GHSA-2r2c-cx56-8933, GHSA-47qp-hqvx-6r3f). -->
+                    <exclusion>
+                        <groupId>org.jline</groupId>
+                        <artifactId>jline</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
## Why I'm doing:

jline (pulled in transitively via hadoop-yarn-client) is only used by YARN's interactive shell, which FE never invokes. Exclude it to drop the vulnerable jline-remote-telnet bundle (GHSA-2r2c-cx56-8933, GHSA-47qp-hqvx-6r3f).

## What I'm doing:

Exclude vulnerable jline from hadoop-yarn-client in FE

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
