### PR TITLE
[Enhancement] Improve row count estimation for ES and Kudu external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -348,6 +348,13 @@ public class EsTable extends Table implements GsonPostProcessable {
         return tTableDescriptor;
     }
 
+    @Override
+    public String getCatalogName() {
+        // EsTable has no resource-mapping path (unlike HiveTable), so fall back directly to the internal catalog
+        // for old-style ES external tables created without an external catalog.
+        return catalogName != null ? catalogName : InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+    }
+
     // TODO, identify the remote table that created after deleted
     @Override
     public String getUUID() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -14,13 +14,23 @@
 
 package com.starrocks.connector.elasticsearch;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.EsTable;
+import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -28,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 
@@ -35,6 +46,12 @@ import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 public class ElasticsearchMetadata
         implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(EsTable.class);
+
+    // Simple fixed-size cache: one long per index, 1-hour TTL, no external config needed.
+    private final Cache<String, Long> rowCountCache = Caffeine.newBuilder()
+            .maximumSize(1000)
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .build();
 
     private final EsRestClient esRestClient;
     private final Map<String, String> properties;
@@ -75,6 +92,27 @@ public class ElasticsearchMetadata
             return null;
         }
         return toEsTable(esRestClient, properties, tblName, dbName, catalogName);
+    }
+
+    @Override
+    public Statistics getTableStatistics(OptimizerContext session,
+                                         Table table,
+                                         Map<ColumnRefOperator, Column> columns,
+                                         List<PartitionKey> partitionKeys,
+                                         ScalarOperator predicate,
+                                         long limit,
+                                         TvrVersionRange tableVersionRange) {
+        Statistics.Builder builder = Statistics.builder();
+        for (ColumnRefOperator col : columns.keySet()) {
+            builder.addColumnStatistic(col, ColumnStatistic.unknown());
+        }
+        EsTable esTable = (EsTable) table;
+        long rowCount = rowCountCache.get(esTable.getIndexName(), key -> {
+            long cnt = esRestClient.getRowCount(key);
+            return cnt >= 0 ? cnt : Config.default_statistics_output_row_count;
+        });
+        builder.setOutputRowCount(rowCount);
+        return builder.build();
     }
 
     public static EsTable toEsTable(EsRestClient esRestClient,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
@@ -168,6 +168,36 @@ public class EsRestClient {
     }
 
     /**
+     * Estimate the number of documents in an index using _cat/indices metadata.
+     * Reads from Lucene segment metadata — near-zero overhead, slightly stale, good enough for CBO.
+     *
+     * @param indexName
+     * @return document count, or -1 on failure
+     */
+    public long getRowCount(String indexName) {
+        String path = "_cat/indices/" + indexName + "?h=docs.count&format=json";
+        try {
+            String response = execute(path);
+            if (response == null) {
+                return -1L;
+            }
+            List list = mapper.readValue(response, List.class);
+            if (!list.isEmpty()) {
+                Object row = list.get(0);
+                if (row instanceof Map) {
+                    Object val = ((Map) row).get("docs.count");
+                    if (val != null) {
+                        return Long.parseLong(val.toString());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to get docs.count for ES index {}: {}", indexName, e.getMessage());
+        }
+        return -1L;
+    }
+
+    /**
      * Get Shard location
      *
      * @param indexName

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
@@ -182,14 +182,19 @@ public class EsRestClient {
                 return -1L;
             }
             List list = mapper.readValue(response, List.class);
-            if (!list.isEmpty()) {
-                Object row = list.get(0);
+            long total = 0;
+            boolean found = false;
+            for (Object row : list) {
                 if (row instanceof Map) {
                     Object val = ((Map) row).get("docs.count");
                     if (val != null) {
-                        return Long.parseLong(val.toString());
+                        total += Long.parseLong(val.toString());
+                        found = true;
                     }
                 }
+            }
+            if (found) {
+                return total;
             }
         } catch (Exception e) {
             LOG.warn("Failed to get docs.count for ES index {}: {}", indexName, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
@@ -219,7 +219,7 @@ public class EsRestClient {
      * @param path the path must not leading with '/'
      * @return response
      */
-    private String execute(String path) throws StarRocksConnectorException {
+    String execute(String path) throws StarRocksConnectorException {
         int retrySize = nodes.length;
         StarRocksConnectorException scratchExceptionForThrow = null;
         OkHttpClient client;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ColumnTypeConverter;
@@ -326,8 +327,9 @@ public class KuduMetadata implements ConnectorMetadata {
                 rowCount = kuduClient.openTable(kuduTableName).getTableStatistics().getLiveRowCount();
             } catch (RpcRemoteException e) {
                 if (isGetTableStatisticsUnsupported(e)) {
-                    LOG.warn("GetTableStatistics method not supported. Fallback to return default row count 1.");
-                    rowCount = 1;
+                    LOG.warn("GetTableStatistics method not supported. Fallback to default row count {}.",
+                            Config.default_statistics_output_row_count);
+                    rowCount = Config.default_statistics_output_row_count;
                 } else {
                     throw new RuntimeException("RPC error while getting table statistics", e);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -925,7 +925,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                     optimizerContext, table.getCatalogName(), table, colRefToColumnMetaMap,
                     Collections.emptyList(), null);
             if (connectorStats != null) {
-                rowCount = (long) connectorStats.getOutputRowCount();
+                double cnt = connectorStats.getOutputRowCount();
+                if (!Double.isNaN(cnt) && cnt > 0) {
+                    rowCount = (long) cnt;
+                }
             }
         } catch (Exception e) {
             LOG.warn("Failed to get ES table statistics for {}: {}", table.getName(), e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -24,8 +24,6 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.BenchmarkTable;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.FileTable;
-import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -791,15 +789,18 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     private Void computeKuduScanNode(Operator node, ExpressionContext context, Table table,
                                      Map<ColumnRefOperator, Column> columnRefOperatorColumnMap) {
-        if (context.getStatistics() == null) {
-            String catalogName = ((KuduTable) table).getCatalogName();
-            Statistics stats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
-                    optimizerContext, catalogName, table, columnRefOperatorColumnMap, null,
-                    node.getPredicate(), -1, TvrTableSnapshot.empty());
-            context.setStatistics(stats);
+        long rowCount = Config.default_statistics_output_row_count;
+        try {
+            Statistics connectorStats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
+                    optimizerContext, table.getCatalogName(), table, columnRefOperatorColumnMap,
+                    Collections.emptyList(), null);
+            if (connectorStats != null) {
+                rowCount = (long) connectorStats.getOutputRowCount();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to get Kudu table statistics for {}: {}", table.getName(), e.getMessage());
         }
-
-        return visitOperator(node, context);
+        return computeNormalExternalTableScanNode(node, context, table, columnRefOperatorColumnMap, rowCount);
     }
 
     public Void visitLogicalHudiScan(LogicalHudiScanOperator node, ExpressionContext context) {
@@ -907,14 +908,28 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalEsScan(LogicalEsScanOperator node, ExpressionContext context) {
-        return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                Config.default_statistics_output_row_count);
+        return computeEsScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap());
     }
 
     @Override
     public Void visitPhysicalEsScan(PhysicalEsScanOperator node, ExpressionContext context) {
-        return computeNormalExternalTableScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap(),
-                Config.default_statistics_output_row_count);
+        return computeEsScanNode(node, context, node.getTable(), node.getColRefToColumnMetaMap());
+    }
+
+    private Void computeEsScanNode(Operator node, ExpressionContext context, Table table,
+                                   Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+        long rowCount = Config.default_statistics_output_row_count;
+        try {
+            Statistics connectorStats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
+                    optimizerContext, table.getCatalogName(), table, colRefToColumnMetaMap,
+                    Collections.emptyList(), null);
+            if (connectorStats != null) {
+                rowCount = (long) connectorStats.getOutputRowCount();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to get ES table statistics for {}: {}", table.getName(), e.getMessage());
+        }
+        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, rowCount);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.BenchmarkTable;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FileTable;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
@@ -21,6 +21,7 @@ import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.type.IntegerType;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
@@ -52,10 +53,13 @@ public class ElasticsearchMetadataTest {
         };
 
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
-        Map<ColumnRefOperator, Column> columns = Collections.emptyMap();
+        ColumnRefOperator colRef = new ColumnRefOperator(0, IntegerType.INT, "col", true);
+        Map<ColumnRefOperator, Column> columns = new HashMap<>();
+        columns.put(colRef, new Column("col", IntegerType.INT));
         Statistics stats = metadata.getTableStatistics(
                 null, esTable, columns, Collections.emptyList(), null, -1, TvrTableSnapshot.empty());
         Assertions.assertEquals(5_000_000D, stats.getOutputRowCount(), 0.01);
+        Assertions.assertTrue(stats.getColumnStatistics().containsKey(colRef));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
@@ -14,12 +14,22 @@
 
 package com.starrocks.connector.elasticsearch;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.EsTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import mockit.Expectations;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 public class ElasticsearchMetadataTest {
 
@@ -28,5 +38,58 @@ public class ElasticsearchMetadataTest {
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
         Assertions.assertNull(metadata.getTable(new ConnectContext(), "default_db", "not_exist_index"));
         Assertions.assertNull(metadata.getTable(new ConnectContext(), "aaaa", "tbl"));
+    }
+
+    @Test
+    public void testGetTableStatistics(@Mocked EsRestClient client, @Mocked EsTable esTable) {
+        new Expectations() {{
+            esTable.getIndexName();
+            result = "my_index";
+            client.getRowCount("my_index");
+            result = 5_000_000L;
+        }};
+
+        ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
+        Map<ColumnRefOperator, Column> columns = Collections.emptyMap();
+        Statistics stats = metadata.getTableStatistics(
+                null, esTable, columns, Collections.emptyList(), null, -1, TvrTableSnapshot.empty());
+        Assertions.assertEquals(5_000_000D, stats.getOutputRowCount(), 0.01);
+    }
+
+    @Test
+    public void testGetTableStatisticsCacheHit(@Mocked EsRestClient client, @Mocked EsTable esTable) {
+        new Expectations() {{
+            esTable.getIndexName();
+            result = "my_index";
+            client.getRowCount("my_index");
+            result = 1_000L;
+        }};
+
+        ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
+        Map<ColumnRefOperator, Column> columns = Collections.emptyMap();
+        metadata.getTableStatistics(null, esTable, columns, Collections.emptyList(), null, -1, TvrTableSnapshot.empty());
+        metadata.getTableStatistics(null, esTable, columns, Collections.emptyList(), null, -1, TvrTableSnapshot.empty());
+
+        // getRowCount should be called only once due to cache
+        new Verifications() {{
+            client.getRowCount(anyString);
+            times = 1;
+        }};
+    }
+
+    @Test
+    public void testGetTableStatisticsFallback(@Mocked EsRestClient client, @Mocked EsTable esTable) {
+        new Expectations() {{
+            esTable.getIndexName();
+            result = "my_index";
+            client.getRowCount("my_index");
+            result = -1L;
+        }};
+
+        ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
+        Statistics stats = metadata.getTableStatistics(
+                null, esTable, Collections.emptyMap(), Collections.emptyList(), null, -1, TvrTableSnapshot.empty());
+        Assertions.assertEquals((double) Config.default_statistics_output_row_count,
+                stats.getOutputRowCount(), 0.01);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
@@ -42,12 +42,14 @@ public class ElasticsearchMetadataTest {
 
     @Test
     public void testGetTableStatistics(@Mocked EsRestClient client, @Mocked EsTable esTable) {
-        new Expectations() {{
-            esTable.getIndexName();
-            result = "my_index";
-            client.getRowCount("my_index");
-            result = 5_000_000L;
-        }};
+        new Expectations() {
+            {
+                esTable.getIndexName();
+                result = "my_index";
+                client.getRowCount("my_index");
+                result = 5_000_000L;
+            }
+        };
 
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
         Map<ColumnRefOperator, Column> columns = Collections.emptyMap();
@@ -58,12 +60,14 @@ public class ElasticsearchMetadataTest {
 
     @Test
     public void testGetTableStatisticsCacheHit(@Mocked EsRestClient client, @Mocked EsTable esTable) {
-        new Expectations() {{
-            esTable.getIndexName();
-            result = "my_index";
-            client.getRowCount("my_index");
-            result = 1_000L;
-        }};
+        new Expectations() {
+            {
+                esTable.getIndexName();
+                result = "my_index";
+                client.getRowCount("my_index");
+                result = 1_000L;
+            }
+        };
 
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
         Map<ColumnRefOperator, Column> columns = Collections.emptyMap();
@@ -71,20 +75,24 @@ public class ElasticsearchMetadataTest {
         metadata.getTableStatistics(null, esTable, columns, Collections.emptyList(), null, -1, TvrTableSnapshot.empty());
 
         // getRowCount should be called only once due to cache
-        new Verifications() {{
-            client.getRowCount(anyString);
-            times = 1;
-        }};
+        new Verifications() {
+            {
+                client.getRowCount(anyString);
+                times = 1;
+            }
+        };
     }
 
     @Test
     public void testGetTableStatisticsFallback(@Mocked EsRestClient client, @Mocked EsTable esTable) {
-        new Expectations() {{
-            esTable.getIndexName();
-            result = "my_index";
-            client.getRowCount("my_index");
-            result = -1L;
-        }};
+        new Expectations() {
+            {
+                esTable.getIndexName();
+                result = "my_index";
+                client.getRowCount("my_index");
+                result = -1L;
+            }
+        };
 
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
         Statistics stats = metadata.getTableStatistics(

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsRestClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsRestClientTest.java
@@ -26,7 +26,7 @@ public class EsRestClientTest {
     public void testGetRowCount() {
         new MockUp<EsRestClient>() {
             @Mock
-            private String execute(String path) {
+            String execute(String path) {
                 return "[{\"docs.count\":\"1234567\"}]";
             }
         };
@@ -38,7 +38,7 @@ public class EsRestClientTest {
     public void testGetRowCountNullResponse() {
         new MockUp<EsRestClient>() {
             @Mock
-            private String execute(String path) {
+            String execute(String path) {
                 return null;
             }
         };
@@ -50,7 +50,7 @@ public class EsRestClientTest {
     public void testGetRowCountOnException() {
         new MockUp<EsRestClient>() {
             @Mock
-            private String execute(String path) {
+            String execute(String path) {
                 throw new StarRocksConnectorException("connection failed");
             }
         };
@@ -62,11 +62,23 @@ public class EsRestClientTest {
     public void testGetRowCountEmptyArray() {
         new MockUp<EsRestClient>() {
             @Mock
-            private String execute(String path) {
+            String execute(String path) {
                 return "[]";
             }
         };
         EsRestClient client = new EsRestClient(new String[] {"http://localhost:9200"}, "", "");
         Assertions.assertEquals(-1L, client.getRowCount("my_index"));
+    }
+
+    @Test
+    public void testGetRowCountMultipleIndices() {
+        new MockUp<EsRestClient>() {
+            @Mock
+            String execute(String path) {
+                return "[{\"docs.count\":\"1000000\"},{\"docs.count\":\"2000000\"},{\"docs.count\":\"500000\"}]";
+            }
+        };
+        EsRestClient client = new EsRestClient(new String[] {"http://localhost:9200"}, "", "");
+        Assertions.assertEquals(3500000L, client.getRowCount("logs-*"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsRestClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsRestClientTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.elasticsearch;
+
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EsRestClientTest {
+
+    @Test
+    public void testGetRowCount() {
+        new MockUp<EsRestClient>() {
+            @Mock
+            private String execute(String path) {
+                return "[{\"docs.count\":\"1234567\"}]";
+            }
+        };
+        EsRestClient client = new EsRestClient(new String[] {"http://localhost:9200"}, "", "");
+        Assertions.assertEquals(1234567L, client.getRowCount("my_index"));
+    }
+
+    @Test
+    public void testGetRowCountNullResponse() {
+        new MockUp<EsRestClient>() {
+            @Mock
+            private String execute(String path) {
+                return null;
+            }
+        };
+        EsRestClient client = new EsRestClient(new String[] {"http://localhost:9200"}, "", "");
+        Assertions.assertEquals(-1L, client.getRowCount("my_index"));
+    }
+
+    @Test
+    public void testGetRowCountOnException() {
+        new MockUp<EsRestClient>() {
+            @Mock
+            private String execute(String path) {
+                throw new StarRocksConnectorException("connection failed");
+            }
+        };
+        EsRestClient client = new EsRestClient(new String[] {"http://localhost:9200"}, "", "");
+        Assertions.assertEquals(-1L, client.getRowCount("my_index"));
+    }
+
+    @Test
+    public void testGetRowCountEmptyArray() {
+        new MockUp<EsRestClient>() {
+            @Mock
+            private String execute(String path) {
+                return "[]";
+            }
+        };
+        EsRestClient client = new EsRestClient(new String[] {"http://localhost:9200"}, "", "");
+        Assertions.assertEquals(-1L, client.getRowCount("my_index"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.kudu;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
@@ -177,7 +178,8 @@ public class KuduMetadataTest {
         Statistics statistics = metadata.getTableStatistics(
                 null, kuduTable, Collections.emptyMap(), Collections.emptyList(), null, -1,
                 TvrTableSnapshot.empty());
-        Assertions.assertEquals(1D, statistics.getOutputRowCount(), 0.01);
+        Assertions.assertEquals((double) Config.default_statistics_output_row_count,
+                statistics.getOutputRowCount(), 0.01);
     }
 
     private RpcRemoteException createRpcRemoteException(String message) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
-import com.starrocks.connector.elasticsearch.EsTablePartitions;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.qe.ConnectContext;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -21,8 +21,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.tvr.TvrTableSnapshot;
@@ -49,12 +49,12 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalKuduScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -113,54 +113,54 @@ public class StatisticsCalculatorTest {
     @BeforeEach
     public void before() throws Exception {
         starRocksAssert.withTable("CREATE TABLE `test_all_type` (\n" +
-                    "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
-                    "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
-                    "  `t1c` int(11) NULL COMMENT \"\",\n" +
-                    "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
-                    "  `t1e` float NULL COMMENT \"\",\n" +
-                    "  `t1f` double NULL COMMENT \"\",\n" +
-                    "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
-                    "  `id_datetime` datetime NULL COMMENT \"\",\n" +
-                    "  `id_date` date NULL COMMENT \"\", \n" +
-                    "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
-                    ") ENGINE=OLAP\n" +
-                    "DUPLICATE KEY(`t1a`)\n" +
-                    "PARTITION BY RANGE (id_date)\n" +
-                    "(\n" +
-                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"), \n" +
-                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")  \n" +
-                    ")\n" +
-                    "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\",\n" +
-                    "\"in_memory\" = \"false\"\n" +
-                    ");");
+                "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
+                "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
+                "  `t1c` int(11) NULL COMMENT \"\",\n" +
+                "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
+                "  `t1e` float NULL COMMENT \"\",\n" +
+                "  `t1f` double NULL COMMENT \"\",\n" +
+                "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
+                "  `id_datetime` datetime NULL COMMENT \"\",\n" +
+                "  `id_date` date NULL COMMENT \"\", \n" +
+                "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`t1a`)\n" +
+                "PARTITION BY RANGE (id_date)\n" +
+                "(\n" +
+                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"), \n" +
+                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")  \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
 
         starRocksAssert.withTable("CREATE TABLE `test_all_type_day_partition` (\n" +
-                    "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
-                    "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
-                    "  `t1c` int(11) NULL COMMENT \"\",\n" +
-                    "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
-                    "  `t1e` float NULL COMMENT \"\",\n" +
-                    "  `t1f` double NULL COMMENT \"\",\n" +
-                    "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
-                    "  `id_datetime` datetime NULL COMMENT \"\",\n" +
-                    "  `id_date` date NULL COMMENT \"\", \n" +
-                    "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
-                    ") ENGINE=OLAP\n" +
-                    "DUPLICATE KEY(`t1a`)\n" +
-                    "PARTITION BY RANGE (id_date)\n" +
-                    "(\n" +
-                    "partition p1 values [('2020-04-23'), ('2020-04-24')),\n" +
-                    "partition p2 values [('2020-04-24'), ('2020-04-25')),\n" +
-                    "partition p3 values [('2020-04-25'), ('2020-04-26')) \n" +
-                    ")\n" +
-                    "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\",\n" +
-                    "\"in_memory\" = \"false\"\n" +
-                    ");");
+                "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
+                "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
+                "  `t1c` int(11) NULL COMMENT \"\",\n" +
+                "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
+                "  `t1e` float NULL COMMENT \"\",\n" +
+                "  `t1f` double NULL COMMENT \"\",\n" +
+                "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
+                "  `id_datetime` datetime NULL COMMENT \"\",\n" +
+                "  `id_date` date NULL COMMENT \"\", \n" +
+                "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`t1a`)\n" +
+                "PARTITION BY RANGE (id_date)\n" +
+                "(\n" +
+                "partition p1 values [('2020-04-23'), ('2020-04-24')),\n" +
+                "partition p2 values [('2020-04-24'), ('2020-04-25')),\n" +
+                "partition p3 values [('2020-04-25'), ('2020-04-26')) \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
     }
 
     @AfterEach
@@ -190,7 +190,7 @@ public class StatisticsCalculatorTest {
         groupExpression.setGroup(new Group(1));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         Assertions.assertEquals(50, expressionContext.getStatistics().getOutputRowCount(), 0.001);
 
@@ -200,11 +200,11 @@ public class StatisticsCalculatorTest {
         groupExpression.setGroup(new Group(1));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         Assertions.assertEquals(
-                    50 * 50 * Math.pow(StatisticsEstimateCoefficient.UNKNOWN_GROUP_BY_CORRELATION_COEFFICIENT, 2),
-                    expressionContext.getStatistics().getOutputRowCount(), 0.001);
+                50 * 50 * Math.pow(StatisticsEstimateCoefficient.UNKNOWN_GROUP_BY_CORRELATION_COEFFICIENT, 2),
+                expressionContext.getStatistics().getOutputRowCount(), 0.001);
     }
 
     @Test
@@ -234,13 +234,13 @@ public class StatisticsCalculatorTest {
         childGroup2.setStatistics(childBuilder2.build());
         // construct group expression
         LogicalUnionOperator unionOperator = new LogicalUnionOperator(Lists.newArrayList(v5, v6),
-                    Lists.newArrayList(Lists.newArrayList(v1, v2), Lists.newArrayList(v3, v4)), true);
+                Lists.newArrayList(Lists.newArrayList(v1, v2), Lists.newArrayList(v3, v4)), true);
         GroupExpression groupExpression =
-                    new GroupExpression(unionOperator, Lists.newArrayList(childGroup1, childGroup2));
+                new GroupExpression(unionOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
 
         ColumnStatistic columnStatisticV5 = expressionContext.getStatistics().getColumnStatistic(v5);
@@ -256,7 +256,7 @@ public class StatisticsCalculatorTest {
         OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test").getTable("test_all_type");
         Collection<Partition> partitions = table.getPartitions();
         List<Long> partitionIds =
-                    partitions.stream().mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
+                partitions.stream().mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
         for (Partition partition : partitions) {
             partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(1000);
         }
@@ -271,32 +271,32 @@ public class StatisticsCalculatorTest {
             columnToRef.put(column, ref);
 
             LogicalOlapScanOperator olapScanOperator = new LogicalOlapScanOperator(table,
-                        refToColumn, columnToRef,
-                        null, -1, null,
-                        ((OlapTable) table).getBaseIndexMetaId(),
-                        partitionIds,
-                        null,
-                        false,
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        false);
+                    refToColumn, columnToRef,
+                    null, -1, null,
+                    ((OlapTable) table).getBaseIndexMetaId(),
+                    partitionIds,
+                    null,
+                    false,
+                    Lists.newArrayList(),
+                    Lists.newArrayList(),
+                    Lists.newArrayList(),
+                    false);
 
             GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
             groupExpression.setGroup(new Group(0));
             ExpressionContext expressionContext = new ExpressionContext(groupExpression);
             Statistics.Builder builder = Statistics.builder();
             olapScanOperator.getOutputColumns().forEach(col ->
-                        builder.addColumnStatistic(col,
-                                    new ColumnStatistic(-100, 100, 0.0, 5.0, 10))
+                    builder.addColumnStatistic(col,
+                            new ColumnStatistic(-100, 100, 0.0, 5.0, 10))
             );
             expressionContext.setStatistics(builder.build());
             StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                        columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
             statisticsCalculator.estimatorStats();
             Assertions.assertEquals(1000 * partitions.size(), expressionContext.getStatistics().getOutputRowCount(), 0.001);
             Assertions.assertEquals(ref.getType().getTypeSize() * 1000 * partitions.size(),
-                        expressionContext.getStatistics().getComputeSize(), 0.001);
+                    expressionContext.getStatistics().getComputeSize(), 0.001);
         }
     }
 
@@ -320,9 +320,9 @@ public class StatisticsCalculatorTest {
         }
 
         BinaryPredicateOperator predicateOperator = new BinaryPredicateOperator(BinaryType.LT,
-                    partitionColumn, ConstantOperator.createInt(50));
+                partitionColumn, ConstantOperator.createInt(50));
         LogicalIcebergScanOperator icebergScanOperator = new LogicalIcebergScanOperator(icebergTable, refToColumn,
-                    columnToRef, -1, predicateOperator, TvrTableSnapshot.empty());
+                columnToRef, -1, predicateOperator, TvrTableSnapshot.empty());
 
         GroupExpression groupExpression = new GroupExpression(icebergScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -331,22 +331,22 @@ public class StatisticsCalculatorTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator,
-                        Column> columns) {
+                    Column> columns) {
                 Statistics.Builder builder = Statistics.builder();
                 icebergScanOperator.getOutputColumns().forEach(col ->
-                            builder.addColumnStatistic(col,
-                                        new ColumnStatistic(0, 100, 0.0, 5.0, 100))
+                        builder.addColumnStatistic(col,
+                                new ColumnStatistic(0, 100, 0.0, 5.0, 100))
                 );
                 builder.setOutputRowCount(100);
                 return builder.build();
             }
         };
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         Assertions.assertEquals(50, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         Assertions.assertEquals(50, expressionContext.getStatistics().
-                    getColumnStatistic(partitionColumn).getMaxValue(), 0.001);
+                getColumnStatistic(partitionColumn).getMaxValue(), 0.001);
         Assertions.assertTrue(optimizerContext.isObtainedFromInternalStatistics());
         optimizerContext.setObtainedFromInternalStatistics(false);
     }
@@ -370,7 +370,7 @@ public class StatisticsCalculatorTest {
         partition3.getDefaultPhysicalPartition().setVisibleVersion(2, System.currentTimeMillis());
         partition3.getDefaultPhysicalPartition().setDataVersion(2);
         List<Long> partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
-                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
 
         new MockUp<CachedStatisticStorage>() {
             @Mock
@@ -381,24 +381,24 @@ public class StatisticsCalculatorTest {
         };
 
         LogicalOlapScanOperator olapScanOperator =
-                    new LogicalOlapScanOperator(table,
-                                ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
-                                ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate),
-                                null, -1, null,
-                                ((OlapTable) table).getBaseIndexMetaId(),
-                                partitionIds,
-                                null,
-                                false,
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                false);
+                new LogicalOlapScanOperator(table,
+                        ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
+                        ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate),
+                        null, -1, null,
+                        ((OlapTable) table).getBaseIndexMetaId(),
+                        partitionIds,
+                        null,
+                        false,
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         ColumnStatistic columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
         Assertions.assertEquals(30, columnStatistic.getDistinctValuesCount(), 0.001);
@@ -430,72 +430,72 @@ public class StatisticsCalculatorTest {
         Collection<Partition> partitions = ((OlapTable) table).getPartitions();
         // select partition p1
         List<Long> partitionIds = partitions.stream().filter(partition -> partition.getName().equalsIgnoreCase("p1")).
-                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
         for (Partition partition : partitions) {
             partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(1000);
         }
 
         LogicalOlapScanOperator olapScanOperator =
-                    new LogicalOlapScanOperator(table,
-                                ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
-                                ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate),
-                                null, -1,
-                                new BinaryPredicateOperator(BinaryType.EQ,
-                                            idDate, ConstantOperator.createDate(LocalDateTime.of(2013, 12, 30, 0, 0, 0))),
-                                ((OlapTable) table).getBaseIndexMetaId(),
-                                partitionIds,
-                                null,
-                                false,
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                false);
+                new LogicalOlapScanOperator(table,
+                        ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
+                        ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate),
+                        null, -1,
+                        new BinaryPredicateOperator(BinaryType.EQ,
+                                idDate, ConstantOperator.createDate(LocalDateTime.of(2013, 12, 30, 0, 0, 0))),
+                        ((OlapTable) table).getBaseIndexMetaId(),
+                        partitionIds,
+                        null,
+                        false,
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         // partition column count distinct values is 30 in table level, after partition prune,
         // the column statistic distinct values is 10, so the estimate row count is 1000 * (1/10)
         Assertions.assertEquals(100, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         ColumnStatistic columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2013, 12, 30, 0, 0, 0)),
-                    columnStatistic.getMaxValue(), 0.001);
+                columnStatistic.getMaxValue(), 0.001);
 
         // select partition p2, p3
         partitionIds.clear();
         partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
-                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
         olapScanOperator =
-                    new LogicalOlapScanOperator(table,
-                                ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
-                                ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate),
-                                null, -1, null, ((OlapTable) table).getBaseIndexMetaId(),
-                                partitionIds,
-                                null,
-                                false,
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                false);
+                new LogicalOlapScanOperator(table,
+                        ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
+                        ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate),
+                        null, -1, null, ((OlapTable) table).getBaseIndexMetaId(),
+                        partitionIds,
+                        null,
+                        false,
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        false);
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryType.GE,
-                    idDate, ConstantOperator.createDate(LocalDateTime.of(2014, 5, 1, 0, 0, 0))));
+                idDate, ConstantOperator.createDate(LocalDateTime.of(2014, 5, 1, 0, 0, 0))));
 
         groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
 
         Assertions.assertEquals(1281.4371, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2014, 5, 1, 0, 0, 0)),
-                    columnStatistic.getMinValue(), 0.001);
+                columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2014, 12, 1, 0, 0, 0)),
-                    columnStatistic.getMaxValue(), 0.001);
+                columnStatistic.getMaxValue(), 0.001);
         Assertions.assertEquals(20, columnStatistic.getDistinctValuesCount(), 0.001);
         FeConstants.runningUnitTest = false;
     }
@@ -507,7 +507,7 @@ public class StatisticsCalculatorTest {
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test")
-                    .getTable("test_all_type_day_partition");
+                .getTable("test_all_type_day_partition");
 
         new MockUp<CachedStatisticStorage>() {
             @Mock
@@ -526,57 +526,57 @@ public class StatisticsCalculatorTest {
         Collection<Partition> partitions = table.getPartitions();
         // select partition p2
         List<Long> partitionIds = partitions.stream().filter(partition -> partition.getName().equalsIgnoreCase("p2")).
-                    mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
+                mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
         for (Partition partition : partitions) {
             partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(1000);
         }
 
         LogicalOlapScanOperator olapScanOperator =
-                    new LogicalOlapScanOperator(table,
-                                ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
-                                ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate), null, -1, null,
-                                ((OlapTable) table).getBaseIndexMetaId(),
-                                partitionIds,
-                                null,
-                                false,
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                false);
+                new LogicalOlapScanOperator(table,
+                        ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
+                        ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate), null, -1, null,
+                        ((OlapTable) table).getBaseIndexMetaId(),
+                        partitionIds,
+                        null,
+                        false,
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
 
         Assertions.assertEquals(1000, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         ColumnStatistic columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 24, 0, 0, 0)),
-                    columnStatistic.getMinValue(), 0.001);
+                columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 25, 0, 0, 0)),
-                    columnStatistic.getMaxValue(), 0.001);
+                columnStatistic.getMaxValue(), 0.001);
         Assertions.assertEquals(1, columnStatistic.getDistinctValuesCount(), 0.001);
 
         // select partition p2, p3
         partitionIds.clear();
         partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
-                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
         olapScanOperator =
-                    new LogicalOlapScanOperator(table,
-                                ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
-                                ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate), null, -1, null,
-                                ((OlapTable) table).getBaseIndexMetaId(),
-                                partitionIds,
-                                null,
-                                false,
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                Lists.newArrayList(),
-                                false);
+                new LogicalOlapScanOperator(table,
+                        ImmutableMap.of(idDate, new Column("id_date", DateType.DATE, true)),
+                        ImmutableMap.of(new Column("id_date", DateType.DATE, true), idDate), null, -1, null,
+                        ((OlapTable) table).getBaseIndexMetaId(),
+                        partitionIds,
+                        null,
+                        false,
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        false);
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryType.GE,
-                    idDate, ConstantOperator.createDate(LocalDateTime.of(2020, 04, 24, 0, 0, 0))));
+                idDate, ConstantOperator.createDate(LocalDateTime.of(2020, 04, 24, 0, 0, 0))));
 
         groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -587,9 +587,9 @@ public class StatisticsCalculatorTest {
         // has two partitions
         Assertions.assertEquals(2000, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 24, 0, 0, 0)),
-                    columnStatistic.getMinValue(), 0.001);
+                columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 26, 0, 0, 0)),
-                    columnStatistic.getMaxValue(), 0.001);
+                columnStatistic.getMaxValue(), 0.001);
         Assertions.assertEquals(2, columnStatistic.getDistinctValuesCount(), 0.001);
         FeConstants.runningUnitTest = false;
     }
