### PR TITLE
[Refactor] Move storage cleanup executor ownership to StorageEngine

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -26,9 +26,9 @@
 #include "fmt/format.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gutil/strings/join.h"
-#include "runtime/exec_env.h"
 #include "storage/data_dir.h"
 #include "storage/replication_txn_manager.h"
+#include "storage/storage_cleanup_executor.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
@@ -318,9 +318,10 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
     g_publish_latency << publish_latency;
     if (st.ok()) {
         if (is_replication_txn) {
-            (void)ExecEnv::GetInstance()->delete_file_thread_pool()->submit_func([transaction_id]() {
+            auto submit_status = StorageEngine::instance()->storage_cleanup_executor()->submit([transaction_id]() {
                 StorageEngine::instance()->replication_txn_manager()->clear_txn(transaction_id);
             });
+            LOG_IF(WARNING, !submit_status.ok()) << "failed to submit replication txn cleanup: " << submit_status;
         }
         VLOG(1) << "publish_version success. txn_id: " << transaction_id << " gtid: " << publish_version_req.gtid
                 << " #partition:" << num_partition << " #tablet:" << tablet_tasks.size() << " time:" << publish_latency

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -772,10 +772,6 @@ uint32_t ExecEnv::calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const {
     return std::min<uint32_t>(dop, 64);
 }
 
-ThreadPool* ExecEnv::delete_file_thread_pool() {
-    return _agent_server ? _agent_server->get_thread_pool(TTaskType::DROP) : nullptr;
-}
-
 void ExecEnv::try_release_resource_before_core_dump() {
     std::set<std::string> modules;
     bool release_all = false;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -209,8 +209,6 @@ public:
 
     query_cache::CacheManagerRawPtr cache_mgr() const;
 
-    ThreadPool* delete_file_thread_pool();
-
     lake::LakePersistentIndexParallelCompactMgr* parallel_compact_mgr() { return _parallel_compact_mgr.get(); }
 
     void try_release_resource_before_core_dump();

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -375,7 +375,8 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
             max_thread_cnt = config::drop_tablet_worker_count;
         }
         auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::DROP);
-        return thread_pool->update_max_threads(max_thread_cnt);
+        RETURN_IF_ERROR(thread_pool->update_max_threads(max_thread_cnt));
+        return StorageEngine::instance()->update_storage_cleanup_thread_pool_max();
     });
     registry->register_callback("make_snapshot_worker_count", [=]() -> Status {
         auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::MAKE_SNAPSHOT);

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -337,6 +337,8 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     daemon.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": daemon threads exit successfully";
 
+    // Keep ExecEnv stop before StorageEngine stop: AgentServer pools may submit
+    // storage cleanup work, and StorageEngine::stop() drains the cleanup executor.
     exec_env->stop();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec engine destroy successfully";
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -103,6 +103,7 @@ set(STORAGE_FILES
     del_file_stream_converter.cpp
     rowset_update_state.cpp
     rowset_column_update_state.cpp
+    storage_cleanup_executor.cpp
     update_compaction_state.cpp
     version_graph.cpp
     storage_engine.cpp

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -34,7 +34,6 @@
 #include "gutil/stl_util.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/util.h"
-#include "runtime/exec_env.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/lake_proto_normalizer.h"
@@ -46,6 +45,8 @@
 #include "storage/lake/tablet_retain_info.h"
 #include "storage/lake/update_manager.h"
 #include "storage/protobuf_file.h"
+#include "storage/storage_cleanup_executor.h"
+#include "storage/storage_engine.h"
 
 namespace starrocks::lake {
 
@@ -73,10 +74,13 @@ struct VacuumTabletMetaVerionRange {
     }
 };
 
+static StorageCleanupExecutor* storage_cleanup_executor() {
+    return StorageEngine::instance()->storage_cleanup_executor();
+}
+
 static int get_num_delete_file_queued_tasks(void*) {
 #ifndef BE_TEST
-    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
-    return tp ? tp->num_queued_tasks() : 0;
+    return storage_cleanup_executor()->thread_pool()->num_queued_tasks();
 #else
     return 0;
 #endif
@@ -84,8 +88,7 @@ static int get_num_delete_file_queued_tasks(void*) {
 
 static int get_num_active_file_queued_tasks(void*) {
 #ifndef BE_TEST
-    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
-    return tp ? tp->active_threads() : 0;
+    return storage_cleanup_executor()->thread_pool()->active_threads();
 #else
     return 0;
 #endif
@@ -271,8 +274,7 @@ void delete_files_async(std::vector<std::string> files_to_delete) {
         return;
     }
     auto task = [files_to_delete = std::move(files_to_delete)]() { (void)delete_files(files_to_delete); };
-    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
-    auto st = tp->submit_func(std::move(task));
+    auto st = storage_cleanup_executor()->submit(std::move(task));
     LOG_IF(ERROR, !st.ok()) << st;
 }
 
@@ -280,19 +282,12 @@ std::future<Status> delete_files_callable(std::vector<std::string> files_to_dele
     if (UNLIKELY(files_to_delete.empty())) {
         return completed_future(Status::OK());
     }
-    auto task = std::make_shared<std::packaged_task<Status()>>(
+    return storage_cleanup_executor()->submit_callable(
             [files_to_delete = std::move(files_to_delete)]() { return delete_files(files_to_delete); });
-    auto packaged_func = [task]() { (*task)(); };
-    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
-    if (auto st = tp->submit_func(std::move(packaged_func)); !st.ok()) {
-        return completed_future(std::move(st));
-    }
-    return task->get_future();
 }
 
 void run_clear_task_async(std::function<void()> task) {
-    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
-    auto st = tp->submit_func(std::move(task));
+    auto st = storage_cleanup_executor()->submit(std::move(task));
     LOG_IF(ERROR, !st.ok()) << st;
 }
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -78,9 +78,17 @@ static StorageCleanupExecutor* storage_cleanup_executor() {
     return StorageEngine::instance()->storage_cleanup_executor();
 }
 
+#ifndef BE_TEST
+static StorageCleanupExecutor* storage_cleanup_executor_for_metrics() {
+    auto* engine = StorageEngine::instance();
+    return engine == nullptr ? nullptr : engine->storage_cleanup_executor();
+}
+#endif
+
 static int get_num_delete_file_queued_tasks(void*) {
 #ifndef BE_TEST
-    return storage_cleanup_executor()->thread_pool()->num_queued_tasks();
+    auto* executor = storage_cleanup_executor_for_metrics();
+    return executor == nullptr ? 0 : executor->num_queued_tasks();
 #else
     return 0;
 #endif
@@ -88,7 +96,8 @@ static int get_num_delete_file_queued_tasks(void*) {
 
 static int get_num_active_file_queued_tasks(void*) {
 #ifndef BE_TEST
-    return storage_cleanup_executor()->thread_pool()->active_threads();
+    auto* executor = storage_cleanup_executor_for_metrics();
+    return executor == nullptr ? 0 : executor->active_threads();
 #else
     return 0;
 #endif

--- a/be/src/storage/storage_cleanup_executor.cpp
+++ b/be/src/storage/storage_cleanup_executor.cpp
@@ -126,6 +126,14 @@ Status StorageCleanupExecutor::update_max_threads() {
     return status;
 }
 
+int StorageCleanupExecutor::num_queued_tasks() const {
+    return _thread_pool == nullptr ? 0 : _thread_pool->num_queued_tasks();
+}
+
+int StorageCleanupExecutor::active_threads() const {
+    return _thread_pool == nullptr ? 0 : _thread_pool->active_threads();
+}
+
 bool StorageCleanupExecutor::_begin_pool_op() {
     std::lock_guard l(_mutex);
     if (_shutting_down) {

--- a/be/src/storage/storage_cleanup_executor.cpp
+++ b/be/src/storage/storage_cleanup_executor.cpp
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/storage_cleanup_executor.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "base/time/monotime.h"
+#include "common/config_agent_fwd.h"
+#include "common/logging.h"
+#include "common/status.h"
+#include "common/system/cpu_info.h"
+#include "common/thread/threadpool.h"
+
+namespace starrocks {
+
+namespace {
+
+int calc_storage_cleanup_worker_count() {
+    return config::drop_tablet_worker_count > 0 ? config::drop_tablet_worker_count
+                                                : std::max(static_cast<int>(CpuInfo::num_cores() / 2), 1);
+}
+
+std::future<Status> completed_future(Status value) {
+    std::promise<Status> promise;
+    promise.set_value(std::move(value));
+    return promise.get_future();
+}
+
+} // namespace
+
+StorageCleanupExecutor::~StorageCleanupExecutor() {
+    shutdown(0);
+}
+
+Status StorageCleanupExecutor::init() {
+    return ThreadPoolBuilder("storage_cleanup")
+            .set_min_threads(1)
+            .set_max_threads(calc_storage_cleanup_worker_count())
+            .set_max_queue_size(std::numeric_limits<int>::max())
+            .build(&_thread_pool);
+}
+
+Status StorageCleanupExecutor::submit(std::function<void()> task) {
+    if (!_begin_pool_op()) {
+        return Status::ServiceUnavailable("storage cleanup executor is shutting down");
+    }
+
+    Status status;
+    if (_thread_pool == nullptr) {
+        status = Status::InternalError("storage cleanup executor is not initialized");
+    } else {
+        status = _thread_pool->submit_func(std::move(task));
+    }
+
+    _finish_pool_op();
+    return status;
+}
+
+std::future<Status> StorageCleanupExecutor::submit_callable(std::function<Status()> task) {
+    auto packaged_task = std::make_shared<std::packaged_task<Status()>>(std::move(task));
+    auto future = packaged_task->get_future();
+    auto status = submit([packaged_task]() { (*packaged_task)(); });
+    if (!status.ok()) {
+        return completed_future(std::move(status));
+    }
+    return future;
+}
+
+void StorageCleanupExecutor::wait() {
+    if (_thread_pool != nullptr) {
+        _thread_pool->wait();
+    }
+}
+
+void StorageCleanupExecutor::shutdown(int64_t drain_timeout_ms) {
+    {
+        std::unique_lock l(_mutex);
+        if (_shutting_down) {
+            return;
+        }
+        _shutting_down = true;
+        _cv.wait(l, [this] { return _active_pool_ops == 0; });
+    }
+
+    if (_thread_pool == nullptr) {
+        return;
+    }
+
+    const auto timeout_ms = std::max<int64_t>(drain_timeout_ms, 0);
+    if (!_thread_pool->wait_for(MonoDelta::FromMilliseconds(timeout_ms))) {
+        LOG(WARNING) << "storage cleanup executor shutdown timed out after " << timeout_ms
+                     << "ms, queued_tasks=" << _thread_pool->num_queued_tasks()
+                     << ", active_threads=" << _thread_pool->active_threads()
+                     << ". Queued cleanup tasks may be cancelled";
+    }
+    _thread_pool->shutdown();
+}
+
+Status StorageCleanupExecutor::update_max_threads() {
+    if (!_begin_pool_op()) {
+        return Status::ServiceUnavailable("storage cleanup executor is shutting down");
+    }
+
+    Status status;
+    if (_thread_pool == nullptr) {
+        status = Status::InternalError("storage cleanup executor is not initialized");
+    } else {
+        status = _thread_pool->update_max_threads(calc_storage_cleanup_worker_count());
+    }
+
+    _finish_pool_op();
+    return status;
+}
+
+bool StorageCleanupExecutor::_begin_pool_op() {
+    std::lock_guard l(_mutex);
+    if (_shutting_down) {
+        return false;
+    }
+    ++_active_pool_ops;
+    return true;
+}
+
+void StorageCleanupExecutor::_finish_pool_op() {
+    std::lock_guard l(_mutex);
+    --_active_pool_ops;
+    if (_shutting_down && _active_pool_ops == 0) {
+        _cv.notify_all();
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/storage_cleanup_executor.h
+++ b/be/src/storage/storage_cleanup_executor.h
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+
+#include "common/status.h"
+
+namespace starrocks {
+
+class ThreadPool;
+
+class StorageCleanupExecutor {
+public:
+    StorageCleanupExecutor() = default;
+    ~StorageCleanupExecutor();
+
+    Status init();
+    Status submit(std::function<void()> task);
+    std::future<Status> submit_callable(std::function<Status()> task);
+
+    void wait();
+    void shutdown(int64_t drain_timeout_ms);
+    Status update_max_threads();
+
+    ThreadPool* thread_pool() const { return _thread_pool.get(); }
+
+private:
+    bool _begin_pool_op();
+    void _finish_pool_op();
+
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    bool _shutting_down = false;
+    int64_t _active_pool_ops = 0;
+
+    std::unique_ptr<ThreadPool> _thread_pool;
+};
+
+} // namespace starrocks

--- a/be/src/storage/storage_cleanup_executor.h
+++ b/be/src/storage/storage_cleanup_executor.h
@@ -39,6 +39,8 @@ public:
     void shutdown(int64_t drain_timeout_ms);
     Status update_max_threads();
 
+    int num_queued_tasks() const;
+    int active_threads() const;
     ThreadPool* thread_pool() const { return _thread_pool.get(); }
 
 private:

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -54,6 +54,7 @@
 #include "base/utility/scoped_cleanup.h"
 #include "common/config_agent_fwd.h"
 #include "common/config_compaction_fwd.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_rowset_fwd.h"
 #include "common/config_storage_fwd.h"
@@ -85,6 +86,7 @@
 #include "storage/rowset/unique_rowset_id_generator.h"
 #include "storage/segment_flush_executor.h"
 #include "storage/segment_replicate_executor.h"
+#include "storage/storage_cleanup_executor.h"
 #include "storage/storage_metrics.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_meta_manager.h"
@@ -98,6 +100,10 @@ StorageEngine* StorageEngine::_p_instance = nullptr;
 
 static int calc_lake_schema_change_thread_pool_max_threads() {
     return std::max(1, config::alter_tablet_worker_count * config::lake_schema_change_per_tablet_parallelism);
+}
+
+static int64_t calc_storage_cleanup_drain_timeout_ms() {
+    return config::loop_count_wait_fragments_finish > 0 ? config::loop_count_wait_fragments_finish * 10 * 1000 : 0;
 }
 
 static Status _validate_options(const EngineOptions& options) {
@@ -126,6 +132,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _replication_txn_manager(new ReplicationTxnManager()),
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),
+          _storage_cleanup_executor(new StorageCleanupExecutor()),
           _update_manager(new UpdateManager(options.update_mem_tracker)),
           _compaction_manager(new CompactionManager()),
           _dictionary_cache_manager(new DictionaryCacheManager()) {
@@ -154,6 +161,10 @@ StorageEngine::StorageEngine(const EngineOptions& options)
 }
 
 StorageEngine::~StorageEngine() {
+    if (_storage_cleanup_executor) {
+        _storage_cleanup_executor->shutdown(0);
+    }
+
     // tablet manager need to destruct before set storage engine instance to nullptr because tablet may access storage
     // engine instance during their destruction.
     _tablet_manager.reset();
@@ -257,6 +268,8 @@ Status StorageEngine::_open(const EngineOptions& options) {
                               "init lake MemTableFlushExecutor failed");
     StorageMetrics::instance()->register_thread_pool_metrics("lake_memtable_flush",
                                                              _lake_memtable_flush_executor->get_thread_pool());
+
+    RETURN_IF_ERROR_WITH_WARN(_storage_cleanup_executor->init(), "init StorageCleanupExecutor failed");
 
     // Pool dedicated to lake schema-change *sub-tasks* (e.g. per-segment
     // index building inside a single ADD INDEX job). Physically isolated
@@ -718,6 +731,11 @@ void StorageEngine::stop() {
         _local_pk_index_manager->stop();
     }
 #endif
+
+    // Drain cleanup after all storage-side producers are quiesced.
+    if (_storage_cleanup_executor) {
+        _storage_cleanup_executor->shutdown(calc_storage_cleanup_drain_timeout_ms());
+    }
 }
 
 Status StorageEngine::update_lake_schema_change_thread_pool_max() {
@@ -726,6 +744,19 @@ Status StorageEngine::update_lake_schema_change_thread_pool_max() {
     }
     int new_max = calc_lake_schema_change_thread_pool_max_threads();
     return _lake_schema_change_thread_pool->update_max_threads(new_max);
+}
+
+Status StorageEngine::update_storage_cleanup_thread_pool_max() {
+    if (_storage_cleanup_executor == nullptr) {
+        return Status::OK();
+    }
+    return _storage_cleanup_executor->update_max_threads();
+}
+
+void StorageEngine::wait_storage_cleanup_tasks() {
+    if (_storage_cleanup_executor != nullptr) {
+        _storage_cleanup_executor->wait();
+    }
 }
 
 void StorageEngine::clear_transaction_task(const TTransactionId transaction_id) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -77,6 +77,7 @@ namespace starrocks {
 class DataDir;
 class EngineTask;
 class MemTableFlushExecutor;
+class StorageCleanupExecutor;
 class Tablet;
 class ReplicationTxnManager;
 class TAllocateAutoIncrementIdParam;
@@ -256,6 +257,10 @@ public:
     // `lake_schema_change_per_tablet_parallelism`. Invoked from the dynamic
     // config update callback when either knob changes.
     Status update_lake_schema_change_thread_pool_max();
+
+    StorageCleanupExecutor* storage_cleanup_executor() { return _storage_cleanup_executor.get(); }
+    Status update_storage_cleanup_thread_pool_max();
+    void wait_storage_cleanup_tasks();
 
     UpdateManager* update_manager() { return _update_manager.get(); }
 
@@ -510,6 +515,8 @@ private:
     // index building). Sized as alter_tablet_worker_count *
     // lake_schema_change_per_tablet_parallelism. See storage_engine.cpp pool init.
     std::unique_ptr<ThreadPool> _lake_schema_change_thread_pool;
+
+    std::unique_ptr<StorageCleanupExecutor> _storage_cleanup_executor;
 
     std::unique_ptr<UpdateManager> _update_manager;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -550,6 +550,7 @@ SET(DW_TEST_FILES
     ./storage/size_tiered_compaction_policy_test.cpp
     ./storage/snapshot_meta_test.cpp
     ./storage/sstable/concatenating_iterator_test.cpp
+    ./storage/storage_cleanup_executor_test.cpp
     ./storage/storage_metrics_test.cpp
     ./storage/storage_engine_compaction_test.cpp
     ./storage/storage_engine_test.cpp

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -548,7 +548,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
                   metadata->rowsets(0).segment_metas(1).filename());
         EXPECT_EQ(987654321, metadata->commit_time());
     }
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     // TxnLog`s should have been deleted
     ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
     ASSERT_TRUE(tablet.get_txn_log(logs[1].txn_id()).status().is_not_found());
@@ -815,7 +815,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     ASSERT_EQ("1.dat", metadata->rowsets(0).segment_metas(0).filename());
     ASSERT_EQ("2.dat", metadata->rowsets(0).segment_metas(1).filename());
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     // TxnLog should't have been deleted
     ASSERT_TRUE(tablet.get_txn_log(1002).status().ok());
     ASSERT_TRUE(tablet.get_txn_log(1003).status().ok());
@@ -905,7 +905,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // TxnLog should have been deleted
         ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
     }
@@ -925,7 +925,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
         _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // TxnLog of logs[0] should have been deleted
         ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
         // the other txn_logs should't have been deleted
@@ -974,7 +974,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // TxnLog should't have been deleted
         ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().ok());
         ASSERT_TRUE(tablet.get_txn_log(logs[1].txn_id()).status().ok());
@@ -999,7 +999,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
         _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // TxnLog of logs[0] should have been deleted
         ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
         // TxnLog of logs[1] should't have been deleted
@@ -1026,7 +1026,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
         _lake_service.publish_version(nullptr, &publish_request_1002, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // TxnLog of logs[1] should have been deleted
         ASSERT_TRUE(tablet.get_txn_log(logs[1].txn_id()).status().is_not_found());
 
@@ -1681,7 +1681,7 @@ TEST_F(LakeServiceTest, test_publish_merging_tablet) {
             ASSERT_EQ(1, inspected_txn_size.load(std::memory_order_relaxed));
             EXPECT_TRUE(saw_rebuild_pindex.load(std::memory_order_relaxed));
 
-            ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+            StorageEngine::instance()->wait_storage_cleanup_tasks();
             EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(old_tablet_id_1, txn_id)));
             EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(old_tablet_id_2, txn_id)));
         }
@@ -1879,7 +1879,7 @@ TEST_F(LakeServiceTest, test_publish_identical_tablet) {
             ASSERT_EQ(0, response.tablet_metas_size());
             ASSERT_EQ(0, response.tablet_ranges_size());
 
-            ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+            StorageEngine::instance()->wait_storage_cleanup_tasks();
             EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_log.txn_id())));
         }
 
@@ -2031,7 +2031,7 @@ TEST_F(LakeServiceTest, test_abort) {
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // TxnLog`s and segments should have been deleted
     for (auto&& log : logs) {
@@ -2166,7 +2166,7 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         request.add_txn_ids(logs.back().txn_id());
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         auto path = _tablet_mgr->txn_log_location(_tablet_id, logs.back().txn_id());
         ASSERT_EQ(TStatusCode::NOT_FOUND, FileSystem::Default()->path_exists(path).code());
     }
@@ -2186,7 +2186,7 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         info->set_combined_txn_log(false);
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         auto path = _tablet_mgr->txn_log_location(_tablet_id, logs.back().txn_id());
         ASSERT_EQ(TStatusCode::NOT_FOUND, FileSystem::Default()->path_exists(path).code());
     }
@@ -2206,7 +2206,7 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         info->set_combined_txn_log(true);
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         auto log_path = _tablet_mgr->combined_txn_log_location(_tablet_id, txn_id);
         ASSERT_TRUE(FileSystem::Default()->path_exists(log_path).is_not_found());
     }
@@ -2583,7 +2583,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id)));
         EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
@@ -2598,7 +2598,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id)));
         EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
