### PR TITLE
[Enhancement] Reduce memory usage for pk compaction in share nothing mode

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -873,6 +873,10 @@ CONF_mBool(enable_new_load_on_memory_limit_exceeded, "false");
 CONF_Int64(compaction_max_memory_limit, "-1");
 CONF_Int32(compaction_max_memory_limit_percent, "100");
 CONF_Int64(compaction_memory_limit_per_worker, "2147483648"); // 2GB
+// Release retained chunk capacity in compaction when the current tracker consumption exceeds this percentage.
+// Currently only used by PK compaction in shared-nothing mode.
+// Set it to a negative value to disable this behavior.
+CONF_mInt32(compaction_chunk_reset_memory_tracker_threshold_percent, "-1");
 CONF_String(consistency_max_memory_limit, "10G");
 CONF_Int32(consistency_max_memory_limit_percent, "20");
 CONF_Int32(update_memory_limit_percent, "60");

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -128,6 +128,11 @@ CONF_mBool(chaos_test_enable_random_compaction_strategy, "false");
 
 CONF_Int64(compaction_memory_limit_per_worker, "2147483648"); // 2GB
 
+// Release retained chunk capacity in compaction when the current tracker consumption exceeds this percentage.
+// Currently only used by PK compaction in shared-nothing mode.
+// Set it to a negative value to disable this behavior.
+CONF_mInt32(compaction_chunk_reset_memory_tracker_threshold_percent, "-1");
+
 // Number of thread for flushing memtable per store.
 CONF_mInt32(flush_thread_num_per_store, "2");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -705,6 +705,7 @@
         "size_tiered_level_num",
         "chaos_test_enable_random_compaction_strategy",
         "compaction_memory_limit_per_worker",
+        "compaction_chunk_reset_memory_tracker_threshold_percent",
         "flush_thread_num_per_store",
         "max_segment_file_size",
         "meta_threshold_to_manual_compact",

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -62,8 +62,7 @@ static bool should_release_compaction_chunk_capacity(const Chunk* chunk, MemTrac
         return false;
     }
 
-    return static_cast<double>(mem_tracker->consumption()) >
-           static_cast<double>(limit) * threshold_percent / 100.0;
+    return static_cast<double>(mem_tracker->consumption()) > static_cast<double>(limit) * threshold_percent / 100.0;
 }
 
 static bool should_release_compaction_chunk_capacity(const Chunk* chunk) {

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -26,6 +26,7 @@
 #include "common/config_compaction_fwd.h"
 #include "common/config_exec_fwd.h"
 #include "gutil/stl_util.h"
+#include "runtime/current_thread.h"
 #include "storage/base/merge_iterator.h"
 #include "storage/chunk_helper.h"
 #include "storage/primitive/empty_iterator.h"
@@ -49,6 +50,25 @@ public:
                             const Schema& schema, const vector<RowsetSharedPtr>& rowsets, RowsetWriter* writer,
                             const MergeConfig& cfg) = 0;
 };
