### PR TITLE
[Feature] Support ClickHouse-compatible CREATE MATERIALIZED VIEW ... …

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -49,9 +49,11 @@
 #include "common/statusor.h"
 #include "common/tracer.h"
 #include "config.h"
+#include "exec/exec_node.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/tablet_sink_colocate_sender.h"
 #include "exprs/expr.h"
+#include "exprs/expr_context.h"
 #include "gutil/strings/fastmem.h"
 #include "gutil/strings/join.h"
 #include "gutil/strings/substitute.h"
@@ -153,6 +155,13 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     // init _colocate_mv_index: Only use colocate mv when both FE/BE's config are set true.
     if (table_sink.__isset.enable_colocate_mv_index) {
         _colocate_mv_index = table_sink.enable_colocate_mv_index && config::enable_load_colocate_mv;
+    }
+
+    // CK-compatible logical sink MVs (`CREATE MATERIALIZED VIEW ... TO <table>`): stash the base sink
+    // here; the child sinks are built in prepare() where the runtime context is fully ready.
+    if (table_sink.__isset.logical_sinks && !table_sink.logical_sinks.empty()) {
+        _base_table_sink = table_sink;
+        _has_logical_sinks = true;
     }
 
     if (state->query_ctx()) {
@@ -323,6 +332,11 @@ Status OlapTableSink::prepare(RuntimeState* state) {
                 std::move(index_channels), std::move(node_channels), _output_expr_ctxs, _enable_replicated_storage,
                 _write_quorum_type, _num_repicas);
     }
+    // CK-compatible TO-table MVs: build the child sinks now (runtime context is ready), then prepare.
+    if (_has_logical_sinks) {
+        RETURN_IF_ERROR(_init_logical_sinks(_base_table_sink, state));
+        RETURN_IF_ERROR(_prepare_logical_sinks(state));
+    }
     return Status::OK();
 }
 
