### PR TITLE
[Enhancement] Scope lake schema-change job locks to the table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
@@ -36,6 +37,8 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
@@ -204,8 +207,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         MarkedCountDownLatch<Long, Long> countDownLatch;
         boolean lightWeight;
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.ROLLUP);
             lightWeight = table.isLightWeightTabletCreation();
 
@@ -308,8 +311,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
 
         // Add shadow indexes to table.
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
             if (table.getState() != OlapTable.OlapTableState.ROLLUP) {
                 throw new IllegalStateException("Table State doesn't equal to ROLLUP, it is " + table.getState() + ".");
             }
@@ -364,12 +367,13 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         long rollupIndexId = rollupIndexMetaId;
         Map<Long, TTabletSchema> indexToBaseTabletReadSchema = new HashMap<>();
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable tbl = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable tbl = getTableOrThrow();
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             Preconditions.checkState(tbl.getState() == OlapTable.OlapTableState.ROLLUP);
             // only needs to analyze once
             AlterReplicaTask.RollupJobV2Params rollupJobV2Params =
-                    RollupJobV2.analyzeAndCreateRollupJobV2Params(tbl, rollupSchema, whereClause, db.getFullName());
+                    RollupJobV2.analyzeAndCreateRollupJobV2Params(tbl, rollupSchema, whereClause, database.getFullName());
             for (Map.Entry<Long, MaterializedIndex> entry : this.physicalPartitionIdToRollupIndex.entrySet()) {
                 long partitionId = entry.getKey();
                 PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
@@ -440,8 +444,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             }
         }
 
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
             commitVersionMap = new HashMap<>();
             for (long physicalPartitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -478,8 +482,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             return;
         }
 
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = (db != null) ? db.getTable(tableId) : null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTable();
             if (table == null) {
                 LOG.info("database or table been dropped while doing schema change job {}", jobId);
                 return;
@@ -516,8 +520,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         this.errMsg = errMsg;
         this.finishedTimeMs = System.currentTimeMillis();
         persistStateChange(this, JobState.CANCELLED, () -> {
-            try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-                OlapTable table = (db != null) ? db.getTable(tableId) : null;
+            try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+                OlapTable table = getTable();
                 if (table != null) {
                     removeRollupIndex(table);
                 }
@@ -595,8 +599,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             this.rollupBatchTask = new AgentBatchTask();
         }
 
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = (db != null) ? db.getTable(tableId) : null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTable();
             if (table == null) {
                 return; // do nothing if the table has been dropped.
             }
@@ -694,8 +698,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
     }
 
     boolean tableHasBeenDropped() {
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            return db == null || db.getTable(tableId) == null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            return getTable() == null;
         }
     }
 
@@ -710,8 +714,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
     }
 
     boolean readyToPublishVersion() throws AlterCancelException {
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition partition = table.getPhysicalPartition(partitionId);
                 Preconditions.checkState(partition != null, partitionId);
@@ -728,8 +732,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
     }
 
     protected boolean lakePublishVersion() {
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
             boolean useAggregatePublish = table.isFileBundling();
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -47,6 +47,8 @@ import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
@@ -270,7 +272,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         indexMetaIdToSchema.put(shadowIdxMetaId, shadowIdxSchema);
     }
 
-    // REQUIRE: has acquired the exclusive lock of database
+    // REQUIRE: has acquired the exclusive (WRITE) lock of the table
     void addShadowIndexToCatalog(@NotNull OlapTable table, long visibleTxnId) {
         Preconditions.checkState(visibleTxnId != -1);
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
@@ -402,8 +404,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         AgentBatchTask batchTask = new AgentBatchTask();
         MarkedCountDownLatch<Long, Long> countDownLatch;
         boolean lightWeight;
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
             lightWeight = table.isLightWeightTabletCreation();
 
@@ -513,8 +515,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         // Add shadow indexes to table.
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
             watershedTxnId = getNextTransactionId();
             watershedGtid = getNextGtid();
@@ -563,8 +565,9 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
         LOG.info("previous transactions are all finished, begin to send schema change tasks. job: {}", jobId);
 
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
             Map<Long, TTabletSchema> indexToBaseTabletReadSchema = new HashMap<>();
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
@@ -625,7 +628,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                                         col.getName(), col.getType(), col.isAllowNull()));
                             }
 
