### PR TITLE
[BugFix] Clean error for ALTER MODIFY COLUMN AFTER a nonexistent column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -1095,6 +1095,9 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
         }
         if (colPos != null && table instanceof OlapTable && colPos.getLastCol() != null) {
             Column afterColumn = table.getColumn(colPos.getLastCol());
+            if (afterColumn == null) {
+                throw new SemanticException("Column[" + colPos.getLastCol() + "] does not exist");
+            }
             if (afterColumn.isGeneratedColumn()) {
                 throw new SemanticException("Can not modify column after Generated Column");
             }

--- a/test/sql/test_alter_table/R/test_alter_modify_after_nonexistent
+++ b/test/sql/test_alter_table/R/test_alter_modify_after_nonexistent
@@ -1,0 +1,22 @@
+-- name: test_alter_modify_after_nonexistent
+CREATE DATABASE IF NOT EXISTS test_alter_modify_after_nonexistent_db;
+-- result:
+-- !result
+USE test_alter_modify_after_nonexistent_db;
+-- result:
+-- !result
+CREATE TABLE t_alt1 (
+  k INT,
+  v INT
+) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER nope;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Column[nope] does not exist.')
+-- !result
+ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER k;
+-- result:
+-- !result

--- a/test/sql/test_alter_table/R/test_alter_modify_after_nonexistent
+++ b/test/sql/test_alter_table/R/test_alter_modify_after_nonexistent
@@ -15,7 +15,7 @@ PROPERTIES ("replication_num" = "1");
 -- !result
 ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER nope;
 -- result:
-[Regex] .*does not exist.*
+[REGEX].*does not exist.*
 -- !result
 ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER k;
 -- result:

--- a/test/sql/test_alter_table/R/test_alter_modify_after_nonexistent
+++ b/test/sql/test_alter_table/R/test_alter_modify_after_nonexistent
@@ -15,7 +15,7 @@ PROPERTIES ("replication_num" = "1");
 -- !result
 ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER nope;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Column[nope] does not exist.')
+[Regex] .*does not exist.*
 -- !result
 ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER k;
 -- result:

--- a/test/sql/test_alter_table/T/test_alter_modify_after_nonexistent
+++ b/test/sql/test_alter_table/T/test_alter_modify_after_nonexistent
@@ -1,0 +1,20 @@
+-- name: test_alter_modify_after_nonexistent
+-- description: ALTER TABLE ... MODIFY COLUMN ... AFTER <nonexistent column> must surface a
+--              clean "Column does not exist" semantic error instead of an internal NPE
+--              (afterColumn was dereferenced without a null check in AlterTableClauseAnalyzer).
+
+CREATE DATABASE IF NOT EXISTS test_alter_modify_after_nonexistent_db;
+USE test_alter_modify_after_nonexistent_db;
+
+CREATE TABLE t_alt1 (
+  k INT,
+  v INT
+) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- AFTER a column that does not exist -> clean semantic error (was: NPE on afterColumn)
+ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER nope;
+
+-- control: AFTER an existing column still works
+ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER k;


### PR DESCRIPTION
## Why I'm doing:

ALTER TABLE ... MODIFY COLUMN ... AFTER <col> where <col> does not exist raised an internal NullPointerException instead of a clean semantic error. AlterTableClauseAnalyzer looked up the AFTER column with table.getColumn(...) and immediately called isGeneratedColumn() on the result; for an unknown column the lookup returns null and the dereference NPEs, preempting the proper "column does not exist" check in SchemaChangeHandler.

Null-check the AFTER column first and throw SemanticException("Column[<name>] does not exist"). Valid AFTER <existing> is unaffected.

Repro: ALTER TABLE t MODIFY COLUMN v BIGINT AFTER nope; now returns "Column[nope] does not exist" instead of an afterColumn-is-null NPE.

Test: test/sql/test_alter_table/{T,R}/test_alter_modify_after_nonexistent.

## What I'm doing:

Fixes #issue

```sql
CREATE TABLE t_alt1 (k INT, v INT) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("replication_num"="1");
ALTER TABLE t_alt1 MODIFY COLUMN v BIGINT AFTER nope;
```
**Observed:** `ERROR 1064 (HY000): Cannot invoke "com.starrocks.catalog.Column.isGeneratedColumn()" because "afterColumn" is null`
**Expected:** clean semantic error, e.g. `Column[nope] does not exist`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
