### PR TITLE
[BugFix] Clean error for PARTITION BY RANGE(<fn>()) with no arguments

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1068,6 +1068,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             String functionName = functionCallExpr.getFunctionName().toLowerCase();
             List<Expr> paramsExpr = functionCallExpr.getParams().exprs();
             if (PARTITION_FUNCTIONS.contains(functionName)) {
+                // A partition function with no arguments (e.g. RANGE(substr(k)) parsed with an
+                // empty arg list) must surface a clean "unsupported expression" error instead of
+                // a raw IndexOutOfBoundsException from paramsExpr.get(0) below.
+                if (paramsExpr.isEmpty()) {
+                    throw new ParsingException(
+                            PARSER_ERROR_MSG.unsupportedExprWithInfo(ExprToSql.toSql(expr), "PARTITION BY"), pos);
+                }
                 Expr firstExpr = paramsExpr.get(0);
                 if (firstExpr instanceof SlotRef) {
                     columnList.add(((SlotRef) firstExpr).getColumnName());

--- a/test/sql/test_partition_by_expr/R/test_range_substr_arity
+++ b/test/sql/test_partition_by_expr/R/test_range_substr_arity
@@ -1,0 +1,21 @@
+-- name: test_range_substr_arity
+CREATE DATABASE IF NOT EXISTS test_range_substr_arity_db;
+-- result:
+-- !result
+USE test_range_substr_arity_db;
+-- result:
+-- !result
+CREATE TABLE ddl3 (k VARCHAR(10) NOT NULL)
+DUPLICATE KEY(k)
+PARTITION BY RANGE(substr(k)) ()
+DISTRIBUTED BY HASH(k);
+-- result:
+E: (1064, "Getting syntax error from line 3, column 19 to line 3, column 27. Detail message: Unsupported expr 'substr()' in PARTITION BY clause.")
+-- !result
+CREATE TABLE ddl4 (k VARCHAR(10) NOT NULL)
+DUPLICATE KEY(k)
+PARTITION BY RANGE(substr(k, 1)) ()
+DISTRIBUTED BY HASH(k);
+-- result:
+E: (1064, 'Expr[substr(k, 1)] type[VARCHAR] cannot be a range partition key.')
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_range_substr_arity
+++ b/test/sql/test_partition_by_expr/T/test_range_substr_arity
@@ -1,0 +1,20 @@
+-- name: test_range_substr_arity
+-- description: PARTITION BY RANGE(substr(col)) with too few arguments must surface a clean
+--              semantic error instead of a raw IndexOutOfBoundsException (PartitionExprAnalyzer
+--              read paramsExprList.get(0)/get(1) without an arity check).
+
+CREATE DATABASE IF NOT EXISTS test_range_substr_arity_db;
+USE test_range_substr_arity_db;
+
+-- 1-arg substr in a RANGE partition expression -> clean semantic error (was: raw AIOOBE)
+CREATE TABLE ddl3 (k VARCHAR(10) NOT NULL)
+DUPLICATE KEY(k)
+PARTITION BY RANGE(substr(k)) ()
+DISTRIBUTED BY HASH(k);
+
+-- 2-arg substr clears the arity guard (records whatever the downstream analysis does;
+-- the point is it no longer throws IndexOutOfBoundsException).
+CREATE TABLE ddl4 (k VARCHAR(10) NOT NULL)
+DUPLICATE KEY(k)
+PARTITION BY RANGE(substr(k, 1)) ()
+DISTRIBUTED BY HASH(k);


### PR DESCRIPTION


## Why I'm doing:

PARTITION BY RANGE(<partition-function>()) with an empty argument list raised a raw IndexOutOfBoundsException instead of a clean parse error. In AstBuilder.checkAndExtractPartitionColForRange, once the function is a known partition function it read paramsExpr.get(0) without checking the arg list was non-empty, so an empty-arg partition function threw "Index 0 out of bounds for length 0".

Guard paramsExpr.isEmpty() before get(0) and throw the same ParsingException(unsupportedExprWithInfo(..., "PARTITION BY")) the other invalid partition expressions already use. Valid partition functions are unaffected.

Repro: CREATE TABLE ... PARTITION BY RANGE(substr(k)) () now returns "Unsupported expr 'substr()' in PARTITION BY clause." instead of an IndexOutOfBounds.

Test: test/sql/test_partition_by_expr/{T,R}/test_range_substr_arity.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
