### PR TITLE
[BugFix] Bound-check truncated percent-escape in url_decode (OOB read)

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2781,6 +2781,13 @@ static Status url_decode_slice(const char* value, size_t len, std::string* to) {
     to->reserve(len);
     for (size_t i = 0; i < len; i++) {
         if (value[i] == '%') {
+            // A '%' must be followed by two hex digits. Without this bound check, a truncated
+            // escape ("...%" or "...%X") at the end of the slice reads 1-2 bytes past it. The
+            // slice is not NUL-terminated for column input (e.g. url_extract_parameter), so this
+            // is an out-of-bounds read of adjacent memory whose result depends on neighbouring data.
+            if (i + 2 >= len) {
+                return Status::RuntimeError("decode string contains an incomplete percent-encoding");
+            }
             char l = value[i + 1];
             char r = value[i + 2];
             if ((l < 'A' || l > 'F') && (l < '0' || l > '9')) {

--- a/test/sql/test_string_functions/R/test_url_extract_parameter_truncated_escape
+++ b/test/sql/test_string_functions/R/test_url_extract_parameter_truncated_escape
@@ -1,0 +1,43 @@
+-- name: test_url_extract_parameter_truncated_escape
+CREATE DATABASE IF NOT EXISTS test_url_extract_parameter_truncated_escape_db;
+-- result:
+-- !result
+USE test_url_extract_parameter_truncated_escape_db;
+-- result:
+-- !result
+CREATE TABLE ta (id INT, u VARCHAR(100)) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE tb (id INT, u VARCHAR(100)) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO ta VALUES (1, 'http://x/p?k1=ab%'), (2, 'ABABABAB');
+-- result:
+-- !result
+INSERT INTO tb VALUES (1, 'http://x/p?k1=ab%'), (2, 'ZZZZZZZZ');
+-- result:
+-- !result
+SELECT id, hex(url_extract_parameter(u, 'k1')) AS vhex FROM ta WHERE id = 1;
+-- result:
+1	None
+-- !result
+SELECT id, hex(url_extract_parameter(u, 'k1')) AS vhex FROM tb WHERE id = 1;
+-- result:
+1	None
+-- !result
+INSERT INTO ta VALUES (3, 'http://x/p?k1=cd%4');
+-- result:
+-- !result
+SELECT id, url_extract_parameter(u, 'k1') FROM ta WHERE id = 3;
+-- result:
+3	None
+-- !result
+INSERT INTO ta VALUES (4, 'http://x/p?k1=z%41');
+-- result:
+-- !result
+SELECT id, url_extract_parameter(u, 'k1') FROM ta WHERE id = 4;
+-- result:
+4	zA
+-- !result

--- a/test/sql/test_string_functions/T/test_url_extract_parameter_truncated_escape
+++ b/test/sql/test_string_functions/T/test_url_extract_parameter_truncated_escape
@@ -1,0 +1,31 @@
+-- name: test_url_extract_parameter_truncated_escape
+-- description: url_extract_parameter on a column value whose parameter ends in a truncated
+--              percent-escape ("...%" or "...%X") must not read past the value. The decoder
+--              previously read value[i+1]/value[i+2] with no bound check; for the non-NUL-
+--              terminated column slice that was an out-of-bounds read of adjacent row bytes,
+--              so the result depended on neighbouring data. With the fix it is a clean error
+--              (NULL) regardless of what follows in memory, and valid escapes still decode.
+
+CREATE DATABASE IF NOT EXISTS test_url_extract_parameter_truncated_escape_db;
+USE test_url_extract_parameter_truncated_escape_db;
+
+CREATE TABLE ta (id INT, u VARCHAR(100)) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+CREATE TABLE tb (id INT, u VARCHAR(100)) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+-- row 1 is identical in both tables; only the following row's bytes differ. Before the fix the
+-- truncated "ab%" read into row 2 and the results diverged (hex 6162AB vs NULL); now both NULL.
+INSERT INTO ta VALUES (1, 'http://x/p?k1=ab%'), (2, 'ABABABAB');
+INSERT INTO tb VALUES (1, 'http://x/p?k1=ab%'), (2, 'ZZZZZZZZ');
+
+SELECT id, hex(url_extract_parameter(u, 'k1')) AS vhex FROM ta WHERE id = 1;
+SELECT id, hex(url_extract_parameter(u, 'k1')) AS vhex FROM tb WHERE id = 1;
+
+-- value ending in a single trailing hex digit after '%' is also truncated -> clean NULL
+INSERT INTO ta VALUES (3, 'http://x/p?k1=cd%4');
+SELECT id, url_extract_parameter(u, 'k1') FROM ta WHERE id = 3;
+
+-- a complete escape still decodes correctly (%41 = 'A')
+INSERT INTO ta VALUES (4, 'http://x/p?k1=z%41');
+SELECT id, url_extract_parameter(u, 'k1') FROM ta WHERE id = 4;


### PR DESCRIPTION
## Why I'm doing:

url_decode_slice read value[i+1] and value[i+2] after seeing '%' with no check that two bytes remain. For column input (e.g. url_extract_parameter) the value slice is not NUL-terminated, so a value ending in a truncated escape ("...%" or "...%X") read 1-2 bytes past the slice into adjacent column memory. The result therefore depended on neighbouring rows -- an out-of-bounds read / cross-row information leak (and the over-read bytes were even echoed into the "illegal hex chars" error message).

Add `if (i + 2 >= len) return error` before reading the two hex digits, so a truncated escape yields a clean error instead of reading out of bounds. Complete escapes still decode.

Repro (column input): two tables identical except for the row following 'http://x/p?k1=ab%'; before the fix url_extract_parameter(u,'k1') returned hex 6162AB when the next row began with hex bytes vs NULL otherwise -- the result varied with adjacent memory. After the fix both return NULL (clean), and a complete '%41' still decodes to 'A'.

Test: test/sql/test_string_functions/{T,R}/test_url_extract_parameter_truncated_escape.

## What I'm doing:

Fixes #issue

ASAN UT:
```
  ==19499==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000000013
     at pc 0x51c72f bp 0x7ffe09109710 sp 0x7ffe09109708
  READ of size 1 at 0x502000000013 thread T0
      #0 0x51c72e in url_decode_slice                  url_oob_repro.cpp:10   ← char l = value[i+1];
      #1 0x51c72e in seek_param_key_in_query_params    url_oob_repro.cpp:27
      #2 0x51c72e in url_extract_parameter             url_oob_repro.cpp:30
      #3 0x51c72e in main                              url_oob_repro.cpp:36
      #4 libc start ...

  0x502000000013 is located 0 bytes after 3-byte region [0x502000000010,0x502000000013)
  allocated by thread T0 here:
      #0 operator new[](unsigned long)
      #1 0x51c56e in main                              url_oob_repro.cpp:33   ← char* buf = new char[3];  // "ab%"

```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
