### PR TITLE
[Enhancement] Add async row-count statistics for JDBC connectors (MySQL, Postgres, ClickHouse)

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -1041,6 +1041,33 @@ This topic introduces the following types of FE configurations:
 - Description: The default expiration time for the JDBC Catalog metadata cache. When `jdbc_meta_default_cache_enable` is set to true, newly created JDBC Catalogs will default to setting the expiration time of the metadata cache.
 - Introduced in: -
 
+### `jdbc_row_count_cache_refresh_sec`
+
+- Default: 600
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Background refresh interval for the JDBC table row-count cache. After this interval, the stale value is returned immediately while a reload runs asynchronously in the background. Overridable per-catalog via the catalog property `jdbc_row_count_cache_refresh_sec`.
+- Introduced in: -
+
+### `jdbc_row_count_cache_expire_sec`
+
+- Default: 1200
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Hard eviction TTL for JDBC table row-count cache entries. Entries not accessed within this window are evicted. Must be greater than `jdbc_row_count_cache_refresh_sec`. Overridable per-catalog via the catalog property `jdbc_row_count_cache_expire_sec`.
+- Introduced in: -
+
+### `jdbc_row_count_cache_max_size`
+
+- Default: 10000
+- Type: Long
+- Unit: -
+- Is mutable: Yes
+- Description: Maximum number of entries in the JDBC table row-count cache per catalog. Limits memory growth for catalogs with large numbers of tables. Overridable per-catalog via the catalog property `jdbc_row_count_cache_max_size`.
+- Introduced in: -
+
 ### `jdbc_minimum_idle_connections`
 
 - Default: 1

--- a/docs/en/data_source/catalog/jdbc_catalog.md
+++ b/docs/en/data_source/catalog/jdbc_catalog.md
@@ -71,6 +71,16 @@ When `driver_class` is set to Oracle, you can configure the following optional p
 | oracle.temporal.to-datetime    | false       | Controls Oracle `DATE`, `TIMESTAMP`, and `TIMESTAMP WITH LOCAL TIME ZONE` mapping. If it is set to `true`, these data types are mapped to StarRocks' `DATETIME` type; otherwise, `DATE` remains `DATE`, and `TIMESTAMP` / `TIMESTAMP WITH LOCAL TIME ZONE` are mapped to `VARCHAR(64)`. |
 | oracle.timestamptz.to-datetime | false       | Controls Oracle `TIMESTAMP WITH TIME ZONE` mapping. If it is set to `true`, it is mapped to StarRocks' `DATETIME` type; otherwise, it is mapped to `VARCHAR(64)`. |
 
+#### Optional row-count cache properties
+
+StarRocks caches per-table row counts from JDBC sources to avoid blocking query planning. These properties let you tune the cache behavior per catalog. If not set, the global FE configuration values are used.
+
+| **Parameter**                       | **Default** | **Description**                                                                                                                                             |
+| ----------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| jdbc_row_count_cache_refresh_sec    | 600         | Background refresh interval (seconds). After this interval, the cached value is returned immediately while a reload runs asynchronously in the background.  |
+| jdbc_row_count_cache_expire_sec     | 1200        | Hard eviction TTL (seconds). Cache entries not accessed within this window are evicted. Must be greater than `jdbc_row_count_cache_refresh_sec`.            |
+| jdbc_row_count_cache_max_size       | 10000       | Maximum number of table entries in the row-count cache for this catalog.                                                                                   |
+
 > **NOTE**
 >
 > The FEs download the JDBC driver JAR package at the time of JDBC catalog creation, and the BEs or CNs download the JDBC driver JAR package at the time of the first query. The amount of time taken for the download varies depending on network conditions.

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -1036,6 +1036,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：JDBC カタログのメタデータキャッシュのデフォルトの有効期限。`jdbc_meta_default_cache_enable` が true に設定されている場合、新しく作成された JDBC カタログはデフォルトでメタデータキャッシュの有効期限を設定します。
 - 導入時期：-
 
+### `jdbc_row_count_cache_refresh_sec`
+
+- デフォルト：600
+- タイプ：Long
+- 単位：Seconds
+- 変更可能：Yes
+- 説明：JDBC テーブルの行数キャッシュのバックグラウンド更新間隔。この間隔を過ぎると、古い値を即座に返しながらバックグラウンドで非同期に再読み込みします。カタログプロパティ `jdbc_row_count_cache_refresh_sec` でカタログごとに上書き可能です。
+- 導入時期：-
+
+### `jdbc_row_count_cache_expire_sec`
+
+- デフォルト：1200
+- タイプ：Long
+- 単位：Seconds
+- 変更可能：Yes
+- 説明：JDBC テーブルの行数キャッシュエントリの強制削除 TTL。この期間内にアクセスされなかったエントリは削除されます。`jdbc_row_count_cache_refresh_sec` より大きい値を設定してください。カタログプロパティ `jdbc_row_count_cache_expire_sec` でカタログごとに上書き可能です。
+- 導入時期：-
+
+### `jdbc_row_count_cache_max_size`
+
+- デフォルト：10000
+- タイプ：Long
+- 単位：-
+- 変更可能：Yes
+- 説明：JDBC カタログごとの行数キャッシュの最大エントリ数。テーブル数が多いカタログのメモリ増大を制限します。カタログプロパティ `jdbc_row_count_cache_max_size` でカタログごとに上書き可能です。
+- 導入時期：-
+
 ### `jdbc_minimum_idle_connections`
 
 - デフォルト：1

