### PR TITLE
[Enhancement] Support key/sort-key schema change for shared-data range-distribution tables

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -448,6 +448,28 @@ std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info
                << ", tablet_id_in_txn_log: " << tablet_info.get_tablet_ids_in_txn_logs() << '}';
 }
 
+void convert_op_write_to_op_schema_change(TxnLogPB* log, int64_t alter_version) {
+    // Rewrite a shadow tablet's historical-rewrite op_write into an op_schema_change anchored at
+    // alter_version, in place. The shadow rewrite is an append-only snapshot, so the single op_write rowset
+    // maps 1:1 to the single op_schema_change rowset. apply_schema_change_log requires a rowset id; the shadow
+    // tablet is freshly
+    // created and published from version 1, so its sole pre-conversion rowset id is the create-time
+    // next_rowset_id (1). The single-rowset invariant is asserted (a future >1-rowset shadow would collide
+    // on id 1). No op_write rowset => empty op_schema_change@alter_version (partition empty at W).
+    const bool has_rowset = log->has_op_write() && log->op_write().has_rowset();
+    RowsetMetadataPB rowset;
+    if (has_rowset) rowset.Swap(log->mutable_op_write()->mutable_rowset());
+    log->clear_op_write();
+    auto* schema_change = log->mutable_op_schema_change();
+    schema_change->set_alter_version(alter_version);
+    if (has_rowset) {
+        DCHECK_EQ(0, schema_change->rowsets_size());
+        auto* new_rowset = schema_change->add_rowsets();
+        new_rowset->Swap(&rowset);
+        new_rowset->set_id(1);
+    }
+}
+
 StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
                                     const PublishTabletInfo& publish_tablet_info) {
     const auto type = publish_tablet_info.get_publish_tablet_type();

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -79,6 +79,12 @@ private:
 
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info);
 
+// Transform a shadow rewrite txn log in-place: move the op_write rowset into
+// op_schema_change.rowsets (with id=1) and set alter_version. If there is no
+// op_write rowset (empty partition at W), leaves an empty op_schema_change with
+// alter_version set.
+void convert_op_write_to_op_schema_change(TxnLogPB* log, int64_t alter_version);
+
 // Convert |txn_log| so it can be applied to the new tablet identified by
 // |publish_tablet_info|.
 //

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -175,6 +175,76 @@ StatusOr<std::vector<TxnLogVector>> load_txn_log(TabletManager* tablet_mgr, std:
     return txn_logs_vector;
 }
 
+// Build the op_schema_change@W log that anchors a TXN_SHADOW_REWRITE flip publish. The shadow tablet's
+// source op_write is transformed in place into op_schema_change@alter_version (W); the post-watershed
+// double-write vlogs W+1..commitVersion then replay as plain op_write (convert_txn_log is a passthrough
+// for the now-PUBLISH_NORMAL shadow tablet). The returned log is handed to publish_version()'s shared
+// apply path as a single (tablet, log) pair.
+//
+// W == 1 means the base partition was empty at the watershed (lake invariant: PARTITION_INIT_VERSION == 1,
+// the first load publishes version 2), so the rewrite produced no source op_write: an empty
+// op_schema_change@1 is synthesized and returned WITHOUT any object-storage access (a source load would 404).
+// For W > 1 the source op_write MUST exist (the rewrite INSERT opens and finishes a delta writer for every
+// shadow tablet, even 0-row ones), so it is loaded and its status propagates as-is -- a not-found is NOT
+// turned into an empty log (that would silently drop the partition's data by advancing the version). The
+// caller routes any error through new_version_metadata_or_error, which hands back an idempotent retry whose
+// source was already consumed by a prior successful publish (new_version already published) and otherwise
+// fails the publish (which then retries).
+static StatusOr<MutableTxnLogPtr> make_shadow_rewrite_schema_change_log(TabletManager* tablet_mgr,
+                                                                        const PublishTabletInfo& tablet_info,
+                                                                        const TxnInfoPB& txn, size_t txns_size,
+                                                                        int64_t base_version, int64_t new_version) {
+    const int64_t alter_version = txn.shadow_rewrite_alter_version();
+    // Release-mode validation: a malformed request must fail loudly, not corrupt the flip. A missing
+    // shadow_rewrite_alter_version reads back as 0 (proto2 implicit zero for an unset optional), which would
+    // anchor the op_schema_change at version 0. The watershed W is always < the reserved commitVersion
+    // (new_version), since commitVersion is reserved AFTER the watershed drain.
+    if (alter_version < 1 || alter_version >= new_version) {
+        return Status::InvalidArgument(
+                fmt::format("shadow rewrite: invalid alter_version {} (new_version {})", alter_version, new_version));
+    }
+    if (base_version != 1) {
+        return Status::InvalidArgument(fmt::format("shadow rewrite: base_version must be 1, got {}", base_version));
+    }
+    if (txns_size != 1) {
+        return Status::InvalidArgument(fmt::format("shadow rewrite: expected exactly one txn, got {}", txns_size));
+    }
+    if (tablet_info.get_tablet_ids_in_txn_logs().size() != 1) {
+        return Status::InvalidArgument("shadow rewrite: expected exactly one source tablet");
+    }
+    // W == 1: the base partition was empty at the watershed (lake invariant: PARTITION_INIT_VERSION == 1,
+    // the first load publishes version 2), so the rewrite produced no source op_write. Synthesize an empty
+    // op_schema_change@1 and return WITHOUT any object-storage access -- no source load (would 404) and no
+    // already-published probe (which also 404s on the common first publish). Idempotent retries of a W == 1
+    // publish are handled upstream in publish_version (the metacache short-circuit and the base-version
+    // read); a cold-cache retry that reaches here re-applies, which is idempotent (vacuum reclaims
+    // oldest-first, so base_version 1 being present implies the post-watershed vlogs are too).
+    if (alter_version == 1) {
+        auto schema_change_log = std::make_shared<TxnLog>();
+        schema_change_log->set_tablet_id(tablet_info.get_tablet_id_in_metadata());
+        schema_change_log->set_txn_id(txn.txn_id());
+        convert_op_write_to_op_schema_change(schema_change_log.get(), alter_version); // no op_write => empty
+        return schema_change_log;
+    }
+
+    // W > 1: a non-empty partition's rewrite INSERT opens and finishes a delta writer for EVERY shadow tablet
+    // (LakeTabletsChannel::_create_delta_writers + finish-all-on-EOS), so even a 0-row shadow tablet gets an
+    // (empty) op_write -- the source MUST exist. A not-found (lost source) is NOT turned into an empty log
+    // here (that would silently drop the partition's pre-watershed data by advancing the version); it
+    // propagates so the caller's new_version_metadata_or_error hands back an idempotent retry whose source
+    // was already consumed (new_version already published) or otherwise fails the publish (which retries).
+    ASSIGN_OR_RETURN(auto source_log, load_txn_log(tablet_mgr, tablet_info.get_tablet_ids_in_txn_logs(), txn));
+
+    // Source present: anchor it as op_schema_change@W.
+    DCHECK(!source_log.empty() && !source_log[0].empty());
+    auto schema_change_log = std::make_shared<TxnLog>();
+    schema_change_log->set_tablet_id(tablet_info.get_tablet_id_in_metadata());
+    schema_change_log->set_txn_id(txn.txn_id());
+    *schema_change_log->mutable_op_write() = source_log[0][0]->op_write();
+    convert_op_write_to_op_schema_change(schema_change_log.get(), alter_version);
+    return schema_change_log;
+}
+
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const PublishTabletInfo& tablet_info,
                                             int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata, int64_t fe_built_version) {
@@ -325,6 +395,18 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
             // advances the partition version without producing any data changes.
             ignore_txn_log = true;
             LOG(INFO) << "txn " << txns[i].txn_id() << " marked as no-op publish on tablet " << tablet_info;
+        } else if (txns[i].txn_type() == TXN_SHADOW_REWRITE) {
+            // Anchor the historical rewrite at the watershed version W during the flip publish: build the
+            // op_schema_change@W (from the shadow tablet's source op_write, or empty for an empty partition)
+            // and hand it to the apply path below as one tablet / one log. On any error -- a lost source at
+            // W > 1, or a malformed/load failure -- new_version_metadata_or_error still returns the metadata
+            // of an idempotent retry whose target version is already published; otherwise it surfaces the error.
+            auto schema_change_log_or = make_shadow_rewrite_schema_change_log(tablet_mgr, tablet_info, txns[i],
+                                                                              txns.size(), base_version, new_version);
+            if (!schema_change_log_or.ok()) {
+                return new_version_metadata_or_error(schema_change_log_or.status());
+            }
+            txn_log_st = std::vector<TxnLogVector>{{std::move(schema_change_log_or).value()}};
         } else {
             txn_log_st = load_txn_log(tablet_mgr, tablet_info.get_tablet_ids_in_txn_logs(), txns[i]);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -460,6 +460,7 @@ SET(DW_TEST_FILES
     ./storage/lake/segment_task_runner_test.cpp
     ./storage/lake/add_index_schema_change_test.cpp
     ./storage/lake/schema_change_test.cpp
+    ./storage/lake/shadow_rewrite_publish_test.cpp
     ./storage/lake/lake_replication_txn_manager_test.cpp
     ./storage/lake/spill_mem_table_sink_test.cpp
     ./storage/lake/starlet_location_provider_test.cpp

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -634,6 +634,93 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     }
 }
 
+// Shadow-rewrite publish through the RPC path: shadow tablets now travel in the request's ordinary
+// tablet_ids, and the publish is keyed on a single TxnInfoPB whose txn_type == TXN_SHADOW_REWRITE and
+// whose shadow_rewrite_alter_version carries the watershed W. This exercises the TXN_SHADOW_REWRITE
+// branch in publish_version that anchors the historical rewrite as an op_schema_change@W during the
+// flip publish, including the W == 1 skip-load (empty partition) path.
+TEST_F(LakeServiceTest, test_publish_version_shadow_rewrite) {
+    // Each shadow tablet is freshly created at version 1; W (alter_version) is the base partition's
+    // watershed, independent of the shadow tablet's base_version and always < new_version.
+    auto fresh_tablet = [&]() {
+        auto meta = lake::generate_simple_tablet_metadata(DUP_KEYS);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(meta));
+        return meta->id();
+    };
+    auto shadow_request = [&](int64_t tablet_id, int64_t new_version, int64_t alter_version) {
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(new_version);
+        req.add_tablet_ids(tablet_id);
+        auto* txn = req.add_txn_infos();
+        txn->set_txn_id(next_id());
+        txn->set_txn_type(TXN_SHADOW_REWRITE);
+        txn->set_shadow_rewrite_alter_version(alter_version);
+        return req;
+    };
+
+    // (a) W == 1: empty base at watershed -> BE skips the source load (no 404) and synthesizes an empty
+    //     op_schema_change@1; the tablet advances 1 -> 2 with no rowsets.
+    {
+        int64_t t = fresh_tablet();
+        auto request = shadow_request(t, /*new=*/2, /*alter_version=*/1);
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.failed_tablets_size());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(t, 2));
+        EXPECT_EQ(2, metadata->version());
+        EXPECT_EQ(0, metadata->rowsets_size());
+    }
+    // (b) W > 1, source load fails with a non-not-found error -> the tablet fails to publish.
+    {
+        int64_t t = fresh_tablet();
+        auto request = shadow_request(t, /*new=*/3, /*alter_version=*/2);
+        TEST_ENABLE_ERROR_POINT("TabletManager::load_txn_log", Status::IOError("injected shadow source load error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::load_txn_log");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(t, response.failed_tablets(0));
+        EXPECT_TRUE(MatchPattern(response.status().error_msgs(0), "injected shadow source load error"))
+                << response.status().error_msgs(0);
+    }
+    // (c) W > 1, no source op_write present and the target version unpublished -> a non-empty partition's
+    //     shadow tablet always has an op_write, so a missing one means the source was lost. The load's
+    //     not-found propagates and the publish FAILS (so it retries) rather than synthesizing an empty
+    //     op_schema_change@W -- which would silently drop the partition's data by advancing the version.
+    {
+        int64_t t = fresh_tablet();
+        auto request = shadow_request(t, /*new=*/3, /*alter_version=*/2);
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(t, response.failed_tablets(0));
+        EXPECT_NE(0, response.status().status_code()) << "lost source must fail the publish";
+        // Crucially, the version did NOT advance with an empty log (no silent data drop).
+        EXPECT_TRUE(_tablet_mgr->get_tablet_metadata(t, 3).status().is_not_found());
+    }
+    // (d) Invalid request: missing alter_version (defaults to 0) -> InvalidArgument (failed tablet).
+    {
+        int64_t t = fresh_tablet();
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(t);
+        auto* txn = request.add_txn_infos();
+        txn->set_txn_id(next_id());
+        txn->set_txn_type(TXN_SHADOW_REWRITE); // shadow_rewrite_alter_version intentionally unset (=> 0)
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(t, response.failed_tablets(0));
+    }
+}
+
 // Verifies the publish-time async VI dispatch gate: only async-mode tables
 // (index_build_mode = "async") generate vector_index_build_infos in the publish
 // response. Sync-mode tables build VI inline during write/compaction, so the FE

