### PR TITLE
[BugFix] Derive LIST-partition MIN/MAX only from single-value partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -173,6 +173,17 @@ public class ListPartitionInfo extends PartitionInfo {
             return CollectionUtils.isEmpty(singleColumnValues) && CollectionUtils.isEmpty(multiColumnValues);
         }
 
+        // Number of values this partition declares in its VALUES IN (...) list.
+        public int valueCount() {
+            if (singleColumnValues != null) {
+                return singleColumnValues.size();
+            }
+            if (multiColumnValues != null) {
+                return multiColumnValues.size();
+            }
+            return 0;
+        }
+
         public ListPartitionValue minValue() {
             if (singleColumnValues != null) {
                 return ListPartitionValue.of(singleColumnValues.stream().min(LiteralExpr::compareTo).get());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -324,7 +324,12 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 if (CollectionUtils.isEmpty(sorted)) {
                     return null;
                 }
-                valueRow.add(minMaxFunction.first.apply(sorted.get(0), partitionInfo));
+                ScalarOperator minValue = minMaxFunction.first.apply(sorted.get(0), partitionInfo);
+                if (minValue == null) {
+                    // the extreme partition's value cannot be determined from metadata; decline
+                    return null;
+                }
+                valueRow.add(minValue);
                 columns.add(entry.getKey());
             } else if (isMax(entry.getValue())) {
                 List<Long> sorted = partitionInfo.getSortedPartitions(false);
@@ -332,7 +337,12 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 if (CollectionUtils.isEmpty(sorted)) {
                     return null;
                 }
-                valueRow.add(minMaxFunction.second.apply(sorted.get(0), partitionInfo));
+                ScalarOperator maxValue = minMaxFunction.second.apply(sorted.get(0), partitionInfo);
+                if (maxValue == null) {
+                    // the extreme partition's value cannot be determined from metadata; decline
+                    return null;
+                }
+                valueRow.add(maxValue);
                 columns.add(entry.getKey());
             }
         }
@@ -347,6 +357,12 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         ListPartitionInfo.ListPartitionCell partitionValues =
                 ((ListPartitionInfo) partitionInfo).getPartitionListExpr(partitionId);
         Preconditions.checkState(!partitionValues.isEmpty());
+        // Only a single-value LIST partition is safe: a non-empty partition that declares exactly
+        // one value must contain that value. A multi-value partition (VALUES IN (a, b, ...)) is not
+        // guaranteed to hold its declared extreme, so its MIN/MAX cannot be derived from metadata.
+        if (partitionValues.valueCount() != 1) {
+            return null;
+        }
         return partitionValues.minValue().toConstant();
     }
 
@@ -354,6 +370,11 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         ListPartitionInfo.ListPartitionCell partitionValues =
                 ((ListPartitionInfo) partitionInfo).getPartitionListExpr(partitionId);
         Preconditions.checkState(!partitionValues.isEmpty());
+        // See getMinListPartitionValue: only a single-value LIST partition's declared value is
+        // guaranteed present in the data.
+        if (partitionValues.valueCount() != 1) {
+            return null;
+        }
         return partitionValues.maxValue().toConstant();
     }
 