--- a/docs/ja/data_source/catalog/jdbc_catalog.md
+++ b/docs/ja/data_source/catalog/jdbc_catalog.md
@@ -71,6 +71,16 @@ JDBC catalog のプロパティ。`PROPERTIES` には以下のパラメーター
 | oracle.temporal.to-datetime    | false       | Oracle の `DATE`、`TIMESTAMP`、および `TIMESTAMP WITH LOCAL TIME ZONE` のマッピングを制御します。この設定が `true` に設定されている場合、これらのデータ型は StarRocks の `DATETIME` 型にマッピングされます。そうでない場合、`DATE` は `DATE` のままとなり、`TIMESTAMP` および `TIMESTAMP WITH LOCAL TIME ZONE` は `VARCHAR(64)` にマッピングされます。 |
 | oracle.timestamptz.to-datetime | false       | Oracle の `TIMESTAMP WITH TIME ZONE` のマッピングを制御します。`true` に設定されている場合、StarRocksの `DATETIME` 型にマッピングされます。それ以外の場合は、 `VARCHAR(64)` にマッピングされます。 |
 
+#### オプションの行数キャッシュプロパティ
+
+StarRocks は JDBC データソースのテーブルごとの行数をキャッシュし、クエリプランニング時のブロッキングを回避します。これらのプロパティを使用して、カタログごとにキャッシュの動作を調整できます。設定しない場合は、グローバル FE 設定値が使用されます。
+
+| **パラメータ**                       | **デフォルト** | **説明**                                                                                                              |
+| ----------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| jdbc_row_count_cache_refresh_sec    | 600          | バックグラウンド更新間隔（秒）。この間隔を過ぎると、古いキャッシュ値を即座に返しながらバックグラウンドで非同期に再読み込みします。 |
+| jdbc_row_count_cache_expire_sec     | 1200         | 強制削除 TTL（秒）。この期間内にアクセスされなかったキャッシュエントリは削除されます。`jdbc_row_count_cache_refresh_sec` より大きい値を設定してください。 |
+| jdbc_row_count_cache_max_size       | 10000        | このカタログの行数キャッシュの最大テーブルエントリ数。                                                                    |
+
 > **注意**
 >
 > FEs は JDBC catalog 作成時に JDBC ドライバー JAR パッケージをダウンロードし、BEs または CNs は最初のクエリ時に JDBC ドライバー JAR パッケージをダウンロードします。ダウンロードにかかる時間はネットワークの状況によって異なります。

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -1040,6 +1040,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: JDBC Catalog 元数据缓存的默认过期时间。当 `jdbc_meta_default_cache_enable` 设置为 true 时，新创建的 JDBC Catalog 将默认设置元数据缓存的过期时间。
 - 引入版本: -
 
+### `jdbc_row_count_cache_refresh_sec`
+
+- 默认值: 600
+- 类型: Long
+- 单位: 秒
+- 是否可变: Yes
+- 描述: JDBC 表行数缓存的后台刷新间隔。超过此间隔后，立即返回旧值，同时在后台异步重新加载。可通过 Catalog 属性 `jdbc_row_count_cache_refresh_sec` 按 Catalog 覆盖。
+- 引入版本: -
+
+### `jdbc_row_count_cache_expire_sec`
+
+- 默认值: 1200
+- 类型: Long
+- 单位: 秒
+- 是否可变: Yes
+- 描述: JDBC 表行数缓存条目的强制淘汰 TTL。在此时间窗口内未访问的条目将被淘汰。必须大于 `jdbc_row_count_cache_refresh_sec`。可通过 Catalog 属性 `jdbc_row_count_cache_expire_sec` 按 Catalog 覆盖。
+- 引入版本: -
+
+### `jdbc_row_count_cache_max_size`
+
+- 默认值: 10000
+- 类型: Long
+- 单位: -
+- 是否可变: Yes
+- 描述: 每个 JDBC Catalog 的行数缓存最大条目数。限制表数量较多的 Catalog 的内存增长。可通过 Catalog 属性 `jdbc_row_count_cache_max_size` 按 Catalog 覆盖。
+- 引入版本: -
+
 ### `jdbc_minimum_idle_connections`
 
 - 默认值: 1

--- a/docs/zh/data_source/catalog/jdbc_catalog.md
+++ b/docs/zh/data_source/catalog/jdbc_catalog.md
@@ -72,6 +72,16 @@ JDBC Catalog 的属性，包含如下必填配置项：
 | oracle.temporal.to-datetime    | false       | 控制 Oracle `DATE`、`TIMESTAMP` 和 `TIMESTAMP WITH LOCAL TIME ZONE` 的映射。如果设置为 `true`，这些数据类型将映射到 StarRocks 的 `DATETIME` 类型；否则，`DATE` 保持为 `DATE`，而 `TIMESTAMP` / `TIMESTAMP WITH LOCAL TIME ZONE` 将映射到 `VARCHAR(64)`。 |
 | oracle.timestamptz.to-datetime | false       | 控制 Oracle `TIMESTAMP WITH TIME ZONE` 的映射。如果设置为 `true`，则映射为 StarRocks 的 `DATETIME` 类型；否则，则映射为 `VARCHAR(64)`。 |
 