-                            TableName tableName = new TableName(db.getFullName(), table.getName());
+                            TableName tableName = new TableName(database.getFullName(), table.getName());
 
                             // sourceScope must be set null tableName for its Field in RelationFields
                             // because we hope slotRef can not be resolved in sourceScope but can be
@@ -643,7 +646,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             if (ConnectContext.get() == null) {
                                 LOG.warn("Connect Context is null when add/modify generated column");
                             } else {
-                                ConnectContext.get().setDatabase(db.getFullName());
+                                ConnectContext.get().setDatabase(database.getFullName());
                             }
 
                             RewriteAliasVisitor visitor =
@@ -748,8 +751,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             }
         }
 
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTableOrThrow();
             commitVersionMap = new HashMap<>();
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -788,8 +791,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         // Replace the current index with shadow index.
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = (db != null) ? db.getTable(tableId) : null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTable();
             if (table == null) {
                 LOG.info("database or table been dropped while doing schema change job {}", jobId);
                 return;
@@ -816,8 +819,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
     // Note: throws AlterCancelException iff the database or table has been dropped.
     boolean readyToPublishVersion() throws AlterCancelException {
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            OlapTable table = getTableOrThrow(db, tableId);
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
             isFileBundling = table.isFileBundling();
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -868,8 +871,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 // For indexes whose schema have not changed, we still need to upgrade the version
                 List<MaterializedIndex> originMaterializedIndices;
                 List<Tablet> allOtherPartitionTablets = new ArrayList<>();
-                try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-                    OlapTable table = getTableOrThrow(db, tableId);
+                try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+                    OlapTable table = getTableOrThrow();
                     PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                     originMaterializedIndices = physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE);
                 }
@@ -937,12 +940,12 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         Map<Long, List<Tablet>> tabletsByPartition = new HashMap<>();
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
             List<Tablet> regularTablets = new ArrayList<>();
-            try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-                // Use the null-returning getTable (not getTableOrThrow) so a
+            try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+                // Use the null-returning getTable() (not getTableOrThrow) so a
                 // concurrent db/table drop is a benign skip rather than a
                 // checked AlterCancelException — there is nothing to advance if
                 // the table is gone.
-                OlapTable table = (db != null) ? db.getTable(tableId) : null;
+                OlapTable table = getTable();
                 if (table == null) {
                     continue;
                 }
@@ -1005,13 +1008,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
     }
 
     boolean tableHasBeenDropped() {
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            return db == null || db.getTable(tableId) == null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            return getTable() == null;
         }
     }
 
     // Update each Partition's nextVersion.
-    // The caller must have acquired the database's exclusive lock.
+    // The caller must have acquired the table's exclusive (WRITE) lock.
     void updateNextVersion(@NotNull OlapTable table) {
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -1064,8 +1067,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             this.forceSkippedAtCommitted = other.forceSkippedAtCommitted;
         }
 
-        try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            OlapTable table = (db != null) ? db.getTable(tableId) : null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+            OlapTable table = getTable();
             if (table == null) {
                 return; // do nothing if the table has been dropped.
             }
