### PR TITLE
[BugFix] Fix spill partition sort sink cancel crash

### DIFF
--- a/be/src/compute_env/spill/spill_components.h
+++ b/be/src/compute_env/spill/spill_components.h
@@ -95,8 +95,6 @@ public:
 
     virtual Status acquire_stream(const SpillPartitionInfo* partition, std::shared_ptr<SpillInputStream>* stream) = 0;
 
-    virtual void cancel() = 0;
-
     virtual void get_spill_partitions(std::vector<const SpillPartitionInfo*>* partitions) = 0;
 
     template <class T>
@@ -168,8 +166,6 @@ public:
     Status acquire_stream(std::shared_ptr<SpillInputStream>* stream) override;
 
     Status acquire_stream(const SpillPartitionInfo* partition, std::shared_ptr<SpillInputStream>* stream) override;
-
-    void cancel() override {}
 
     void get_spill_partitions(std::vector<const SpillPartitionInfo*>* partitions) override {}
 
@@ -262,8 +258,6 @@ public:
     void reset_partition(const std::vector<const SpillPartitionInfo*>& partitions);
 
     void reset_partition(RuntimeState* state, size_t num_partitions);
-
-    void cancel() override {}
 
     void shuffle(std::vector<uint32_t>& dst, const SpillHashColumn* hash_column);
 

--- a/be/src/compute_env/spill/spiller.h
+++ b/be/src/compute_env/spill/spiller.h
@@ -270,10 +270,7 @@ public:
 
     bool is_cancel() const { return _is_cancel; }
 
-    void cancel() {
-        _is_cancel = true;
-        _writer->cancel();
-    }
+    void cancel() { _is_cancel = true; }
 
     void set_finished() { cancel(); }
 

--- a/be/src/exec/spillable_chunks_sorter.cpp
+++ b/be/src/exec/spillable_chunks_sorter.cpp
@@ -97,15 +97,7 @@ Status SpillableChunksSorter<TChunksSorter>::do_done(RuntimeState* state) {
 template <DerivedFromChunksSorter TChunksSorter>
 void SpillableChunksSorter<TChunksSorter>::cancel() {
     if (_spiller->spilled()) {
-        if (_spill_channel->has_task()) {
-            std::function<StatusOr<ChunkPtr>()> cancel_task = [this]() -> StatusOr<ChunkPtr> {
-                _spiller->cancel();
-                return Status::EndOfFile("eos");
-            };
-            _spill_channel->add_spill_task(std::move(cancel_task));
-        } else {
-            _spiller->cancel();
-        }
+        _spiller->cancel();
     }
 }
 

--- a/test/sql/test_spill/R/test_spill_sort_cancel
+++ b/test/sql/test_spill/R/test_spill_sort_cancel
@@ -1,0 +1,45 @@
+-- name: test_spill_sort_cancel @sequential
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="NONE";
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(100))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 100000 - generate_series FROM TABLE(generate_series(1, 300000));
+-- result:
+-- !result
+admin enable failpoint 'chunk_sorter_spill_on_set_finishing';
+-- result:
+-- !result
+admin enable failpoint 'spill_submit_error';
+-- result:
+-- !result
+select sum(k1),sum(crc32(k2)) from (select k1,k2 from t1 order by k1,k2 limit 270000, 10)t;
+-- result:
+[REGEX].*inject spill_submit_error.*
+-- !result
+select sum(k1),sum(crc32(k2)),sum(rn) from (select k1,k2, row_number() over (PARTITION BY k1 order by k2) as rn from t1)t;
+-- result:
+[REGEX].*inject spill_submit_error.*
+-- !result
+admin disable failpoint 'spill_submit_error';
+-- result:
+-- !result
+admin disable failpoint 'chunk_sorter_spill_on_set_finishing';
+-- result:
+-- !result
+select sum(k1),sum(crc32(k2)) from (select k1,k2 from t1 order by k1,k2 limit 270000, 10)t;
+-- result:
+2700055	24200037139
+-- !result
+CLEANUP {
+    admin disable failpoint 'spill_submit_error';
+    admin disable failpoint 'chunk_sorter_spill_on_set_finishing';
+} END CLEANUP