@@ -401,22 +415,37 @@ Status OlapTableSink::open(RuntimeState* state) {
     auto open_span = Tracer::Instance().add_span("open", _span);
     SCOPED_TIMER(_profile->total_time_counter());
     SCOPED_TIMER(_ts_profile->open_timer);
+    // try_open()/open_wait() already drive the logical-sink child opens (see below), so the
+    // synchronous path needs no extra step here.
     RETURN_IF_ERROR(try_open(state));
     RETURN_IF_ERROR(open_wait());
-
     return Status::OK();
 }
 
 Status OlapTableSink::try_open(RuntimeState* state) {
-    return _tablet_sink_sender->try_open(state);
+    RETURN_IF_ERROR(_tablet_sink_sender->try_open(state));
+    // Issue the child (TO-table MV) open RPCs alongside the base sink's. The pipeline operator drives
+    // opening through try_open()/is_open_done()/open_wait() and never calls the synchronous open(), so
+    // the child opens must be wired into this async protocol or their tablets channels are never created.
+    if (!_logical_sinks.empty()) {
+        RETURN_IF_ERROR(_try_open_logical_sinks(state));
+    }
+    return Status::OK();
 }
 
 bool OlapTableSink::is_open_done() {
-    return _tablet_sink_sender->is_open_done();
+    if (!_tablet_sink_sender->is_open_done()) {
+        return false;
+    }
+    return _is_logical_sinks_open_done();
 }
 
 Status OlapTableSink::open_wait() {
-    return _tablet_sink_sender->open_wait();
+    RETURN_IF_ERROR(_tablet_sink_sender->open_wait());
+    if (!_logical_sinks.empty()) {
+        RETURN_IF_ERROR(_open_wait_logical_sinks());
+    }
+    return Status::OK();
 }
 
 bool OlapTableSink::is_full() {
@@ -651,6 +680,15 @@ Status OlapTableSink::_send_chunk(RuntimeState* state, Chunk* chunk, bool nonblo
             DCHECK_EQ(chunk->get_slot_id_to_index_map().size(), _output_tuple_desc->slots().size());
         }
 
+        // CK-compatible logical sink MV fan-out: forward transformed rows into each target table within
+        // the same load transaction. The MV transform exprs are SlotRefs into this (base) sink's output
+        // tuple, so the fan-out must run AFTER the projection/slot-id remap above — at this point `chunk`
+        // is keyed by the base output-tuple slot ids the transform exprs reference (before the remap the
+        // chunk still carries the upstream query slot ids and the exprs hit "slot_id not found").
+        if (!_logical_sinks.empty()) {
+            RETURN_IF_ERROR(_fanout_logical_sinks(state, chunk));
+        }
+
         {
             SCOPED_TIMER(_ts_profile->alloc_auto_increment_timer);
             RETURN_IF_ERROR(_fill_auto_increment_id(chunk));
@@ -857,6 +895,179 @@ bool OlapTableSink::is_close_done() {
     return _tablet_sink_sender->is_close_done();
 }
 
+Status OlapTableSink::_init_logical_sinks(const TOlapTableSink& table_sink, RuntimeState* state) {
+    int logical_idx = 0;
+    for (const auto& t_logical : table_sink.logical_sinks) {
+        auto channel = std::make_unique<LogicalSinkChannel>();
+        channel->mv_id = t_logical.__isset.mv_id ? t_logical.mv_id : 0;
+        channel->mv_name = t_logical.__isset.mv_name ? t_logical.mv_name : "";
+
+        // Build a TOlapTableSink for the target table: target descriptors come from the logical sink,
+        // while txn_id/db_id/num_replicas/nodes_info are shared with this (base) sink so both writes
+        // belong to the same load transaction.
+        // NOTE: load_id/txn_id/db_id/table_id/tuple_id/num_replicas/need_gen_rollup/schema/partition/
+        // location/nodes_info are `required` in TOlapTableSink, so they have no __isset member and are
+        // assigned directly; only optional fields below set __isset.
+        TOlapTableSink child;
+        // Give the child its OWN load_id (derived from the base load_id) so it gets a dedicated BE
+        // LoadChannel with the target table's schema/row_desc/chunk-meta. The base and target tables
+        // have different schemas, but a LoadChannel is single-schema: sharing the base load_id makes
+        // the child's open hit "Unknown index_id" and its chunk be deserialized with the base meta.
+        // txn_id stays shared, so both still commit in the same transaction; commit infos flow back to
+        // the FE through the shared RuntimeState. The mixing constant spreads bits to avoid collisions.
+        child.load_id = table_sink.load_id;
+        child.load_id.lo = static_cast<int64_t>(static_cast<uint64_t>(table_sink.load_id.lo) ^
+                                                (0x9E3779B97F4A7C15ULL * static_cast<uint64_t>(logical_idx + 1)));
+        child.txn_id = table_sink.txn_id;
+        child.db_id = table_sink.db_id;
+        child.table_id = t_logical.__isset.target_table_id ? t_logical.target_table_id : 0;
+        child.tuple_id = t_logical.__isset.tuple_id ? t_logical.tuple_id : 0;
+        child.num_replicas = table_sink.num_replicas;
+        child.need_gen_rollup = false;
+        if (t_logical.__isset.schema) {
+            child.schema = t_logical.schema;
+        }
+        if (t_logical.__isset.partition) {
+            child.partition = t_logical.partition;
+        }
+        if (t_logical.__isset.location) {
+            child.location = t_logical.location;
+        }
+        child.nodes_info = table_sink.nodes_info;
+        if (t_logical.__isset.keys_type) {
+            child.keys_type = t_logical.keys_type;
+            child.__isset.keys_type = true;
+        }
+        if (table_sink.__isset.enable_replicated_storage) {
+            child.enable_replicated_storage = table_sink.enable_replicated_storage;
+            child.__isset.enable_replicated_storage = true;
+        }
+        if (table_sink.__isset.write_quorum_type) {
+            child.write_quorum_type = table_sink.write_quorum_type;
+            child.__isset.write_quorum_type = true;
+        }
+        if (table_sink.__isset.db_name) {
+            child.db_name = table_sink.db_name;
+            child.__isset.db_name = true;
+        }
+
+        TDataSink child_data_sink;
+        child_data_sink.type = TDataSinkType::OLAP_TABLE_SINK;
+        child_data_sink.olap_table_sink = child;
+        child_data_sink.__isset.olap_table_sink = true;
+
+        // The child carries the MV's per-target-column transform exprs as its own output exprs; feeding
+        // it the base chunk yields rows shaped like the target schema.
+        std::vector<TExpr> output_exprs;
+        if (t_logical.__isset.transform_exprs) {
+            output_exprs = t_logical.transform_exprs;
+        }
+        Status st = Status::OK();
+        auto sink = std::make_unique<OlapTableSink>(_pool, output_exprs, &st, state);
+        RETURN_IF_ERROR(st);
+        RETURN_IF_ERROR(sink->init(child_data_sink, state));
+        channel->sink = std::move(sink);
+
+        // The MV's optional WHERE predicate is evaluated by THIS (base) sink over the base chunk before
+        // fan-out (CK applies the MV's SELECT, including WHERE, per inserted block). Its SlotRefs point at
+        // the same base output-tuple slots the transform exprs reference, so it is evaluated on the same
+        // post-projection chunk fed to the child below.
+        if (t_logical.__isset.where_predicate) {
+            ExprContext* where_ctx = nullptr;
+            RETURN_IF_ERROR(Expr::create_expr_tree(_pool, t_logical.where_predicate, &where_ctx, state));
+            channel->where_ctxs.push_back(where_ctx);
+        }
+        LOG(INFO) << "init logical sink MV " << channel->mv_name << " -> target table " << child.table_id
+                  << ", txn_id=" << child.txn_id << ", child_load_id=" << print_id(child.load_id)
+                  << ", has_where=" << (!channel->where_ctxs.empty());
+        _logical_sinks.emplace_back(std::move(channel));
+        ++logical_idx;
+    }
+    return Status::OK();
+}
+
+Status OlapTableSink::_prepare_logical_sinks(RuntimeState* state) {
+    for (auto& ch : _logical_sinks) {
+        if (ch->sink != nullptr) {
+            RETURN_IF_ERROR(ch->sink->prepare(state));
+        }
+        RETURN_IF_ERROR(Expr::prepare(ch->where_ctxs, state));
+    }
+    return Status::OK();
+}
+
+Status OlapTableSink::_try_open_logical_sinks(RuntimeState* state) {
+    for (auto& ch : _logical_sinks) {
+        if (ch->sink != nullptr) {
+            RETURN_IF_ERROR(ch->sink->try_open(state));
+        }
+        // Open the WHERE predicate contexts here (prepared in _prepare_logical_sinks); _open_wait has no
+        // RuntimeState and the predicates must be open before the first fan-out in send_chunk.
+        RETURN_IF_ERROR(Expr::open(ch->where_ctxs, state));
+    }
+    return Status::OK();
+}
+
+bool OlapTableSink::_is_logical_sinks_open_done() {
+    for (auto& ch : _logical_sinks) {
+        if (ch->sink != nullptr && !ch->sink->is_open_done()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Status OlapTableSink::_open_wait_logical_sinks() {
+    for (auto& ch : _logical_sinks) {
+        if (ch->sink != nullptr) {
+            RETURN_IF_ERROR(ch->sink->open_wait());
+        }
+    }
+    return Status::OK();
+}
+
+Status OlapTableSink::_fanout_logical_sinks(RuntimeState* state, Chunk* chunk) {
+    for (auto& ch : _logical_sinks) {
+        if (ch->sink == nullptr) {
+            continue;
+        }
+        // No WHERE: forward the whole base chunk. The child applies its transform (output) exprs and
+        // writes the resulting rows into the target table within the same load transaction.
+        if (ch->where_ctxs.empty()) {
+            RETURN_IF_ERROR(ch->sink->send_chunk(state, chunk));
+            continue;
+        }
+        // WHERE present: evaluate the predicate over the base chunk WITHOUT mutating it (the same chunk
+        // is fanned out to other MVs and then written to the base table), then forward only the rows that
+        // pass. apply_filter=false makes eval_conjuncts compute the filter into `filter` and leave `chunk`
+        // untouched; a null filter means "all rows pass".
+        FilterPtr filter;
+        RETURN_IF_ERROR(ExecNode::eval_conjuncts(ch->where_ctxs, chunk, &filter, /*apply_filter=*/false));
+        size_t num_rows = chunk->num_rows();
+        size_t selected = filter == nullptr ? num_rows : SIMD::count_nonzero(*filter);
+        if (selected == 0) {
+            continue; // no row qualifies for this MV
+        }
+        if (selected == num_rows) {
+            RETURN_IF_ERROR(ch->sink->send_chunk(state, chunk));
+            continue;
+        }
+        // Materialize an independent, filtered copy (preserves the base output-tuple slot mapping so the
+        // child's transform exprs still resolve), then forward it.
+        std::vector<uint32_t> selected_idx;
+        selected_idx.reserve(selected);
+        for (uint32_t i = 0; i < filter->size(); ++i) {
+            if ((*filter)[i]) {
+                selected_idx.push_back(i);
+            }
+        }
+        ChunkUniquePtr filtered = chunk->clone_empty_with_slot(selected);
+        filtered->append_selective(*chunk, selected_idx.data(), 0, selected_idx.size());
+        RETURN_IF_ERROR(ch->sink->send_chunk(state, filtered.get()));
+    }
+    return Status::OK();
+}
+
 Status OlapTableSink::close(RuntimeState* state, Status close_status) {
     if (close_status.ok()) {
         SCOPED_TIMER(_profile->total_time_counter());
@@ -881,6 +1092,19 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
     COUNTER_SET(_ts_profile->filtered_rows_counter, _number_filtered_rows);
     COUNTER_SET(_ts_profile->convert_chunk_timer, _convert_batch_ns);
     COUNTER_SET(_ts_profile->validate_data_timer, _validate_data_ns);
+
+    // Close logical sink MV child sinks within the same load transaction; surface the first error.
+    for (auto& ch : _logical_sinks) {
+        if (ch && ch->sink) {
+            Status st = ch->sink->close(state, close_status);
+            if (!st.ok() && close_status.ok()) {
+                close_status = st;
+            }
+        }
+        if (ch) {
+            Expr::close(ch->where_ctxs, state);
+        }
+    }
 
     if (_tablet_sink_sender == nullptr) {
         return close_status;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -182,6 +182,40 @@ private:
     TupleDescriptor* _output_tuple_desc = nullptr;
     std::vector<ExprContext*> _output_expr_ctxs;
 
+    // CK-compatible logical sink MV (`CREATE MATERIALIZED VIEW ... TO <table>`) fan-out. Each channel
+    // is a child OlapTableSink writing into a separate target table within the same load transaction.
+    // The child carries the MV's per-target-column transform expressions as its own output exprs, so
+    // feeding it the base chunk yields the transformed rows written into the target table.
+    struct LogicalSinkChannel {
+        int64_t mv_id = 0;
+        std::string mv_name;
+        std::unique_ptr<OlapTableSink> sink;
+        // CK-compatible MV WHERE predicate (`... AS SELECT ... WHERE <pred>`). Evaluated over the base
+        // chunk before fan-out; rows failing it are not forwarded to this child sink. Empty when the MV
+        // has no WHERE clause. Owned by this sink's _pool; prepared/opened/closed alongside the child.
+        std::vector<ExprContext*> where_ctxs;
+    };
+    std::vector<std::unique_ptr<LogicalSinkChannel>> _logical_sinks;
+    // The base TOlapTableSink is stashed in init() and the child sinks are built in prepare(), where
+    // the runtime context (state, descriptors) is fully ready -- building them in init() is too early
+    // in the pipeline engine.
+    TOlapTableSink _base_table_sink;
+    bool _has_logical_sinks = false;
+
+    // Construct one child OlapTableSink per table_sink.logical_sinks entry (shares this sink's
+    // load_id/txn_id/nodes_info). Called from prepare().
+    Status _init_logical_sinks(const TOlapTableSink& table_sink, RuntimeState* state);
+    // Forward `chunk` (the base load chunk) to each child sink, which applies the MV transform and
+    // writes into its target table. Called from send_chunk for every base chunk.
+    Status _fanout_logical_sinks(RuntimeState* state, Chunk* chunk);
+    // Drive child-sink prepare()/open() within this sink's prepare()/open(). The open path follows the
+    // async try_open()/is_open_done()/open_wait() protocol so the child open RPCs are issued alongside
+    // the base sink's (the pipeline operator never calls the synchronous open()).
+    Status _prepare_logical_sinks(RuntimeState* state);
+    Status _try_open_logical_sinks(RuntimeState* state);
+    bool _is_logical_sinks_open_done();
+    Status _open_wait_logical_sinks();
+
     // number of senders used to insert into OlapTable, if we only support single node insert,
     // all data from select should collectted and then send to OlapTable.
     // To support multiple senders, we maintain a channel for each sender.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -41,6 +41,7 @@ import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LogicalSinkMVMeta;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
@@ -175,6 +176,20 @@ public class AlterJobMgr {
                 }
             }
             if (table == null) {
+                // Not a sync MV (rollup index). It may be a CK-compatible logical sink (TO-table) MV,
+                // which is registered in OlapTable.logicalSinkMVs rather than as a rollup index.
+                for (Table t : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
+                    if (!(t instanceof OlapTable) || !((OlapTable) t).hasLogicalSinkMV()) {
+                        continue;
+                    }
+                    for (LogicalSinkMVMeta meta : ((OlapTable) t).getLogicalSinkMVs().values()) {
+                        if (meta.getMvName().equals(stmt.getMvName())) {
+                            GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .dropLogicalSinkMaterializedView(db, (OlapTable) t, meta);
+                            return;
+                        }
+                    }
+                }
                 throw new MetaNotFoundException("Materialized view " + stmt.getMvName() + " is not found");
             }
             // check table type

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LogicalSinkMVMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LogicalSinkMVMeta.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.util.List;
+
+/**
+ * Metadata of a ClickHouse-compatible logical sink materialized view created via
+ * {@code CREATE MATERIALIZED VIEW mv TO <target> AS SELECT ... FROM <base>}.
+ *
+ * <p>Unlike a synchronous rollup MV, a logical sink MV holds no storage of its own and creates no
+ * tablets: it is a write-triggered transformation rule attached to the base table. On every load
+ * into the base table, the base rows are filtered and projected by this rule and the resulting rows
+ * are written into the existing, user-managed target OLAP table within the same load transaction.
+ *
+ * <p>Following the synchronous MV convention, only the originating {@code defineStmt} is persisted;
+ * the per-column define expressions and the optional WHERE predicate are recovered by re-parsing
+ * the statement (see {@code CreateMaterializedViewStmt#parseDefineExprWithoutAnalyze}). This keeps
+ * the metadata small and avoids serializing analyzed Expr trees.
+ */
+public class LogicalSinkMVMeta {
+
+    @SerializedName(value = "mvId")
+    private long mvId;
+
+    @SerializedName(value = "mvName")
+    private String mvName;
+
+    @SerializedName(value = "dbId")
+    private long dbId;
+
+    @SerializedName(value = "baseTableId")
+    private long baseTableId;
+
+    // The existing target OLAP table the transformed rows are written into.
+    @SerializedName(value = "targetTableId")
+    private long targetTableId;
+
+    // Original `CREATE MATERIALIZED VIEW ... TO ... AS SELECT ...`, re-parsed to recover the
+    // per-column transform expressions and the optional WHERE predicate.
+    @SerializedName(value = "defineStmt")
+    private String defineStmt;
+
+    // Phase-1 projection mapping: for each target column (in order), the base column name the MV's
+    // SELECT item projects from, when that item is a plain column reference. Empty string means the
+    // item is a scalar/JSON expression (not yet supported by the write-path fan-out).
+    @SerializedName(value = "projectBaseColumns")
+    private List<String> projectBaseColumns;
+
+    public LogicalSinkMVMeta() {
+    }
+
+    public LogicalSinkMVMeta(long mvId, String mvName, long dbId, long baseTableId, long targetTableId,
+                             String defineStmt) {
+        this.mvId = mvId;
+        this.mvName = mvName;
+        this.dbId = dbId;
+        this.baseTableId = baseTableId;
+        this.targetTableId = targetTableId;
+        this.defineStmt = defineStmt;
+    }
+
+    public long getMvId() {
+        return mvId;
+    }
+
+    public String getMvName() {
+        return mvName;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public long getBaseTableId() {
+        return baseTableId;
+    }
+
+    public long getTargetTableId() {
+        return targetTableId;
+    }
+
+    public String getDefineStmt() {
+        return defineStmt;
+    }
+
+    public List<String> getProjectBaseColumns() {
+        return projectBaseColumns;
+    }
+
+    public void setProjectBaseColumns(List<String> projectBaseColumns) {
+        this.projectBaseColumns = projectBaseColumns;
+    }
+
+    // True only when every target column maps to a plain base column projection (Phase-1 supported).
+    public boolean isPlainProjection() {
+        if (projectBaseColumns == null || projectBaseColumns.isEmpty()) {
+            return false;
+        }
+        for (String c : projectBaseColumns) {
+            if (c == null || c.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return GsonUtils.GSON.toJson(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -215,6 +215,12 @@ public class OlapTable extends Table {
     @SerializedName(value = "indexNameToId")
     protected Map<String, Long> indexNameToId = Maps.newHashMap();
 
+    // CK-compatible logical sink MVs (`CREATE MATERIALIZED VIEW ... TO <table>`) attached to this
+    // base table, keyed by MV id. These hold no storage/tablets; on every load into this table the
+    // load path fans transformed rows out to each MV's target table within the same transaction.
+    @SerializedName(value = "logicalSinkMVs")
+    protected Map<Long, LogicalSinkMVMeta> logicalSinkMVs = Maps.newHashMap();
+
     @SerializedName(value = "keysType")
     protected KeysType keysType;
 
@@ -1088,6 +1094,29 @@ public class OlapTable extends Table {
 
     public Map<Long, MaterializedIndexMeta> getIndexIdToMeta() {
         return indexIdToMeta;
+    }
+
+    // ---- CK-compatible logical sink MVs (`CREATE MATERIALIZED VIEW ... TO <table>`) ----
+
+    public Map<Long, LogicalSinkMVMeta> getLogicalSinkMVs() {
+        if (logicalSinkMVs == null) {
+            logicalSinkMVs = Maps.newHashMap();
+        }
+        return logicalSinkMVs;
+    }
+
+    public boolean hasLogicalSinkMV() {
+        return logicalSinkMVs != null && !logicalSinkMVs.isEmpty();
+    }
+
+    public void addLogicalSinkMV(LogicalSinkMVMeta meta) {
+        getLogicalSinkMVs().put(meta.getMvId(), meta);
+    }
+
+    public void removeLogicalSinkMV(long mvId) {
+        if (logicalSinkMVs != null) {
+            logicalSinkMVs.remove(mvId);
+        }
     }
 
     public Map<Long, MaterializedIndexMeta> getCopiedIndexIdToMeta() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3072,6 +3072,22 @@ public class Config extends ConfigBase {
     public static boolean enable_experimental_mv = true;
 
     /**
+     * Enable ClickHouse-compatible `CREATE MATERIALIZED VIEW ... TO <table>` (logical sink MV):
+     * the synchronous, write-triggered MV writes its transformed rows into an existing
+     * user-managed target table instead of a rollup index. Disabled by default; turn on to
+     * gray-release the feature. See materialized view TO-table design.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_mv_to_table = false;
+
+    /**
+     * Max number of logical sink (TO-table) MVs that can be attached to a single base table.
+     * Bounds the write amplification a single base load incurs (1 base write + N target writes).
+     */
+    @ConfField(mutable = true)
+    public static int max_mv_to_table_per_base_table = 5;
+
+    /**
      * Whether to support colocate mv index in olap table sink, tablet sink will only send chunk once
      * if enabled to speed up the sync mv's transformation performance.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -732,6 +732,16 @@ public class EditLog {
                     globalStateMgr.getLocalMetastore().replayConvertDistributionType(tableInfo);
                     break;
                 }
+                case OperationType.OP_CREATE_LOGICAL_SINK_MV: {
+                    LogicalSinkMVOpLog info = (LogicalSinkMVOpLog) journal.data();
+                    globalStateMgr.getLocalMetastore().replayCreateLogicalSinkMV(info);
+                    break;
+                }
+                case OperationType.OP_DROP_LOGICAL_SINK_MV: {
+                    LogicalSinkMVOpLog info = (LogicalSinkMVOpLog) journal.data();
+                    globalStateMgr.getLocalMetastore().replayDropLogicalSinkMV(info);
+                    break;
+                }
                 case OperationType.OP_DYNAMIC_PARTITION:
                 case OperationType.OP_MODIFY_IN_MEMORY:
                 case OperationType.OP_SET_FORBIDDEN_GLOBAL_DICT:
@@ -1444,6 +1454,14 @@ public class EditLog {
 
     public void logAddPartition(PartitionPersistInfoV2 info) {
         logEdit(OperationType.OP_ADD_PARTITION_V2, info);
+    }
+
+    public void logCreateLogicalSinkMV(LogicalSinkMVOpLog info) {
+        logEdit(OperationType.OP_CREATE_LOGICAL_SINK_MV, info);
+    }
+
+    public void logDropLogicalSinkMV(LogicalSinkMVOpLog info) {
+        logEdit(OperationType.OP_DROP_LOGICAL_SINK_MV, info);
     }
 
     public void logAddPartitions(AddPartitionsInfoV2 info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -95,6 +95,8 @@ public class EditLogDeserializer {
             .put(OperationType.OP_ERASE_MULTI_TABLES, MultiEraseTableInfo.class)
             .put(OperationType.OP_DISABLE_TABLE_RECOVERY, DisableTableRecoveryInfo.class)
             .put(OperationType.OP_DISABLE_PARTITION_RECOVERY, DisablePartitionRecoveryInfo.class)
+            .put(OperationType.OP_CREATE_LOGICAL_SINK_MV, LogicalSinkMVOpLog.class)
+            .put(OperationType.OP_DROP_LOGICAL_SINK_MV, LogicalSinkMVOpLog.class)
             .put(OperationType.OP_ADD_PARTITION_V2, PartitionPersistInfoV2.class)
             .put(OperationType.OP_ADD_SUB_PARTITIONS_V2, AddSubPartitionsInfoV2.class)
             .put(OperationType.OP_ADD_PARTITIONS_V2, AddPartitionsInfoV2.class)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/LogicalSinkMVOpLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/LogicalSinkMVOpLog.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.LogicalSinkMVMeta;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+/**
+ * Journal entry for creating/dropping a CK-compatible logical sink MV
+ * ({@code CREATE MATERIALIZED VIEW ... TO <table>}). Persisted via Gson.
+ *
+ * <p>For create, {@link #meta} carries the full binding. For drop, only {@link #dbId},
+ * {@link #baseTableId} and {@link #mvId} are meaningful.
+ */
+public class LogicalSinkMVOpLog implements Writable {
+
+    @SerializedName(value = "dbId")
+    private long dbId;
+
+    @SerializedName(value = "baseTableId")
+    private long baseTableId;
+
+    // Present for create.
+    @SerializedName(value = "meta")
+    private LogicalSinkMVMeta meta;
+
+    // Present for drop.
+    @SerializedName(value = "mvId")
+    private long mvId;
+
+    public LogicalSinkMVOpLog() {
+    }
+
+    public static LogicalSinkMVOpLog forCreate(long dbId, long baseTableId, LogicalSinkMVMeta meta) {
+        LogicalSinkMVOpLog log = new LogicalSinkMVOpLog();
+        log.dbId = dbId;
+        log.baseTableId = baseTableId;
+        log.meta = meta;
+        log.mvId = meta.getMvId();
+        return log;
+    }
+
+    public static LogicalSinkMVOpLog forDrop(long dbId, long baseTableId, long mvId) {
+        LogicalSinkMVOpLog log = new LogicalSinkMVOpLog();
+        log.dbId = dbId;
+        log.baseTableId = baseTableId;
+        log.mvId = mvId;
+        return log;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public long getBaseTableId() {
+        return baseTableId;
+    }
+
+    public LogicalSinkMVMeta getMeta() {
+        return meta;
+    }
+
+    public long getMvId() {
+        return mvId;
+    }
+
+    public static LogicalSinkMVOpLog read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, LogicalSinkMVOpLog.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -636,6 +636,10 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_SET_VIEW_SECURITY_LOG = 13542;
 
+    // CK-compatible logical sink MV (`CREATE MATERIALIZED VIEW ... TO <table>`).
+    public static final short OP_CREATE_LOGICAL_SINK_MV = 13601;
+    public static final short OP_DROP_LOGICAL_SINK_MV = 13602;
+
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, please follow the above sequence number
      */

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -40,6 +40,8 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
+import com.starrocks.analysis.CastExpr;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.LiteralExpr;
@@ -60,8 +62,10 @@ import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.LogicalSinkMVMeta;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
@@ -69,6 +73,7 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -92,11 +97,20 @@ import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TOlapTableColumnParam;
 import com.starrocks.thrift.TOlapTableIndexSchema;
@@ -105,6 +119,7 @@ import com.starrocks.thrift.TOlapTableLocationParam;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
 import com.starrocks.thrift.TOlapTableSchemaParam;
+import com.starrocks.thrift.TOlapTableLogicalSink;
 import com.starrocks.thrift.TOlapTableSink;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TTabletLocation;
@@ -224,6 +239,229 @@ public class OlapTableSink extends DataSink {
         }
     }
 
+    // CK-compatible logical sink MVs (`CREATE MATERIALIZED VIEW ... TO <table>`) attached to the base
+    // table. Built at plan time (where the DescriptorTable is available) and carried on the base sink;
+    // the BE constructs a child sink per entry to fan transformed rows out to each target table within
+    // this load transaction.
+    private List<TOlapTableLogicalSink> logicalSinks = null;
+
+    public void setLogicalSinks(List<TOlapTableLogicalSink> logicalSinks) {
+        this.logicalSinks = logicalSinks;
+    }
+
+    // Build the secondary sinks for all TO-table MVs on the base table. Must be called at plan time:
+    // it allocates a target TupleDescriptor in {@code descTbl} and reuses the same schema/partition/
+    // location builders used for the base table. Each child carries the MV's per-target-column transform
+    // expressions (plain projection or scalar/JSON/conditional exprs over the base columns) and an optional
+    // WHERE predicate, all bound to the base sink's output-tuple slots. MVs whose definition is outside the
+    // supported shape (CTE/UNION, join/subquery, aggregation, `SELECT *`) are skipped (logged).
+    public static List<TOlapTableLogicalSink> buildLogicalSinks(long dbId, OlapTable baseTable,
+                                                                TupleDescriptor baseTupleDesc,
+                                                                DescriptorTable descTbl,
+                                                                long warehouseId) throws StarRocksException {
+        List<TOlapTableLogicalSink> result = Lists.newArrayList();
+        if (!baseTable.hasLogicalSinkMV()) {
+            return result;
+        }
+        // Map base column name -> base input slot (base tuple slots follow the base full schema order).
+        Map<String, SlotDescriptor> nameToSlot = new HashMap<>();
+        List<Column> baseSchema = baseTable.getBaseSchema();
+        List<SlotDescriptor> baseSlots = baseTupleDesc.getSlots();
+        for (int i = 0; i < baseSchema.size() && i < baseSlots.size(); i++) {
+            nameToSlot.put(baseSchema.get(i).getName().toLowerCase(), baseSlots.get(i));
+        }
+
+        for (LogicalSinkMVMeta meta : baseTable.getLogicalSinkMVs().values()) {
+            Table target = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(meta.getDbId(), meta.getTargetTableId());
+            if (!(target instanceof OlapTable)) {
+                LOG.warn("logical sink MV {} target table id {} missing or not olap; skip",
+                        meta.getMvName(), meta.getTargetTableId());
+                continue;
+            }
+            OlapTable targetTable = (OlapTable) target;
+
+            // Compile the MV's per-target-column transform expressions and optional WHERE predicate from
+            // the persisted define statement, binding every column reference to the base sink's output
+            // tuple slots so the BE can evaluate them directly over the base load chunk. Handles plain
+            // column projection as well as scalar / JSON / conditional expressions and a row filter.
+            List<TExpr> transformExprs;
+            TExpr wherePredicate = null;
+            try {
+                LogicalSinkExprs compiled = compileLogicalSinkExprs(meta, targetTable, nameToSlot);
+                if (compiled == null) {
+                    continue; // unsupported shape (CTE/join/aggregate/`SELECT *`); already logged
+                }
+                transformExprs = compiled.transformExprs;
+                wherePredicate = compiled.wherePredicate;
+            } catch (Exception e) {
+                LOG.warn("logical sink MV {}: failed to compile transform exprs ({}); write-path fan-out skipped",
+                        meta.getMvName(), e.getMessage());
+                continue;
+            }
+
+            // Target sink descriptors (a dedicated tuple so the child sink maps by target columns).
+            TupleDescriptor targetTuple = descTbl.createTupleDescriptor();
+            for (Column col : targetTable.getBaseSchema()) {
+                SlotDescriptor sd = descTbl.addSlotDescriptor(targetTuple);
+                sd.setIsMaterialized(true);
+                sd.setType(col.getType());
+                sd.setColumn(col);
+                sd.setIsNullable(col.isAllowNull());
+            }
+            targetTuple.computeMemLayout();
+
+            List<Long> targetPartitionIds = targetTable.getPartitions().stream()
+                    .map(Partition::getId).collect(Collectors.toList());
+            TOlapTablePartitionParam partitionParam = createPartition(dbId, targetTable, targetTuple,
+                    false, 0, targetPartitionIds);
+            TOlapTableLogicalSink t = new TOlapTableLogicalSink();
+            t.setMv_id(meta.getMvId());
+            t.setMv_name(meta.getMvName());
+            t.setTarget_table_id(meta.getTargetTableId());
+            t.setKeys_type(targetTable.getKeysType().toThrift());
+            t.setTuple_id(targetTuple.getId().asInt());
+            t.setSchema(createSchema(dbId, targetTable, targetTuple));
+            t.setPartition(partitionParam);
+            t.setLocation(createLocation(targetTable, partitionParam, targetTable.enableReplicatedStorage(),
+                    warehouseId));
+            t.setTransform_exprs(transformExprs);
+            if (wherePredicate != null) {
+                t.setWhere_predicate(wherePredicate);
+            }
+            result.add(t);
+        }
+        return result;
+    }
+
+    // Holder for a logical sink MV's compiled write-path expressions.
+    private static class LogicalSinkExprs {
+        final List<TExpr> transformExprs;
+        final TExpr wherePredicate; // nullable: no WHERE clause
+
+        LogicalSinkExprs(List<TExpr> transformExprs, TExpr wherePredicate) {
+            this.transformExprs = transformExprs;
+            this.wherePredicate = wherePredicate;
+        }
+    }
+
+    // Recover the MV's SELECT items and optional WHERE from the persisted define statement, analyze them
+    // against the base table, and bind every column reference to the base output-tuple slots in {@code
+    // nameToSlot} so the BE evaluates them over the base load chunk. SELECT item i maps to target column i
+    // (CK TO-table positional semantics); each transform expr is cast to its target column type. Returns
+    // null for shapes the write-path fan-out does not support (CTE/UNION, join/subquery, aggregation,
+    // `SELECT *`); throws when an expression fails to analyze (e.g. references a non-base column).
+    private static LogicalSinkExprs compileLogicalSinkExprs(LogicalSinkMVMeta meta, OlapTable targetTable,
+                                                            Map<String, SlotDescriptor> nameToSlot) {
+        String defineStmt = meta.getDefineStmt();
+        if (defineStmt == null || defineStmt.isEmpty()) {
+            // Legacy meta without a define statement: fall back to the recorded plain-projection mapping.
+            return plainProjectionExprs(meta, nameToSlot);
+        }
+
+        ConnectContext ctx = ConnectContext.get() != null ? ConnectContext.get() : new ConnectContext();
+        long sqlMode = ctx.getSessionVariable().getSqlMode();
+        List<StatementBase> stmts = SqlParser.parse(defineStmt, sqlMode);
+        StatementBase parsed = stmts.get(0);
+        if (!(parsed instanceof CreateMaterializedViewStmt)) {
+            LOG.warn("logical sink MV {}: define stmt is not a CREATE MATERIALIZED VIEW; skip", meta.getMvName());
+            return null;
+        }
+        QueryStatement queryStatement = ((CreateMaterializedViewStmt) parsed).getQueryStatement();
+        QueryRelation qr = queryStatement.getQueryRelation();
+        if (qr.hasWithClause() || !(qr instanceof SelectRelation)) {
+            LOG.warn("logical sink MV {}: only a single-level SELECT over the base table is supported by "
+                    + "write-path fan-out (no CTE/UNION); flatten the definition. Skip.", meta.getMvName());
+            return null;
+        }
+        SelectRelation select = (SelectRelation) qr;
+        if (select.getGroupByClause() != null || !(select.getRelation() instanceof TableRelation)) {
+            LOG.warn("logical sink MV {}: aggregation/join/subquery in the definition is not supported by "
+                    + "write-path fan-out; skip.", meta.getMvName());
+            return null;
+        }
+
+        List<Column> targetColumns = targetTable.getBaseSchema();
+        List<SelectListItem> items = select.getSelectList().getItems();
+        if (items.size() != targetColumns.size()) {
+            LOG.warn("logical sink MV {}: SELECT item count {} != target column count {}; skip.",
+                    meta.getMvName(), items.size(), targetColumns.size());
+            return null;
+        }
+
+        List<TExpr> transformExprs = Lists.newArrayList();
+        for (int i = 0; i < targetColumns.size(); i++) {
+            SelectListItem item = items.get(i);
+            if (item.isStar()) {
+                LOG.warn("logical sink MV {}: `SELECT *` is not supported; list columns explicitly. Skip.",
+                        meta.getMvName());
+                return null;
+            }
+            Expr expr = rewriteAndAnalyze(item.getExpr().clone(), nameToSlot);
+            if (expr.containsAggregate()) {
+                LOG.warn("logical sink MV {}: aggregate functions are not supported by write-path fan-out; skip.",
+                        meta.getMvName());
+                return null;
+            }
+            Type targetType = targetColumns.get(i).getType();
+            if (!expr.getType().matchesType(targetType)) {
+                expr = new CastExpr(targetType, expr);
+            }
+            transformExprs.add(expr.treeToThrift());
+        }
+
+        TExpr wherePredicate = null;
+        if (select.hasWhereClause() && select.getWhereClause() != null) {
+            Expr where = rewriteAndAnalyze(select.getWhereClause().clone(), nameToSlot);
+            wherePredicate = where.treeToThrift();
+        }
+        return new LogicalSinkExprs(transformExprs, wherePredicate);
+    }
+
+    // Replace every base-column SlotRef in {@code expr} with a real SlotRef into the base output tuple
+    // (resolved by column name), then analyze + cast-fold so function signatures and implicit casts are
+    // bound for BE evaluation. analyzeAndCastFold ignores slots, so the descriptor bindings are preserved.
+    private static Expr rewriteAndAnalyze(Expr expr, Map<String, SlotDescriptor> nameToSlot) {
+        expr = bindBaseSlots(expr, nameToSlot);
+        return Expr.analyzeAndCastFold(expr);
+    }
+
+    // Recursively rebind base-column SlotRef leaves to the base output-tuple slot descriptors.
+    private static Expr bindBaseSlots(Expr expr, Map<String, SlotDescriptor> nameToSlot) {
+        if (expr instanceof SlotRef) {
+            String col = ((SlotRef) expr).getColumnName();
+            SlotDescriptor sd = col == null ? null : nameToSlot.get(col.toLowerCase());
+            if (sd == null) {
+                throw new SemanticException("logical sink MV references unknown base column '" + col + "'");
+            }
+            SlotRef ref = new SlotRef(sd);
+            ref.setColumnName(col);
+            return ref;
+        }
+        List<Expr> children = expr.getChildren();
+        for (int i = 0; i < children.size(); i++) {
+            expr.setChild(i, bindBaseSlots(children.get(i), nameToSlot));
+        }
+        return expr;
+    }
+
+    // Fast path for legacy meta lacking a define statement: one plain SlotRef per recorded base column.
+    private static LogicalSinkExprs plainProjectionExprs(LogicalSinkMVMeta meta,
+                                                         Map<String, SlotDescriptor> nameToSlot) {
+        if (!meta.isPlainProjection()) {
+            return null;
+        }
+        List<TExpr> transformExprs = Lists.newArrayList();
+        for (String baseCol : meta.getProjectBaseColumns()) {
+            SlotDescriptor sd = nameToSlot.get(baseCol.toLowerCase());
+            if (sd == null) {
+                return null;
+            }
+            transformExprs.add(new SlotRef(sd).treeToThrift());
+        }
+        return new LogicalSinkExprs(transformExprs, null);
+    }
+
     public void setMissAutoIncrementColumn() {
         this.missAutoIncrementColumn = true;
     }
@@ -305,6 +543,10 @@ public class OlapTableSink extends DataSink {
                 enableAutomaticPartition, automaticBucketSize, getOpenPartitions());
         tSink.setPartition(partitionParam);
         tSink.setLocation(createLocation(dstTable, partitionParam, enableReplicatedStorage, warehouseId));
+        // CK-compatible TO-table MVs: secondary sinks built at plan time; the BE fans rows out to each.
+        if (logicalSinks != null && !logicalSinks.isEmpty()) {
+            tSink.setLogical_sinks(logicalSinks);
+        }
         tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(warehouseId,
                 getSystemInfoService(dstTable)));
         tSink.setPartial_update_mode(this.partialUpdateMode);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -77,6 +77,7 @@ import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.LogicalSinkMVMeta;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -152,6 +153,7 @@ import com.starrocks.persist.DropPartitionsInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.ListPartitionPersistInfo;
+import com.starrocks.persist.LogicalSinkMVOpLog;
 import com.starrocks.persist.ModifyColumnCommentLog;
 import com.starrocks.persist.ModifyPartitionInfo;
 import com.starrocks.persist.ModifyTableColumnOperationLog;
@@ -211,6 +213,7 @@ import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.IntervalLiteral;
+import com.starrocks.sql.ast.MVColumnItem;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.PartitionRenameClause;
@@ -2960,9 +2963,110 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             olapTable.checkStableAndNormal();
 
-            materializedViewHandler.processCreateMaterializedView(stmt, db, olapTable);
+            if (stmt.isLogicalSinkMV()) {
+                // CK-compatible `... TO <table>`: register a write-triggered transformation rule on the
+                // base table. No rollup index / tablets are created and no historical data is backfilled.
+                createLogicalSinkMaterializedView(stmt, db, olapTable);
+            } else {
+                materializedViewHandler.processCreateMaterializedView(stmt, db, olapTable);
+            }
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), LockType.WRITE);
+        }
+    }
+
+    // Register a CK-compatible logical sink MV (`CREATE MATERIALIZED VIEW ... TO <table>`) on the base
+    // table. Called while holding the base table's WRITE lock. Persists the binding via the edit log;
+    // the actual incremental maintenance happens on the load path (OlapTableSink fan-out), so there is
+    // no rollup job and no historical backfill (matching ClickHouse TO-table semantics).
+    private void createLogicalSinkMaterializedView(CreateMaterializedViewStmt stmt, Database db, OlapTable baseTable)
+            throws DdlException {
+        if (baseTable.getLogicalSinkMVs().size() >= Config.max_mv_to_table_per_base_table) {
+            throw new DdlException("Too many TO-table materialized views on base table '" + baseTable.getName()
+                    + "' (limit " + Config.max_mv_to_table_per_base_table + ", see Config.max_mv_to_table_per_base_table)");
+        }
+        OlapTable targetTable = stmt.getToTable();
+        if (targetTable == null) {
+            throw new DdlException("Target table is not resolved for logical sink MV '" + stmt.getMVName() + "'");
+        }
+        for (LogicalSinkMVMeta existing : baseTable.getLogicalSinkMVs().values()) {
+            if (existing.getMvName().equalsIgnoreCase(stmt.getMVName())) {
+                throw new DdlException("Materialized view '" + stmt.getMVName() + "' already exists on table '"
+                        + baseTable.getName() + "'");
+            }
+        }
+
+        long mvId = GlobalStateMgr.getCurrentState().getNextId();
+        String defineStmt = stmt.getOrigStmt() == null ? null : stmt.getOrigStmt().originStmt;
+        LogicalSinkMVMeta meta = new LogicalSinkMVMeta(mvId, stmt.getMVName(), db.getId(), baseTable.getId(),
+                targetTable.getId(), defineStmt);
+        // Phase-1 write-path mapping: record, per output column (in SELECT order), the base column it
+        // projects from when the item is a plain column reference; "" for scalar/JSON exprs.
+        List<String> projectBaseColumns = Lists.newArrayList();
+        for (MVColumnItem item : stmt.getMVColumnItemList()) {
+            Expr define = item.getDefineExpr();
+            if (define instanceof SlotRef) {
+                projectBaseColumns.add(((SlotRef) define).getColumnName());
+            } else {
+                projectBaseColumns.add("");
+            }
+        }
+        meta.setProjectBaseColumns(projectBaseColumns);
+        baseTable.addLogicalSinkMV(meta);
+
+        GlobalStateMgr.getCurrentState().getEditLog().logCreateLogicalSinkMV(
+                LogicalSinkMVOpLog.forCreate(db.getId(), baseTable.getId(), meta));
+        LOG.info("create logical sink MV {} (id={}) on base table {} -> target table {}",
+                stmt.getMVName(), mvId, baseTable.getName(), targetTable.getName());
+    }
+
+    public void replayCreateLogicalSinkMV(LogicalSinkMVOpLog info) {
+        Database db = getDb(info.getDbId());
+        if (db == null || info.getMeta() == null) {
+            return;
+        }
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            Table table = getTable(info.getDbId(), info.getBaseTableId());
+            if (table instanceof OlapTable) {
+                ((OlapTable) table).addLogicalSinkMV(info.getMeta());
+            }
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
+        }
+    }
+
+    // Drop a logical sink (TO-table) MV registered on baseTable: remove the metadata and journal it.
+    // The target table itself is user-managed and is NOT dropped here.
+    public void dropLogicalSinkMaterializedView(Database db, OlapTable baseTable, LogicalSinkMVMeta meta) {
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            baseTable.removeLogicalSinkMV(meta.getMvId());
+            GlobalStateMgr.getCurrentState().getEditLog().logDropLogicalSinkMV(
+                    LogicalSinkMVOpLog.forDrop(db.getId(), baseTable.getId(), meta.getMvId()));
+            LOG.info("drop logical sink MV {} (id={}) on base table {}",
+                    meta.getMvName(), meta.getMvId(), baseTable.getName());
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
+        }
+    }
+
+    public void replayDropLogicalSinkMV(LogicalSinkMVOpLog info) {
+        Database db = getDb(info.getDbId());
+        if (db == null) {
+            return;
+        }
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            Table table = getTable(info.getDbId(), info.getBaseTableId());
+            if (table instanceof OlapTable) {
+                ((OlapTable) table).removeLogicalSinkMV(info.getMvId());
+            }
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -449,6 +449,12 @@ public class InsertPlanner {
                     Load.checkMergeCondition(insertStmt.getMergingCondition(), olapTable, outputFullSchema,
                             ((OlapTableSink) dataSink).missAutoIncrementColumn());
                     olapTableSink.init(session.getExecutionId(), insertStmt.getTxnId(), db.getId(), session.getExecTimeout());
+                    // CK-compatible TO-table MVs: build the secondary sinks here (DescriptorTable is in
+                    // scope) so the base load fans transformed rows out to each target table.
+                    if (olapTable.hasLogicalSinkMV()) {
+                        olapTableSink.setLogicalSinks(OlapTableSink.buildLogicalSinks(
+                                db.getId(), olapTable, tupleDesc, descriptorTable, session.getCurrentWarehouseId()));
+                    }
                     olapTableSink.complete(insertStmt.getMergingCondition());
                 } catch (StarRocksException e) {
                     throw new SemanticException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.LogicalSinkMVMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.catalog.Table;
@@ -588,9 +589,24 @@ public class StatementPlanner {
         } else {
             long warehouseId = session.getCurrentWarehouseId();
             long dbId = db.getId();
+            // For TO-table MVs (CREATE MATERIALIZED VIEW ... TO <table>), a load into the base table
+            // fans out into each MV's target table within the SAME transaction. The target tables must
+            // therefore be part of the txn so their tablets are committed and published together.
+            List<Long> txnTableIds = Lists.newArrayList(targetTable.getId());
+            List<OlapTable> sinkTargetTables = Lists.newArrayList();
+            if (targetTable instanceof OlapTable && ((OlapTable) targetTable).hasLogicalSinkMV()) {
+                for (LogicalSinkMVMeta meta : ((OlapTable) targetTable).getLogicalSinkMVs().values()) {
+                    Table tgt = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(dbId, meta.getTargetTableId());
+                    if (tgt instanceof OlapTable && !txnTableIds.contains(tgt.getId())) {
+                        txnTableIds.add(tgt.getId());
+                        sinkTargetTables.add((OlapTable) tgt);
+                    }
+                }
+            }
             txnId = transactionMgr.beginTransaction(
                     dbId,
-                    Lists.newArrayList(targetTable.getId()),
+                    txnTableIds,
                     label,
                     new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
                             FrontendOptions.getLocalHostAddress()),
@@ -602,6 +618,9 @@ public class StatementPlanner {
             if (targetTable instanceof OlapTable) {
                 TransactionState txnState = transactionMgr.getTransactionState(dbId, txnId);
                 txnState.addTableIndexes((OlapTable) targetTable);
+                for (OlapTable sinkTargetTable : sinkTargetTables) {
+                    txnState.addTableIndexes(sinkTargetTable);
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -51,8 +51,11 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PrimitiveType;
@@ -61,11 +64,13 @@ import com.starrocks.catalog.Type;
 import com.starrocks.catalog.View;
 import com.starrocks.catalog.combinator.AggStateDesc;
 import com.starrocks.catalog.combinator.AggStateUnionCombinator;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -134,6 +139,13 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     private final TableName mvTableName;
     private final Map<String, String> properties;
 
+    // CK-compatible `CREATE MATERIALIZED VIEW ... TO <table>`: when non-null, this is a logical
+    // sink MV whose transformed rows are written into an existing user-managed table instead of
+    // being stored as a rollup index on the base table. The MV itself holds no storage.
+    private TableName toTableName;
+    // Target table resolved during analyze() when isLogicalSinkMV() is true.
+    private OlapTable toTable;
+
     private final QueryStatement queryStatement;
     /**
      * origin stmt: select k1, k2, v1, sum(v2) from base_table group by k1, k2, v1
@@ -177,6 +189,24 @@ public class CreateMaterializedViewStmt extends DdlStmt {
 
     public String getMVName() {
         return mvTableName.getTbl();
+    }
+
+    public TableName getToTableName() {
+        return toTableName;
+    }
+
+    public void setToTableName(TableName toTableName) {
+        this.toTableName = toTableName;
+    }
+
+    // True when this is a logical sink MV created via `... TO <table>` (CK TO-table semantics).
+    public boolean isLogicalSinkMV() {
+        return toTableName != null;
+    }
+
+    // Resolved target table; non-null only after analyze() of a logical sink MV.
+    public OlapTable getToTable() {
+        return toTable;
     }
 
     public List<MVColumnItem> getMVColumnItemList() {
@@ -372,6 +402,92 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         }
         // analyze table if it has alias
         analyzeExprWithTableAlias(context, this.dbName, table, getMVColumnItemList());
+
+        // CK-compatible `... TO <table>`: validate the existing target table against the MV output.
+        if (isLogicalSinkMV()) {
+            analyzeToTable(context, (OlapTable) table);
+        }
+    }
+
+    // Validate a CK-compatible `... TO <table>` (logical sink) MV: the target table must already
+    // exist as an OLAP table, the MV's produced columns must align with the target schema by
+    // position/type, and (Phase 1) the target distribution must allow node-local routing without a
+    // shuffle, i.e. it is RANDOM-distributed or hash-distributed identically to the base table.
+    private void analyzeToTable(ConnectContext context, OlapTable baseTable) {
+        if (!Config.enable_mv_to_table) {
+            throw new SemanticException("CREATE MATERIALIZED VIEW ... TO <table> is disabled. " +
+                    "Set FE config 'enable_mv_to_table' = true to enable it.");
+        }
+
+        String targetDbName = Strings.isNullOrEmpty(toTableName.getDb()) ? dbName : toTableName.getDb();
+        // The logical sink MV is maintained on the base table's write path; keep the target table in
+        // the same database as the base table to avoid cross-db write coupling (Phase 1 limit).
+        if (!Strings.isNullOrEmpty(targetDbName) && !Strings.isNullOrEmpty(dbName)
+                && !targetDbName.equalsIgnoreCase(dbName)) {
+            throw new SemanticException(String.format(
+                    "TO target table's db '%s' must be the same as the base table's db '%s'",
+                    targetDbName, dbName));
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(targetDbName);
+        if (db == null) {
+            throw new SemanticException("Target table's database '" + targetDbName + "' does not exist");
+        }
+        Table target = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(targetDbName, toTableName.getTbl());
+        if (target == null) {
+            throw new SemanticException(String.format(
+                    "Target table '%s.%s' does not exist; create the target table before the materialized view " +
+                            "(TO-table MV does not create the target table)", targetDbName, toTableName.getTbl()));
+        }
+        if (!(target instanceof OlapTable)) {
+            throw new SemanticException("Target table '" + toTableName.getTbl() + "' must be an OLAP table");
+        }
+        OlapTable targetTable = (OlapTable) target;
+
+        // Column alignment: the MV's produced columns (SELECT output, in order) are written into the
+        // target table; require equal count and per-column implicit castability.
+        List<MVColumnItem> items = getMVColumnItemList();
+        List<Column> targetColumns = targetTable.getBaseSchema();
+        if (items.size() != targetColumns.size()) {
+            throw new SemanticException(String.format(
+                    "Column count mismatch: materialized view produces %d columns but target table '%s' has %d columns",
+                    items.size(), targetTable.getName(), targetColumns.size()));
+        }
+        for (int i = 0; i < items.size(); i++) {
+            Type srcType = items.get(i).getType();
+            Type dstType = targetColumns.get(i).getType();
+            if (srcType == null || dstType == null) {
+                continue;
+            }
+            if (!srcType.matchesType(dstType) && !Type.canCastTo(srcType, dstType)) {
+                throw new SemanticException(String.format(
+                        "Column %d type mismatch: materialized view produces %s but target column '%s' is %s",
+                        i + 1, srcType.toSql(), targetColumns.get(i).getName(), dstType.toSql()));
+            }
+        }
+
+        // Distribution constraint (Phase 1): avoid cross-node shuffle when fanning rows out to the
+        // target. Allowed when the target is RANDOM-distributed, or hash-distributed identically to
+        // the base table (same distribution columns and bucket number).
+        DistributionInfo baseDist = baseTable.getDefaultDistributionInfo();
+        DistributionInfo targetDist = targetTable.getDefaultDistributionInfo();
+        if (targetDist.getType() != DistributionInfo.DistributionInfoType.RANDOM) {
+            boolean sameHash = baseDist instanceof HashDistributionInfo
+                    && targetDist instanceof HashDistributionInfo
+                    && ((HashDistributionInfo) targetDist).getBucketNum()
+                            == ((HashDistributionInfo) baseDist).getBucketNum()
+                    && ((HashDistributionInfo) targetDist).getDistributionColumns()
+                            .equals(((HashDistributionInfo) baseDist).getDistributionColumns());
+            if (!sameHash) {
+                throw new SemanticException(String.format(
+                        "Target table '%s' distribution is not supported for TO-table MV (Phase 1): it must be " +
+                                "RANDOM-distributed, or hash-distributed identically to the base table '%s' " +
+                                "(same distribution columns and bucket number) to avoid a shuffle",
+                        targetTable.getName(), baseTable.getName()));
+            }
+        }
+
+        this.toTable = targetTable;
     }
 
     private void analyzeExprWithTableAlias(ConnectContext context,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2005,6 +2005,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         QualifiedName qualifiedName = getQualifiedName(context.mvName);
         TableName tableName = qualifiedNameToTableName(qualifiedName);
 
+        // CK-compatible `... TO <table>`: target table the logical sink MV writes into.
+        TableName toTableName = context.toTableName == null ? null :
+                qualifiedNameToTableName(getQualifiedName(context.toTableName));
+
         List<ColWithComment> colWithComments = null;
         if (!context.columnNameWithComment().isEmpty()) {
             colWithComments = visit(context.columnNameWithComment(), ColWithComment.class);
@@ -2104,7 +2108,15 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 throw new ParsingException(PARSER_ERROR_MSG.forbidClauseInMV("SYNC refresh type", "DISTRIBUTION BY"),
                         distributionDesc.getPos());
             }
-            return new CreateMaterializedViewStmt(tableName, queryStatement, properties);
+            CreateMaterializedViewStmt syncMvStmt = new CreateMaterializedViewStmt(tableName, queryStatement, properties);
+            syncMvStmt.setToTableName(toTableName);
+            return syncMvStmt;
+        }
+        // `TO <table>` is only supported on the synchronous (write-triggered) MV path. Any clause
+        // (e.g. DISTRIBUTION/REFRESH) that routes to an asynchronous MV is incompatible with TO.
+        if (toTableName != null) {
+            throw new ParsingException(PARSER_ERROR_MSG.forbidClauseInMV("ASYNC materialized view", "TO clause"),
+                    createPos(context));
         }
         if (refreshSchemeDesc instanceof AsyncRefreshSchemeDesc) {
             AsyncRefreshSchemeDesc asyncRefreshSchemeDesc = (AsyncRefreshSchemeDesc) refreshSchemeDesc;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -679,6 +679,7 @@ createMaterializedViewStatement
     : CREATE MATERIALIZED VIEW (IF NOT EXISTS)? mvName=qualifiedName
     ('(' columnNameWithComment (',' columnNameWithComment)* (',' indexDesc)* ')')?
     comment?
+    (TO toTableName=qualifiedName)?
     materializedViewDesc*
     AS queryStatement
     ;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/MaterializedViewToTableParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/MaterializedViewToTableParserTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.StatementBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Parser-level tests for CK-compatible {@code CREATE MATERIALIZED VIEW ... TO <table>} (logical sink MV).
+ */
+public class MaterializedViewToTableParserTest {
+
+    private static StatementBase parseOne(String sql) {
+        return SqlParser.parse(sql, new SessionVariable()).get(0);
+    }
+
+    @Test
+    public void testParseToTableRoutesToSyncMvWithTarget() {
+        String sql = "CREATE MATERIALIZED VIEW test_mv TO test_db.target_tbl AS " +
+                "SELECT k1, sum(v1) FROM test_db.base_tbl GROUP BY k1";
+        StatementBase stmt = parseOne(sql);
+        Assertions.assertTrue(stmt instanceof CreateMaterializedViewStmt,
+                "TO-table MV should route to the synchronous CreateMaterializedViewStmt");
+        CreateMaterializedViewStmt mvStmt = (CreateMaterializedViewStmt) stmt;
+        Assertions.assertTrue(mvStmt.isLogicalSinkMV());
+        Assertions.assertNotNull(mvStmt.getToTableName());
+        Assertions.assertEquals("target_tbl", mvStmt.getToTableName().getTbl());
+        Assertions.assertEquals("test_db", mvStmt.getToTableName().getDb());
+    }
+
+    @Test
+    public void testParseToTableWithoutDb() {
+        String sql = "CREATE MATERIALIZED VIEW test_mv TO target_tbl AS SELECT k1 FROM base_tbl";
+        CreateMaterializedViewStmt mvStmt = (CreateMaterializedViewStmt) parseOne(sql);
+        Assertions.assertTrue(mvStmt.isLogicalSinkMV());
+        Assertions.assertEquals("target_tbl", mvStmt.getToTableName().getTbl());
+    }
+
+    @Test
+    public void testRegularSyncMvHasNoToTable() {
+        String sql = "CREATE MATERIALIZED VIEW test_mv AS SELECT k1, sum(v1) FROM base_tbl GROUP BY k1";
+        StatementBase stmt = parseOne(sql);
+        Assertions.assertTrue(stmt instanceof CreateMaterializedViewStmt);
+        Assertions.assertFalse(((CreateMaterializedViewStmt) stmt).isLogicalSinkMV());
+        Assertions.assertNull(((CreateMaterializedViewStmt) stmt).getToTableName());
+    }
+
+    @Test
+    public void testToTableWithAsyncClauseIsRejected() {
+        // DISTRIBUTION routes to the asynchronous MV path, which is incompatible with TO.
+        String sql = "CREATE MATERIALIZED VIEW test_mv TO target_tbl " +
+                "DISTRIBUTED BY HASH(k1) REFRESH ASYNC AS SELECT k1 FROM base_tbl";
+        Assertions.assertThrows(Exception.class, () -> parseOne(sql));
+    }
+}

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -204,6 +204,25 @@ struct TDictionaryCacheSink {
     6: optional i32 key_size
 }
 
+// CK-compatible logical sink MV (`CREATE MATERIALIZED VIEW ... TO <table>`): a secondary sink that,
+// for each chunk written to the base table, applies an optional predicate and per-column transform
+// expressions and writes the resulting rows into an existing target OLAP table within the same
+// load transaction. Carried alongside the base TOlapTableSink and fanned out on the BE.
+struct TOlapTableLogicalSink {
+    1: optional i64 mv_id
+    2: optional string mv_name
+    3: optional i64 target_table_id
+    4: optional Descriptors.TOlapTableSchemaParam schema
+    5: optional Descriptors.TOlapTablePartitionParam partition
+    6: optional Descriptors.TOlapTableLocationParam location
+    // Per target column, the expression evaluated over the base chunk (in target column order).
+    7: optional list<Exprs.TExpr> transform_exprs
+    // Optional WHERE predicate evaluated over the base chunk; rows failing it are not sinked.
+    8: optional Exprs.TExpr where_predicate
+    9: optional Types.TKeysType keys_type
+    10: optional i32 tuple_id
+}
+
 struct TOlapTableSink {
     1: required Types.TUniqueId load_id
     2: required i64 txn_id
@@ -238,6 +257,9 @@ struct TOlapTableSink {
     30: optional bool ignore_out_of_partition
     31: optional binary encryption_meta;
     32: optional bool dynamic_overwrite
+    // CK-compatible TO-table MVs attached to the base table; each writes transformed rows into its
+    // own target table within the same load transaction as the base write.
+    33: optional list<TOlapTableLogicalSink> logical_sinks
 }
 
 struct TSchemaTableSink {


### PR DESCRIPTION
…TO <table>

Add a logical-sink (TO-table) materialized view. On every load into the base table, rows are filtered and transformed by the MV's SELECT (scalar / JSON / conditional expressions + optional WHERE) and written into a pre-existing, user-managed target table within the same load transaction. The MV holds no storage of its own (no rollup index, no tablets) and does not backfill history, matching ClickHouse TO-table semantics.

Syntax: one optional `(TO toTableName=qualifiedName)?` clause on the existing CREATE MATERIALIZED VIEW statement, reusing the synchronous-MV parser/analyzer (`TO` is already a lexer token). When TO is present the MV is a logical sink.

FE: OlapTableSink.buildLogicalSinks() compiles per-target-column transform expressions and the optional WHERE predicate from the persisted define statement, binds column refs to the base sink output tuple, and serializes them into TOlapTableLogicalSink. StatementPlanner includes the target tables in the load transaction so their rowsets publish atomically with the base write. DROP MATERIALIZED VIEW and edit-log persistence/replay are supported.

BE: OlapTableSink builds one child sink per logical sink (separate child load_id, shared txn_id), evaluates the WHERE predicate over the base chunk without mutating it, and forwards only passing rows; the child applies the transform expressions as its output exprs and writes into the target table.

Unsupported and rejected at CREATE time: CTE/UNION, join/subquery, aggregation, SELECT *. Row-wise per-block transformation only.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