@@ -1301,8 +1304,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         this.finishedTimeMs = System.currentTimeMillis();
 
         persistStateChange(this, JobState.CANCELLED, () -> {
-            try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-                OlapTable table = (db != null) ? db.getTable(tableId) : null;
+            try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
+                OlapTable table = getTable();
                 if (table != null) {
                     if (advanceVersionForForce) {
                         // We just no-op published tablet_metadata at commitVersion

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -18,11 +18,10 @@ package com.starrocks.alter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -31,6 +30,7 @@ import com.starrocks.transaction.GlobalTransactionMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -59,16 +59,28 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         this.watershedGtid = job.watershedGtid;
     }
 
-    @Nullable
-    protected ReadLockedDatabase getReadLockedDatabase(long dbId) {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-        return db != null ? new ReadLockedDatabase(db) : null;
-    }
+    // NOTE: Metadata access in these jobs locks only the job's own table
+    // (`tableId`) with an intensive db lock (IS/IX on the database + S/X on the
+    // table) via AutoCloseableLock, NOT the whole database:
+    //
+    //     try (AutoCloseableLock ignore =
+    //             new AutoCloseableLock(dbId, List.of(tableId), LockType.READ /* or WRITE */)) {
+    //         OlapTable table = getTableOrThrow(); // or getTable() to skip-on-missing
+    //         ...
+    //     }
+    //
+    // The intention lock on the database still blocks DROP DATABASE (which takes
+    // db WRITE) and the IS/IX still blocks DROP TABLE (which takes db WRITE), so
+    // db/table existence is preserved across the critical section just as the
+    // old full-db lock guaranteed, while leaving unrelated tables in the same
+    // database free of contention. This mirrors LakeTableAlterMetaJobBase and
+    // the non-lake SchemaChangeJobV2.
 
+    // Returns the job's table, or null if the database or the table has been
+    // dropped. The caller must already hold the table lock.
     @Nullable
-    protected WriteLockedDatabase getWriteLockedDatabase(long dbId) {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-        return db != null ? new WriteLockedDatabase(db) : null;
+    protected OlapTable getTable() {
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
     }
 
     // Check whether transactions of the given database which txnId is less than 'watershedTxnId' are finished.
@@ -78,70 +90,9 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         return globalTxnMgr.isPreviousTransactionsFinished(txnId, dbId, Lists.newArrayList(tableId));
     }
 
-    protected abstract static class LockedDatabase implements AutoCloseable {
-        protected final Database db;
-        protected Locker locker;
-
-        LockedDatabase(@NotNull Database db) {
-            this.locker = new Locker();
-            lock(db);
-            this.db = db;
-        }
-
-        abstract void lock(Database db);
-
-        abstract void unlock(Database db);
-
-        @Nullable
-        OlapTable getTable(long tableId) {
-            return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
-        }
-
-        @Override
-        public void close() {
-            unlock(db);
-        }
-    }
-
-    protected static class ReadLockedDatabase extends LockedDatabase {
-        ReadLockedDatabase(@NotNull Database db) {
-            super(db);
-        }
-
-        @Override
-        void lock(Database db) {
-            locker.lockDatabase(db.getId(), LockType.READ);
-        }
-
-        @Override
-        void unlock(Database db) {
-            locker.unLockDatabase(db.getId(), LockType.READ);
-        }
-
-        public String getFullName() {
-            return db.getFullName();
-        }
-    }
-
-    protected static class WriteLockedDatabase extends LockedDatabase {
-        WriteLockedDatabase(@NotNull Database db) {
-            super(db);
-        }
-
-        @Override
-        void lock(Database db) {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
-        }
-
-        @Override
-        void unlock(Database db) {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
-        }
-    }
-
     protected boolean tableExists() {
-        try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            return db != null && db.getTable(tableId) != null;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            return getTable() != null;
         }
     }
 
@@ -150,12 +101,15 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         return watershedTxnId < 0 ? Optional.empty() : Optional.of(watershedTxnId);
     }
 
+    // Returns the job's table, or throws AlterCancelException distinguishing a
+    // dropped database from a dropped table. The caller must already hold the
+    // table lock.
     @NotNull
-    OlapTable getTableOrThrow(@Nullable LockedDatabase db, long tableId) throws AlterCancelException {
-        if (db == null) {
+    OlapTable getTableOrThrow() throws AlterCancelException {
+        if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId) == null) {
             throw new AlterCancelException("Database does not exist");
         }
-        OlapTable table = db.getTable(tableId);
+        OlapTable table = getTable();
         if (table == null) {
             throw new AlterCancelException("Table does not exist. tableId=" + tableId);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -31,6 +31,9 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
@@ -71,6 +74,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -152,6 +156,59 @@ public class LakeTableSchemaChangeJobTest {
         db.dropTable(table.getName());
         schemaChangeJob.cancel("test");
         Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
+    }
+
+    // Regression test for pushing the lake schema-change job's metadata lock down
+    // from the whole database to just the altered table. Asserts both directions:
+    //   1) an unrelated table in the same database is NOT blocked by the alter;
+    //   2) a conflicting WRITE on the altered table still blocks.
+    @Test
+    public void testSchemaChangeLocksOnlyItsTable() throws Exception {
+        LakeTable other = createTable(connectContext,
+                "CREATE TABLE t_other(c0 INT) duplicate key(c0) distributed by hash(c0) buckets " + NUM_BUCKETS);
+        // Kick off a schema change so t0 is a real altered table (mirrors production).
+        alterTableAddColumn();
+        long dbId = db.getId();
+        long alteredTableId = table.getId();
+        long otherTableId = other.getId();
+
+        // The lake schema-change / rollup jobs guard their critical sections with
+        // exactly this table-scoped lock (see LakeTableSchemaChangeJobBase); hold
+        // it and verify the scope.
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(alteredTableId), LockType.WRITE)) {
+            // 1) The contention win: an unrelated table in the same DB can still be
+            // WRITE-locked from another thread (it is not blocked by the alter).
+            Assertions.assertTrue(tryLockTableFromOtherThread(dbId, otherTableId, LockType.WRITE, 30000),
+                    "altering t0 must not block locking an unrelated table in the same database");
+
+            // 2) The safety: a conflicting WRITE on the altered table still blocks.
+            Assertions.assertFalse(tryLockTableFromOtherThread(dbId, alteredTableId, LockType.WRITE, 500),
+                    "a conflicting WRITE on the altered table must still block");
+        }
+
+        // Once the lock is released, the altered table can be WRITE-locked again.
+        Assertions.assertTrue(tryLockTableFromOtherThread(dbId, alteredTableId, LockType.WRITE, 30000),
+                "the altered table must be lockable again once the lock is released");
+    }
+
+    // Locker ownership is thread-based, so the contending acquire must run on a
+    // separate thread: a same-thread re-acquire would be reentrant and would
+    // never reflect cross-thread contention. NOTE: tryLockTableWithIntensiveDbLock
+    // ignores the TimeUnit argument and treats the timeout value as milliseconds.
+    private boolean tryLockTableFromOtherThread(long dbId, long tableId, LockType lockType, long timeoutMs)
+            throws InterruptedException {
+        AtomicBoolean acquired = new AtomicBoolean(false);
+        Thread thread = new Thread(() -> {
+            Locker locker = new Locker();
+            boolean ok = locker.tryLockTableWithIntensiveDbLock(dbId, tableId, lockType, timeoutMs, TimeUnit.MILLISECONDS);
+            acquired.set(ok);
+            if (ok) {
+                locker.unLockTableWithIntensiveDbLock(dbId, tableId, lockType);
+            }
+        });
+        thread.start();
+        thread.join();
+        return acquired.get();
     }
 
     @Test


### PR DESCRIPTION
The lake schema-change and rollup jobs accessed metadata under a whole- database READ/WRITE lock via getReadLockedDatabase/getWriteLockedDatabase, even though each job only touches its own table. Push those locks down to a table-scoped intensive db lock (IS/IX on the database + S/X on the table) on the job's tableId, so concurrent operations on other tables in the same database are no longer blocked. The database intention lock still blocks DROP DATABASE/DROP TABLE, preserving the existence guarantee the old full-db lock provided. This mirrors LakeTableAlterMetaJobBase and the non-lake SchemaChangeJobV2.

Replace the bespoke LockedDatabase/ReadLockedDatabase/WriteLockedDatabase holder hierarchy with the standard AutoCloseableLock at every call site in LakeTableSchemaChangeJob and LakeRollupJob. Existence handling is kept via getTable() (null on drop, for skip-on-missing sites) and getTableOrThrow() (which preserves the distinct "Database does not exist" vs "Table does not exist" messages).

Add a regression test asserting both directions: an unrelated table in the same database is not blocked while the lock is held, and a conflicting WRITE on the altered table still blocks.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
