### PR TITLE
[BugFix] Fix query failure on Iceberg V1 table after dropping partition field

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -522,6 +522,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
     private List<Integer> buildPartitionSlotIds(PartitionSpec spec) {
         return spec.fields().stream()
+                .filter(x -> x.transform().isIdentity())
                 .map(x -> desc.getColumnSlot(x.name()))
                 .filter(Objects::nonNull)
                 .map(SlotDescriptor::getId)
@@ -531,6 +532,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
     private List<Integer> getPartitionFieldIndexes(PartitionSpec spec, BiMap<Integer, PartitionField> indexToField) {
         return spec.fields().stream()
+                .filter(x -> x.transform().isIdentity())
                 .filter(x -> desc.getColumnSlot(x.name()) != null)
                 .map(x -> indexToField.inverse().get(x))
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -67,6 +67,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -106,7 +107,8 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private final RemoteFileInfoSource remoteFileInfoSource;
 
     private final Map<Long, DescriptorTable.ReferencedPartitionInfo> referencedPartitions = new HashMap<>();
-    private final Map<PartitionKey, Long> partitionKeyToId = Maps.newHashMap();
+    // specId, StructLikeWrapper -> partitionId
+    private final Map<Pair<Integer, StructLikeWrapper>, Long> partitionKeyToId = Maps.newHashMap();
 
     // spec_id -> Map(partition_field_index_in_partitionSpec, PartitionField)
     private final Map<Integer, BiMap<Integer, PartitionField>> indexToFieldCache = Maps.newHashMap();
@@ -501,7 +503,11 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         StructLike origPartition = task.partition();
         PartitionKey partitionKey = getPartitionKey(origPartition, task.spec(), partitionFieldIndexes, indexToPartitionField);
 
-        Long cachedId = partitionKeyToId.get(partitionKey);
+        StructLikeWrapper wrappedPartition = StructLikeWrapper.forType(spec.partitionType())
+                .copyFor(task.file().partition());
+        Pair<Integer, StructLikeWrapper> cacheKey = Pair.create(spec.specId(), wrappedPartition);
+
+        Long cachedId = partitionKeyToId.get(cacheKey);
         if (cachedId != null) {
             return cachedId;
         }
@@ -513,7 +519,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                 new DescriptorTable.ReferencedPartitionInfo(partitionId, partitionKey,
                         filePath.getParent().toString());
 
-        partitionKeyToId.put(partitionKey, partitionId);
+        partitionKeyToId.put(cacheKey, partitionId);
         referencedPartitions.put(partitionId, referencedPartitionInfo);
         checkPartitionNumLimit(table, partitionKeyToId.size());
         return partitionId;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -67,7 +67,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ContentFileUtil;
-import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -107,7 +106,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private final RemoteFileInfoSource remoteFileInfoSource;
 
     private final Map<Long, DescriptorTable.ReferencedPartitionInfo> referencedPartitions = new HashMap<>();
-    private final Map<StructLikeWrapper, Long> partitionKeyToId = Maps.newHashMap();
+    private final Map<PartitionKey, Long> partitionKeyToId = Maps.newHashMap();
 
     // spec_id -> Map(partition_field_index_in_partitionSpec, PartitionField)
     private final Map<Integer, BiMap<Integer, PartitionField>> indexToFieldCache = Maps.newHashMap();
@@ -493,20 +492,20 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             partitionSlotIdsCache.put(spec.specId(), buildPartitionSlotIds(task.spec()));
         }
 
-        // Make sure the partition data with byte[], decimal value object etc. can get the same hash code.
-        StructLike origPartition = task.partition();
-        StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(spec.partitionType());
-        StructLikeWrapper partition = partitionWrapper.copyFor(task.file().partition());
-        if (partitionKeyToId.containsKey(partition)) {
-            return partitionKeyToId.get(partition);
-        }
-
         BiMap<Integer, PartitionField> indexToPartitionField = indexToFieldCache.computeIfAbsent(spec.specId(),
                 ignore -> getIdentityPartitions(task.spec()));
 
         List<Integer> partitionFieldIndexes = indexesCache.computeIfAbsent(spec.specId(),
                 ignore -> getPartitionFieldIndexes(spec, indexToPartitionField));
+
+        StructLike origPartition = task.partition();
         PartitionKey partitionKey = getPartitionKey(origPartition, task.spec(), partitionFieldIndexes, indexToPartitionField);
+
+        Long cachedId = partitionKeyToId.get(partitionKey);
+        if (cachedId != null) {
+            return cachedId;
+        }
+
         long partitionId = partitionIdGenerator.getOrGenerate(partitionKey);
 
         Path filePath = new Path(URLDecoder.decode(task.file().path().toString(), StandardCharsets.UTF_8));
@@ -514,7 +513,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                 new DescriptorTable.ReferencedPartitionInfo(partitionId, partitionKey,
                         filePath.getParent().toString());
 
-        partitionKeyToId.put(partition, partitionId);
+        partitionKeyToId.put(partitionKey, partitionId);
         referencedPartitions.put(partitionId, referencedPartitionInfo);
         checkPartitionNumLimit(table, partitionKeyToId.size());
         return partitionId;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -34,6 +34,7 @@ import com.starrocks.thrift.THdfsScanRange;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -898,6 +899,112 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
                 Assertions.assertEquals(0, keyExprsSize,
                         "VoidTransform field must NOT contribute to partition_key_exprs");
             }