+#### 可选行数缓存属性
+
+StarRocks 会缓存 JDBC 数据源的每张表的行数，以避免在查询规划阶段产生阻塞。这些属性允许您按 Catalog 调整缓存行为。若未设置，则使用全局 FE 配置值。
+
+| **参数**                             | **默认** | **描述**                                                                                                               |
+| ----------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| jdbc_row_count_cache_refresh_sec    | 600      | 后台刷新间隔（秒）。超过此间隔后，立即返回缓存的旧值，同时在后台异步重新加载。                                             |
+| jdbc_row_count_cache_expire_sec     | 1200     | 强制淘汰 TTL（秒）。在此时间窗口内未被访问的缓存条目将被淘汰。必须大于 `jdbc_row_count_cache_refresh_sec`。               |
+| jdbc_row_count_cache_max_size       | 10000    | 该 Catalog 行数缓存的最大表条目数。                                                                                      |
+
 > **说明**
 >
 > FE 会在创建 JDBC Catalog 时去获取 JDBC 驱动程序，BE（或 CN）会在第一次执行查询时去获取驱动程序。获取驱动程序的耗时跟网络条件相关。

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4205,6 +4205,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long jdbc_meta_default_cache_expire_sec = 600L;
 
+    @ConfField(mutable = true)
+    public static long jdbc_row_count_cache_refresh_sec = 600L;
+
+    @ConfField(mutable = true)
+    public static long jdbc_row_count_cache_expire_sec = 1200L;
+
+    @ConfField(mutable = true)
+    public static long jdbc_row_count_cache_max_size = 10000L;
+
     // the retention time for host disconnection events
     @ConfField(mutable = true)
     public static long black_host_history_sec = 2 * 60; // 2min

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -21,6 +21,7 @@ import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -152,5 +153,23 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
         return TypeFactory.createType(primitiveType);
     }
 
+    @Override
+    public long getTableRowCount(Connection connection, String dbName, String tableName) throws SQLException {
+        // system.tables.total_rows is maintained by ClickHouse for most table engines (MergeTree, etc.)
+        // and is NULL for engines that do not track it (e.g. Distributed over remote shards).
+        String sql = "SELECT total_rows FROM system.tables WHERE database = ? AND name = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, dbName);
+            ps.setString(2, tableName);
+            ps.setQueryTimeout(getQueryTimeoutSeconds());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long rows = rs.getLong(1);
+                    return rs.wasNull() ? -1L : rows;
+                }
+            }
+        }
+        return -1L;
+    }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -197,17 +197,16 @@ public class JDBCMetadata implements ConnectorMetadata {
         tableIdCache = new JDBCMetaCache<>(properties, true);
         tableInstanceCache = new JDBCMetaCache<>(properties, false);
         partitionInfoCache = new JDBCMetaCache<>(properties, false);
-        rowCountCache = buildRowCountCache(properties);
+        rowCountCache = buildRowCountCache();
     }
 