--- a/test/sql/test_list_partition/R/test_list_partition_minmax_declared_absent
+++ b/test/sql/test_list_partition/R/test_list_partition_minmax_declared_absent
@@ -1,0 +1,52 @@
+-- name: test_list_partition_minmax_declared_absent
+CREATE DATABASE IF NOT EXISTS test_list_partition_minmax_declared_absent_db;
+-- result:
+-- !result
+USE test_list_partition_minmax_declared_absent_db;
+-- result:
+-- !result
+CREATE TABLE lpm (k INT) DUPLICATE KEY(k)
+PARTITION BY LIST(k) (
+  PARTITION p1 VALUES IN ('1','2','3'),
+  PARTITION p2 VALUES IN ('10','20','30')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO lpm VALUES (1), (10);
+-- result:
+-- !result
+SET enable_rewrite_partition_column_minmax = false;
+-- result:
+-- !result
+SELECT max(k) mx, min(k) mn FROM lpm;
+-- result:
+10	1
+-- !result
+SET enable_rewrite_partition_column_minmax = true;
+-- result:
+-- !result
+SELECT max(k) mx, min(k) mn FROM lpm;
+-- result:
+10	1
+-- !result
+CREATE TABLE lpv (k INT) DUPLICATE KEY(k)
+PARTITION BY LIST(k) (
+  PARTITION s1 VALUES IN ('5'),
+  PARTITION s2 VALUES IN ('15')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO lpv VALUES (5), (15);
+-- result:
+-- !result
+SET enable_rewrite_partition_column_minmax = true;
+-- result:
+-- !result
+SELECT max(k) mx, min(k) mn FROM lpv;
+-- result:
+15	5
+-- !result

--- a/test/sql/test_list_partition/T/test_list_partition_minmax_declared_absent
+++ b/test/sql/test_list_partition/T/test_list_partition_minmax_declared_absent
@@ -1,0 +1,39 @@
+-- name: test_list_partition_minmax_declared_absent
+-- description: MIN/MAX(partition_col) on a LIST table must reflect the data, not the declared
+--              VALUES IN (...) extremes. PartitionColumnMinMaxRewriteRule used to answer from the
+--              largest/smallest declared list value (gated only by hasData()), so MAX returned a
+--              declared value (30) absent from the data. Must equal the rewrite-off result.
+
+CREATE DATABASE IF NOT EXISTS test_list_partition_minmax_declared_absent_db;
+USE test_list_partition_minmax_declared_absent_db;
+
+CREATE TABLE lpm (k INT) DUPLICATE KEY(k)
+PARTITION BY LIST(k) (
+  PARTITION p1 VALUES IN ('1','2','3'),
+  PARTITION p2 VALUES IN ('10','20','30')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- data omits the extreme declared values (3, 20, 30): real max=10, min=1
+INSERT INTO lpm VALUES (1), (10);
+
+SET enable_rewrite_partition_column_minmax = false;
+SELECT max(k) mx, min(k) mn FROM lpm;
+
+-- with the rewrite ON the LIST declared-values path is declined -> still 10,1 (was 30,1)
+SET enable_rewrite_partition_column_minmax = true;
+SELECT max(k) mx, min(k) mn FROM lpm;
+
+-- single-value LIST partitions: each non-empty partition holds exactly its one declared
+-- value, so the metadata rewrite is still applied and stays correct (max=15, min=5).
+CREATE TABLE lpv (k INT) DUPLICATE KEY(k)
+PARTITION BY LIST(k) (
+  PARTITION s1 VALUES IN ('5'),
+  PARTITION s2 VALUES IN ('15')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO lpv VALUES (5), (15);
+SET enable_rewrite_partition_column_minmax = true;
+SELECT max(k) mx, min(k) mn FROM lpv;


### PR DESCRIPTION
## Why I'm doing:

PartitionColumnMinMaxRewriteRule answered MIN/MAX(partition_col) on a LIST-partitioned table from the largest/smallest declared VALUES IN (...) value, gated only by hasData(). A non-empty partition is not guaranteed to contain its extreme declared value, so e.g. a partition VALUES IN ('10','20','30') holding only 10 made MAX(k) return 30 -- a value no row holds (silent wrong result).

A non-empty *single-value* LIST partition, however, must contain its one declared value (rows route by value), exactly like the rule's day-wide DATE range path (a one-day interval on a DATE column admits a single value). So restrict the LIST rewrite to single-value partitions: getMin/getMaxListPartitionValue return null for a multi-value partition, and optimizeWithPartitionValues then declines, falling back to the partition-prune / top-N paths that compute MIN/MAX from real data.

Adds ListPartitionCell.valueCount(). The range path is unchanged.

Repro: LIST(k) with p1 IN (1,2,3), p2 IN (10,20,30), data {1,10}: MAX(k) returned 30 with enable_rewrite_partition_column_minmax=true vs the correct 10; now 10. A single-value LIST table (s1 IN (5), s2 IN (15)) still uses the rewrite and correctly returns 15/5.

Test: test/sql/test_list_partition/{T,R}/test_list_partition_minmax_declared_absent.

## What I'm doing:

```sql
CREATE TABLE lpm (k INT) DUPLICATE KEY(k) PARTITION BY LIST(k) (PARTITION p1 VALUES IN ('1','2','3'), PARTITION p2 VALUES IN ('10','20','30')) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("replication_num"="1");
INSERT INTO lpm VALUES (1),(10);
SET enable_rewrite_partition_column_minmax=false; SELECT max(k) FROM lpm;  -- 10 (correct)
SET enable_rewrite_partition_column_minmax=true;  SELECT max(k) FROM lpm;  -- 30 (WRONG — declared list max of p2)
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
