### PR TITLE
[BugFix] Do not roll up a date_trunc('week') MV to month/quarter/year

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 import java.util.Set;
 
 import static com.starrocks.sql.common.TimeUnitUtils.DATE_TRUNC_SUPPORTED_TIME_MAP;
+import static com.starrocks.sql.common.TimeUnitUtils.WEEK;
 
 public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
     public static final DateTruncEquivalent INSTANCE = new DateTruncEquivalent();
@@ -149,6 +150,16 @@ public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
             int oldTimeUnit = DATE_TRUNC_SUPPORTED_TIME_MAP.get(oldChild0.getVarchar());
             int newTimeUnit = DATE_TRUNC_SUPPORTED_TIME_MAP.get(newChild0.getVarchar());
             if (oldTimeUnit > newTimeUnit) {
+                return null;
+            }
+            // 'week' buckets do not nest inside larger calendar units: a week that straddles a
+            // month/quarter/year boundary is split across two of them, so a week-grain value
+            // cannot be rolled up to a coarser unit without mis-bucketing those rows.
+            // DATE_TRUNC_SUPPORTED_TIME_MAP ranks WEEK(5) between DAY(4) and MONTH(6), which
+            // would otherwise admit this invalid rollup (the sibling TIME_MAP omits week for the
+            // same reason). Finer-than-week units (day/hour/...) do nest inside a week, so
+            // day->week etc. stay allowed; only week rolled up to a different unit is rejected.
+            if (WEEK.equalsIgnoreCase(oldChild0.getVarchar()) && oldTimeUnit != newTimeUnit) {
                 return null;
             }
             CallOperator rewritten = (CallOperator) newCall.clone();

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_date_trunc_week_rollup
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_date_trunc_week_rollup
@@ -1,0 +1,54 @@
+-- name: test_mv_date_trunc_week_rollup
+CREATE DATABASE IF NOT EXISTS test_mv_date_trunc_week_rollup_db;
+-- result:
+-- !result
+USE test_mv_date_trunc_week_rollup_db;
+-- result:
+-- !result
+CREATE TABLE wkt (
+  dt DATE,
+  v INT
+) DUPLICATE KEY(dt)
+DISTRIBUTED BY HASH(dt) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO wkt VALUES ('2024-12-30', 1), ('2024-12-31', 1), ('2025-01-01', 1);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_week
+REFRESH MANUAL
+AS SELECT date_trunc('week', dt) AS wk, sum(v) AS s FROM wkt GROUP BY date_trunc('week', dt);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_week WITH SYNC MODE;
+SET enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+SELECT date_trunc('month', dt) mo, sum(v) s FROM wkt GROUP BY date_trunc('month', dt) ORDER BY mo;
+-- result:
+2024-12-01	2
+2025-01-01	1
+-- !result
+SET enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+SELECT date_trunc('month', dt) mo, sum(v) s FROM wkt GROUP BY date_trunc('month', dt) ORDER BY mo;
+-- result:
+2024-12-01	2
+2025-01-01	1
+-- !result
+SELECT date_trunc('quarter', dt) q, sum(v) s FROM wkt GROUP BY date_trunc('quarter', dt) ORDER BY q;
+-- result:
+2024-10-01	2
+2025-01-01	1
+-- !result
+SELECT date_trunc('year', dt) y, sum(v) s FROM wkt GROUP BY date_trunc('year', dt) ORDER BY y;
+-- result:
+2024-01-01	2
+2025-01-01	1
+-- !result
+SELECT date_trunc('week', dt) wk, sum(v) s FROM wkt GROUP BY date_trunc('week', dt) ORDER BY wk;
+-- result:
+2024-12-30	3
+-- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_date_trunc_week_rollup
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_date_trunc_week_rollup
@@ -1,0 +1,39 @@
+-- name: test_mv_date_trunc_week_rollup
+-- description: Regression for the MV date_trunc rollup that rewrote a month/quarter/year
+--              query using a date_trunc('week') MV. A week can straddle a month/quarter/year
+--              boundary, so the week-grain rollup mis-bucketed those rows -> wrong result.
+--              The rewrite must be declined when rolling a week grain up to a coarser unit,
+--              so the answer is identical with the MV rewrite on and off.
+
+CREATE DATABASE IF NOT EXISTS test_mv_date_trunc_week_rollup_db;
+USE test_mv_date_trunc_week_rollup_db;
+
+CREATE TABLE wkt (
+  dt DATE,
+  v INT
+) DUPLICATE KEY(dt)
+DISTRIBUTED BY HASH(dt) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- week of Mon 2024-12-30 spans into Jan 2025 (2024-12-30, 2024-12-31 in Dec; 2025-01-01 in Jan)
+INSERT INTO wkt VALUES ('2024-12-30', 1), ('2024-12-31', 1), ('2025-01-01', 1);
+
+CREATE MATERIALIZED VIEW mv_week
+REFRESH MANUAL
+AS SELECT date_trunc('week', dt) AS wk, sum(v) AS s FROM wkt GROUP BY date_trunc('week', dt);
+REFRESH MATERIALIZED VIEW mv_week WITH SYNC MODE;
+
+-- month rollup, rewrite OFF: correct baseline (Dec=2, Jan=1)
+SET enable_materialized_view_rewrite = false;
+SELECT date_trunc('month', dt) mo, sum(v) s FROM wkt GROUP BY date_trunc('month', dt) ORDER BY mo;
+
+-- month rollup, rewrite ON: must match (week->month rollup declined); was wrongly {Dec=3}
+SET enable_materialized_view_rewrite = true;
+SELECT date_trunc('month', dt) mo, sum(v) s FROM wkt GROUP BY date_trunc('month', dt) ORDER BY mo;
+
+-- quarter and year rollups must also stay correct with rewrite ON
+SELECT date_trunc('quarter', dt) q, sum(v) s FROM wkt GROUP BY date_trunc('quarter', dt) ORDER BY q;
+SELECT date_trunc('year', dt) y, sum(v) s FROM wkt GROUP BY date_trunc('year', dt) ORDER BY y;
+
+-- a week-grain query CAN still use the week MV (identical unit) with rewrite ON
+SELECT date_trunc('week', dt) wk, sum(v) s FROM wkt GROUP BY date_trunc('week', dt) ORDER BY wk;