@@ -2614,7 +2614,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
     // Publish combined txn log
@@ -2651,7 +2651,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         for (auto tablet_id : tablet_ids) {
             EXPECT_TRUE(fs::path_exist(_tablet_mgr->combined_txn_log_location(tablet_id, txn_id)));
             EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(tablet_id, version)));
@@ -2726,7 +2726,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids) {
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // The materialized .vlog must exist and contain the merged segments and
     // accumulated counters across both statements.
@@ -2846,7 +2846,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids_partial) {
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version)));
         // The single source .log must remain so the operator can recover.
         EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
@@ -2883,7 +2883,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids_partial) {
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // The pre-existing .vlog stays intact and the stale .log is cleaned.
         EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version)));
         EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
@@ -2983,7 +2983,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_merge_repeated_fields) {
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     _tablet_mgr->prune_metacache();
 
     ASSIGN_OR_ABORT(auto vlog, _tablet_mgr->get_txn_vlog(_tablet_id, version));
@@ -3081,7 +3081,7 @@ TEST_F(LakeServiceTest, test_abort_with_load_ids) {
     AbortTxnResponse response;
     _lake_service.abort_txn(nullptr, &request, &response, nullptr);
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // Every per-load_id .log file and every segment they referenced must be
     // gone -- nothing should be left in shared storage from this txn.
@@ -3153,7 +3153,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
 
         _tablet_mgr->prune_metacache();
         ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
@@ -3182,7 +3182,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
 
         _tablet_mgr->prune_metacache();
         ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
@@ -3251,7 +3251,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         for (auto txn_id : txn_ids) {
             for (auto tablet_id : tablet_ids) {
                 EXPECT_TRUE(fs::path_exist(_tablet_mgr->combined_txn_log_location(tablet_id, txn_id)));
@@ -3344,7 +3344,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch_with_load_ids) {
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // Both .vlogs land; every source .log -- 4-segment for the multi-statement
     // txn, 2-segment for the single one -- is cleaned up by its own branch.
@@ -3553,7 +3553,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
     ASSERT_EQ(14, rowset2.data_size());
     ASSERT_EQ(3, rowset2.segment_metas_size());
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, 1000)));
     EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, 1001)));
     EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 4)));