+        } finally {
+            if (prevCtx == null) {
+                ConnectContext.remove();
+            } else {
+                prevCtx.setThreadLocalInfo();
+            }
+        }
+    }
+
+    @Test
+    public void testCacheKeyShouldUseEffectiveIdentityKey() throws Exception {
+        ConnectContext prevCtx = ConnectContext.get();
+        new ConnectContext().setThreadLocalInfo();
+        try {
+            PartitionSpec specBothIdentity =
+                    PartitionSpec.builderFor(SCHEMA_F).identity("k1").identity("dt").build();
+            TestTables.TestTable v1Table = create(SCHEMA_F, specBothIdentity, "ti_reuse", 1);
+            Assertions.assertEquals(1, v1Table.operations().current().formatVersion());
+
+            PartitionKey oldKey = new PartitionKey(specBothIdentity, SCHEMA_F);
+            oldKey.set(0, null); // k1 = NULL
+            oldKey.set(1, null); // dt = NULL
+            DataFile oldFile = DataFiles.builder(specBothIdentity)
+                    .withPath("/path/to/old-before-drop.parquet")
+                    .withFileSizeInBytes(10)
+                    .withPartition(oldKey)
+                    .withRecordCount(2)
+                    .build();
+            v1Table.newFastAppend().appendFile(oldFile).commit();
+
+            // Drop the identity partition field "k1". For V1 this rewrites it to VoidTransform,
+            // i.e. new spec = [void(k1), identity(dt)]. VoidTransform always writes NULL for k1.
+            v1Table.updateSpec().removeField("k1").commit();
+            PartitionSpec newSpec = v1Table.spec();
+            Assertions.assertNotEquals(specBothIdentity.specId(), newSpec.specId(),
+                    "drop should produce a new spec id");
+            Assertions.assertTrue(newSpec.fields().stream()
+                            .anyMatch(f -> f.name().equals("k1") && !f.transform().isIdentity()),
+                    "after V1 drop, k1 should still be present but with VoidTransform");
+
+            // New file under the new spec, partition struct = (void=NULL, dt=NULL).
+            PartitionKey newKey = new PartitionKey(newSpec, SCHEMA_F);
+            newKey.set(0, null); // void(k1) = NULL (mandatory)
+            newKey.set(1, null); // dt = NULL (same value as old file)
+            DataFile newFile = DataFiles.builder(newSpec)
+                    .withPath("/path/to/new-after-drop.parquet")
+                    .withFileSizeInBytes(10)
+                    .withPartition(newKey)
+                    .withRecordCount(2)
+                    .build();
+            v1Table.newFastAppend().appendFile(newFile).commit();
+
+            // Build the tuple descriptor with both partition columns materialised.
+            TupleDescriptor localTuple = new TupleDescriptor(new TupleId(201));
+            SlotDescriptor k1Slot = new SlotDescriptor(new SlotId(1), localTuple);
+            k1Slot.setType(INT);
+            k1Slot.setColumn(new Column("k1", INT));
+            localTuple.addSlot(k1Slot);
+            SlotDescriptor dtSlot = new SlotDescriptor(new SlotId(2), localTuple);
+            dtSlot.setType(INT);
+            dtSlot.setColumn(new Column("dt", INT));
+            localTuple.addSlot(dtSlot);
+
+            List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", INT));
+            IcebergTable icebergTable = new IcebergTable(1, "iceberg_reuse", "iceberg_catalog",
+                    "resource", "db", "table", "", schema, v1Table, Maps.newHashMap());
+
+            IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                    RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTuple, Optional.empty(),
+                    PartitionIdGenerator.of(), false, false);
+
+            List<FileScanTask> allTasks = Lists.newArrayList(v1Table.newScan().planFiles());
+            FileScanTask oldTask = allTasks.stream()
+                    .filter(t -> t.file().path().toString().endsWith("old-before-drop.parquet"))
+                    .findFirst().orElseThrow();
+            FileScanTask newTask = allTasks.stream()
+                    .filter(t -> t.file().path().toString().endsWith("new-after-drop.parquet"))
+                    .findFirst().orElseThrow();
+            // Sanity check: the two files come from different specs.
+            Assertions.assertNotEquals(oldTask.spec().specId(), newTask.spec().specId(),
+                    "old and new file must use different specs to reproduce the bug");
+
+            long oldPid = scanRangeSource.addPartition(oldTask);
+            long newPid = scanRangeSource.addPartition(newTask);
+
+            Assertions.assertNotEquals(oldPid, newPid,
+                    "Files from different specs must NOT share a partition id, even when their "
+                            + "raw Iceberg partition structs happen to be equal.");
+
+            THdfsScanRange oldRange = scanRangeSource.buildScanRange(oldTask, oldTask.file(), oldPid);
+            THdfsScanRange newRange = scanRangeSource.buildScanRange(newTask, newTask.file(), newPid);
+
+            int oldKeyExprs = oldRange.getPartition_value().getPartition_key_exprs().size();
+            int oldIdentitySlotIds = oldRange.getIdentity_partition_slot_ids() == null
+                    ? 0 : oldRange.getIdentity_partition_slot_ids().size();
+            int newKeyExprs = newRange.getPartition_value().getPartition_key_exprs().size();
+            int newIdentitySlotIds = newRange.getIdentity_partition_slot_ids() == null
+                    ? 0 : newRange.getIdentity_partition_slot_ids().size();
+
+            Assertions.assertEquals(2, oldKeyExprs);
+            Assertions.assertEquals(2, oldIdentitySlotIds);
+            Assertions.assertEquals(1, newKeyExprs);
+            Assertions.assertEquals(1, newIdentitySlotIds);
+            Assertions.assertEquals(newKeyExprs, newIdentitySlotIds,
+                    "partition_key_exprs.size() and identity_partition_slot_ids.size() must match — "
+                            + "otherwise BE's _init_partition_values goes out of sync.");
         } finally {
             if (prevCtx == null) {
                 ConnectContext.remove();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -29,8 +29,12 @@ import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.THdfsPartition;
 import com.starrocks.thrift.THdfsScanRange;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -764,5 +768,142 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
             scanRangeSource.addPartition(task);
         }
         Assertions.assertEquals(2, scanRangeSource.selectedPartitionCount());
+    }
+
+    /**
+     * Test that for an Iceberg V1 table, dropping an identity partition field does not cause NPE
+     * when scanning files.
+     * Background: For V1 tables, Iceberg's `removeField` does NOT remove the field from the spec.
+     * Instead, the field is kept with its transform rewritten to `VoidTransform` (always-null),
+     * and the field name stays the same as the source column. Such a void field would still pass
+     * the `desc.getColumnSlot(name) != null` check inside `getPartitionFieldIndexes`, but it is
+     * NOT in `indexToField` (which only holds identity fields), so `indexToField.inverse().get(x)`
+     * returns null and later triggers NPE on `field.sourceId()` in `getPartitionKey`.
+     */
+    @Test
+    public void testAddPartitionWithV1DroppedIdentityPartitionFieldDoesNotThrow() throws Exception {
+        PartitionSpec specIdentityK1 = PartitionSpec.builderFor(SCHEMA_F).identity("k1").build();
+        TestTables.TestTable v1Table = create(SCHEMA_F, specIdentityK1, "ti_k1", 1);
+        Assertions.assertEquals(1, v1Table.operations().current().formatVersion());
+
+        DataFile fileBeforeDrop = DataFiles.builder(v1Table.spec())
+                .withPath("/path/to/i-before-drop.parquet")
+                .withFileSizeInBytes(10)
+                .withPartitionPath("k1=1")
+                .withRecordCount(2)
+                .build();
+        v1Table.newFastAppend().appendFile(fileBeforeDrop).commit();
+        // Drop the identity partition field "k1".
+        // For V1, this keeps the field in the spec with VoidTransform.
+        v1Table.updateSpec().removeField("k1").commit();
+        // Sanity check: the new spec still contains a field whose name is "k1"
+        // (V1 semantics), but its transform is no longer identity.
+        PartitionSpec newSpec = v1Table.spec();
+        Assertions.assertTrue(newSpec.fields().stream()
+                        .anyMatch(f -> f.name().equals("k1") && !f.transform().isIdentity()),
+                "V1 drop identity partition field should keep a non-identity (void) field with the same name");
+        DataFile fileAfterDrop = DataFiles.builder(newSpec)
+                .withPath("/path/to/i-after-drop.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build();
+        v1Table.newFastAppend().appendFile(fileAfterDrop).commit();
+
+        TupleDescriptor localTuple = new TupleDescriptor(new TupleId(101));
+        SlotDescriptor k1Slot = new SlotDescriptor(new SlotId(1), localTuple);
+        k1Slot.setType(INT);
+        k1Slot.setColumn(new Column("k1", INT));
+        localTuple.addSlot(k1Slot);
+        SlotDescriptor dtSlot = new SlotDescriptor(new SlotId(2), localTuple);
+        dtSlot.setType(INT);
+        dtSlot.setColumn(new Column("dt", INT));
+        localTuple.addSlot(dtSlot);
+
+        List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", INT));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v1_drop_id", "iceberg_catalog",
+                "resource", "db", "table", "", schema, v1Table, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTuple, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        List<FileScanTask> tasks = Lists.newArrayList(v1Table.newScan().planFiles());
+        Assertions.assertFalse(tasks.isEmpty(), "should scan at least one file");
+        for (FileScanTask task : tasks) {
+            long pid = Assertions.assertDoesNotThrow(() -> scanRangeSource.addPartition(task),
+                    "addPartition should not throw NPE for V1 table with dropped identity partition field");
+            Assertions.assertTrue(pid >= 0);
+        }
+    }
+
+    /**
+     * V1 iceberg table with the only identity partition field dropped. The spec
+     * is rewritten to {@code [VoidTransform(k1)]}. Both lists must end up empty so that
+     * BE's {@code _init_partition_values} does NOT read past the end of {@code _partition_values}.
+     */
+    @Test
+    public void testBuildPartitionSlotIdsExcludesVoidFieldAfterDrop() throws Exception {
+        ConnectContext prevCtx = ConnectContext.get();
+        new ConnectContext().setThreadLocalInfo();
+        try {
+            PartitionSpec specIdentityK1 = PartitionSpec.builderFor(SCHEMA_F).identity("k1").build();
+            TestTables.TestTable v1Table = create(SCHEMA_F, specIdentityK1, "ti_void_only", 1);
+
+            // Drop the only identity partition field; for V1 this rewrites it to VoidTransform.
+            v1Table.updateSpec().removeField("k1").commit();
+            PartitionSpec newSpec = v1Table.spec();
+            Assertions.assertTrue(newSpec.fields().stream().noneMatch(f -> f.transform().isIdentity()),
+                    "after drop, spec should contain no identity field");
+
+            DataFile fileAfterDrop = DataFiles.builder(newSpec)
+                    .withPath("/path/to/void-only.parquet")
+                    .withFileSizeInBytes(10)
+                    .withRecordCount(2)
+                    .build();
+            v1Table.newFastAppend().appendFile(fileAfterDrop).commit();
+
+            TupleDescriptor localTuple = new TupleDescriptor(new TupleId(102));
+            SlotDescriptor k1Slot = new SlotDescriptor(new SlotId(1), localTuple);
+            k1Slot.setType(INT);
+            k1Slot.setColumn(new Column("k1", INT));
+            localTuple.addSlot(k1Slot);
+            SlotDescriptor dtSlot = new SlotDescriptor(new SlotId(2), localTuple);
+            dtSlot.setType(INT);
+            dtSlot.setColumn(new Column("dt", INT));
+            localTuple.addSlot(dtSlot);
+
+            List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", INT));
+            IcebergTable icebergTable = new IcebergTable(1, "iceberg_void_only", "iceberg_catalog",
+                    "resource", "db", "table", "", schema, v1Table, Maps.newHashMap());
+
+            IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                    RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTuple, Optional.empty(),
+                    PartitionIdGenerator.of(), false, false);
+
+            List<FileScanTask> tasks = Lists.newArrayList(v1Table.newScan().planFiles());
+            Assertions.assertFalse(tasks.isEmpty());
+            for (FileScanTask task : tasks) {
+                long pid = scanRangeSource.addPartition(task);
+                THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(task, task.file(), pid);
+
+                List<Integer> identitySlotIds = hdfsScanRange.getIdentity_partition_slot_ids();
+                int identitySlotIdsSize = identitySlotIds == null ? 0 : identitySlotIds.size();
+
+                THdfsPartition partitionValue = hdfsScanRange.getPartition_value();
+                int keyExprsSize = partitionValue == null || partitionValue.getPartition_key_exprs() == null
+                        ? 0 : partitionValue.getPartition_key_exprs().size();
+
+                Assertions.assertEquals(0, identitySlotIdsSize,
+                        "VoidTransform field must NOT contribute to identity_partition_slot_ids");
+                Assertions.assertEquals(0, keyExprsSize,
+                        "VoidTransform field must NOT contribute to partition_key_exprs");
+            }
+        } finally {
+            if (prevCtx == null) {
+                ConnectContext.remove();
+            } else {
+                prevCtx.setThreadLocalInfo();
+            }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -28,10 +28,10 @@ import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.type.DateType;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.THdfsPartition;
 import com.starrocks.thrift.THdfsScanRange;
+import com.starrocks.type.DateType;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
@@ -59,16 +59,16 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     public void setUp() {
         // Setup tuple descriptor
         tupleDescriptor = new TupleDescriptor(new TupleId(1));
-        
+
         // Setup slot descriptors
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), tupleDescriptor);
         idSlot.setType(INT);
         idSlot.setColumn(new Column("id", INT));
-        
+
         SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), tupleDescriptor);
         dataSlot.setType(VARCHAR);
         dataSlot.setColumn(new Column("data", VARCHAR));