--- a/test/sql/test_spill/T/test_spill_sort_cancel
+++ b/test/sql/test_spill/T/test_spill_sort_cancel
@@ -1,0 +1,38 @@
+-- name: test_spill_sort_cancel @sequential
+
+set enable_spill=true;
+set spill_mode="NONE";
+
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(100))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+insert into t1 SELECT generate_series, 100000 - generate_series FROM TABLE(generate_series(1, 300000));
+
+-- Force the order-by/window sort to spill, then inject a spill-submit error so the
+-- fragment is cancelled while the spillable sorter has already spilled (and may still
+-- have a pending spill task on its channel). On cancel, SpillablePartitionSortSinkOperator
+-- drives SpillableChunksSorter::cancel() on that spilled sorter.
+--
+-- Regression: the cancel path used to enqueue an extra cancel task onto the spill
+-- channel when a task was pending; combined with the now-removed SpillerWriter::cancel(),
+-- this could dereference query-scoped spill state after teardown (ASAN heap-use-after-free).
+-- The query is expected to fail gracefully with the injected error and the BE must NOT crash.
+admin enable failpoint 'chunk_sorter_spill_on_set_finishing';
+admin enable failpoint 'spill_submit_error';
+
+select sum(k1),sum(crc32(k2)) from (select k1,k2 from t1 order by k1,k2 limit 270000, 10)t;
+select sum(k1),sum(crc32(k2)),sum(rn) from (select k1,k2, row_number() over (PARTITION BY k1 order by k2) as rn from t1)t;
+
+admin disable failpoint 'spill_submit_error';
+admin disable failpoint 'chunk_sorter_spill_on_set_finishing';
+
+-- After disabling the failpoints the same queries must succeed again, proving the
+-- cancel path left no corrupted state behind.
+select sum(k1),sum(crc32(k2)) from (select k1,k2 from t1 order by k1,k2 limit 270000, 10)t;
+
+CLEANUP {
+    admin disable failpoint 'spill_submit_error';
+    admin disable failpoint 'chunk_sorter_spill_on_set_finishing';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
query_id:019eeaeb-1f60-7a10-91c6-6e56b50b2f0d, fragment_instance:019eeaeb-1f60-7a10-91c6-6e56b50b2f33, plan_node_id:-1
*** Aborted at 1782057782 (unix time) try "date -d @1782057782" if you are using GNU date ***
PC: @          0xc338684 std::_Function_handler<starrocks::StatusOr<std::shared_ptr<starrocks::Chunk> > (), starrocks::SpillableChunksSorterFullSort::cancel()::{lambda()#1}>::_M_invoke(std::_Any_data const&)
*** SIGSEGV (@0x2c44454c45466e) received by PID 2384877 (TID 0xfe275504fa00) LWP(2385624) from PID 1279608430; stack trace: ***
    @     0xfe27cec853dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @         0x10cda188 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xfe27cfccfa84 PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0]
    @     0xfe27cfcd043c JVM_handle_linux_signal
    @     0xfe27d03398f8 ([vdso]+0x8f7)
    @          0xc338684 std::_Function_handler<starrocks::StatusOr<std::shared_ptr<starrocks::Chunk> > (), starrocks::SpillableChunksSorterFullSort::cancel()::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @          0xc0e0ca4 starrocks::SpillProcessChannel::close()
    @          0xc0de8cc starrocks::pipeline::SpillProcessOperator::close(starrocks::RuntimeState*)
    @          0xad6ef6c starrocks::pipeline::PipelineDriver::_mark_operator_closed(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0xad6f2b4 starrocks::pipeline::PipelineDriver::_close_operators(starrocks::RuntimeState*)
    @          0xad6f624 starrocks::pipeline::PipelineDriver::finalize(starrocks::RuntimeState*, starrocks::pipeline::DriverState)
    @          0xbdc7038 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xd904914 starrocks::ThreadPool::dispatch_thread()
    @          0xd8fb4f8 starrocks::thread::supervise_thread(void*)
    @     0xfe27cec80398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xfe27cece9e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