@@ -3641,7 +3641,7 @@ TEST_F(LakeServiceTest, test_publish_version_issue28244) {
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 102301).status().is_not_found());
 }
 
@@ -4335,7 +4335,7 @@ TEST_F(LakeServiceTest, test_abort3) {
 
     _lake_service.abort_txn(nullptr, &request, &response, nullptr);
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, log.txn_id())));
 }
@@ -4503,7 +4503,7 @@ TEST_F(LakeServiceTest, test_publish_version_with_combined_log) {
         ASSERT_OK(_tablet_mgr->put_combined_txn_log(combined_log));
 
         do_test(txn_id, TStatusCode::OK);
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
 
         // CombinedTxnLogPB should still exist
         auto path = _tablet_mgr->combined_txn_log_location(_tablet_id, txn_id);
@@ -4561,7 +4561,7 @@ TEST_F(LakeServiceTest, test_publish_version_with_txn_info) {
                   metadata->rowsets(0).segment_metas(1).filename());
         EXPECT_EQ(987654321, metadata->commit_time());
     }
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     // TxnLog`s should have been deleted
     ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
 }
@@ -4601,7 +4601,7 @@ TEST_F(LakeServiceTest, test_abort_with_combined_txn_log) {
 
         AbortTxnResponse response;
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
 
         for (auto&& log : combined_log->txn_logs()) {
             for (auto&& s : log.op_write().rowset().segment_metas()) {
@@ -4614,7 +4614,7 @@ TEST_F(LakeServiceTest, test_abort_with_combined_txn_log) {
         AbortTxnResponse response;
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
 
         // TxnLog`s and segments should have been deleted
         for (auto&& log : combined_log->txn_logs()) {

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -132,7 +132,7 @@ protected:
         config::enable_transparent_data_encryption = false;
 
         // check primary index cache's ref
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // check trash files already removed
         for (const auto& file : _trash_files) {
             EXPECT_FALSE(fs::path_exist(file));
@@ -655,7 +655,7 @@ protected:
     }
 
     void TearDown() override {
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         ASSERT_OK(fs::remove_all(_test_dir));
     }
 
@@ -850,7 +850,7 @@ protected:
         SyncPoint::GetInstance()->ClearAllCallBacks();
         SyncPoint::GetInstance()->DisableProcessing();
 
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         ASSERT_OK(fs::remove_all(_test_dir));
     }
 

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -116,7 +116,7 @@ public:
     void TearDown() override {
         // check primary index cache's ref
         EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         // check trash files already removed
         for (const auto& file : _trash_files) {
             EXPECT_FALSE(fs::path_exist(file));
@@ -1533,7 +1533,7 @@ public:
     void TearDown() override {
         // check primary index cache's ref
         EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         remove_test_dir_or_die();
     }
 
@@ -4247,7 +4247,7 @@ public:
     }
 
     void TearDown() override {
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         remove_test_dir_or_die();
     }
 

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -219,7 +219,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     EXPECT_EQ(new_tablet_metadata1->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata1->rowsets(2).num_dels(), 0);
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     // make sure delvecs have been generated
     for (int i = 0; i < 2; i++) {
         auto itr = new_tablet_metadata1->delvec_meta().version_to_file().find(version - i);
@@ -929,7 +929,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_remove_compaction_state) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata1, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata1->rowsets_size(), 3);
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     // make sure delvecs have been generated
     for (int i = 0; i < 2; i++) {
         auto itr = new_tablet_metadata1->delvec_meta().version_to_file().find(version - i);
@@ -1013,7 +1013,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_abort_txn) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata1, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata1->rowsets_size(), 3);
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     // make sure delvecs have been generated
     for (int i = 0; i < 2; i++) {
         auto itr = new_tablet_metadata1->delvec_meta().version_to_file().find(version - i);
@@ -1873,7 +1873,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_rows_mapper) {
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
@@ -1949,7 +1949,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_data_load_conc) {
     }
     ASSERT_EQ(kChunkSize * 2, read(version));
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // upsert chunk 0 again without publish
     auto load_txn_id = next_id();
@@ -2224,7 +2224,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_concurrent_compaction_and_publish) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata1, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata1->rowsets_size(), 3);
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // two concurrent compaction tasks
     // task-1

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -284,7 +284,7 @@ TEST_P(LakeTabletWriterTest, test_close_without_finish) {
     // `close()` directly without calling `finish()`
     writer->close();
 
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
 
     // segment file should be deleted
     ASSERT_TRUE(fs->path_exists(seg_path).is_not_found());

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -41,6 +41,7 @@
 #include "storage/lake/tablet_reshard.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
+#include "storage/storage_engine.h"
 #include "storage/tablet_meta_manager.h"
 
 namespace starrocks::lake {
@@ -80,7 +81,7 @@ public:
         }
         // Wait for all vacuum tasks finished processing before destroying
         // _tablet_mgr.
-        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
         (void)fs::remove_all(_test_dir);
     }
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -3804,7 +3804,7 @@ TEST(LakeVacuumTest2, test_delete_files_async) {
     ASSERT_OK(f2->close());
 
     delete_files_async({"test_vacuum_delete_files1.txt", "test_vacuum_delete_files2.txt"});
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     ASSERT_FALSE(fs::path_exist("test_vacuum_delete_files1.txt"));
     ASSERT_FALSE(fs::path_exist("test_vacuum_delete_files2.txt"));
 }
@@ -5751,7 +5751,7 @@ TEST_P(LakeVacuumTest, vacuum_load_spill_flat_parses_valid_name) {
     int64_t deleted = 0;
     ASSERT_OK(vacuum_load_spill(kTestDir, /*min_active_txn_id=*/1000,
                                 /*cleanup_legacy_load_spill=*/false, &deleted));
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     EXPECT_FALSE(path_exists(victim));
     EXPECT_EQ(1, deleted);
 }
@@ -5817,7 +5817,7 @@ TEST_P(LakeVacuumTest, vacuum_load_spill_flat_threshold_strict_less_than) {
     int64_t deleted = 0;
     ASSERT_OK(vacuum_load_spill(kTestDir, /*min_active_txn_id=*/100,
                                 /*cleanup_legacy_load_spill=*/false, &deleted));
-    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
     EXPECT_TRUE(path_exists(kept));
     EXPECT_FALSE(path_exists(victim));
     EXPECT_EQ(1, deleted);

--- a/be/test/storage/storage_cleanup_executor_test.cpp
+++ b/be/test/storage/storage_cleanup_executor_test.cpp
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/storage_cleanup_executor.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <future>
+#include <thread>
+
+#include "base/testutil/assert.h"
+#include "common/config_agent_fwd.h"
+#include "common/status.h"
+#include "common/thread/threadpool.h"
+
+namespace starrocks {
+
+class StorageCleanupExecutorTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _old_drop_tablet_worker_count = config::drop_tablet_worker_count;
+        config::drop_tablet_worker_count = 1;
+    }
+
+    void TearDown() override { config::drop_tablet_worker_count = _old_drop_tablet_worker_count; }
+
+private:
+    int32_t _old_drop_tablet_worker_count = 0;
+};
+
+TEST_F(StorageCleanupExecutorTest, SubmitAndCallable) {
+    StorageCleanupExecutor executor;
+    ASSERT_OK(executor.init());
+
+    std::atomic<int> ran = 0;
+    ASSERT_OK(executor.submit([&ran] { ++ran; }));
+    auto future = executor.submit_callable([] { return Status::OK(); });
+
+    executor.wait();
+    EXPECT_EQ(1, ran.load());
+    ASSERT_TRUE(future.valid());
+    ASSERT_OK(future.get());
+}
+
+TEST_F(StorageCleanupExecutorTest, RejectsSubmitAfterShutdown) {
+    StorageCleanupExecutor executor;
+    ASSERT_OK(executor.init());
+
+    executor.shutdown(1000);
+
+    auto status = executor.submit([] {});
+    EXPECT_TRUE(status.is_service_unavailable()) << status;
+    auto future = executor.submit_callable([] { return Status::OK(); });
+    ASSERT_TRUE(future.valid());
+    EXPECT_TRUE(future.get().is_service_unavailable());
+}
+
+TEST_F(StorageCleanupExecutorTest, ShutdownDrainsAcceptedTasks) {
+    StorageCleanupExecutor executor;
+    ASSERT_OK(executor.init());
+
+    std::promise<void> first_started_promise;
+    auto first_started = first_started_promise.get_future();
+    std::promise<void> release_first_promise;
+    auto release_first = release_first_promise.get_future().share();
+    std::atomic<int> ran = 0;
+
+    ASSERT_OK(executor.submit([&] {
+        first_started_promise.set_value();
+        release_first.wait();
+        ++ran;
+    }));
+    ASSERT_OK(executor.submit([&] { ++ran; }));
+
+    first_started.wait();
+    std::thread shutdown_thread([&executor] { executor.shutdown(5000); });
+    release_first_promise.set_value();
+    shutdown_thread.join();
+
+    EXPECT_EQ(2, ran.load());
+}
+
+TEST_F(StorageCleanupExecutorTest, UpdateMaxThreadsUsesDropTabletWorkerCount) {
+    StorageCleanupExecutor executor;
+    ASSERT_OK(executor.init());
+    ASSERT_EQ(1, executor.thread_pool()->max_threads());
+
+    config::drop_tablet_worker_count = 3;
+    ASSERT_OK(executor.update_max_threads());
+    ASSERT_EQ(3, executor.thread_pool()->max_threads());
+}
+
+} // namespace starrocks

