### PR TITLE
[BugFix] Fix lake ADD INDEX (IDG) fast-path: page-cache collision, non-PK gating, BF type check

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -277,9 +277,16 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
         seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(
                 _tablet_mgr, nullptr, seg_options.lake_io_opts.fill_data_cache, seg_options.lake_io_opts);
         seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
-        seg_options.idg_loader = std::make_shared<LakeIndexDeltaGroupLoader>(_tablet_metadata);
-        seg_options.version = options.version;
     }
+    // The Index Delta Group (ADD INDEX fast-path) sidecar applies to ALL lake
+    // key types, not just PRIMARY_KEYS: CREATE INDEX / SET bloom_filter_columns
+    // on DUPLICATE / UNIQUE / AGGREGATE lake tables also writes a standalone
+    // .idx file. The loader and query version must therefore be wired outside
+    // the is_primary_keys block; otherwise non-PK tables get a null idg_loader
+    // (and version 0), the .idx is invisible at query time, and the index is
+    // silently never applied. delvec/dcg above stay PK-only.
+    seg_options.idg_loader = std::make_shared<LakeIndexDeltaGroupLoader>(_tablet_metadata);
+    seg_options.version = options.version;
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(_index);
     }

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -367,8 +367,12 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
-        rs_opts.version = _tablet_metadata->version();
     }