-        
+
         tupleDescriptor.addSlot(idSlot);
         tupleDescriptor.addSlot(dataSlot);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -28,6 +28,7 @@ import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.type.DateType;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.THdfsPartition;
 import com.starrocks.thrift.THdfsScanRange;
@@ -776,10 +777,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
      * when scanning files.
      * Background: For V1 tables, Iceberg's `removeField` does NOT remove the field from the spec.
      * Instead, the field is kept with its transform rewritten to `VoidTransform` (always-null),
-     * and the field name stays the same as the source column. Such a void field would still pass
-     * the `desc.getColumnSlot(name) != null` check inside `getPartitionFieldIndexes`, but it is
-     * NOT in `indexToField` (which only holds identity fields), so `indexToField.inverse().get(x)`
-     * returns null and later triggers NPE on `field.sourceId()` in `getPartitionKey`.
+     * and the field name stays the same as the source column. This is why we need to check for
+     * `isIdentity` when adding partitions.
      */
     @Test
     public void testAddPartitionWithV1DroppedIdentityPartitionFieldDoesNotThrow() throws Exception {
@@ -816,11 +815,11 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         k1Slot.setColumn(new Column("k1", INT));
         localTuple.addSlot(k1Slot);
         SlotDescriptor dtSlot = new SlotDescriptor(new SlotId(2), localTuple);
-        dtSlot.setType(INT);
-        dtSlot.setColumn(new Column("dt", INT));
+        dtSlot.setType(DateType.DATE);
+        dtSlot.setColumn(new Column("dt", DateType.DATE));
         localTuple.addSlot(dtSlot);
 
-        List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", INT));
+        List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", DateType.DATE));
         IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v1_drop_id", "iceberg_catalog",
                 "resource", "db", "table", "", schema, v1Table, Maps.newHashMap());
 
