### PR TITLE
[BugFix] Fix CLucene skip list reader crash in match_all queries

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -763,6 +763,7 @@ if [[ -d $TP_SOURCE_DIR/$CLUCENE_SOURCE ]] ; then
     if [ ! -f "$PATCHED_MARK" ] ; then
         patch -p1 < "$TP_PATCH_DIR/clucene-gcc14.patch"
         patch -p0 < "$TP_PATCH_DIR/clucene-no-hidden.patch"
+        patch -p1 < "$TP_PATCH_DIR/clucene-skiplist-reader.patch"
         touch "$PATCHED_MARK"
     fi
     cd -

--- a/thirdparty/patches/clucene-skiplist-reader.patch
+++ b/thirdparty/patches/clucene-skiplist-reader.patch
@@ -1,0 +1,27 @@
+Fix MATCH_ALL crash: DefaultSkipListReader::readSkipData reads the wrong skip
+VInts and dereferences an unallocated proxPointer.
+
+The skip stream written by DefaultSkipListWriter emits two VInts after the doc
+delta (FreqSkip then ProxSkip). The reader regressed (StarRocks/clucene PR #3)
+to read a single VInt into proxPointer, which the constructor no longer
+allocates. On large posting lists (df >= skipInterval) the conjunction scorer
+used by MATCH_ALL calls skipTo(), reaching this code and crashing the backend.
+
+Read FreqSkip into the allocated freqPointer and consume-and-discard the
+ProxSkip VInt to keep the stream aligned. proxPointer is never dereferenced.
+
+--- a/src/core/CLucene/index/SkipListReader.cpp
++++ b/src/core/CLucene/index/SkipListReader.cpp
+@@ -308,7 +308,11 @@
+ 	} else {
+ 		delta = _skipStream->readVInt();
+ 	}
+-	proxPointer[level] += _skipStream->readVInt();
++	// Must match DefaultSkipListWriter::writeSkipData: DocSkip [, PayloadLength?], FreqSkip, ProxSkip.
++	// Accumulate FreqSkip in freqPointer for freqStream->seek() after skipTo(); consume ProxSkip to
++	// keep the skip stream aligned (proxPointer is not allocated on the term-docs path).
++	freqPointer[level] += _skipStream->readVInt();
++	_skipStream->readVInt();
+ 
+ 	return delta;
+ }


### PR DESCRIPTION
## Why I'm doing:
[CLucene PR #3](https://github.com/StarRocks/clucene/pull/3) removed **proxPointer** allocation but left code accessing it → NULL pointer crash when document frequency ≥ 16.

## What I'm doing:
Fixes backend crash in match_all queries on inverted indexes with large posting lists.

## Test Plan

file: https://raw.githubusercontent.com/zygmuntz/goodbooks-10k/refs/heads/master/books.csv
```
ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");

CREATE TABLE books (
    book_id BIGINT NOT NULL,
    title STRING,
    INDEX idx_title (title) USING GIN ("parser" = "english")
)
ENGINE=OLAP
DUPLICATE KEY(book_id)
DISTRIBUTED BY HASH(book_id) BUCKETS 8
PROPERTIES (
    "replication_num" = "1"
);

INSERT INTO books (book_id, title)
SELECT
    CAST($1 AS BIGINT),
    $11
FROM FILES(
    "path" = "file:///tmp/books.csv",
    "format" = "csv",
    "csv.skip_header" = "1",
    "csv.column_separator" = ",",
    "csv.enclose" = "\""
);
```

### before
```
mysql> select * from test.books where title match_all 'day and';
ERROR 1064 (HY000): Backend node not found. Check if any backend node is down.backend: [127.0.0.1 alive: true inBlacklist: true]
```

### after
```
mysql> select * from test.books where title match_all 'day and';
+---------+-------------------------------------------------------------+
| book_id | title                                                       |
+---------+-------------------------------------------------------------+
|    1835 | The Devil and Miss Prym (On the Seventh Day, #3)            |
|     661 | Alexander and the Terrible, Horrible, No Good, Very Bad Day |
+---------+-------------------------------------------------------------+
2 rows in set (0.02 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