@@ -632,21 +632,21 @@ public class StatisticsCalculatorTest {
         columnRefFactory.updateColumnToRelationIds(v6.getId(), 4);
         // on predicate : t0.v1 = t1.v3 and t0.v2 = t1.v4
         BinaryPredicateOperator eqOnPredicate1 =
-                    new BinaryPredicateOperator(BinaryType.EQ, v1, v3);
+                new BinaryPredicateOperator(BinaryType.EQ, v1, v3);
         BinaryPredicateOperator eqOnPredicate2 =
-                    new BinaryPredicateOperator(BinaryType.EQ, v2, v4);
+                new BinaryPredicateOperator(BinaryType.EQ, v2, v4);
         BinaryPredicateOperator eqOnPredicate3 =
-                    new BinaryPredicateOperator(BinaryType.EQ, v5, v6);
+                new BinaryPredicateOperator(BinaryType.EQ, v5, v6);
         // construct group expression
         LogicalJoinOperator joinOperator =
-                    new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
-                                CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, eqOnPredicate2));
+                new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
+                        CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, eqOnPredicate2));
         GroupExpression groupExpression =
-                    new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
+                new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         // use middle ground method to estimate
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();
@@ -667,13 +667,13 @@ public class StatisticsCalculatorTest {
         // on predicate : t0.v1 = t1.v3 and t0.v2 = t2.v4 and t3.v5 = t4.v6
         // construct group expression
         joinOperator = new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
-                    CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, new CompoundPredicateOperator(
-                    CompoundPredicateOperator.CompoundType.AND, eqOnPredicate2, eqOnPredicate3)));
+                CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, eqOnPredicate2, eqOnPredicate3)));
         groupExpression = new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         // use middle ground method to estimate
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();
@@ -681,18 +681,18 @@ public class StatisticsCalculatorTest {
 
         // on predicate : t0.v1 = t1.v3 + t1.v4 and t0.v2 = t1.v3 + t1.v4
         BinaryPredicateOperator eqOnPredicateWithAdd1 =
-                    new BinaryPredicateOperator(BinaryType.EQ, v1,
-                                new CallOperator("add", IntegerType.BIGINT, Lists.newArrayList(v3, v4)));
+                new BinaryPredicateOperator(BinaryType.EQ, v1,
+                        new CallOperator("add", IntegerType.BIGINT, Lists.newArrayList(v3, v4)));
         BinaryPredicateOperator eqOnPredicateWithAdd2 =
-                    new BinaryPredicateOperator(BinaryType.EQ, v2,
-                                new CallOperator("add", IntegerType.BIGINT, Lists.newArrayList(v3, v4)));
+                new BinaryPredicateOperator(BinaryType.EQ, v2,
+                        new CallOperator("add", IntegerType.BIGINT, Lists.newArrayList(v3, v4)));
         joinOperator = new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
-                    CompoundPredicateOperator.CompoundType.AND, eqOnPredicateWithAdd1, eqOnPredicateWithAdd2));
+                CompoundPredicateOperator.CompoundType.AND, eqOnPredicateWithAdd1, eqOnPredicateWithAdd2));
         groupExpression = new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                columnRefFactory, optimizerContext);
         // use middle ground method to estimate
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();
@@ -792,7 +792,6 @@ public class StatisticsCalculatorTest {
         Assertions.assertEquals(outerNullFraction, outerJoinKeyStatAfterJoin.getNullsFraction(), 0.001,
                 "Outer join key null fraction should be preserved after " + outerJoin.name());
     }