+    // Read version is required by the Index Delta Group (ADD INDEX fast-path)
+    // visibility filter for ALL key types, not only PRIMARY_KEYS. Leaving it 0
+    // for DUPLICATE / UNIQUE / AGGREGATE reads hides every .idx entry
+    // (entry.version > 0 == query_version), so the index is silently skipped.
+    rs_opts.version = _tablet_metadata->version();
     rs_opts.reader_type = params.reader_type;
 
     if (keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS) {

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -429,10 +429,20 @@ Status ColumnReader::_new_idg_backed_bitmap_index_iterator(const IndexReadOption
 
     // Build a transient BitmapIndexReader backed by the .idx file. The
     // upstream IndexReadOptions points at the original segment data; swap
-    // in the .idx stream so the underlying page reads come from the right
+    // in the .idx file so the underlying page reads come from the right
     // file. Stats / cache options are inherited.
+    //
+    // Use the RandomAccessFile WRAPPER (not idx_file->stream(), the inner
+    // SeekableInputStream): the page cache key is derived from
+    // read_file->page_cache_key(), and only the wrapper carries the unique
+    // .idx path. The inner stream (e.g. lake StarletInputStream) leaves
+    // filename() empty, which collapses every .idx page key to ("", offset)
+    // and makes the global StoragePageCache return a CRC-valid page from an
+    // unrelated .idx file/column -> "Failed to decode value at position 0"
+    // or wrong rows. The wrapper outlives the reader: idx_file is moved into
+    // the OwningBitmapIndexIterator below and its object address is stable.
     IndexReadOptions sub_opts = opts;
-    sub_opts.read_file = idx_file->stream().get();
+    sub_opts.read_file = idx_file.get();
 
     auto bitmap_reader = std::make_unique<BitmapIndexReader>();
     ASSIGN_OR_RETURN(auto first_load, bitmap_reader->load(sub_opts, meta->bitmap_index()));
@@ -589,8 +599,16 @@ Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& pre
                 if (meta == nullptr || !meta->has_bloom_filter_index()) {
                     return Status::Corruption("IDG entry references missing bloom filter in .idx file");
                 }
+                // Use the RandomAccessFile WRAPPER, not its inner stream: the
+                // page cache key comes from read_file->page_cache_key(), and
+                // only the wrapper carries the unique .idx path. Passing the
+                // inner stream (whose filename() is empty on lake) collapses
+                // all .idx page keys to ("", offset) and returns the wrong
+                // file's cached page. idg_file_holder outlives bf_iter (both
+                // are stack locals; the holder is declared first so it is
+                // destroyed last).
                 IndexReadOptions sub_opts = opts;
-                sub_opts.read_file = idg_file_holder->stream().get();
+                sub_opts.read_file = idg_file_holder.get();
                 idg_reader_holder = std::make_unique<BloomFilterIndexReader>();
                 ASSIGN_OR_RETURN(auto bf_first_load, idg_reader_holder->load(sub_opts, meta->bloom_filter_index()));
                 (void)bf_first_load;

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -23,6 +23,7 @@
 #include "cache/mem_cache/page_cache.h"
 #include "fs/bundle_file.h"
 #include "fs/fs_memory.h"
+#include "io/seekable_input_stream.h"
 #include "storage/rowset/binary_plain_page.h"
 #include "storage/rowset/bitshuffle_page.h"
 
@@ -504,6 +505,108 @@ TEST_F(PageIOTest, test_distinct_files_do_not_collide_in_page_cache) {
         Int32Column col;
         ASSERT_OK(decoder.next_batch(&size, &col));
         ASSERT_EQ(col.debug_string(), "[10, 20, 30]");
+    }
+}
+
+// Regression for StarRocksTest#11468 RC#1: the lake ADD INDEX (IDG) read path
+// must hand the page cache the .idx file's NAMED identity (the RandomAccessFile
+// wrapper), not its inner SeekableInputStream. On shared-data the inner stream
+// (StarletInputStream) leaves filename() empty, so page_cache_key() collapses to
+// ("", offset); the global StoragePageCache then returns a CRC-valid page from an
+// unrelated .idx file/column -> "Failed to decode value at position 0" or wrong
+// rows. column_reader.cpp previously passed idx_file->stream().get(); the fix
+// passes idx_file.get(). Here a base io::SeekableInputStreamWrapper plays the
+// nameless inner stream: it reproduces the collision, while the named wrapper
+// avoids it. (test_distinct_files_do_not_collide_in_page_cache covers the named
+// side; this adds the nameless-inner-stream half that the fix actually removes.)
+TEST_F(PageIOTest, test_idg_read_file_must_use_named_wrapper) {
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+
+    // Two distinct .idx-like files, each one uncompressed page at offset 0.
+    // _build_data_page encodes exactly 3 values, so use 3 distinct values per
+    // file (equal encoded size keeps the two pages the same length).
+    OwnedSlice page_a = _build_data_page({11, 12, 13});
+    OwnedSlice page_b = _build_data_page({21, 22, 23});
+    PageFooterPB footer_a = _build_page_footer(page_a.slice().size);
+    PageFooterPB footer_b = _build_page_footer(page_b.slice().size);
+
+    ASSIGN_OR_ASSERT_FAIL(auto write_a, _fs->new_writable_file(write_opts, "/idg_a.idx"));
+    PagePointer pp_a;
+    std::vector<Slice> body_a{page_a.slice()};
+    ASSERT_OK(PageIO::write_page(write_a.get(), body_a, footer_a, &pp_a));
+    ASSERT_OK(write_a->close());
+    uint64_t size_a = write_a->size();
+
+    ASSIGN_OR_ASSERT_FAIL(auto write_b, _fs->new_writable_file(write_opts, "/idg_b.idx"));
+    PagePointer pp_b;
+    std::vector<Slice> body_b{page_b.slice()};
+    ASSERT_OK(PageIO::write_page(write_b.get(), body_b, footer_b, &pp_b));
+    ASSERT_OK(write_b->close());
+    uint64_t size_b = write_b->size();
+
+    ASSIGN_OR_ASSERT_FAIL(auto file_a, _fs->new_random_access_file("/idg_a.idx"));
+    ASSIGN_OR_ASSERT_FAIL(auto file_b, _fs->new_random_access_file("/idg_b.idx"));
+
+    // Simulate the lake StarletInputStream: a base io::SeekableInputStreamWrapper
+    // forwards reads to the real inner stream but carries no name, so
+    // page_cache_key() falls back to ("", offset).
+    io::SeekableInputStreamWrapper nameless_a(file_a->stream().get(), kDontTakeOwnership);
+    io::SeekableInputStreamWrapper nameless_b(file_b->stream().get(), kDontTakeOwnership);
+
+    // Bug precondition (nameless inner streams collide) vs fix invariant
+    // (named wrappers stay distinct).
+    ASSERT_EQ(nameless_a.page_cache_key(0), nameless_b.page_cache_key(0));
+    ASSERT_NE(file_a->page_cache_key(0), file_b->page_cache_key(0));
+
+    auto decode_values = [](const Slice& body) -> std::string {
+        BitShufflePageDecoder<TYPE_INT> decoder(body);
+        Status st = decoder.init();
+        EXPECT_TRUE(st.ok()) << st.to_string();
+        size_t n = 16;
+        Int32Column col;
+        st = decoder.next_batch(&n, &col);
+        EXPECT_TRUE(st.ok()) << st.to_string();
+        return col.debug_string();
+    };
+
+    // Buggy choice (inner nameless stream): warm the cache from file B, then read
+    // file A at offset 0 -> collides on ("", 0) and returns file B's page.
+    {
+        PageReadOptions ro = _build_read_options(&nameless_b, 0, size_b, true);
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(ro, &handle, &body, &read_footer));
+        ASSERT_EQ(decode_values(body), "[21, 22, 23]");
+    }
+    {
+        PageReadOptions ro = _build_read_options(&nameless_a, 0, size_a, true);
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(ro, &handle, &body, &read_footer));
+        // Collision: reading file A returns file B's cached page.
+        ASSERT_EQ(decode_values(body), "[21, 22, 23]");
+    }
+
+    // Fixed choice (named wrapper): distinct keys, so each file reads its own page
+    // even though the cache is warm with the ("", 0) collision entry.
+    {
+        PageReadOptions ro = _build_read_options(file_a.get(), 0, size_a, true);
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(ro, &handle, &body, &read_footer));
+        ASSERT_EQ(decode_values(body), "[11, 12, 13]");
+    }
+    {
+        PageReadOptions ro = _build_read_options(file_b.get(), 0, size_b, true);
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(ro, &handle, &body, &read_footer));
+        ASSERT_EQ(decode_values(body), "[21, 22, 23]");
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifier.java
@@ -14,14 +14,17 @@
 
 package com.starrocks.alter;
 
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.DropIndexClause;
 import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -248,6 +251,37 @@ public final class SchemaChangeIndexFastPathClassifier {
             // new set atomically.
             LOG.debug("BF fast-path rejected: mixed add+drop");
             return null;
+        }
+        // Validate column-type / key-column eligibility for every newly added
+        // bloom-filter column. The legacy createJob path
+        // (PropertyAnalyzer.analyzeBloomFilterColumns -> Type.supportBloomFilter
+        // plus the key/agg rule) is bypassed once the fast path is taken, so
+        // without this guard unsupported types (JSON, ARRAY and other
+        // complex/float types) on the bloom_filter_columns property would
+        // silently succeed instead of erroring. On any ineligible column, fall
+        // back to the legacy path, which raises the canonical error message.
+        if (!added.isEmpty()) {
+            boolean isPrimaryKey = table.getKeysType() == KeysType.PRIMARY_KEYS;
+            for (String addedCol : added) {
+                Column column = null;
+                for (Column c : table.getBaseSchema()) {
+                    if (c.getName().equalsIgnoreCase(addedCol)) {
+                        column = c;
+                        break;
+                    }
+                }
+                if (column == null || !column.getType().supportBloomFilter()) {
+                    LOG.debug("BF fast-path rejected: column {} missing or unsupported type", addedCol);
+                    return null;
+                }
+                // Bloom filter is only allowed on DUP/PRIMARY columns or the key
+                // columns of UNIQUE/AGG tables, mirroring the legacy validation.
+                if (!(column.isKey() || isPrimaryKey || column.getAggregationType() == AggregateType.NONE)) {
+                    LOG.debug("BF fast-path rejected: column {} is a non-key value column of a UNIQUE/AGG table",
+                            addedCol);
+                    return null;
+                }
+            }
         }
         return new BloomFilterDelta(
                 Collections.unmodifiableSet(added), Collections.unmodifiableSet(dropped));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifier.java