-    private AsyncLoadingCache<JDBCTableName, Long> buildRowCountCache(Map<String, String> properties) {
-        boolean cacheEnabled = Boolean.parseBoolean(properties.getOrDefault(
-                "jdbc_meta_cache_enable", String.valueOf(Config.jdbc_meta_default_cache_enable)));
-        if (!cacheEnabled) {
+    private AsyncLoadingCache<JDBCTableName, Long> buildRowCountCache() {
+        // Reuse the enable/expire settings already parsed by an existing JDBCMetaCache instance
+        // to avoid duplicating property-parsing logic.
+        if (!tableInstanceCache.isEnableCache()) {
             return null;
         }
-        long expireSec = Long.parseLong(properties.getOrDefault(
-                "jdbc_meta_cache_expire_sec", String.valueOf(Config.jdbc_meta_default_cache_expire_sec)));
+        long expireSec = tableInstanceCache.getCurrentExpireSec();
         // refreshAfterWrite: return stale value while reloading asynchronously after expireSec.
         // expireAfterWrite (2x): hard evict entries that are no longer actively queried.
         return Caffeine.newBuilder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -197,21 +197,27 @@ public class JDBCMetadata implements ConnectorMetadata {
         tableIdCache = new JDBCMetaCache<>(properties, true);
         tableInstanceCache = new JDBCMetaCache<>(properties, false);
         partitionInfoCache = new JDBCMetaCache<>(properties, false);
-        rowCountCache = buildRowCountCache();
+        rowCountCache = buildRowCountCache(properties);
     }
 
-    private AsyncLoadingCache<JDBCTableName, Long> buildRowCountCache() {
-        // Reuse the enable/expire settings already parsed by an existing JDBCMetaCache instance
-        // to avoid duplicating property-parsing logic.
-        if (!tableInstanceCache.isEnableCache()) {
-            return null;
-        }
-        long expireSec = tableInstanceCache.getCurrentExpireSec();
-        // refreshAfterWrite: return stale value while reloading asynchronously after expireSec.
-        // expireAfterWrite (2x): hard evict entries that are no longer actively queried.
+    private AsyncLoadingCache<JDBCTableName, Long> buildRowCountCache(Map<String, String> properties) {
+        // Row-count cache is always enabled regardless of jdbc_meta_cache_enable.
+        // jdbc_meta_cache_enable controls schema metadata freshness; statistics are a
+        // separate concern and must never block planning — async loading is mandatory.
+        // Each parameter can be overridden per-catalog via the JDBC catalog properties map.
+        long refreshSec = Long.parseLong(properties.getOrDefault(
+                "jdbc_row_count_cache_refresh_sec",
+                String.valueOf(Config.jdbc_row_count_cache_refresh_sec)));
+        long expireSec = Long.parseLong(properties.getOrDefault(
+                "jdbc_row_count_cache_expire_sec",
+                String.valueOf(Config.jdbc_row_count_cache_expire_sec)));
+        long maxSize = Long.parseLong(properties.getOrDefault(
+                "jdbc_row_count_cache_max_size",
+                String.valueOf(Config.jdbc_row_count_cache_max_size)));
         return Caffeine.newBuilder()
-                .refreshAfterWrite(expireSec, TimeUnit.SECONDS)
-                .expireAfterWrite(expireSec * 2, TimeUnit.SECONDS)
+                .maximumSize(maxSize)
+                .refreshAfterWrite(refreshSec, TimeUnit.SECONDS)
+                .expireAfterWrite(expireSec, TimeUnit.SECONDS)
                 .executor(ROW_COUNT_EXECUTOR)
                 .buildAsync(key -> loadRowCount(key));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.connector.jdbc;
 
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -21,9 +23,11 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorTableId;
@@ -33,6 +37,10 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.zaxxer.hikari.HikariConfig;
@@ -48,8 +56,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class JDBCMetadata implements ConnectorMetadata {
@@ -65,10 +75,15 @@ public class JDBCMetadata implements ConnectorMetadata {
     private JDBCMetaCache<JDBCTableName, Long> tableIdCache;
     private JDBCMetaCache<JDBCTableName, Table> tableInstanceCache;
     private JDBCMetaCache<JDBCTableName, List<Partition>> partitionInfoCache;
+    // Async row-count cache: never blocks planning. On cold start returns the default immediately
+    // and loads in background; refreshAfterWrite keeps the value warm with async reload.
+    private AsyncLoadingCache<JDBCTableName, Long> rowCountCache;
 
     private HikariDataSource dataSource;
     private static final ExecutorService NETWORK_TIMEOUT_EXECUTOR = Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("jdbc-network-timeout-%d").build());
+    private static final ExecutorService ROW_COUNT_EXECUTOR = Executors.newFixedThreadPool(
+            2, new ThreadFactoryBuilder().setDaemon(true).setNameFormat("jdbc-row-count-%d").build());
 
     // HikariCP connection lifecycle constants
     static final long MINIMUM_MAX_LIFETIME_MS = 30_000L;
@@ -182,6 +197,35 @@ public class JDBCMetadata implements ConnectorMetadata {
         tableIdCache = new JDBCMetaCache<>(properties, true);
         tableInstanceCache = new JDBCMetaCache<>(properties, false);
         partitionInfoCache = new JDBCMetaCache<>(properties, false);
+        rowCountCache = buildRowCountCache(properties);
+    }
+
+    private AsyncLoadingCache<JDBCTableName, Long> buildRowCountCache(Map<String, String> properties) {
+        boolean cacheEnabled = Boolean.parseBoolean(properties.getOrDefault(
+                "jdbc_meta_cache_enable", String.valueOf(Config.jdbc_meta_default_cache_enable)));
+        if (!cacheEnabled) {
+            return null;
+        }
+        long expireSec = Long.parseLong(properties.getOrDefault(
+                "jdbc_meta_cache_expire_sec", String.valueOf(Config.jdbc_meta_default_cache_expire_sec)));
+        // refreshAfterWrite: return stale value while reloading asynchronously after expireSec.
+        // expireAfterWrite (2x): hard evict entries that are no longer actively queried.
+        return Caffeine.newBuilder()
+                .refreshAfterWrite(expireSec, TimeUnit.SECONDS)
+                .expireAfterWrite(expireSec * 2, TimeUnit.SECONDS)
+                .executor(ROW_COUNT_EXECUTOR)
+                .buildAsync(key -> loadRowCount(key));
+    }
+
+    private long loadRowCount(JDBCTableName key) {
+        try (Connection connection = getConnection()) {
+            long count = schemaResolver.getTableRowCount(connection, key.getDatabaseName(), key.getTableName());
+            return count > 0 ? count : Config.default_statistics_output_row_count;
+        } catch (Exception e) {
+            LOG.warn("Failed to load row count for {}.{}: {}", key.getDatabaseName(), key.getTableName(),
+                    e.getMessage());
+            return Config.default_statistics_output_row_count;
+        }
     }
 
     public void checkAndSetSupportPartitionInformation() {
@@ -468,6 +512,32 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public Statistics getTableStatistics(OptimizerContext session, Table table,
+            Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+            ScalarOperator predicate, long limit, TvrVersionRange tableVersionRange) {
+        if (rowCountCache == null) {
+            return Statistics.builder().setOutputRowCount(Config.default_statistics_output_row_count).build();
+        }
+        JDBCTable jdbcTable = (JDBCTable) table;
+        JDBCTableName key = new JDBCTableName(null, jdbcTable.getCatalogDBName(), jdbcTable.getName());
+
+        long rowCount = Config.default_statistics_output_row_count;
+        CompletableFuture<Long> future = rowCountCache.getIfPresent(key);
+        if (future == null) {
+            // Cold start: fire async load, return default for this planning round.
+            rowCountCache.get(key);
+        } else if (future.isDone() && !future.isCompletedExceptionally()) {
+            try {
+                rowCount = future.getNow(Config.default_statistics_output_row_count);
+            } catch (Exception e) {
+                LOG.warn("Unexpected error reading row count for {}.{}", key.getDatabaseName(), key.getTableName(), e);
+            }
+        }
+        // Future in-flight or completed exceptionally: fall through to default.
+        return Statistics.builder().setOutputRowCount(rowCount).build();
+    }
+
+    @Override
     public void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
         JDBCTable jdbcTable = (JDBCTable) table;
         JDBCTableName jdbcTableName = new JDBCTableName(null, jdbcTable.getCatalogDBName(), jdbcTable.getName());
@@ -476,6 +546,9 @@ public class JDBCMetadata implements ConnectorMetadata {
         }
         partitionNamesCache.invalidate(jdbcTableName);
         partitionInfoCache.invalidate(jdbcTableName);
+        if (rowCountCache != null) {
+            rowCountCache.synchronous().invalidate(jdbcTableName);
+        }
     }
 
     public void refreshCache(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -219,7 +219,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     private long loadRowCount(JDBCTableName key) {
         try (Connection connection = getConnection()) {
             long count = schemaResolver.getTableRowCount(connection, key.getDatabaseName(), key.getTableName());
-            return count > 0 ? count : Config.default_statistics_output_row_count;
+            return count >= 0 ? count : Config.default_statistics_output_row_count;
         } catch (Exception e) {
             LOG.warn("Failed to load row count for {}.{}: {}", key.getDatabaseName(), key.getTableName(),
                     e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -235,4 +235,14 @@ public abstract class JDBCSchemaResolver {
         return supportPartitionInformation;
     }
 
+    /**
+     * Return approximate row count for a table. Implementations query cheap catalog metadata
+     * (e.g. information_schema, pg_class) and must NOT run a full COUNT(*).
+     *
+     * @return estimated row count, or -1 if unsupported by this dialect
+     */
+    public long getTableRowCount(Connection connection, String dbName, String tableName) throws SQLException {
+        return -1L;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -317,6 +317,25 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
      * @param table
      * @return
      */
+    @Override
+    public long getTableRowCount(Connection connection, String dbName, String tableName) throws SQLException {
+        // information_schema.tables.table_rows is an optimizer statistic updated by ANALYZE TABLE.
+        // It is an approximation for InnoDB but zero-cost (no COUNT(*)).
+        String sql = "SELECT table_rows FROM information_schema.tables WHERE table_schema = ? AND table_name = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, dbName);
+            ps.setString(2, tableName);
+            ps.setQueryTimeout(getQueryTimeoutSeconds());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long rows = rs.getLong(1);
+                    return rs.wasNull() ? -1L : rows;
+                }
+            }
+        }
+        return -1L;
+    }
+
     @NotNull
     private static String getPartitionQuery(Table table) {
         final String partitionsQuery = "SELECT PARTITION_DESCRIPTION AS NAME, " +

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -27,6 +27,7 @@ import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -200,6 +201,27 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
             }
             return TypeFactory.createUnifiedDecimalType(precision, max(digits, 0));
         }
+    }
+
+    @Override
+    public long getTableRowCount(Connection connection, String dbName, String tableName) throws SQLException {
+        // pg_class.reltuples is updated by ANALYZE and auto-vacuum; it is an estimate, not exact.
+        // The cast to bigint avoids returning a float to Java.
+        String sql = "SELECT c.reltuples::bigint FROM pg_class c " +
+                     "JOIN pg_namespace n ON c.relnamespace = n.oid " +
+                     "WHERE n.nspname = ? AND c.relname = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, dbName);
+            ps.setString(2, tableName);
+            ps.setQueryTimeout(getQueryTimeoutSeconds());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long rows = rs.getLong(1);
+                    return rs.wasNull() ? -1L : rows;
+                }
+            }
+        }
+        return -1L;
     }
 
     public List<Partition> getPartitions(Connection connection, Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -912,14 +912,28 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalJDBCScan(LogicalJDBCScanOperator node, ExpressionContext context) {
-        return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                Config.default_statistics_output_row_count);
+        return computeJDBCScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap());
     }
 
     @Override
     public Void visitPhysicalJDBCScan(PhysicalJDBCScanOperator node, ExpressionContext context) {
-        return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                Config.default_statistics_output_row_count);
+        return computeJDBCScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap());
+    }
+
+    private Void computeJDBCScanNode(Operator node, ExpressionContext context, Table table,
+                                     Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+        long rowCount = Config.default_statistics_output_row_count;
+        try {
+            String catalogName = table.getCatalogName();
+            Statistics connectorStats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
+                    optimizerContext, catalogName, table, colRefToColumnMetaMap, null, null);
+            if (connectorStats != null) {
+                rowCount = (long) connectorStats.getOutputRowCount();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to get JDBC table statistics for {}: {}", table.getName(), e.getMessage());
+        }
+        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, rowCount);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -48,6 +49,9 @@ public class ClickhouseSchemaResolverTest {
 
     @Mocked
     Connection connection;
+
+    @Mocked
+    PreparedStatement preparedStatement;
 
     private Map<String, String> properties;
     private MockResultSet dbResult;
@@ -243,5 +247,75 @@ public class ClickhouseSchemaResolverTest {
         List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
         List<String> expectResult = Lists.newArrayList("clickhouse", "template1", "test");
         Assertions.assertEquals(expectResult, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // getTableRowCount tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetTableRowCountReturnsCount() throws SQLException {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("total_rows", Arrays.asList(2_000_000L));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
+        Assertions.assertEquals(2_000_000L, count);
+    }
+
+    @Test
+    public void testGetTableRowCountReturnsNegativeOneWhenEmpty() throws SQLException {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("total_rows", Arrays.asList());
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
+        Assertions.assertEquals(-1L, count, "Should return -1 when result set is empty");
+    }
+
+    @Test
+    public void testGetTableRowCountReturnsNegativeOneWhenNull() throws SQLException {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("total_rows", Arrays.asList((Object) null));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
+        Assertions.assertEquals(-1L, count, "Should return -1 when total_rows is NULL (e.g. Distributed engine)");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -1015,7 +1015,8 @@ public class JDBCMetadataTest {
 
     @Test
     public void testGetTableStatisticsCacheDisabledReturnsDefault() {
-        // When jdbc_meta_cache_enable=false, rowCountCache is null → return default immediately.
+        // Row-count cache is always built regardless of jdbc_meta_cache_enable.
+        // Cold start (nothing loaded yet) must return default_statistics_output_row_count immediately.
         Map<String, String> props = new HashMap<>(properties);
         props.put("jdbc_meta_cache_enable", "false");
 
@@ -1139,17 +1140,4 @@ public class JDBCMetadataTest {
                 "Row count should fall back to default when dialect returns -1 (unsupported)");
     }
 
-    @Test
-    public void testRowCountCacheNullWhenCacheDisabled() {
-        Map<String, String> props = new HashMap<>(properties);
-        props.put("jdbc_meta_cache_enable", "false");
-
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
-        // rowCountCache is private; verify indirectly — getTableStatistics must not throw
-        // and must return the default value even when table is valid.
-        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
-        Statistics stats = jdbcMetadata.getTableStatistics(null, jdbcTable,
-                java.util.Collections.emptyMap(), java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
-        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) stats.getOutputRowCount());
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -1134,9 +1134,9 @@ public class JDBCMetadataTest {
         Statistics stats = jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
                 java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
 
-        // Must never return -1; must be default or greater.
-        Assertions.assertTrue((long) stats.getOutputRowCount() >= Config.default_statistics_output_row_count,
-                "Row count must not be negative; should fall back to default when dialect returns -1");
+        // Empty result set → getTableRowCount returns -1 → loadRowCount stores default.
+        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) stats.getOutputRowCount(),
+                "Row count should fall back to default when dialect returns -1 (unsupported)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -1140,4 +1140,86 @@ public class JDBCMetadataTest {
                 "Row count should fall back to default when dialect returns -1 (unsupported)");
     }
 
+    @Test
+    public void testBaseSchemaResolverGetTableRowCountReturnsNegativeOne() throws Exception {
+        // OracleSchemaResolver inherits the default JDBCSchemaResolver.getTableRowCount() which returns -1.
+        JDBCSchemaResolver resolver = new OracleSchemaResolver();
+        long count = resolver.getTableRowCount(connection, "anydb", "anytable");
+        Assertions.assertEquals(-1L, count);
+    }
+
+    @Test
+    public void testLoadRowCountExceptionFallsBackToDefault() throws Exception {
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "true");
+
+        new Expectations() {
+            {
+                preparedStatement.executeQuery();
+                result = new SQLException("simulated connection error");
+                minTimes = 0;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+
+        // Trigger async load; the loader will throw and fall into the catch block.
+        jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+        Thread.sleep(500);
+
+        Statistics stats = jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) stats.getOutputRowCount(),
+                "Exception in loadRowCount must fall back to default_statistics_output_row_count");
+    }
+
+    @Test
+    public void testRefreshTableInvalidatesRowCountCache() throws Exception {
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "true");
+
+        long expectedRowCount = 7_000_000L;
+        MockResultSet rowCountResult = new MockResultSet("row_count");
+        rowCountResult.addColumn("table_rows", Arrays.asList(expectedRowCount));
+
+        new Expectations() {
+            {
+                preparedStatement.executeQuery();
+                result = rowCountResult;
+                minTimes = 0;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+
+        // Trigger async load and wait for real row count to be cached.
+        jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+        long deadline = System.currentTimeMillis() + 3000;
+        Statistics stats = null;
+        while (System.currentTimeMillis() < deadline) {
+            stats = jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                    java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+            if ((long) stats.getOutputRowCount() != Config.default_statistics_output_row_count) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+        Assertions.assertNotNull(stats);
+        Assertions.assertEquals(expectedRowCount, (long) stats.getOutputRowCount(),
+                "Row count should be loaded from cache after async load completes");
+
+        // Invalidate via refreshTable — covers rowCountCache.synchronous().invalidate().
+        jdbcMetadata.refreshTable("test", jdbcTable, null, false);
+
+        // Cache entry evicted → next call is cold start → returns default.
+        Statistics afterRefresh = jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) afterRefresh.getOutputRowCount(),
+                "After refreshTable, row-count cache entry must be invalidated");
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -20,9 +20,11 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.TypeFactory;
@@ -1005,5 +1007,149 @@ public class JDBCMetadataTest {
             Config.jdbc_connection_keepalive_time_ms = origKeepalive;
             Config.jdbc_connection_leak_detection_threshold_ms = origLeakDetection;
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Row-count cache & getTableStatistics tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetTableStatisticsCacheDisabledReturnsDefault() {
+        // When jdbc_meta_cache_enable=false, rowCountCache is null → return default immediately.
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "false");
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+
+        Statistics stats = jdbcMetadata.getTableStatistics(
+                null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+
+        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) stats.getOutputRowCount());
+    }
+
+    @Test
+    public void testGetTableStatisticsColdStartReturnsDefault() throws Exception {
+        // On first call with cache enabled and no prior load, return default and trigger async load.
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "true");
+        props.put("jdbc_meta_cache_expire_sec", "600");
+
+        // Row-count query returns a future value of 5_000_000, but the first planning
+        // call happens before the async load completes → must see the default.
+        MockResultSet rowCountResult = new MockResultSet("row_count");
+        rowCountResult.addColumn("table_rows", Arrays.asList(5_000_000L));
+
+        new Expectations() {
+            {
+                preparedStatement.executeQuery();
+                result = rowCountResult;
+                minTimes = 0;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+
+        // Cold start: cache is empty → returns default_statistics_output_row_count.
+        Statistics stats = jdbcMetadata.getTableStatistics(
+                null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+
+        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) stats.getOutputRowCount(),
+                "Cold start must return default without blocking");
+    }
+
+    @Test
+    public void testGetTableStatisticsReturnsCachedRowCount() throws Exception {
+        // After the async load completes, the second call should return the real row count.
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "true");
+        props.put("jdbc_meta_cache_expire_sec", "600");
+
+        long expectedRowCount = 3_000_000L;
+        MockResultSet rowCountResult = new MockResultSet("row_count");
+        rowCountResult.addColumn("table_rows", Arrays.asList(expectedRowCount));
+
+        new Expectations() {
+            {
+                preparedStatement.executeQuery();
+                result = rowCountResult;
+                minTimes = 0;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+
+        // Trigger cold start (fires async load).
+        jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+
+        // Wait for the background load to finish (max 3 s).
+        long deadline = System.currentTimeMillis() + 3000;
+        Statistics stats = null;
+        while (System.currentTimeMillis() < deadline) {
+            stats = jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                    java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+            if ((long) stats.getOutputRowCount() != Config.default_statistics_output_row_count) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+
+        Assertions.assertNotNull(stats);
+        Assertions.assertEquals(expectedRowCount, (long) stats.getOutputRowCount(),
+                "After async load completes, should return real row count");
+    }
+
+    @Test
+    public void testLoadRowCountFallsBackOnNegativeOne() throws Exception {
+        // Dialect returns -1 (unsupported) → loadRowCount must store default, not -1.
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "true");
+        props.put("jdbc_meta_cache_expire_sec", "600");
+
+        // preparedStatement.executeQuery() returns an empty ResultSet (no row) → getTableRowCount returns -1.
+        MockResultSet emptyResult = new MockResultSet("empty");
+        emptyResult.addColumn("table_rows", Arrays.asList());
+
+        new Expectations() {
+            {
+                preparedStatement.executeQuery();
+                result = emptyResult;
+                minTimes = 0;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+
+        // Trigger load and wait.
+        jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+        Thread.sleep(500);
+
+        Statistics stats = jdbcMetadata.getTableStatistics(null, jdbcTable, java.util.Collections.emptyMap(),
+                java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+
+        // Must never return -1; must be default or greater.
+        Assertions.assertTrue((long) stats.getOutputRowCount() >= Config.default_statistics_output_row_count,
+                "Row count must not be negative; should fall back to default when dialect returns -1");
+    }
+
+    @Test
+    public void testRowCountCacheNullWhenCacheDisabled() {
+        Map<String, String> props = new HashMap<>(properties);
+        props.put("jdbc_meta_cache_enable", "false");
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(props, "catalog", dataSource);
+        // rowCountCache is private; verify indirectly — getTableStatistics must not throw
+        // and must return the default value even when table is valid.
+        JDBCTable jdbcTable = (JDBCTable) jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+        Statistics stats = jdbcMetadata.getTableStatistics(null, jdbcTable,
+                java.util.Collections.emptyMap(), java.util.Collections.<PartitionKey>emptyList(), null, -1, null);
+        Assertions.assertEquals(Config.default_statistics_output_row_count, (long) stats.getOutputRowCount());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -435,4 +435,77 @@ public class MysqlSchemaResolverTest {
             com.starrocks.common.Config.jdbc_query_timeout_ms = originalTimeout;
         }
     }
+
+    // -----------------------------------------------------------------------
+    // getTableRowCount tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetTableRowCountReturnsValue() throws SQLException {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("table_rows", Arrays.asList(1_000_000L));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
+        Assertions.assertEquals(1_000_000L, count);
+    }
+
+    @Test
+    public void testGetTableRowCountReturnsNegativeOneWhenEmpty() throws SQLException {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("table_rows", Arrays.asList());  // no rows
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
+        Assertions.assertEquals(-1L, count, "Should return -1 when result set is empty");
+    }
+
+    @Test
+    public void testGetTableRowCountReturnsNegativeOneWhenNull() throws SQLException {
+        MysqlSchemaResolver resolver = new MysqlSchemaResolver();
+
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("table_rows", Arrays.asList((Object) null));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
+        Assertions.assertEquals(-1L, count, "Should return -1 when table_rows is NULL");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
@@ -42,6 +43,9 @@ public class PostgresSchemaResolverTest {
 
     @Mocked
     Connection connection;
+
+    @Mocked
+    PreparedStatement preparedStatement;
 
     private Map<String, String> properties;
     private MockResultSet dbResult;
@@ -235,5 +239,75 @@ public class PostgresSchemaResolverTest {
                 Types.TIMESTAMP, "timestamp with time zone", 0, 0).isDatetime());
         Assertions.assertTrue(postgresSchemaResolver.convertColumnType(
                 Types.TIMESTAMP_WITH_TIMEZONE, "timestamp with time zone", 0, 0).isDatetime());
+    }
+
+    // -------------------------------------------------------------------------
+    // getTableRowCount tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetTableRowCountReturnsCount() throws SQLException {
+        PostgresSchemaResolver resolver = new PostgresSchemaResolver();
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("reltuples", Arrays.asList(5_000_000L));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "public", "orders");
+        Assertions.assertEquals(5_000_000L, count);
+    }
+
+    @Test
+    public void testGetTableRowCountReturnsNegativeOneWhenEmpty() throws SQLException {
+        PostgresSchemaResolver resolver = new PostgresSchemaResolver();
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("reltuples", Arrays.asList());
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "public", "orders");
+        Assertions.assertEquals(-1L, count, "Should return -1 when table is not found in pg_class");
+    }
+
+    @Test
+    public void testGetTableRowCountReturnsNegativeOneWhenNull() throws SQLException {
+        PostgresSchemaResolver resolver = new PostgresSchemaResolver();
+        MockResultSet rs = new MockResultSet("row_count");
+        rs.addColumn("reltuples", Arrays.asList((Object) null));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = rs;
+                minTimes = 1;
+            }
+        };
+
+        long count = resolver.getTableRowCount(connection, "public", "orders");
+        Assertions.assertEquals(-1L, count, "Should return -1 when reltuples is NULL");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

