### PR TITLE
[BugFix] Fix flaky AND-only MATCH queries

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3628,6 +3628,8 @@ Status SegmentIterator::_init_global_dict_decoder() {
 }
 
 Status SegmentIterator::_rewrite_predicates() {
+    RETURN_IF(_scan_range.empty(), Status::OK());
+
     {
         // in normal case it can always rewrite the predicate,
         // but for JSON extended column, it might be a JsonExtractColumnIterator, so we need to fallback to the orignal predicate


### PR DESCRIPTION
## Why I'm doing:
Starrocks would sometimes return `Match can only used as a pushdown predicate on column with GIN in a single query.` error for valid AND-only MATCH queries. The same query would also sometimes succeed.

This flaky behaviour was due to the error only occurring when a segment was empty (either initialized empty or after being pruned by ranges/bitmap/indices/sampling/etc.)

If the segment was empty, we would skip deleting the MATCH predicate during `_apply_inverted_index` and proceed to `_rewrite_predicates` which would then see the MATCH predicate and cause the error.

## What I'm doing:
Check if the segment is empty before attempting rewriting the predicates.
If the segment is empty, we don't need to rewrite because there are no rows anyways.

With this fix, it is possible that an invalid MATCH query would return 0 rows instead of raising an error.
This case would be very rare because it would require all segments to be empty after pruning, so we would never attempt predicate rewriting + raise the MATCH error. 

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
