### PR TITLE
[BugFix] Restrict time_slice() MV rewrite to sound binary operators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceRewriteEquivalent.java
@@ -14,8 +14,10 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
+import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -23,11 +25,19 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 import com.starrocks.type.PrimitiveType;
+
+import java.util.Set;
 // mv:    SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table
 // query: SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table WHERE dt > '2023-06-01'
 // if '2023-06-01'=time_slice('2023-06-01', INTERVAL 5 MINUTE), can replace predicate dt => t
 public class TimeSliceRewriteEquivalent extends IPredicateRewriteEquivalent {
     public static TimeSliceRewriteEquivalent INSTANCE = new TimeSliceRewriteEquivalent();
+
+    // time_slice() floors a timestamp to the start of its bucket, so for a bucket-aligned constant
+    // `c`, only `dt >= c` and `dt < c` are equivalent to `time_slice(dt) >= c` / `< c`. `=`, `<=`
+    // and `>` would match the whole bucket (e.g. `dt = c` becomes `time_slice(dt) = c`, selecting
+    // every row in [c, c+interval)), so the rewrite must be declined for them.
+    private static final Set<BinaryType> SUPPORTED_BINARY_TYPES = ImmutableSet.of(BinaryType.GE, BinaryType.LT);
 
     public TimeSliceRewriteEquivalent() {}
 
@@ -79,6 +89,9 @@ public class TimeSliceRewriteEquivalent extends IPredicateRewriteEquivalent {
                                   ColumnRefOperator replace,
                                   ScalarOperator newInput) {
         if (!(newInput instanceof BinaryPredicateOperator)) {
+            return null;
+        }
+        if (!SUPPORTED_BINARY_TYPES.contains(((BinaryPredicateOperator) newInput).getBinaryType())) {
             return null;
         }
         ScalarOperator left = newInput.getChild(0);

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_time_slice_predicate_rewrite
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_time_slice_predicate_rewrite
@@ -1,0 +1,59 @@
+-- name: test_mv_time_slice_predicate_rewrite
+CREATE DATABASE IF NOT EXISTS test_mv_time_slice_predicate_rewrite_db;
+-- result:
+-- !result
+USE test_mv_time_slice_predicate_rewrite_db;
+-- result:
+-- !result
+CREATE TABLE ts_base (id INT, dt DATETIME) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO ts_base VALUES
+  (1,'2023-06-01 00:00:00'),(2,'2023-06-01 00:02:00'),(3,'2023-06-01 00:04:59'),(4,'2023-06-01 00:05:00');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW ts_mv DISTRIBUTED BY HASH(t) BUCKETS 1 REFRESH MANUAL AS
+SELECT time_slice(dt, INTERVAL 5 MINUTE) t, count(*) c FROM ts_base GROUP BY time_slice(dt, INTERVAL 5 MINUTE);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW ts_mv WITH SYNC MODE;
+SET enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+SELECT count(*) FROM ts_base WHERE dt = '2023-06-01 00:00:00';
+-- result:
+1
+-- !result
+SET enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+SELECT count(*) FROM ts_base WHERE dt = '2023-06-01 00:00:00';
+-- result:
+1
+-- !result
+SET enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+SELECT count(*) FROM ts_base WHERE dt <= '2023-06-01 00:00:00';
+-- result:
+1
+-- !result
+SET enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+SELECT count(*) FROM ts_base WHERE dt <= '2023-06-01 00:00:00';
+-- result:
+1
+-- !result
+SET enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+SELECT count(*) FROM ts_base WHERE dt >= '2023-06-01 00:05:00';
+-- result:
+1
+-- !result
+SELECT count(*) FROM ts_base WHERE dt <  '2023-06-01 00:05:00';
+-- result:
+3
+-- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_time_slice_predicate_rewrite
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_time_slice_predicate_rewrite
@@ -1,0 +1,35 @@
+-- name: test_mv_time_slice_predicate_rewrite
+-- description: A time_slice() rollup MV must only rewrite a raw-timestamp predicate when the
+--              operator is sound for the floor bucketing. time_slice(dt) floors dt to its bucket
+--              start, so dt >= c / dt < c (bucket-aligned c) map to time_slice(dt) >= c / < c, but
+--              dt = c / <= c / > c would over-select the whole bucket. The rewrite previously kept
+--              any operator; results must now equal the rewrite-off answer for all operators.
+
+CREATE DATABASE IF NOT EXISTS test_mv_time_slice_predicate_rewrite_db;
+USE test_mv_time_slice_predicate_rewrite_db;
+
+CREATE TABLE ts_base (id INT, dt DATETIME) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO ts_base VALUES
+  (1,'2023-06-01 00:00:00'),(2,'2023-06-01 00:02:00'),(3,'2023-06-01 00:04:59'),(4,'2023-06-01 00:05:00');
+
+CREATE MATERIALIZED VIEW ts_mv DISTRIBUTED BY HASH(t) BUCKETS 1 REFRESH MANUAL AS
+SELECT time_slice(dt, INTERVAL 5 MINUTE) t, count(*) c FROM ts_base GROUP BY time_slice(dt, INTERVAL 5 MINUTE);
+REFRESH MATERIALIZED VIEW ts_mv WITH SYNC MODE;
+
+-- = : was over-selecting the whole bucket (3); must be 1 with rewrite on, matching rewrite off
+SET enable_materialized_view_rewrite = false;
+SELECT count(*) FROM ts_base WHERE dt = '2023-06-01 00:00:00';
+SET enable_materialized_view_rewrite = true;
+SELECT count(*) FROM ts_base WHERE dt = '2023-06-01 00:00:00';
+
+-- <= : also unsound for time_slice; must match rewrite off
+SET enable_materialized_view_rewrite = false;
+SELECT count(*) FROM ts_base WHERE dt <= '2023-06-01 00:00:00';
+SET enable_materialized_view_rewrite = true;
+SELECT count(*) FROM ts_base WHERE dt <= '2023-06-01 00:00:00';
+
+-- >= and < remain sound (rewrite still allowed) and must stay correct
+SET enable_materialized_view_rewrite = true;
+SELECT count(*) FROM ts_base WHERE dt >= '2023-06-01 00:05:00';
+SELECT count(*) FROM ts_base WHERE dt <  '2023-06-01 00:05:00';


### PR DESCRIPTION
## Why I'm doing:

TimeSliceRewriteEquivalent lets a time_slice() rollup MV answer a query that filters the raw timestamp by rewriting `dt OP c` (bucket-aligned c) to `time_slice(dt) OP c`, but it kept the same operator with no guard. time_slice() floors a timestamp to its bucket start, so only `>=` and `<` are equivalent on the raw column; `=`, `<=` and `>` select the whole bucket [c, c+interval), giving a silently wrong result.

Guard the rewrite with SUPPORTED_BINARY_TYPES = {GE, LT} and decline any other operator. This is stricter than DateTruncEquivalent (which also allows GT, sound for its DATE/day identity-like case); time_slice with a sub-day interval genuinely buckets, so GT is unsound.

Repro: a 5-minute time_slice MV with rows in [00:00,00:05); count(*) WHERE dt='2023-06-01 00:00:00' returned 3 (whole bucket) with the rewrite on vs the correct 1. After the fix `=` and `<=` match the rewrite-off answer while `>=`/`<` still use the MV.

Test: test/sql/test_materialized_view_rewrite/{T,R}/test_mv_time_slice_predicate_rewrite.

## What I'm doing:

Fixes #issue

```
  -- minimal repro: a time_slice() rollup MV over-selects the whole bucket for a `=` filter on raw dt

  CREATE TABLE t (dt DATETIME) DUPLICATE KEY(dt)
  DISTRIBUTED BY HASH(dt) BUCKETS 1 PROPERTIES("replication_num"="1");
  -- two rows in the SAME 5-minute bucket [00:00, 00:05)
  INSERT INTO t VALUES ('2023-06-01 00:00:00'), ('2023-06-01 00:01:00');

  CREATE MATERIALIZED VIEW mv REFRESH MANUAL AS
  SELECT time_slice(dt, INTERVAL 5 MINUTE) AS t, count(*) AS c
  FROM t GROUP BY time_slice(dt, INTERVAL 5 MINUTE);
  REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;

  SELECT count(*) FROM t WHERE dt = '2023-06-01 00:00:00';
  -- enable_materialized_view_rewrite = false : 1   (correct — only the 00:00:00 row)
  -- enable_materialized_view_rewrite = true  : 2   (WRONG — both rows in the 00:00 bucket)


```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
