### PR TITLE
[BugFix] Do not rewrite avg(DISTINCT x) via a sum/count materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
@@ -59,6 +59,12 @@ public class AggregateFunctionRewriter {
         }
 
         CallOperator aggFunc = (CallOperator) op;
+        // Rewriting avg(DISTINCT x) as sum(x)/count(x) over the MV's non-distinct
+        // sum/count would silently drop DISTINCT and return a wrong result, so decline
+        // the rewrite for any distinct aggregate.
+        if (aggFunc.isDistinct()) {
+            return false;
+        }
         String aggFuncName = aggFunc.getFnName();
         if (aggFuncName.equals(FunctionSet.AVG)) {
             return true;

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_avg_distinct_rewrite
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_avg_distinct_rewrite
@@ -1,0 +1,40 @@
+-- name: test_mv_avg_distinct_rewrite
+CREATE DATABASE IF NOT EXISTS test_mv_avg_distinct_rewrite_db;
+-- result:
+-- !result
+USE test_mv_avg_distinct_rewrite_db;
+-- result:
+-- !result
+CREATE TABLE t_avgd (
+  k INT,
+  x INT
+) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_avgd VALUES (1, 10), (1, 10), (1, 40);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_avgd
+REFRESH MANUAL
+AS SELECT k, sum(x) AS s, count(x) AS c FROM t_avgd GROUP BY k;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_avgd WITH SYNC MODE;
+SET enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+SELECT k, avg(DISTINCT x) FROM t_avgd GROUP BY k ORDER BY k;
+-- result:
+1	25.0
+-- !result
+SET enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+SELECT k, avg(DISTINCT x) FROM t_avgd GROUP BY k ORDER BY k;
+-- result:
+1	25.0
+-- !result
+SELECT k, avg(x) FROM t_avgd GROUP BY k ORDER BY k;
+-- result:
+1	20.0
+-- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_avg_distinct_rewrite
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_avg_distinct_rewrite
@@ -1,0 +1,32 @@
+-- name: test_mv_avg_distinct_rewrite
+-- description: Regression for the MV aggregate rewrite that turned avg(DISTINCT x) into a
+--              non-distinct sum(x)/count(x), silently dropping DISTINCT and returning a
+--              wrong result. The rewrite must be declined for distinct aggregates, so the
+--              answer is identical with the MV rewrite on and off.
+
+CREATE DATABASE IF NOT EXISTS test_mv_avg_distinct_rewrite_db;
+USE test_mv_avg_distinct_rewrite_db;
+
+CREATE TABLE t_avgd (
+  k INT,
+  x INT
+) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+-- group k=1 has duplicate x=10; distinct {10,40} -> avg 25, non-distinct 60/3 -> 20.
+INSERT INTO t_avgd VALUES (1, 10), (1, 10), (1, 40);
+
+CREATE MATERIALIZED VIEW mv_avgd
+REFRESH MANUAL
+AS SELECT k, sum(x) AS s, count(x) AS c FROM t_avgd GROUP BY k;
+REFRESH MATERIALIZED VIEW mv_avgd WITH SYNC MODE;
+
+-- with the rewrite disabled (baseline correct answer)
+SET enable_materialized_view_rewrite = false;
+SELECT k, avg(DISTINCT x) FROM t_avgd GROUP BY k ORDER BY k;
+
+-- with the rewrite enabled: must still be 25 (rewrite declined for distinct agg)
+SET enable_materialized_view_rewrite = true;
+SELECT k, avg(DISTINCT x) FROM t_avgd GROUP BY k ORDER BY k;
+
+-- non-distinct avg may still use the MV rewrite and must stay correct
+SELECT k, avg(x) FROM t_avgd GROUP BY k ORDER BY k;


### PR DESCRIPTION
## Why I'm doing:

The MV aggregate rewrite turns avg(x) into sum(x)/count(x) so a query average can be
answered from a materialized view exposing sum/count for the same group. But
AggregateFunctionRewriter.canRewriteAggFunction accepted AVG without checking
isDistinct(), and rewriteAvg builds sum/count from the children without propagating
DISTINCT. So avg(DISTINCT x) was rewritten to the non-distinct sum(x)/count(x),
silently dropping DISTINCT and returning a wrong result when x has duplicates in a
group.

Decline the rewrite for distinct aggregates (canRewriteAggFunction returns false when
isDistinct()), so the query keeps its original correct aggregation. canRewriteAggFunction
only ever rewrote AVG, so the sole behavior change is that avg(DISTINCT x) is no longer
mis-rewritten; non-distinct avg(x) still uses the MV rewrite.

Repro: avg(DISTINCT x) over a sum/count MV returned 20 (= 60/3) with rewrite on vs the
correct 25 with rewrite off; now returns 25 in both cases.

Test: test/sql/test_materialized_view_rewrite/{T,R}/test_mv_avg_distinct_rewrite.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5


Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>