-
 
     @ParameterizedTest
     @EnumSource(value = OuterJoin.class)
@@ -1199,15 +1198,16 @@ public class StatisticsCalculatorTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public Statistics getTableStatistics(OptimizerContext session, String catalogName, Table table,
-                    Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
-                    ScalarOperator predicate) {
+                                                 Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                                                 ScalarOperator predicate) {
                 return Statistics.builder().setOutputRowCount(999_000).build();
             }
         };
         new MockUp<StatisticsCalcUtils>() {
             @Mock
             public Statistics.Builder estimateScanColumns(Table table,
-                    Map<ColumnRefOperator, Column> colRefToColumnMetaMap, OptimizerContext ctx) {
+                                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                          OptimizerContext ctx) {
                 return Statistics.builder();
             }
         };
@@ -1230,15 +1230,16 @@ public class StatisticsCalculatorTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public Statistics getTableStatistics(OptimizerContext session, String catalogName, Table table,
-                    Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
-                    ScalarOperator predicate) {
+                                                 Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                                                 ScalarOperator predicate) {
                 return Statistics.builder().setOutputRowCount(888_000).build();
             }
         };
         new MockUp<StatisticsCalcUtils>() {
             @Mock
             public Statistics.Builder estimateScanColumns(Table table,
-                    Map<ColumnRefOperator, Column> colRefToColumnMetaMap, OptimizerContext ctx) {
+                                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                          OptimizerContext ctx) {
                 return Statistics.builder();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -18,9 +18,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.EsTable;
+import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.elasticsearch.EsTablePartitions;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.qe.ConnectContext;
@@ -40,10 +44,13 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.LogicalProperty;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalKuduScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -57,6 +64,7 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -1177,5 +1185,67 @@ public class StatisticsCalculatorTest {
         if (err.get() != null) {
             throw new AssertionError(err.get());
         }
+    }
+
+    @Test
+    public void testComputeEsScanNode(@Mocked EsTable esTable) {
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        LogicalEsScanOperator scanOperator =
+                new LogicalEsScanOperator(esTable, refToColumn, columnToRef, -1, null, null);
+        GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+        groupExpression.setGroup(new Group(0));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Statistics getTableStatistics(OptimizerContext session, String catalogName, Table table,
+                    Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                    ScalarOperator predicate) {
+                return Statistics.builder().setOutputRowCount(999_000).build();
+            }
+        };
+        new MockUp<StatisticsCalcUtils>() {
+            @Mock
+            public Statistics.Builder estimateScanColumns(Table table,
+                    Map<ColumnRefOperator, Column> colRefToColumnMetaMap, OptimizerContext ctx) {
+                return Statistics.builder();
+            }
+        };
+
+        StatisticsCalculator calculator = new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext);
+        calculator.estimatorStats();
+        Assertions.assertEquals(999_000D, expressionContext.getStatistics().getOutputRowCount(), 0.01);
+    }
+
+    @Test
+    public void testComputeKuduScanNode(@Mocked KuduTable kuduTable) {
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        LogicalKuduScanOperator scanOperator =
+                new LogicalKuduScanOperator(kuduTable, refToColumn, columnToRef, -1, null);
+        GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+        groupExpression.setGroup(new Group(0));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Statistics getTableStatistics(OptimizerContext session, String catalogName, Table table,
+                    Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                    ScalarOperator predicate) {
+                return Statistics.builder().setOutputRowCount(888_000).build();
+            }
+        };
+        new MockUp<StatisticsCalcUtils>() {
+            @Mock
+            public Statistics.Builder estimateScanColumns(Table table,
+                    Map<ColumnRefOperator, Column> colRefToColumnMetaMap, OptimizerContext ctx) {
+                return Statistics.builder();
+            }
+        };
+
+        StatisticsCalculator calculator = new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext);
+        calculator.estimatorStats();
+        Assertions.assertEquals(888_000D, expressionContext.getStatistics().getOutputRowCount(), 0.01);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
External connector tables that have no collected statistics return `cardinality=1` to the CBO by default, causing severely wrong join-order decisions (e.g. a multi-million-row ES index treated as a 1-row lookup table).

## What I'm doing:

**Elasticsearch**: implement `getTableStatistics()` in `ElasticsearchMetadata` using the ES `_cat/indices/<index>?h=docs.count` API to retrieve the document count from Lucene segment metadata. This is essentially free — it reads pre-computed cluster state rather than executing a search across shards. Results are cached in a per-instance Caffeine cache (max 1000 entries, 1-hour TTL, no new config knobs) so repeated planning calls within the same FE session don't hit the network.

```
Query planning (getTableStatistics)
        │
        ▼
 rowCountCache (Caffeine, 1h TTL)
    hit ──► return cached count
    miss──► GET _cat/indices/<index>?h=docs.count   ← reads Lucene segment metadata, ~0 overhead
              │  success ──► cache & return count
              └─ failure  ──► fallback to default_statistics_output_row_count
```

**Kudu**: the `getLiveRowCount()` RPC path already works correctly for servers that support it. The only fix is the fallback when the server is too old to support `GetTableStatistics`: instead of hardcoding `1`, use `Config.default_statistics_output_row_count` so operators can tune the default without a code change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
