### PR TITLE
[BugFix] Clamp UTF-8 char_size in split/split_part/str_to_map empty-delimiter path

### DIFF
--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -45,8 +45,8 @@ static inline std::vector<std::string> split_utf8_characters(const Slice& str) {
     for (int i = 0; i < str.size;) {
         // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than remain;
         // clamp to the rest of the string to avoid an out-of-bounds read of adjacent memory.
-        size_t char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])],
-                                            str.size - i);
+        size_t char_size =
+                std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])], str.size - i);
         chars.emplace_back(str.data + i, char_size);
         i += char_size;
     }
@@ -218,8 +218,8 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             if (delimiter.size == 0) { // split each character
                 for (auto h = 0; h < str.size;) {
                     // Clamp to the remaining bytes: a tail lead byte may claim more than is left.
-                    size_t char_size = std::min<size_t>(
-                            UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[h])], str.size - h);
+                    size_t char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[h])],
+                                                        str.size - h);
                     array_binary_column->append(Slice(str.data + h, char_size));
                     h += char_size;
                     ++offset;

--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -43,7 +43,10 @@ struct SplitState {
 static inline std::vector<std::string> split_utf8_characters(const Slice& str) {
     std::vector<std::string> chars;
     for (int i = 0; i < str.size;) {
-        auto char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])];
+        // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than remain;
+        // clamp to the rest of the string to avoid an out-of-bounds read of adjacent memory.
+        size_t char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])],
+                                            str.size - i);
         chars.emplace_back(str.data + i, char_size);
         i += char_size;
     }
@@ -141,7 +144,9 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
                 Slice haystack = string_viewer.value(row);
 
                 for (int h = 0; h < haystack.size;) {
-                    auto char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])];
+                    // Clamp to the remaining bytes: a tail lead byte may claim more than is left.
+                    size_t char_size = std::min<size_t>(
+                            UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])], haystack.size - h);
                     v.emplace_back(haystack.data + h, char_size);
                     h += char_size;
                     ++offset;
@@ -212,7 +217,9 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             Slice delimiter = delimiter_viewer.value(row);
             if (delimiter.size == 0) { // split each character
                 for (auto h = 0; h < str.size;) {
-                    auto char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[h])];
+                    // Clamp to the remaining bytes: a tail lead byte may claim more than is left.
+                    size_t char_size = std::min<size_t>(
+                            UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[h])], str.size - h);
                     array_binary_column->append(Slice(str.data + h, char_size));
                     h += char_size;
                     ++offset;

--- a/be/src/exprs/split_part.cpp
+++ b/be/src/exprs/split_part.cpp
@@ -155,13 +155,18 @@ StatusOr<ColumnPtr> StringFunctions::split_part(FunctionContext* context, const 
             } else {
                 int char_size = 0, h = 0;
                 for (auto num = 0; h < haystack.size && num < part_number - 1; h += char_size) {
-                    char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])];
+                    // Clamp to the remaining bytes so a tail lead byte never overshoots the input.
+                    char_size = std::min<int>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])],
+                                              static_cast<int>(haystack.size) - h);
                     ++num;
                 }
                 if (h >= haystack.size) {
                     res.append("");
                 } else {
-                    char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])];
+                    // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than
+                    // remain; clamp to avoid an out-of-bounds read that leaks adjacent memory.
+                    char_size = std::min<int>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])],
+                                              static_cast<int>(haystack.size) - h);
                     res.append(Slice(haystack.data + h, char_size));
                 }
             }