--- a/be/test/storage/lake/shadow_rewrite_publish_test.cpp
+++ b/be/test/storage/lake/shadow_rewrite_publish_test.cpp
@@ -1,0 +1,368 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk.h"
+#include "column/chunk_factory.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "common/status.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_reshard.h"
+#include "storage/lake/transactions.h"
+#include "storage/lake/txn_log.h"
+#include "storage/lake/update_manager.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/tablet_schema.h"
+#include "test_util.h"
+
+namespace starrocks::lake {
+
+using VSchema = starrocks::Schema;
+using VChunk = starrocks::Chunk;
+
+// Build a shadow-rewrite txn info: a normal txn info re-keyed with txn_type == TXN_SHADOW_REWRITE and
+// carrying the watershed W in shadow_rewrite_alter_version. The shadow tablet is then published via an
+// ordinary PUBLISH_NORMAL PublishTabletInfo; publish_version dispatches on the txn type.
+static TxnInfoPB TEST_shadow_rewrite_txn_info(int64_t txn_id, int64_t alter_version, int64_t commit_time) {
+    TxnInfoPB info = TEST_txn_info(txn_id, commit_time);
+    info.set_txn_type(TXN_SHADOW_REWRITE);
+    info.set_shadow_rewrite_alter_version(alter_version);
+    return info;
+}
+
+// Behavior tests for the SHADOW_REWRITE early-interception branch in publish_version:
+// the historical-rewrite source op_write@rewriteTxn is anchored as an op_schema_change@W
+// during the flip publish (present => carries the rowset; absent => empty), then the
+// post-watershed double-write vlogs W+1..commitVersion replay as plain op_write.
+//
+// The flip publishes the shadow tablet under the partition's own rewriteTxnId (the publish
+// txn id is free because vlog replay is version-keyed), base_version=1, new_version=commitVersion.
+
+// DUP_KEYS fixture: c0 (key INT), c1 (value INT). Exercises cases (a) present, (b) absent+vlogs,
+// (c) absent+no-vlogs. Modeled on SchemaChangeFlipReplayTest.
+class ShadowRewritePublishDupTest : public TestBase {
+public:
+    ShadowRewritePublishDupTest() : TestBase(kTestDir) {}
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_next_rowset_id(1);
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        {
+            auto c0 = schema->add_column();
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        {
+            auto c1 = schema->add_column();
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation("NONE");
+        }
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(_tablet_schema));
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDir = "test_lake_shadow_rewrite_publish_dup";
+
+    // Write one (c0, c1) row to |tablet_id| under |txn_id| as a plain op_write (no publish).
+    void write_row(int64_t tablet_id, int64_t txn_id, int32_t c0_val, int32_t c1_val) {
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_datum(Datum(c0_val));
+        c1->append_datum(Datum(c1_val));
+        VChunk chunk({std::move(c0), std::move(c1)}, _schema);
+        uint32_t indexes[1] = {0};
+
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk, indexes, sizeof(indexes) / sizeof(indexes[0])));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    static ChunkPtr read(const VersionedTablet& tablet) {
+        auto metadata = tablet.metadata();
+        auto schema = tablet.get_schema();
+        auto reader = std::make_shared<TabletReader>(tablet.tablet_manager(), metadata, *(schema->schema()));
+        CHECK_OK(reader->prepare());
+        TabletReaderParams params;
+        CHECK_OK(reader->open(params));
+        auto chunk = ChunkFactory::new_chunk(*(schema->schema()), 16);
+        while (true) {
+            auto tmp = ChunkFactory::new_chunk(*(schema->schema()), 16);
+            auto st = reader->get_next(tmp.get());
+            if (st.ok()) {
+                chunk->append(*tmp);
+            } else if (st.is_end_of_file()) {
+                break;
+            } else {
+                CHECK(false) << st;
+            }
+        }
+        return chunk;
+    }
+
+    std::map<int32_t, int32_t> read_rows(int64_t tablet_id, int64_t version) {
+        auto tablet = _tablet_mgr->get_tablet(tablet_id, version).value();
+        auto chunk = read(tablet);
+        std::map<int32_t, int32_t> rows;
+        for (size_t i = 0; i < chunk->num_rows(); ++i) {
+            rows[chunk->get(i)[0].get_int32()] = chunk->get(i)[1].get_int32();
+        }
+        return rows;
+    }
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<VSchema> _schema;
+    int64_t _partition_id = 100;
+};
+
+// Case (a): present source op_write@rewriteTxn, no vlogs.
+// Result @ commitVersion carries the historical rowset, anchored at W.
+TEST_F(ShadowRewritePublishDupTest, PresentSourceNoVlogs) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    const int64_t W = 2; // present source => W >= 2 so the source load runs (not the W==1 skip)
+    const int64_t rewrite_txn_id = 20001;
+    const int64_t new_version = W + 1; // commitVersion: anchor only, no double-writes
+
+    write_row(tablet_id, rewrite_txn_id, /*c0=*/0, /*c1=*/100);
+
+    auto txn_info = TEST_shadow_rewrite_txn_info(rewrite_txn_id, W, time(nullptr));
+    ASSIGN_OR_ABORT(auto new_metadata,
+                    publish_version(_tablet_mgr.get(), PublishTabletInfo(tablet_id),
+                                    /*base_version=*/1, new_version, std::span<const TxnInfoPB>(&txn_info, 1), false));
+    ASSERT_EQ(new_version, new_metadata->version());
+
+    auto rows = read_rows(tablet_id, new_version);
+    ASSERT_EQ(1, rows.size());
+    EXPECT_EQ(100, rows[0]);
+}
+
+// Case (b): at W > 1 every shadow tablet MUST have a source op_write -- the rewrite INSERT opens and
+// finishes a delta writer for every shadow tablet (LakeTabletsChannel::_create_delta_writers +
+// finish-all-on-EOS), so even a 0-row shadow tablet gets an (empty) op_write. A missing source op_write at
+// W > 1 with the target version unpublished therefore means the source was lost: the load's not-found
+// propagates and the publish FAILS (so it retries) rather than synthesizing an empty op_schema_change@W --
+// which would silently drop the partition's pre-watershed data while still replaying the post-watershed
+// vlogs (a partial, corrupt result).
+TEST_F(ShadowRewritePublishDupTest, AbsentSourceAtWGreaterThanOneFails) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    const int64_t W = 2; // W > 1: a missing source op_write is a lost source, not a legitimate empty tablet
+    const int64_t rewrite_txn_id = 20001;
+
+    // Post-watershed double-write vlogs exist, but the source op_write@rewriteTxn is absent.
+    const int64_t post_txn_1 = 30001;
+    write_row(tablet_id, post_txn_1, /*c0=*/1, /*c1=*/200);
+    ASSERT_OK(publish_single_log_version(tablet_id, post_txn_1, /*log_version=*/W + 1));
+
+    const int64_t new_version = W + 2; // commitVersion (unpublished)
+    auto txn_info = TEST_shadow_rewrite_txn_info(rewrite_txn_id, W, time(nullptr));
+    auto res = publish_version(_tablet_mgr.get(), PublishTabletInfo(tablet_id),
+                               /*base_version=*/1, new_version, std::span<const TxnInfoPB>(&txn_info, 1), false);
+    ASSERT_FALSE(res.ok()) << "W>1 with a missing source op_write must fail, not synthesize empty";
+    EXPECT_TRUE(res.status().is_not_found()) << res.status();
+}
+
+// Case (c): absent source op_write, no vlogs, W == 1 (empty partition at the watershed).
+// W == 1 means the base partition was empty: BE skips the source load entirely and synthesizes an
+// empty op_schema_change@1, so the version advances empty with no rowsets and no source load occurs.
+TEST_F(ShadowRewritePublishDupTest, AbsentSourceNoVlogsEmptyAdvance) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    const int64_t W = 1; // W == 1 => skip-load empty path
+    const int64_t rewrite_txn_id = 20001;
+    const int64_t new_version = W + 1; // commitVersion: empty advance
+
+    auto txn_info = TEST_shadow_rewrite_txn_info(rewrite_txn_id, W, time(nullptr));
+    ASSIGN_OR_ABORT(auto new_metadata,
+                    publish_version(_tablet_mgr.get(), PublishTabletInfo(tablet_id),
+                                    /*base_version=*/1, new_version, std::span<const TxnInfoPB>(&txn_info, 1), false));
+    ASSERT_EQ(new_version, new_metadata->version());
+    EXPECT_EQ(0, new_metadata->rowsets_size());
+
+    auto rows = read_rows(tablet_id, new_version);
+    EXPECT_EQ(0, rows.size());
+}
+
+// W == 1 skip-load path: with an injected load_txn_log error point active, a W == 1 shadow publish must
+// still succeed because the source load is skipped entirely (never 404s, never hits the error point).
+// The tablet advances 1 -> 2 empty, matching AbsentSourceNoVlogsEmptyAdvance but proving no load ran.
+TEST_F(ShadowRewritePublishDupTest, EmptyAtW1SkipsLoad) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    const int64_t W = 1; // W == 1 => skip-load empty path
+    const int64_t rewrite_txn_id = 20002;
+    const int64_t new_version = W + 1; // commitVersion: empty advance
+
+    TEST_ENABLE_ERROR_POINT("TabletManager::load_txn_log",
+                            Status::IOError("load_txn_log must not run for W==1 shadow rewrite"));
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        TEST_DISABLE_ERROR_POINT("TabletManager::load_txn_log");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    auto txn_info = TEST_shadow_rewrite_txn_info(rewrite_txn_id, W, time(nullptr));
+    ASSIGN_OR_ABORT(auto new_metadata,
+                    publish_version(_tablet_mgr.get(), PublishTabletInfo(tablet_id),
+                                    /*base_version=*/1, new_version, std::span<const TxnInfoPB>(&txn_info, 1), false));
+    ASSERT_EQ(new_version, new_metadata->version());
+    EXPECT_EQ(0, new_metadata->rowsets_size());
+}
+
+// PRIMARY_KEYS fixture: case (d) newer-wins. Modeled on LakePrimaryKeyPublishTest.
+// Present source rows at keys K, a vlog at W+1 overwriting one K; after publish the newer
+// (vlog) value wins. FAILS before the early-interception branch if _base_version is not
+// anchored to W (PK replay mis-orders / publish errors on the missing primary log).
+class ShadowRewritePublishPkTest : public TestBase {
+public:
+    ShadowRewritePublishPkTest() : TestBase(kTestDir) {
+        _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(_tablet_schema));
+        _slot_cid_map.emplace(0, 0);
+        _slot_cid_map.emplace(1, 1);
+        _slot_cid_map.emplace(2, 2);
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDir = "test_lake_shadow_rewrite_publish_pk";
+
+    // Build a (c0, c1, __op=UPSERT) chunk for the given key/value pairs.
+    ChunkPtr gen_chunk(const std::vector<int32_t>& keys, const std::vector<int32_t>& vals) {
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int8Column::create();
+        for (size_t i = 0; i < keys.size(); ++i) {
+            c0->append_datum(Datum(keys[i]));
+            c1->append_datum(Datum(vals[i]));
+            c2->append_datum(Datum((int8_t)TOpType::UPSERT));
+        }
+        return std::make_shared<VChunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
+    }
+
+    // Write a PK op_write (no publish) under |txn_id|.
+    void write_pk(int64_t tablet_id, int64_t txn_id, const std::vector<int32_t>& keys,
+                  const std::vector<int32_t>& vals) {
+        auto chunk = gen_chunk(keys, vals);
+        std::vector<uint32_t> indexes(chunk->num_rows());
+        for (uint32_t i = 0; i < chunk->num_rows(); ++i) indexes[i] = i;
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    std::map<int32_t, int32_t> read_rows(int64_t tablet_id, int64_t version) {
+        auto metadata = _tablet_mgr->get_tablet_metadata(tablet_id, version).value();
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        std::map<int32_t, int32_t> rows;
+        while (true) {
+            auto tmp = ChunkFactory::new_chunk(*_schema, 64);
+            auto st = reader->get_next(tmp.get());
+            if (st.is_end_of_file()) break;
+            CHECK_OK(st);
+            for (size_t i = 0; i < tmp->num_rows(); ++i) {
+                rows[tmp->get(i)[0].get_int32()] = tmp->get(i)[1].get_int32();
+            }
+        }
+        return rows;
+    }
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<VSchema> _schema;
+    int64_t _partition_id = next_id();
+    Chunk::SlotHashMap _slot_cid_map;
+};
+
+// Case (d): PK present source (keys 0,1 => 100,101), vlog at W+1 overwriting key 1 => 999.
+// After publish the newer (vlog) value for key 1 wins; key 0 keeps the anchored base value.
+TEST_F(ShadowRewritePublishPkTest, NewerWinsUnderVlog) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    const int64_t W = 2; // present source => W >= 2 so the source load runs (not the W==1 skip)
+    const int64_t rewrite_txn_id = 20001;
+
+    // 1) Historical source snapshot keyed by the rewrite txn id (op_write, no publish).
+    write_pk(tablet_id, rewrite_txn_id, {0, 1}, {100, 101});
+
+    // 2) A post-watershed double-write overwrites key 1 -> 999, landing as a vtxn log at W+1.
+    const int64_t post_txn_1 = 30001;
+    write_pk(tablet_id, post_txn_1, {1}, {999});
+    ASSERT_OK(publish_single_log_version(tablet_id, post_txn_1, /*log_version=*/W + 1));
+
+    // 3) Flip publish under the rewrite txn id; commitVersion = W + 2.
+    const int64_t new_version = W + 2;
+    auto txn_info = TEST_shadow_rewrite_txn_info(rewrite_txn_id, W, time(nullptr));
+    ASSIGN_OR_ABORT(auto new_metadata,
+                    publish_version(_tablet_mgr.get(), PublishTabletInfo(tablet_id),
+                                    /*base_version=*/1, new_version, std::span<const TxnInfoPB>(&txn_info, 1), false));
+    ASSERT_EQ(new_version, new_metadata->version());
+
+    auto rows = read_rows(tablet_id, new_version);
+    ASSERT_EQ(2, rows.size());
+    EXPECT_EQ(100, rows[0]); // anchored base@W
+    EXPECT_EQ(999, rows[1]); // newer vlog @W+1 wins
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -10376,5 +10376,31 @@ TEST(SplitFamilyInferenceTest, mix_orphan_and_family) {
     EXPECT_EQ(0u, result.old_tablet_to_family[2]);
 }
 
+// Tests for convert_op_write_to_op_schema_change (SHADOW_REWRITE transform helper).
+// These use only scalar RowsetMetadataPB fields (id/num_rows/data_size) to stay
+// independent of segment file naming conventions.
+
+TEST(ShadowRewriteTransformTest, ShadowRewriteTransformMovesRowsetAndAnchors) {
+    TxnLogPB log;
+    auto* rs = log.mutable_op_write()->mutable_rowset();
+    rs->set_num_rows(7);
+    rs->set_data_size(123);
+    starrocks::lake::convert_op_write_to_op_schema_change(&log, /*alter_version=*/9);
+    ASSERT_FALSE(log.has_op_write());
+    ASSERT_TRUE(log.has_op_schema_change());
+    EXPECT_EQ(9, log.op_schema_change().alter_version());
+    ASSERT_EQ(1, log.op_schema_change().rowsets_size());
+    EXPECT_EQ(1, log.op_schema_change().rowsets(0).id());
+    EXPECT_EQ(7, log.op_schema_change().rowsets(0).num_rows());
+}
+
+TEST(ShadowRewriteTransformTest, ShadowRewriteTransformEmptyWhenNoRowset) {
+    TxnLogPB log; // no op_write
+    starrocks::lake::convert_op_write_to_op_schema_change(&log, /*alter_version=*/9);
+    ASSERT_TRUE(log.has_op_schema_change());
+    EXPECT_EQ(9, log.op_schema_change().alter_version());
+    EXPECT_EQ(0, log.op_schema_change().rowsets_size());
+}
+
 // =============================================================================
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
@@ -1,0 +1,1579 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.authorization.PrivilegeBuiltinConstants;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.ParseUtil;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.lake.Utils;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
+import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.warehouse.Warehouse;
+import io.opentelemetry.api.trace.StatusCode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Abstract parent for shared-data (lake) online rewrite schema-change jobs that re-route every
+ * physical partition's data into a fresh K-tablet shadow index, double-write incoming loads into
+ * the shadow once a watershed is allocated, rewrite the historical snapshot into the shadow via an
+ * internal INSERT, and finish with a single atomic catalog flip.
+ *
+ * <p>This base holds the generic state machine shared by such jobs: the per-partition rewrite state
+ * ({@link PartitionRewriteState} in {@link #partitionStates}), the shadow index identity, the
+ * watershed allocation / shadow exposure, the resumable per-partition rewrite, the reserve / publish
+ * / flip chain, force-cancel handling, and journal replay. The rewrite-flavor specifics (how a
+ * partition's shadow layout is planned, how the shadow index meta is registered, what the atomic
+ * flip mutates, which columns inactivate dependent MVs, and what the rewrite INSERT selects) are
+ * left to the subclass through the abstract hooks declared below.
+ *
+ * <p>The job drives the full {@code PENDING -> WAITING_TXN -> RUNNING -> FINISHED_REWRITING ->
+ * FINISHED} lifecycle (with {@code CANCELLED} as the failure/force terminus).
+ */
+public abstract class LakeOnlineRewriteJobBase
+        extends LakeTableSchemaChangeJobBase {
+    private static final Logger LOG = LogManager.getLogger(LakeOnlineRewriteJobBase.class);
+
+    // The shadow index meta id shared across all physical partitions (one new index per table).
+    @SerializedName(value = "shadowIndexMetaId")
+    protected long shadowIndexMetaId = -1;
+    // The origin (base) index meta id this shadow replaces at flip.
+    @SerializedName(value = "originIndexMetaId")
+    protected long originIndexMetaId = -1;
+    // The shadow index name (__starrocks_shadow_xxx).
+    @SerializedName(value = "shadowIndexName")
+    protected String shadowIndexName;
+
+    // Transient: cached full DB name (e.g. "catalog.db") resolved once in runPendingJob and
+    // reused by runRunningJob. DB rename is not supported during an ALTER, so the name is
+    // stable for the job's lifetime. Not serialized; re-resolved after replay on first tick.
+    private transient String cachedDbName;
+
+    /**
+     * Durable per-partition state of the rewrite, journaled inside {@link #partitionStates}. Built
+     * incrementally: shadowIndex/tabletCount/boundaries in PENDING, watershedVersion in WAITING_TXN,
+     * rewriteTxnId in RUNNING, commitVersion at the flip. The version/txn fields are boxed (null = not
+     * yet set) to preserve the absent-key semantics the six maps had.
+     */
+    static final class PartitionRewriteState {
+        @SerializedName(value = "shadowIndex")
+        MaterializedIndex shadowIndex;
+        @SerializedName(value = "tabletCount")
+        int tabletCount;
+        @SerializedName(value = "boundaries")
+        List<Tuple> boundaries;
+        @SerializedName(value = "watershedVersion")
+        Long watershedVersion;
+        @SerializedName(value = "rewriteTxnId")
+        Long rewriteTxnId;
+        @SerializedName(value = "commitVersion")
+        Long commitVersion;
+
+        PartitionRewriteState() {}
+
+        PartitionRewriteState(PartitionRewriteState other) {
+            this.shadowIndex = other.shadowIndex;
+            this.tabletCount = other.tabletCount;
+            this.boundaries = other.boundaries == null ? null : new ArrayList<>(other.boundaries);
+            this.watershedVersion = other.watershedVersion;
+            this.rewriteTxnId = other.rewriteTxnId;
+            this.commitVersion = other.commitVersion;
+        }
+    }
+
+    // physical partition id -> durable per-partition rewrite state.
+    @SerializedName(value = "partitionStates")
+    protected Map<Long, PartitionRewriteState> partitionStates = Maps.newHashMap();
+
+    protected PartitionRewriteState stateOf(long physicalPartitionId) {
+        return partitionStates.computeIfAbsent(physicalPartitionId, k -> new PartitionRewriteState());
+    }
+
+    // for deserialization
+    public LakeOnlineRewriteJobBase() {
+        super(JobType.SCHEMA_CHANGE);
+    }
+
+    public LakeOnlineRewriteJobBase(long jobId, long dbId, long tableId, String tableName, long timeoutMs) {
+        super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
+    }
+
+    // Deep-copy constructor used by copyForPersist(): the WAL must record a snapshot, not a live
+    // reference, so journaling never mutates the running job's state. Chains through
+    // AlterJobV2(AlterJobV2)/LakeTableSchemaChangeJobBase(...) for the base + watershed fields and
+    // deep-copies the generic rewrite state. Transient executors/seams are intentionally NOT copied.
+    protected LakeOnlineRewriteJobBase(LakeOnlineRewriteJobBase other) {
+        super(other);
+        this.shadowIndexMetaId = other.shadowIndexMetaId;
+        this.originIndexMetaId = other.originIndexMetaId;
+        this.shadowIndexName = other.shadowIndexName;
+        this.partitionStates = Maps.newHashMap();
+        for (Map.Entry<Long, PartitionRewriteState> entry : other.partitionStates.entrySet()) {
+            this.partitionStates.put(entry.getKey(), new PartitionRewriteState(entry.getValue()));
+        }
+    }
+
+    public long getShadowIndexMetaId() {
+        return shadowIndexMetaId;
+    }
+
+    @VisibleForTesting
+    public MaterializedIndex getShadowIndex(long physicalPartitionId) {
+        PartitionRewriteState partitionState = partitionStates.get(physicalPartitionId);
+        return partitionState == null ? null : partitionState.shadowIndex;
+    }
+
+    @VisibleForTesting
+    public int getTabletCount(long physicalPartitionId) {
+        PartitionRewriteState partitionState = partitionStates.get(physicalPartitionId);
+        return partitionState == null ? 0 : partitionState.tabletCount;
+    }
+
+    @VisibleForTesting
+    public List<Tuple> getBoundaries(long physicalPartitionId) {
+        PartitionRewriteState partitionState = partitionStates.get(physicalPartitionId);
+        return partitionState == null ? null : partitionState.boundaries;
+    }
+
+    @VisibleForTesting
+    public Long getWatershedVersion(long physicalPartitionId) {
+        PartitionRewriteState partitionState = partitionStates.get(physicalPartitionId);
+        return partitionState == null ? null : partitionState.watershedVersion;
+    }
+
+    @VisibleForTesting
+    public Long getRewriteTxnId(long physicalPartitionId) {
+        PartitionRewriteState partitionState = partitionStates.get(physicalPartitionId);
+        return partitionState == null ? null : partitionState.rewriteTxnId;
+    }
+
+    @VisibleForTesting
+    public void setRewriteTxnIdForTest(long physicalPartitionId, long txnId) {
+        stateOf(physicalPartitionId).rewriteTxnId = txnId;
+    }
+
+    // ---- Abstract hooks: the rewrite-flavor specifics ---------------------------------------------
+
+    /** Plan one partition's shadow layout and build its shadow MaterializedIndex (runPendingJob stage 2,
+     *  lock-free). Sets plan.boundaries/shadowTabletCount/shadowIndex. Range rewrite samples by the new sort key;
+     *  a future optimize derives layout from the new distribution. */
+    protected abstract void planPartitionShadow(PendingPartitionPlan plan, OlapTable table, String dbName)
+            throws AlterCancelException;
+
+    /** Register the shadow index's MaterializedIndexMeta (PENDING stage 3, under the write lock).
+     *  Idempotent (re-runnable on replay). */
+    protected abstract void registerShadowIndexMeta(OlapTable table);
+
+    /** The atomic catalog flip (under the edit-log applier's write lock). MUST iterate all physical
+     *  partitions, assert each has a reserved commitVersion, and be idempotent (guard a second replay). */
+    protected abstract void visualiseShadowIndex(OlapTable table);
+
+    /** Columns whose dependent async MVs are inactivated at the flip (empty if none). */
+    protected abstract Set<String> affectedColumnsForMvInactivation(OlapTable table);
+
+    /** Non-generated column names the rewrite INSERT selects (the rewrite is INSERT INTO ... SELECT these
+     *  FROM the same partition). Range rewrite returns the new-schema column names (== base column names,
+     *  column set unchanged); kept as a hook so a future flow can differ. */
+    protected abstract List<String> rewriteSelectColumnNames(OlapTable table);
+
+    /** Validate subclass-specific job configuration before the PENDING stages run. Throws
+     *  AlterCancelException if the rewrite config is incomplete. Called once at the top of runPendingJob,
+     *  before stage 1 — the base cannot see subclass config fields. */
+    protected abstract void validateRewriteConfig() throws AlterCancelException;
+
+    // ---- PENDING ---------------------------------------------------------------------------------
+
+    @Override
+    protected void runPendingJob() throws AlterCancelException {
+        Preconditions.checkState(jobState == JobState.PENDING, jobState);
+        Preconditions.checkState(shadowIndexMetaId != -1, "shadow index meta id is not set");
+        validateRewriteConfig();
+
+        // Stage 1 (READ-lock snapshot): validate table state and capture the immutable per-partition
+        // inputs needed for sampling and shard building. A DB WRITE lock must NOT be held across the
+        // sampling SQL round-trip or the StarOS createShards RPC (fe/CLAUDE.md "Database and Table
+        // Locks"), so the heavy work in stage 2 runs lock-free. Mirrors LakeTableSchemaChangeJob's
+        // READ-snapshot -> network-outside-lock -> WRITE-commit shape.
+        OlapTable table;
+        List<PendingPartitionPlan> pendingPlans = new ArrayList<>();
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            table = getTableOrThrow();
+            Preconditions.checkState(table.getState() == OlapTable.OlapTableState.NORMAL
+                            || table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE,
+                    table.getState());
+            cachedDbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId).getFullName();
+            String tableName = table.getName();
+
+            for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+                long physicalPartitionId = physicalPartition.getId();
+                // Resolve by META id, not physical index id: a range-distribution table that has gone
+                // through tablet split/merge resharding keeps the same index meta id but the latest
+                // MaterializedIndex carries a new physical index id, so getIndex(metaId) (a physical-id
+                // lookup) would miss it. getLatestIndex(metaId) is the meta-id lookup the rest of the
+                // alter/reshard code uses (e.g. LakeTableAlterJobV2Builder).
+                MaterializedIndex baseIndex = physicalPartition.getLatestIndex(originIndexMetaId);
+                if (baseIndex == null) {
+                    throw new AlterCancelException("base index missing in partition " + physicalPartitionId);
+                }
+                // The sampler addresses the logical parent by name; capture it now so stage 2 needs no lock.
+                String partitionName = table.getPartition(physicalPartition.getParentId()).getName();
+                pendingPlans.add(new PendingPartitionPlan(physicalPartitionId, baseIndex,
+                        baseIndex.getShardGroupId(), partitionName, baseIndex.getDataSize(),
+                        tableName, physicalPartition));
+            }
+        }
+
+        // Stages 2-3 run after the read lock is released and create StarOS shards before recording them
+        // in partitionStates (stage 3). cancelImpl cleans only recorded shadow indexes, so on any
+        // failure here drop the shards built in stage 2 that were not yet recorded, otherwise a transient
+        // create failure or a concurrent partition change would orphan them until lake GC.
+        // The applier below advances this.jobState to WAITING_TXN as its first action once the journal is
+        // durable (the edit log runs the applier only after writing the entry). The finally uses that same
+        // jobState as the single commit marker: PENDING means no durable WAITING_TXN entry, so drop the
+        // shards this run built; WAITING_TXN means the journal already references them, so keep them.
+        try {
+            // Stage 2 (lock-free): per partition, plan the shadow layout and build the shadow
+            // MaterializedIndex via the StarOS createShards RPC. NO db lock is held here. The work reads
+            // stable path/medium/id metadata off the live table/partition references captured above,
+            // exactly as LakeTableSchemaChangeJob.runPendingJob reads its snapshotted index objects when
+            // sending create-replica tasks outside the lock.
+            for (PendingPartitionPlan plan : pendingPlans) {
+                planPartitionShadow(plan, table, cachedDbName);
+            }
+
+            // Stage 3 (WRITE-lock commit): re-fetch and re-validate the table (TOCTOU: it may have been
+            // dropped/altered while the lock was released), then install the built shadow indexes, journal
+            // the durable state, and transition to WAITING_TXN.
+            try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+                OlapTable committedTable = getTableOrThrow();
+                Preconditions.checkState(committedTable.getState() == OlapTable.OlapTableState.NORMAL
+                                || committedTable.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE,
+                        committedTable.getState());
+                // The partition set must be unchanged between snapshot and commit; a partition that was
+                // dropped/added in the window means the sampled boundaries no longer describe the data, so
+                // fail the alter cleanly rather than silently skipping.
+                for (PendingPartitionPlan plan : pendingPlans) {
+                    if (committedTable.getPhysicalPartition(plan.physicalPartitionId) == null) {
+                        throw new AlterCancelException("partition " + plan.physicalPartitionId
+                                + " was dropped while building the range-rewrite shadow index");
+                    }
+                }
+                if (committedTable.getPhysicalPartitions().size() != pendingPlans.size()) {
+                    throw new AlterCancelException(
+                            "partition set changed while building the range-rewrite shadow index");
+                }
+
+                for (PendingPartitionPlan plan : pendingPlans) {
+                    PartitionRewriteState partitionState = stateOf(plan.physicalPartitionId);
+                    partitionState.shadowIndex = plan.shadowIndex;
+                    partitionState.tabletCount = plan.shadowTabletCount;
+                    partitionState.boundaries = plan.boundaries;
+                }
+
+                // Journal the durable job state (the shadow index id, K, boundaries, and shadow tablet ids
+                // recorded in partitionStates above) FIRST, then apply the catalog mutations in the
+                // applier. The edit log runs the applier only after the WAITING_TXN entry is durably
+                // written, so the catalog install is atomic with the journal: a journal/serialization
+                // failure leaves no shadow-index meta or inverted-index entry to orphan, and replay
+                // re-applies the install from the journaled partitionStates (reconstructShadowCatalogState).
+                // The shadow index meta/tablets are registered, but the per-partition shadow
+                // MaterializedIndex is intentionally NOT exposed to the catalog index map yet: incoming
+                // loads must not double-write the shadow until the watershed is allocated (WAITING_TXN).
+                persistStateChange(this, JobState.WAITING_TXN, () -> {
+                    // The journal is durable by the time this applier runs. Advance the live jobState to
+                    // WAITING_TXN as the FIRST action -- before the catalog install -- so the live job can
+                    // never sit at PENDING against a durable WAITING_TXN entry: even an (effectively
+                    // impossible, write-lock + TOCTOU-guarded) throw from the install below cannot then make
+                    // the scheduler re-run runPendingJob and build a second shadow set, nor make the finally
+                    // delete shards the durable entry already references. persistStateChange assigns jobState
+                    // again after the applier returns (a harmless no-op). If the install does throw, restart
+                    // replays the entry and reconstructShadowCatalogState re-applies it idempotently.
+                    this.jobState = JobState.WAITING_TXN;
+                    registerShadowIndexMeta(committedTable);
+                    addShadowTabletsToInvertedIndex(committedTable);
+                    committedTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+                });
+            }
+        } finally {
+            if (jobState != JobState.WAITING_TXN) {
+                // jobState is still PENDING: the applier advances it to WAITING_TXN as its first action once
+                // the journal is durable, so PENDING here means no WAITING_TXN entry was journaled and
+                // everything this run built is an orphan. Drop ALL stage-2 shards (including any already
+                // copied into partitionStates) on ANY failure -- AlterCancelException or an unchecked one (a
+                // Preconditions check, a createShards RPC failure, or a journal/serialization failure) -- and
+                // clear the partitionStates entries populated this run so a retry starts clean and cannot
+                // lose the cleanup handle. The catalog install (shadow meta + inverted-index entries) runs
+                // only in the post-journal applier above, so a failure before the journal commits leaves no
+                // catalog entry to undo.
+                dropOrphanedShadowShards(pendingPlans);
+                for (PendingPartitionPlan plan : pendingPlans) {
+                    partitionStates.remove(plan.physicalPartitionId);
+                }
+            }
+        }
+
+        if (span != null) {
+            span.addEvent("setWaitingTxn");
+        }
+        LOG.info("transfer range-rewrite schema change job {} state to {}", jobId, this.jobState);
+    }
+
+    /**
+     * Drop the StarOS shards built in {@link #runPendingJob} stage 2 on a pending-phase failure.
+     * Called from the {@code runPendingJob} cleanup when the WAITING_TXN journal did not commit, so
+     * every built shadow shard is unreferenced -- the catalog install (shadow index meta + inverted-index
+     * entries) runs only in the post-journal applier, so there is no catalog or inverted-index entry to
+     * undo. Best-effort: lake GC reclaims the shards even if this delete fails.
+     */
+    private void dropOrphanedShadowShards(@NotNull List<PendingPartitionPlan> plans) {
+        Set<Long> orphanShardIds = Sets.newHashSet();
+        for (PendingPartitionPlan plan : plans) {
+            if (plan.shadowIndex == null) {
+                continue;
+            }
+            for (Tablet tablet : plan.shadowIndex.getTablets()) {
+                orphanShardIds.add(tablet.getId());
+            }
+        }
+        if (orphanShardIds.isEmpty()) {
+            return;
+        }
+        try {
+            GlobalStateMgr.getCurrentState().getStarOSAgent().deleteShards(orphanShardIds);
+        } catch (Exception e) {
+            LOG.warn("range-rewrite schema change job {}: failed to drop {} orphaned shadow shards; "
+                    + "lake GC will reclaim them: {}", jobId, orphanShardIds.size(), e.getMessage());
+        }
+    }
+
+    /**
+     * Mutable per-partition working state for {@link #runPendingJob}: the immutable inputs captured
+     * under the read lock (ids + base index + shard group), and the boundaries / shadow tablet count / built
+     * shadow index produced lock-free in stage 2 by {@link #planPartitionShadow} and consumed under the
+     * write lock in stage 3.
+     */
+    protected static final class PendingPartitionPlan {
+        final long physicalPartitionId;
+        final MaterializedIndex baseIndex;
+        final long shardGroupId;
+        final String partitionName;
+        final long partitionDataSize;
+        final String tableName;
+        // Live references captured under the read lock; read lock-free in stage 2 for stable metadata.
+        final PhysicalPartition physicalPartition;
+        List<Tuple> boundaries;
+        int shadowTabletCount;
+        MaterializedIndex shadowIndex;
+
+        PendingPartitionPlan(long physicalPartitionId, MaterializedIndex baseIndex, long shardGroupId,
+                             String partitionName, long partitionDataSize, String tableName,
+                             PhysicalPartition physicalPartition) {
+            this.physicalPartitionId = physicalPartitionId;
+            this.baseIndex = baseIndex;
+            this.shardGroupId = shardGroupId;
+            this.partitionName = partitionName;
+            this.partitionDataSize = partitionDataSize;
+            this.tableName = tableName;
+            this.physicalPartition = physicalPartition;
+        }
+    }
+
+    /**
+     * Idempotently add the per-partition shadow tablets to the tablet inverted index. Guarded so a
+     * second call (e.g. a replay re-run) does not double-add: a tablet already present is skipped.
+     * The caller holds the database write lock.
+     */
+    protected void addShadowTabletsToInvertedIndex(@NotNull OlapTable table) {
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        for (Map.Entry<Long, PartitionRewriteState> entry : partitionStates.entrySet()) {
+            long physicalPartitionId = entry.getKey();
+            MaterializedIndex shadowIndex = entry.getValue().shadowIndex;
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
+                continue;
+            }
+            TStorageMedium medium = table.getPartitionInfo()
+                    .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+            TabletMeta shadowTabletMeta =
+                    new TabletMeta(dbId, tableId, physicalPartitionId, shadowIndexMetaId, medium, true);
+            for (Tablet shadowTablet : shadowIndex.getTablets()) {
+                if (invertedIndex.getTabletMeta(shadowTablet.getId()) == null) {
+                    invertedIndex.addTablet(shadowTablet.getId(), shadowTabletMeta);
+                }
+            }
+        }
+    }
+
+    // ---- WAITING_TXN -----------------------------------------------------------------------------
+
+    /**
+     * Drives the {@code WAITING_TXN} phase, mirroring the standard lake schema-change watershed.
+     *
+     * <p>On the first run ({@code watershedTxnId == -1}) it allocates the watershed transaction id,
+     * exposes each partition's shadow {@link MaterializedIndex} to the catalog with
+     * {@code visibleTxnId = watershedTxnId} (so loads after the watershed double-write base+shadow
+     * while loads before it ignore the shadow), runs the next-txn guard, and re-journals
+     * {@code WAITING_TXN}.
+     *
+     * <p>On each subsequent run it waits until every transaction before the watershed has finished;
+     * only then does it capture each physical partition's visible version as the per-partition
+     * watershed version {@code W} (the rewrite must re-sort everything visible at the watershed) and
+     * transition to {@code RUNNING}.
+     */
+    @Override
+    protected void runWaitingTxnJob() throws AlterCancelException {
+        Preconditions.checkState(jobState == JobState.WAITING_TXN, jobState);
+
+        if (watershedTxnId == -1) {
+            allocateWatershedAndExposeShadow();
+            return;
+        }
+
+        try {
+            if (!isPreviousLoadFinished(dbId, tableId, watershedTxnId)) {
+                LOG.info("wait transactions before {} to be finished, range-rewrite schema change job: {}",
+                        watershedTxnId, jobId);
+                return;
+            }
+        } catch (AnalysisException e) {
+            throw new AlterCancelException(e.getMessage());
+        }
+
+        LOG.info("previous transactions are all finished, capturing watershed versions. job: {}", jobId);
+
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
+            Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+            // Capture W = visible version only after the drain: anything visible at the watershed must
+            // be re-sorted by the new key in RUNNING.
+            for (long physicalPartitionId : partitionStates.keySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
+                long watershedVersion = physicalPartition.getVisibleVersion();
+                stateOf(physicalPartitionId).watershedVersion = watershedVersion;
+                // Block vacuum of the watershed snapshot W the RUNNING rewrite SELECT will read. Pin it
+                // here, at the durable WAITING_TXN -> RUNNING transition, so it is in place before any
+                // leader crash; minRetainVersion is not persisted, so replay re-applies it (see
+                // reconstructShadowCatalogState).
+                physicalPartition.setMinRetainVersion(watershedVersion);
+            }
+            // Journal the captured watershed versions before transitioning to RUNNING.
+            persistStateChange(this, JobState.RUNNING);
+        }
+
+        if (span != null) {
+            span.addEvent("setRunning");
+        }
+        LOG.info("transfer range-rewrite schema change job {} state to {}", jobId, this.jobState);
+    }
+
+    /**
+     * First {@code WAITING_TXN} run: allocate the watershed transaction id and expose every
+     * partition's shadow index to the catalog so post-watershed loads double-write it. Mirrors the
+     * standard lake schema-change watershed, including the next-txn guard that detects a transaction
+     * sneaking in between allocating the watershed and exposing the shadow.
+     */
+    private void allocateWatershedAndExposeShadow() throws AlterCancelException {
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
+            Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+            watershedTxnId = getNextTransactionId();
+            watershedGtid = getNextGtid();
+            exposeShadowIndexToCatalog(table);
+
+            // Getting the watershed and exposing the shadow are not atomic. A transaction beginning in
+            // between is safe as long as it gets the tablet list (under the database lock) after
+            // beginTransaction(), so it sees the shadow and writes to it; all import transactions do
+            // this. beginTransaction()-first is a convention not a requirement, so guard against a new
+            // beginTransaction() succeeding in the window, which would let a txn > watershedTxnId miss
+            // the shadow.
+            long nextTxnId = peekNextTransactionId();
+            if (nextTxnId != watershedTxnId + 1) {
+                throw new AlterCancelException(
+                        "concurrent transaction detected while adding shadow index, please re-run the alter table command");
+            }
+
+            // Re-journal WAITING_TXN so the allocated watershed and the exposure are durable; the
+            // exposure is idempotent, so a leader transfer re-runs it harmlessly.
+            persistStateChange(this, JobState.WAITING_TXN);
+        }
+
+        if (span != null) {
+            span.setAttribute("watershedTxnId", this.watershedTxnId);
+            span.addEvent("exposeShadow");
+        }
+        LOG.info("range-rewrite schema change job {} allocated watershed txn id {} and exposed shadow index",
+                jobId, watershedTxnId);
+    }
+
+    /**
+     * Idempotently expose every partition's shadow {@link MaterializedIndex} to the catalog index map
+     * with {@code visibleTxnId = watershedTxnId}, so loads after the watershed double-write the shadow
+     * while loads before it ignore it. A partition already carrying the shadow (e.g. a replay re-run)
+     * is skipped. The caller holds the database write lock.
+     */
+    private void exposeShadowIndexToCatalog(@NotNull OlapTable table) {
+        Preconditions.checkState(watershedTxnId != -1, "watershed txn id is not set");
+        for (Map.Entry<Long, PartitionRewriteState> entry : partitionStates.entrySet()) {
+            long physicalPartitionId = entry.getKey();
+            MaterializedIndex shadowIndex = entry.getValue().shadowIndex;
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
+                continue;
+            }
+            if (physicalPartition.getLatestIndex(shadowIndexMetaId) != null) {
+                // Already exposed (replay re-run): do not double-add.
+                continue;
+            }
+            Preconditions.checkState(shadowIndex.getState() == MaterializedIndex.IndexState.SHADOW,
+                    shadowIndex.getState());
+            shadowIndex.setVisibleTxnId(watershedTxnId);
+            physicalPartition.createRollupIndex(shadowIndex);
+        }
+    }
+
+    // ---- RUNNING ---------------------------------------------------------------------------------
+
+    /**
+     * Drives the {@code RUNNING} phase: for each physical partition not yet rewritten, run a
+     * version-pinned internal {@code INSERT...SELECT} that re-sorts/dedups the watershed snapshot into
+     * the shadow index only, and resume safely across FE leader failover.
+     *
+     * <p>The SELECT is pinned to the per-partition watershed version {@code W} via
+     * {@code ConnectContext.setScanVersionOverride}; the write targets only the shadow index
+     * ({@code targetWriteIndexId}); and the publish converts the committed {@code op_write} into
+     * {@code op_schema_change@W} keyed by {@code watershedTxnId} (the carrier is wired into the
+     * {@link com.starrocks.transaction.InsertTxnCommitAttachment} via {@code InsertStmt}). The commit
+     * version is <em>not</em> pinned ({@code isVersionOverwrite} is deliberately not used).
+     *
+     * <p>Resume is three-state per partition's journaled rewrite txn id:
+     * <ul>
+     *   <li>published/converted (VISIBLE) &rarr; skip;</li>
+     *   <li>committed-not-yet-visible (COMMITTED/PREPARE/PREPARED) &rarr; stay in {@code RUNNING} and
+     *       wait for the next scheduler tick;</li>
+     *   <li>not-started (no journaled id / txn dropped) or aborted &rarr; re-run the same
+     *       watershed-pinned INSERT under a fresh txn id.</li>
+     * </ul>
+     * The shadow tablets are never dropped/rebuilt on resume: post-watershed double-writes have
+     * already published into them, so dropping would lose data.
+     *
+     * <p>When every partition's rewrite has published, the job transitions to
+     * {@code FINISHED_REWRITING}; the atomic flip is performed there (a later phase).
+     */
+    @Override
+    protected void runRunningJob() throws AlterCancelException {
+        Preconditions.checkState(jobState == JobState.RUNNING, jobState);
+
+        // Snapshot the per-partition INSERT plans (logical partition name + base column projection)
+        // under the database lock and pin the watershed snapshot against vacuum; the executions
+        // themselves run without holding the lock.
+        List<RewritePlan> plans = new ArrayList<>();
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
+            Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+            if (cachedDbName == null) {
+                // Fallback for replayed jobs where runPendingJob was not re-run in this JVM lifetime.
+                cachedDbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId).getFullName();
+            }
+
+            List<String> selectColumnNames = rewriteSelectColumnNames(table);
+
+            for (long physicalPartitionId : partitionStates.keySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                if (physicalPartition == null) {
+                    throw new AlterCancelException("partition " + physicalPartitionId + " missing during rewrite");
+                }
+                Long watershedVersion = partitionStates.get(physicalPartitionId).watershedVersion;
+                Preconditions.checkState(watershedVersion != null,
+                        "watershed version not captured for partition " + physicalPartitionId);
+                // Re-assert the vacuum pin on the watershed snapshot the SELECT reads (first set at the
+                // WAITING_TXN capture / re-applied by replay; re-asserting here is idempotent).
+                physicalPartition.setMinRetainVersion(watershedVersion);
+                // A physical partition is not directly addressable in SQL; address its parent logical
+                // partition by name, exactly as the PENDING-phase sampler does. The read-version
+                // override (keyed by physical partition id) pins the SELECT to the watershed snapshot.
+                Partition logicalParent = table.getPartition(physicalPartition.getParentId());
+                // The INSERT scans the whole logical parent, but the read-version override pins only THIS
+                // physical partition. Range-distribution OLAP tables are 1:1 logical:physical, so the scan
+                // touches exactly the pinned physical partition. Guard that invariant: a >1:1 mapping would
+                // leave the other physicals reading their live (post-watershed) version and double-count.
+                if (logicalParent.getSubPartitions().size() != 1) {
+                    throw new AlterCancelException("range-rewrite requires a 1:1 logical-to-physical partition "
+                            + "mapping, but logical partition " + logicalParent.getId() + " has "
+                            + logicalParent.getSubPartitions().size() + " physical partitions");
+                }
+                String partitionName = logicalParent.getName();
+                plans.add(new RewritePlan(physicalPartitionId, partitionName, watershedVersion, selectColumnNames));
+            }
+        }
+
+        for (RewritePlan plan : plans) {
+            switch (classifyRewrite(plan.physicalPartitionId)) {
+                case DONE:
+                    continue;
+                case IN_FLIGHT:
+                    // Committed-not-yet-visible: stay in RUNNING; the scheduler re-invokes this method.
+                    LOG.info("range-rewrite schema change job {}: rewrite txn {} for partition {} in flight, waiting",
+                            jobId, partitionStates.get(plan.physicalPartitionId).rewriteTxnId,
+                            plan.physicalPartitionId);
+                    return;
+                case NEEDS_RUN:
+                default:
+                    runPartitionRewrite(cachedDbName, plan);
+                    // After kicking off (or completing) one partition's rewrite, yield: re-check status on
+                    // the next scheduler tick rather than blocking the scheduler thread on every partition.
+                    return;
+            }
+        }
+
+        // All partitions' rewrites have published: hand off to the flip phase.
+        this.finishedTimeMs = System.currentTimeMillis();
+        persistStateChange(this, JobState.FINISHED_REWRITING);
+
+        if (span != null) {
+            span.addEvent("finishedRewriting");
+        }
+        LOG.info("range-rewrite schema change job {} finished rewriting historical data, state to {}",
+                jobId, this.jobState);
+    }
+
+    protected enum RewriteStatus {
+        DONE,        // the journaled rewrite txn published (op_schema_change@W converted) -> skip
+        IN_FLIGHT,   // committed but not yet visible -> wait for the next tick
+        NEEDS_RUN    // never started / dropped / aborted -> (re-)run the watershed-pinned INSERT
+    }
+
+    /**
+     * Classify a partition's rewrite by the status of its journaled rewrite txn id. A missing journaled
+     * id, a txn the manager no longer knows about, or an ABORTED txn all mean "(re-)run". Never reuse an
+     * aborted txn id (BE forbids it), so the next attempt journals a fresh id.
+     *
+     * <p>The journaled id is the next-txn-id <em>peeked</em> before the INSERT began, then reconciled to
+     * the actual id only after {@code execute()} returns. A concurrent txn slipping into the peek-&gt;begin
+     * window can make the journaled id belong to a foreign load txn; a leader crash between the peek-journal
+     * and the reconcile-journal leaves that foreign id persisted. So a VISIBLE txn is treated as DONE only
+     * when it is genuinely this job's shadow-rewrite carrier: {@code isShadowRewrite()} with a watershed txn
+     * id matching this job and an alter version matching this partition's captured watershed {@code W}.
+     * Otherwise (a foreign or mismatched VISIBLE txn) the journaled id does not count as DONE and the
+     * partition is re-run; re-running is harmless because foreign/aborted txns published nothing into the
+     * shadow and the real rewrite is re-issued under a fresh id.
+     */
+    protected RewriteStatus classifyRewrite(long physicalPartitionId) {
+        PartitionRewriteState partitionState = partitionStates.get(physicalPartitionId);
+        Long txnId = (partitionState == null) ? null : partitionState.rewriteTxnId;
+        if (txnId == null) {
+            return RewriteStatus.NEEDS_RUN;
+        }
+        TransactionState txnState =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(dbId, txnId);
+        if (txnState == null) {
+            // The manager no longer has this txn (never committed, or expired before publish): re-run.
+            return RewriteStatus.NEEDS_RUN;
+        }
+        TransactionStatus status = txnState.getTransactionStatus();
+        if (status == TransactionStatus.VISIBLE) {
+            // Count VISIBLE as DONE only if this is genuinely THIS job's shadow-rewrite txn: a foreign
+            // load txn that slipped into the peek->begin window and was journaled by mistake must NOT
+            // skip the partition (that would flip a shadow missing op_schema_change@W -> data loss).
+            Long watershedVersion = partitionState.watershedVersion;
+            if (txnState.isShadowRewrite()
+                    && txnState.getShadowRewriteWatershedTxnId() == watershedTxnId
+                    && watershedVersion != null
+                    && txnState.getShadowRewriteAlterVersion() == watershedVersion) {
+                return RewriteStatus.DONE;
+            }
+            return RewriteStatus.NEEDS_RUN;
+        }
+        if (status == TransactionStatus.ABORTED || status == TransactionStatus.UNKNOWN) {
+            return RewriteStatus.NEEDS_RUN;
+        }
+        // PREPARE / PREPARED / COMMITTED: in flight, wait.
+        return RewriteStatus.IN_FLIGHT;
+    }
+
+    /**
+     * Build, journal, and execute one partition's watershed-pinned shadow-rewrite INSERT.
+     *
+     * <p>The rewrite txn id is journaled <em>before</em> the INSERT executes (an aborted txn id cannot
+     * be reused, so the next attempt must record a fresh id). The scan-version override is cleared in a
+     * {@code finally}.
+     */
+    private void runPartitionRewrite(String dbName, RewritePlan plan) throws AlterCancelException {
+        String sql = "insert into " + ParseUtil.backquote(dbName) + "." + ParseUtil.backquote(tableName)
+                + " partition (" + ParseUtil.backquote(plan.partitionName) + ") select "
+                + String.join(", ", plan.selectColumnNames)
+                + " from " + ParseUtil.backquote(dbName) + "." + ParseUtil.backquote(tableName)
+                + " partition (" + ParseUtil.backquote(plan.partitionName) + ")";
+
+        ConnectContext context = buildConnectContext();
+        context.setScanVersionOverride(Map.of(plan.physicalPartitionId, plan.watershedVersion));
+        try (var scope = context.bindScope()) {
+            StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
+            Preconditions.checkState(parsedStmt instanceof InsertStmt, "rewrite SQL did not parse to an INSERT");
+            InsertStmt insertStmt = (InsertStmt) parsedStmt;
+            // Write only the shadow index; convert its op_write to op_schema_change@W under
+            // watershedTxnId at publish. Do NOT pin the commit version (no setIsVersionOverwrite).
+            insertStmt.setShadowRewrite(true);
+            insertStmt.setTargetWriteIndexId(shadowIndexMetaId);
+            insertStmt.setShadowRewriteWatershedTxnId(watershedTxnId);
+            insertStmt.setShadowRewriteAlterVersion(plan.watershedVersion);
+
+            SessionVariable sessionVariable = context.getSessionVariable();
+            sessionVariable.setUsePageCache(false);
+            sessionVariable.setEnableMaterializedViewRewrite(false);
+            sessionVariable.setInsertTimeoutS((int) (timeoutMs / 2000));
+
+            // Journal the rewrite txn id BEFORE executing: peekNextTransactionId() is the id the
+            // INSERT's beginTransaction will allocate, so record it as durable evidence of which txn
+            // this attempt commits/converts. The actual id is re-confirmed from the parsed stmt below.
+            long rewriteTxnId = peekNextTransactionId();
+            stateOf(plan.physicalPartitionId).rewriteTxnId = rewriteTxnId;
+            persistStateChange(this, JobState.RUNNING);
+
+            getRewriteExecutor().execute(context, insertStmt);
+
+            // Re-confirm the txn id the INSERT actually used (defends against a concurrent txn slipping
+            // in between the peek and beginTransaction) and re-journal it for the resume classifier.
+            long actualTxnId = insertStmt.getTxnId();
+            if (actualTxnId != DmlStmt.INVALID_TXN_ID && actualTxnId != rewriteTxnId) {
+                stateOf(plan.physicalPartitionId).rewriteTxnId = actualTxnId;
+                persistStateChange(this, JobState.RUNNING);
+            }
+
+            if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                LOG.warn("range-rewrite schema change job {}: rewrite INSERT failed for partition {}: {}",
+                        jobId, plan.physicalPartitionId, context.getState().getErrorMessage());
+                throw new AlterCancelException(context.getState().getErrorMessage());
+            }
+        } catch (AlterCancelException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AlterCancelException("rewrite INSERT failed for partition " + plan.physicalPartitionId
+                    + ": " + e.getMessage());
+        } finally {
+            context.setScanVersionOverride(null);
+        }
+    }
+
+    /** Mirrors {@code OnlineOptimizeJobV2.buildConnectContext}: an inner ROOT context for the INSERT. */
+    private ConnectContext buildConnectContext() {
+        ConnectContext context = ConnectContext.buildInner();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        context.setQualifiedUser(UserIdentity.ROOT.getUser());
+        context.setCurrentComputeResource(computeResource);
+        return context;
+    }
+
+    /**
+     * Seam over the internal-INSERT execution (which needs a backend). Production runs the statement via
+     * {@link StmtExecutor}; tests inject a stub to assert the built {@link InsertStmt} and the
+     * scan-version override without executing.
+     */
+    @FunctionalInterface
+    interface RewriteExecutor {
+        void execute(ConnectContext context, InsertStmt insertStmt) throws Exception;
+    }
+
+    // Execution seam. Production runs the real INSERT; tests inject a stub. Not serialized.
+    private transient RewriteExecutor rewriteExecutor;
+
+    @VisibleForTesting
+    public void setRewriteExecutor(RewriteExecutor rewriteExecutor) {
+        this.rewriteExecutor = rewriteExecutor;
+    }
+
+    private RewriteExecutor getRewriteExecutor() {
+        if (rewriteExecutor == null) {
+            rewriteExecutor = (context, insertStmt) -> {
+                StmtExecutor executor = StmtExecutor.newInternalExecutor(context, insertStmt);
+                context.setExecutor(executor);
+                context.setQueryId(UUIDUtil.genUUID());
+                context.setStartTime();
+                executor.execute();
+            };
+        }
+        return rewriteExecutor;
+    }
+
+    /** Immutable per-partition rewrite plan snapshotted under the database lock. */
+    private static final class RewritePlan {
+        final long physicalPartitionId;
+        final String partitionName;
+        final long watershedVersion;
+        final List<String> selectColumnNames;
+
+        RewritePlan(long physicalPartitionId, String partitionName, long watershedVersion,
+                    List<String> selectColumnNames) {
+            this.physicalPartitionId = physicalPartitionId;
+            this.partitionName = partitionName;
+            this.watershedVersion = watershedVersion;
+            this.selectColumnNames = selectColumnNames;
+        }
+    }
+
+    // ---- FINISHED_REWRITING (reserve / publish / flip) -------------------------------------------
+
+    /**
+     * Drives the {@code FINISHED_REWRITING} phase: the single, idempotent atomic flip. It reuses the
+     * proven lake schema-change flip chain (reserve commit version &rarr; {@code lakePublishVersion}
+     * &rarr; {@code visualiseShadowIndex}), adapted to the K-tablet shadow index this job builds.
+     *
+     * <p>Step by step (mirrors {@link LakeTableSchemaChangeJob#runFinishedRewritingJob}):
+     * <ol>
+     *   <li><b>Reserve</b> a per-partition {@code commitVersion = physicalPartition.getNextVersion()}
+     *       and bump {@code nextVersion} so no new load reuses it. Done once and journaled with the
+     *       {@code FINISHED_REWRITING} re-entry record (idempotent: a re-run reuses the reserved map).</li>
+     *   <li><b>Ready check</b>: every partition's {@code commitVersion == visibleVersion + 1}
+     *       (all prior loads published), else return and re-check next tick.</li>
+     *   <li><b>Publish</b>: {@code lakePublishVersion} publishes the K shadow tablets
+     *       {@code baseVersion=1 -> commitVersion} (BE replays the {@code op_schema_change@W} base plus
+     *       the post-watershed double-write vlogs) and the origin/base index tablets as a {@code TXN_EMPTY}
+     *       no-op {@code commitVersion-1 -> commitVersion}.</li>
+     *   <li><b>Flip</b>: {@code visualiseShadowIndex} atomically swaps each partition's base index for
+     *       the shadow (and so the table-level schema / keysType / sortKeyIdxes / range distribution,
+     *       all derived from the base index meta, follow), under the edit-log lock and the table write
+     *       lock; then inactivates dependent async MVs, releases the GC pin, and resets the table state
+     *       to {@code NORMAL}.</li>
+     * </ol>
+     */
+    @Override
+    protected void runFinishedRewritingJob() throws AlterCancelException {
+        Preconditions.checkState(jobState == JobState.FINISHED_REWRITING, jobState);
+
+        // Reserve the per-partition commit version once (idempotent across re-entry/replay): only the
+        // first run with no reserved commit versions reserves + bumps nextVersion.
+        reserveCommitVersionIfNeeded();
+
+        // If the table or database has been dropped, readyToPublishVersion() throws AlterCancelException
+        // and the job is cancelled.
+        if (!readyToPublishVersion()) {
+            return;
+        }
+
+        if (!getPublishExecutor().publish(this)) {
+            return;
+        }
+
+        // Atomic catalog flip: replace each partition's base index with the shadow, flip the table-level
+        // schema/keysType/sortKeyIdxes/distribution, and inactivate dependent async MVs.
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTable();
+            if (table == null) {
+                LOG.info("database or table dropped while flipping range-rewrite schema change job {}", jobId);
+                return;
+            }
+            // Collect the columns whose meaning changed (keyness flip / sort-key reorder) BEFORE the flip,
+            // so dependent async MVs hanging on the old schema can be inactivated.
+            Set<String> modifiedColumns = affectedColumnsForMvInactivation(table);
+            this.finishedTimeMs = System.currentTimeMillis();
+
+            persistStateChange(this, JobState.FINISHED, () -> {
+                // Below this point all queries and loads use the new schema/sort key.
+                visualiseShadowIndex(table);
+                AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(table, modifiedColumns);
+                table.onReload();
+            });
+        }
+
+        if (span != null) {
+            span.end();
+        }
+        LOG.info("range-rewrite schema change job finished: {}", jobId);
+    }
+
+    /**
+     * Reserve a per-partition commit version for the flip and bump each partition's {@code nextVersion}
+     * past it, exactly as {@link LakeTableSchemaChangeJob#runRunningJob} does at its
+     * {@code FINISHED_REWRITING} transition. Idempotent: once the commit versions are populated (a
+     * re-entry after a non-ready tick, or a replayed job), the already-reserved versions are reused. The
+     * reservation is journaled with the {@code FINISHED_REWRITING} re-entry record so a leader transfer
+     * recovers the same versions.
+     */
+    private void reserveCommitVersionIfNeeded() throws AlterCancelException {
+        if (partitionStates.values().stream().anyMatch(state -> state.commitVersion != null)) {
+            return;
+        }
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
+            for (long physicalPartitionId : partitionStates.keySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
+                // Release the watershed-snapshot GC pin set in RUNNING: the historical snapshot has been
+                // rewritten into the shadow, so it no longer needs protecting from vacuum.
+                physicalPartition.setMinRetainVersion(0);
+                long commitVersion = physicalPartition.getNextVersion();
+                stateOf(physicalPartitionId).commitVersion = commitVersion;
+            }
+
+            persistStateChange(this, JobState.FINISHED_REWRITING, () -> {
+                // NOTE: below this point the flip must succeed unless the database/table is dropped.
+                updateNextVersion(table);
+            });
+        }
+    }
+
+    /**
+     * Ready when every partition's reserved {@code commitVersion == visibleVersion + 1}: all loads before
+     * the flip have published, so publishing the shadow at {@code commitVersion} is the next dense
+     * version. Throws {@link AlterCancelException} iff the database/table has been dropped. Mirrors
+     * {@link LakeTableSchemaChangeJob#readyToPublishVersion}.
+     */
+    private boolean readyToPublishVersion() throws AlterCancelException {
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
+            for (long physicalPartitionId : partitionStates.keySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkState(physicalPartition != null, physicalPartitionId);
+                long commitVersion = partitionStates.get(physicalPartitionId).commitVersion;
+                if (commitVersion != physicalPartition.getVisibleVersion() + 1) {
+                    Preconditions.checkState(physicalPartition.getVisibleVersion() < commitVersion,
+                            "partition=" + physicalPartitionId + " visibleVersion="
+                                    + physicalPartition.getVisibleVersion() + " commitVersion=" + commitVersion);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Publish the flip on BE, adapted from {@link LakeTableSchemaChangeJob#lakePublishVersion} for the
+     * K-tablet shadow. For each partition: publish the shadow tablets {@code 1 -> commitVersion} (BE
+     * applies the {@code op_schema_change@W} base and replays the post-watershed double-write vlogs to
+     * materialize the shadow at {@code commitVersion}); publish the origin/base index tablets as a
+     * {@code TXN_EMPTY} / txnId=-1 no-op {@code commitVersion-1 -> commitVersion} so their version chain
+     * advances without applying any change.
+     */
+    protected boolean lakePublishVersion() {
+        // Collect all per-partition tablet lists under a single lock, then publish outside the lock.
+        boolean isFileBundling;
+        List<PartitionPublishInfo> publishInfos = new ArrayList<>();
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
+            isFileBundling = table.isFileBundling();
+            for (long physicalPartitionId : partitionStates.keySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
+                MaterializedIndex shadowIndex = physicalPartition.getLatestIndex(shadowIndexMetaId);
+                Preconditions.checkNotNull(shadowIndex, shadowIndexMetaId);
+                List<Tablet> shadowTablets = new ArrayList<>(shadowIndex.getTablets());
+                // The base index (and any other unchanged visible index) only needs its version
+                // upgraded via the no-op publish.
+                List<Tablet> originTablets = new ArrayList<>();
+                for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                    originTablets.addAll(index.getTablets());
+                }
+                PartitionRewriteState state = partitionStates.get(physicalPartitionId);
+                long commitVersion = state.commitVersion;
+                Long rewriteTxnId = state.rewriteTxnId;
+                Preconditions.checkState(rewriteTxnId != null,
+                        "rewrite txn id not journaled for partition " + physicalPartitionId);
+                Long watershedVersion = state.watershedVersion;
+                Preconditions.checkState(watershedVersion != null,
+                        "watershed version not captured for partition " + physicalPartitionId);
+                publishInfos.add(new PartitionPublishInfo(shadowTablets, originTablets,
+                        commitVersion, rewriteTxnId, watershedVersion));
+            }
+        } catch (AlterCancelException e) {
+            LOG.warn("range-rewrite schema change job {}: table dropped before publish", jobId);
+            return false;
+        }
+
+        try {
+            // txnId == -1 means BE does nothing, just upgrades the tablet_meta version (no-op publish).
+            TxnInfoPB originTxnInfo = new TxnInfoPB();
+            originTxnInfo.txnId = -1L;
+            originTxnInfo.combinedTxnLog = false;
+            originTxnInfo.commitTime = finishedTimeMs / 1000;
+            originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
+            originTxnInfo.gtid = watershedGtid;
+
+            for (PartitionPublishInfo info : publishInfos) {
+                // The shadow tablets publish through the ordinary tablet_ids path (base_version 1); the
+                // TXN_SHADOW_REWRITE txn type is what tells BE to anchor their op_write as
+                // op_schema_change@watershedVersion and replay the post-watershed double-writes. So this
+                // reuses the same Utils.publishVersion / createSubRequestForAggregatePublish as any publish,
+                // just with a shadow-rewrite TxnInfoPB.
+                TxnInfoPB shadowTxnInfo = new TxnInfoPB();
+                shadowTxnInfo.txnId = info.rewriteTxnId;
+                shadowTxnInfo.txnType = TxnTypePB.TXN_SHADOW_REWRITE;
+                shadowTxnInfo.combinedTxnLog = false;
+                shadowTxnInfo.commitTime = finishedTimeMs / 1000;
+                shadowTxnInfo.gtid = watershedGtid;
+                shadowTxnInfo.shadowRewriteAlterVersion = info.watershedVersion;
+                if (!isFileBundling) {
+                    Utils.publishVersion(info.shadowTablets, shadowTxnInfo, 1, info.commitVersion,
+                            computeResource, false);
+                    Utils.publishVersion(info.originTablets, originTxnInfo, info.commitVersion - 1,
+                            info.commitVersion, computeResource, false);
+                } else {
+                    AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
+                    Utils.createSubRequestForAggregatePublish(info.shadowTablets, Lists.newArrayList(shadowTxnInfo),
+                            1, info.commitVersion, null, computeResource, request);
+                    Utils.createSubRequestForAggregatePublish(info.originTablets, Lists.newArrayList(originTxnInfo),
+                            info.commitVersion - 1, info.commitVersion, null, computeResource, request);
+                    List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null,
+                            vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to publish version for range-rewrite schema change job {}", jobId, e);
+            return false;
+        }
+    }
+
+    private static final class PartitionPublishInfo {
+        final List<Tablet> shadowTablets;
+        final List<Tablet> originTablets;
+        final long commitVersion;
+        final long rewriteTxnId;
+        final long watershedVersion;
+
+        PartitionPublishInfo(List<Tablet> shadowTablets, List<Tablet> originTablets,
+                             long commitVersion, long rewriteTxnId, long watershedVersion) {
+            this.shadowTablets = shadowTablets;
+            this.originTablets = originTablets;
+            this.commitVersion = commitVersion;
+            this.rewriteTxnId = rewriteTxnId;
+            this.watershedVersion = watershedVersion;
+        }
+    }
+
+    /**
+     * No-op publish for the FORCE-cancel escape hatch, adapted from
+     * {@link LakeTableSchemaChangeJob#lakePublishVersionWithSkip} for the K-tablet shadow. Sends a
+     * publish_version RPC with {@code TxnInfoPB.noOpPublish=true} for each partition's visible (non-shadow)
+     * indices at the alter's reserved {@code commitVersion}, so the partition version chain advances past
+     * the cancelled alter without applying any of its changes. The shadow indices are deliberately skipped:
+     * {@link #removeShadowIndexOnCancel} is about to drop them, so publishing them would only produce orphan
+     * metadata. Returns {@code false} if any RPC fails or throws; the caller then leaves the job at
+     * {@code FINISHED_REWRITING} so the operator can retry.
+     */
+    protected boolean lakePublishVersionWithSkip(String reason) {
+        // Dispatch keys off the table's CURRENT file_bundling format read fresh here (not a cached field
+        // that is not serialized): a replayed job force-cancelled before the publish daemon runs must
+        // still route correctly. Mirrors LakeTableSchemaChangeJob.lakePublishVersionWithSkip.
+        // Collect all per-partition tablet lists under a single lock, then publish outside the lock.
+        boolean useAggregatePublish = false;
+        Map<Long, List<Tablet>> tabletsByPartition = new HashMap<>();
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            // Use the null-returning getTable so a concurrent db/table drop is a benign skip.
+            OlapTable table = getTable();
+            if (table != null) {
+                useAggregatePublish = table.isFileBundling();
+                for (long physicalPartitionId : partitionStates.keySet()) {
+                    PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                    if (physicalPartition == null) {
+                        continue;
+                    }
+                    List<Tablet> regularTablets = new ArrayList<>();
+                    for (MaterializedIndex index :
+                            physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                        regularTablets.addAll(index.getTablets());
+                    }
+                    tabletsByPartition.put(physicalPartitionId, regularTablets);
+                }
+            }
+        }
+        return Utils.noOpPublishForForceSkip(jobId, reason, watershedTxnId, watershedGtid,
+                commitVersionMapView(), tabletsByPartition, computeResource, useAggregatePublish);
+    }
+
+    /**
+     * Update each partition's {@code nextVersion} past the reserved commit version, mirroring
+     * {@link LakeTableSchemaChangeJob#updateNextVersion}. The caller holds the database write lock.
+     */
+    protected void updateNextVersion(@NotNull OlapTable table) {
+        for (long physicalPartitionId : partitionStates.keySet()) {
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            Long commitVersion = partitionStates.get(physicalPartitionId).commitVersion;
+            if (commitVersion == null) {
+                // The first FINISHED_REWRITING journal entry (the RUNNING -> FINISHED_REWRITING transition
+                // at runRunningJob) is written before reserveCommitVersionIfNeeded reserves a commit
+                // version, so its replayed image carries no commit version yet. Nothing is reserved, so
+                // there is nothing to bump; the reservation is applied by the second FINISHED_REWRITING
+                // entry. Skip rather than unbox a null (replaying this entry must not NPE leader recovery).
+                continue;
+            }
+            if (physicalPartition.getNextVersion() == commitVersion + 1) {
+                // Already bumped (a second replay of the same FINISHED_REWRITING log entry): no-op.
+                continue;
+            }
+            Preconditions.checkState(physicalPartition.getNextVersion() == commitVersion,
+                    "partitionNextVersion=" + physicalPartition.getNextVersion() + " commitVersion=" + commitVersion);
+            physicalPartition.setNextVersion(commitVersion + 1);
+        }
+    }
+
+    /**
+     * Seam over the flip publish (which sends RPCs to BE). Production runs the inherited async
+     * {@link #publishVersion()} wrapper (submits {@link #lakePublishVersion()} and polls the future);
+     * tests inject a stub returning {@code true} so the catalog flip can be asserted without a backend.
+     * The argument binds to the concrete job type so a test can pass {@code Subclass::lakePublishVersion}.
+     * Not serialized.
+     */
+    @FunctionalInterface
+    public interface PublishExecutor {
+        boolean publish(LakeOnlineRewriteJobBase job);
+    }
+
+    private transient PublishExecutor publishExecutor;
+
+    @VisibleForTesting
+    public void setPublishExecutor(PublishExecutor publishExecutor) {
+        this.publishExecutor = publishExecutor;
+    }
+
+    private PublishExecutor getPublishExecutor() {
+        if (publishExecutor == null) {
+            publishExecutor = LakeOnlineRewriteJobBase::publishVersion;
+        }
+        return publishExecutor;
+    }
+
+    protected Map<Long, Long> commitVersionMapView() {
+        Map<Long, Long> view = Maps.newHashMap();
+        for (Map.Entry<Long, PartitionRewriteState> entry : partitionStates.entrySet()) {
+            if (entry.getValue().commitVersion != null) {
+                view.put(entry.getKey(), entry.getValue().commitVersion);
+            }
+        }
+        return view;
+    }
+
+    // ---- CANCEL ----------------------------------------------------------------------------------
+
+    /**
+     * All-or-nothing cancel: abort any in-flight per-partition rewrite load txn, drop all shadow
+     * indexes and their tablets from the catalog and the inverted index, remove the shadow
+     * {@code MaterializedIndexMeta} from the table, release the GC pin, reset the table state
+     * to {@link OlapTable.OlapTableState#NORMAL}, and journal CANCELLED. No-op when the job is
+     * already FINISHED or CANCELLED. Safe if cancel runs before the shadow was exposed (PENDING):
+     * only drops what exists, guarded by null/contains checks.
+     */
+    @Override
+    protected boolean cancelImpl(String errMsg) {
+        return cancelImpl(errMsg, false);
+    }
+
+    /**
+     * Force-aware cancel, mirroring {@link LakeTableSchemaChangeJob#cancelImpl(String, boolean)}.
+     *
+     * <p>Once the job reaches {@code FINISHED_REWRITING}, {@link #reserveCommitVersionIfNeeded()} has
+     * bumped each partition's {@code nextVersion} to {@code commitVersion + 1} while its
+     * {@code visibleVersion} is still {@code commitVersion - 1}. Dropping the shadow then leaves a
+     * permanent version hole at {@code commitVersion} that blocks all future publishes on those
+     * partitions. So:
+     * <ul>
+     *   <li>a normal cancel ({@code force == false}) from {@code FINISHED_REWRITING} while the table
+     *       still exists is refused (return false) — the flip should complete/retry;</li>
+     *   <li>a force cancel ({@code force == true}) from {@code FINISHED_REWRITING} first no-op publishes
+     *       the partitions' visible/origin indices to {@code commitVersion} (so the BE version chain
+     *       advances past the cancelled alter) and advances FE {@code visibleVersion} to match, then
+     *       drops the shadow — no hole;</li>
+     *   <li>other states (PENDING/WAITING_TXN/RUNNING) keep the existing cleanup unchanged.</li>
+     * </ul>
+     */
+    @Override
+    protected boolean cancelImpl(String errMsg, boolean force) {
+        if (jobState == JobState.CANCELLED || jobState == JobState.FINISHED) {
+            return false;
+        }
+
+        // Refuse a normal cancel from FINISHED_REWRITING while the table still exists: the reserved
+        // commit version has already bumped nextVersion, so dropping the shadow now would leave a
+        // permanent version hole. Only an operator-driven force cancel (or a dropped table/db) may
+        // proceed past this point. Mirrors LakeTableSchemaChangeJob.cancelImpl.
+        if (jobState == JobState.FINISHED_REWRITING && tableExists() && !force) {
+            return false;
+        }
+
+        // Force-cancel from FINISHED_REWRITING: advance the partition version chain past the reserved
+        // commit version BEFORE the cancel cleanup resets the table state, so no version hole remains
+        // and new loads do not queue forever waiting for the cancelled alter's missing version.
+        boolean advanceVersionForForce = force && jobState == JobState.FINISHED_REWRITING && tableExists();
+        if (advanceVersionForForce) {
+            if (!lakePublishVersionWithSkip(errMsg)) {
+                return false;
+            }
+            // Mark the job force-skipped only after the no-op publish actually advanced the partition
+            // version on BE, so copyForPersist snapshots it into the edit log and replay re-applies the
+            // VisibleVersion bump identically.
+            forceSkippedAtCommitted = true;
+        }
+
+        // Abort any in-flight per-partition rewrite load txns (PREPARE/PREPARED/COMMITTED state).
+        // Guard against txns that are unknown (never started, already expired), already terminal
+        // (VISIBLE/ABORTED), or that throw (e.g. txn manager says the db does not exist).
+        for (PartitionRewriteState partitionState : partitionStates.values()) {
+            Long txnId = partitionState.rewriteTxnId;
+            if (txnId == null) {
+                continue;
+            }
+            TransactionState txnState =
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(dbId, txnId);
+            if (txnState == null) {
+                continue;
+            }
+            TransactionStatus txnStatus = txnState.getTransactionStatus();
+            if (txnStatus.isFinalStatus()) {
+                continue;
+            }
+            try {
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .abortTransaction(dbId, txnId, errMsg);
+            } catch (Exception e) {
+                LOG.warn("range-rewrite schema change job {}: failed to abort rewrite txn {}: {}",
+                        jobId, txnId, e.getMessage());
+            }
+        }
+
+        this.errMsg = errMsg;
+        this.finishedTimeMs = System.currentTimeMillis();
+
+        persistStateChange(this, JobState.CANCELLED, () -> {
+            try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+                OlapTable table = getTable();
+                if (table != null) {
+                    if (advanceVersionForForce) {
+                        // The no-op publish wrote tablet_metadata at commitVersion on BE; advance the
+                        // FE-side partition visible version to match so subsequent loads compute their
+                        // publish base correctly. Shared with the replay CANCELLED branch so the live and
+                        // replay paths bump identically.
+                        advanceVisibleVersionForForceSkip(table, commitVersionMapView());
+                    }
+                    removeShadowIndexOnCancel(table);
+                }
+            }
+        });
+
+        if (span != null) {
+            span.setStatus(StatusCode.ERROR, errMsg);
+            span.end();
+        }
+
+        LOG.info("range-rewrite schema change job cancelled, jobId: {}, error: {}", jobId, errMsg);
+        return true;
+    }
+
+    /**
+     * Drop all shadow artifacts built by this job from the catalog in-memory state. Mirrors
+     * {@link LakeTableSchemaChangeJob#removeShadowIndex} adapted to this job's per-partition
+     * structure. Each step is guarded so a partial-exposure cancel (e.g. PENDING before the
+     * shadow was added to the partition catalog map) does not throw. The caller holds the
+     * database write lock.
+     */
+    protected void removeShadowIndexOnCancel(@NotNull OlapTable table) {
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+
+        for (Map.Entry<Long, PartitionRewriteState> entry : partitionStates.entrySet()) {
+            long physicalPartitionId = entry.getKey();
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
+                continue;
+            }
+            // Release the GC pin (may have been set in RUNNING or not at all).
+            physicalPartition.setMinRetainVersion(0);
+            // Drop the shadow index from the partition's catalog index map (if it was exposed).
+            physicalPartition.deleteMaterializedIndexByMetaId(shadowIndexMetaId);
+        }
+
+        // Remove the shadow index meta registered on the table (if it was registered).
+        if (shadowIndexName != null) {
+            table.deleteIndexInfo(shadowIndexName);
+        }
+
+        // Remove all shadow tablets from the tablet inverted index.
+        for (PartitionRewriteState partitionState : partitionStates.values()) {
+            if (partitionState.shadowIndex == null) {
+                continue;
+            }
+            for (Tablet tablet : partitionState.shadowIndex.getTablets()) {
+                invertedIndex.deleteTablet(tablet.getId());
+            }
+        }
+
+        table.setState(OlapTable.OlapTableState.NORMAL);
+    }
+
+    // ---- SHOW / replay ---------------------------------------------------------------------------
+
+    @Override
+    protected void getInfo(List<List<Comparable>> infos) {
+        // Progress: partitions whose rewrite has published / total. Only meaningful while RUNNING.
+        String progress = FeConstants.NULL_STRING;
+        if (jobState == JobState.RUNNING && !partitionStates.isEmpty()) {
+            int published = 0;
+            for (long physicalPartitionId : partitionStates.keySet()) {
+                if (classifyRewrite(physicalPartitionId) == RewriteStatus.DONE) {
+                    published++;
+                }
+            }
+            progress = published + "/" + partitionStates.size();
+        }
+
+        // One display row for the single shadow index this job builds.
+        List<Comparable> info = Lists.newArrayList();
+        info.add(jobId);
+        info.add(tableName);
+        info.add(TimeUtils.longToTimeString(createTimeMs));
+        info.add(TimeUtils.longToTimeString(finishedTimeMs));
+        // Only show the origin index name (strip the shadow column-name prefix).
+        info.add(Column.removeNamePrefix(shadowIndexName));
+        info.add(shadowIndexMetaId);
+        info.add(originIndexMetaId);
+        info.add("0:0"); // schema version and schema hash
+        info.add(watershedTxnId);
+        info.add(jobState.name());
+        info.add(errMsg);
+        info.add(progress);
+        info.add(timeoutMs / 1000);
+
+        Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseId);
+        if (warehouse == null) {
+            info.add("null");
+        } else {
+            info.add(warehouse.getName());
+        }
+
+        infos.add(info);
+    }
+
+    @Override
+    public void replay(AlterJobV2 replayedJob) {
+        LakeOnlineRewriteJobBase other = (LakeOnlineRewriteJobBase) replayedJob;
+
+        LOG.info("Replaying range-rewrite schema change job. state={} jobId={}",
+                replayedJob.jobState, replayedJob.jobId);
+
+        if (this != other) {
+            Preconditions.checkState(this.type.equals(other.type));
+            Preconditions.checkState(this.jobId == other.jobId);
+            Preconditions.checkState(this.dbId == other.dbId);
+            Preconditions.checkState(this.tableId == other.tableId);
+
+            this.jobState = other.jobState;
+            this.createTimeMs = other.createTimeMs;
+            this.finishedTimeMs = other.finishedTimeMs;
+            this.errMsg = other.errMsg;
+            this.timeoutMs = other.timeoutMs;
+
+            this.shadowIndexMetaId = other.shadowIndexMetaId;
+            this.originIndexMetaId = other.originIndexMetaId;
+            this.shadowIndexName = other.shadowIndexName;
+            this.partitionStates = other.partitionStates;
+            this.watershedTxnId = other.watershedTxnId;
+            this.watershedGtid = other.watershedGtid;
+            this.forceSkippedAtCommitted = other.forceSkippedAtCommitted;
+        }
+
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTable();
+            if (table == null) {
+                return; // do nothing if the database or table has been dropped.
+            }
+
+            if (jobState == JobState.PENDING) {
+                // A PENDING job has installed NO durable catalog state yet. On the leader the shadow index
+                // meta + tablets are registered only inside the WAITING_TXN applier (runPendingJob),
+                // atomically with the WAITING_TXN journal entry, so the only PENDING journal entry (the
+                // initial ALTER log) carries empty partitionStates and nothing installed. Reconstructing
+                // here would call registerShadowIndexMeta with no per-partition shadow index, leaving the
+                // table with a shadow schema that OlapTableSink.createSchema() sees while createPartition()
+                // has no matching partition index -- loads to the table then fail until the job advances.
+                // So replay installs nothing for PENDING; the resuming leader's runPendingJob builds the
+                // shadow fresh.
+                LOG.info("Replaying PENDING range-rewrite job {}; no durable shadow state to reconstruct.", jobId);
+            } else if (jobState == JobState.WAITING_TXN || jobState == JobState.RUNNING) {
+                // WAITING_TXN and RUNNING share the same durable catalog state: the shadow index meta is
+                // registered, the shadow tablets are in the inverted index, the table is in SCHEMA_CHANGE,
+                // and (watershed allocated from WAITING_TXN onwards) the shadow index is exposed to the
+                // catalog with visibleTxnId = watershedTxnId so post-watershed loads double-write it.
+                // RUNNING only adds in-flight rewrite txns on top of the WAITING_TXN catalog state; those
+                // are resumed by the live scheduler's three-state resume (rewriteTxnId is journaled) after
+                // the leader takes over, never by replay. So replay just reconstructs the shared shadow
+                // catalog state idempotently for both states.
+                reconstructShadowCatalogState(table);
+            } else if (jobState == JobState.FINISHED_REWRITING) {
+                // The reserved commit versions are journaled in partitionStates (GSON); re-apply the
+                // nextVersion bump that the live reserve performed so the follower's partition version
+                // chain matches the leader's before the flip.
+                updateNextVersion(table);
+                // Mirror the live reserve's GC-pin release. reserveCommitVersionIfNeeded releases the
+                // watershed snapshot pin (setMinRetainVersion(0)) when it reserves the commit version, but
+                // on a journal-replay failover that live call short-circuits (a commit version is already
+                // reserved) while RUNNING replay re-pinned W via reapplyWatershedGcPin -- so replay of the
+                // post-reserve FINISHED_REWRITING entry must release the pin itself, or vacuum can never
+                // reclaim versions below W on the recovered leader.
+                releaseWatershedGcPinForReservedPartitions(table);
+            } else if (jobState == JobState.FINISHED) {
+                // Re-apply the atomic flip from the journaled image: the catalog state (commit versions,
+                // the exposed shadow index, baseIndexMetaId) is what visualiseShadowIndex consumes, all
+                // journaled. onReload first, exactly as the standard lake schema change does. The flip
+                // drops the origin index meta and repoints the base meta at the shadow, so if it has
+                // already been applied (a second replay of the same FINISHED log entry) the origin index
+                // meta is gone; guard on that so the flip runs at most once (no double-flip).
+                if (table.getIndexMetaByMetaId(originIndexMetaId) != null) {
+                    table.onReload();
+                    visualiseShadowIndex(table);
+                }
+            } else if (jobState == JobState.CANCELLED) {
+                // A FORCE-cancel out of FINISHED_REWRITING left BE with a no-op tablet_metadata at
+                // commitVersion and the live path bumped partition.VisibleVersion to match. Replay must
+                // do the same, otherwise an FE recovering from a pre-cancel image keeps
+                // visibleVersion=commitVersion-1 and subsequent load publishes compute the wrong base.
+                if (forceSkippedAtCommitted) {
+                    advanceVisibleVersionForForceSkip(table, commitVersionMapView());
+                }
+                // Remove all shadow artifacts so the catalog is clean after cancel replay.
+                removeShadowIndexOnCancel(table);
+            } else {
+                throw new RuntimeException("unknown job state '" + jobState.name() + "'");
+            }
+        }
+    }
+
+    /**
+     * Idempotently reconstruct the durable shadow catalog state shared by WAITING_TXN and
+     * RUNNING on a follower replaying the journal. (PENDING installs nothing — see replay().)
+     * The shadow {@link MaterializedIndex}(es) are
+     * themselves serialized in {@link #partitionStates}, so GSON has already rebuilt them (with their
+     * tablet ids and ranges) on deserialization; the StarOS shards they reference were created in the
+     * live run and are not re-created here. We only re-attach the durable catalog state: the shadow
+     * index meta, the inverted-index entries, the table's SCHEMA_CHANGE state and, once the watershed
+     * has been allocated, the catalog exposure of the shadow index. Every step is guarded so a second
+     * replay is a no-op (no double-add of meta, tablets or the exposed index).
+     *
+     * <p>The catalog state in RUNNING is identical to WAITING_TXN; the only RUNNING-specific state is
+     * the in-flight rewrite txns, which are resumed by the live scheduler's three-state resume
+     * ({@code rewriteTxnId} is journaled) after the leader takes over — never by replay, which must not
+     * re-run the rewrite INSERT. The caller holds the database write lock.
+     */
+    private void reconstructShadowCatalogState(@NotNull OlapTable table) {
+        registerShadowIndexMeta(table);
+        // Make the shadow tablets discoverable to the tablet inverted index (skips tablets already
+        // present, so a second replay does not double-add).
+        addShadowTabletsToInvertedIndex(table);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        // Once the watershed has been allocated (WAITING_TXN onwards) the live path also exposed the
+        // shadow index to the catalog so post-watershed loads double-write it. Re-apply that exposure
+        // idempotently (a partition already carrying the shadow is skipped). When watershedTxnId is
+        // still -1 (journaled at PENDING -> WAITING_TXN but the first WAITING_TXN run has not happened
+        // yet) there is nothing to expose; the next live WAITING_TXN run allocates the watershed and
+        // exposes.
+        if (watershedTxnId != -1) {
+            exposeShadowIndexToCatalog(table);
+        }
+        // Re-apply the watershed GC pin: minRetainVersion is not persisted, so a follower that took
+        // over after RUNNING was journaled must re-pin W before its first rewrite SELECT, or vacuum
+        // could GC the exact snapshot the rewrite reads. Gated per partition on a captured W, so this
+        // is a no-op for PENDING/WAITING_TXN (no W yet) and only pins for RUNNING.
+        reapplyWatershedGcPin(table);
+    }
+
+    /**
+     * Re-pin each partition's captured watershed version against vacuum on a follower replaying a
+     * RUNNING image. {@code minRetainVersion} is not serialized, so it resets to 0 on failover; the
+     * rewrite SELECT in RUNNING still reads W, so the pin must be restored. Gated on a captured W
+     * (no captured watershed version before RUNNING means nothing to pin). The pin is released at
+     * FINISHED_REWRITING by the live {@code reserveCommitVersionIfNeeded} and, on a journal-replay
+     * failover, by {@link #releaseWatershedGcPinForReservedPartitions}; and by cancel. The caller holds
+     * the database write lock.
+     */
+    private void reapplyWatershedGcPin(@NotNull OlapTable table) {
+        for (Map.Entry<Long, PartitionRewriteState> entry : partitionStates.entrySet()) {
+            Long watershedVersion = entry.getValue().watershedVersion;
+            if (watershedVersion == null) {
+                continue;
+            }
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(entry.getKey());
+            if (physicalPartition != null) {
+                physicalPartition.setMinRetainVersion(watershedVersion);
+            }
+        }
+    }
+
+    /**
+     * Release the watershed-snapshot GC pin on a follower replaying a post-reserve FINISHED_REWRITING
+     * image. The live {@link #reserveCommitVersionIfNeeded} releases the pin ({@code setMinRetainVersion(0)})
+     * when it reserves the commit version, but on a journal-replay failover that live call short-circuits
+     * (a commit version is already reserved) and the RUNNING replay re-pinned W via
+     * {@link #reapplyWatershedGcPin}; so replay of the FINISHED_REWRITING entry must release the pin, or
+     * vacuum can never reclaim versions below W on the recovered leader. Gated per partition on a reserved
+     * commit version, so it is a no-op for the first (pre-reserve, null-commit) FINISHED_REWRITING entry --
+     * matching the leader, which had not released the pin yet at that point. The caller holds the database
+     * write lock.
+     */
+    private void releaseWatershedGcPinForReservedPartitions(@NotNull OlapTable table) {
+        for (Map.Entry<Long, PartitionRewriteState> entry : partitionStates.entrySet()) {
+            if (entry.getValue().commitVersion == null) {
+                continue;
+            }
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(entry.getKey());
+            if (physicalPartition != null) {
+                physicalPartition.setMinRetainVersion(0);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
@@ -1,0 +1,439 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.alter.reshard.TabletReshardUtils;
+import com.starrocks.alter.reshard.presplit.BoundaryPlanner;
+import com.starrocks.alter.reshard.presplit.BoundaryPlannerResult;
+import com.starrocks.alter.reshard.presplit.DefaultPreSplitPipeline;
+import com.starrocks.alter.reshard.presplit.Estimates;
+import com.starrocks.alter.reshard.presplit.InternalPartitionScanContext;
+import com.starrocks.alter.reshard.presplit.ReservoirSampler;
+import com.starrocks.alter.reshard.presplit.SampleRequest;
+import com.starrocks.alter.reshard.presplit.SampleSet;
+import com.starrocks.alter.reshard.presplit.Sampler;
+import com.starrocks.alter.reshard.presplit.TabletPreSplitCoordinator;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.ParseUtil;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Schema-change job for shared-data (lake) range-distribution OLAP tables whose key change
+ * shifts the range sort key (sort-key reorder or keyness flip) with the column set unchanged.
+ *
+ * <p>Unlike the 1:1 shadow-index rewrite of {@link LakeTableSchemaChangeJob}, this job re-routes
+ * each partition's data into a fresh K-tablet shadow index whose tablet boundaries are sampled by
+ * the <em>new</em> sort key, then materializes the shadow via an internal INSERT and an atomic flip.
+ *
+ * <p>The generic shared-data online double-write rewrite machinery (the
+ * {@code PENDING -> WAITING_TXN -> RUNNING -> FINISHED_REWRITING -> FINISHED} state machine, the
+ * watershed allocation and shadow exposure, the resumable per-partition rewrite, the reserve /
+ * publish / flip chain, force-cancel handling and journal replay) lives in
+ * {@link LakeOnlineRewriteJobBase}. This subclass supplies the range-rewrite specifics: the new key
+ * configuration applied at the flip, the boundary sampling by the new sort key, and the abstract
+ * hooks that plan the K-tablet shadow layout, register the shadow index meta, perform the catalog
+ * flip, choose the columns that inactivate dependent MVs, and project the rewrite INSERT.
+ */
+public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
+    private static final Logger LOG = LogManager.getLogger(LakeRangeRewriteSchemaChangeJob.class);
+
+    // The rewritten base-index schema and key configuration applied at flip. These describe the
+    // new key space the shadow is sorted/distributed by; the column set itself is unchanged.
+    @SerializedName(value = "newSchema")
+    private List<Column> newSchema;
+    @SerializedName(value = "newKeysType")
+    private KeysType newKeysType;
+    @SerializedName(value = "newSortKeyIdxes")
+    private List<Integer> newSortKeyIdxes;
+    @SerializedName(value = "newSortKeyUniqueIds")
+    private List<Integer> newSortKeyUniqueIds;
+
+    // The new sort-key columns (a projection of newSchema) used to sample and to plan the K-tablet
+    // boundaries. Kept separately because the boundary planner and the sampler take a Column list.
+    @SerializedName(value = "newSortKeyColumns")
+    private List<Column> newSortKeyColumns;
+
+    // The shadow index short-key column count.
+    @SerializedName(value = "shadowShortKeyColumnCount")
+    private short shadowShortKeyColumnCount;
+
+    // Sampling seam. Production samples a partition's base by the new sort key via a SQL sub-query
+    // (needs a backend); tests inject a stub returning a canned SampleSet. Not serialized.
+    private transient Sampler sampler;
+
+    // for deserialization
+    public LakeRangeRewriteSchemaChangeJob() {
+        super();
+    }
+
+    public LakeRangeRewriteSchemaChangeJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs) {
+        super(jobId, dbId, tableId, tableName, timeoutMs);
+    }
+
+    // Deep-copy constructor used by copyForPersist(): the WAL must record a snapshot, not a live
+    // reference, so journaling never mutates the running job's state. Chains through
+    // super(other) for the base + watershed + shadow-identity + partitionStates fields and
+    // deep-copies this job's own collections. The transient sampler is intentionally NOT copied.
+    protected LakeRangeRewriteSchemaChangeJob(LakeRangeRewriteSchemaChangeJob other) {
+        super(other);
+        this.newSchema = other.newSchema == null ? null : new ArrayList<>(other.newSchema);
+        this.newKeysType = other.newKeysType;
+        this.newSortKeyIdxes = other.newSortKeyIdxes == null ? null : new ArrayList<>(other.newSortKeyIdxes);
+        this.newSortKeyUniqueIds = other.newSortKeyUniqueIds == null ? null : new ArrayList<>(other.newSortKeyUniqueIds);
+        this.newSortKeyColumns = other.newSortKeyColumns == null ? null : new ArrayList<>(other.newSortKeyColumns);
+        this.shadowShortKeyColumnCount = other.shadowShortKeyColumnCount;
+    }
+
+    public void setNewSchema(List<Column> newSchema) {
+        this.newSchema = newSchema;
+    }
+
+    @VisibleForTesting
+    public List<Column> getNewSchema() {
+        return newSchema;
+    }
+
+    public void setNewKeysType(KeysType newKeysType) {
+        this.newKeysType = newKeysType;
+    }
+
+    public void setNewSortKeyIdxes(List<Integer> newSortKeyIdxes) {
+        this.newSortKeyIdxes = newSortKeyIdxes;
+    }
+
+    public void setNewSortKeyUniqueIds(List<Integer> newSortKeyUniqueIds) {
+        this.newSortKeyUniqueIds = newSortKeyUniqueIds;
+    }
+
+    public void setNewSortKeyColumns(List<Column> newSortKeyColumns) {
+        this.newSortKeyColumns = newSortKeyColumns;
+    }
+
+    public void setShadowIndex(long shadowIndexMetaId, long originIndexMetaId, String shadowIndexName,
+                               short shadowShortKeyColumnCount) {
+        this.shadowIndexMetaId = shadowIndexMetaId;
+        this.originIndexMetaId = originIndexMetaId;
+        this.shadowIndexName = shadowIndexName;
+        this.shadowShortKeyColumnCount = shadowShortKeyColumnCount;
+    }
+
+    /**
+     * Inject the sampler used by {@link #planPartitionShadow}. Tests use this to bypass the real SQL
+     * sample sub-query (which needs a backend); production leaves it null so {@link #getSampler}
+     * lazily builds the real internal-partition sampler.
+     */
+    @VisibleForTesting
+    public void setSampler(Sampler sampler) {
+        this.sampler = sampler;
+    }
+
+    private Sampler getSampler() {
+        if (sampler == null) {
+            sampler = ReservoirSampler.forInternalPartition();
+        }
+        return sampler;
+    }
+
+    @Override
+    protected void validateRewriteConfig() throws AlterCancelException {
+        Preconditions.checkNotNull(newSchema, "new schema is not set");
+        Preconditions.checkNotNull(newKeysType, "new keys type is not set");
+        Preconditions.checkState(newSortKeyColumns != null && !newSortKeyColumns.isEmpty(),
+                "new sort key columns are not set");
+    }
+
+    /**
+     * Plan one partition's K-tablet shadow layout lock-free: choose {@code K} from the base data size
+     * and the active compute-node count, sample by the new sort key, plan the boundaries, and build the
+     * shadow {@link MaterializedIndex} via the StarOS createShards RPC. NO db lock is held here.
+     */
+    @Override
+    protected void planPartitionShadow(PendingPartitionPlan plan, OlapTable table, String dbName)
+            throws AlterCancelException {
+        int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(computeResource);
+        int requestedTabletCount = chooseTabletCount(plan.partitionDataSize, activeComputeNodeCount);
+        List<Tuple> boundaries = planBoundaries(dbName, plan.tableName, plan.partitionName,
+                plan.physicalPartitionId, plan.partitionDataSize, requestedTabletCount);
+        // K may collapse to 1 (sampling failure / no-distinction): a single full-range tablet.
+        int shadowTabletCount = boundaries.size() + 1;
+        List<TabletRange> ranges = buildTabletRanges(boundaries);
+        MaterializedIndex shadowIndex;
+        try {
+            shadowIndex = LakeTableAlterJobV2Builder.buildRangeShadowIndex(
+                    dbId, table, plan.physicalPartition, shadowIndexMetaId, shadowTabletCount, ranges,
+                    plan.shardGroupId, computeResource);
+        } catch (DdlException e) {
+            throw new AlterCancelException("failed to build shadow index for partition "
+                    + plan.physicalPartitionId + ": " + e.getMessage());
+        }
+        plan.boundaries = boundaries;
+        plan.shadowTabletCount = shadowTabletCount;
+        plan.shadowIndex = shadowIndex;
+    }
+
+    /**
+     * Idempotently register the shadow index's {@link MaterializedIndexMeta} (schema, keysType,
+     * sort-key indexes) on the table. Re-runnable on replay: {@code setIndexMeta} overwrites the
+     * meta for {@code shadowIndexMetaId}, so a second call is a no-op-equivalent. The caller holds
+     * the database write lock.
+     */
+    @Override
+    protected void registerShadowIndexMeta(@NotNull OlapTable table) {
+        table.setIndexMeta(shadowIndexMetaId, shadowIndexName, newSchema, 0, 0, shadowShortKeyColumnCount,
+                TStorageType.COLUMN, newKeysType, null, newSortKeyIdxes, newSortKeyUniqueIds);
+        MaterializedIndexMeta originIndexMeta = table.getIndexMetaByMetaId(originIndexMetaId);
+        MaterializedIndexMeta shadowIndexMeta = table.getIndexMetaByMetaId(shadowIndexMetaId);
+        Preconditions.checkNotNull(originIndexMeta);
+        Preconditions.checkNotNull(shadowIndexMeta);
+        rebuildMaterializedIndexMeta(originIndexMeta, shadowIndexMeta);
+    }
+
+    /**
+     * Choose {@code K} from the partition's base data size and the active compute-node count.
+     * {@link TabletPreSplitCoordinator#selectTabletCount} clamps to {@code [2, maxSplitCount]}, so the
+     * requested count is always {@code >= 2}; the actual effective K may still collapse to 1 in
+     * {@link #planBoundaries} when the sample shows no useful distinction.
+     */
+    private int chooseTabletCount(long partitionDataSize, int activeComputeNodeCount) {
+        Estimates estimates = new Estimates(partitionDataSize, 0L);
+        return TabletPreSplitCoordinator.selectTabletCount(estimates, activeComputeNodeCount);
+    }
+
+    /**
+     * Sample the partition by the new sort key and plan {@code K-1} boundaries. A sampling failure or
+     * a no-distinction sample (empty sample / all-equal keys → planner NO_SPLIT) degrades to an empty
+     * boundary list = a single full-range tablet (K=1 fallback). All inputs are captured snapshots so
+     * this runs lock-free (the sampler itself re-acquires a read lock for its SQL round-trip).
+     */
+    private List<Tuple> planBoundaries(String dbName, String tableName, String partitionName,
+                                       long physicalPartitionId, long partitionDataSize,
+                                       int requestedTabletCount) {
+        try {
+            SampleSet sampleSet = sampleByNewSortKey(dbName, tableName, partitionName, partitionDataSize);
+            if (sampleSet.isEmpty()) {
+                return List.of();
+            }
+            BoundaryPlannerResult planResult =
+                    BoundaryPlanner.planRowQuantileBoundaries(sampleSet, requestedTabletCount, newSortKeyColumns);
+            if (planResult.isNoSplit()) {
+                return List.of();
+            }
+            return planResult.getBoundaries();
+        } catch (StarRocksException | RuntimeException e) {
+            // Sampling / planning failure must not fail the alter: fall back to a single full-range
+            // shadow tablet (the rewrite still re-sorts by the new key; it just isn't split).
+            LOG.warn("range-rewrite schema change job {}: sampling/planning failed for partition {}, "
+                    + "falling back to a single full-range shadow tablet", jobId, physicalPartitionId, e);
+            return List.of();
+        }
+    }
+
+    private SampleSet sampleByNewSortKey(String dbName, String tableName, String partitionName,
+                                         long partitionDataSize) throws StarRocksException {
+        List<String> sortKeySourceColumnNames =
+                newSortKeyColumns.stream().map(Column::getName).collect(Collectors.toList());
+        // The sample sub-query addresses the logical partition by name; physical partitions are not
+        // directly addressable in SQL. Boundaries only need to be representative, so sampling the
+        // parent partition is sufficient.
+        InternalPartitionScanContext scanContext = new InternalPartitionScanContext(
+                dbName,
+                tableName,
+                partitionName,
+                sortKeySourceColumnNames,
+                List.of(),
+                partitionDataSize,
+                computeResource);
+        SampleRequest request = new SampleRequest(
+                scanContext, newSortKeyColumns, Config.tablet_pre_split_sample_byte_limit, jobId);
+        return getSampler().sample(request);
+    }
+
+    /**
+     * Tile {@code (-inf, +inf)} with one {@link TabletRange} per tablet given the {@code K-1}
+     * sorted boundaries: {@code (-inf, c1), [c1, c2), ..., [c_{K-1}, +inf)}. An empty boundary list
+     * yields a single full-range tablet (K=1 case).
+     */
+    @VisibleForTesting
+    static List<TabletRange> buildTabletRanges(List<Tuple> boundaries) {
+        if (boundaries.isEmpty()) {
+            List<TabletRange> singleRange = new ArrayList<>(1);
+            singleRange.add(new TabletRange(Range.all()));
+            return singleRange;
+        }
+        return DefaultPreSplitPipeline.buildTabletRanges(boundaries);
+    }
+
+    /**
+     * Non-generated column names the rewrite INSERT selects: the new-schema columns (the column set is
+     * unchanged from the base, so these are the base column names re-projected in the new order).
+     */
+    @Override
+    protected List<String> rewriteSelectColumnNames(@NotNull OlapTable table) {
+        return newSchema.stream()
+                .filter(column -> !column.isGeneratedColumn())
+                .map(column -> ParseUtil.backquote(column.getName()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The atomic catalog flip, adapted from {@link LakeTableSchemaChangeJob#visualiseShadowIndex} for the
+     * single base-index-&rarr;K-tablet-shadow swap. Runs inside the edit-log applier under the table write
+     * lock. For each partition: advance the visible version to {@code commitVersion}, drop the origin
+     * (base) index, and promote the shadow index to NORMAL as the new base. Then rename the shadow index
+     * to the origin name, repoint {@code baseIndexMetaId} at the shadow meta (so the table-level schema /
+     * keysType / sortKeyIdxes / range distribution all follow, since the range distribution columns are
+     * derived from the base index sort key), rebuild the full schema, and reset the table to NORMAL.
+     */
+    @Override
+    protected void visualiseShadowIndex(@NotNull OlapTable table) {
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+
+        for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+            PartitionRewriteState partitionState = partitionStates.get(physicalPartition.getId());
+            Preconditions.checkState(partitionState != null && partitionState.commitVersion != null,
+                    physicalPartition.getId());
+            long commitVersion = partitionState.commitVersion;
+
+            Preconditions.checkState(commitVersion == physicalPartition.getVisibleVersion() + 1,
+                    commitVersion + " vs " + physicalPartition.getVisibleVersion());
+            physicalPartition.setVisibleVersion(commitVersion, finishedTimeMs);
+
+            TStorageMedium medium =
+                    table.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+
+            // Look the shadow index up from the live catalog (not the journaled state): a job recovered
+            // from the edit log holds a different MaterializedIndex object than the one in globalStateMgr,
+            // so mutating the journaled object would not reflect into the catalog.
+            MaterializedIndex shadowIndex = physicalPartition.getLatestIndex(shadowIndexMetaId);
+            Preconditions.checkNotNull(shadowIndex, shadowIndexMetaId);
+            List<MaterializedIndex> droppedOriginIndices =
+                    physicalPartition.deleteMaterializedIndexByMetaId(originIndexMetaId);
+            Preconditions.checkState(!droppedOriginIndices.isEmpty(),
+                    originIndexMetaId + " vs. " + shadowIndexMetaId);
+
+            TabletMeta shadowTabletMeta =
+                    new TabletMeta(dbId, tableId, physicalPartition.getId(), shadowIndex.getId(), medium, true);
+            for (Tablet tablet : shadowIndex.getTablets()) {
+                invertedIndex.addTablet(tablet.getId(), shadowTabletMeta);
+            }
+
+            physicalPartition.visualiseShadowIndex(shadowIndex.getId(),
+                    originIndexMetaId == table.getBaseIndexMetaId());
+
+            // The origin tablets created under the old key can leave FE metadata.
+            for (MaterializedIndex droppedIdx : droppedOriginIndices) {
+                for (Tablet originTablet : droppedIdx.getTablets()) {
+                    invertedIndex.deleteTablet(originTablet.getId());
+                }
+            }
+        }
+
+        // Flip the table-level index identity: rename the shadow index to the origin name (also strips the
+        // shadow column-name prefix) and repoint the base index meta id at the shadow meta.
+        String shadowIndexName = table.getIndexNameByMetaId(shadowIndexMetaId);
+        String originIndexName = table.getIndexNameByMetaId(originIndexMetaId);
+        table.deleteIndexInfo(originIndexName);
+        table.renameIndexForSchemaChange(shadowIndexName, originIndexName);
+        table.renameColumnNamePrefix(shadowIndexMetaId);
+        if (originIndexMetaId == table.getBaseIndexMetaId()) {
+            table.setBaseIndexMetaId(shadowIndexMetaId);
+        }
+        table.rebuildFullSchema();
+
+        table.setState(OlapTable.OlapTableState.NORMAL);
+    }
+
+    /**
+     * The columns whose meaning changed for this range-rewrite (column set unchanged), so dependent async
+     * MVs built on the old schema get inactivated: every column whose key membership flipped between the
+     * origin and new schema, plus the new sort-key columns (their ordering / role changed). Empty when
+     * nothing relevant changed and there are no dependent MVs.
+     */
+    @Override
+    protected Set<String> affectedColumnsForMvInactivation(@NotNull OlapTable table) {
+        if (table.getRelatedMaterializedViews().isEmpty()) {
+            return Sets.newHashSet();
+        }
+        Set<String> affected = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        Map<String, Boolean> originIsKey = new HashMap<>();
+        for (Column column : table.getSchemaByIndexMetaId(originIndexMetaId)) {
+            originIsKey.put(column.getName(), column.isKey());
+        }
+        for (Column column : newSchema) {
+            Boolean wasKey = originIsKey.get(column.getName());
+            if (wasKey != null && wasKey != column.isKey()) {
+                affected.add(column.getName());
+            }
+        }
+        for (Column sortKeyColumn : newSortKeyColumns) {
+            affected.add(sortKeyColumn.getName());
+        }
+        return affected;
+    }
+
+    @Override
+    public void replay(AlterJobV2 replayedJob) {
+        // Copy the subclass-specific journaled fields first (the shared base fields and the catalog
+        // reconstruction are handled by super.replay), so the base's catalog reconstruction hooks
+        // (registerShadowIndexMeta / visualiseShadowIndex) see this job's new schema/key config.
+        if (this != replayedJob) {
+            LakeRangeRewriteSchemaChangeJob other = (LakeRangeRewriteSchemaChangeJob) replayedJob;
+            this.newSchema = other.newSchema;
+            this.newKeysType = other.newKeysType;
+            this.newSortKeyIdxes = other.newSortKeyIdxes;
+            this.newSortKeyUniqueIds = other.newSortKeyUniqueIds;
+            this.newSortKeyColumns = other.newSortKeyColumns;
+            this.shadowShortKeyColumnCount = other.shadowShortKeyColumnCount;
+        }
+        super.replay(replayedJob);
+    }
+
+    @Override
+    public AlterJobV2 copyForPersist() {
+        // The WAL records a deep snapshot (not a live reference) so journaling never mutates the
+        // running job. getTransactionId() (keyed off watershedTxnId) is inherited from the base.
+        return new LakeRangeRewriteSchemaChangeJob(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.lake.LakeTablet;
@@ -95,10 +96,7 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
                 // TODO: It is not good enough to create shards into the same group id, schema change PR needs to
                 //  revise the code again.
                 List<Long> originTabletIds = originTablets.stream().map(Tablet::getId).collect(Collectors.toList());
-                Map<String, String> properties = new HashMap<>();
-                properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
-                properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
-                properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(shadowIndexId));
+                Map<String, String> properties = buildShadowShardProperties(table, physicalPartitionId, shadowIndexId);
                 List<Long> shadowTabletIds = createShards(originTablets.size(),
                         table.getPartitionFilePathInfo(physicalPartitionId),
                         table.getPartitionFileCacheInfo(physicalPartitionId), shardGroupId,
@@ -138,6 +136,78 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
                     entry.getValue());
         } // end for index
         return schemaChangeJob;
+    }
+
+    /**
+     * Build a shadow {@link MaterializedIndex} with K tablets whose ranges are provided by the caller.
+     * This is the N→K path: K may differ from the origin tablet count, so {@code matchShardIds} is
+     * {@code null} (no origin-shard preference). Shards are allocated internally via
+     * {@link #createShards}, and every resulting tablet is stamped with its sampled range before
+     * being added to the index.
+     *
+     * <p>Unlike the 1:1 alter path, this does not stamp {@code vectorIndexBuiltVersion}: the rewrite
+     * produces shadow data via an internal INSERT, not an inline alter build, so the vector index
+     * (if any) builds through the normal load path — leaving {@code vectorIndexBuiltVersion = 0}
+     * (build-needed) is intentional and correct here.
+     *
+     * @param dbId            database id (for TabletMeta construction)
+     * @param table           the source table (used for storage path / cache info and partition info)
+     * @param partition       the physical partition being shadowed
+     * @param shadowIndexId   id for the new shadow index
+     * @param tabletCount     K: the number of shadow tablets to create (must equal ranges.size())
+     * @param ranges          one range per tablet (size == K)
+     * @param shardGroupId    shard group for the new index
+     * @param computeResource compute resource for shard allocation
+     * @return the new shadow index, in SHADOW state, containing K tablets
+     */
+    public static MaterializedIndex buildRangeShadowIndex(
+            long dbId,
+            OlapTable table,
+            PhysicalPartition partition,
+            long shadowIndexId,
+            int tabletCount,
+            List<TabletRange> ranges,
+            long shardGroupId,
+            ComputeResource computeResource) throws DdlException {
+        Preconditions.checkArgument(tabletCount == ranges.size(),
+                "tabletCount (%s) != ranges.size() (%s)", tabletCount, ranges.size());
+
+        long physicalPartitionId = partition.getId();
+        Map<String, String> properties = buildShadowShardProperties(table, physicalPartitionId, shadowIndexId);
+
+        // No origin-shard preference for the K-tablet shadow: matchShardIds = null.
+        List<Long> allocatedShardIds = createShards(tabletCount,
+                table.getPartitionFilePathInfo(physicalPartitionId),
+                table.getPartitionFileCacheInfo(physicalPartitionId),
+                shardGroupId, null, properties, computeResource);
+        Preconditions.checkState(allocatedShardIds.size() == tabletCount);
+
+        TStorageMedium medium = table.getPartitionInfo().getDataProperty(partition.getParentId()).getStorageMedium();
+        TabletMeta shadowTabletMeta =
+                new TabletMeta(dbId, table.getId(), physicalPartitionId, shadowIndexId, medium, true);
+        MaterializedIndex shadowIndex =
+                new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW, shardGroupId);
+        for (int i = 0; i < tabletCount; i++) {
+            LakeTablet shadowTablet = new LakeTablet(allocatedShardIds.get(i));
+            shadowTablet.setRange(ranges.get(i));
+            // updateInvertedIndex=false: this shadow index is built lock-free, before the job's PENDING
+            // state is journaled. Registering the tablets in the global TabletInvertedIndex now would
+            // leave orphan entries on a pre-journal failure (dropOrphanedShadowShards only reclaims the
+            // StarOS shards, not inverted-index entries). The range-rewrite job registers them via
+            // LakeOnlineRewriteJobBase#addShadowTabletsToInvertedIndex once the shadow index is durably
+            // installed in the catalog (PENDING stage 3, and on replay).
+            shadowIndex.addTablet(shadowTablet, shadowTabletMeta, false);
+        }
+        return shadowIndex;
+    }
+
+    private static Map<String, String> buildShadowShardProperties(OlapTable table, long physicalPartitionId,
+                                                                       long shadowIndexId) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
+        properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
+        properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(shadowIndexId));
+        return properties;
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -364,20 +364,6 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
     }
 
     @VisibleForTesting
-    public static long getNextTransactionId() {
-        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
-    }
-
-    @VisibleForTesting
-    public static long peekNextTransactionId() {
-        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().peekNextTransactionId();
-    }
-
-    public static long getNextGtid() {
-        return GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
-    }
-
-    @VisibleForTesting
     public void setIsCancelling(boolean isCancelling) {
         this.isCancelling.set(isCancelling);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -121,4 +121,18 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         AgentTaskQueue.addBatchTask(batchTask);
         AgentTaskExecutor.submit(batchTask);
     }
+
+    @VisibleForTesting
+    public static long getNextTransactionId() {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+    }
+
+    @VisibleForTesting
+    public static long peekNextTransactionId() {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().peekNextTransactionId();
+    }
+
+    public static long getNextGtid() {
+        return GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -269,7 +269,7 @@ public class SchemaChangeHandler extends AlterHandler {
         return buildColumnInternal(columnDef, table);
     }
 
-    private Column buildColumnInternal(ColumnDef columnDef, Table table) {
+    private static Column buildColumnInternal(ColumnDef columnDef, Table table) {
         if (columnDef.isGeneratedColumn()) {
             return ColumnBuilder.buildGeneratedColumn(table, columnDef);
         }
@@ -1032,7 +1032,11 @@ public class SchemaChangeHandler extends AlterHandler {
             // A keyness flip (value <-> key) changes the key column set, which shifts
             // the key-derived range sort key on AGG/UNIQUE tables and on tables without
             // an explicit ORDER BY, even when the column itself is not in the sort key.
-            if (oriColumn.isKey() != modColumn.isKey()) {
+            // On shared-data tables an eligible keyness flip that shifts the range sort key is
+            // routed to LakeRangeRewriteSchemaChangeJob (handled in analyzeAndCreateJob); the
+            // throw is kept for every other case.
+            boolean isRoutedRangeRewrite = needsRangeRewriteSchemaChange(olapTable, alterClause);
+            if (oriColumn.isKey() != modColumn.isKey() && !isRoutedRangeRewrite) {
                 throw new DdlException("MODIFY COLUMN that changes keyness is not supported on tables with " +
                         "range distribution, because adding to or removing from the key column set shifts the " +
                         "range sort key on AGG/UNIQUE tables and on tables without explicit ORDER BY. Column: " +
@@ -1041,7 +1045,10 @@ public class SchemaChangeHandler extends AlterHandler {
             boolean fastPathVarcharWiden = columnPos == null
                     && isOnlyDifferentFromColumnType && isVarcharLengthIncrease
                     && fastSchemaEvolutionEligible;
-            if (!fastPathVarcharWiden) {
+            // A routed range-rewrite re-sorts/re-routes all data into a freshly sampled K-tablet
+            // shadow index, so the stored boundary values do not need to stay valid -- skip the
+            // sort-key touch reject for it.
+            if (!fastPathVarcharWiden && !isRoutedRangeRewrite) {
                 rejectIfTouchesRangeSortKey(olapTable, indexMetaIdForFindingColumn, "MODIFY COLUMN", newColName);
             }
         }
@@ -1194,7 +1201,10 @@ public class SchemaChangeHandler extends AlterHandler {
     private void processModifySortKeyColumn(ReorderColumnsClause alterClause, OlapTable olapTable,
                                             Map<Long, LinkedList<Column>> indexMetaIdToSchema, List<Integer> sortKeyIdxes,
                                             List<Integer> sortKeyUniqueIds) throws DdlException {
-        if (olapTable.isRangeDistribution()) {
+        // On shared-data range tables a sort-key reorder is routed to LakeRangeRewriteSchemaChangeJob
+        // (the caller builds the job); compute the new sort key here and skip the reject. Every other
+        // range table keeps the existing rejection -- the sort key defines tablet boundaries.
+        if (olapTable.isRangeDistribution() && !needsRangeRewriteSchemaChange(olapTable, alterClause)) {
             throw new DdlException(
                 "Modifying sort key (ALTER TABLE ... ORDER BY) is not " +
                 "supported on tables with range distribution, because the " +
@@ -2131,6 +2141,113 @@ public class SchemaChangeHandler extends AlterHandler {
         return jobBuilder.build();
     }
 
+    /**
+     * Build a {@link LakeRangeRewriteSchemaChangeJob} for a sort-key reorder
+     * ({@code ALTER TABLE ... ORDER BY (...)}) on a shared-data range table. The column set and
+     * keysType are unchanged; only the sort key is permuted, so the new schema is the base schema and
+     * the new sort key is given by {@code sortKeyIdxes}.
+     */
+    private AlterJobV2 createRangeRewriteJob(Database db, OlapTable olapTable, List<Integer> sortKeyIdxes,
+                                             List<Integer> sortKeyUniqueIds) throws StarRocksException {
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        List<Column> newSchema = olapTable.getSchemaByIndexMetaId(baseIndexMetaId);
+        short shortKeyColumnCount = (sortKeyIdxes != null)
+                ? GlobalStateMgr.calcShortKeyColumnCount(newSchema, null, sortKeyIdxes)
+                : GlobalStateMgr.calcShortKeyColumnCount(newSchema, null);
+        return buildRangeRewriteJob(db, olapTable, baseIndexMetaId, newSchema, olapTable.getKeysType(),
+                sortKeyIdxes, sortKeyUniqueIds, shortKeyColumnCount);
+    }
+
+    /**
+     * Build a {@link LakeRangeRewriteSchemaChangeJob} for a MODIFY COLUMN keyness flip on a
+     * shared-data range table. The new base schema (with the flipped column already applied by
+     * {@link #processModifyColumn}) is passed in; keysType is unchanged by a keyness flip, and the new
+     * range sort key is key-derived (a routed keyness flip only occurs when no explicit sort key
+     * pins the column positions), so {@code sortKeyIdxes} is left null and the job derives the sort
+     * key from the new key columns.
+     */
+    private AlterJobV2 createRangeRewriteJob(Database db, OlapTable olapTable, List<Column> newSchema)
+            throws StarRocksException {
+        Preconditions.checkState(newSchema != null, "range-rewrite: missing new schema for base index");
+        // processModifyColumn shadow-prefixes the modified column's name (__starrocks_shadow_*). The
+        // range rewrite materializes the shadow index via an INSERT ... SELECT over the BASE column
+        // names and routes by per-index distribution expressions resolved against those names, so the
+        // shadow schema must use the un-prefixed names -- exactly as the sort-key reorder path does,
+        // which passes the base schema. Strip the prefix here while preserving the flipped keyness;
+        // otherwise the rewrite INSERT fails to resolve the prefixed routing column.
+        List<Column> shadowIndexSchema = new ArrayList<>(newSchema.size());
+        for (Column column : newSchema) {
+            Column copy = column.deepCopy();
+            copy.setName(Column.removeNamePrefix(column.getName()));
+            shadowIndexSchema.add(copy);
+        }
+        short shortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(shadowIndexSchema, null);
+        return buildRangeRewriteJob(db, olapTable, olapTable.getBaseIndexMetaId(), shadowIndexSchema,
+                olapTable.getKeysType(), null, null, shortKeyColumnCount);
+    }
+
+    /**
+     * Construct and populate a {@link LakeRangeRewriteSchemaChangeJob} with the new-schema information
+     * it consumes before {@code runPendingJob}: the new full schema, the new sort key
+     * ({@code sortKeyIdxes}/{@code sortKeyUniqueIds} and the projected sort-key {@link Column}s used to
+     * sample the K-tablet boundaries), the (unchanged) keysType, and the shadow/origin index
+     * identity. The shadow index id is freshly allocated; the shadow tablets are built later in the
+     * job's PENDING phase.
+     */
+    private AlterJobV2 buildRangeRewriteJob(Database db, OlapTable olapTable, long originIndexMetaId,
+                                            List<Column> newSchema, KeysType keysType, List<Integer> sortKeyIdxes,
+                                            List<Integer> sortKeyUniqueIds, short shortKeyColumnCount)
+            throws StarRocksException {
+        if (olapTable.getState() == OlapTableState.ROLLUP) {
+            throw new DdlException("Table[" + olapTable.getName() + "] is doing ROLLUP job");
+        }
+        Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
+
+        final ConnectContext connectContext = ConnectContext.get();
+        final ComputeResource computeResource = connectContext != null
+                ? connectContext.getCurrentComputeResource() : WarehouseManager.DEFAULT_RESOURCE;
+        final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        if (!warehouseManager.isResourceAvailable(computeResource)) {
+            throw new DdlException("no available compute nodes:" + computeResource);
+        }
+
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        long shadowIndexMetaId = GlobalStateMgr.getCurrentState().getNextId();
+        String shadowIndexName = SHADOW_NAME_PREFIX + olapTable.getIndexNameByMetaId(originIndexMetaId);
+
+        LakeRangeRewriteSchemaChangeJob job = new LakeRangeRewriteSchemaChangeJob(
+                jobId, db.getId(), olapTable.getId(), olapTable.getName(), Config.alter_table_timeout_second * 1000L);
+        job.setNewSchema(newSchema);
+        job.setNewKeysType(keysType);
+        job.setNewSortKeyIdxes(sortKeyIdxes);
+        job.setNewSortKeyUniqueIds(sortKeyUniqueIds);
+        job.setNewSortKeyColumns(resolveSortKeyColumns(newSchema, sortKeyIdxes));
+        job.setShadowIndex(shadowIndexMetaId, originIndexMetaId, shadowIndexName, shortKeyColumnCount);
+        job.setComputeResource(computeResource);
+        return job;
+    }
+
+    /**
+     * Project the new sort-key {@link Column}s out of the new schema: the columns at
+     * {@code sortKeyIdxes} when an explicit sort key is set, else the key columns. Mirrors
+     * {@link MetaUtils#getRangeDistributionColumns(OlapTable, long)} on the new schema.
+     */
+    private static List<Column> resolveSortKeyColumns(List<Column> newSchema, List<Integer> sortKeyIdxes) {
+        List<Column> sortKeyColumns = new ArrayList<>();
+        if (sortKeyIdxes != null) {
+            for (Integer idx : sortKeyIdxes) {
+                sortKeyColumns.add(newSchema.get(idx));
+            }
+        } else {
+            for (Column column : newSchema) {
+                if (column.isKey()) {
+                    sortKeyColumns.add(column);
+                }
+            }
+        }
+        return sortKeyColumns;
+    }
+
     @Override
     protected void runAfterLeaseValid() {
         super.runAfterLeaseValid();
@@ -2312,6 +2429,28 @@ public class SchemaChangeHandler extends AlterHandler {
                 // modify column
                 fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexMetaIdToSchema,
                                                            alterIndexMetaIdToIncrVarcharLenColNames);
+                List<Column> postFlipBaseSchema = indexMetaIdToSchema.get(olapTable.getBaseIndexMetaId());
+                if (needsRangeRewriteSchemaChange(olapTable, modifyColumnClause)
+                        && rangeRewriteKeySchemaIsValid(postFlipBaseSchema)) {
+                    // A keyness flip on a shared-data range table whose flip shifts the range sort key:
+                    // re-route/re-sort/re-aggregate all data into a freshly sampled K-tablet shadow
+                    // index and flip. Routed here (early return), bypassing finalAnalyze, because a
+                    // keyness flip changes the column's aggregation type -- which the generic
+                    // compatibility check rejects -- but the rewrite re-aggregates under the new key.
+                    // Only a post-flip schema that still satisfies finalAnalyze's key invariants (at least
+                    // one key column, every value after every key) is routed; an invalid flip -- the
+                    // last/only key demoted to a value, or a value column promoted ahead of a key -- falls
+                    // through to finalAnalyze, which rejects it synchronously with the precise "No key
+                    // column left" / "value should be after key" error instead of the rewrite job failing
+                    // asynchronously later.
+                    if (alterClauses.size() > 1) {
+                        throw new DdlException("MODIFY COLUMN that changes keyness on a range-distribution table "
+                                + "can not be combined with other alter operations");
+                    }
+                    AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
+                            MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()));
+                    return createRangeRewriteJob(db, olapTable, postFlipBaseSchema);
+                }
             } else if (alterClause instanceof ModifyColumnCommentClause) {
                 // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
                 if (alterClauses.size() > 1) {
@@ -2363,6 +2502,9 @@ public class SchemaChangeHandler extends AlterHandler {
                     // If optimized olap table contains related mvs, set those mv state to inactive.
                     AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                             MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()));
+                    if (needsRangeRewriteSchemaChange(olapTable, alterClause)) {
+                        return createRangeRewriteJob(db, olapTable, sortKeyIdxes, sortKeyUniqueIds);
+                    }
                     return createJobForProcessModifySortKeyColumn(db.getId(), olapTable, sortKeyIdxes, sortKeyUniqueIds);
                 } else {
                     processReorderColumn((ReorderColumnsClause) alterClause, olapTable, indexMetaIdToSchema);
@@ -3987,6 +4129,172 @@ public class SchemaChangeHandler extends AlterHandler {
                 && oriColumn.isKey() == modColumn.isKey()
                 && oriColumn.isAllowNull() == modColumn.isAllowNull()
                 && oriColumn.isHidden() == modColumn.isHidden();
+    }
+
+    /**
+     * Whether the given alter clause is an eligible range-distribution key change that must be
+     * routed to {@link LakeRangeRewriteSchemaChangeJob} rather than rejected.
+     *
+     * <p>Eligible iff ALL of:
+     * <ul>
+     *   <li>the table is a shared-data (cloud-native) OLAP table — the rewrite job is lake-only, so a
+     *       non-lake range table must never reach it. Materialized views are excluded (this gates on
+     *       {@code isCloudNativeTable()}, not {@code isCloudNativeTableOrMaterializedView()}): a
+     *       key/sort-key {@code ALTER TABLE} on an MV is already rejected by
+     *       {@code AlterTableStatementAnalyzer}, and the rewrite's internal INSERT would be rejected
+     *       by {@code InsertAnalyzer} on a non-system MV target;</li>
+     *   <li>the table uses range distribution;</li>
+     *   <li>the clause is either a sort-key reorder ({@code ALTER TABLE ... ORDER BY (...)}, which
+     *       always shifts the range sort key) or a {@link ModifyColumnClause} that flips a column's
+     *       keyness AND that flip shifts the range sort key.</li>
+     * </ul>
+     *
+     * <p>Column-set-changing operations (add/drop key) remain out of scope and are rejected
+     * elsewhere; this predicate only decides between routing and the existing keyness-flip /
+     * sort-key-reorder rejections.
+     */
+    public static boolean needsRangeRewriteSchemaChange(OlapTable table, AlterClause clause) {
+        if (!table.isCloudNativeTable() || !table.isRangeDistribution()) {
+            return false;
+        }
+        // Range-colocate and AUTO_INCREMENT-key tables stay rejected (returning false here keeps the
+        // existing range-distribution rejection on both the reorder and keyness-flip paths). A colocate
+        // table's tablets must stay range-aligned with its ColocateRangeMgr expected ranges; the rewrite
+        // samples a fresh K-tablet layout independently, which would desync colocate scan/join routing
+        // after the flip. AUTO_INCREMENT columns are likewise out of scope for the re-route.
+        if (GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(table.getId())
+                || table.hasAutoIncrementColumn()) {
+            return false;
+        }
+        // Tables with user rollup / synchronous-MV indexes beyond the base index are not eligible:
+        // createRangeRewriteJob / buildRangeRewriteJob rebuild ONLY the base index (baseIndexMetaId),
+        // so rollup indexes would be left with stale key/sort-key metadata after the rewrite.
+        if (table.getIndexMetaIdToMeta().size() > 1) {
+            return false;
+        }
+        // NOTE: PRIMARY_KEYS range-distribution tables are intentionally NOT excluded. The rewrite is
+        // designed to support them -- the op_write->op_schema_change@W conversion plus version-ordered
+        // vlog replay gives PK/UNIQUE/AGG-REPLACE newer-wins (see the P1b design's "PK flip at
+        // base_version = W" correctness obligation). PK column keyness is fixed (no MODIFY-COLUMN
+        // keyness flip is possible), so only the sort-key-reorder path can route a PK table.
+        if (clause instanceof ReorderColumnsClause) {
+            // A sort-key reorder (ALTER TABLE ... ORDER BY with fewer columns than the base schema)
+            // always shifts the range sort key. A full-schema reorder is handled on a different path
+            // and is not a range-rewrite.
+            return ((ReorderColumnsClause) clause).getColumnsByPos().size() != table.getBaseSchema().size();
+        }
+        if (clause instanceof ModifyColumnClause) {
+            return modifyColumnShiftsRangeSortKey(table, (ModifyColumnClause) clause);
+        }
+        return false;
+    }
+
+    /**
+     * Whether a MODIFY COLUMN flips the named column's keyness AND that flip shifts the range sort
+     * key of the base index. The "after" sort key is computed on a candidate base schema in which the
+     * modified column's key bit is flipped, then compared with the current sort key (mirroring how
+     * {@link MetaUtils#getRangeDistributionColumns(OlapTable, long)} resolves the sort key from the
+     * index's {@code sortKeyIdxes}, or from the key columns when no explicit sort key is set).
+     */
+    private static boolean modifyColumnShiftsRangeSortKey(OlapTable table, ModifyColumnClause clause) {
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        if (indexMeta == null) {
+            return false;
+        }
+        String columnName = clause.getColumnDef().getName();
+        Column oriColumn = null;
+        for (Column column : indexMeta.getSchema()) {
+            if (column.getName().equalsIgnoreCase(columnName)) {
+                oriColumn = column;
+                break;
+            }
+        }
+        if (oriColumn == null) {
+            return false;
+        }
+        boolean newIsKey = resolveModifyColumnKeyness(table, clause.getColumnDef(), oriColumn);
+        if (oriColumn.isKey() == newIsKey) {
+            return false;
+        }
+        if (!isPureKeynessFlip(oriColumn, clause.getColumnDef(), table)) {
+            // Only a *pure* keyness flip is routed to the range rewrite. If the MODIFY COLUMN also
+            // changes the type/length, nullability, default value, aggregation, generated expression,
+            // etc., it is not a pure flip: returning false here lets it fall through to finalAnalyze,
+            // where the generic compatibility checks (e.g. "Cannot shorten string length") reject or
+            // handle it exactly as they would without this routing. This keeps the routing from
+            // bypassing those validations when a keyness flip is bundled with another change.
+            return false;
+        }
+        List<String> currentSortKeyNames = MetaUtils.getRangeDistributionColumns(table, baseIndexMetaId).stream()
+                .map(Column::getName).collect(Collectors.toList());
+        Map<String, Boolean> keynessOverride = Map.of(columnName, newIsKey);
+        List<String> candidateSortKeyNames = MetaUtils.getRangeDistributionColumns(table, baseIndexMetaId,
+                        keynessOverride).stream()
+                .map(Column::getName).collect(Collectors.toList());
+        return !currentSortKeyNames.equals(candidateSortKeyNames);
+    }
+
+    /**
+     * Whether {@code schema} still satisfies the key-set invariants that {@link #finalAnalyze} enforces:
+     * at least one key column, and every value column positioned after every key column (the key columns
+     * form a contiguous prefix). A routed keyness flip bypasses finalAnalyze, so the routing re-checks
+     * these here and declines to route a flip that would violate them -- the last/only key demoted to a
+     * value, or a value column promoted ahead of a key. Such a flip then falls through to finalAnalyze,
+     * which rejects it synchronously with the precise error rather than letting the rewrite job fail later.
+     */
+    private static boolean rangeRewriteKeySchemaIsValid(List<Column> schema) {
+        if (schema == null) {
+            return false;
+        }
+        boolean meetValue = false;
+        boolean hasKey = false;
+        for (Column column : schema) {
+            if (column.isKey() && meetValue) {
+                return false; // a value column precedes a key column
+            }
+            if (column.isKey()) {
+                hasKey = true;
+            } else {
+                meetValue = true;
+            }
+        }
+        return hasKey;
+    }
+
+    /**
+     * Whether a MODIFY COLUMN is a *pure* keyness flip: the column it would produce differs from the
+     * existing column in {@link Column#isKey()} only (type, length/precision/scale, nullability,
+     * default value, aggregation, generated expression, etc. all unchanged). Only such flips are
+     * routed to the range rewrite; a keyness flip bundled with any other change must fall through to
+     * finalAnalyze so its generic compatibility checks still run.
+     *
+     * <p>Consequence: an AGG value&harr;key flip inherently changes the column's aggregation state (a
+     * value column carries an aggregation function, a key does not), so it is not a pure keyness flip
+     * and is correctly not routed -- it falls through to the existing rejection. Pure keyness flips
+     * are mainly DUP (and any case where only the key bit toggles).
+     */
+    private static boolean isPureKeynessFlip(Column oriColumn, ColumnDef columnDef, OlapTable table) {
+        Column modColumn = buildColumnInternal(columnDef, table);
+        return oriColumn.differsOnlyInKeyness(modColumn);
+    }
+
+    /**
+     * Resolve the post-modify keyness of a column, mirroring the keys-type-driven key adjustments in
+     * {@link #processModifyColumn} (AGG promotes a no-aggregate column to KEY; PK keeps an existing
+     * key column a key; DUP/UNIQUE take the keyness from the clause).
+     */
+    private static boolean resolveModifyColumnKeyness(OlapTable table, ColumnDef columnDef, Column oriColumn) {
+        KeysType keysType = table.getKeysType();
+        if (keysType == KeysType.AGG_KEYS) {
+            // In aggregate-key tables a column with no aggregation method is a key column.
+            return columnDef.getAggregateType() == null || columnDef.isKey();
+        }
+        if (keysType == KeysType.PRIMARY_KEYS && oriColumn.isKey()) {
+            // Backward compatibility: a PK key column stays a key column when not respecified.
+            return true;
+        }
+        return columnDef.isKey();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -312,8 +312,10 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
     }
 
     /** Cuts {@code c1 < c2 < ... < c_{K-1}} → tablet ranges
-     *  {@code (-∞, c1), [c1, c2), [c2, c3), ..., [c_{K-1}, +∞)}. */
-    static List<TabletRange> buildTabletRanges(List<Tuple> boundaries) {
+     *  {@code (-∞, c1), [c1, c2), [c2, c3), ..., [c_{K-1}, +∞)}.
+     *  Requires a non-empty boundary list; callers that need to handle the empty case must guard
+     *  before calling (e.g. return a single {@code Range.all()} tablet). */
+    public static List<TabletRange> buildTabletRanges(List<Tuple> boundaries) {
         Preconditions.checkArgument(!boundaries.isEmpty(), "boundaries must be non-empty");
         List<TabletRange> ranges = new ArrayList<>(boundaries.size() + 1);
         Tuple previousBoundary = null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InternalPartitionSampleSubqueryExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InternalPartitionSampleSubqueryExecutor.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.catalog.Column;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.SqlUtils;
+
+import java.util.List;
+
+/**
+ * {@link SampleSubqueryExecutor} for sampling a single partition of an
+ * internal (OLAP) table with a new sort key. Synthesizes a
+ * {@code SELECT <sort_key_cols>[, <partition_source_cols>] FROM `db`.`tbl`
+ * PARTITION (`part`) WHERE rand(...) < rate ORDER BY rand(...) LIMIT N}
+ * sub-query and decodes the JSON result rows using the target column types
+ * supplied by the {@link SampleRequest}.
+ *
+ * <p>Source column names from the {@link InternalPartitionScanContext} drive the
+ * SELECT projection; the corresponding target {@link Column} objects from the
+ * request drive the JSON decode so each cell is coerced to the destination
+ * schema type. The sampling rate and row limit are computed by the inherited
+ * helpers in {@link AbstractSqlSampleSubqueryExecutor}.
+ */
+final class InternalPartitionSampleSubqueryExecutor extends AbstractSqlSampleSubqueryExecutor {
+
+    private static final String ERROR_PREFIX = "internal-partition ";
+
+    InternalPartitionSampleSubqueryExecutor() {
+        super(ERROR_PREFIX, "TabletPreSplitInternalPartitionSubquery");
+    }
+
+    @VisibleForTesting
+    InternalPartitionSampleSubqueryExecutor(SampleQueryRunner sampleQueryRunner) {
+        super(ERROR_PREFIX, sampleQueryRunner);
+    }
+
+    @Override
+    protected SampleSpec resolveSampleSpec(SampleRequest request) throws StarRocksException {
+        ScanContext scanContext = request.getScanContext();
+        if (!(scanContext instanceof InternalPartitionScanContext context)) {
+            throw new StarRocksException(ERROR_PREFIX + "received a "
+                    + scanContext.getClass().getSimpleName()
+                    + " — wire only the internal-partition scan context here");
+        }
+        String fromClauseSql = SqlUtils.getIdentSql(context.dbName())
+                + "." + SqlUtils.getIdentSql(context.tableName())
+                + " PARTITION (" + SqlUtils.getIdentSql(context.partitionName()) + ")";
+        List<Column> sortKeyColumns = request.getSortKey();
+        List<Column> partitionSourceColumns = request.getPartitionSourceColumns();
+        return new SampleSpec(
+                fromClauseSql,
+                /*whereClauseSqlOrNull=*/ null,
+                context.partitionSizeBytes(),
+                context.computeResource(),
+                identsOf(context.sortKeySourceColumnNames()),
+                identsOf(context.partitionSourceColumnNames()),
+                sortKeyColumns,
+                partitionSourceColumns);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InternalPartitionScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InternalPartitionScanContext.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.starrocks.warehouse.cngroup.ComputeResource;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link ScanContext} for sampling a single partition of an internal (OLAP) table.
+ * Carries the database name, table name, and partition name that compose the
+ * {@code FROM <db>.<table> PARTITION(<partition>)} clause, the source column names
+ * that map the new sort key and partition-source columns back to their positions in
+ * the source table, and the partition's data size estimate used to derive the
+ * Bernoulli sampling rate.
+ */
+public record InternalPartitionScanContext(
+        String dbName,
+        String tableName,
+        String partitionName,
+        List<String> sortKeySourceColumnNames,
+        List<String> partitionSourceColumnNames,
+        long partitionSizeBytes,
+        ComputeResource computeResource) implements ScanContext {
+
+    public InternalPartitionScanContext {
+        Objects.requireNonNull(dbName, "dbName");
+        Objects.requireNonNull(tableName, "tableName");
+        Objects.requireNonNull(partitionName, "partitionName");
+        Objects.requireNonNull(sortKeySourceColumnNames, "sortKeySourceColumnNames");
+        Objects.requireNonNull(partitionSourceColumnNames, "partitionSourceColumnNames");
+        Objects.requireNonNull(computeResource, "computeResource");
+        if (partitionSizeBytes < 0) {
+            throw new IllegalArgumentException("partitionSizeBytes must be non-negative, was " + partitionSizeBytes);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ReservoirSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ReservoirSampler.java
@@ -46,6 +46,17 @@ public final class ReservoirSampler implements Sampler {
         this.executor = Objects.requireNonNull(executor, "executor");
     }
 
+    /**
+     * Production sampler for a single partition of an internal (OLAP) table, sampling
+     * by a (possibly new) sort key. Wraps the package-private
+     * {@link InternalPartitionSampleSubqueryExecutor} so callers outside this package
+     * (e.g. the range-rewrite schema-change job) can obtain a ready-to-use {@link Sampler}
+     * without reaching into the executor directly.
+     */
+    public static ReservoirSampler forInternalPartition() {
+        return new ReservoirSampler(new InternalPartitionSampleSubqueryExecutor());
+    }
+
     @Override
     public SampleSet sample(SampleRequest request) throws StarRocksException {
         Objects.requireNonNull(request, "request");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -485,7 +485,7 @@ public final class TabletPreSplitCoordinator {
      * @param activeComputeNodeCount total provisioned compute nodes in the load's warehouse.
      *                               Must be {@code >= 1}.
      */
-    static int selectTabletCount(Estimates estimates, int activeComputeNodeCount) {
+    public static int selectTabletCount(Estimates estimates, int activeComputeNodeCount) {
         Objects.requireNonNull(estimates, "estimates");
         Preconditions.checkArgument(activeComputeNodeCount >= 1,
                 "activeComputeNodeCount must be >= 1, was %s", activeComputeNodeCount);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -949,6 +949,56 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return comment == null ? other.comment == null : comment.equals(other.getComment());
     }
 
+    /**
+     * Whether {@code other} differs from this column in {@link #isKey()} only -- i.e. a pure keyness
+     * flip. Every other column attribute that {@link #equals(Object)} considers must be identical,
+     * except: the comment is intentionally ignored (a comment change is not a keyness flip but must
+     * not block one either), and the aggregation type is compared keyness-tolerantly so that the
+     * null vs NONE artifact a key/value distinction carries is not treated as a real change. A real
+     * aggregation function (e.g. an AGG value column carrying SUM) therefore is NOT a keyness flip.
+     *
+     * <p>Maintenance: this attribute list must stay in sync with the column's compatibility checks
+     * (the fields {@link #equals(Object)} considers). If a new column attribute is added there but not
+     * here, a MODIFY COLUMN that changes only that new attribute would be misclassified as a pure
+     * keyness flip and routed to the range rewrite, bypassing finalAnalyze's compatibility validation.
+     */
+    public boolean differsOnlyInKeyness(Column other) {
+        if (other == null) {
+            return false;
+        }
+        if (!this.name.equalsIgnoreCase(other.getName())) {
+            return false;
+        }
+        if (!this.getType().equals(other.getType())) {
+            return false;
+        }
+        if (!(this.aggregationType == other.aggregationType ||
+                (AggregateType.isNullOrNone(this.aggregationType) &&
+                        AggregateType.isNullOrNone(other.getAggregationType())))) {
+            return false;
+        }
+        if (this.aggStateDesc != null && !this.aggStateDesc.equals(other.aggStateDesc)) {
+            return false;
+        }
+        if (this.isAllowNull != other.isAllowNull) {
+            return false;
+        }
+        if (!this.isSameDefaultValue(other)) {
+            return false;
+        }
+        if (this.isGeneratedColumn() != other.isGeneratedColumn()) {
+            return false;
+        }
+        if (this.isGeneratedColumn() &&
+                !this.generatedColumnExpr.equals(other.generatedColumnExpr)) {
+            return false;
+        }
+        if (this.isAutoIncrement != other.isAutoIncrement) {
+            return false;
+        }
+        return this.isHidden == other.isHidden();
+    }
+
     public boolean isSchemaCompatible(Column other) {
         if (!this.name.equalsIgnoreCase(other.getName())) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.alter.LakeRangeRewriteSchemaChangeJob;
 import com.starrocks.alter.LakeRollupJob;
 import com.starrocks.alter.LakeTableAddIndexJob;
 import com.starrocks.alter.LakeTableAlterMetaJob;
@@ -243,6 +244,7 @@ public class RuntimeTypeAdapterTypes {
                         .registerSubtype(OnlineOptimizeJobV2.class, "OnlineOptimizeJobV2")
                         .registerSubtype(MergePartitionJob.class, "MergePartitionJob")
                         .registerSubtype(LakeTableSchemaChangeJob.class, "LakeTableSchemaChangeJob")
+                        .registerSubtype(LakeRangeRewriteSchemaChangeJob.class, "LakeRangeRewriteSchemaChangeJob")
                         .registerSubtype(LakeTableAlterMetaJob.class, "LakeTableAlterMetaJob")
                         .registerSubtype(LakeRollupJob.class, "LakeRollupJob")
                         .registerSubtype(LakeTableAsyncFastSchemaChangeJob.class, "LakeTableFastSchemaEvolutionJob")

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -611,6 +611,23 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         alreadyFoundSomeLivingCn = true;
     }
 
+    /**
+     * Returns the version to use when scanning {@code physicalPartitionId}.
+     * If {@code override} contains an entry for this partition, that version is returned;
+     * otherwise {@code visibleVersion} is returned unchanged.
+     * Passing {@code null} for {@code override} is equivalent to an empty map.
+     */
+    public static long chooseScanVersion(long visibleVersion, long physicalPartitionId,
+                                         @Nullable Map<Long, Long> override) {
+        if (override != null) {
+            Long overriddenVersion = override.get(physicalPartitionId);
+            if (overriddenVersion != null) {
+                return overriddenVersion;
+            }
+        }
+        return visibleVersion;
+    }
+
     public void addScanRangeLocations(Partition partition,
                                       PhysicalPartition physicalPartition,
                                       MaterializedIndex index,
@@ -624,7 +641,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         int logNum = 0;
         int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
         String schemaHashStr = String.valueOf(schemaHash);
-        long visibleVersion = physicalPartition.getVisibleVersion();
+        ConnectContext ctx = ConnectContext.get();
+        long visibleVersion = chooseScanVersion(physicalPartition.getVisibleVersion(), physicalPartition.getId(),
+                ctx == null ? null : ctx.getScanVersionOverride());
         scanPartitionVersions.put(physicalPartition.getId(), visibleVersion);
         String visibleVersionStr = String.valueOf(visibleVersion);
         boolean fillDataCache = olapTable.isEnableFillDataCache(partition);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -284,6 +284,19 @@ public class ConnectContext {
     // Track if current write is CTAS (Create Table As Select)
     private boolean isCTAS = false;
 
+    // Per-physical-partition read-version override: if set, OlapScanNode uses the mapped version
+    // instead of physicalPartition.getVisibleVersion() for each entry in this map.
+    // Null means no override (normal visible-version path).
+    private Map<Long, Long> scanVersionOverride = null;
+
+    public void setScanVersionOverride(Map<Long, Long> scanVersionOverride) {
+        this.scanVersionOverride = scanVersionOverride;
+    }
+
+    public Map<Long, Long> getScanVersionOverride() {
+        return scanVersionOverride;
+    }
+
     public void setTxnId(long txnId) {
         this.txnId = txnId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3655,6 +3655,10 @@ public class StmtExecutor {
                     } else {
                         attachment = new InsertTxnCommitAttachment(loadedRows);
                     }
+                    if (insertStmt.isShadowRewrite()) {
+                        attachment.setShadowRewriteWatershedTxnId(insertStmt.getShadowRewriteWatershedTxnId());
+                        attachment.setShadowRewriteAlterVersion(insertStmt.getShadowRewriteAlterVersion());
+                    }
                 } else {
                     attachment = new InsertTxnCommitAttachment(loadedRows);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -443,6 +443,9 @@ public class InsertPlanner {
                 if (session.getTxnId() != 0) {
                     ((OlapTableSink) dataSink).setIsMultiStatementsTxn(true);
                 }
+                if (insertStmt.getTargetWriteIndexId() != null) {
+                    ((OlapTableSink) dataSink).setTargetWriteIndexId(insertStmt.getTargetWriteIndexId());
+                }
 
                 // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
                 session.getSessionVariable().setPreferComputeNode(false);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -611,7 +611,9 @@ public class StatementPlanner {
         }
 
         GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
+        TransactionState.LoadJobSourceType sourceType = (stmt instanceof InsertStmt && ((InsertStmt) stmt).isShadowRewrite())
+                ? TransactionState.LoadJobSourceType.SHADOW_REWRITE
+                : TransactionState.LoadJobSourceType.INSERT_STREAMING;
         long txnId = DmlStmt.INVALID_TXN_ID;
         if (targetTable instanceof ExternalOlapTable) {
             if (!(stmt instanceof InsertStmt)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -96,6 +96,14 @@ public class InsertStmt extends DmlStmt {
 
     private boolean isVersionOverwrite = false;
 
+    private boolean isShadowRewrite = false;
+    private Long targetWriteIndexId = null;
+    // For a shadow-rewrite INSERT: the watershed txn id the converted op_schema_change log must be
+    // keyed by, and the alter version W it is anchored at. Forwarded to the InsertTxnCommitAttachment
+    // at commit so the publish path can convert the committed op_write into op_schema_change@W.
+    private long shadowRewriteWatershedTxnId = 0;
+    private long shadowRewriteAlterVersion = 0;
+
     // hint in each part of ast. used to ast to sql
     protected List<HintNode> hintNodes;
 
@@ -203,6 +211,38 @@ public class InsertStmt extends DmlStmt {
 
     public boolean isVersionOverwrite() {
         return isVersionOverwrite;
+    }
+
+    public void setShadowRewrite(boolean isShadowRewrite) {
+        this.isShadowRewrite = isShadowRewrite;
+    }
+
+    public boolean isShadowRewrite() {
+        return isShadowRewrite;
+    }
+
+    public void setTargetWriteIndexId(Long targetWriteIndexId) {
+        this.targetWriteIndexId = targetWriteIndexId;
+    }
+
+    public Long getTargetWriteIndexId() {
+        return targetWriteIndexId;
+    }
+
+    public void setShadowRewriteWatershedTxnId(long shadowRewriteWatershedTxnId) {
+        this.shadowRewriteWatershedTxnId = shadowRewriteWatershedTxnId;
+    }
+
+    public long getShadowRewriteWatershedTxnId() {
+        return shadowRewriteWatershedTxnId;
+    }
+
+    public void setShadowRewriteAlterVersion(long shadowRewriteAlterVersion) {
+        this.shadowRewriteAlterVersion = shadowRewriteAlterVersion;
+    }
+
+    public long getShadowRewriteAlterVersion() {
+        return shadowRewriteAlterVersion;
     }
 
     public void setIsDynamicOverwrite(boolean isDynamicOverwrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -294,6 +294,18 @@ public class MetaUtils {
      *         rollup).
      */
     public static List<Column> getRangeDistributionColumns(OlapTable olapTable, long indexMetaId) {
+        return getRangeDistributionColumns(olapTable, indexMetaId, null);
+    }
+
+    /**
+     * Variant that applies a keyness override when computing the sort-key columns. Used to compute
+     * the hypothetical sort key after a keyness flip without mutating the schema.
+     *
+     * @param keynessOverride a column-name → isKey map applied when {@code sortKeyIdxes} is absent;
+     *                        null or empty means no override (identical to the 2-arg overload)
+     */
+    public static List<Column> getRangeDistributionColumns(OlapTable olapTable, long indexMetaId,
+                                                            Map<String, Boolean> keynessOverride) {
         MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaId);
         if (indexMeta == null) {
             throw new IllegalArgumentException(String.format(
@@ -308,7 +320,16 @@ public class MetaUtils {
             }
         } else {
             for (Column column : schema) {
-                if (column.isKey()) {
+                boolean isKey = column.isKey();
+                if (keynessOverride != null) {
+                    for (Map.Entry<String, Boolean> e : keynessOverride.entrySet()) {
+                        if (e.getKey().equalsIgnoreCase(column.getName())) {
+                            isKey = e.getValue();
+                            break;
+                        }
+                    }
+                }
+                if (isKey) {
                     sortKeyColumns.add(column);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -371,9 +371,13 @@ public class DatabaseTransactionMgr {
                 return;
             }
             // For compatible reason, the default behavior of empty load is still returning
-            // "No rows were imported from upstream" and abort transaction.
+            // "No rows were imported from upstream" and abort transaction. A shadow-rewrite txn is exempt
+            // too: an empty-partition range rewrite produces zero rows but must still commit so the flip
+            // can anchor an empty op_schema_change@W on that partition (the BE converter tolerates an empty
+            // source). Without this it would abort with ERR_NO_ROWS_IMPORTED and cancel the schema change.
             if (Config.empty_load_as_error && tabletCommitInfos.isEmpty()
-                    && transactionState.getSourceType() != TransactionState.LoadJobSourceType.INSERT_STREAMING) {
+                    && transactionState.getSourceType() != TransactionState.LoadJobSourceType.INSERT_STREAMING
+                    && !transactionState.isShadowRewrite()) {
                 throw new TransactionCommitFailedException(ERR_NO_ROWS_IMPORTED.formatErrorMsg());
             }
 
@@ -1027,11 +1031,15 @@ public class DatabaseTransactionMgr {
                     // 1. Replication transactions: may have non-consecutive versions
                     // 2. DELETE transactions: each delete predicate needs its own version
                     //    to ensure proper ordering during tablet merge operations
+                    // 3. Shadow-rewrite transactions: allocate no partition version, so they must
+                    //    never be mixed into a normal-version batch (the version-adjacency check and
+                    //    checkTxnStateBatchConsistent() would otherwise see the sentinel version).
                     // e.g. assume there are 4 txns in `states`: <txn_normal_0, txn_rep_0, txn_normal_1, txn_normal_2>
                     // 3 txn batch will be generated as: <txn_normal_0>, <txn_rep_0>, <txn_normal_1, txn_normal_2>
                     if (tableInfo == null
                             || state.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
-                            || state.getSourceType() == TransactionState.LoadJobSourceType.DELETE) {
+                            || state.getSourceType() == TransactionState.LoadJobSourceType.DELETE
+                            || state.isShadowRewrite()) {
                         states = states.subList(0, Math.max(i, 1));
                         break;
                     }
@@ -1110,6 +1118,7 @@ public class DatabaseTransactionMgr {
                     if (txn.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
                             !txn.isVersionOverwrite() &&
                             !partitionCommitInfo.isDoubleWrite() &&
+                            !txn.isShadowRewrite() &&
                             partition.getVisibleVersion() != partitionCommitInfo.getVersion() - 1) {
                         return false;
                     }
@@ -1273,6 +1282,7 @@ public class DatabaseTransactionMgr {
                         if (copiedState.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
                                 !copiedState.isVersionOverwrite() &&
                                 !partitionCommitInfo.isDoubleWrite() &&
+                                !copiedState.isShadowRewrite() &&
                                 physicalPartition.getVisibleVersion() != partitionCommitInfo.getVersion() - 1) {
                             // prevent excessive logging
                             if (copiedState.getLastErrTimeMs() + 3000 < System.nanoTime() / 1000000) {
@@ -1510,6 +1520,11 @@ public class DatabaseTransactionMgr {
                     LOG.warn("partition {} is dropped, skip and remove it from transaction state {}",
                             partitionId,
                             transactionState);
+                    continue;
+                }
+                // A shadow-rewrite txn allocates no partition version; its PartitionCommitInfo keeps
+                // its sentinel version (-1) and is converted to an op_schema_change log at publish.
+                if (transactionState.isShadowRewrite()) {
                     continue;
                 }
                 long parentPartitionId = partition.getParentId();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/InsertTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/InsertTxnCommitAttachment.java
@@ -26,6 +26,14 @@ public class InsertTxnCommitAttachment extends TxnCommitAttachment {
     @SerializedName("partitionVersion")
     private long partitionVersion;
 
+    // For a shadow-rewrite transaction: the watershed txn id the converted
+    // op_schema_change log must be keyed by, and the alter version it is anchored at.
+    @SerializedName("shadowRewriteWatershedTxnId")
+    private long shadowRewriteWatershedTxnId = 0;
+
+    @SerializedName("shadowRewriteAlterVersion")
+    private long shadowRewriteAlterVersion = 0;
+
     public InsertTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.INSERT_STREAMING);
     }
@@ -53,6 +61,19 @@ public class InsertTxnCommitAttachment extends TxnCommitAttachment {
         return partitionVersion;
     }
 
+    public void setShadowRewriteWatershedTxnId(long shadowRewriteWatershedTxnId) {
+        this.shadowRewriteWatershedTxnId = shadowRewriteWatershedTxnId;
+    }
 
+    public long getShadowRewriteWatershedTxnId() {
+        return shadowRewriteWatershedTxnId;
+    }
 
+    public void setShadowRewriteAlterVersion(long shadowRewriteAlterVersion) {
+        this.shadowRewriteAlterVersion = shadowRewriteAlterVersion;
+    }
+
+    public long getShadowRewriteAlterVersion() {
+        return shadowRewriteAlterVersion;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -57,6 +57,11 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                 continue;
             }
 
+            // A shadow-rewrite txn does not allocate or advance any partition version.
+            if (txnState.isShadowRewrite()) {
+                continue;
+            }
+
             // The version of a replication transaction may not continuously
             if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
                 partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
@@ -82,6 +87,11 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             PhysicalPartition partition = table.getPhysicalPartition(partitionId);
             if (partition == null) {
                 LOG.warn("ignored dropped partition {} when applying visible log", partitionId);
+                continue;
+            }
+            // A shadow-rewrite txn does not advance the partition's visible version; its rowsets
+            // are anchored later when the schema-change flip publishes the converted op_schema_change log.
+            if (txnState.isShadowRewrite()) {
                 continue;
             }
             long version = partitionCommitInfo.getVersion();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -193,6 +193,10 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             } else {
                 partitionCommitInfo = new PartitionCommitInfo(partitionId, -1, 0);
             }
+            // A shadow-rewrite txn writes a real, non-version-advancing PartitionCommitInfo so the
+            // publish daemon has a work item. The sentinel version (-1) and the txn sourceType
+            // (txnState.isShadowRewrite()) keep it out of all version allocation, adjacency checks,
+            // and visible-version advances.
             tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             isFirstPartition = false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -1078,7 +1078,10 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 LOG.info("Ignore non-exist partition {} of table {} in txn {}", partitionId, table.getName(), txnLabel);
                 return true;
             }
-            if (txnState.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
+            // A shadow-rewrite txn allocates no partition version (txnVersion is the sentinel -1),
+            // so the visibleVersion+1 adjacency guard does not apply; it only converts shadow logs.
+            if (!txnState.isShadowRewrite() &&
+                    txnState.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
                     partition.getVisibleVersion() + 1 != txnVersion) {
                 return false;
             }
@@ -1104,6 +1107,12 @@ public class PublishVersionDaemon extends LeaderDaemon {
         TxnInfoPB txnInfo = TxnInfoHelper.fromTransactionState(txnState);
         long rpcStartMs = System.currentTimeMillis();
         try {
+            if (txnState.isShadowRewrite()) {
+                // Conversion-only no-op: the rewrite txn commits its op_write at shadowRewriteWatershedTxnId
+                // without advancing any partition version. The flip publish later anchors that op_write as
+                // op_schema_change@W via the TXN_SHADOW_REWRITE publish txn; nothing to publish here.
+                return true;
+            }
             if (CollectionUtils.isNotEmpty(shadowTablets)) {
                 Utils.publishLogVersion(shadowTablets, txnInfo, txnVersion, computeResource);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -113,7 +113,8 @@ public class TransactionState implements Writable, GsonPreProcessable {
         MV_REFRESH(9, false),                  // Refresh MV
         REPLICATION(10, false),                // Replication
         BYPASS_WRITE(11, false),               // Bypass BE, and write data file directly
-        MULTI_STATEMENT_STREAMING(12, false);  // multi statement streaming load
+        MULTI_STATEMENT_STREAMING(12, false),  // multi statement streaming load
+        SHADOW_REWRITE(13, false);             // shadow-index rewrite phase of a range-dist key schema change
 
         private final int flag;
         private final boolean loadingTransaction;
@@ -969,6 +970,22 @@ public class TransactionState implements Writable, GsonPreProcessable {
     public boolean isVersionOverwrite() {
         return txnCommitAttachment instanceof InsertTxnCommitAttachment
                 && ((InsertTxnCommitAttachment) txnCommitAttachment).getIsVersionOverwrite();
+    }
+
+    public boolean isShadowRewrite() {
+        return sourceType == LoadJobSourceType.SHADOW_REWRITE;
+    }
+
+    // The watershed txn id that a shadow-rewrite txn's converted op_schema_change log is keyed by.
+    public long getShadowRewriteWatershedTxnId() {
+        return txnCommitAttachment instanceof InsertTxnCommitAttachment
+                ? ((InsertTxnCommitAttachment) txnCommitAttachment).getShadowRewriteWatershedTxnId() : 0;
+    }
+
+    // The alter version a shadow-rewrite txn's rewritten data is anchored at.
+    public long getShadowRewriteAlterVersion() {
+        return txnCommitAttachment instanceof InsertTxnCommitAttachment
+                ? ((InsertTxnCommitAttachment) txnCommitAttachment).getShadowRewriteAlterVersion() : 0;
     }
 
     // return true if txn is in final status and label is expired

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
@@ -1,0 +1,1672 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.alter.reshard.presplit.Estimates;
+import com.starrocks.alter.reshard.presplit.SampleSet;
+import com.starrocks.alter.reshard.presplit.Sampler;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.lake.Utils;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.InsertTxnCommitAttachment;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+public class LakeRangeRewriteSchemaChangeJobTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "db_lake_range_rewrite_test";
+    private static Database db;
+    private OlapTable table;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
+        Config.enable_range_distribution = true;
+    }
+
+    @BeforeEach
+    public void before() throws Exception {
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(DB_NAME);
+        connectContext.setDatabase(DB_NAME);
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        // A range-distribution table: data is routed by the range sort key (k1, k2).
+        String sql = "create table t_range (k1 int, k2 int, v1 int)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_range");
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, DB_NAME, true);
+    }
+
+    /**
+     * Builds a job whose new sort key reorders the base key to (k2, k1) and wires a stub sampler.
+     */
+    private LakeRangeRewriteSchemaChangeJob newJob(Sampler sampler) {
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        long shadowIndexMetaId = GlobalStateMgr.getCurrentState().getNextId();
+        LakeRangeRewriteSchemaChangeJob job = new LakeRangeRewriteSchemaChangeJob(
+                jobId, db.getId(), table.getId(), table.getName(), 3600_000L);
+        // New schema = base schema (column set unchanged for a sort-key reorder).
+        List<Column> baseSchema = table.getSchemaByIndexMetaId(table.getBaseIndexMetaId());
+        job.setNewSchema(new ArrayList<>(baseSchema));
+        job.setNewKeysType(KeysType.DUP_KEYS);
+        // Reorder the sort key to (k2, k1): indexes into the schema.
+        job.setNewSortKeyIdxes(List.of(1, 0));
+        job.setNewSortKeyColumns(List.of(baseSchema.get(1), baseSchema.get(0)));
+        job.setShadowIndex(shadowIndexMetaId, table.getBaseIndexMetaId(),
+                SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getName(), (short) 2);
+        job.setSampler(sampler);
+        return job;
+    }
+
+    /** A stub sampler returning canned sort-key tuples; used to drive boundary planning deterministically. */
+    private static Sampler stubSampler(List<Tuple> tuples) {
+        return request -> tuples.isEmpty()
+                ? SampleSet.EMPTY
+                : new SampleSet(tuples, new Estimates(1024L, tuples.size()));
+    }
+
+    private static Tuple keyTuple(int k2, int k1) {
+        return new Tuple(List.of(
+                Variant.of(IntegerType.INT, Integer.toString(k2)),
+                Variant.of(IntegerType.INT, Integer.toString(k1))));
+    }
+
+    @Test
+    public void testRunPendingTransitionsToWaitingTxnAndBuildsShadow() throws Exception {
+        // A diverse sample so the boundary planner produces >= 1 cut → K >= 2.
+        List<Tuple> sample = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            sample.add(keyTuple(i, i));
+        }
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(sample));
+
+        job.runPendingJob();
+
+        // 1. State machine advanced PENDING -> WAITING_TXN.
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        // 2. The table is now SCHEMA_CHANGE and carries the shadow MaterializedIndexMeta.
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+        MaterializedIndexMeta shadowMeta = table.getIndexMetaByMetaId(job.getShadowIndexMetaId());
+        Assertions.assertNotNull(shadowMeta);
+        Assertions.assertEquals(List.of(1, 0), shadowMeta.getSortKeyIdxes());
+
+        // 3. A SHADOW MaterializedIndex with >= 1 tablet was built and journaled for the partition,
+        //    and K = boundaries + 1.
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        MaterializedIndex shadowIndex = job.getShadowIndex(physicalPartitionId);
+        Assertions.assertNotNull(shadowIndex);
+        Assertions.assertEquals(MaterializedIndex.IndexState.SHADOW, shadowIndex.getState());
+        Assertions.assertTrue(shadowIndex.getTablets().size() >= 1);
+        Assertions.assertTrue(job.getTabletCount(physicalPartitionId) >= 2,
+                "diverse sample should yield K >= 2");
+        Assertions.assertEquals(job.getTabletCount(physicalPartitionId),
+                job.getBoundaries(physicalPartitionId).size() + 1);
+
+        // 4. The shadow index is NOT yet exposed in the partition's catalog index map (exposure is
+        //    deferred to WAITING_TXN once the watershed is allocated).
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        Assertions.assertNull(physicalPartition.getIndex(job.getShadowIndexMetaId()),
+                "shadow index must not be in the partition catalog index map during PENDING");
+    }
+
+    @Test
+    public void testNoDistinctionSampleFallsBackToSingleFullRangeTablet() throws Exception {
+        // All-equal keys: the boundary planner collapses to NO_SPLIT → K = 1.
+        List<Tuple> sample = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            sample.add(keyTuple(7, 7));
+        }
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(sample));
+
+        job.runPendingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        Assertions.assertEquals(1, job.getTabletCount(physicalPartitionId),
+                "no-distinction sample must fall back to a single full-range tablet");
+        Assertions.assertTrue(job.getBoundaries(physicalPartitionId).isEmpty());
+        MaterializedIndex shadowIndex = job.getShadowIndex(physicalPartitionId);
+        Assertions.assertEquals(1, shadowIndex.getTablets().size());
+        Assertions.assertTrue(shadowIndex.getTablets().get(0).getRange().getRange().isAll());
+    }
+
+    @Test
+    public void testEmptySampleFallsBackToSingleFullRangeTablet() throws Exception {
+        // Empty sample (sampling found no rows): K = 1 fallback.
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(List.of()));
+
+        job.runPendingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        Assertions.assertEquals(1, job.getTabletCount(physicalPartitionId));
+        Assertions.assertEquals(1, job.getShadowIndex(physicalPartitionId).getTablets().size());
+    }
+
+    @Test
+    public void testSamplingFailureFallsBackToSingleFullRangeTablet() throws Exception {
+        // A sampler that throws must not fail the alter; it degrades to K = 1.
+        Sampler throwing = request -> {
+            throw new com.starrocks.common.StarRocksException("boom");
+        };
+        LakeRangeRewriteSchemaChangeJob job = newJob(throwing);
+
+        job.runPendingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        Assertions.assertEquals(1, job.getTabletCount(physicalPartitionId));
+    }
+
+    @Test
+    public void testGsonRoundTripPreservesSubtypeAndFields() throws Exception {
+        // Drive PENDING so the job carries a full journaled state, then serialize/deserialize
+        // through the AlterJobV2 runtime-type adapter exactly as the edit log does.
+        List<Tuple> sample = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            sample.add(keyTuple(i, i));
+        }
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(sample));
+        job.runPendingJob();
+
+        // copyForPersist() is what EditLog.logAlterJob serializes; it must be a deep snapshot.
+        AlterJobV2 persistCopy = job.copyForPersist();
+        Assertions.assertNotSame(job, persistCopy);
+
+        String text = GsonUtils.GSON.toJson(persistCopy);
+        // The runtime-type adapter must emit the discriminator so replay can pick the subtype.
+        Assertions.assertTrue(text.contains("\"clazz\""), "serialized text must carry the clazz discriminator");
+        Assertions.assertTrue(text.contains("LakeRangeRewriteSchemaChangeJob"),
+                "serialized text must carry the LakeRangeRewriteSchemaChangeJob label");
+
+        AlterJobV2 restored = GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        Assertions.assertInstanceOf(LakeRangeRewriteSchemaChangeJob.class, restored);
+        LakeRangeRewriteSchemaChangeJob restoredJob = (LakeRangeRewriteSchemaChangeJob) restored;
+
+        // Key fields survive the round trip.
+        Assertions.assertEquals(job.getJobId(), restoredJob.getJobId());
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, restoredJob.getJobState());
+        Assertions.assertEquals(job.getShadowIndexMetaId(), restoredJob.getShadowIndexMetaId());
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        Assertions.assertEquals(job.getTabletCount(physicalPartitionId),
+                restoredJob.getTabletCount(physicalPartitionId));
+        MaterializedIndex restoredShadow = restoredJob.getShadowIndex(physicalPartitionId);
+        Assertions.assertNotNull(restoredShadow);
+        Assertions.assertEquals(MaterializedIndex.IndexState.SHADOW, restoredShadow.getState());
+        Assertions.assertEquals(job.getShadowIndex(physicalPartitionId).getTablets().size(),
+                restoredShadow.getTablets().size());
+    }
+
+    @Test
+    public void testReplayWaitingTxnReconstructsShadowMetaAndIsIdempotent() throws Exception {
+        List<Tuple> sample = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            sample.add(keyTuple(i, i));
+        }
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(sample));
+        job.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        // Serialize the journaled job, then simulate FE recovery from a pre-change image: reset the
+        // table back to NORMAL and strip the shadow meta + inverted-index entries the live run added.
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        TabletInvertedIndex invertedIndex =
+                GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        table.deleteIndexInfo(SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getName());
+        for (long tabletId : shadowTabletIds) {
+            invertedIndex.deleteTablet(tabletId);
+        }
+        table.setState(OlapTable.OlapTableState.NORMAL);
+        Assertions.assertNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
+                "precondition: shadow meta removed before replay");
+
+        // Replay the deserialized journaled image onto an in-memory job loaded from the same image
+        // (its jobId/dbId/tableId match, as they would after FE recovery). The TABLE is what was
+        // reset above; replay must rebuild the table's in-memory state from the journaled fields.
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        // The shadow meta, the table state, and the inverted-index entries are reconstructed.
+        MaterializedIndexMeta shadowMeta = table.getIndexMetaByMetaId(job.getShadowIndexMetaId());
+        Assertions.assertNotNull(shadowMeta, "replay must re-register the shadow MaterializedIndexMeta");
+        Assertions.assertEquals(List.of(1, 0), shadowMeta.getSortKeyIdxes());
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+        for (long tabletId : shadowTabletIds) {
+            Assertions.assertNotNull(invertedIndex.getTabletMeta(tabletId),
+                    "replay must re-add the shadow tablets to the inverted index");
+        }
+
+        // A second replay is a no-op: same meta, no double-added tablets.
+        inMemory.replay(replayed);
+        Assertions.assertNotNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()));
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+        for (long tabletId : shadowTabletIds) {
+            Assertions.assertNotNull(invertedIndex.getTabletMeta(tabletId));
+        }
+    }
+
+    @Test
+    public void testReplayPendingDoesNotInstallShadowMeta() throws Exception {
+        // A PENDING job has run no stages yet: partitionStates is empty and nothing is installed on the
+        // table (on the leader the shadow meta is registered only in the WAITING_TXN applier, atomically
+        // with that journal entry). Replaying the initial PENDING journal entry must therefore install
+        // NOTHING -- otherwise the table would carry a shadow index schema with no per-partition index,
+        // and loads would fail (OlapTableSink.createSchema() sees the shadow while createPartition() has
+        // no matching partition index) until the job advances.
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
+        Assertions.assertNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
+                "precondition: no shadow meta before runPendingJob");
+        OlapTable.OlapTableState stateBefore = table.getState();
+
+        String text = GsonUtils.GSON.toJson(job.copyForPersist());
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        Assertions.assertNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
+                "replay of a PENDING entry must not register the shadow MaterializedIndexMeta");
+        Assertions.assertEquals(stateBefore, table.getState(),
+                "replay of a PENDING entry must not change the table state");
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, inMemory.getJobState());
+    }
+
+    @Test
+    public void testRunPendingResolvesBaseIndexByMetaIdAfterReshard() throws Exception {
+        // Simulate a tablet split/merge reshard: the base index keeps its meta id, but its latest
+        // MaterializedIndex carries a NEW physical index id and the old physical version is gone.
+        // runPendingJob must resolve the base index by META id (getLatestIndex), not by physical index id
+        // (getIndex) -- otherwise it cancels with "base index missing" for resharded range tables.
+        long baseMetaId = table.getBaseIndexMetaId();
+        for (PhysicalPartition pp : table.getPhysicalPartitions()) {
+            MaterializedIndex oldBase = pp.getIndex(baseMetaId);
+            Assertions.assertNotNull(oldBase, "fresh table: physical index id == meta id");
+            long newPhysId = GlobalStateMgr.getCurrentState().getNextId();
+            Assertions.assertNotEquals(baseMetaId, newPhysId);
+            MaterializedIndex newBase = new MaterializedIndex(newPhysId, baseMetaId,
+                    MaterializedIndex.IndexState.NORMAL, oldBase.getShardGroupId());
+            for (Tablet t : oldBase.getTablets()) {
+                newBase.addTablet(t, new TabletMeta(db.getId(), table.getId(), pp.getId(), newPhysId,
+                        com.starrocks.thrift.TStorageMedium.HDD, true), false);
+            }
+            pp.addMaterializedIndex(newBase, true);
+            pp.deleteMaterializedIndexByIndexId(oldBase.getId());
+            // After the reshard the physical-id lookup misses; only the meta-id lookup finds the base.
+            Assertions.assertNull(pp.getIndex(baseMetaId), "getIndex(metaId) must miss a resharded index");
+            Assertions.assertEquals(newBase, pp.getLatestIndex(baseMetaId));
+        }
+
+        // With the fix, runPendingJob resolves the resharded base index and advances to WAITING_TXN;
+        // before the fix it threw AlterCancelException("base index missing in partition ...").
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+    }
+
+    /** A diverse sample so the boundary planner produces >= 1 cut → K >= 2. */
+    private static List<Tuple> diverseSample() {
+        List<Tuple> sample = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            sample.add(keyTuple(i, i));
+        }
+        return sample;
+    }
+
+    @Test
+    public void testEnterWaitingTxnAllocatesWatershedAndExposesShadow() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        // Precondition: PENDING did not expose the shadow to the partition catalog index map.
+        Assertions.assertNull(physicalPartition.getLatestIndex(job.getShadowIndexMetaId()));
+
+        // First WAITING_TXN run: allocate the watershed and expose the shadow. The drain is not
+        // checked yet (no W captured), so stay in WAITING_TXN.
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        // The watershed was allocated.
+        Assertions.assertTrue(job.getTransactionId().isPresent());
+        long watershedTxnId = job.getTransactionId().get();
+        Assertions.assertTrue(watershedTxnId >= 0);
+
+        // The shadow MaterializedIndex is now exposed in the partition catalog index map with
+        // visibleTxnId == watershedTxnId, so post-watershed loads double-write it.
+        MaterializedIndex exposed = physicalPartition.getLatestIndex(job.getShadowIndexMetaId());
+        Assertions.assertNotNull(exposed, "WAITING_TXN must expose the shadow index to the partition catalog map");
+        Assertions.assertEquals(MaterializedIndex.IndexState.SHADOW, exposed.getState());
+        // visibleTxnId == watershedTxnId: transactions at/after the watershed see the shadow (and so
+        // double-write it), transactions before it ignore it.
+        Assertions.assertTrue(exposed.visibleForTransaction(watershedTxnId));
+        Assertions.assertFalse(exposed.visibleForTransaction(watershedTxnId - 1));
+
+        // No watershed version captured yet (the drain has not been confirmed finished).
+        Assertions.assertNull(job.getWatershedVersion(physicalPartitionId));
+    }
+
+    @Test
+    public void testWaitingTxnStaysWhenPreviousLoadsUnfinished() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+
+        // First WAITING_TXN run allocates the watershed and exposes the shadow.
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+
+        // Prior loads are not finished: the drain check returns false, so stay in WAITING_TXN and do
+        // NOT capture W.
+        new MockUp<LakeRangeRewriteSchemaChangeJob>() {
+            @Mock
+            public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) {
+                return false;
+            }
+        };
+
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        Assertions.assertNull(job.getWatershedVersion(physicalPartitionId),
+                "W must not be captured before the drain is confirmed finished");
+    }
+
+    @Test
+    public void testWaitingTxnCapturesWatershedVersionAndTransitionsToRunning() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+
+        // First WAITING_TXN run allocates the watershed and exposes the shadow.
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        long visibleVersion = table.getPhysicalPartition(physicalPartitionId).getVisibleVersion();
+
+        // Prior loads are finished: the drain check returns true, so capture W = visible version and
+        // transition to RUNNING.
+        new MockUp<LakeRangeRewriteSchemaChangeJob>() {
+            @Mock
+            public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) {
+                return true;
+            }
+        };
+
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        Assertions.assertEquals(visibleVersion, job.getWatershedVersion(physicalPartitionId),
+                "W must equal the partition visible version captured after the drain");
+    }
+
+    @Test
+    public void testWaitingTxnAnalysisExceptionCancelsJob() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        new MockUp<LakeRangeRewriteSchemaChangeJob>() {
+            @Mock
+            public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) throws AnalysisException {
+                throw new AnalysisException("drain check failed");
+            }
+        };
+
+        Assertions.assertThrows(AlterCancelException.class, job::runWaitingTxnJob);
+    }
+
+    @Test
+    public void testReplayWaitingTxnReExposesShadowAfterWatershed() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        // Allocate the watershed and expose the shadow on the live job.
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        long watershedTxnId = job.getTransactionId().get();
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        // Snapshot the journaled (post-watershed) image.
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        // Simulate FE recovery from a pre-exposure image: strip the shadow meta, the exposed index,
+        // the inverted-index entries, and reset the table to NORMAL.
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        physicalPartition.deleteMaterializedIndexByMetaId(job.getShadowIndexMetaId());
+        table.deleteIndexInfo(SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getName());
+        for (long tabletId : shadowTabletIds) {
+            invertedIndex.deleteTablet(tabletId);
+        }
+        table.setState(OlapTable.OlapTableState.NORMAL);
+        Assertions.assertNull(physicalPartition.getLatestIndex(job.getShadowIndexMetaId()),
+                "precondition: shadow index exposure removed before replay");
+
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        // Replay re-exposes the shadow index to the partition catalog map with the journaled watershed.
+        MaterializedIndex reExposed = physicalPartition.getLatestIndex(job.getShadowIndexMetaId());
+        Assertions.assertNotNull(reExposed, "replay must re-expose the shadow index after the watershed");
+        Assertions.assertEquals(MaterializedIndex.IndexState.SHADOW, reExposed.getState());
+        Assertions.assertTrue(reExposed.visibleForTransaction(watershedTxnId));
+        Assertions.assertFalse(reExposed.visibleForTransaction(watershedTxnId - 1));
+
+        // A second replay is a no-op: the exposure is idempotent (no double-add crash).
+        inMemory.replay(replayed);
+        Assertions.assertNotNull(physicalPartition.getLatestIndex(job.getShadowIndexMetaId()));
+    }
+
+    /** Drive a job through PENDING + both WAITING_TXN runs into RUNNING with W captured. */
+    private LakeRangeRewriteSchemaChangeJob jobInRunning() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        // First WAITING_TXN run allocates the watershed and exposes the shadow.
+        job.runWaitingTxnJob();
+        // Second run: prior loads finished -> capture W and transition to RUNNING.
+        new MockUp<LakeRangeRewriteSchemaChangeJob>() {
+            @Mock
+            public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) {
+                return true;
+            }
+        };
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        return job;
+    }
+
+    /** A TransactionState reporting the given status, so the resume classifier can be driven. */
+    private static void mockTransactionStatus(TransactionStatus status) {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                if (status == null) {
+                    return null;
+                }
+                TransactionState state = new TransactionState();
+                state.setTransactionStatus(status);
+                return state;
+            }
+        };
+    }
+
+    /**
+     * A VISIBLE TransactionState for a shadow-rewrite txn, so the tightened resume classifier
+     * can be driven. The tighter gate only counts a VISIBLE txn as DONE when it is genuinely this job's
+     * shadow-rewrite carrier: {@code isShadowRewrite()} with a matching watershed txn id and alter version.
+     */
+    private static void mockShadowRewriteTransaction(long watershedTxnId, long alterVersion) {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                TransactionState state = new TransactionState(dbId, new ArrayList<>(), transactionId, "shadow",
+                        null, TransactionState.LoadJobSourceType.SHADOW_REWRITE,
+                        new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "127.0.0.1"),
+                        0L, 60_000L);
+                state.setTransactionStatus(TransactionStatus.VISIBLE);
+                InsertTxnCommitAttachment attachment = new InsertTxnCommitAttachment();
+                attachment.setShadowRewriteWatershedTxnId(watershedTxnId);
+                attachment.setShadowRewriteAlterVersion(alterVersion);
+                state.setTxnCommitAttachment(attachment);
+                return state;
+            }
+        };
+    }
+
+    @Test
+    public void testRunningBuildsShadowRewriteInsertAndJournalsTxnIdBeforeExecute() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        long watershed = job.getWatershedVersion(physicalPartitionId);
+        long watershedTxnId = job.getTransactionId().get();
+
+        // The seam captures the built InsertStmt + the scan-version override WITHOUT executing. It also
+        // asserts the rewrite txn id was journaled BEFORE the INSERT runs (an aborted id can't be reused).
+        AtomicReference<InsertStmt> captured = new AtomicReference<>();
+        AtomicReference<Long> overrideAtExecute = new AtomicReference<>();
+        AtomicReference<Long> journaledTxnIdAtExecute = new AtomicReference<>();
+        job.setRewriteExecutor((context, insertStmt) -> {
+            captured.set(insertStmt);
+            overrideAtExecute.set(context.getScanVersionOverride().get(physicalPartitionId));
+            journaledTxnIdAtExecute.set(job.getRewriteTxnId(physicalPartitionId));
+        });
+
+        job.runRunningJob();
+
+        InsertStmt stmt = captured.get();
+        Assertions.assertNotNull(stmt, "the rewrite INSERT must be built and handed to the executor");
+        Assertions.assertTrue(stmt.isShadowRewrite(), "INSERT must be marked shadow-rewrite");
+        Assertions.assertEquals(job.getShadowIndexMetaId(), stmt.getTargetWriteIndexId().longValue(),
+                "INSERT must write only the shadow index");
+        // The watershed carrier reaches the InsertStmt so the publish converts op_write -> op_schema_change@W.
+        Assertions.assertEquals(watershedTxnId, stmt.getShadowRewriteWatershedTxnId());
+        Assertions.assertEquals(watershed, stmt.getShadowRewriteAlterVersion());
+        // The read-pin is the scan override, NOT isVersionOverwrite.
+        Assertions.assertFalse(stmt.isVersionOverwrite(), "rewrite must not pin the commit version");
+        Assertions.assertEquals(watershed, overrideAtExecute.get().longValue(),
+                "the SELECT must read the watershed snapshot W");
+
+        // The rewrite txn id was journaled before the INSERT executed.
+        Assertions.assertNotNull(journaledTxnIdAtExecute.get(),
+                "rewrite txn id must be journaled BEFORE executing the INSERT");
+    }
+
+    @Test
+    public void testRunningResumePublishedSkipsAndTransitionsToFinishedRewriting() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+
+        // Seed a journaled rewrite txn id and report it VISIBLE AND a matching shadow-rewrite carrier
+        // (this job's watershed txn id + this partition's captured W): the partition is already rewritten.
+        job.setRewriteTxnIdForTest(physicalPartitionId, 123456L);
+        mockShadowRewriteTransaction(job.getTransactionId().get(), job.getWatershedVersion(physicalPartitionId));
+
+        AtomicReference<Boolean> executed = new AtomicReference<>(false);
+        job.setRewriteExecutor((context, insertStmt) -> executed.set(true));
+
+        job.runRunningJob();
+
+        Assertions.assertFalse(executed.get(), "a published partition must be skipped (no re-execute)");
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState(),
+                "all partitions published -> transition to FINISHED_REWRITING");
+    }
+
+    @Test
+    public void testRunningResumeVisibleForeignTxnReRunsNotSkips() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+
+        // The journaled id belongs to a VISIBLE txn that is NOT this job's shadow-rewrite carrier (a
+        // foreign load txn that slipped into the peek->begin window and was journaled by mistake before a
+        // leader crash). Under the tightened gate it must NOT skip (DONE) -> classify NEEDS_RUN and re-run.
+        job.setRewriteTxnIdForTest(physicalPartitionId, 123456L);
+        mockTransactionStatus(TransactionStatus.VISIBLE); // plain VISIBLE, no shadow-rewrite attachment
+
+        AtomicReference<Boolean> executed = new AtomicReference<>(false);
+        job.setRewriteExecutor((context, insertStmt) -> executed.set(true));
+
+        job.runRunningJob();
+
+        Assertions.assertTrue(executed.get(),
+                "a VISIBLE foreign (non-shadow-rewrite) txn must re-run the rewrite INSERT, not skip");
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState(),
+                "a mis-journaled foreign VISIBLE txn must not flip to FINISHED_REWRITING");
+    }
+
+    @Test
+    public void testRunningResumeVisibleShadowRewriteWithMismatchedWatershedReRuns() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+
+        // A VISIBLE shadow-rewrite txn whose watershed carrier does NOT match this job (wrong watershed
+        // txn id): it is not this job's rewrite -> classify NEEDS_RUN and re-run, never skip.
+        job.setRewriteTxnIdForTest(physicalPartitionId, 123456L);
+        mockShadowRewriteTransaction(job.getTransactionId().get() + 1, job.getWatershedVersion(physicalPartitionId));
+
+        AtomicReference<Boolean> executed = new AtomicReference<>(false);
+        job.setRewriteExecutor((context, insertStmt) -> executed.set(true));
+
+        job.runRunningJob();
+
+        Assertions.assertTrue(executed.get(),
+                "a VISIBLE shadow-rewrite txn with a mismatched watershed must re-run, not skip");
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+    }
+
+    @Test
+    public void testRunningResumeAbortedReRunsWithoutDroppingShadow() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        // Snapshot the shadow tablet ids so we can prove they are NOT dropped on a resume re-run.
+        List<Long> shadowTabletIdsBefore = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        // A prior attempt aborted: classify as NEEDS_RUN and re-run the SAME watershed-pinned INSERT.
+        job.setRewriteTxnIdForTest(physicalPartitionId, 999L);
+        mockTransactionStatus(TransactionStatus.ABORTED);
+
+        AtomicReference<Boolean> executed = new AtomicReference<>(false);
+        job.setRewriteExecutor((context, insertStmt) -> executed.set(true));
+
+        job.runRunningJob();
+
+        Assertions.assertTrue(executed.get(), "an aborted partition must re-run the rewrite INSERT");
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        // The shadow tablets are untouched: post-watershed double-writes are already published into them.
+        List<Long> shadowTabletIdsAfter = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+        Assertions.assertEquals(shadowTabletIdsBefore, shadowTabletIdsAfter,
+                "resume must never drop/rebuild the shadow tablets");
+    }
+
+    @Test
+    public void testRunningResumeCommittedWaitsWithoutExecuting() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+
+        // Committed-not-yet-visible: stay in RUNNING and do NOT re-execute (wait for publish).
+        job.setRewriteTxnIdForTest(physicalPartitionId, 777L);
+        mockTransactionStatus(TransactionStatus.COMMITTED);
+
+        AtomicReference<Boolean> executed = new AtomicReference<>(false);
+        job.setRewriteExecutor((context, insertStmt) -> executed.set(true));
+
+        job.runRunningJob();
+
+        Assertions.assertFalse(executed.get(), "a committed-not-visible partition must wait, not re-execute");
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState(),
+                "committed-not-visible -> stay in RUNNING");
+    }
+
+    /**
+     * Drive a job all the way into FINISHED_REWRITING: PENDING -> WAITING_TXN -> RUNNING, then report
+     * the per-partition rewrite txn published (a matching shadow-rewrite carrier) so RUNNING flips to
+     * FINISHED_REWRITING.
+     */
+    private LakeRangeRewriteSchemaChangeJob jobInFinishedRewriting() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        job.setRewriteTxnIdForTest(physicalPartitionId, 123456L);
+        mockShadowRewriteTransaction(job.getTransactionId().get(), job.getWatershedVersion(physicalPartitionId));
+        job.setRewriteExecutor((context, insertStmt) -> { });
+        job.runRunningJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        return job;
+    }
+
+    @Test
+    public void testReplayFirstFinishedRewritingEntryWithoutReservedCommitVersionDoesNotNpe() throws Exception {
+        // The RUNNING -> FINISHED_REWRITING transition (runRunningJob) journals a FINISHED_REWRITING entry
+        // BEFORE reserveCommitVersionIfNeeded runs, so that entry's partitionStates carry no commit
+        // version. Replaying it (leader failover / follower catch-up) reaches the FINISHED_REWRITING replay
+        // branch -> updateNextVersion, which must skip the unreserved partition instead of unboxing a null
+        // commit version (which previously NPE'd and aborted journal replay / leader recovery).
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        // Precondition: this is the first FINISHED_REWRITING entry's state -- no commit version reserved.
+        Assertions.assertTrue(job.commitVersionMapView().isEmpty(),
+                "precondition: the first FINISHED_REWRITING entry has no reserved commit version");
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        long nextVersionBefore = physicalPartition.getNextVersion();
+
+        // Serialize that null-commit-version FR image and replay it onto a fresh in-memory job, exactly as
+        // a follower would on journal catch-up.
+        String text = GsonUtils.GSON.toJson(job.copyForPersist());
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        Assertions.assertDoesNotThrow(() -> inMemory.replay(replayed),
+                "replaying the unreserved FINISHED_REWRITING entry must not NPE");
+
+        // Nothing was reserved, so replay must not bump nextVersion.
+        Assertions.assertEquals(nextVersionBefore, physicalPartition.getNextVersion(),
+                "replay of the unreserved FINISHED_REWRITING entry must not bump nextVersion");
+    }
+
+    @Test
+    public void testFinishedRewritingFlipsBaseToShadowAndResetsTable() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        long originBaseIndexMetaId = table.getBaseIndexMetaId();
+        long shadowIndexMetaId = job.getShadowIndexMetaId();
+        Assertions.assertNotEquals(originBaseIndexMetaId, shadowIndexMetaId);
+        // The shadow index is exposed (WAITING_TXN) and carries the new sort key (k2, k1).
+        MaterializedIndex shadowIndex = physicalPartition.getLatestIndex(shadowIndexMetaId);
+        Assertions.assertNotNull(shadowIndex);
+        List<Long> shadowTabletIds = shadowIndex.getTablets().stream().map(Tablet::getId).collect(Collectors.toList());
+        long visibleBeforeFlip = physicalPartition.getVisibleVersion();
+
+        // Stub the publish (no backend): the catalog flip is the unit under test, not the BE RPC.
+        job.setPublishExecutor(j -> true);
+
+        job.runFinishedRewritingJob();
+
+        // 1. State machine reached FINISHED and the table is back to NORMAL.
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+
+        // 2. The base index meta id now points at the shadow meta, which carries the new sortKeyIdxes (1,0).
+        Assertions.assertEquals(shadowIndexMetaId, table.getBaseIndexMetaId());
+        MaterializedIndexMeta baseMeta = table.getIndexMetaByMetaId(table.getBaseIndexMetaId());
+        Assertions.assertEquals(List.of(1, 0), baseMeta.getSortKeyIdxes(),
+                "the new base index meta must carry the reordered sort key");
+
+        // 3. The origin base index meta is gone; the partition's base index is now the K shadow tablets,
+        //    promoted to NORMAL, tiling the new key space.
+        Assertions.assertNull(table.getIndexMetaByMetaId(originBaseIndexMetaId),
+                "the origin base index meta must be dropped after the flip");
+        MaterializedIndex newBaseIndex = physicalPartition.getLatestBaseIndex();
+        Assertions.assertEquals(shadowIndexMetaId, newBaseIndex.getMetaId());
+        Assertions.assertEquals(MaterializedIndex.IndexState.NORMAL, newBaseIndex.getState());
+        Assertions.assertEquals(shadowTabletIds,
+                newBaseIndex.getTablets().stream().map(Tablet::getId).collect(Collectors.toList()),
+                "the flipped base index must hold exactly the K shadow tablets");
+
+        // 4. Range distribution columns are derived from the base index sort key, so they now follow the
+        //    reorder: (k2, k1).
+        List<String> distCols = com.starrocks.sql.common.MetaUtils.getRangeDistributionColumnNames(table);
+        Assertions.assertEquals(List.of("k2", "k1"), distCols,
+                "range distribution columns follow the flipped base sort key");
+
+        // 5. The partition visible version advanced by exactly one (commitVersion = visibleVersion + 1).
+        Assertions.assertEquals(visibleBeforeFlip + 1, physicalPartition.getVisibleVersion());
+
+        // 6. The GC pin set in RUNNING was released.
+        Assertions.assertEquals(0, physicalPartition.getMinRetainVersion());
+
+        // 7. The shadow tablets are registered in the inverted index under the new base index id.
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        for (long tabletId : shadowTabletIds) {
+            Assertions.assertNotNull(invertedIndex.getTabletMeta(tabletId));
+        }
+    }
+
+    @Test
+    public void testFinishedRewritingStaysWhenPublishNotDone() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+
+        // The async publish has not completed yet (mirrors AlterJobV2.publishVersion returning false on
+        // the first submit): the job must stay in FINISHED_REWRITING and re-check next tick, NOT flip.
+        job.setPublishExecutor(j -> false);
+
+        job.runFinishedRewritingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState(),
+                "an incomplete publish must leave the job in FINISHED_REWRITING");
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState(),
+                "the table must not flip to NORMAL until the publish completes");
+    }
+
+    @Test
+    public void testFinishedRewritingInactivatesDependentMaterializedViews() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+
+        // Capture the columns handed to the MV-inactivation path. For a sort-key reorder to (k2, k1)
+        // the affected set is the new sort-key columns (k1, k2).
+        AtomicReference<Set<String>> inactivatedColumns = new AtomicReference<>();
+        new MockUp<AlterMVJobExecutor>() {
+            @Mock
+            public void inactiveRelatedMaterializedViewsRecursive(OlapTable olapTable, Set<String> modifiedColumns) {
+                inactivatedColumns.set(modifiedColumns);
+            }
+        };
+
+        // A dependent async MV must exist for collectAffectedColumnsForRelatedMVs to compute a non-empty
+        // set; register one against the base table id.
+        table.addRelatedMaterializedView(new MvId(db.getId(), GlobalStateMgr.getCurrentState().getNextId()));
+
+        job.setPublishExecutor(j -> true);
+        job.runFinishedRewritingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assertions.assertNotNull(inactivatedColumns.get(),
+                "the flip must explicitly invoke dependent-MV inactivation");
+        Assertions.assertTrue(inactivatedColumns.get().contains("k1")
+                        && inactivatedColumns.get().contains("k2"),
+                "the new sort-key columns must be reported as affected for MV inactivation");
+    }
+
+    @Test
+    public void testBuildTabletRangesTilesNegInfToPosInf() {
+        // Empty boundaries -> one full-range tablet.
+        Assertions.assertEquals(1, LakeRangeRewriteSchemaChangeJob.buildTabletRanges(List.of()).size());
+        Assertions.assertTrue(LakeRangeRewriteSchemaChangeJob.buildTabletRanges(List.of())
+                .get(0).getRange().isAll());
+
+        // Two boundaries -> three tablets: (-inf, c1), [c1, c2), [c2, +inf).
+        List<Tuple> boundaries = List.of(keyTuple(10, 10), keyTuple(20, 20));
+        var ranges = LakeRangeRewriteSchemaChangeJob.buildTabletRanges(boundaries);
+        Assertions.assertEquals(3, ranges.size());
+        Assertions.assertTrue(ranges.get(0).getRange().isMinimum());
+        Assertions.assertFalse(ranges.get(0).getRange().isMaximum());
+        Assertions.assertTrue(ranges.get(2).getRange().isMaximum());
+        Assertions.assertFalse(ranges.get(2).getRange().isMinimum());
+    }
+
+    // ---- cancelImpl tests ---------------------------------------------------------------
+
+    /**
+     * Helper: assert the shadow index is fully cleaned up after a cancel — no catalog exposure, no
+     * inverted-index entries, table state NORMAL, GC pin released.
+     */
+    private void assertShadowCleanedUp(LakeRangeRewriteSchemaChangeJob job, long physicalPartitionId,
+                                       List<Long> shadowTabletIds) {
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        Assertions.assertNull(physicalPartition.getLatestIndex(job.getShadowIndexMetaId()),
+                "shadow index must be absent from the partition catalog map after cancel");
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState(),
+                "table state must be reset to NORMAL after cancel");
+        Assertions.assertEquals(0, physicalPartition.getMinRetainVersion(),
+                "GC pin must be released after cancel");
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        for (long tabletId : shadowTabletIds) {
+            Assertions.assertNull(invertedIndex.getTabletMeta(tabletId),
+                    "shadow tablet must be removed from the inverted index after cancel: " + tabletId);
+        }
+    }
+
+    @Test
+    public void testCancelInWaitingTxnDropsShadowAndResetsTable() throws Exception {
+        // Drive to WAITING_TXN (shadow exposed to catalog).
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        job.runWaitingTxnJob(); // allocates watershed + exposes shadow
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+        // Shadow is exposed.
+        Assertions.assertNotNull(table.getPhysicalPartition(physicalPartitionId)
+                .getLatestIndex(job.getShadowIndexMetaId()));
+
+        boolean cancelled = job.cancelImpl("test cancel in WAITING_TXN");
+
+        Assertions.assertTrue(cancelled, "cancelImpl must return true when not already cancelled/finished");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+        assertShadowCleanedUp(job, physicalPartitionId, shadowTabletIds);
+    }
+
+    @Test
+    public void testCancelInRunningAbortsRewriteTxnAndDropsShadow() throws Exception {
+        // Drive to RUNNING (watershed captured, shadow exposed).
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+
+        // Seed a journaled rewrite txn id (PREPARE state = in-flight); cancel must attempt to abort it.
+        long rewriteTxnId = 888L;
+        job.setRewriteTxnIdForTest(physicalPartitionId, rewriteTxnId);
+
+        AtomicReference<Long> abortedTxnId = new AtomicReference<>();
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                TransactionState state = new TransactionState();
+                state.setTransactionStatus(TransactionStatus.PREPARE);
+                return state;
+            }
+
+            @Mock
+            public void abortTransaction(long dbId, long transactionId, String reason)
+                    throws com.starrocks.common.StarRocksException {
+                abortedTxnId.set(transactionId);
+            }
+        };
+
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        boolean cancelled = job.cancelImpl("test cancel in RUNNING");
+
+        Assertions.assertTrue(cancelled);
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+        // The in-flight rewrite txn was aborted.
+        Assertions.assertEquals(rewriteTxnId, abortedTxnId.get(),
+                "cancelImpl must abort the in-flight rewrite txn");
+        assertShadowCleanedUp(job, physicalPartitionId, shadowTabletIds);
+    }
+
+    @Test
+    public void testCancelInRunningSkipsAbortForTerminalRewriteTxn() throws Exception {
+        // A rewrite txn that is already VISIBLE must NOT be re-aborted: abort on a VISIBLE txn would throw.
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        job.setRewriteTxnIdForTest(physicalPartitionId, 999L);
+
+        AtomicReference<Boolean> abortCalled = new AtomicReference<>(false);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                TransactionState state = new TransactionState();
+                state.setTransactionStatus(TransactionStatus.VISIBLE);
+                return state;
+            }
+
+            @Mock
+            public void abortTransaction(long dbId, long transactionId, String reason)
+                    throws com.starrocks.common.StarRocksException {
+                abortCalled.set(true);
+            }
+        };
+
+        job.cancelImpl("test cancel with VISIBLE rewrite txn");
+
+        Assertions.assertFalse(abortCalled.get(),
+                "cancelImpl must not abort a txn that is already in a terminal status");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+    }
+
+    @Test
+    public void testCancelInWaitingTxnBeforeShadowExposedIsClean() throws Exception {
+        // runPendingJob() transitions to WAITING_TXN but does not expose the shadow to the partition
+        // catalog map (exposure happens on the first runWaitingTxnJob run). So at this point the shadow
+        // meta and tablets are in the inverted index, but the shadow is NOT in the partition catalog map.
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+        // At this point the shadow IS in the inverted index but NOT in the partition catalog map.
+        Assertions.assertNull(table.getPhysicalPartition(physicalPartitionId)
+                .getLatestIndex(job.getShadowIndexMetaId()),
+                "precondition: shadow not yet in partition catalog map");
+
+        boolean cancelled = job.cancelImpl("cancel after PENDING");
+
+        Assertions.assertTrue(cancelled);
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+        assertShadowCleanedUp(job, physicalPartitionId, shadowTabletIds);
+    }
+
+    @Test
+    public void testNormalCancelInFinishedRewritingIsRefused() throws Exception {
+        // Drive into FINISHED_REWRITING and reserve the commit version (bumps nextVersion past it while
+        // visibleVersion is still commitVersion-1). A normal (non-force) cancel must be refused so the
+        // shadow is NOT dropped and no version hole is created; the flip should complete/retry instead.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        // First runFinishedRewritingJob run reserves the commit version and bumps nextVersion, but the
+        // stubbed publish reports "not done", so the job stays in FINISHED_REWRITING.
+        job.setPublishExecutor(j -> false);
+        job.runFinishedRewritingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        long nextVersionAfterReserve = physicalPartition.getNextVersion();
+        long visibleVersionAfterReserve = physicalPartition.getVisibleVersion();
+
+        boolean cancelled = job.cancelImpl("normal cancel in FINISHED_REWRITING");
+
+        Assertions.assertFalse(cancelled,
+                "a normal cancel from FINISHED_REWRITING while the table exists must be refused");
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState(),
+                "the job must stay in FINISHED_REWRITING after a refused normal cancel");
+        // The shadow must NOT have been dropped and the version chain must be intact.
+        Assertions.assertNotNull(physicalPartition.getLatestIndex(job.getShadowIndexMetaId()),
+                "the shadow index must not be dropped by a refused normal cancel");
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState(),
+                "the table must remain in SCHEMA_CHANGE after a refused normal cancel");
+        Assertions.assertEquals(nextVersionAfterReserve, physicalPartition.getNextVersion());
+        Assertions.assertEquals(visibleVersionAfterReserve, physicalPartition.getVisibleVersion());
+    }
+
+    @Test
+    public void testForceCancelInFinishedRewritingAdvancesVisibleVersionThenDropsShadow() throws Exception {
+        // Drive into FINISHED_REWRITING and reserve the commit version (the hole scenario: nextVersion is
+        // commitVersion+1 while visibleVersion is commitVersion-1). A force cancel must no-op publish the
+        // visible/origin indices to commitVersion, advance FE visibleVersion to commitVersion (closing the
+        // hole), then drop the shadow and reach CANCELLED.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        job.setPublishExecutor(j -> false);
+        job.runFinishedRewritingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        long visibleBeforeForceCancel = physicalPartition.getVisibleVersion();
+        long commitVersion = visibleBeforeForceCancel + 1;
+        Assertions.assertEquals(commitVersion + 1, physicalPartition.getNextVersion(),
+                "precondition: nextVersion was bumped past commitVersion, leaving a hole");
+
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        // Stub the no-op publish seam (no backend): capture that the force-cancel requested the version
+        // advance via Utils.noOpPublishForForceSkip and report success.
+        AtomicReference<Long> publishedCommitVersion = new AtomicReference<>();
+        new MockUp<com.starrocks.lake.Utils>() {
+            @Mock
+            public boolean noOpPublishForForceSkip(long jobId, String reason, long watershedTxnId, long watershedGtid,
+                                                   java.util.Map<Long, Long> commitVersionMap,
+                                                   java.util.Map<Long, List<Tablet>> tabletsByPartition,
+                                                   com.starrocks.warehouse.cngroup.ComputeResource cr,
+                                                   boolean useAggregatePublish) {
+                publishedCommitVersion.set(commitVersionMap.get(physicalPartitionId));
+                return true;
+            }
+        };
+
+        boolean cancelled = job.cancelImpl("force cancel in FINISHED_REWRITING", true);
+
+        Assertions.assertTrue(cancelled, "a force cancel from FINISHED_REWRITING must proceed");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+        // The no-op publish was requested for the reserved commit version.
+        Assertions.assertEquals(commitVersion, publishedCommitVersion.get().longValue(),
+                "force cancel must no-op publish the reserved commit version");
+        // The FE visible version advanced to commitVersion: no hole (nextVersion == visibleVersion + 1).
+        Assertions.assertEquals(commitVersion, physicalPartition.getVisibleVersion(),
+                "force cancel must advance visibleVersion to commitVersion (closing the hole)");
+        Assertions.assertEquals(physicalPartition.getVisibleVersion() + 1, physicalPartition.getNextVersion(),
+                "after force cancel the version chain must be dense (no hole)");
+        // The shadow was then dropped.
+        assertShadowCleanedUp(job, physicalPartitionId, shadowTabletIds);
+    }
+
+    @Test
+    public void testForceCancelReplayAdvancesVisibleVersion() throws Exception {
+        // Regression: forceSkippedAtCommitted was not copied in replay()'s field-copy block,
+        // so a follower replaying a force-cancelled job (recovered from a pre-cancel image) saw
+        // forceSkippedAtCommitted=false, skipped advanceVisibleVersionForForceSkip, and left
+        // visibleVersion=commitVersion-1 — a version hole against BE metadata already at commitVersion.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        // Reserve the commit version without actually flipping: setPublishExecutor returns false so
+        // runFinishedRewritingJob bumps nextVersion (reserves the slot) but stays in FINISHED_REWRITING.
+        job.setPublishExecutor(j -> false);
+        job.runFinishedRewritingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        long commitVersion = physicalPartition.getVisibleVersion() + 1;
+
+        // Stub the no-op publish so the force-cancel succeeds without a backend.
+        new MockUp<com.starrocks.lake.Utils>() {
+            @Mock
+            public boolean noOpPublishForForceSkip(long jobId, String reason, long watershedTxnId, long watershedGtid,
+                                                   java.util.Map<Long, Long> commitVersionMap,
+                                                   java.util.Map<Long, List<Tablet>> tabletsByPartition,
+                                                   com.starrocks.warehouse.cngroup.ComputeResource cr,
+                                                   boolean useAggregatePublish) {
+                return true;
+            }
+        };
+
+        // Run the live force-cancel; the persisted copy must carry the marker.
+        Assertions.assertTrue(job.cancelImpl("force-cancel-replay-test", /*force=*/ true));
+        AlterJobV2 persistCopy = job.copyForPersist();
+        Assertions.assertTrue(persistCopy.isForceSkippedAtCommitted(),
+                "copyForPersist must carry forceSkippedAtCommitted=true after a force cancel");
+
+        // Simulate FE recovery from a pre-cancel image: build an in-memory job WITHOUT the marker
+        // and reset the partition's visibleVersion back to commitVersion-1 (not yet bumped).
+        LakeRangeRewriteSchemaChangeJob staleInMemory = new LakeRangeRewriteSchemaChangeJob(job);
+        staleInMemory.forceSkippedAtCommitted = false;
+        staleInMemory.setJobState(AlterJobV2.JobState.FINISHED_REWRITING);
+        physicalPartition.setVisibleVersion(commitVersion - 1, 0);
+
+        // Replay: the field-copy block must propagate forceSkippedAtCommitted so the CANCELLED
+        // branch applies advanceVisibleVersionForForceSkip and bumps visibleVersion to commitVersion.
+        staleInMemory.replay(persistCopy);
+
+        Assertions.assertTrue(staleInMemory.isForceSkippedAtCommitted(),
+                "replay must copy forceSkippedAtCommitted from the persisted entry");
+        Assertions.assertEquals(commitVersion, physicalPartition.getVisibleVersion(),
+                "replay must advance visibleVersion to commitVersion when forceSkippedAtCommitted=true");
+    }
+
+    @Test
+    public void testFlipPublishIssuesShadowRewritePublishPerPartition() throws Exception {
+        // The flip publishes shadow tablets through the generic Utils.publishVersion /
+        // createSubRequestForAggregatePublish, under a TXN_SHADOW_REWRITE TxnInfoPB whose txnId is that
+        // partition's journaled rewriteTxnId (not the watershed txn id) and whose shadowRewriteAlterVersion
+        // is the watershed W. The shadow tablets travel in the request's ordinary tabletIds.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        long watershedVersion = job.getWatershedVersion(physicalPartitionId);
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        // Intercept Utils calls so we can verify the shape without requiring a live BE.
+        List<Long> publishedShadowTabletIds = new ArrayList<>();
+        AtomicReference<Long> capturedRewriteTxnId = new AtomicReference<>();
+        AtomicReference<Long> capturedAlterVersion = new AtomicReference<>();
+        new MockUp<Utils>() {
+            // Non-bundling path: both shadow and origin tablets go through the generic publishVersion.
+            // The shadow publish is the one carrying a TXN_SHADOW_REWRITE TxnInfoPB; the origin no-op
+            // publish carries TXN_EMPTY and is not under test here.
+            @Mock
+            public void publishVersion(List<Tablet> tablets, com.starrocks.proto.TxnInfoPB txnInfo,
+                    long baseVersion, long newVersion, ComputeResource cr,
+                    boolean useAggregatePublish) {
+                if (txnInfo.txnType == com.starrocks.proto.TxnTypePB.TXN_SHADOW_REWRITE) {
+                    tablets.forEach(t -> publishedShadowTabletIds.add(t.getId()));
+                    capturedRewriteTxnId.set(txnInfo.txnId);
+                    capturedAlterVersion.set(txnInfo.shadowRewriteAlterVersion);
+                }
+            }
+
+            // Bundling path: both shadow and origin tablets go through the generic
+            // createSubRequestForAggregatePublish. The shadow sub-request carries a TXN_SHADOW_REWRITE txn.
+            @Mock
+            public void createSubRequestForAggregatePublish(List<Tablet> tablets,
+                    List<com.starrocks.proto.TxnInfoPB> txnInfos, long baseVersion, long newVersion,
+                    java.util.Map<com.starrocks.system.ComputeNode, List<Long>> nodeToTablets,
+                    ComputeResource cr,
+                    com.starrocks.proto.AggregatePublishVersionRequest req) {
+                com.starrocks.proto.TxnInfoPB txnInfo = txnInfos.get(0);
+                if (txnInfo.txnType == com.starrocks.proto.TxnTypePB.TXN_SHADOW_REWRITE) {
+                    tablets.forEach(t -> publishedShadowTabletIds.add(t.getId()));
+                    capturedRewriteTxnId.set(txnInfo.txnId);
+                    capturedAlterVersion.set(txnInfo.shadowRewriteAlterVersion);
+                }
+            }
+
+            @Mock
+            public void sendAggregatePublishVersionRequest(
+                    com.starrocks.proto.AggregatePublishVersionRequest req, long baseVersion,
+                    ComputeResource cr, java.util.Map<Long, Double> compactionScores,
+                    java.util.Map<Long, Long> tabletRowNum,
+                    List<com.starrocks.proto.VectorIndexBuildInfoPB> vectorInfos) {
+                // no-op: aggregate publish RPC is not under test here
+            }
+        };
+
+        // Drive the flip through the REAL lakePublishVersion (reserve commit version, then publish).
+        job.setPublishExecutor(LakeOnlineRewriteJobBase::lakePublishVersion);
+        job.runFinishedRewritingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+
+        // The flip must have published the shadow tablets under a TXN_SHADOW_REWRITE txn.
+        Assertions.assertFalse(publishedShadowTabletIds.isEmpty(),
+                "the flip must publish shadow tablets (carried in tabletIds under a TXN_SHADOW_REWRITE txn)");
+
+        // Every shadow tablet must be published.
+        Assertions.assertTrue(publishedShadowTabletIds.containsAll(shadowTabletIds),
+                "the flip must publish every shadow tablet");
+
+        // The txnId must be the journaled per-partition rewrite txn id (seeded as 123456L).
+        Assertions.assertEquals(123456L, capturedRewriteTxnId.get().longValue(),
+                "SHADOW_REWRITE txnId must be the journaled per-partition rewrite txn id");
+
+        // The alterVersion must be the captured watershed version W.
+        Assertions.assertEquals(watershedVersion, capturedAlterVersion.get().longValue(),
+                "SHADOW_REWRITE alterVersion must be the captured watershed version W");
+    }
+
+    @Test
+    public void testCancelFinishedJobIsNoOp() throws Exception {
+        // Drive all the way to FINISHED, then attempt to cancel.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        job.setPublishExecutor(j -> true);
+        job.runFinishedRewritingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+
+        boolean cancelled = job.cancelImpl("attempt to cancel a finished job");
+
+        Assertions.assertFalse(cancelled, "cancelImpl must return false (no-op) when job is FINISHED");
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState(),
+                "job state must remain FINISHED after no-op cancel");
+    }
+
+    @Test
+    public void testCancelAlreadyCancelledJobIsNoOp() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        job.cancelImpl("first cancel");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+
+        boolean secondCancel = job.cancelImpl("second cancel");
+
+        Assertions.assertFalse(secondCancel, "cancelImpl must return false (no-op) when already CANCELLED");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+    }
+
+    @Test
+    public void testReplayCancelledRemovesShadow() throws Exception {
+        // Drive to WAITING_TXN (shadow exposed), then cancel, then replay the CANCELLED log entry.
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(diverseSample()));
+        job.runPendingJob();
+        job.runWaitingTxnJob();
+        job.cancelImpl("replay test cancel");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        List<Long> shadowTabletIds = new ArrayList<>(
+                job.getShadowIndex(physicalPartitionId).getTablets()
+                        .stream().map(Tablet::getId).collect(Collectors.toList()));
+
+        // Serialize the CANCELLED state, then manually re-add some shadow state (simulating a follower
+        // that had not yet applied the cancel) and replay onto a fresh in-memory job.
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        // Simulate the follower seeing a pre-cancel state: re-expose the shadow index + add tablets back.
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        // Restore shadow exposure (replaying from a prior WAITING_TXN snapshot).
+        MaterializedIndex shadowIdx = job.getShadowIndex(physicalPartitionId);
+        physicalPartition.createRollupIndex(shadowIdx);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        physicalPartition.setMinRetainVersion(5L);
+        for (long tabletId : shadowTabletIds) {
+            invertedIndex.addTablet(tabletId,
+                    new TabletMeta(db.getId(), table.getId(),
+                            physicalPartitionId, job.getShadowIndexMetaId(),
+                            com.starrocks.thrift.TStorageMedium.HDD, true));
+        }
+
+        // Replay the CANCELLED log entry: must undo all shadow state.
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        assertShadowCleanedUp(inMemory, physicalPartitionId, shadowTabletIds);
+
+        // A second replay is a no-op: removing already-absent shadow state must not crash.
+        inMemory.replay(replayed);
+        assertShadowCleanedUp(inMemory, physicalPartitionId, shadowTabletIds);
+    }
+
+    // ---- cross-state replay idempotency ------------------------------------------------
+    //
+    // Replay must, for every journaled state, reconstruct the leader's catalog on the follower and be
+    // safe to apply twice (a follower can re-see the same log entry across a restart). WAITING_TXN and
+    // CANCELLED are covered above (testReplayWaitingTxn*, testReplayCancelledRemovesShadow); PENDING is
+    // covered above too (testReplayPendingDoesNotInstallShadowMeta — a PENDING entry has no durable shadow
+    // state, so replay installs nothing); the tests below cover the remaining journaled states RUNNING,
+    // FINISHED_REWRITING and FINISHED.
+
+    @Test
+    public void testReplayRunningReconstructsWaitingTxnCatalogStateAndIsIdempotent() throws Exception {
+        // RUNNING has the same durable catalog state as WAITING_TXN (shadow exposed with
+        // visibleTxnId=watershed); the in-flight rewrite txns are resumed by the live scheduler, never by
+        // replay. So replaying a RUNNING image reconstructs the WAITING_TXN catalog state idempotently and
+        // never re-runs the rewrite INSERT.
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        long watershedTxnId = job.getTransactionId().get();
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        List<Long> shadowTabletIds = job.getShadowIndex(physicalPartitionId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        // Simulate FE recovery from a pre-exposure image: strip the shadow meta, the exposed index, the
+        // inverted-index entries, and reset the table to NORMAL.
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        physicalPartition.deleteMaterializedIndexByMetaId(job.getShadowIndexMetaId());
+        table.deleteIndexInfo(SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getName());
+        for (long tabletId : shadowTabletIds) {
+            invertedIndex.deleteTablet(tabletId);
+        }
+        table.setState(OlapTable.OlapTableState.NORMAL);
+
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        // The rewrite executor must never run during replay; fail loudly if it is invoked.
+        inMemory.setRewriteExecutor((context, insertStmt) ->
+                Assertions.fail("replay must not re-run the rewrite INSERT"));
+        inMemory.replay(replayed);
+
+        // The shadow catalog state is reconstructed: meta registered, tablets in the inverted index,
+        // table in SCHEMA_CHANGE, shadow index re-exposed with visibleTxnId=watershed.
+        Assertions.assertNotNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
+                "replay must re-register the shadow meta");
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+        MaterializedIndex reExposed = physicalPartition.getLatestIndex(job.getShadowIndexMetaId());
+        Assertions.assertNotNull(reExposed, "RUNNING replay must re-expose the shadow index");
+        Assertions.assertEquals(MaterializedIndex.IndexState.SHADOW, reExposed.getState());
+        Assertions.assertTrue(reExposed.visibleForTransaction(watershedTxnId));
+        Assertions.assertFalse(reExposed.visibleForTransaction(watershedTxnId - 1));
+        for (long tabletId : shadowTabletIds) {
+            Assertions.assertNotNull(invertedIndex.getTabletMeta(tabletId),
+                    "RUNNING replay must re-add the shadow tablets to the inverted index");
+        }
+
+        // A second replay is a no-op: no double-add of the exposed index/tablets/meta.
+        inMemory.replay(replayed);
+        Assertions.assertNotNull(physicalPartition.getLatestIndex(job.getShadowIndexMetaId()));
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+    }
+
+    /**
+     * Drive a job into FINISHED_REWRITING with the per-partition commit version reserved (nextVersion
+     * bumped, visibleVersion still commitVersion-1) but the publish not yet completed, so the catalog is
+     * still in the pre-flip state. This is the catalog state a follower holds when it replays a
+     * FINISHED_REWRITING (and, after we relabel the journaled state, FINISHED) log entry.
+     */
+    private LakeRangeRewriteSchemaChangeJob jobInFinishedRewritingWithCommitReserved() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewriting();
+        job.setPublishExecutor(j -> false);
+        job.runFinishedRewritingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        return job;
+    }
+
+    @Test
+    public void testReplayFinishedRewritingBumpsNextVersionAndIsIdempotent() throws Exception {
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewritingWithCommitReserved();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        long commitVersion = physicalPartition.getNextVersion() - 1;
+        long visibleVersion = physicalPartition.getVisibleVersion();
+
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        // Simulate a follower recovering from a pre-reserve image: roll nextVersion back to commitVersion
+        // (the leader bumped it past commitVersion when it reserved). Replay must re-apply that bump.
+        physicalPartition.setNextVersion(commitVersion);
+
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        Assertions.assertEquals(commitVersion + 1, physicalPartition.getNextVersion(),
+                "replay must bump nextVersion past the reserved commit version");
+        Assertions.assertEquals(visibleVersion, physicalPartition.getVisibleVersion(),
+                "FINISHED_REWRITING replay must not advance visibleVersion (the flip has not happened)");
+
+        // A second replay is a no-op: no double version bump.
+        inMemory.replay(replayed);
+        Assertions.assertEquals(commitVersion + 1, physicalPartition.getNextVersion(),
+                "a second replay must not bump nextVersion again");
+    }
+
+    @Test
+    public void testReplayFinishedRewritingReleasesWatershedGcPin() throws Exception {
+        // On a journal-replay failover, RUNNING replay re-pins minRetainVersion=W (reapplyWatershedGcPin);
+        // then the FINISHED_REWRITING entry replays. The live reserve released that pin when it reserved
+        // the commit version, so replay of the post-reserve FINISHED_REWRITING entry must release it too,
+        // or vacuum can never reclaim versions below W on the recovered leader.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewritingWithCommitReserved();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        // Simulate the journal-replay-failover state: the RUNNING entry's replay left the pin set
+        // (minRetainVersion is transient, re-derived by reapplyWatershedGcPin, never serialized).
+        physicalPartition.setMinRetainVersion(5L);
+        Assertions.assertEquals(5L, physicalPartition.getMinRetainVersion());
+
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        Assertions.assertEquals(0, physicalPartition.getMinRetainVersion(),
+                "FINISHED_REWRITING replay must release the watershed GC pin once the commit version is reserved");
+
+        // Idempotent: a second replay keeps it released.
+        physicalPartition.setMinRetainVersion(5L);
+        inMemory.replay(replayed);
+        Assertions.assertEquals(0, physicalPartition.getMinRetainVersion());
+    }
+
+    @Test
+    public void testReplayFinishedFlipsBaseToShadowAndIsIdempotent() throws Exception {
+        // Drive into FINISHED_REWRITING with the commit version reserved (catalog still pre-flip), then
+        // relabel the journaled state to FINISHED so replay applies the flip the leader would have.
+        LakeRangeRewriteSchemaChangeJob job = jobInFinishedRewritingWithCommitReserved();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+
+        long originBaseIndexMetaId = table.getBaseIndexMetaId();
+        long shadowIndexMetaId = job.getShadowIndexMetaId();
+        long visibleBeforeFlip = physicalPartition.getVisibleVersion();
+        List<Long> shadowTabletIds = physicalPartition.getLatestIndex(shadowIndexMetaId).getTablets()
+                .stream().map(Tablet::getId).collect(Collectors.toList());
+
+        // Journal a FINISHED image (finishedTimeMs must be set so visualiseShadowIndex stamps the version).
+        job.setJobState(AlterJobV2.JobState.FINISHED);
+        job.setFinishedTimeMs(System.currentTimeMillis());
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        // The flip was applied: base meta repointed at the shadow (new sort key), origin meta dropped,
+        // table back to NORMAL, visibleVersion advanced by one.
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Assertions.assertEquals(shadowIndexMetaId, table.getBaseIndexMetaId());
+        Assertions.assertNull(table.getIndexMetaByMetaId(originBaseIndexMetaId),
+                "the origin base index meta must be dropped after the replayed flip");
+        Assertions.assertEquals(List.of(1, 0),
+                table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSortKeyIdxes());
+        Assertions.assertEquals(visibleBeforeFlip + 1, physicalPartition.getVisibleVersion());
+        MaterializedIndex newBaseIndex = physicalPartition.getLatestBaseIndex();
+        Assertions.assertEquals(shadowIndexMetaId, newBaseIndex.getMetaId());
+        Assertions.assertEquals(MaterializedIndex.IndexState.NORMAL, newBaseIndex.getState());
+
+        // A second replay is a no-op: the origin meta is gone, so the guard skips the flip (no double-flip,
+        // no double version bump).
+        inMemory.replay(replayed);
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Assertions.assertEquals(shadowIndexMetaId, table.getBaseIndexMetaId());
+        Assertions.assertEquals(visibleBeforeFlip + 1, physicalPartition.getVisibleVersion(),
+                "a second replay must not advance the visible version again");
+        for (long tabletId : shadowTabletIds) {
+            Assertions.assertNotNull(invertedIndexTabletMeta(tabletId),
+                    "the flipped base index tablets must remain registered");
+        }
+    }
+
+    private static TabletMeta invertedIndexTabletMeta(long tabletId) {
+        return GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletMeta(tabletId);
+    }
+
+    // ---- getInfo (SHOW ALTER TABLE COLUMN) ---------------------------------------------
+
+    @Test
+    public void testGetInfoEmitsRowForRunningJob() throws Exception {
+        // A RUNNING job must be visible in SHOW ALTER TABLE COLUMN: getInfo emits one display row
+        // carrying the jobId, table name, the running state, and the watershed txn id.
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+
+        List<List<Comparable>> infos = new ArrayList<>();
+        job.getInfo(infos);
+
+        Assertions.assertEquals(1, infos.size(), "getInfo must emit exactly one row for the single shadow index");
+        List<Comparable> row = infos.get(0);
+        // Mirrors LakeTableSchemaChangeJob.getInfo: 14 columns matching SchemaChangeProcDir.TITLE_NAMES.
+        Assertions.assertEquals(14, row.size(), "row must carry the full SHOW ALTER TABLE COLUMN column set");
+        Assertions.assertEquals(job.getJobId(), row.get(0), "first column must be the jobId");
+        Assertions.assertEquals(table.getName(), row.get(1), "second column must be the table name");
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING.name(), row.get(9),
+                "the state column must report RUNNING");
+        Assertions.assertEquals(job.getTransactionId().get(), row.get(8),
+                "the watershed txn id column must carry the allocated watershed");
+    }
+
+    // ---- FIX: durable GC retention pin restored on RUNNING replay ----------------------
+
+    @Test
+    public void testReplayRunningRestoresWatershedGcPin() throws Exception {
+        // The watershed GC pin (minRetainVersion) is NOT persisted, so a follower that takes over after
+        // RUNNING was journaled must re-apply it on replay, or vacuum could GC the exact snapshot W the
+        // rewrite SELECT reads.
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        long watershed = job.getWatershedVersion(physicalPartitionId);
+        Assertions.assertTrue(watershed > 0, "precondition: a watershed version was captured");
+
+        AlterJobV2 persistCopy = job.copyForPersist();
+        String text = GsonUtils.GSON.toJson(persistCopy);
+
+        // Simulate a follower recovering from an image where minRetainVersion reset to 0 (not persisted).
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        physicalPartition.setMinRetainVersion(0);
+        Assertions.assertEquals(0, physicalPartition.getMinRetainVersion(),
+                "precondition: the GC pin reset to 0 on the follower image");
+
+        LakeRangeRewriteSchemaChangeJob replayed =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        LakeRangeRewriteSchemaChangeJob inMemory =
+                (LakeRangeRewriteSchemaChangeJob) GsonUtils.GSON.fromJson(text, AlterJobV2.class);
+        inMemory.replay(replayed);
+
+        Assertions.assertEquals(watershed, physicalPartition.getMinRetainVersion(),
+                "RUNNING replay must restore the watershed GC pin to W");
+
+        // A second replay is a no-op (the pin is already W).
+        inMemory.replay(replayed);
+        Assertions.assertEquals(watershed, physicalPartition.getMinRetainVersion());
+    }
+
+    // ---- FIX: 1:1 logical-to-physical partition guard in RUNNING -----------------------
+
+    @Test
+    public void testRunningRequiresOneToOneLogicalPhysicalPartition() throws Exception {
+        // Range-distribution OLAP tables are 1:1 logical:physical, so the watershed-pinned rewrite (which
+        // scans the logical parent but pins only one physical partition) is correct. Assert the guard sees
+        // the 1:1 mapping and the rewrite proceeds for the default table.
+        LakeRangeRewriteSchemaChangeJob job = jobInRunning();
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+        Partition logicalParent = table.getPartition(physicalPartition.getParentId());
+        Assertions.assertEquals(1, logicalParent.getSubPartitions().size(),
+                "precondition: a range table's logical partition has exactly one physical partition");
+
+        // The rewrite builds the INSERT (the 1:1 guard does not throw) and stays in RUNNING after kicking
+        // off one partition's rewrite.
+        AtomicReference<InsertStmt> captured = new AtomicReference<>();
+        job.setRewriteExecutor((context, insertStmt) -> captured.set(insertStmt));
+        job.runRunningJob();
+
+        Assertions.assertNotNull(captured.get(),
+                "the 1:1 guard must pass and the rewrite INSERT must be built");
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+    }
+
+    // ---- empty-partition characterization (NOTE in the brief) --------------------------
+
+    @Test
+    public void testEmptyPartitionRewriteFlowsThroughStateMachineToFinished() throws Exception {
+        // Characterize the CURRENT behavior for an EMPTY partition (empty sample -> K=1 single full-range
+        // shadow tablet). The job flows PENDING -> WAITING_TXN -> RUNNING -> FINISHED_REWRITING -> FINISHED
+        // and the flip swaps the base index for the single-tablet shadow. The deeper empty-DATA handling
+        // (an empty-result INSERT producing zero PartitionCommitInfos, so the publish has no
+        // op_schema_change@W to apply) is BE-owned and gated on cluster e2e; here we only document that the
+        // FE state machine completes without error and produces the expected single-tablet shadow.
+        LakeRangeRewriteSchemaChangeJob job = newJob(stubSampler(List.of()));
+        job.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+
+        long physicalPartitionId = table.getPhysicalPartitions().iterator().next().getId();
+        // Empty partition -> a single full-range shadow tablet.
+        Assertions.assertEquals(1, job.getTabletCount(physicalPartitionId));
+
+        // Allocate watershed + expose shadow, then drain finished -> capture W -> RUNNING.
+        job.runWaitingTxnJob();
+        new MockUp<LakeRangeRewriteSchemaChangeJob>() {
+            @Mock
+            public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) {
+                return true;
+            }
+        };
+        job.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+
+        // Report the rewrite txn as a published shadow-rewrite carrier (the empty-result INSERT's commit,
+        // as the BE converter would mark it) so RUNNING flips to FINISHED_REWRITING.
+        job.setRewriteTxnIdForTest(physicalPartitionId, 424242L);
+        mockShadowRewriteTransaction(job.getTransactionId().get(), job.getWatershedVersion(physicalPartitionId));
+        job.setRewriteExecutor((context, insertStmt) -> { });
+        job.runRunningJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+
+        // Flip completes: table back to NORMAL, base meta repointed at the single-tablet shadow.
+        long shadowIndexMetaId = job.getShadowIndexMetaId();
+        job.setPublishExecutor(j -> true);
+        job.runFinishedRewritingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Assertions.assertEquals(shadowIndexMetaId, table.getBaseIndexMetaId());
+        MaterializedIndex newBaseIndex = table.getPhysicalPartition(physicalPartitionId).getLatestBaseIndex();
+        Assertions.assertEquals(1, newBaseIndex.getTablets().size(),
+                "an empty partition flips to a single full-range tablet");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterJobV2BuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterJobV2BuilderTest.java
@@ -1,0 +1,223 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.RangeDistributionInfo;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.NextIdLog;
+import com.starrocks.persist.WALApplier;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests for {@link LakeTableAlterJobV2Builder#buildRangeShadowIndex}.
+ */
+public class LakeTableAlterJobV2BuilderTest {
+
+    private static final int K = 3;
+
+    private LakeTable table;
+    private PhysicalPartition physicalPartition;
+    private long partitionId;
+    private long physicalPartitionId;
+
+    // Tablet ids that the mocked createShards will return.
+    private final List<Long> allocatedShardIds = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        allocatedShardIds.clear();
+
+        // Prevent getNextId from trying to persist to an absent EditLog.
+        new MockUp<EditLog>() {
+            @Mock
+            public void logSaveNextId(long nextId, WALApplier applier) {
+                applier.apply(new NextIdLog(nextId));
+            }
+        };
+        GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
+        GlobalStateMgr.getCurrentState().setStarOSAgent(new StarOSAgent());
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(int shardCount, FilePathInfo path, FileCacheInfo cache, long groupId,
+                                           List<Long> matchShardIds, Map<String, String> properties,
+                                           ComputeResource computeResource)
+                    throws DdlException {
+                List<Long> ids = new ArrayList<>();
+                for (int i = 0; i < shardCount; i++) {
+                    ids.add(GlobalStateMgr.getCurrentState().getNextId());
+                }
+                allocatedShardIds.addAll(ids);
+                return ids;
+            }
+        };
+
+        long dbId = GlobalStateMgr.getCurrentState().getNextId();
+        long tableId = GlobalStateMgr.getCurrentState().getNextId();
+        partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        long indexId = GlobalStateMgr.getCurrentState().getNextId();
+
+        Column c0 = new Column("c0", IntegerType.INT, true);
+        DistributionInfo dist = new RangeDistributionInfo();
+        PartitionInfo partitionInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+
+        table = new LakeTable(tableId, "t0", Collections.singletonList(c0), KeysType.DUP_KEYS,
+                partitionInfo, dist);
+        table.setTableProperty(new TableProperty(new HashMap<>()));
+
+        // Provide a minimal FilePathInfo so getPartitionFilePathInfo returns non-null.
+        FilePathInfo.Builder fpBuilder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = fpBuilder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3Builder = fsBuilder.getS3FsInfoBuilder();
+        s3Builder.setBucket("test-bucket");
+        s3Builder.setRegion("us-east-1");
+        fsBuilder.setS3FsInfo(s3Builder.build());
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fpBuilder.setFsInfo(fsBuilder.build());
+        fpBuilder.setFullPath("s3://test-bucket/test-table");
+        table.setStorageInfo(fpBuilder.build(), new DataCacheInfo(false, false));
+
+        table.setIndexMeta(indexId, "t0", Collections.singletonList(c0), 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS);
+        table.setBaseIndexMetaId(indexId);
+
+        MaterializedIndex baseIndex = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(partitionId, physicalPartitionId, "p0", baseIndex, dist);
+        table.addPartition(partition);
+        physicalPartition = partition.getDefaultPhysicalPartition();
+    }
+
+    /**
+     * Builds a K-tablet shadow index and checks that:
+     * 1. The index state is SHADOW.
+     * 2. The index contains exactly K tablets.
+     * 3. Each tablet's range equals the corresponding input range.
+     * 4. createShards was called with matchShardIds == null (verified via the mock capturing the call).
+     */
+    @Test
+    public void testBuildRangeShadowIndex() throws DdlException {
+        long shadowIndexId = 9001L;
+        long shardGroupId = 500L;
+
+        List<TabletRange> ranges = new ArrayList<>();
+        for (int i = 0; i < K; i++) {
+            ranges.add(new TabletRange());
+        }
+
+        AtomicBoolean matchShardIdsWasNull = new AtomicBoolean(false);
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(int shardCount, FilePathInfo path, FileCacheInfo cache, long groupId,
+                                           List<Long> matchShardIds, Map<String, String> properties,
+                                           ComputeResource computeResource)
+                    throws DdlException {
+                matchShardIdsWasNull.set(matchShardIds == null);
+                List<Long> ids = new ArrayList<>();
+                for (int i = 0; i < shardCount; i++) {
+                    ids.add(GlobalStateMgr.getCurrentState().getNextId());
+                }
+                allocatedShardIds.addAll(ids);
+                return ids;
+            }
+        };
+        allocatedShardIds.clear();
+
+        MaterializedIndex shadowIndex = LakeTableAlterJobV2Builder.buildRangeShadowIndex(
+                1L /* dbId */,
+                table,
+                physicalPartition,
+                shadowIndexId,
+                K,
+                ranges,
+                shardGroupId,
+                WarehouseComputeResource.of(0L));
+
+        // 1. State must be SHADOW.
+        Assertions.assertEquals(MaterializedIndex.IndexState.SHADOW, shadowIndex.getState());
+
+        // 2. Exactly K tablets.
+        List<Tablet> tablets = shadowIndex.getTablets();
+        Assertions.assertEquals(K, tablets.size());
+
+        // 3. Each tablet's range is the exact same object as the corresponding input range.
+        //    TabletRange has no equals(), so identity (assertSame) is the real invariant:
+        //    the method must store the exact range instance passed for index i.
+        for (int i = 0; i < K; i++) {
+            TabletRange got = tablets.get(i).getRange();
+            Assertions.assertNotNull(got, "range at index " + i + " should not be null");
+            Assertions.assertSame(ranges.get(i), got, "range identity mismatch at index " + i);
+        }
+
+        // 4. matchShardIds was null (no origin-shard preference).
+        Assertions.assertTrue(matchShardIdsWasNull.get(), "createShards should receive null matchShardIds");
+    }
+
+    /**
+     * Verifies the precondition: tabletCount != ranges.size() throws.
+     */
+    @Test
+    public void testSizeMismatchThrows() {
+        List<TabletRange> ranges = List.of(new TabletRange()); // size 1 != tabletCount 2
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                LakeTableAlterJobV2Builder.buildRangeShadowIndex(
+                        1L, table, physicalPartition, 9001L,
+                        2, ranges, 500L, WarehouseComputeResource.of(0L)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter;
 
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
@@ -24,6 +25,8 @@ import com.starrocks.server.RunMode;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -126,22 +129,23 @@ public class RangeDistributionGuardTest {
     }
 
     /**
-     * The SCHEMA_CHANGE alter path in {@code AlterJobExecutor} catches
-     * {@code StarRocksException} and re-throws as {@code AlterJobException}
-     * with only the message (no cause), so tests on that path assert
-     * directly on the top exception's message rather than going through
-     * {@link #assertThrowsDdlException} which walks the cause chain.
+     * On a shared-data (lake) range table a sort-key reorder shifts the range sort key, so it is now
+     * routed to {@link LakeRangeRewriteSchemaChangeJob} instead of being rejected. The job is built
+     * (not run) via {@code analyzeAndCreateJob} to assert the routing without needing a backend.
      */
     @Test
-    public void testModifySortKeyRejectedOnRangeDistribution() throws Exception {
+    public void testModifySortKeyRoutedToRangeRewriteOnRangeDistribution() throws Exception {
         starRocksAssert.withTable(rangeTableDdl("t_guard_orderby"));
-        // Column list SHORTER than base schema routes to
-        // processModifySortKeyColumn (not the schema-reorder overload).
-        Throwable exception = assertThrows(Throwable.class, () ->
-                starRocksAssert.alterTable(
-                        "alter table t_guard_orderby order by (k1)"));
-        assertTrue(exception.getMessage().toLowerCase(Locale.ROOT).contains("range distribution"),
-                "Expected 'range distribution' in: " + exception.getMessage());
+        // Column list SHORTER than base schema routes to processModifySortKeyColumn (sort-key modify).
+        com.starrocks.sql.ast.AlterTableStmt stmt = (com.starrocks.sql.ast.AlterTableStmt)
+                UtFrameUtils.parseStmtWithNewParser("alter table t_guard_orderby order by (k1)", connectContext);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable("test", "t_guard_orderby");
+        AlterJobV2 job = GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                .analyzeAndCreateJob(stmt.getAlterClauseList(),
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test"), table);
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "Expected a LakeRangeRewriteSchemaChangeJob, got: " + job);
     }
 
     @Test
@@ -169,6 +173,38 @@ public class RangeDistributionGuardTest {
                         "alter table t_guard_addkey add column k_new int key default '0'"));
         assertTrue(exception.getMessage().toLowerCase(Locale.ROOT).contains("range distribution"),
                 "Expected 'range distribution' in: " + exception.getMessage());
+    }
+
+    /**
+     * A range-COLOCATE table stays rejected: the rewrite would resample a fresh K-tablet layout
+     * independently of the colocate range manager's expected ranges, desyncing colocate routing after
+     * the flip. The routing predicate must therefore exclude colocate tables, keeping the existing
+     * range-distribution rejection. (Colocate membership is simulated; create-time colocate+range
+     * wiring is orthogonal to the routing decision under test.)
+     */
+    @Test
+    public void testColocateRangeTableRejectsSortKeyReorder() throws Exception {
+        starRocksAssert.withTable(rangeTableDdl("t_guard_colocate"));
+        new MockUp<ColocateTableIndex>() {
+            @Mock
+            public boolean isColocateTable(long tableId) {
+                return true;
+            }
+        };
+        assertAlterRejectedWithRangeDistribution("alter table t_guard_colocate order by (k2, k1)");
+    }
+
+    /**
+     * A range table carrying an AUTO_INCREMENT column stays rejected (out of scope for the re-route).
+     */
+    @Test
+    public void testAutoIncrementRangeTableRejectsSortKeyReorder() throws Exception {
+        starRocksAssert.withTable("create table t_guard_autoinc "
+                + "(k1 int not null, k2 int not null, id bigint not null auto_increment)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        assertAlterRejectedWithRangeDistribution("alter table t_guard_autoinc order by (k2, k1)");
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeRewriteRoutingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeRewriteRoutingTest.java
@@ -1,0 +1,366 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Routing tests for {@link SchemaChangeHandler#needsRangeRewriteSchemaChange}: an eligible
+ * range-distribution key change on a shared-data table is routed to
+ * {@link LakeRangeRewriteSchemaChangeJob}; everything else keeps the existing rejection.
+ */
+public class RangeRewriteRoutingTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static boolean savedEnableRangeDistribution;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        savedEnableRangeDistribution = Config.enable_range_distribution;
+        Config.enable_range_distribution = true;
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        Config.enable_range_distribution = savedEnableRangeDistribution;
+    }
+
+    private static SchemaChangeHandler handler() {
+        return GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+    }
+
+    private static Database db() {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+    }
+
+    private static OlapTable table(String name) {
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", name);
+    }
+
+    /** Run analyzeAndCreateJob (without running the job) and return the created AlterJobV2. */
+    private static AlterJobV2 createJob(String tableName, String alterSql) throws Exception {
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql, connectContext);
+        return handler().analyzeAndCreateJob(stmt.getAlterClauseList(), db(), table(tableName));
+    }
+
+    /** Extract the underlying DdlException from a (possibly wrapped) throwable. */
+    private static DdlException assertThrowsDdlException(Executable executable) {
+        Throwable thrown = assertThrows(Throwable.class, executable);
+        for (Throwable current = thrown; current != null; current = current.getCause()) {
+            if (current instanceof DdlException) {
+                return (DdlException) current;
+            }
+        }
+        fail("Expected DdlException in cause chain of " + thrown);
+        return null; // unreachable
+    }
+
+    // (a) Lake range DUP table: ALTER ... ORDER BY (reordered) routes to the rewrite job.
+    @Test
+    public void testReorderSortKeyRoutesToRangeRewriteJob() throws Exception {
+        starRocksAssert.withTable("create table t_route_reorder (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        AlterJobV2 job = createJob("t_route_reorder", "alter table t_route_reorder order by (k2, k1)");
+        assertInstanceOf(LakeRangeRewriteSchemaChangeJob.class, job);
+    }
+
+    // (b) Lake range DUP table: MODIFY COLUMN keyness flip that shifts the (key-derived) sort key
+    // routes to the rewrite job. DUP is used because all DUP columns carry the same (NONE)
+    // aggregation type, so promoting a value column to a key is a valid schema change (an AGG
+    // value->key flip is independently rejected by the aggregation-type compatibility check).
+    @Test
+    public void testKeynessFlipShiftingSortKeyRoutesToRangeRewriteJob() throws Exception {
+        // DUP range table with explicit keys but no explicit ORDER BY -> the range sort key is
+        // derived from the key columns, so promoting v1 to a key shifts it.
+        starRocksAssert.withTable("create table t_route_keyflip (k1 int, v1 int)\n"
+                + "duplicate key(k1)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_keyflip");
+        org.junit.jupiter.api.Assertions.assertTrue(table.isRangeDistribution(),
+                "expected a range-distribution table");
+        AlterJobV2 job = createJob("t_route_keyflip", "alter table t_route_keyflip modify column v1 int key");
+        assertInstanceOf(LakeRangeRewriteSchemaChangeJob.class, job);
+        // Regression (e2e-found): the rewrite schema must carry un-prefixed (base) column names.
+        // processModifyColumn shadow-prefixes the flipped column (__starrocks_shadow_v1); if that name
+        // leaks into the rewrite job, the INSERT ... SELECT (over base names) cannot resolve the routing
+        // column and the job cancels at RUNNING. The reorder path already passes the base schema.
+        for (com.starrocks.catalog.Column c : ((LakeRangeRewriteSchemaChangeJob) job).getNewSchema()) {
+            org.junit.jupiter.api.Assertions.assertFalse(
+                    c.getName().startsWith(SchemaChangeHandler.SHADOW_NAME_PREFIX),
+                    "rewrite schema column must be un-prefixed, got: " + c.getName());
+        }
+    }
+
+    // (c) ADD COLUMN ... KEY on a range table stays rejected (column-set change, out of scope).
+    @Test
+    public void testAddKeyColumnStillRejected() throws Exception {
+        starRocksAssert.withTable("create table t_route_addkey (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        DdlException e = assertThrowsDdlException(() ->
+                createJob("t_route_addkey", "alter table t_route_addkey add column k_new int key default '0'"));
+        org.junit.jupiter.api.Assertions.assertTrue(
+                e.getMessage().toLowerCase().contains("range distribution"), e.getMessage());
+    }
+
+    // (d) OPTIMIZE on a range table stays rejected.
+    @Test
+    public void testOptimizeStillRejected() throws Exception {
+        starRocksAssert.withTable("create table t_route_optimize (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        // OPTIMIZE is triggered by `alter table ... distributed by ...`; the analyzer rejects it
+        // before a job is created, so this asserts on the (wrapped) message.
+        Throwable e = assertThrows(Throwable.class, () ->
+                starRocksAssert.alterTable("alter table t_route_optimize distributed by hash(k1)"));
+        org.junit.jupiter.api.Assertions.assertTrue(
+                e.getMessage().toLowerCase().contains("range distribution"), e.getMessage());
+    }
+
+    // (e) A non-lake (shared-nothing) range table must NOT route to the lake rewrite job. The lake
+    // gate is exercised by making isCloudNativeTable() report false for the table; both a reorder and
+    // a keyness flip must then keep the existing rejection rather than building a
+    // LakeRangeRewriteSchemaChangeJob.
+    @Test
+    public void testNonLakeRangeTableNotRouted() throws Exception {
+        starRocksAssert.withTable("create table t_route_nonlake (k1 int, v1 int sum)\n"
+                + "aggregate key(k1)\n"
+                + "properties('replication_num' = '1');");
+        starRocksAssert.withTable("create table t_route_nonlake_dup (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public boolean isCloudNativeTable() {
+                return false;
+            }
+        };
+
+        // Predicate is false for both the keyness flip and the reorder once the table is not lake.
+        AlterTableStmt flipStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_nonlake modify column v1 int key", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table("t_route_nonlake"), flipStmt.getAlterClauseList().get(0)));
+        AlterTableStmt reorderStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_nonlake_dup order by (k2, k1)", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table("t_route_nonlake_dup"), reorderStmt.getAlterClauseList().get(0)));
+
+        // And the dispatch keeps the existing rejection (it throws rather than building any job, so
+        // in particular no LakeRangeRewriteSchemaChangeJob is created).
+        assertThrows(Throwable.class, () ->
+                createJob("t_route_nonlake", "alter table t_route_nonlake modify column v1 int key"));
+        assertThrows(Throwable.class, () ->
+                createJob("t_route_nonlake_dup", "alter table t_route_nonlake_dup order by (k2, k1)"));
+    }
+
+    // (f) Regression guard: a keyness flip BUNDLED with a type change (here a VARCHAR shorten) is NOT
+    // a pure keyness flip, so it must NOT be routed. It instead falls into the existing range-
+    // distribution rejection path rather than building a rewrite job that would have bypassed
+    // validation -- the gap this gate closes.
+    @Test
+    public void testKeynessFlipBundledWithTypeChangeNotRouted() throws Exception {
+        starRocksAssert.withTable("create table t_route_keyflip_shorten (k1 int, v1 varchar(10))\n"
+                + "duplicate key(k1)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_keyflip_shorten");
+        org.junit.jupiter.api.Assertions.assertTrue(table.isRangeDistribution(),
+                "expected a range-distribution table");
+        // The flip alone would shift the sort key, but the bundled VARCHAR(10)->VARCHAR(5) shorten
+        // means it is no longer a pure keyness flip, so the predicate is false.
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_keyflip_shorten modify column v1 varchar(5) key", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, stmt.getAlterClauseList().get(0)));
+        // And the dispatch rejects it with a DdlException rather than building any rewrite job.
+        DdlException e = assertThrowsDdlException(() -> createJob("t_route_keyflip_shorten",
+                "alter table t_route_keyflip_shorten modify column v1 varchar(5) key"));
+        org.junit.jupiter.api.Assertions.assertTrue(
+                e.getMessage().toLowerCase().contains("range distribution"), e.getMessage());
+    }
+
+    // (g) An AGG value->key flip inherently changes the column's aggregation state (a value column
+    // carries an aggregation function, a key does not), so it is not a pure keyness flip and is not
+    // routed; it falls through to the existing aggregation-type-compatibility rejection.
+    @Test
+    public void testAggValueToKeyFlipNotRouted() throws Exception {
+        starRocksAssert.withTable("create table t_route_agg_flip (k1 int, v1 int sum)\n"
+                + "aggregate key(k1)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_agg_flip");
+        org.junit.jupiter.api.Assertions.assertTrue(table.isRangeDistribution(),
+                "expected a range-distribution table");
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_agg_flip modify column v1 int key", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, stmt.getAlterClauseList().get(0)));
+        // The dispatch keeps the existing rejection rather than building a rewrite job.
+        assertThrows(Throwable.class, () ->
+                createJob("t_route_agg_flip", "alter table t_route_agg_flip modify column v1 int key"));
+    }
+
+    // (h) A lake range-distribution table that has rollup / synchronous-MV indexes beyond the base
+    // index must NOT be routed to the range-rewrite job: createRangeRewriteJob / buildRangeRewriteJob
+    // only rebuild the base index, so rollup indexes would be left stale. The presence of extra
+    // indexes is simulated by mocking getIndexMetaIdToMeta() to return a two-entry map (base + rollup).
+    @Test
+    public void testRollupTableNotRouted() throws Exception {
+        starRocksAssert.withTable("create table t_route_rollup (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_rollup");
+        org.junit.jupiter.api.Assertions.assertTrue(table.isRangeDistribution(),
+                "expected a range-distribution table");
+
+        // Simulate a rollup index by making getIndexMetaIdToMeta() report two entries.
+        MaterializedIndexMeta fakeMeta = table.getIndexMetaByMetaId(table.getBaseIndexMetaId());
+        new MockUp<OlapTable>() {
+            @Mock
+            public Map<Long, MaterializedIndexMeta> getIndexMetaIdToMeta() {
+                return ImmutableMap.of(
+                        table.getBaseIndexMetaId(), fakeMeta,
+                        table.getBaseIndexMetaId() + 1L, fakeMeta);
+            }
+        };
+
+        // Both a sort-key reorder and a keyness flip must be blocked when a rollup exists.
+        AlterTableStmt reorderStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_rollup order by (k2, k1)", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, reorderStmt.getAlterClauseList().get(0)),
+                "reorder must not route to range-rewrite when rollup exists");
+
+        AlterTableStmt flipStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_rollup modify column v1 int key", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, flipStmt.getAlterClauseList().get(0)),
+                "keyness flip must not route to range-rewrite when rollup exists");
+    }
+
+    // (i) A pure keyness flip whose sort-key shift would leave NO key column (the only/last key demoted to
+    // a value) must NOT be routed. createRangeRewriteJob would otherwise build a shadow with zero key
+    // columns and the job would fail asynchronously at validateRewriteConfig. The routing re-checks the
+    // post-flip key invariants and declines, so the flip is rejected synchronously at DDL time instead.
+    @Test
+    public void testKeynessFlipLeavingNoKeyRejectedSynchronously() throws Exception {
+        starRocksAssert.withTable("create table t_route_demote_only_key (k1 int, v1 int)\n"
+                + "duplicate key(k1)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_demote_only_key");
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_demote_only_key modify column k1 int", connectContext);
+        // The flip shifts the (key-derived) sort key, so the routing predicate still matches...
+        org.junit.jupiter.api.Assertions.assertTrue(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, stmt.getAlterClauseList().get(0)),
+                "demoting the only key shifts the sort key, so the predicate matches");
+        // ...but the post-flip schema has no key column, so it must be rejected synchronously (no
+        // LakeRangeRewriteSchemaChangeJob is built) rather than failing later inside the rewrite job.
+        assertThrowsDdlException(() ->
+                createJob("t_route_demote_only_key", "alter table t_route_demote_only_key modify column k1 int"));
+    }
+
+    // (j) A pure keyness flip whose sort-key shift would place a VALUE column before a KEY column
+    // (demoting a non-last key) must NOT be routed: the post-flip schema violates the key-prefix
+    // invariant finalAnalyze enforces. The routing declines and the flip is rejected synchronously.
+    @Test
+    public void testKeynessFlipPuttingValueBeforeKeyRejectedSynchronously() throws Exception {
+        starRocksAssert.withTable("create table t_route_demote_first_key (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_demote_first_key");
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_demote_first_key modify column k1 int", connectContext);
+        org.junit.jupiter.api.Assertions.assertTrue(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, stmt.getAlterClauseList().get(0)),
+                "demoting the first of two keys shifts the sort key, so the predicate matches");
+        assertThrowsDdlException(() ->
+                createJob("t_route_demote_first_key", "alter table t_route_demote_first_key modify column k1 int"));
+    }
+
+    // (k) A cloud-native MATERIALIZED VIEW must NOT route to the range-rewrite job, even though it is a
+    // range-distribution lake object. The predicate gates on isCloudNativeTable() (table-only), not
+    // isCloudNativeTableOrMaterializedView(): a key/sort-key ALTER TABLE on an MV is already rejected
+    // upstream by AlterTableStatementAnalyzer, and the rewrite drives an internal INSERT that
+    // InsertAnalyzer rejects on a non-system MV target -- so the MV must be declined here regardless.
+    // The MV nature is simulated by making the table report as a cloud-native MV (not a plain table).
+    @Test
+    public void testMaterializedViewNotRouted() throws Exception {
+        starRocksAssert.withTable("create table t_route_mv_guard (k1 int, v1 int)\n"
+                + "duplicate key(k1)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = table("t_route_mv_guard");
+        org.junit.jupiter.api.Assertions.assertTrue(table.isRangeDistribution(),
+                "expected a range-distribution table");
+
+        // Report as a cloud-native MV: isCloudNativeTable() is false, but the broad
+        // isCloudNativeTableOrMaterializedView() (its default OR) still reports true.
+        new MockUp<OlapTable>() {
+            @Mock
+            public boolean isCloudNativeTable() {
+                return false;
+            }
+
+            @Mock
+            public boolean isCloudNativeMaterializedView() {
+                return true;
+            }
+        };
+        org.junit.jupiter.api.Assertions.assertTrue(table.isCloudNativeTableOrMaterializedView(),
+                "guard models an MV: the broad predicate still matches");
+
+        // A keyness flip that would otherwise route must be declined because the target is an MV.
+        AlterTableStmt flipStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "alter table t_route_mv_guard modify column v1 int key", connectContext);
+        assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(
+                table, flipStmt.getAlterClauseList().get(0)),
+                "a cloud-native materialized view must not route to the range-rewrite job");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InternalPartitionSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InternalPartitionSampleSubqueryExecutorTest.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.type.IntegerType;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.jsonResultBatch;
+
+class InternalPartitionSampleSubqueryExecutorTest {
+
+    // ---------------------------------------------------------------------------
+    // SQL-shape tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void buildsSelectFromInternalPartition() throws Exception {
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(partitionRequest("mydb", "mytbl", "p202401",
+                List.of("k"), List.of(),
+                /*partitionSizeBytes=*/ 0L,
+                List.of(bigintColumn("k")), List.of()));
+
+        // partitionSizeBytes=0 → rate = 1.0; seed=0 → order-shuffle seed = 6510615555426900570;
+        // byte limit = Long.MAX_VALUE → row limit capped at SAMPLE_ROW_HARD_LIMIT = 200000.
+        // No user WHERE → only the Bernoulli rand filter in the WHERE clause.
+        Assertions.assertEquals(
+                "SELECT `k` FROM `mydb`.`mytbl` PARTITION (`p202401`)"
+                        + " WHERE rand(0) < 1.0 ORDER BY rand(6510615555426900570) LIMIT 200000",
+                capturedSql.toString());
+    }
+
+    @Test
+    void backtickQuotesBothDbAndTableAndPartition() throws Exception {
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(partitionRequest("my-db", "my-tbl", "p0",
+                List.of("k"), List.of(), 0L,
+                List.of(bigintColumn("k")), List.of()));
+
+        String sql = capturedSql.toString();
+        Assertions.assertTrue(sql.contains("`my-db`.`my-tbl` PARTITION (`p0`)"),
+                "DB, table and partition must all be backtick-quoted: " + sql);
+    }
+
+    @Test
+    void projectsPartitionColumnsAfterSortKey() throws Exception {
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(partitionRequest("db", "tbl", "p1",
+                List.of("k"), List.of("dt"), 0L,
+                List.of(bigintColumn("k")), List.of(bigintColumn("dt"))));
+
+        Assertions.assertTrue(capturedSql.toString().contains("SELECT `k`, `dt` FROM"),
+                "sort-key column then partition column in projection: " + capturedSql);
+    }
+
+    @Test
+    void largePartitionSizeProducesSubUnitSamplingRate() throws Exception {
+        // 10 GiB → rate < 1.0 so the WHERE carries rand(...) < <fraction>
+        long tenGib = 10L * 1024L * 1024L * 1024L;
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(partitionRequest("db", "tbl", "p_large",
+                List.of("k"), List.of(), tenGib,
+                List.of(bigintColumn("k")), List.of()));
+
+        String sql = capturedSql.toString();
+        Assertions.assertFalse(sql.contains("rand(0) < 1.0"),
+                "10 GiB partition must yield a sub-unit sampling rate: " + sql);
+        Assertions.assertTrue(sql.contains("WHERE rand(0) <"),
+                "Bernoulli filter must still appear: " + sql);
+    }
+
+    @Test
+    void zeroPartitionSizeProducesValidSql() throws Exception {
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        Assertions.assertDoesNotThrow(() -> executor.execute(
+                partitionRequest("db", "tbl", "p0",
+                        List.of("k"), List.of(), 0L,
+                        List.of(bigintColumn("k")), List.of())));
+
+        Assertions.assertTrue(capturedSql.toString().startsWith("SELECT"),
+                "must produce a SELECT even with zero partition size: " + capturedSql);
+        Assertions.assertTrue(capturedSql.toString().contains("LIMIT"),
+                "SELECT must include LIMIT: " + capturedSql);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Decode tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void decodesJsonRowsUsingTargetSortKeyTypes() throws Exception {
+        Column targetIntColumn = new Column("k", IntegerType.INT);
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> List.of(jsonResultBatch("{\"data\":[\"42\"]}")));
+
+        SampleSubqueryExecutor.SampleExecution execution = executor.execute(
+                partitionRequest("db", "tbl", "p0",
+                        List.of("k"), List.of(), 0L,
+                        List.of(targetIntColumn), List.of()));
+
+        List<SampleRow> rows = Lists.newArrayList(execution.rows());
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("42", rows.get(0).sortKeyTuple().get(0).getStringValue(),
+                "decoded value must match the JSON cell string");
+    }
+
+    @Test
+    void decodesPartitionColumnsIntoPartitionSourceTuple() throws Exception {
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> List.of(
+                        jsonResultBatch("{\"data\":[\"10\", \"20\"]}")));
+
+        SampleSubqueryExecutor.SampleExecution execution = executor.execute(
+                partitionRequest("db", "tbl", "p0",
+                        List.of("k"), List.of("dt"), 0L,
+                        List.of(bigintColumn("k")), List.of(bigintColumn("dt"))));
+
+        List<SampleRow> rows = Lists.newArrayList(execution.rows());
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(1, rows.get(0).sortKeyTuple().size());
+        Assertions.assertEquals("10", rows.get(0).sortKeyTuple().get(0).getStringValue());
+        Assertions.assertEquals(1, rows.get(0).partitionSourceTuple().size());
+        Assertions.assertEquals("20", rows.get(0).partitionSourceTuple().get(0).getStringValue());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Error-path tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void wrongScanContextTypeThrows() {
+        SampleRequest request = new SampleRequest(
+                new BrokerLoadScanContext(
+                        /*brokerDesc=*/ null,
+                        List.of(),
+                        List.of(),
+                        Mockito.mock(ComputeResource.class)),
+                List.of(bigintColumn("k")),
+                /*sampleByteLimit=*/ Long.MAX_VALUE,
+                /*seed=*/ 0L);
+
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> List.of());
+
+        StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
+                () -> executor.execute(request));
+        Assertions.assertTrue(thrown.getMessage().contains("internal-partition "),
+                "error message must contain ERROR_PREFIX: " + thrown.getMessage());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static SampleRequest partitionRequest(
+            String dbName,
+            String tableName,
+            String partitionName,
+            List<String> sortKeySourceColumnNames,
+            List<String> partitionSourceColumnNames,
+            long partitionSizeBytes,
+            List<Column> sortKeyColumns,
+            List<Column> partitionSourceColumns) {
+        ComputeResource computeResource = Mockito.mock(ComputeResource.class);
+        InternalPartitionScanContext scanContext = new InternalPartitionScanContext(
+                dbName, tableName, partitionName,
+                sortKeySourceColumnNames, partitionSourceColumnNames,
+                partitionSizeBytes, computeResource);
+        return new SampleRequest(
+                scanContext, sortKeyColumns, partitionSourceColumns,
+                /*sampleByteLimit=*/ Long.MAX_VALUE, /*seed=*/ 0L);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.VectorSearchOptions;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.IntegerType;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.thrift.TPlanNode;
@@ -28,8 +29,14 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OlapScanNodeTest {
+
+    private static final long PHYSICAL_PARTITION_ID = 42L;
 
     private OlapScanNode createOlapScanNode(Table.TableType tableType) {
         OlapTable table = new OlapTable(tableType);
@@ -104,5 +111,16 @@ public class OlapScanNodeTest {
 
         Assertions.assertNotNull(msg.lake_scan_node);
         Assertions.assertFalse(msg.lake_scan_node.isSetVector_search_options());
+    }
+
+    @Test
+    public void testScanVersionOverridePinsRequestedVersion() {
+        Map<Long, Long> override = new HashMap<>();
+        override.put(PHYSICAL_PARTITION_ID, 7L);
+        assertEquals(7L, OlapScanNode.chooseScanVersion(10L, PHYSICAL_PARTITION_ID, override));
+        assertEquals(10L, OlapScanNode.chooseScanVersion(10L, PHYSICAL_PARTITION_ID, null));
+        ConnectContext ctx = new ConnectContext();
+        ctx.setScanVersionOverride(override);
+        assertEquals(Long.valueOf(7L), ctx.getScanVersionOverride().get(PHYSICAL_PARTITION_ID));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -1492,4 +1492,113 @@ public class OlapTableSinkTest {
         Assertions.assertTrue(e.getMessage().contains("not found in partition"),
                 "missing target index must fail with a 'not found in partition' message, got: " + e.getMessage());
     }
+
+    // Verify that setTargetWriteIndexId() on the sink — which InsertPlanner calls when
+    // insertStmt.getTargetWriteIndexId() is non-null — causes createSchema to emit only the
+    // target index. The OlapTableSinkTest harness does not run a full InsertPlanner pipeline,
+    // so this test exercises the sink-side forwarding contract that InsertPlanner depends on.
+    @Test
+    public void testInsertPlannerForwardsTargetWriteIndexIdToSink() {
+        List<Column> schema = targetIndexSchema();
+        expectTargetWriteSchema(schema);
+        TupleDescriptor tuple = buildOutputTuple(schema);
+
+        // Simulate what InsertPlanner does: create the sink and call setTargetWriteIndexId.
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(900L),
+                TWriteQuorumType.MAJORITY, false, false, false);
+        sink.setTargetWriteIndexId(TARGET_ROLLUP_INDEX_ID);
+
+        // Verify that the schema emitted via createSchema (which complete() delegates to) is
+        // restricted to the single target index — the invariant the BE relies on.
+        TOlapTableSchemaParam schema2 =
+                OlapTableSink.createSchema(TARGET_TABLE_ID, dstTable, tuple, TARGET_ROLLUP_INDEX_ID);
+        Assertions.assertEquals(1, schema2.getIndexes().size(),
+                "schema must contain exactly one index when targetWriteIndexId is set");
+        Assertions.assertEquals(TARGET_ROLLUP_INDEX_ID, schema2.getIndexes().get(0).getId(),
+                "the single index in the schema must be the target write index");
+    }
+
+    // Verify that a SHADOW index whose MaterializedIndexMeta carries a reordered sort key emits
+    // distributed_exprs over the NEW key order, so range-routing for double-writes uses the new key.
+    //
+    // Scenario: base sort key is (k1, k2) (sortKeyIdxes=[0,1]); shadow sort key is (k2, k1)
+    // (sortKeyIdxes=[1,0]). The output tuple carries shadow-prefixed columns whose slot-binding key
+    // is the column name (isShadowColumn() == true → getName()). We verify:
+    //   1. MetaUtils.getRangeDistributionColumns returns (shadow_k2, shadow_k1) for the shadow meta.
+    //   2. The TOlapTableIndexSchema for the shadow index has distributed_exprs set.
+    //   3. The exprs have 2 slot-refs in shadow-key order: first points to shadow_k2, second to shadow_k1.
+    @Test
+    public void testShadowIndexEmitsDistributedExprsForNewSortKeyOrder() {
+        // Shadow columns: prefix mirrors SchemaChangeHandler.SHADOW_NAME_PREFIX = "__starrocks_shadow_"
+        String shadowPrefix = "__starrocks_shadow_";
+        Column shadowK1 = new Column(shadowPrefix + "k1", IntegerType.INT, true, null, false, null, "");
+        Column shadowK2 = new Column(shadowPrefix + "k2", IntegerType.INT, true, null, false, null, "");
+        Column v1 = new Column("v1", IntegerType.INT, false, null, true, null, "");
+        // Schema order: [shadowK1(0), shadowK2(1), v1(2)].
+        // sortKeyIdxes=[1,0] → sort key is (shadowK2, shadowK1), i.e. the reordered/permuted new key.
+        List<Column> schema = Lists.newArrayList(shadowK1, shadowK2, v1);
+        long shadowMetaId = 300L;
+        MaterializedIndexMeta shadowMeta = new MaterializedIndexMeta(shadowMetaId, schema, 0, 0, (short) 2,
+                TStorageType.COLUMN, KeysType.DUP_KEYS, null, Lists.newArrayList(1, 0));
+        Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newLinkedHashMap();
+        indexMetaIdToMeta.put(shadowMetaId, shadowMeta);
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = 1L;
+                dstTable.getBaseIndexMetaId();
+                result = shadowMetaId;
+                dstTable.getIndexMetaByMetaId(shadowMetaId);
+                result = shadowMeta;
+                dstTable.getIndexMetaIdToMeta();
+                result = indexMetaIdToMeta;
+                dstTable.getKeysType();
+                result = KeysType.DUP_KEYS;
+                dstTable.getIndexes();
+                result = Lists.newArrayList();
+                dstTable.getBfColumnIds();
+                result = Sets.newHashSet();
+                dstTable.isRangeDistribution();
+                result = true;
+            }
+        };
+
+        // 1. Verify MetaUtils returns the new key order: (shadowK2, shadowK1).
+        List<Column> routingCols = MetaUtils.getRangeDistributionColumns(dstTable, shadowMetaId);
+        Assertions.assertEquals(2, routingCols.size());
+        Assertions.assertEquals(shadowPrefix + "k2", routingCols.get(0).getName(),
+                "first routing column must be shadow_k2 (the reordered new key)");
+        Assertions.assertEquals(shadowPrefix + "k1", routingCols.get(1).getName(),
+                "second routing column must be shadow_k1");
+
+        // 2 & 3. Verify createSchema emits distributed_exprs with slot-refs in the new key order.
+        TupleDescriptor tuple = buildOutputTuple(schema);
+        TOlapTableSchemaParam schemaParam = OlapTableSink.createSchema(1L, dstTable, tuple, null, true);
+
+        Assertions.assertEquals(1, schemaParam.getIndexes().size());
+        TOlapTableIndexSchema indexSchema = schemaParam.getIndexes().get(0);
+        Assertions.assertTrue(indexSchema.isSetDistributed_exprs(),
+                "shadow range-distribution index must carry distributed_exprs");
+        List<TExpr> exprs = indexSchema.getDistributed_exprs();
+        Assertions.assertEquals(2, exprs.size(), "one routing expr per new sort-key column");
+
+        // Resolve slot_id → column name via the schema param's slot descriptors.
+        Map<Integer, String> slotIdToColName = Maps.newHashMap();
+        for (TSlotDescriptor slotDesc : schemaParam.getSlot_descs()) {
+            slotIdToColName.put(slotDesc.getId(), slotDesc.getColName());
+        }
+
+        // First expr must point to shadow_k2; second to shadow_k1 (the new key order, not the schema order).
+        for (TExpr expr : exprs) {
+            Assertions.assertEquals(1, expr.getNodes().size(), "each routing expr is a single slot-ref node");
+            Assertions.assertEquals(TExprNodeType.SLOT_REF, expr.getNodes().get(0).getNode_type());
+        }
+        int slotId0 = exprs.get(0).getNodes().get(0).getSlot_ref().getSlot_id();
+        int slotId1 = exprs.get(1).getNodes().get(0).getSlot_ref().getSlot_id();
+        Assertions.assertEquals(shadowPrefix + "k2", slotIdToColName.get(slotId0),
+                "first distributed_expr slot must resolve to shadow_k2 (new key order)");
+        Assertions.assertEquals(shadowPrefix + "k1", slotIdToColName.get(slotId1),
+                "second distributed_expr slot must resolve to shadow_k1 (new key order)");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -1240,6 +1240,7 @@ public class PseudoBackend {
             response.status = pStatus;
             return CompletableFuture.completedFuture(response);
         }
+
     }
 
     static TStatus status(TStatusCode code, String msg) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -439,6 +439,42 @@ public class DatabaseTransactionMgrTest {
     }
 
     @Test
+    public void testEmptyShadowRewriteTxnCommitsWithoutNoRowsError() throws StarRocksException {
+        // Regression: an empty-partition range rewrite produces zero rows, but its SHADOW_REWRITE txn must
+        // still commit so the flip can anchor an empty op_schema_change@W on that partition. With
+        // empty_load_as_error on (the default), the empty-load guard must exempt SHADOW_REWRITE just as it
+        // exempts INSERT_STREAMING; otherwise the commit aborts with ERR_NO_ROWS_IMPORTED and cancels the
+        // whole schema change.
+        boolean savedEmptyLoadAsError = Config.empty_load_as_error;
+        Config.empty_load_as_error = true;
+        try {
+            DatabaseTransactionMgr masterDbTransMgr =
+                    masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+
+            // Control: a non-exempt (FRONTEND) txn committing with no tablets DOES hit the guard, proving
+            // empty_load_as_error is in effect for this fixture.
+            long frontendTxnId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                    Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                    "empty_frontend_label", transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            assertThrows(TransactionCommitFailedException.class, () ->
+                    masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, frontendTxnId,
+                            Lists.newArrayList(), Lists.newArrayList(), null));
+
+            // A SHADOW_REWRITE txn committing with no tablets must NOT throw and must reach COMMITTED.
+            long shadowTxnId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                    Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                    "empty_shadow_rewrite_label", transactionSource,
+                    TransactionState.LoadJobSourceType.SHADOW_REWRITE, Config.stream_load_default_timeout_second);
+            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, shadowTxnId,
+                    Lists.newArrayList(), Lists.newArrayList(), null);
+            assertEquals(TransactionStatus.COMMITTED, masterDbTransMgr.getTxnState(shadowTxnId).getStatus());
+        } finally {
+            Config.empty_load_as_error = savedEmptyLoadAsError;
+        }
+    }
+
+    @Test
     public void testAbortTransactionWithAttachment() throws StarRocksException {
         DatabaseTransactionMgr masterDbTransMgr =
                 masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.collect.Lists;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
@@ -216,6 +217,35 @@ public class LakeTableTxnLogApplierTest extends LakeTableTestHelper {
         // addReshardCandidate must not have been invoked at all.
         Assertions.assertEquals(0, addCandidateCalls.get(),
                 "addReshardCandidate must not be called on a non-leader node");
+    }
+
+    @Test
+    public void testShadowRewriteTxnApplyLogsDoNotTouchPartitionVersion() {
+        LakeTable table = buildLakeTable();
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        // Shadow-rewrite txns are now identified by LoadJobSourceType.SHADOW_REWRITE on the txn.
+        TransactionState state = new TransactionState(dbId, Lists.newArrayList(tableId), nextTxnId++,
+                "label_shadow", null, TransactionState.LoadJobSourceType.SHADOW_REWRITE, null, 0, 60_000);
+        state.setTransactionStatus(TransactionStatus.COMMITTED);
+
+        // PartitionCommitInfo uses sentinel version -1; no per-partition isShadowRewrite marker needed.
+        PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(physicalPartitionId, -1, 0);
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(tableId);
+        tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
+
+        long vis0 = table.getPartition(partitionId).getDefaultPhysicalPartition().getVisibleVersion();
+        long next0 = table.getPartition(partitionId).getDefaultPhysicalPartition().getNextVersion();
+
+        // applyCommitLog must not bump nextVersion for a shadow-rewrite txn.
+        applier.applyCommitLog(state, tableCommitInfo);
+        Assertions.assertEquals(vis0, table.getPartition(partitionId).getDefaultPhysicalPartition().getVisibleVersion());
+        Assertions.assertEquals(next0, table.getPartition(partitionId).getDefaultPhysicalPartition().getNextVersion());
+
+        // applyVisibleLog must not advance visibleVersion for a shadow-rewrite txn.
+        state.setTransactionStatus(TransactionStatus.VISIBLE);
+        applier.applyVisibleLog(state, tableCommitInfo, /*unused*/null);
+        Assertions.assertEquals(vis0, table.getPartition(partitionId).getDefaultPhysicalPartition().getVisibleVersion());
+        Assertions.assertEquals(next0, table.getPartition(partitionId).getDefaultPhysicalPartition().getNextVersion());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PartitionCommitInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PartitionCommitInfoTest.java
@@ -14,11 +14,29 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.collect.Lists;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.proto.TabletStatPB;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PartitionCommitInfoTest {
+    private static final long PID = 12345L;
+    private static final long TABLE_ID = 6789L;
+
+    // Round-trip a PartitionCommitInfo through TableCommitInfo + TransactionState copies, the path
+    // used by finish/replay, and return the copied PartitionCommitInfo.
+    private PartitionCommitInfo copyViaTransactionState(PartitionCommitInfo pci) {
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(TABLE_ID);
+        tableCommitInfo.addPartitionCommitInfo(pci);
+        TransactionState state = new TransactionState(1000L, Lists.newArrayList(TABLE_ID),
+                3000, "label", null, TransactionState.LoadJobSourceType.INSERT_STREAMING, null, 0, 60_000);
+        state.putIdToTableCommitInfo(TABLE_ID, tableCommitInfo);
+
+        TransactionState copied = new TransactionState(state);
+        return copied.getTableCommitInfo(TABLE_ID).getPartitionCommitInfo(PID);
+    }
+
     @Test
     public void testTabletStatsCopiedByCopyConstructor() {
         PartitionCommitInfo src = new PartitionCommitInfo(1L, 2L, 3L);
@@ -30,5 +48,48 @@ public class PartitionCommitInfoTest {
         PartitionCommitInfo copy = new PartitionCommitInfo(src);
         Assertions.assertEquals(1, copy.getTabletStats().size());
         Assertions.assertEquals(100L, copy.getTabletStats().get(7L).dataSize);
+    }
+
+    @Test
+    public void testPartitionCommitInfoCopyAndJsonRoundTrip() {
+        PartitionCommitInfo pci = new PartitionCommitInfo(PID, 5, 0);
+
+        // copy ctor preserves version
+        Assertions.assertEquals(5L, new PartitionCommitInfo(pci).getVersion());
+
+        // GSON round-trip preserves version
+        Assertions.assertEquals(5L,
+                GsonUtils.GSON.fromJson(GsonUtils.GSON.toJson(pci), PartitionCommitInfo.class).getVersion());
+
+        // TableCommitInfo copy
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(TABLE_ID);
+        tableCommitInfo.addPartitionCommitInfo(pci);
+        Assertions.assertEquals(5L,
+                new TableCommitInfo(tableCommitInfo).getPartitionCommitInfo(PID).getVersion());
+
+        // through TransactionState copy used by finish/replay
+        Assertions.assertEquals(5L, copyViaTransactionState(pci).getVersion());
+    }
+
+    @Test
+    public void testShadowRewriteTxnUsesSourceType() {
+        // Shadow-rewrite partitions use sentinel version -1; the guard is now on
+        // TransactionState.isShadowRewrite() (sourceType == SHADOW_REWRITE), not on a
+        // per-partition boolean.
+        PartitionCommitInfo pci = new PartitionCommitInfo(PID, -1, 0);
+
+        // PartitionCommitInfo itself has no isShadowRewrite marker; verify it round-trips normally.
+        Assertions.assertEquals(-1L, new PartitionCommitInfo(pci).getVersion());
+        Assertions.assertEquals(-1L,
+                GsonUtils.GSON.fromJson(GsonUtils.GSON.toJson(pci), PartitionCommitInfo.class).getVersion());
+
+        // The txn-level isShadowRewrite is driven by sourceType.
+        TransactionState txn = new TransactionState(1000L, Lists.newArrayList(TABLE_ID),
+                3000, "label", null, TransactionState.LoadJobSourceType.SHADOW_REWRITE, null, 0, 60_000);
+        Assertions.assertTrue(txn.isShadowRewrite());
+
+        TransactionState normal = new TransactionState(1000L, Lists.newArrayList(TABLE_ID),
+                3000, "label", null, TransactionState.LoadJobSourceType.INSERT_STREAMING, null, 0, 60_000);
+        Assertions.assertFalse(normal.isShadowRewrite());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ShadowRewriteBatchFormationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ShadowRewriteBatchFormationTest.java
@@ -1,0 +1,150 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+// Verifies that a shadow-rewrite transaction is split out at batch formation
+// (getReadyToPublishTxnListBatch) so it is never batched with normal version-advancing txns.
+public class ShadowRewriteBatchFormationTest {
+    private static final long DB_ID = 1000L;
+    private static final long TABLE_ID = 20000L;
+    private static final long PARTITION_ID = 30000L;
+
+    private DatabaseTransactionMgr newDbTxnMgr() {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public com.starrocks.persist.EditLog getEditLog() {
+                return null;
+            }
+        };
+        return new DatabaseTransactionMgr(DB_ID, GlobalStateMgr.getCurrentState());
+    }
+
+    private TransactionState newState(long txnId, boolean shadowRewrite, long version) {
+        TransactionState.LoadJobSourceType sourceType = shadowRewrite
+                ? TransactionState.LoadJobSourceType.SHADOW_REWRITE
+                : TransactionState.LoadJobSourceType.INSERT_STREAMING;
+        TransactionState state = new TransactionState(DB_ID, Lists.newArrayList(TABLE_ID),
+                txnId, "label" + txnId, UUIDUtil.genTUniqueId(), sourceType,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "fe1"), 50000L, 60_000L);
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(TABLE_ID);
+        PartitionCommitInfo pci = new PartitionCommitInfo(PARTITION_ID, version, 0);
+        tableCommitInfo.addPartitionCommitInfo(pci);
+        state.putIdToTableCommitInfo(TABLE_ID, tableCommitInfo);
+        state.setTransactionStatus(TransactionStatus.COMMITTED);
+        return state;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void inject(DatabaseTransactionMgr mgr, TransactionState... states) {
+        TransactionGraph graph = new TransactionGraph();
+        Map<Long, TransactionState> running =
+                (Map<Long, TransactionState>) Deencapsulation.getField(mgr, "idToRunningTransactionState");
+        for (TransactionState state : states) {
+            running.put(state.getTransactionId(), state);
+            graph.add(state.getTransactionId(), Lists.newArrayList(TABLE_ID));
+        }
+        Deencapsulation.setField(mgr, "transactionGraph", graph);
+    }
+
+    private TransactionStateBatch findBatchContaining(List<TransactionStateBatch> batches, long txnId) {
+        for (TransactionStateBatch batch : batches) {
+            for (TransactionState state : batch.getTransactionStates()) {
+                if (state.getTransactionId() == txnId) {
+                    return batch;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void testShadowRewriteTxnIsNeverBatchedWithNormalDml() {
+        int oldMin = Config.lake_batch_publish_min_version_num;
+        int oldMax = Config.lake_batch_publish_max_version_num;
+        Config.lake_batch_publish_min_version_num = 1;
+        Config.lake_batch_publish_max_version_num = 10;
+        try {
+            DatabaseTransactionMgr mgr = newDbTxnMgr();
+            // A shadow-rewrite txn (sentinel version -1) committed before two adjacent normal DML txns.
+            TransactionState shadowRewrite = newState(101, true, -1);
+            TransactionState normal1 = newState(102, false, 2);
+            TransactionState normal2 = newState(103, false, 3);
+            inject(mgr, shadowRewrite, normal1, normal2);
+
+            List<TransactionStateBatch> batches = mgr.getReadyToPublishTxnListBatch();
+
+            TransactionStateBatch shadowBatch = findBatchContaining(batches, 101);
+            Assertions.assertNotNull(shadowBatch, "shadow-rewrite txn must still yield a publish work item");
+            Assertions.assertEquals(1, shadowBatch.size(), "shadow-rewrite txn must be its own size-1 batch");
+
+            // The shadow-rewrite txn must never share a batch with a normal txn.
+            for (TransactionStateBatch batch : batches) {
+                boolean hasShadow = false;
+                boolean hasNormal = false;
+                for (TransactionState state : batch.getTransactionStates()) {
+                    if (state.getTransactionId() == 101) {
+                        hasShadow = true;
+                    } else {
+                        hasNormal = true;
+                    }
+                }
+                Assertions.assertFalse(hasShadow && hasNormal,
+                        "shadow-rewrite txn must never be batched with a normal txn");
+            }
+        } finally {
+            Config.lake_batch_publish_min_version_num = oldMin;
+            Config.lake_batch_publish_max_version_num = oldMax;
+        }
+    }
+
+    @Test
+    public void testNormalDmlBatchesTogetherWithoutShadowRewrite() {
+        int oldMin = Config.lake_batch_publish_min_version_num;
+        int oldMax = Config.lake_batch_publish_max_version_num;
+        Config.lake_batch_publish_min_version_num = 1;
+        Config.lake_batch_publish_max_version_num = 10;
+        try {
+            DatabaseTransactionMgr mgr = newDbTxnMgr();
+            // Record loaded index ids so the batch-formation index snapshot stays identical across txns.
+            TransactionState normal1 = newState(201, false, 2);
+            TransactionState normal2 = newState(202, false, 3);
+            normal1.addPartitionLoadedIndexes(TABLE_ID, PARTITION_ID, Lists.newArrayList(1L));
+            normal2.addPartitionLoadedIndexes(TABLE_ID, PARTITION_ID, Lists.newArrayList(1L));
+            inject(mgr, normal1, normal2);
+
+            List<TransactionStateBatch> batches = mgr.getReadyToPublishTxnListBatch();
+            TransactionStateBatch batch = findBatchContaining(batches, 201);
+            Assertions.assertNotNull(batch);
+            // Two adjacent normal DML txns with consecutive versions batch together.
+            Assertions.assertEquals(2, batch.size());
+        } finally {
+            Config.lake_batch_publish_min_version_num = oldMin;
+            Config.lake_batch_publish_max_version_num = oldMax;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -310,6 +310,25 @@ public class TransactionStateTest {
     }
 
     @Test
+    public void testShadowRewriteViaSourceType() {
+        // isShadowRewrite() is now driven solely by LoadJobSourceType.SHADOW_REWRITE on the txn.
+        TransactionState txn = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
+                3000, "label_shadow", null,
+                LoadJobSourceType.SHADOW_REWRITE, new TxnCoordinator(TxnSourceType.FE, "127.0.0.1"), 0L, 60_000L);
+        assertTrue(txn.isShadowRewrite());
+
+        TransactionState normal = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
+                3000, "label_normal", null,
+                LoadJobSourceType.INSERT_STREAMING, new TxnCoordinator(TxnSourceType.FE, "127.0.0.1"), 0L, 60_000L);
+        assertFalse(normal.isShadowRewrite());
+
+        // Verify sourceType round-trips through GSON (it is serialized as "st" on TransactionState).
+        String json = GsonUtils.GSON.toJson(txn);
+        TransactionState replayed = GsonUtils.GSON.fromJson(json, TransactionState.class);
+        assertTrue(replayed.isShadowRewrite());
+    }
+
+    @Test
     public void testPartitionLoadedIndexes() {
         long tableId = 100L;
         long physicalPartitionId = 200L;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -176,6 +176,10 @@ public class MockedBackend {
     private static final AtomicInteger BASE_PORT = new AtomicInteger(8000);
     private static final long PATH_HASH = 123456;
 
+    // Most-recently-created instance; allows tests to access the active MockLakeService
+    // without needing a direct reference to the MockedBackend.
+    private static volatile MockedBackend lastCreated;
+
     private final int backendId;
     private final String host;
     private final int brpcPort;
@@ -212,6 +216,7 @@ public class MockedBackend {
         pbService = new MockPBackendService();
 
         lakeService = new MockLakeService();
+        lastCreated = this;
 
         ((MockGenericPool<?>) ThriftConnectionPool.beHeartbeatPool).register(this);
         ((MockGenericPool<?>) ThriftConnectionPool.backendPool).register(this);
@@ -228,6 +233,14 @@ public class MockedBackend {
             }
         };
 
+    }
+
+    public MockLakeService getMockLakeService() {
+        return lakeService;
+    }
+
+    public static MockedBackend getLastCreated() {
+        return lastCreated;
     }
 
     public void setBackendService(PBackendService backendService) {
@@ -619,9 +632,21 @@ public class MockedBackend {
         private final ConcurrentLinkedQueue<PublishLogVersionBatchRequest> publishLogVersionBatchRequests =
                 new ConcurrentLinkedQueue<>();
 
+        private final ConcurrentLinkedQueue<PublishVersionRequest> publishVersionRequests =
+                new ConcurrentLinkedQueue<>();
+
         @Override
         public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
+            publishVersionRequests.add(request);
             return CompletableFuture.completedFuture(null);
+        }
+
+        public ConcurrentLinkedQueue<PublishVersionRequest> getPublishVersionRequests() {
+            return publishVersionRequests;
+        }
+
+        public void clearPublishVersionRequests() {
+            publishVersionRequests.clear();
         }
 
         @Override
@@ -744,5 +769,6 @@ public class MockedBackend {
             response.status = pStatus;
             return CompletableFuture.completedFuture(response);
         }
+
     }
 }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -552,6 +552,10 @@ message TxnInfoPB {
     // to unblock a stuck-publish transaction. Only meaningful for load/compaction
     // txn types in the current implementation; alter is not supported yet.
     optional bool no_op_publish = 12;
+    // Watershed version W for a TXN_SHADOW_REWRITE flip publish: the shadow tablet's source op_write is
+    // anchored as op_schema_change@W. W == 1 means the base partition was empty at the watershed
+    // (PARTITION_INIT_VERSION == 1), so there is no source op_write and BE synthesizes an empty one.
+    optional int64 shadow_rewrite_alter_version = 13;
 }
 
 message SplittingTabletInfoPB {
@@ -585,6 +589,9 @@ message ReshardingTabletInfoPB {
     optional SplittingTabletInfoPB splitting_tablet_info = 1;
     optional MergingTabletInfoPB merging_tablet_info = 2;
     optional IdenticalTabletInfoPB identical_tablet_info = 3;
+    // Ordinal 4 was shadow_rewrite_tablet_info (removed; shadow rewrite is now keyed on
+    // TxnInfoPB.txn_type == TXN_SHADOW_REWRITE). Do NOT reuse ordinal 4 in this message. The proto2
+    // `reserved 4;` keyword is intentionally NOT used: the FE jprotobuf generator's parser rejects it.
 }
 
 // Placeholder for external cluster snapshot feature.

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -108,6 +108,7 @@ enum TxnTypePB {
      TXN_REPLICATION = 1;
      TXN_EMPTY = 2;
      TXN_TABLET_RESHARD = 3;
+     TXN_SHADOW_REWRITE = 4;   // Range-rewrite flip publish: anchor op_write as op_schema_change@alter_version
 }
 
 enum ReplicationTxnStatePB {


### PR DESCRIPTION
## Why I'm doing:

Shared-data (cloud-native) range-distribution OLAP tables cannot change their key / sort-key layout today. An `ALTER TABLE ... ORDER BY (...)` that shifts the range sort key, or a key-ness flip on a range-distributed table, is rejected: the range distribution is derived from the base-index sort key, so changing it requires re-routing every row across newly chosen tablet boundaries, which the existing 1:1 shadow-index schema-change job cannot do.

## What I'm doing:

Add `LakeRangeRewriteSchemaChangeJob`, an `AlterJobV2` that rewrites a shared-data range-distribution table's key/sort-key layout when the change shifts the range sort key (sort-key reorder, or a **pure** key-ness flip) while the **column set is unchanged**. For each physical partition it:

1. samples the base data by the **new** sort key and plans K-1 boundaries (reusing the sample-based pre-split sampler), collapsing to a single full-range tablet when the sample shows no useful split;
2. builds a K-tablet shadow index tiling the new key space;
3. materializes the shadow through an internal, watershed-version-pinned `INSERT` with concurrent double-write of incoming loads; and
4. performs the atomic catalog flip (swap the base index for the shadow, repoint the base meta, rebuild the table schema/keysType/sort key/distribution).

**Concurrency safety.** The rewrite `INSERT`'s `op_write` log is converted on the BE into an `op_schema_change` log keyed at the watershed transaction id and anchored at the watershed version `W`. The proven flip therefore orders before any concurrent post-watershed write replays on top of it, so newer writes win and no historical value is resurrected (verified for DUP / PRIMARY / AGG-REPLACE).

**Scope (everything else is unchanged).** Lake-only, **cloud-native tables only** — materialized views are out of scope (the routing predicate gates on `isCloudNativeTable()`); only sort-key reorder and pure key-ness flips with an unchanged column set are routed to this job. `ALTER ... OPTIMIZE` on range tables, add/drop key column, AGG value↔key flips (they change aggregation state, not just key-ness), range-colocate tables, AUTO_INCREMENT-key tables, and materialized views all remain rejected / unrouted exactly as before.

**Notes for review.**
- Reuses the lake schema-change watershed/flip/cancel machinery, the per-index distribution-expression routing, and the existing transaction-publish path; the BE change is a single `op_write`→`op_schema_change` converter invoked inline in `publish_version`, dispatched on a new `TXN_SHADOW_REWRITE` transaction type that carries the watershed version `W` (`TxnInfoPB.shadow_rewrite_alter_version`).
- The state machine is all-or-nothing and crash-replay idempotent on the follower (shadow reconstruction, GC-retention pin restore, double-flip / version-hole guards).
- Backend/compute-node upgrade strictly precedes frontend upgrade, so there is no frontend version gate; the capability is on by default with no config toggle.
- Key-ness-flip routing is intentionally narrow (pure flips only — mainly DUP tables without an explicit `ORDER BY`); AGG value↔key changes are deliberately **not** routed and stay rejected. Flagging this scope boundary for maintainer confirmation.

Testing: FE unit tests cover the full state machine, replay idempotency, RUNNING-resume classification, cancel/force-cancel version-hole handling, the watershed GC-pin restore, routing/rejection surface (including the materialized-view exclusion), observability, and the empty-partition flip path. BE unit tests cover the `op_write`→`op_schema_change` conversion: present source with post-watershed overwrite-wins for PRIMARY/AGG; the **W==1 empty-partition skip-load** path that synthesizes an empty anchor without any object-storage access; and a **missing source at W>1** failing the publish rather than synthesizing empty (the data-loss guard). Cluster end-to-end validation (shared-data 1 FE + 3 CN, TSP build of this PR) **passed** — DUP sort-key reorder and value→key keyness flip (data conserved), empty-partition `W==1` skip-load plus loaded `W>1` source-load in a single ALTER, and the PK concurrent newer-wins gate (DML interleaved during the rewrite window → last write wins, no stale resurrection of the watershed snapshot, count conserved). Full results are posted as a PR comment.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