The CBO always assigned a hardcoded `default_statistics_output_row_count` to every JDBC scan
node, regardless of actual table size. This causes poor plans for JDBC-heavy queries — wrong
join order, bad parallelism estimates, suboptimal broadcast vs. shuffle decisions.

Root cause: `visitLogicalJDBCScan` / `visitPhysicalJDBCScan` in `StatisticsCalculator` called
`computeNormalExternalTableScanNode` with a fixed constant and never consulted
`MetadataMgr.getTableStatistics()`, so `JDBCMetadata.getTableStatistics()` was unreachable
from the optimizer path entirely.

## What I'm doing:

**1. Per-dialect metadata row-count queries (no COUNT(*))**

Add `getTableRowCount()` to `JDBCSchemaResolver` (default: `-1`, unsupported). Each dialect
queries its own cheap catalog view:

| Dialect     | Source                                | Notes                                     |
|-------------|---------------------------------------|-------------------------------------------|
| MySQL       | `information_schema.tables.table_rows`| Updated by ANALYZE; approx for InnoDB    |
| PostgreSQL  | `pg_class.reltuples`                  | Updated by ANALYZE / autovacuum           |
| ClickHouse  | `system.tables.total_rows`            | NULL for Distributed engines → returns -1 |

**2. Non-blocking async cache in `JDBCMetadata`**