--- a/be/test/storage/storage_cleanup_executor_test.cpp
+++ b/be/test/storage/storage_cleanup_executor_test.cpp
@@ -54,6 +54,13 @@ TEST_F(StorageCleanupExecutorTest, SubmitAndCallable) {
     ASSERT_OK(future.get());
 }
 
+TEST_F(StorageCleanupExecutorTest, MetricsBeforeInitReturnZero) {
+    StorageCleanupExecutor executor;
+
+    EXPECT_EQ(0, executor.num_queued_tasks());
+    EXPECT_EQ(0, executor.active_threads());
+}
+
 TEST_F(StorageCleanupExecutorTest, RejectsSubmitAfterShutdown) {
     StorageCleanupExecutor executor;
     ASSERT_OK(executor.init());

--- a/be/test/testutil/init_test_env.h
+++ b/be/test/testutil/init_test_env.h
@@ -146,11 +146,10 @@ int init_test_env(int argc, char** argv) {
     CHECK(engine->tablet_manager()->start_trash_sweep().ok());
     (void)butil::DeleteFile(storage_root, true);
     exec_env->wait_for_finish();
-    // delete engine
-    engine->stop();
-    // destroy exec env
     tls_thread_status.set_mem_tracker(nullptr);
+    // Stop ExecEnv first so AgentServer pools cannot submit new storage cleanup tasks while StorageEngine drains them.
     exec_env->stop();
+    engine->stop();
 #ifdef USE_STAROS
     if (exec_env->lake_tablet_manager() != nullptr) {
         exec_env->lake_tablet_manager()->stop();

--- a/build-support/exec_env_singleton_allowlist.txt
+++ b/build-support/exec_env_singleton_allowlist.txt
@@ -1,7 +1,6 @@
 # Production files that still call ExecEnv::GetInstance() directly.
 src/agent/agent_task.cpp
 src/agent/heartbeat_server.cpp
-src/agent/publish_version.cpp
 src/agent/resource_group_usage_recorder.cpp
 src/agent/task_worker_pool.cpp
 src/exec/pipeline/fragment_executor.cpp
@@ -27,7 +26,6 @@ src/storage/lake/metacache.cpp
 src/storage/lake/tablet_reshard.cpp
 src/storage/lake/transactions.cpp
 src/storage/lake/update_manager.cpp
-src/storage/lake/vacuum.cpp
 src/storage/lake/vertical_compaction_task.cpp
 src/storage/load_chunk_spiller.cpp
 src/storage/load_spill_block_manager.cpp


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