+
+static bool should_release_compaction_chunk_capacity(const Chunk* chunk, MemTracker* mem_tracker) {
+    const int32_t threshold_percent = config::compaction_chunk_reset_memory_tracker_threshold_percent;
+    if (chunk == nullptr || mem_tracker == nullptr || threshold_percent < 0) {
+        return false;
+    }
+
+    int64_t limit = config::compaction_memory_limit_per_worker;
+    if (limit <= 0) {
+        return false;
+    }
+
+    return static_cast<double>(mem_tracker->consumption()) >
+           static_cast<double>(limit) * threshold_percent / 100.0;
+}
+
+static bool should_release_compaction_chunk_capacity(const Chunk* chunk) {
+    return should_release_compaction_chunk_capacity(chunk, CurrentThread::mem_tracker());
+}
 
 template <class T>
 struct MergeEntry {
@@ -111,7 +131,14 @@ struct MergeEntry {
 
     Status next() {
         DCHECK(pk_cur == nullptr || pk_cur > pk_last);
-        chunk->reset();
+        if (should_release_compaction_chunk_capacity(chunk.get())) {
+            if (chunk_pk_column != nullptr) {
+                chunk_pk_column = chunk_pk_column->clone_empty();
+            }
+            chunk = chunk->clone_empty(0);
+        } else {
+            chunk->reset();
+        }
         rssid_rowids.clear();
         auto st = Status::OK();
         if (need_rssid_rowids) {
@@ -427,7 +454,11 @@ private:
         auto chunk = ChunkFactory::new_chunk(schema, _chunk_size);
         vector<uint64_t> rssid_rowids;
         while (true) {
-            chunk->reset();
+            if (should_release_compaction_chunk_capacity(chunk.get())) {
+                chunk = chunk->clone_empty(0);
+            } else {
+                chunk->reset();
+            }
             rssid_rowids.clear();
             Status status = get_next(chunk.get(), source_masks.get(), &rssid_rowids);
             if (!status.ok()) {
@@ -585,7 +616,11 @@ private:
             auto char_field_indexes = ChunkSchemaHelper::get_char_field_indexes(schema);
 
             while (true) {
-                chunk->reset();
+                if (should_release_compaction_chunk_capacity(chunk.get())) {
+                    chunk = chunk->clone_empty(0);
+                } else {
+                    chunk->reset();
+                }
                 Status status = iter->get_next(chunk.get(), source_masks.get());
                 if (!status.ok()) {
                     if (status.is_end_of_file()) {

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -17,12 +17,18 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
+#include "column/binary_column.h"
 #include "column/chunk_factory.h"
 #include "column/global_dict/types.h"
 #include "column/raw_data_visitor.h"
+#include "column/schema.h"
 #include "common/config_compaction_fwd.h"
+#include "common/config_exec_fwd.h"
 #include "gutil/strings/substitute.h"
 #include "gutil/walltime.h"
+#include "runtime/current_thread.h"
+#include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/primitive/empty_iterator.h"
 #include "storage/primitive/primary_key_encoder.h"
@@ -35,6 +41,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_reader.h"
+#include "storage/tablet_updates.h"
 #include "storage/update_manager.h"
 
 namespace starrocks {
@@ -51,6 +58,7 @@ public:
     }
 
     Status add_chunk(const Chunk& chunk, const std::vector<uint64_t>& rssid_rowids) override {
+        added_chunks.emplace_back(&chunk);
         all_pks->append(*(chunk.get_column_raw_ptr_by_index(0)), 0, chunk.num_rows());
         return Status::OK();
     }
@@ -103,6 +111,7 @@ public:
 
     MutableColumnPtr all_pks;
     vector<uint32_t> all_rssids;
+    std::vector<const Chunk*> added_chunks;
 
     MutableColumns non_key_columns;
 };
@@ -230,6 +239,68 @@ static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
         return -1;
     }
     return read_until_eof(iter);
+}
+
+static ChunkPtr create_large_varchar_chunk(size_t num_rows, size_t value_size) {
+    auto field = std::make_shared<Field>(0, "v", TYPE_VARCHAR, false);
+    auto schema = std::make_shared<Schema>(Fields{field});
+    auto column = BinaryColumn::create();
+    std::string value(value_size, 'x');
+    std::vector<Slice> values(num_rows, Slice(value));
+    column->append_strings(values.data(), values.size());
+    return std::make_shared<Chunk>(Columns{std::move(column)}, schema);
+}
+
+TEST_F(RowsetMergerTest, compaction_chunk_clone_empty_releases_capacity) {
+    auto chunk = create_large_varchar_chunk(256, 4096);
+    const auto memory_before_reset = chunk->memory_usage();
+    ASSERT_GT(memory_before_reset, 512 * 1024);
+
+    chunk->reset();
+    ASSERT_EQ(0, chunk->num_rows());
+    const auto memory_after_reset = chunk->memory_usage();
+    ASSERT_GT(memory_after_reset, memory_before_reset / 2);
+
+    chunk = chunk->clone_empty(0);
+    EXPECT_EQ(0, chunk->num_rows());
+    EXPECT_LT(chunk->memory_usage(), memory_after_reset / 8);
+}
+
+TEST_F(RowsetMergerTest, compaction_chunk_reset_memory_tracker_threshold_percent_triggers_output_chunk_release) {
+    const auto old_vector_chunk_size = config::vector_chunk_size;
+    const auto old_reset_memory_tracker_threshold_percent = config::compaction_chunk_reset_memory_tracker_threshold_percent;
+    const auto old_vertical_compaction_max_columns_per_group = config::vertical_compaction_max_columns_per_group;
+    DeferOp restore_config([&]() {
+        config::vector_chunk_size = old_vector_chunk_size;
+        config::compaction_chunk_reset_memory_tracker_threshold_percent = old_reset_memory_tracker_threshold_percent;
+        config::vertical_compaction_max_columns_per_group = old_vertical_compaction_max_columns_per_group;
+    });
+
+    config::vector_chunk_size = 2;
+    config::compaction_chunk_reset_memory_tracker_threshold_percent = 0;
+    config::vertical_compaction_max_columns_per_group = 5;
+
+    MemTracker tracker(-1, "compaction_chunk_reset_test", nullptr);
+    tracker.consume(1);
+    MemTracker* old_tracker = tls_thread_status.set_mem_tracker(&tracker);
+    DeferOp restore_tracker([&]() { tls_thread_status.set_mem_tracker(old_tracker); });
+
+    create_tablet(GetCurrentTimeMicros(), GetCurrentTimeMicros() & 0x7fffffff);
+    std::vector<int64_t> pks = {1, 2, 3, 4, 5};
+    auto rowset = create_rowset(_tablet, pks);
+    ASSERT_TRUE(_tablet->rowset_commit(2, rowset).ok());
+    std::vector<RowsetSharedPtr> applied_rowsets;
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(2, &applied_rowsets).ok());
+
+    TestRowsetWriter writer;
+    Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1)
+                        .ok());
+    MergeConfig cfg;
+    ASSERT_TRUE(compaction_merge_rowsets(*_tablet, 2, {rowset}, &writer, cfg).ok());
+    ASSERT_EQ(pks.size(), writer.all_pks->size());
+    ASSERT_GE(writer.added_chunks.size(), 2);
+    EXPECT_NE(writer.added_chunks[0], writer.added_chunks[1]);
 }
 
 TEST_F(RowsetMergerTest, horizontal_merge) {

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -268,7 +268,8 @@ TEST_F(RowsetMergerTest, compaction_chunk_clone_empty_releases_capacity) {
 
 TEST_F(RowsetMergerTest, compaction_chunk_reset_memory_tracker_threshold_percent_triggers_output_chunk_release) {
     const auto old_vector_chunk_size = config::vector_chunk_size;
-    const auto old_reset_memory_tracker_threshold_percent = config::compaction_chunk_reset_memory_tracker_threshold_percent;
+    const auto old_reset_memory_tracker_threshold_percent =
+            config::compaction_chunk_reset_memory_tracker_threshold_percent;
     const auto old_vertical_compaction_max_columns_per_group = config::vertical_compaction_max_columns_per_group;
     DeferOp restore_config([&]() {
         config::vector_chunk_size = old_vector_chunk_size;

--- a/docs/en/administration/management/BE_parameters/stats_storage.md
+++ b/docs/en/administration/management/BE_parameters/stats_storage.md
@@ -253,6 +253,15 @@ This topic introduces the following types of BE configurations:
 - Description: The maximum memory size allowed for each Compaction thread.
 - Introduced in: -
 
+### compaction_chunk_reset_memory_tracker_threshold_percent
+
+- Default: -1
+- Type: Int
+- Unit: Percent
+- Is mutable: Yes
+- Description: Controls when compaction releases retained internal chunk capacity. Currently, this parameter takes effect only for Primary Key table compaction in shared-nothing clusters. When the current compaction task memory tracker consumption exceeds `compaction_memory_limit_per_worker * compaction_chunk_reset_memory_tracker_threshold_percent / 100`, StarRocks releases retained chunk capacity while resetting internal chunks. A negative value disables this behavior.
+- Introduced in: -
+
 ### compaction_trace_threshold
 
 - Default: 60

--- a/docs/ja/administration/management/BE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/BE_parameters/stats_storage.md
@@ -199,6 +199,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 各コンパクションスレッドに許可される最大メモリサイズ。
 - 導入バージョン: -
 
+### compaction_chunk_reset_memory_tracker_threshold_percent
+
+- デフォルト: -1
+- タイプ: Int
+- 単位: Percent
+- 変更可能: はい
+- 説明: コンパクションが内部 Chunk の保持容量を解放するタイミングを制御します。現在、このパラメータは共有なしクラスタの主キーテーブルコンパクションでのみ有効です。現在のコンパクションタスクのメモリトラッカー使用量が `compaction_memory_limit_per_worker * compaction_chunk_reset_memory_tracker_threshold_percent / 100` を超えると、StarRocks は内部 Chunk をリセットするときに保持容量を解放します。負の値に設定すると、この動作は無効になります。
+- 導入バージョン: -
+
 ### compaction_trace_threshold
 
 - デフォルト: 60

--- a/docs/zh/administration/management/BE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/BE_parameters/stats_storage.md
@@ -241,6 +241,15 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 描述：每个 Compaction 线程允许的最大内存大小。
 - 引入版本：-
 
+### compaction_chunk_reset_memory_tracker_threshold_percent
+
+- 默认值：-1
+- 类型：Int
+- 单位：Percent
+- 是否动态：是
+- 描述：控制 Compaction 释放内部 Chunk 保留容量的时机。当前该参数仅在存算一体集群的主键表 Compaction 中生效。当当前 Compaction 任务的 Memory Tracker 使用量超过 `compaction_memory_limit_per_worker * compaction_chunk_reset_memory_tracker_threshold_percent / 100` 时，StarRocks 在重置内部 Chunk 时释放其保留容量。取值为负数时，关闭该行为。
+- 引入版本：-
+
 ### compaction_max_memory_limit_percent
 
 - 默认值：20


### PR DESCRIPTION
## What I'm doing:
Try to release memory capacity for some internal chunk to reduce the memory usage for pk compaction in share nothing mode
Introduce a new config to control the behavior:

compaction_chunk_reset_memory_tracker_threshold_percent: Release retained chunk capacity in PK compaction when the current tracker consumption exceeds this percentage.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
