### PR TITLE
[BugFix] Keep full 128 bits of a LARGEINT literal in JIT codegen

### DIFF
--- a/be/src/exprs/jit/ir_helper.cpp
+++ b/be/src/exprs/jit/ir_helper.cpp
@@ -115,7 +115,13 @@ StatusOr<llvm::Value*> IRHelper::load_ir_number(llvm::IRBuilder<>& b, const Logi
         return b.getInt64(reinterpret_cast<const int64_t*>(value)[0]);
     case TYPE_LARGEINT:
     case TYPE_DECIMAL128: {
-        llvm::APInt value_128(128, reinterpret_cast<const int128_t*>(value)[0], true);
+        // The APInt(numBits, uint64_t, isSigned) overload would narrow the int128 to 64 bits and
+        // drop the high half (zeroing/wrapping any literal >= 2^64). Build it from both 64-bit
+        // words (little-endian: low word first) so the full 128-bit literal is preserved.
+        const int128_t raw = reinterpret_cast<const int128_t*>(value)[0];
+        const uint64_t words[2] = {static_cast<uint64_t>(static_cast<__uint128_t>(raw)),
+                                   static_cast<uint64_t>(static_cast<__uint128_t>(raw) >> 64)};
+        llvm::APInt value_128(128, llvm::ArrayRef<uint64_t>(words, 2));
         return llvm::ConstantInt::get(b.getContext(), value_128);
     }
     case TYPE_FLOAT:

--- a/test/sql/test_agg/R/test_jit_largeint_literal
+++ b/test/sql/test_agg/R/test_jit_largeint_literal
@@ -1,0 +1,35 @@
+-- name: test_jit_largeint_literal
+CREATE DATABASE IF NOT EXISTS test_jit_largeint_literal_db;
+-- result:
+-- !result
+USE test_jit_largeint_literal_db;
+-- result:
+-- !result
+CREATE TABLE jitli (id INT, v LARGEINT NULL) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO jitli SELECT generate_series, 1 FROM TABLE(generate_series(1, 5000)) g;
+-- result:
+-- !result
+SET jit_level = 0;
+-- result:
+-- !result
+SELECT sum(v + 18446744073709551616 - v) FROM jitli;
+-- result:
+92233720368547758080000
+-- !result
+SET jit_level = -1;
+-- result:
+-- !result
+SELECT sum(v + 18446744073709551616 - v) FROM jitli;
+-- result:
+92233720368547758080000
+-- !result
+SET jit_level = -1;
+-- result:
+-- !result
+SELECT sum(v + 100000000000000000000 - v) FROM jitli;
+-- result:
+500000000000000000000000
+-- !result

--- a/test/sql/test_agg/T/test_jit_largeint_literal
+++ b/test/sql/test_agg/T/test_jit_largeint_literal
@@ -1,0 +1,22 @@
+-- name: test_jit_largeint_literal
+-- description: A JIT-compiled expression must keep the full 128 bits of a LARGEINT literal.
+--              ir_helper built the constant via APInt(128, uint64_t,...), narrowing the int128
+--              and dropping the high half, so any literal >= 2^64 was zeroed/wrapped under JIT
+--              (jit_level=-1) while the interpreter (jit_level=0) was correct. The two must match.
+
+CREATE DATABASE IF NOT EXISTS test_jit_largeint_literal_db;
+USE test_jit_largeint_literal_db;
+
+CREATE TABLE jitli (id INT, v LARGEINT NULL) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO jitli SELECT generate_series, 1 FROM TABLE(generate_series(1, 5000)) g;
+
+-- 2^64 literal: interpreter and JIT must agree (= 5000 * 2^64)
+SET jit_level = 0;
+SELECT sum(v + 18446744073709551616 - v) FROM jitli;
+SET jit_level = -1;
+SELECT sum(v + 18446744073709551616 - v) FROM jitli;
+
+-- 10^20 literal (also > 2^64), forced JIT: must equal 5000 * 10^20
+SET jit_level = -1;
+SELECT sum(v + 100000000000000000000 - v) FROM jitli;


### PR DESCRIPTION
## Why I'm doing:

IRHelper::load_ir_number built a 128-bit constant for a TYPE_LARGEINT / TYPE_DECIMAL128 literal via APInt(128, reinterpret_cast<const int128_t*>(value)[0], true). The matched overload is APInt(unsigned, uint64_t, bool) -- there is no __int128 form -- so the int128 argument was narrowed to uint64_t and the high 64 bits were dropped. Any LARGEINT literal
>= 2^64 was zeroed/wrapped under JIT while the interpreter kept the full value.

Build the APInt from both 64-bit words of the int128 (little-endian, low word first) so the full 128-bit literal is preserved. Values that fit in 64 bits are unaffected (the high word is the correct sign/zero extension). int128 columns were already correct; only literals were wrong.

Repro: sum(v + 18446744073709551616 - v) over a LARGEINT column returned 0 at jit_level=-1 vs the correct 5000*2^64 at jit_level=0; now equal.

Test: test/sql/test_agg/{T,R}/test_jit_largeint_literal.

## What I'm doing:

Fixes #issue
```sql
CREATE TABLE jitli(id INT, v LARGEINT NULL) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
INSERT INTO jitli SELECT generate_series, 1 FROM TABLE(generate_series(1,5000)) g;

SET jit_level=0;  SELECT sum(v + 18446744073709551616 - v) FROM jitli;   -- 92233720368547758080000 (=5000·2^64)
SET jit_level=-1; SELECT sum(v + 18446744073709551616 - v) FROM jitli;   -- 0   (2^64 literal truncated to 0)
-- also: literal 10^20 → interp 500000000000000000000000 vs JIT 38831398157261209600000 (low-64-bit wrap)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