--- a/be/src/exprs/str_to_map.cpp
+++ b/be/src/exprs/str_to_map.cpp
@@ -135,9 +135,8 @@ StatusOr<ColumnPtr> StringFunctions::str_to_map_v1(FunctionContext* context, con
                 // A truncated/invalid UTF-8 lead byte can claim more bytes than the haystack holds.
                 // Clamp char_size so the key slice stays in bounds and `haystack.size - char_size`
                 // (the value length) does not underflow into a huge size_t.
-                auto char_size =
-                        std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[0])],
-                                         haystack.size);
+                auto char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[0])],
+                                                  haystack.size);
                 if (is_unique(tmp_slice, Slice(haystack.data, char_size))) {
                     tmp_keys.emplace(haystack.data, char_size);
                     tmp_values.emplace(haystack.data + char_size, haystack.size - char_size);

--- a/be/src/exprs/str_to_map.cpp
+++ b/be/src/exprs/str_to_map.cpp
@@ -132,7 +132,12 @@ StatusOr<ColumnPtr> StringFunctions::str_to_map_v1(FunctionContext* context, con
                 continue;
             }
             if (delimiter.size == 0) { // return {`1-th`:`rest`}
-                auto char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[0])];
+                // A truncated/invalid UTF-8 lead byte can claim more bytes than the haystack holds.
+                // Clamp char_size so the key slice stays in bounds and `haystack.size - char_size`
+                // (the value length) does not underflow into a huge size_t.
+                auto char_size =
+                        std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[0])],
+                                         haystack.size);
                 if (is_unique(tmp_slice, Slice(haystack.data, char_size))) {
                     tmp_keys.emplace(haystack.data, char_size);
                     tmp_values.emplace(haystack.data + char_size, haystack.size - char_size);

--- a/test/sql/test_string_functions/R/test_split_empty_delim_oob
+++ b/test/sql/test_string_functions/R/test_split_empty_delim_oob
@@ -1,0 +1,49 @@
+-- name: test_split_empty_delim_oob @sequential
+CREATE DATABASE IF NOT EXISTS test_split_empty_delim_oob_db;
+-- result:
+-- !result
+USE test_split_empty_delim_oob_db;
+-- result:
+-- !result
+CREATE TABLE t (
+  id INT,
+  s VARCHAR(65533)
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES (1, unhex('F0')), (2, char(228)), (3, unhex('E4B8')), (4, 'ok');
+-- result:
+-- !result
+SELECT id, length(s) AS len, length(split_part(s, '', 1)) AS sp_len,
+       length(split_part(s, '', 1)) <= length(s) AS in_bounds
+FROM t ORDER BY id;
+-- result:
+1	1	1	1
+2	1	1	1
+3	2	2	1
+4	2	1	1
+-- !result
+SELECT id, hex(split_part(s, '', 1)) AS sp_hex FROM t ORDER BY id;
+-- result:
+1	F0
+2	E4
+3	E4B8
+4	6F
+-- !result
+SELECT id, map_size(str_to_map(s, ',', '')) AS map_sz FROM t ORDER BY id;
+-- result:
+1	1
+2	1
+3	1
+4	1
+-- !result
+SELECT id, array_length(split(s, '')) AS n_parts FROM t ORDER BY id;
+-- result:
+1	1
+2	1
+3	1
+4	2
+-- !result

--- a/test/sql/test_string_functions/T/test_split_empty_delim_oob
+++ b/test/sql/test_string_functions/T/test_split_empty_delim_oob
@@ -1,0 +1,41 @@
+-- name: test_split_empty_delim_oob @sequential
+-- description: Regression for the split / split_part / str_to_map empty-delimiter path,
+--              where a truncated/invalid UTF-8 lead byte at the tail made char_size
+--              (from UTF8_BYTE_LENGTH_TABLE) exceed the remaining bytes -> out-of-bounds
+--              heap read that leaked adjacent row bytes, plus a size_t underflow in
+--              str_to_map (haystack.size - char_size) that triggered a huge allocation.
+--              Results are kept ASCII-safe (hex / sizes) so the raw invalid bytes never
+--              reach the UTF-8 result decoder.
+
+CREATE DATABASE IF NOT EXISTS test_split_empty_delim_oob_db;
+USE test_split_empty_delim_oob_db;
+
+CREATE TABLE t (
+  id INT,
+  s VARCHAR(65533)
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- Rows ending in a truncated/invalid UTF-8 lead byte:
+--   F0   -> length table claims 4 bytes, only 1 present
+--   E4   -> claims 3, only 1 present
+--   E4B8 -> claims 3, only 2 present
+--   ok   -> valid ASCII (control)
+INSERT INTO t VALUES (1, unhex('F0')), (2, char(228)), (3, unhex('E4B8')), (4, 'ok');
+
+-- split_part: the first "character" must never be longer than the whole input.
+-- A longer result means it read out of bounds and leaked adjacent row bytes.
+SELECT id, length(s) AS len, length(split_part(s, '', 1)) AS sp_len,
+       length(split_part(s, '', 1)) <= length(s) AS in_bounds
+FROM t ORDER BY id;
+-- Exact bytes of the first part (hex keeps it ASCII-safe); must equal the input prefix.
+SELECT id, hex(split_part(s, '', 1)) AS sp_hex FROM t ORDER BY id;
+
+-- str_to_map empty delimiter: executing it proves the size_t underflow is gone (the
+-- pre-fix path attempted a ~SIZE_MAX allocation). map_size stays a small, sane number.
+SELECT id, map_size(str_to_map(s, ',', '')) AS map_sz FROM t ORDER BY id;
+
+-- split empty delimiter: every element stays within the input; array_length is bounded.
+SELECT id, array_length(split(s, '')) AS n_parts FROM t ORDER BY id;


### PR DESCRIPTION
## Why I'm doing:

A truncated or invalid UTF-8 lead byte at the tail of the input made char_size (from UTF8_BYTE_LENGTH_TABLE) exceed the remaining bytes. split() / split_part() then read up to 3 bytes past the end of the string, leaking adjacent row data; str_to_map() additionally computed haystack.size - char_size, which underflowed into a ~SIZE_MAX value length and drove a huge allocation (BE RSS spike + std::length_error / DoS).

Clamp char_size to the remaining bytes (min(char_size, remaining)) in every empty-delimiter path, mirroring the existing guard in string_functions.cpp.

Repro (column-driven, ASAN build): split_part(unhex('F0'),'',1) returned 4 bytes leaking 3 adjacent row bytes; str_to_map(char(228),',','') ballooned BE RSS to ~23GB then threw std::length_error.

Test: test/sql/test_string_functions/{T,R}/test_split_empty_delim_oob (@sequential).

## What I'm doing:

Fixes #issue

```
*** Aborted at 1781850982 (unix time) try "date -d @1781850982" if you are using GNU date ***
PC: @     0x7fd2dbdff9fc pthread_kill
*** SIGABRT (@0x45f0) received by PID 17904 (TID 0x7fcf713b9640) LWP(18711) from PID 17904; stack trace: ***
    @         0x31e5cb47 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fd2dbe02ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x31e5c346 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fd2dbdab520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fd2dbdff9fc pthread_kill
    @     0x7fd2dbdab476 raise
    @     0x7fd2dbd917f3 abort
    @         0x29367d99 starrocks::failure_function()
    @         0x31e5039d google::LogMessage::Fail()
    @         0x31e51484 google::LogMessageFatal::~LogMessageFatal()
    @         0x2cd1a74a starrocks::BinaryColumnBase<unsigned int>::append_continuous_strings(starrocks::Slice const*, unsigned long)
    @         0x24ef94bf starrocks::StringFunctions::split(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)
    @         0x2470c4e9 starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > std::__invoke_impl<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<st@
    @         0x2470b770 std::enable_if<is_invocable_r_v<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starroc@
    @         0x2470ac1d std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::C@
    @         0x24bd6cae std::function<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::I@
    @         0x24e4bef2 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a52b21d starrocks::ArrayElementExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a51e4f3 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x24e4b66b starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a51e4f3 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2a51dd24 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x1f06e216 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x2980d72f starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x29083033 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x290813e0 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x29088f9c void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x290886e2 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x290881b2 std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1cae4886 std::function<void ()>::operator()() const
    @         0x2d360b0a starrocks::FunctionRunnable::run()
    @         0x2d35ab51 starrocks::ThreadPool::dispatch_thread()
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
