### PR TITLE
[Doc] Clarify that table-level flat_json properties take effect at table creation time

### DIFF
--- a/docs/en/using_starrocks/Flat_json.md
+++ b/docs/en/using_starrocks/Flat_json.md
@@ -70,17 +70,6 @@ Setting Flat JSON-related properties on table level is supported from v4.0 onwar
 
 1. When creating the table, you can set `flat_json.enable` and other Flat JSON-related properties. For detailed instructions, see [CREATE TABLE](../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-flat-json-properties-on-table-level).
 
-   Alternatively, you can set these properties using [ALTER TABLE](../sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md).
-
-   Example:
-
-   ```SQL
-   ALTER TABLE t1 SET ("flat_json.enable" = "true");
-   ALTER TABLE t1 SET ("flat_json.null.factor" = "0.1");
-   ALTER TABLE t1 SET ("flat_json.sparsity.factor" = "0.8");
-   ALTER TABLE t1 SET ("flat_json.column.max" = "90");
-   ```
-
 2. Enable FE pruning feature:
 
    ```SQL
@@ -232,6 +221,7 @@ SET cbo_json_v2_dict_opt = true;
 - Enabling Flat JSON will increase the time taken to load JSON. The more JSON extracted, the longer it takes.
 - Flat JSON can only support materializing common keys in JSON Objects, not keys in JSON Arrays.
 - Flat JSON does not change the data sorting method, so query performance and data compression rate will still be affected by data sorting. To achieve optimal performance, further adjustments to data sorting may be necessary.
+- Table-level Flat JSON properties (`flat_json.*`) take effect only when set at table creation time.
 
 ## Version Notes
 

--- a/docs/ja/using_starrocks/Flat_json.md
+++ b/docs/ja/using_starrocks/Flat_json.md
@@ -69,17 +69,6 @@ v4.0 以降では、この機能はテーブルレベルで設定可能です。
 
 1. テーブルを作成する際、`flat_json.enable` を含む Flat JSON に関連するプロパティを設定できます。詳細な手順については、[CREATE TABLE](../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#テーブルレベルの-flat-json-プロパティを設定) を参照してください。
 
-   または、これらのプロパティを [ALTER TABLE](../sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md) を使用して設定することもできます。
-
-   例：
-
-   ```SQL
-   ALTER TABLE t1 SET ("flat_json.enable" = "true");
-   ALTER TABLE t1 SET ("flat_json.null.factor" = "0.1");
-   ALTER TABLE t1 SET ("flat_json.sparsity.factor" = "0.8");
-   ALTER TABLE t1 SET ("flat_json.column.max" = "90");
-   ```
-
 2. FE プルーニング機能を有効化します：
 
    ```SQL
@@ -231,6 +220,7 @@ SET cbo_json_v2_dict_opt = true;
 - Flat JSON を有効にすると、JSON のロードにかかる時間が増加します。抽出される JSON が多いほど、時間がかかります。
 - Flat JSON は JSON オブジェクト内の共通キーのみをマテリアライズすることをサポートし、JSON 配列内のキーはサポートしません。
 - Flat JSON はデータのソート方法を変更しないため、クエリパフォーマンスとデータ圧縮率はデータのソートによって影響を受け続けます。最適なパフォーマンスを達成するためには、データソートのさらなる調整が必要な場合があります。
+- テーブルレベルの Flat JSON プロパティ（`flat_json.*`）は、テーブル作成時に設定した場合にのみ有効になります。
 
 ## バージョンノート
 

--- a/docs/zh/using_starrocks/Flat_json.md
+++ b/docs/zh/using_starrocks/Flat_json.md
@@ -69,17 +69,6 @@ Flat JSON的核心原理是在导入时检测JSON数据，并从JSON数据中提
 
 1. 在创建表时，您可以设置 `flat_json.enable` 及其他与 Flat JSON 相关的属性。如需详细说明，请参阅 [CREATE TABLE](../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#在表级别设置-flat-json-属性)。
 
-   或者，您可以使用 [ALTER TABLE](../sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md) 语句设置这些属性。
-
-   示例：
-
-   ```SQL
-   ALTER TABLE t1 SET ("flat_json.enable" = "true");
-   ALTER TABLE t1 SET ("flat_json.null.factor" = "0.1");
-   ALTER TABLE t1 SET ("flat_json.sparsity.factor" = "0.8");
-   ALTER TABLE t1 SET ("flat_json.column.max" = "90");
-   ```
-
 2. 启用FE分区裁剪功能：
 
    ```SQL
@@ -231,6 +220,7 @@ SET cbo_json_v2_dict_opt = true;
 - 启用Flat JSON会增加JSON的导入时间，提取的JSON越多，所需时间越长。
 - Flat JSON仅支持物化JSON对象中的常用键，不支持JSON数组中的键。
 - Flat JSON不改变数据排序方式，因此查询性能和数据压缩率仍会受到数据排序的影响。为了达到最佳性能，可能需要进一步调整数据排序。
+- 表级 Flat JSON 属性（`flat_json.*`）仅在建表时设置才会生效。
 
 ## 版本说明
 


### PR DESCRIPTION
## Why I'm doing

Table-level Flat JSON properties (`flat_json.*`) currently take effect only when they are set at
table-creation time. The docs presented `ALTER TABLE ... SET ("flat_json.*" = ...)` as an
alternative way to set them, which is misleading because that path is not effective on an
existing table. This change makes the docs match the current behavior.

For background, see #73846 and #74747.

## What I'm doing

- Remove the table-level `ALTER TABLE` flat_json example from the "Enable Flat JSON on table level"
  section, since it does not take effect.
- Add an entry under "Feature Limitations": table-level `flat_json.*` properties take effect only
  when set at table creation time.
- Updated in all three language docs (en / zh / ja).

## Relationship with #74747 / #73846

If #74747 (or any change that makes `ALTER TABLE` propagation effective) lands, this constraint no
longer holds. In that case this PR should be closed (or reverted) and the `ALTER TABLE` example
restored, so the docs match the new behavior.

## Checklist
- [x] Documentation only — `docs/en|zh|ja/using_starrocks/Flat_json.md` updated in sync