### PR TITLE
[BugFix] array_map/transform drops NULL rows when all non-null arrays are empty

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -398,13 +398,27 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
                     ->get_total_elements_num(result_null_column);
 
     if (total_elements_num == 0) {
-        // if all input rows are empty arrays, return a const empty array column as result
+        // All non-null input arrays are empty. When some rows are null we cannot use a const
+        // column (null rows and empty-`[]` rows differ): build `num_rows` empty arrays and apply
+        // the per-row null mask so null inputs stay null instead of being rendered as `[]` (and
+        // so the row count is correct). With no null rows every row is identical, so a const
+        // empty array column is fine.
         column = ColumnHelper::create_column(type().children[0], true);
         auto aligned_offsets = UInt32Column::create(0);
+        if (result_null_column) {
+            // all-zero offsets (num_rows + 1 of them) -> every row is an empty array
+            aligned_offsets->append_default(chunk->num_rows() + 1);
+            auto array_col = ArrayColumn::create(std::move(column), std::move(aligned_offsets));
+            array_col->check_or_die();
+            auto result_null_mut = NullColumn::static_pointer_cast(std::move(*result_null_column).mutate());
+            auto result = NullableColumn::create(std::move(array_col), std::move(result_null_mut));
+            result->check_or_die();
+            return result;
+        }
         aligned_offsets->append_default(2);
         auto array_col = ArrayColumn::create(std::move(column), std::move(aligned_offsets));
         array_col->check_or_die();
-        auto result = ConstColumn::create(std::move(array_col), chunk->num_rows() - null_rows);
+        auto result = ConstColumn::create(std::move(array_col), chunk->num_rows());
         result->check_or_die();
         return result;
     }

--- a/test/sql/test_array_fn/R/test_array_map_null_empty_rows
+++ b/test/sql/test_array_fn/R/test_array_map_null_empty_rows
@@ -1,0 +1,38 @@
+-- name: test_array_map_null_empty_rows
+CREATE DATABASE IF NOT EXISTS test_array_map_null_empty_rows_db;
+-- result:
+-- !result
+USE test_array_map_null_empty_rows_db;
+-- result:
+-- !result
+CREATE TABLE amt (id INT, arr ARRAY<INT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO amt VALUES (1, NULL), (2, []), (3, []);
+-- result:
+-- !result
+SELECT id, array_map(x -> x + 1, arr) AS am, array_filter(x -> x > 0, arr) AS af FROM amt ORDER BY id;
+-- result:
+1	None	None
+2	[]	[]
+3	[]	[]
+-- !result
+SELECT sum(if(array_map(x -> x + 1, arr) IS NULL, 1, 0)) AS am_nullcnt,
+       sum(if(arr IS NULL, 1, 0)) AS real_nullcnt FROM amt;
+-- result:
+1	1
+-- !result
+CREATE TABLE amt2 (id INT, arr ARRAY<INT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO amt2 VALUES (1, NULL), (2, []), (3, [5]);
+-- result:
+-- !result
+SELECT id, array_map(x -> x + 1, arr) AS am FROM amt2 ORDER BY id;
+-- result:
+1	None
+2	[]
+3	[6]
+-- !result

--- a/test/sql/test_array_fn/T/test_array_map_null_empty_rows
+++ b/test/sql/test_array_fn/T/test_array_map_null_empty_rows
@@ -1,0 +1,24 @@
+-- name: test_array_map_null_empty_rows
+-- description: array_map/transform must preserve NULL input rows even when, within a chunk, no
+--              row is fully-null but every non-null input array is empty. The total_elements_num
+--              == 0 fast path returned a const empty-array column without the null mask, so NULL
+--              rows were silently rendered as [] (and the row count was wrong). array_filter uses
+--              a different path and was already correct; the result must match it.
+
+CREATE DATABASE IF NOT EXISTS test_array_map_null_empty_rows_db;
+USE test_array_map_null_empty_rows_db;
+
+CREATE TABLE amt (id INT, arr ARRAY<INT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+-- chunk where the only non-null arrays are empty: NULL must stay NULL, not become []
+INSERT INTO amt VALUES (1, NULL), (2, []), (3, []);
+SELECT id, array_map(x -> x + 1, arr) AS am, array_filter(x -> x > 0, arr) AS af FROM amt ORDER BY id;
+SELECT sum(if(array_map(x -> x + 1, arr) IS NULL, 1, 0)) AS am_nullcnt,
+       sum(if(arr IS NULL, 1, 0)) AS real_nullcnt FROM amt;
+
+-- control: mixing in a non-empty array takes the general path and was already correct
+CREATE TABLE amt2 (id INT, arr ARRAY<INT>) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO amt2 VALUES (1, NULL), (2, []), (3, [5]);
+SELECT id, array_map(x -> x + 1, arr) AS am FROM amt2 ORDER BY id;


### PR DESCRIPTION
## Why I'm doing:

In array_map_expr.cpp, when a chunk has some null rows (so it does not take the all-null fast path) but every non-null input array is empty (total_elements_num == 0), the fast path returned a ConstColumn of empty arrays sized num_rows - null_rows and without a null mask. So null input rows were rendered as [] (NULL silently dropped) and the row count was wrong. The adjacent all-null branch correctly uses num_rows and a NullableColumn; array_filter uses a different path and was already correct.

When there are null rows, build num_rows empty arrays and wrap them in a NullableColumn with the per-row null mask (a const column cannot represent the mix of NULL and [] rows). With no null rows the rows are identical, so the const empty-array column is kept.

Repro: array_map(x->x+1, arr) over rows (NULL,[],[]) returned [] for the NULL row (and count(... IS NULL)=0) vs array_filter's correct NULL; now array_map returns NULL too.

Test: test/sql/test_array_fn/{T,R}/test_array_map_null_empty_rows.

## What I'm doing:

Fixes #issue

```
  CREATE TABLE amt(id INT, arr ARRAY<INT>) DUPLICATE KEY(id)
    DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
  INSERT INTO amt VALUES (1, NULL), (2, []), (3, []);

  SELECT id, array_map(x -> x+1, arr) AS am FROM amt ORDER BY id;
  SELECT count(*) FROM amt WHERE array_map(x -> x+1, arr) IS NULL;   -- expect 1 (the NULL row)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
