### PR TITLE
[Enhancement] Pass 0 to _init_chunk_if_needed in HiveDataSource to avoid unnecessary column pre-reservation

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -1004,7 +1004,7 @@ Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     }
 
     do {
-        RETURN_IF_ERROR(_init_chunk_if_needed(chunk, _runtime_state->chunk_size()));
+        RETURN_IF_ERROR(_init_chunk_if_needed(chunk, 0));
         Status st = _scanner->get_next(state, chunk);
         if (!st.ok()) {
             return _scanner->reinterpret_status(st);


### PR DESCRIPTION
## Why I'm doing:
All other connectors (JDBC, MySQL) already pass `0` to `_init_chunk_if_needed`, which creates chunk columns without pre-reserving row capacity. HiveDataSource was the only one passing `chunk_size()`, which pre-allocates capacity for each column upfront. This pre-allocation is unnecessary since the scanner's `get_next` will fill the chunk with actual data, and it can cause issues when downstream logic (e.g., variant projection) dynamically appends new columns to the chunk — those newly appended columns would have a different size than the pre-reserved ones, leading to inconsistency.

## What I'm doing:
Align `HiveDataSource::get_next` with other connectors by passing `0` instead of `chunk_size()` to `_init_chunk_if_needed`, so the chunk is created with empty columns and no pre-reserved row capacity.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
