### PR TITLE
[BugFix][CVE] exclude vulnerable org.jline:jline (jline-remote-telnet) from hadoop transitive deps

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -181,6 +181,7 @@ dependencies {
     implementation("org.apache.hadoop:hadoop-client") {
         exclude(group = "org.slf4j", module = "slf4j-reload4j")
         exclude(group = "ch.qos.reload4j", module = "reload4j")
+        exclude(group = "org.jline", module = "jline")
     }
     implementation("org.apache.hadoop:hadoop-client-api")
     implementation("org.apache.hadoop:hadoop-client-runtime") {

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -965,6 +965,10 @@ under the License.
                         <groupId>ch.qos.reload4j</groupId>
                         <artifactId>reload4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jline</groupId>
+                        <artifactId>jline</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -326,6 +326,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jline</groupId>
+                        <artifactId>jline</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
Fixes GHSA-2r2c-cx56-8933 and GHSA-47qp-hqvx-6r3f (org.jline:jline-remote-telnet < 4.2.1, unauthenticated Telnet-server DoS: NAWS CPU exhaustion + NEW-ENVIRON heap exhaustion). The vulnerable telnet classes are shaded into the org.jline:jline:3.9.0 bundle, pulled transitively via hadoop-yarn-client. StarRocks uses jline nowhere, so exclude it rather than bump:
- fe: exclude from hadoop-client (Maven dependencyManagement + Gradle).
- java-extensions: exclude from hadoop-mapreduce-client-core (Maven).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
