### PR TITLE
[Enhancement] Estimate row count for Files/FileTable from file sizes instead of hardcoded 1

### DIFF
--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -91,6 +91,15 @@ This topic introduces the following types of FE configurations:
 - Description: Timeout in milliseconds applied to the BRPC TalkTimeoutController before sending a plan fragment. `BackendServiceClient.sendPlanFragmentAsync` sets this value prior to calling the backend `execPlanFragmentAsync`. It governs how long BRPC will wait when borrowing an idle connection from the connection pool and while performing the send; if exceeded, the RPC will fail and may trigger the method's retry logic. Set this lower to fail fast under contention, or raise it to tolerate transient pool exhaustion or slow networks. Be cautious: very large values can delay failure detection and block request threads.
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
+### `connector_row_size_estimate_bytes`
+
+- Default: 256
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: The estimated average row size in bytes used by the optimizer to estimate row counts for external file tables (FILES() and ENGINE=file tables) when the storage format is unknown or the column schema is not available. The row count is estimated as `total_file_bytes / connector_row_size_estimate_bytes`. A smaller value produces a higher row count estimate and may affect join ordering decisions.
+- Introduced in: v3.4
+
 ### `connector_table_query_trigger_analyze_large_table_interval`
 
 - Default: 12 * 3600

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -91,6 +91,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 在发送计划片段之前应用于 BRPC TalkTimeoutController 的超时（毫秒）。`BackendServiceClient.sendPlanFragmentAsync` 在调用后端 `execPlanFragmentAsync` 之前设置此值。它控制 BRPC 在从连接池借用空闲连接以及执行发送时将等待多长时间；如果超过，RPC 将失败并可能触发该方法的重试逻辑。在争用情况下，将此值设置得更低以快速失败，或提高它以容忍瞬时池耗尽或慢速网络。请谨慎：非常大的值可能会延迟故障检测并阻塞请求线程。
 - 引入版本: v3.3.11, v3.4.1, v3.5.0
 