@@ -869,11 +868,11 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
             k1Slot.setColumn(new Column("k1", INT));
             localTuple.addSlot(k1Slot);
             SlotDescriptor dtSlot = new SlotDescriptor(new SlotId(2), localTuple);
-            dtSlot.setType(INT);
-            dtSlot.setColumn(new Column("dt", INT));
+            dtSlot.setType(DateType.DATE);
+            dtSlot.setColumn(new Column("dt", DateType.DATE));
             localTuple.addSlot(dtSlot);
 
-            List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", INT));
+            List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", DateType.DATE));
             IcebergTable icebergTable = new IcebergTable(1, "iceberg_void_only", "iceberg_catalog",
                     "resource", "db", "table", "", schema, v1Table, Maps.newHashMap());
 
@@ -958,11 +957,11 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
             k1Slot.setColumn(new Column("k1", INT));
             localTuple.addSlot(k1Slot);
             SlotDescriptor dtSlot = new SlotDescriptor(new SlotId(2), localTuple);
-            dtSlot.setType(INT);
-            dtSlot.setColumn(new Column("dt", INT));
+            dtSlot.setType(DateType.DATE);
+            dtSlot.setColumn(new Column("dt", DateType.DATE));
             localTuple.addSlot(dtSlot);
 
-            List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", INT));
+            List<Column> schema = Lists.newArrayList(new Column("k1", INT), new Column("dt", DateType.DATE));
             IcebergTable icebergTable = new IcebergTable(1, "iceberg_reuse", "iceberg_catalog",
                     "resource", "db", "table", "", schema, v1Table, Maps.newHashMap());
 


### PR DESCRIPTION
## Why I'm doing:
Background

Iceberg V1 spec evolution has a special rule for DROP PARTITION FIELD:
For V1 tables, dropping a partition field does not physically remove it from the spec. The field is kept with its transform rewritten to VoidTransform (always returns null), and its name remains identical to the source column.

https://iceberg.apache.org/spec/#partition-evolution

https://github.com/apache/iceberg/blob/0b30919372df34afb632f037df88c05cdba0b134/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java#L315-L326

This V1-specific behavior breaks two pieces of FE logic in IcebergConnectorScanRangeSource.java

```
ER_PARSE_ERROR: Cannot invoke "org.apache.iceberg.PartitionField.sourceId()" because "field" is null
```
## What I'm doing:

Add support for the partiton evolution delete partition in v1.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