### PR DESCRIPTION
## Why I'm doing:

DateTruncEquivalent lets a date_trunc MV answer a coarser date_trunc query, gated by oldTimeUnit > newTimeUnit using DATE_TRUNC_SUPPORTED_TIME_MAP. That map ranks WEEK(5) between DAY(4) and MONTH(6), so a week-grain MV passes the guard for a month/quarter/year query and date_trunc('month', dt) is rewritten to date_trunc('month', <week_start>).

But a week does not nest inside a month/quarter/year: a week that straddles the boundary is split across two of them. The MV collapses such a week's rows to its Monday's week-start, mis-bucketing the rows on the far side of the boundary -> silent wrong result. (The sibling TIME_MAP omits week for exactly this reason.)

Reject the rollup when the MV grain is week and the query unit differs. Identical week->week stays valid, and finer-than-week units (day/hour/...) genuinely nest inside a week so day->week etc. are unaffected.

Repro: month rollup of a date_trunc('week') MV over rows in a week spanning Dec/Jan returned {Dec:3} with rewrite on vs the correct {Dec:2, Jan:1}; now correct in both.

Test: test/sql/test_materialized_view_rewrite/{T,R}/test_mv_date_trunc_week_rollup.

## What I'm doing:

Fixes #issue

```sql
CREATE TABLE wkt (dt DATE, v INT) DUPLICATE KEY(dt) DISTRIBUTED BY HASH(dt) BUCKETS 1 PROPERTIES("replication_num"="1");
INSERT INTO wkt VALUES ('2024-12-30',1),('2024-12-31',1),('2025-01-01',1);   -- week of Mon 2024-12-30 spans into Jan
CREATE MATERIALIZED VIEW mv_week REFRESH MANUAL AS SELECT date_trunc('week', dt) wk, sum(v) s FROM wkt GROUP BY date_trunc('week', dt);
REFRESH MATERIALIZED VIEW mv_week WITH SYNC MODE;

SET enable_materialized_view_rewrite=false; SELECT date_trunc('month',dt) mo, sum(v) s FROM wkt GROUP BY date_trunc('month',dt) ORDER BY mo;  -- {2024-12-01:2, 2025-01-01:1}
SET enable_materialized_view_rewrite=true;  SELECT date_trunc('month',dt) mo, sum(v) s FROM wkt GROUP BY date_trunc('month',dt) ORDER BY mo;  -- {2024-12-01:3}  ← WRONG
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
