### PR TITLE
[BugFix] Reject VARIANT as an OLAP column type at DDL (was a BE crash)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -130,6 +130,19 @@ public class ColumnDefAnalyzer {
 
         Type type = typeDef.getType();
 
+        // VARIANT is only an internal representation for reading external catalogs (e.g. Iceberg);
+        // it has no native storage write path, so an OLAP column containing VARIANT -- at the top
+        // level or nested inside ARRAY/MAP/STRUCT -- is accepted by DDL but aborts the BE on the
+        // first insert. ChunkFactory::column_from_field recurses into sub-fields and
+        // field_type_dispatch_column still hits its default LOG(FATAL) for TYPE_VARIANT, so a nested
+        // VARIANT crashes the node just like a top-level one. Reject any contained VARIANT at DDL for
+        // native tables; external engines keep using it for reads (their schema does not go through
+        // this OLAP column validation).
+        if (isOlap && type.containsVariant()) {
+            throw new AnalysisException(
+                    String.format("VARIANT is not supported as a column type for OLAP tables: column '%s'", name));
+        }
+
         if (isKey && isOlap && !type.canDistributedBy()) {
             if (type.isFloatingPointType()) {
                 throw new AnalysisException(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -611,6 +611,16 @@ public class MaterializedViewAnalyzer {
                 if (colWithComments != null) {
                     colName = colWithComments.get(i).getColName();
                 }
+                // A materialized view is stored as a native OLAP table. VARIANT (and complex types that
+                // nest it) has no native storage write path, so a generated MV column carrying VARIANT
+                // would abort the BE on refresh (the storage LogicalType dispatch hits its default
+                // LOG(FATAL) for TYPE_VARIANT) -- exactly the case ColumnDefAnalyzer rejects for CREATE
+                // TABLE. The MV column path does not go through ColumnDefAnalyzer, so reject it here too.
+                if (type.containsVariant()) {
+                    throw new SemanticException(
+                            "VARIANT is not supported as a column type for materialized views: column '" +
+                                    colName + "'");
+                }
                 Column column = new Column(colName, type, colNullable);
                 if (IvmOpUtils.COLUMN_ROW_ID.equalsIgnoreCase(colName)) {
                     column.setIsKey(true);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -294,8 +294,7 @@ public class AggStateCombinatorTest extends MVTestBase {
                 "c26 varbinary,\n" +
                 "c27 map<varchar(1048576),varchar(1048576)>,\n" +
                 "c28 struct<`col1` array<varchar(1048576)>>,\n" +
-                "c29 array<varchar(100)>,\n" +
-                "c30 variant";
+                "c29 array<varchar(100)>";
         String[] splits = define.split(",\n");
         for (String colType : splits) {
             String[] parts = colType.split(" ");
@@ -314,6 +313,12 @@ public class AggStateCombinatorTest extends MVTestBase {
                 break;
             }
             List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
+            // VARIANT can no longer be an OLAP column, so a base-table column of that type cannot be
+            // created; skip agg functions that take a VARIANT argument (the base table t1 below would
+            // otherwise need a VARIANT column and fail DDL analysis).
+            if (argTypes.stream().anyMatch(Type::containsVariant)) {
+                continue;
+            }
             List<String> argTypeStr = argTypes.stream().map(this::mockType).map(Type::toSql).collect(Collectors.toList());
             aggArgTypes.add(argTypeStr);
             for (String argType : argTypeStr) {
@@ -779,23 +784,23 @@ public class AggStateCombinatorTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "  1:Project\n" +
                     "  |  output columns:\n" +
                     "  |  1 <-> [1: k1, DATE, true]\n" +
-                    "  |  33 <-> multi_distinct_sum_state[([8: c6, DOUBLE, true]); args: DOUBLE; " +
+                    "  |  32 <-> multi_distinct_sum_state[([8: c6, DOUBLE, true]); args: DOUBLE; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  34 <-> multi_distinct_sum_state[([9: c7, FLOAT, true]); args: FLOAT; " +
+                    "  |  33 <-> multi_distinct_sum_state[([9: c7, FLOAT, true]); args: FLOAT; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  35 <-> multi_distinct_sum_state[([2: c0, BOOLEAN, true]); args: BOOLEAN; " +
+                    "  |  34 <-> multi_distinct_sum_state[([2: c0, BOOLEAN, true]); args: BOOLEAN; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  36 <-> multi_distinct_sum_state[([3: c1, TINYINT, true]); args: TINYINT; " +
+                    "  |  35 <-> multi_distinct_sum_state[([3: c1, TINYINT, true]); args: TINYINT; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  37 <-> multi_distinct_sum_state[([4: c2, SMALLINT, true]); args: SMALLINT; " +
+                    "  |  36 <-> multi_distinct_sum_state[([4: c2, SMALLINT, true]); args: SMALLINT; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  38 <-> multi_distinct_sum_state[([5: c3, INT, true]); args: INT; " +
+                    "  |  37 <-> multi_distinct_sum_state[([5: c3, INT, true]); args: INT; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  39 <-> multi_distinct_sum_state[([6: c4, BIGINT, true]); args: BIGINT; " +
+                    "  |  38 <-> multi_distinct_sum_state[([6: c4, BIGINT, true]); args: BIGINT; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  40 <-> multi_distinct_sum_state[([7: c5, LARGEINT, true]); args: LARGEINT; " +
+                    "  |  39 <-> multi_distinct_sum_state[([7: c5, LARGEINT, true]); args: LARGEINT; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
-                    "  |  41 <-> multi_distinct_sum_state[([10: c8, DECIMAL64(10,2), true]); args: DECIMAL64; " +
+                    "  |  40 <-> multi_distinct_sum_state[([10: c8, DECIMAL64(10,2), true]); args: DECIMAL64; " +
                     "result: VARBINARY; args nullable: true; result nullable: true]\n" +
                     "  |  cardinality: 1");
             PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
@@ -918,7 +923,7 @@ public class AggStateCombinatorTest extends MVTestBase {
         {
             String sql1 = "select k1, " + Joiner.on(", ").join(stateColumns) + " from t1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
-            PlanTestBase.assertContains(plan, "33 <-> array_agg_state[([26: c24, VARCHAR, true]); args: VARCHAR; " +
+            PlanTestBase.assertContains(plan, "32 <-> array_agg_state[([26: c24, VARCHAR, true]); args: VARCHAR; " +
                     "result: struct<`col1` array<varchar(100)>>; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
                     "     table: t1, rollup: t1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -130,6 +130,22 @@ public class MaterializedViewAnalyzerTest {
     }
 
     @Test
+    public void testCreateMaterializedViewWithVariantColumnRejected() throws Exception {
+        starRocksAssert.useDatabase("test");
+        // A materialized view is stored as a native OLAP table, so a VARIANT value column projected
+        // from an external (Iceberg) base table must be rejected at analysis: the generated MV column
+        // path does not go through ColumnDefAnalyzer, and a native VARIANT column would abort the BE
+        // on refresh (storage LogicalType dispatch LOG(FATAL)). A native VARIANT base column can no
+        // longer be created, so an external catalog is the only way to reach this path.
+        analyzeFail("CREATE MATERIALIZED VIEW test.mv_variant\n" +
+                        "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\"replication_num\" = \"1\")\n" +
+                        "AS SELECT id, v FROM iceberg0.unpartitioned_db.variant_t0;",
+                "VARIANT is not supported as a column type for materialized views");
+    }
+
+    @Test
     public void testCreateIcebergTable2() throws Exception {
         String mvName = "iceberg_parttbl_mv1";
         starRocksAssert.useDatabase("test")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -103,17 +103,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
-        starRocksAssert.withTable("CREATE TABLE `variant0` (\n" +
-                "  `v1` bigint NULL, \n" +
-                "  `v` VARIANT NULL \n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`v1`)\n" +
-                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\",\n" +
-                "\"storage_format\" = \"DEFAULT\"\n" +
-                ");");
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS t1(\n" +
                 "    tenant_id BIGINT NOT NULL,\n" +
                 "    id BIGINT NOT NULL,\n" +
@@ -1155,45 +1144,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String sql = "select get_json_bool(j1, 'a') from js0";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
-    }
-
-    @Test
-    public void testVariantSubfieldPruning() throws Exception {
-        String sql = "select get_variant_int(v, '$.a.b'), get_variant_string(v, '$.c') from variant0";
-        String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/a/b(bigint(20)), /v/c(varchar)]");
-
-        sql = "select get_variant_int(v, '$.a'), get_variant_string(v, '$.a') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
-
-        sql = "select variant_query(v, '$.profile.rank') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/profile/rank(variant)]");
-
-        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(1);
-
-        sql = "select get_variant_int(v, '$.a.b') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
-
-        sql = "select get_variant_int(v, '$.a[0]') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
-
-        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(20);
-
-        sql = "select get_variant_int(v, 'a.b'), get_variant_string(v, '$.\"profile.name\".first') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/\"profile.name\"/first(varchar), /v/a/b(bigint(20))]");
-
-        sql = "select variant_query(v, '$.a.b'), get_variant_string(v, '$.a.b') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/a/b(variant)]");
-
-        sql = "select get_variant_int(v, '$.a.b'), get_variant_double(v, '$.a.b') from variant0";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/v/a/b(variant)]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VariantPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VariantPathRewriteTest.java
@@ -225,6 +225,55 @@ public class VariantPathRewriteTest extends ConnectorPlanTestBase {
     }
 
     @Test
+    public void testVariantSubfieldPruning() throws Exception {
+        // Generic subfield pruning (variant path rewrite disabled): the prune-subfield rule populates
+        // ColumnAccessPath on the scan node. It is scan-agnostic and is exposed for Iceberg variant
+        // columns the same way it was for the (now DDL-rejected) OLAP variant column.
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(false);
+        int prevDepth = connectContext.getSessionVariable().getCboPruneJsonSubfieldDepth();
+        try {
+            String sql = "select get_variant_int(v, '$.a.b'), get_variant_string(v, '$.c') from " + VARIANT_TABLE;
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/a/b(bigint(20)), /v/c(varchar)]");
+
+            sql = "select get_variant_int(v, '$.a'), get_variant_string(v, '$.a') from " + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
+
+            sql = "select variant_query(v, '$.profile.rank') from " + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/profile/rank(variant)]");
+
+            connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(1);
+
+            sql = "select get_variant_int(v, '$.a.b') from " + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
+
+            sql = "select get_variant_int(v, '$.a[0]') from " + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
+
+            connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(20);
+
+            sql = "select get_variant_int(v, 'a.b'), get_variant_string(v, '$.\"profile.name\".first') from "
+                    + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/\"profile.name\"/first(varchar), /v/a/b(bigint(20))]");
+
+            sql = "select variant_query(v, '$.a.b'), get_variant_string(v, '$.a.b') from " + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/a/b(variant)]");
+
+            sql = "select get_variant_int(v, '$.a.b'), get_variant_double(v, '$.a.b') from " + VARIANT_TABLE;
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "ColumnAccessPath: [/v/a/b(variant)]");
+        } finally {
+            connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(prevDepth);
+        }
+    }
+
+    @Test
     public void testExtendedColumnInheritsSourcePhysicalName() {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         VariantPathRewriteRule.VariantPathRewriteContext context =

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -305,6 +305,26 @@ public abstract class Type implements Cloneable {
                 && !isBinaryType() && !isVariantType();
     }
 
+    // Returns true if this type is VARIANT or transitively contains a VARIANT inside an
+    // ARRAY/MAP/STRUCT. VARIANT has no native storage write path: an OLAP column (or generated MV
+    // column) containing it aborts the BE on write (the storage LogicalType dispatch hits its
+    // default LOG(FATAL) for TYPE_VARIANT), so native schemas must reject any contained VARIANT.
+    public boolean containsVariant() {
+        if (isVariantType()) {
+            return true;
+        }
+        if (isArrayType()) {
+            return ((ArrayType) this).getItemType().containsVariant();
+        }
+        if (isMapType()) {
+            return ((MapType) this).getKeyType().containsVariant() || ((MapType) this).getValueType().containsVariant();
+        }
+        if (isStructType()) {
+            return ((StructType) this).getFields().stream().anyMatch(sf -> sf.getType().containsVariant());
+        }
+        return false;
+    }
+
     public boolean canDistributedBy() {
         // TODO(mofei) support distributed by for JSON
         // Allow VARBINARY as distribution key

--- a/test/sql/test_create_table/R/test_reject_variant_olap_column
+++ b/test/sql/test_create_table/R/test_reject_variant_olap_column
@@ -1,0 +1,43 @@
+-- name: test_reject_variant_olap_column
+CREATE DATABASE IF NOT EXISTS test_reject_variant_olap_column_db;
+-- result:
+-- !result
+USE test_reject_variant_olap_column_db;
+-- result:
+-- !result
+CREATE TABLE vtest (id INT, v VARIANT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: VARIANT is not supported as a column type for OLAP tables: column 'v'.")
+-- !result
+CREATE TABLE varr (id INT, a ARRAY<VARIANT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: VARIANT is not supported as a column type for OLAP tables: column 'a'.")
+-- !result
+CREATE TABLE vmap (id INT, m MAP<INT, VARIANT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: VARIANT is not supported as a column type for OLAP tables: column 'm'.")
+-- !result
+CREATE TABLE vstruct (id INT, s STRUCT<f VARIANT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: VARIANT is not supported as a column type for OLAP tables: column 's'.")
+-- !result
+CREATE TABLE vnest (id INT, a ARRAY<STRUCT<f VARIANT>>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: VARIANT is not supported as a column type for OLAP tables: column 'a'.")
+-- !result
+CREATE TABLE vok (id INT, j JSON) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO vok VALUES (1, parse_json('{"a":1}'));
+-- result:
+-- !result
+SELECT count(*) FROM vok;
+-- result:
+1
+-- !result

--- a/test/sql/test_create_table/T/test_reject_variant_olap_column
+++ b/test/sql/test_create_table/T/test_reject_variant_olap_column
@@ -1,0 +1,35 @@
+-- name: test_reject_variant_olap_column
+-- description: A VARIANT column on a native OLAP table must be rejected at DDL. VARIANT has no
+--              native storage write path (it is only an internal type for reading external
+--              catalogs such as Iceberg), so previously CREATE TABLE accepted it and the first
+--              INSERT aborted the BE (storage LogicalType dispatch LOG(FATAL)). Now DDL fails
+--              with a clean semantic error and the BE is never reached.
+
+CREATE DATABASE IF NOT EXISTS test_reject_variant_olap_column_db;
+USE test_reject_variant_olap_column_db;
+
+-- rejected at analysis with a clean error (was: accepted -> BE SIGABRT on insert)
+CREATE TABLE vtest (id INT, v VARIANT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+-- VARIANT nested inside ARRAY/MAP/STRUCT is rejected too: the BE storage column dispatch recurses
+-- into sub-fields and still hits LOG(FATAL) for TYPE_VARIANT, so a nested VARIANT crashes the node
+-- on insert just like a top-level one.
+CREATE TABLE varr (id INT, a ARRAY<VARIANT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE vmap (id INT, m MAP<INT, VARIANT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE vstruct (id INT, s STRUCT<f VARIANT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+-- deeply nested VARIANT (array of struct) is rejected as well
+CREATE TABLE vnest (id INT, a ARRAY<STRUCT<f VARIANT>>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+-- a normal table with no VARIANT column still creates fine
+CREATE TABLE vok (id INT, j JSON) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO vok VALUES (1, parse_json('{"a":1}'));
+SELECT count(*) FROM vok;


### PR DESCRIPTION


## Why I'm doing:

CREATE TABLE on a native OLAP table accepted a VARIANT column, but VARIANT has no native storage write path -- it is only an internal representation for reading external catalogs (e.g. Iceberg). The first INSERT therefore aborted the BE: the storage column dispatch (field_type_dispatch_column / ChunkFactory::column_from_field_type) hit its default LOG(FATAL) ("unknown type"), a hard CHECK that crashes the node in release builds too and does not auto-restart. Any user creating a VARIANT OLAP table and loading one row downs the BE.

Reject a VARIANT column for OLAP tables in ColumnDefAnalyzer.analyze (gated on isOlap), so DDL fails with a clean semantic error and the BE is never reached. External engines keep using VARIANT for reads (their schema does not go through this OLAP column validation).

Repro: CREATE TABLE vtest (id INT, v VARIANT) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1; INSERT ... -> BE SIGABRT. Now the CREATE TABLE returns "VARIANT is not supported as a column type for OLAP tables" and the BE stays alive.

Test: test/sql/test_create_table/{T,R}/test_reject_variant_olap_column.

## What I'm doing:

Fixes #issue

```
*** Aborted at 1782064189 (unix time) try "date -d @1782064189" if you are using GNU date ***
PC: @     0x7fb3019ab9fc pthread_kill
*** SIGABRT (@0x110cf) received by PID 69839 (TID 0x7fa931f1a640) LWP(98041) from PID 69839; stack trace: ***
    @         0x31f3d287 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fb3019aeee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x31f3ca86 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fb301957520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fb3019ab9fc pthread_kill
    @     0x7fb301957476 raise
    @     0x7fb30193d7f3 abort
    @         0x29431535 starrocks::failure_function()
    @         0x31f30add google::LogMessage::Fail()
    @         0x31f31bc4 google::LogMessageFatal::~LogMessageFatal()
    @         0x2cb2237a auto starrocks::field_type_dispatch_column<starrocks::ColumnBuilder, bool&>(starrocks::LogicalType, starrocks::ColumnBuilder, bool&)
    @         0x2cb1d63a starrocks::ChunkFactory::column_from_field_type(starrocks::LogicalType, bool)
    @         0x2cb1e8e9 starrocks::ChunkFactory::column_from_field(starrocks::Field const&)
    @         0x2cb1ee55 starrocks::ChunkFactory::new_chunk(starrocks::Schema const&, unsigned long)
    @         0x2825a5f2 starrocks::MemTable::insert(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @         0x28240843 starrocks::DeltaWriter::write(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @         0x2927fd90 starrocks::AsyncDeltaWriter::_execute(void*, bthread::TaskIterator<starrocks::AsyncDeltaWriter::Task>&)
    @         0x29285f78 bthread::ExecutionQueue<starrocks::AsyncDeltaWriter::Task>::execute_task(void*, void*, bthread::TaskIteratorBase&)
    @         0x3213a33c bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*)
    @         0x3213b327 bthread::ExecutionQueueBase::_execute_tasks(void*)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