Backed by Caffeine `AsyncLoadingCache` on a dedicated 2-thread pool (`jdbc-row-count-*`).
The cache is always built regardless of `jdbc_meta_cache_enable` (that flag controls schema
metadata; row-count statistics are a separate concern).

Hot-path behavior during query planning:

```
getTableStatistics()
  ├── getIfPresent(key) == null  →  fire async load, return default (this plan round)
  ├── future in-flight           →  return default (next plan round it'll be ready)
  └── future.isDone()            →  return real row count  ✓
```

The planning thread **never blocks** — always returns in O(1) via a ConcurrentHashMap lookup.

**3. Wire StatisticsCalculator → MetadataMgr → JDBCMetadata**

`visitLogicalJDBCScan` / `visitPhysicalJDBCScan` now call a new `computeJDBCScanNode()` that
fetches statistics through `MetadataMgr.getTableStatistics()`, replacing the hardcoded constant.

**4. Configurable cache with per-catalog overrides**

Three new FE configs (all mutable at runtime), each overridable per-catalog via
`CREATE CATALOG ... PROPERTIES`:

| Config                           | Default | Description                        |
|----------------------------------|---------|------------------------------------|
| `jdbc_row_count_cache_refresh_sec` | 600   | Background async refresh interval  |
| `jdbc_row_count_cache_expire_sec`  | 1200  | Hard eviction TTL                  |
| `jdbc_row_count_cache_max_size`    | 10000 | Max entries per catalog            |

**Performance impact:**
- **Planning hot path**: zero blocking — single ConcurrentHashMap lookup
- **Cold start**: returns `default_statistics_output_row_count` immediately; async load fires on
  background pool, does not touch the query thread
- **Memory**: ~200–500 bytes/entry; 10 000 entries ≈ 2–5 MB per catalog
- **Remote cost**: one cheap catalog-metadata query per table per refresh interval; no `COUNT(*)`
  is ever issued
- **On refresh**: `refreshAfterWrite` returns the stale value immediately while reload runs in
  background — zero planning latency at TTL expiry

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5