+### `connector_row_size_estimate_bytes`
+
+- 默认值: 256
+- 类型: Long
+- 单位: Bytes
+- 是否可变: Yes
+- 描述: 优化器在存储格式未知或列 Schema 不可用时，用于估算外部文件表（FILES() 和 ENGINE=file 表）行数的平均行大小（字节）。行数估算公式为 `总文件字节数 / connector_row_size_estimate_bytes`。值越小，估算行数越大，可能影响 Join 顺序决策。
+- 引入版本: v3.4
+
 ### `connector_table_query_trigger_analyze_large_table_interval`
 
 - 默认值: 12 * 3600

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -64,6 +64,11 @@ public class FileTable extends Table {
     @SerializedName(value = "fp")
     private Map<String, String> fileProperties = Maps.newHashMap();
 
+    // Cached file descriptors to avoid redundant remote listing within the same instance
+    // (e.g., statistics computation and scan-range setup both call getFileDescsFromHdfs).
+    // No TTL needed: FileTable is a per-query construct; cross-query stale reads are acceptable.
+    private volatile List<RemoteFileDesc> cachedFileDescs;
+
     public FileTable() {
         super(TableType.FILE);
     }
@@ -112,6 +117,9 @@ public class FileTable extends Table {
     }
 
     public List<RemoteFileDesc> getFileDescsFromHdfs() throws DdlException {
+        if (cachedFileDescs != null) {
+            return cachedFileDescs;
+        }
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(fileProperties);
         Configuration configuration = hdfsEnvironment.getConfiguration();
         HiveRemoteFileIO remoteFileIO = new HiveRemoteFileIO(configuration);
@@ -133,7 +141,8 @@ public class FileTable extends Table {
                     throw new DdlException("the path is a directory but didn't end with '/'");
                 }
             }
-            return remoteFileDescs;
+            cachedFileDescs = remoteFileDescs;
+            return cachedFileDescs;
         } catch (StarRocksConnectorException e) {
             throw new DdlException("doesn't get file with path: " + getTableLocation(), e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -64,11 +64,6 @@ public class FileTable extends Table {
     @SerializedName(value = "fp")
     private Map<String, String> fileProperties = Maps.newHashMap();
 
-    // Cached file descriptors to avoid redundant remote listing within the same instance
-    // (e.g., statistics computation and scan-range setup both call getFileDescsFromHdfs).
-    // No TTL needed: FileTable is a per-query construct; cross-query stale reads are acceptable.
-    private volatile List<RemoteFileDesc> cachedFileDescs;
-
     public FileTable() {
         super(TableType.FILE);
     }
@@ -117,9 +112,6 @@ public class FileTable extends Table {
     }
 
     public List<RemoteFileDesc> getFileDescsFromHdfs() throws DdlException {
-        if (cachedFileDescs != null) {
-            return cachedFileDescs;
-        }
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(fileProperties);
         Configuration configuration = hdfsEnvironment.getConfiguration();
         HiveRemoteFileIO remoteFileIO = new HiveRemoteFileIO(configuration);
@@ -141,8 +133,7 @@ public class FileTable extends Table {
                     throw new DdlException("the path is a directory but didn't end with '/'");
                 }
             }
-            cachedFileDescs = remoteFileDescs;
-            return cachedFileDescs;
+            return remoteFileDescs;
         } catch (StarRocksConnectorException e) {
             throw new DdlException("doesn't get file with path: " + getTableLocation(), e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4523,6 +4523,15 @@ public class Config extends ConfigBase {
     public static long default_statistics_output_row_count = 1L;
 
     /**
+     * Default estimated bytes per row used by {@code RowCountEstimator} when the file format
+     * is unknown or does not support schema-based size estimation (e.g. SEQUENCE files).
+     * This value is divided into the total file size to produce an approximate row count for
+     * external file tables that have no statistics collected yet.
+     */
+    @ConfField(mutable = true)
+    public static long connector_row_size_estimate_bytes = 256L;
+
+    /**
      * Whether enable range distribution.
      */
     @ConfField(mutable = true, comment = "Whether enable range distribution.")

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/RowCountEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/RowCountEstimator.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.common.Config;
+import com.starrocks.connector.hive.HiveStorageFormat;
+import com.starrocks.type.ScalarType;
+
+import java.util.List;
+
+/**
+ * Estimates the row count of an external file-based table from its total file size,
+ * schema, and storage format — all available at planning time with zero extra IO.
+ *
+ * <p>Formula: {@code rowCount = max(totalBytes / estimatedRowSize, 1)}
+ *
+ * <p>Row-size is derived from column type widths scaled by a format-specific compression
+ * factor:
+ * <ul>
+ *   <li>Parquet / ORC: 0.25  (columnar + compression reduces on-disk size ~4–10x)</li>
+ *   <li>Text / Avro / RC: 1.5  (row-oriented, minimal encoding overhead)</li>
+ *   <li>Unknown format: falls back to {@link Config#connector_row_size_estimate_bytes}</li>
+ * </ul>
+ */
+public class RowCountEstimator {
+
+    private static final double COLUMNAR_FORMAT_FACTOR = 0.25;
+    private static final double ROW_FORMAT_FACTOR = 1.5;
+    private static final long MIN_ROW_SIZE_BYTES = 8L;
+    // VARCHAR/CHAR representative size cap — actual stored length varies widely.
+    private static final int MAX_STRING_COL_SIZE = 64;
+
+    private RowCountEstimator() {}
+
+    /**
+     * Estimates row count from total file bytes, column list, and storage format.
+     *
+     * @param totalBytes  sum of all file sizes in bytes
+     * @param dataColumns schema columns (used only for type-size computation)
+     * @param format      storage format; {@code null} or unsupported values use the config default
+     * @return estimated row count, at least 1
+     */
+    public static long estimate(long totalBytes, List<Column> dataColumns, HiveStorageFormat format) {
+        if (totalBytes <= 0) {
+            return 1L;
+        }
+        long rowSize = computeRowSize(dataColumns, format);
+        return Math.max(totalBytes / rowSize, 1L);
+    }
+
+    private static long computeRowSize(List<Column> dataColumns, HiveStorageFormat format) {
+        Double factor = factorFor(format);
+        if (factor == null) {
+            // Unknown format — use the config default directly as bytes/row.
+            return Math.max(Config.connector_row_size_estimate_bytes, MIN_ROW_SIZE_BYTES);
+        }
+
+        long rawSize = 0;
+        for (Column col : dataColumns) {
+            rawSize += colTypeSize(col);
+        }
+        if (rawSize <= 0) {
+            return Math.max(Config.connector_row_size_estimate_bytes, MIN_ROW_SIZE_BYTES);
+        }
+        return Math.max((long) (rawSize * factor), MIN_ROW_SIZE_BYTES);
+    }
+
+    /**
+     * Returns the compression factor for the given format, or {@code null} if unknown
+     * (meaning the config default should be used instead of the schema-based estimate).
+     */
+    private static Double factorFor(HiveStorageFormat format) {
+        if (format == null) {
+            return null;
+        }
+        switch (format) {
+            case PARQUET:
+            case ORC:
+                return COLUMNAR_FORMAT_FACTOR;
+            case TEXTFILE:
+            case AVRO:
+            case RCTEXT:
+            case RCBINARY:
+                return ROW_FORMAT_FACTOR;
+            default:
+                return null;
+        }
+    }
+
+    private static int colTypeSize(Column col) {
+        if (col.getType().isStringType() && col.getType() instanceof ScalarType) {
+            int len = ((ScalarType) col.getType()).getLength();
+            return (len > 0) ? Math.min(len, MAX_STRING_COL_SIZE) : MAX_STRING_COL_SIZE;
+        }
+        return col.getType().getTypeSize();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -674,11 +674,6 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private long estimateFileScanRowCount(FileTable fileTable) {
-        if (optimizerContext != null
-                && optimizerContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable()
-                && optimizerContext.getSourceTablesCount() == 1) {
-            return Config.default_statistics_output_row_count;
-        }
         try {
             // Use getFileDescsFromHdfs() — we only need file sizes, not text-format metadata.
             List<RemoteFileDesc> fileDescs = fileTable.getFileDescsFromHdfs();
@@ -703,11 +698,6 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private long estimateTableFunctionScanRowCount(TableFunctionTable table) {
-        if (optimizerContext != null
-                && optimizerContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable()
-                && optimizerContext.getSourceTablesCount() == 1) {
-            return Config.default_statistics_output_row_count;
-        }
         try {
             List<TBrokerFileStatus> fileStatuses = table.loadFileList();
             if (fileStatuses == null || fileStatuses.isEmpty()) {
@@ -723,7 +713,12 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 return RowCountEstimator.estimate(totalBytes, Collections.emptyList(), null);
             }
 
-            HiveStorageFormat format = HiveStorageFormat.get(table.getFormat());
+            // CSV is stored as TEXTFILE in HiveStorageFormat; map it explicitly so the
+            // row-format compression factor (1.5) is applied rather than falling back to
+            // connector_row_size_estimate_bytes.
+            String fmt = table.getFormat();
+            HiveStorageFormat format = "csv".equalsIgnoreCase(fmt)
+                    ? HiveStorageFormat.TEXTFILE : HiveStorageFormat.get(fmt);
             return RowCountEstimator.estimate(totalBytes, table.getBaseSchema(), format);
         } catch (Exception e) {
             LOG.warn("Failed to estimate row count for TableFunctionTable [{}], fallback to default",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.BenchmarkTable;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FileTable;
 import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
@@ -33,16 +34,20 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.benchmark.BenchmarkRowCountCalculator;
 import com.starrocks.connector.benchmark.RowCountEstimate;
+import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.connector.iceberg.IcebergMORParams;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
+import com.starrocks.connector.statistics.RowCountEstimator;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -159,6 +164,7 @@ import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.rule.transformation.ListPartitionPruner;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.columns.PredicateColumnsMgr;
+import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.type.DateType;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -370,7 +376,8 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalTableFunctionTableScan(LogicalTableFunctionTableScanOperator node, ExpressionContext context) {
-        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap());
+        return computeTableFunctionScanNode(node, context, node.getColRefToColumnMetaMap(),
+                (TableFunctionTable) node.getTable());
     }
 
     private Void computeOlapScanNode(Operator node, ExpressionContext context, Table table,
@@ -645,26 +652,84 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalFileScan(LogicalFileScanOperator node, ExpressionContext context) {
-        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap());
+        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap(), (FileTable) node.getTable());
     }
 
     @Override
     public Void visitPhysicalFileScan(PhysicalFileScanOperator node, ExpressionContext context) {
-        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap());
+        return computeFileScanNode(node, context, node.getColRefToColumnMetaMap(), (FileTable) node.getTable());
     }
 
     private Void computeFileScanNode(Operator node, ExpressionContext context,
-                                     Map<ColumnRefOperator, Column> columnRefOperatorColumnMap) {
-        // Use default statistics for now.
+                                     Map<ColumnRefOperator, Column> columnRefOperatorColumnMap,
+                                     FileTable fileTable) {
         Statistics.Builder builder = Statistics.builder();
         for (ColumnRefOperator columnRefOperator : columnRefOperatorColumnMap.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
         }
-        // cause we don't know the real schema in file，just use the default Row Count now
-        builder.setOutputRowCount(1);
+        builder.setOutputRowCount(estimateFileScanRowCount(fileTable));
         context.setStatistics(builder.build());
 
         return visitOperator(node, context);
+    }
+
+    private long estimateFileScanRowCount(FileTable fileTable) {
+        if (optimizerContext != null
+                && optimizerContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable()
+                && optimizerContext.getSourceTablesCount() == 1) {
+            return Config.default_statistics_output_row_count;
+        }
+        try {
+            // Use getFileDescsFromHdfs() — we only need file sizes, not text-format metadata.
+            List<RemoteFileDesc> fileDescs = fileTable.getFileDescsFromHdfs();
+            long totalBytes = fileDescs.stream().mapToLong(RemoteFileDesc::getLength).sum();
+            return RowCountEstimator.estimate(totalBytes, fileTable.getBaseSchema(), fileTable.getFileFormat());
+        } catch (Exception e) {
+            LOG.warn("Failed to estimate row count for FileTable [{}], fallback to default", fileTable.getName(), e);
+            return Config.default_statistics_output_row_count;
+        }
+    }
+
+    private Void computeTableFunctionScanNode(Operator node, ExpressionContext context,
+                                              Map<ColumnRefOperator, Column> columnRefOperatorColumnMap,
+                                              TableFunctionTable table) {
+        Statistics.Builder builder = Statistics.builder();
+        for (ColumnRefOperator columnRefOperator : columnRefOperatorColumnMap.keySet()) {
+            builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
+        }
+        builder.setOutputRowCount(estimateTableFunctionScanRowCount(table));
+        context.setStatistics(builder.build());
+        return visitOperator(node, context);
+    }
+
+    private long estimateTableFunctionScanRowCount(TableFunctionTable table) {
+        if (optimizerContext != null
+                && optimizerContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable()
+                && optimizerContext.getSourceTablesCount() == 1) {
+            return Config.default_statistics_output_row_count;
+        }
+        try {
+            List<TBrokerFileStatus> fileStatuses = table.loadFileList();
+            if (fileStatuses == null || fileStatuses.isEmpty()) {
+                return Config.default_statistics_output_row_count;
+            }
+            long totalBytes = fileStatuses.stream().mapToLong(f -> f.size).sum();
+
+            // When the user explicitly provides a "schema" property, the declared columns are
+            // a user-chosen subset and may not reflect the full file layout — so the schema-based
+            // row-size estimate would be too small and would wildly overestimate the row count.
+            // Pass an empty column list so RowCountEstimator falls back to the config default bytes/row.
+            if (table.getProperties().containsKey(TableFunctionTable.PROPERTY_SCHEMA)) {
+                return RowCountEstimator.estimate(totalBytes, Collections.emptyList(), null);
+            }
+
+            HiveStorageFormat format = HiveStorageFormat.get(table.getFormat());
+            return RowCountEstimator.estimate(totalBytes, table.getBaseSchema(), format);
+        } catch (Exception e) {
+            LOG.warn("Failed to estimate row count for TableFunctionTable [{}], fallback to default",
+                    table.getName(), e);
+            return Config.default_statistics_output_row_count;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/statistics/RowCountEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/statistics/RowCountEstimatorTest.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.common.Config;
+import com.starrocks.connector.hive.HiveStorageFormat;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RowCountEstimatorTest {
+
+    private static Column intCol(String name) {
+        return new Column(name, IntegerType.INT);
+    }
+
+    private static Column bigintCol(String name) {
+        return new Column(name, IntegerType.BIGINT);
+    }
+
+    private static Column varcharCol(String name, int len) {
+        return new Column(name, TypeFactory.createVarcharType(len));
+    }
+
+    // --- boundary cases ---
+
+    @Test
+    public void testZeroBytes() {
+        List<Column> cols = Arrays.asList(intCol("a"), intCol("b"));
+        assertEquals(1L, RowCountEstimator.estimate(0, cols, HiveStorageFormat.PARQUET));
+    }
+
+    @Test
+    public void testNegativeBytes() {
+        List<Column> cols = Arrays.asList(intCol("a"));
+        assertEquals(1L, RowCountEstimator.estimate(-1, cols, HiveStorageFormat.PARQUET));
+    }
+
+    @Test
+    public void testEmptyColumnList() {
+        // No schema → falls back to Config.connector_row_size_estimate_bytes
+        long rowCount = RowCountEstimator.estimate(100_000_000L, Collections.emptyList(), HiveStorageFormat.PARQUET);
+        long expected = 100_000_000L / Math.max(Config.connector_row_size_estimate_bytes, 8L);
+        assertEquals(expected, rowCount);
+    }
+
+    // --- format factor ---
+
+    @Test
+    public void testParquetGivesHigherRowCountThanText() {
+        // Same bytes, same schema: Parquet has smaller on-disk row size → more rows
+        List<Column> cols = Arrays.asList(intCol("a"), intCol("b"), intCol("c"));
+        long parquetRows = RowCountEstimator.estimate(100_000_000L, cols, HiveStorageFormat.PARQUET);
+        long textRows   = RowCountEstimator.estimate(100_000_000L, cols, HiveStorageFormat.TEXTFILE);
+        assertTrue(parquetRows > textRows,
+                "Parquet rows=" + parquetRows + " should be > text rows=" + textRows);
+    }
+
+    @Test
+    public void testOrcSameAsParquet() {
+        List<Column> cols = Arrays.asList(intCol("a"), bigintCol("b"));
+        long parquetRows = RowCountEstimator.estimate(50_000_000L, cols, HiveStorageFormat.PARQUET);
+        long orcRows     = RowCountEstimator.estimate(50_000_000L, cols, HiveStorageFormat.ORC);
+        assertEquals(parquetRows, orcRows);
+    }
+
+    @Test
+    public void testUnknownFormatUsesConfigDefault() {
+        List<Column> cols = Arrays.asList(intCol("a"));
+        // SEQUENCE falls through to null factor → uses connector_row_size_estimate_bytes
+        long rowCount = RowCountEstimator.estimate(100_000_000L, cols, HiveStorageFormat.SEQUENCE);
+        long expected = 100_000_000L / Math.max(Config.connector_row_size_estimate_bytes, 8L);
+        assertEquals(expected, rowCount);
+    }
+
+    @Test
+    public void testNullFormatUsesConfigDefault() {
+        List<Column> cols = Arrays.asList(intCol("a"));
+        long rowCount = RowCountEstimator.estimate(100_000_000L, cols, null);
+        long expected = 100_000_000L / Math.max(Config.connector_row_size_estimate_bytes, 8L);
+        assertEquals(expected, rowCount);
+    }
+
+    // --- VARCHAR capping ---
+
+    @Test
+    public void testVarcharLengthIsCapped() {
+        // A very wide VARCHAR should not make row size explode; capped at MAX_STRING_COL_SIZE (64)
+        Column wideVarchar = varcharCol("s", 10000);
+        Column narrowVarchar = varcharCol("s", 10);
+
+        long rowsWide   = RowCountEstimator.estimate(100_000_000L, Collections.singletonList(wideVarchar),
+                HiveStorageFormat.TEXTFILE);
+        long rowsNarrow = RowCountEstimator.estimate(100_000_000L, Collections.singletonList(narrowVarchar),
+                HiveStorageFormat.TEXTFILE);
+
+        // VARCHAR(10000) should not give a wildly smaller row count than VARCHAR(10)
+        // because the cap at 64 bytes kicks in for wide columns
+        assertTrue(rowsWide >= rowsNarrow / 10,
+                "Wide VARCHAR row count=" + rowsWide + " should not be orders of magnitude below narrow=" + rowsNarrow);
+    }
+
+    // --- sanity: Parquet 100MB, 5 INT cols ---
+
+    @Test
+    public void testParquetSanityCheck() {
+        // 5 INT cols, 4 bytes each = 20 raw bytes; factor 0.25 → 5 bytes/row on disk
+        // 100MB / 5 = 20M rows expected
+        List<Column> cols = Arrays.asList(intCol("a"), intCol("b"), intCol("c"), intCol("d"), intCol("e"));
+        long rowCount = RowCountEstimator.estimate(100_000_000L, cols, HiveStorageFormat.PARQUET);
+        assertTrue(rowCount > 1_000_000L,
+                "Expected >> 1M rows for 100MB Parquet with 5 INT cols, got: " + rowCount);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilesSchemaPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilesSchemaPlanTest.java
@@ -22,6 +22,10 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -96,6 +100,37 @@ public class FilesSchemaPlanTest extends PlanTestBase {
         assertEquals(PrimitiveType.BIGINT, t.getColumn("x").getType().getPrimitiveType());
         assertNotNull(t.getColumn("y"));
         assertEquals(PrimitiveType.VARCHAR, t.getColumn("y").getType().getPrimitiveType());
+    }
+
+    /**
+     * Verifies that FILES() row count is estimated from file sizes rather than hardcoded to 1.
+     *
+     * fake:// produces two files: 1024 + 2048 = 3072 bytes total.
+     * With explicit 'schema' property present, RowCountEstimator falls back to
+     * connector_row_size_estimate_bytes (default 256), giving 3072 / 256 = 12 rows.
+     *
+     * Uses the optimizer layer directly (no fragment build) to avoid Hadoop FS init for fake://.
+     */
+    @Test
+    public void testFilesRowCountEstimation() throws Exception {
+        String sql = "SELECT * FROM FILES(" +
+                "  'path' = 'fake://bucket/dir/'," +
+                "  'format' = 'parquet'," +
+                "  'schema' = 'x BIGINT, y VARCHAR(64)')";
+        Statistics stats = optimizerStatsForQuery(sql);
+        // fake:// files: 1024 + 2048 = 3072 bytes; connector_row_size_estimate_bytes=256 → 12 rows
+        assertEquals(12L, (long) stats.getOutputRowCount(),
+                "Row count should be file-size-based, not hardcoded to 1");
+    }
+
+    /** Runs the query through the CBO optimizer and returns the root node's statistics. */
+    private static Statistics optimizerStatsForQuery(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        LogicalPlan logicalPlan =
+                UtFrameUtils.getQueryLogicalPlan(connectContext, columnRefFactory, (QueryStatement) stmt);
+        OptExpression optExpr = UtFrameUtils.getQueryOptExpression(connectContext, columnRefFactory, logicalPlan);
+        return optExpr.getStatistics();
     }
 
     @Test

--- a/test/sql/test_files/R/test_files_row_count_estimation
+++ b/test/sql/test_files/R/test_files_row_count_estimation
@@ -1,0 +1,21 @@
+-- name: test_files_row_count_estimation
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 cp --force ./sql/test_files/parquet_format/basic_type.parquet oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 2,281. OK num: 1(upload 1 files).
+-- !result
+function: assert_explain_costs_contains("select * from files('path'='oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*', 'format'='parquet', 'aws.s3.access_key'='${oss_ak}', 'aws.s3.secret_key'='${oss_sk}', 'aws.s3.endpoint'='${oss_endpoint}', 'schema'='k2 INT');", "cardinality: 8")
+-- result:
+None
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null
+-- result:
+0
+-- !result

--- a/test/sql/test_files/T/test_files_row_count_estimation
+++ b/test/sql/test_files/T/test_files_row_count_estimation
@@ -1,0 +1,12 @@
+-- name: test_files_row_count_estimation
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 cp --force ./sql/test_files/parquet_format/basic_type.parquet oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ | grep -Pv "(average|elapsed)"
+
+-- basic_type.parquet is 2281 bytes; with explicit 'schema' (PROPERTY_SCHEMA present),
+-- RowCountEstimator falls back to connector_row_size_estimate_bytes=256 => 2281/256 = 8 rows.
+function: assert_explain_costs_contains("select * from files('path'='oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*', 'format'='parquet', 'aws.s3.access_key'='${oss_ak}', 'aws.s3.secret_key'='${oss_sk}', 'aws.s3.endpoint'='${oss_endpoint}', 'schema'='k2 INT');", "cardinality: 8")
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

The optimizer hardcodes `row count = 1` for `FILES()` (TableFunctionTable) and `ENGINE=file` (FileTable) scan nodes, regardless of actual data volume. This causes the CBO to treat multi-gigabyte external scans as single-row lookups, leading to poor join ordering and cardinality propagation errors downstream.

File sizes are already available at planning time with zero extra IO, so a much better estimate is within reach at no cost.

## What I'm doing:

**New utility: `RowCountEstimator`**

Estimates row count as `totalFileBytes / estimatedRowSize`, where row size is derived from column type widths scaled by a format-aware compression factor:

```
PARQUET / ORC          → factor 0.25  (columnar + compressed ≈ 4x smaller on disk)
TEXTFILE / AVRO / RC   → factor 1.5   (row-oriented, minimal encoding)
unknown format         → use Config.connector_row_size_estimate_bytes (default 256)
```

**`StatisticsCalculator` wiring**

- `computeFileScanNode` — calls `FileTable.getFileDescsFromHdfs()` for file sizes, then feeds into `RowCountEstimator`.
- `computeTableFunctionScanNode` — uses the already-populated `TableFunctionTable.loadFileList()` (no extra IO); when an explicit `schema` property is present (user-declared column subset), falls back to `connector_row_size_estimate_bytes` to avoid underestimating row size.
- CSV format is mapped to `TEXTFILE` before estimation (`HiveStorageFormat.get("csv")` returns `UNSUPPORTED`).

**New config knob**

`connector_row_size_estimate_bytes` (default 256, mutable) — controls the fallback bytes-per-row when format or schema is unknown.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
