### PR TITLE
[BugFix] bar(): reject negative/huge width instead of growing unbounded (DoS)

### DIFF
--- a/be/src/exprs/utility_functions.cpp
+++ b/be/src/exprs/utility_functions.cpp
@@ -365,6 +365,9 @@ StatusOr<ColumnPtr> UtilityFunctions::get_query_profile(FunctionContext* context
 
 StatusOr<ColumnPtr> UtilityFunctions::bar(FunctionContext* context, const Columns& columns) {
     static std::u8string kBar = u8"\u2593";
+    // Upper bound on the rendered bar length. The per-row result is a plain std::string that is
+    // NOT tracked by the MemTracker, so an unbounded width can exhaust BE memory (DoS).
+    constexpr int64_t kMaxBarWidth = 1000000;
     RETURN_IF(columns.size() != 4, Status::InvalidArgument("expect 4 arguments"));
     RETURN_IF(!columns[1]->is_constant(), Status::InvalidArgument("argument[min] must be constant"));
     RETURN_IF(!columns[2]->is_constant(), Status::InvalidArgument("argument[max] must be constant"));
@@ -377,14 +380,18 @@ StatusOr<ColumnPtr> UtilityFunctions::bar(FunctionContext* context, const Column
     size_t rows = columns[0]->size();
     ColumnBuilder<TYPE_VARCHAR> builder(rows);
 
-    size_t min = viewer_min.value(0);
-    size_t max = viewer_max.value(0);
-    size_t width = viewer_width.value(0);
+    // Read as signed: width/min/max come from BIGINT and may legitimately be negative. Reading
+    // width into an unsigned size_t made a negative value (e.g. -1) wrap to SIZE_MAX and slip past
+    // the `width <= 0` guard, then drive an unbounded append loop below.
+    int64_t min = viewer_min.value(0);
+    int64_t max = viewer_max.value(0);
+    int64_t width = viewer_width.value(0);
     RETURN_IF(min >= max, Status::InvalidArgument("requirement: min < max"));
     RETURN_IF(width <= 0, Status::InvalidArgument("requirement: width > 0"));
+    RETURN_IF(width > kMaxBarWidth, Status::InvalidArgument("requirement: width <= 1000000"));
 
     for (size_t i = 0; i < rows; i++) {
-        size_t size = viewer_size.value(i);
+        int64_t size = viewer_size.value(i);
         RETURN_IF(size < min, Status::InvalidArgument("requirement: size >= min"));
         RETURN_IF(size > max, Status::InvalidArgument("requirement: size <= max"));
 

--- a/test/sql/test_function/R/test_bar_negative_width
+++ b/test/sql/test_function/R/test_bar_negative_width
@@ -1,0 +1,34 @@
+-- name: test_bar_negative_width
+CREATE DATABASE IF NOT EXISTS test_bar_negative_width_db;
+-- result:
+-- !result
+USE test_bar_negative_width_db;
+-- result:
+-- !result
+CREATE TABLE t_bar (v INT) DUPLICATE KEY(v)
+DISTRIBUTED BY HASH(v) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_bar VALUES (0), (50), (100);
+-- result:
+-- !result
+SELECT length(bar(v, 0, 100, -1)) FROM t_bar;
+-- result:
+E: (1064, 'requirement: width > 0: BE:10002')
+-- !result
+SELECT length(bar(v, 0, 100, 0)) FROM t_bar;
+-- result:
+E: (1064, 'requirement: width > 0: BE:10002')
+-- !result
+SELECT length(bar(v, 0, 100, 100000000000)) FROM t_bar;
+-- result:
+E: (1064, 'requirement: width <= 1000000: BE:10002')
+-- !result
+SELECT bar(5, 0, 10, 20);
+-- result:
+▓▓▓▓▓▓▓▓▓▓
+-- !result
+SELECT length(bar(-5, -10, 0, 20));
+-- result:
+30
+-- !result

--- a/test/sql/test_function/R/test_bar_negative_width
+++ b/test/sql/test_function/R/test_bar_negative_width
@@ -22,7 +22,7 @@ E: (1064, 'requirement: width > 0: BE:10002')
 -- !result
 SELECT length(bar(v, 0, 100, 100000000000)) FROM t_bar;
 -- result:
-E: (1064, 'requirement: width <= 1000000: BE:10002')
+[REGEX].*requirement.*
 -- !result
 SELECT bar(5, 0, 10, 20);
 -- result:

--- a/test/sql/test_function/T/test_bar_negative_width
+++ b/test/sql/test_function/T/test_bar_negative_width
@@ -1,0 +1,27 @@
+-- name: test_bar_negative_width
+-- description: bar() read width/min/max into an unsigned size_t, so a negative width (BIGINT)
+--              wrapped to SIZE_MAX and slipped past the `width > 0` guard, driving an unbounded
+--              std::string append loop -> BE memory exhaustion / hang (DoS). Read signed and
+--              also bound the width. A negative or zero width, and an absurdly large width, must
+--              now return a clean error; valid widths (incl. negative value ranges) still render.
+--              The unbounded-growth case itself is intentionally NOT exercised here (it would
+--              exhaust memory and ignores cancellation).
+
+CREATE DATABASE IF NOT EXISTS test_bar_negative_width_db;
+USE test_bar_negative_width_db;
+
+CREATE TABLE t_bar (v INT) DUPLICATE KEY(v)
+DISTRIBUTED BY HASH(v) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO t_bar VALUES (0), (50), (100);
+
+-- negative width: clean error (was: wrapped to SIZE_MAX -> unbounded growth / hang)
+SELECT length(bar(v, 0, 100, -1)) FROM t_bar;
+-- zero width: clean error
+SELECT length(bar(v, 0, 100, 0)) FROM t_bar;
+-- absurdly large width: clean error (bounded to avoid OOM)
+SELECT length(bar(v, 0, 100, 100000000000)) FROM t_bar;
+
+-- valid width still renders a bar
+SELECT bar(5, 0, 10, 20);
+-- valid render over a negative value range (signed read keeps this correct)
+SELECT length(bar(-5, -10, 0, 20));


### PR DESCRIPTION
## Why I'm doing:

bar(size, min, max, width) read its width/min/max BIGINT arguments into an unsigned size_t. A negative width (e.g. -1) wrapped to SIZE_MAX and slipped past the `width <= 0` guard (which only rejects 0 for an unsigned value); result_width = ratio * width then became ~SIZE_MAX and the inner `for (j < result_width) bar.append(...)` grew a plain std::string without bound. That string is not tracked by the MemTracker, so a single query exhausted BE memory and hung the node (KILL QUERY could not stop the append loop; unrelated to query_mem_limit) -- a DoS.

Read width/min/max/size as signed int64_t (they come from BIGINT and may legitimately be negative), so a negative width now correctly fails `width <= 0` and negative value ranges render correctly. Also bound width with kMaxBarWidth (1000000) so even a large positive width cannot grow the result unbounded.

Repro: SELECT length(bar(v,0,100,-1)) hung with BE RSS climbing past 88GB. After the fix bar(...,-1)/(...,0)/(...,1e11) return a clean "requirement: width ..." error, bar(5,0,10,20) renders "▓▓▓▓▓▓▓▓▓▓", and bar(-5,-10,0,20) renders correctly.

Test: test/sql/test_function/{T,R}/test_bar_negative_width (the unbounded-growth case is intentionally not exercised).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