@@ -261,10 +261,16 @@ public final class SchemaChangeIndexFastPathClassifier {
         // silently succeed instead of erroring. On any ineligible column, fall
         // back to the legacy path, which raises the canonical error message.
         if (!added.isEmpty()) {
+            List<Column> baseSchema = table.getBaseSchema();
+            if (baseSchema == null) {
+                // Defensive: without a base schema we cannot validate column
+                // types, so fall back to the legacy path rather than risk an NPE.
+                return null;
+            }
             boolean isPrimaryKey = table.getKeysType() == KeysType.PRIMARY_KEYS;
             for (String addedCol : added) {
                 Column column = null;
-                for (Column c : table.getBaseSchema()) {
+                for (Column c : baseSchema) {
                     if (c.getName().equalsIgnoreCase(addedCol)) {
                         column = c;
                         break;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifierTest.java
@@ -14,15 +14,22 @@
 
 package com.starrocks.alter;
 
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.DropIndexClause;
 import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.JsonType;
+import com.starrocks.type.Type;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -49,6 +56,29 @@ public class SchemaChangeIndexFastPathClassifierTest {
     private static OlapTable lakeTable() {
         OlapTable t = mock(OlapTable.class);
         when(t.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        // Default DUPLICATE schema with c1/c2/c3 so the column-type validation
+        // added to classifyBloomFilterChange (the IDG bloom-filter fix) can
+        // resolve the bf columns used by the pure-add tests below. Drop /
+        // add-index tests don't reach that validation, so this is harmless.
+        when(t.getKeysType()).thenReturn(KeysType.DUP_KEYS);
+        when(t.getBaseSchema()).thenReturn(List.of(
+                keyCol("c1", IntegerType.INT), keyCol("c2", IntegerType.INT), keyCol("c3", IntegerType.INT)));
+        return t;
+    }
+
+    private static Column keyCol(String name, Type type) {
+        Column c = new Column(name, type);
+        c.setIsKey(true);
+        return c;
+    }
+
+    private static OlapTable lakeTableWithSchema(KeysType keys, Column... cols) {
+        OlapTable t = mock(OlapTable.class);
+        when(t.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        when(t.getKeysType()).thenReturn(keys);
+        when(t.getBaseSchema()).thenReturn(List.of(cols));
+        when(t.getBfFpp()).thenReturn(0.05);
+        when(t.getBfColumnNames()).thenReturn(Collections.emptySet());
         return t;
     }
 
@@ -454,6 +484,79 @@ public class SchemaChangeIndexFastPathClassifierTest {
         } finally {
             Config.enable_lake_add_index_fast_path = prev;
         }
+    }
+
+    // -----------------------------------------------------------------
+    // classifyBloomFilterChange: column-type / key-column validation.
+    // The fast path must NOT accept bloom filters on column types the legacy
+    // path rejects (JSON, ARRAY, ...) — it must fall back (return null) so the
+    // legacy createJob raises the canonical error. Reproduces A4 from
+    // StarRocksTest#11468 (test_json_modify_column_err_* / test_alter_array).
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testBfClassify_JsonColumnRejected() {
+        // PRIMARY KEY table with a JSON column k3: SET bloom_filter_columns=k3
+        // must NOT take the fast path (JSON does not support bloom filter).
+        OlapTable t = lakeTableWithSchema(KeysType.PRIMARY_KEYS,
+                keyCol("k1", IntegerType.INT), new Column("k3", JsonType.JSON));
+        assertNull(SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange(t,
+                List.of(bfPropClause(Map.of(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k3")))));
+    }
+
+    @Test
+    public void testBfClassify_ArrayColumnRejected() {
+        // DUPLICATE table with an ARRAY<INT> column c1: ARRAY is not a scalar
+        // type, so supportBloomFilter() is false and the fast path must reject.
+        OlapTable t = lakeTableWithSchema(KeysType.DUP_KEYS,
+                new Column("c0", IntegerType.INT), new Column("c1", new ArrayType(IntegerType.INT)));
+        assertNull(SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange(t,
+                List.of(bfPropClause(Map.of(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "c1")))));
+    }
+
+    @Test
+    public void testBfClassify_UnknownColumnRejected() {
+        // A bf column that does not exist in the schema falls back to legacy,
+        // which raises "Invalid bloom filter column 'cX': not exists".
+        OlapTable t = lakeTableWithSchema(KeysType.DUP_KEYS, keyCol("c1", IntegerType.INT));
+        assertNull(SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange(t,
+                List.of(bfPropClause(Map.of(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "cX")))));
+    }
+
+    @Test
+    public void testBfClassify_NonKeyValueColumnOfAggTableRejected() {
+        // AGGREGATE table: bloom filter is only allowed on key columns. A
+        // non-key SUM value column (supported scalar type) must still reject.
+        OlapTable t = lakeTableWithSchema(KeysType.AGG_KEYS,
+                keyCol("k1", IntegerType.INT),
+                new Column("v1", IntegerType.INT, false, AggregateType.SUM, "0", ""));
+        assertNull(SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange(t,
+                List.of(bfPropClause(Map.of(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "v1")))));
+    }
+
+    @Test
+    public void testBfClassify_AggKeyColumnAccepted() {
+        // Positive control: a key column of an AGG table with a supported
+        // scalar type stays on the fast path.
+        OlapTable t = lakeTableWithSchema(KeysType.AGG_KEYS,
+                keyCol("k1", IntegerType.INT),
+                new Column("v1", IntegerType.INT, false, AggregateType.SUM, "0", ""));
+        SchemaChangeIndexFastPathClassifier.BloomFilterDelta delta =
+                SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange(t,
+                        List.of(bfPropClause(Map.of(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k1"))));
+        assertNotNull(delta);
+        assertTrue(delta.isPureAdd());
+    }
+
+    @Test
+    public void testBfClassify_SupportedScalarAccepted() {
+        // Positive control: INT key column on a DUP table is bf-eligible.
+        OlapTable t = lakeTableWithSchema(KeysType.DUP_KEYS, keyCol("c1", IntegerType.INT));
+        SchemaChangeIndexFastPathClassifier.BloomFilterDelta delta =
+                SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange(t,
+                        List.of(bfPropClause(Map.of(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "c1"))));
+        assertNotNull(delta);
+        assertTrue(delta.isPureAdd());
     }
 
     private static ModifyTablePropertiesClause bfPropClause(Map<String, String> props) {


### PR DESCRIPTION
## Why I'm doing:

PR #71689 added the shared-data (lake) **Index Delta Group (IDG)** fast path: `CREATE INDEX ... USING BITMAP` and `ALTER TABLE ... SET ("bloom_filter_columns"=...)` write a standalone `.idx` sidecar instead of rewriting segments, and queries read the index from the `.idx` file. On shared-data clusters this currently produces wrong/missing index results and a hard decode error (tracked in `StarRocks/StarRocksTest#11468`). Root-causing the failure list found three independent defects, all introduced by #71689.

## What I'm doing:

**1. Page-cache key collision → wrong rows / `Failed to decode value at position 0` (BE).**
The IDG bitmap and bloom readers passed `idx_file->stream().get()` — the *inner* `io::SeekableInputStream`. On lake that inner stream is `StarletInputStream`, which never sets `filename()`, so `SeekableInputStream::page_cache_key()` collapses to `("", offset)`. The global `StoragePageCache` then returns a CRC-valid page from an *unrelated* `.idx` file/column at the same offset — `verify_checksum` passes (so it is not reported as a checksum mismatch) but the bytes are the wrong column's, so the string dictionary page fails to decode ("Failed to decode value at position 0") or the query returns wrong rows. Only the `RandomAccessFile` wrapper carries the unique `.idx` path and overrides `page_cache_key`; every other read path passes the wrapper, IDG was the only caller passing the inner stream. Fix: pass the wrapper (`idx_file.get()` / `idg_file_holder.get()`) in `column_reader.cpp`.

**2. IDG read context gated to PRIMARY_KEYS only → index silently not applied (BE).**
`rowset.cpp` and `tablet_reader.cpp` set `idg_loader` and the read `version` only inside the `is_primary_keys` branch. For `DUPLICATE`/`UNIQUE`/`AGGREGATE` lake tables the loader stayed null and version stayed 0, so the `.idx` was invisible at query time and the index was never applied (no `BitmapIndexFilterRows`/`BloomFilterFilterRows` in the profile). Fix: wire `idg_loader` and the read version for all lake key types; `delvec`/`dcg` loaders remain PK-only. `version` elsewhere on the segment path is guarded by `is_primary_keys && version > 0`, so non-PK reads are unaffected apart from IDG visibility.

**3. FE bloom-filter fast path skipped column-type validation (FE).**
`SchemaChangeIndexFastPathClassifier.classifyBloomFilterChange` computed the add/drop delta with no type check, bypassing the legacy `PropertyAnalyzer.analyzeBloomFilterColumns` → `Type.supportBloomFilter()` + key/agg rule. So `ALTER TABLE ... SET ("bloom_filter_columns"=<JSON/ARRAY column>)` wrongly succeeded. Fix: validate every newly added bloom-filter column against `Type.supportBloomFilter()` and the key/agg rule; on any ineligible column, fall back to the legacy path, which raises the canonical error. (The `ADD INDEX BITMAP` path is already protected via `IndexAnalyzer.checkColumn`.)

Related: `StarRocks/StarRocksTest#11468`. The buggy feature (#71689) exists only on `main`, so no backport is required.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: index reads on shared-data tables now return correct results; `SET ("bloom_filter_columns"=...)` on unsupported column types (JSON/ARRAY) now errors instead of silently succeeding

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
  - BE: `page_io_test.cpp::test_idg_read_file_must_use_named_wrapper` — deterministically reproduces the page-cache key collision (nameless inner stream) and confirms the named wrapper avoids it.
  - FE: `SchemaChangeIndexFastPathClassifierTest` — JSON / ARRAY / unknown-column / non-key-value-of-AGG rejection cases plus positive controls for the bloom-filter column-type validation.
  - Still pending: end-to-end shared-data cluster validation of the A1 (non-PK gating) path, which needs the real lake scan wiring (the BE unit harness cannot supply a nameless StarletInputStream for non-PK reads).
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
