### PR TITLE
[BugFix] Make ADLS2 ListPaths tolerate non-HNS accounts (CN SIGSEGV + vacuum failure)

### DIFF
--- a/thirdparty/patches/azure-storage-files-shares_12.12.0.patch
+++ b/thirdparty/patches/azure-storage-files-shares_12.12.0.patch
@@ -52,3 +52,60 @@ index fcc5b35fa..1883fec05 100644
  endif()
  
  target_include_directories(
+
+diff --git a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+index e82c1d6..06394dc 100644
+--- a/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
++++ b/sdk/storage/azure-storage-files-datalake/src/datalake_file_system_client.cpp
+@@ -299,12 +299,18 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
+       item.EncryptionScope = std::move(path.EncryptionScope);
+       item.EncryptionContext = std::move(path.EncryptionContext);
+       item.ETag = std::move(path.ETag);
+-      if (path.CreatedOn.HasValue())
++      // StarRocks patch (issue #74961): on non-HNS accounts creationTime/expiryTime
++      // are returned as RFC1123 date strings, not Win32 FILETIME ticks, so std::stoll
++      // throws std::invalid_argument. Only convert when the value is numeric ticks;
++      // otherwise leave it unset.
++      if (path.CreatedOn.HasValue() && !path.CreatedOn.Value().empty()
++          && path.CreatedOn.Value().find_first_not_of("0123456789") == std::string::npos)
+       {
+         item.CreatedOn = _detail::Win32FileTimeConverter::Win32FileTimeToDateTime(
+             std::stoll(path.CreatedOn.Value()));
+       }
+-      if (path.ExpiresOn.HasValue() && path.ExpiresOn.Value() != "0")
++      if (path.ExpiresOn.HasValue() && path.ExpiresOn.Value() != "0"
++          && path.ExpiresOn.Value().find_first_not_of("0123456789") == std::string::npos)
+       {
+         item.ExpiresOn = _detail::Win32FileTimeConverter::Win32FileTimeToDateTime(
+             std::stoll(path.ExpiresOn.Value()));
+diff --git a/sdk/storage/azure-storage-files-datalake/src/rest_client.cpp b/sdk/storage/azure-storage-files-datalake/src/rest_client.cpp
+index 8b24eb0..cbae724 100644
+--- a/sdk/storage/azure-storage-files-datalake/src/rest_client.cpp
++++ b/sdk/storage/azure-storage-files-datalake/src/rest_client.cpp
+@@ -110,9 +110,23 @@ namespace Azure { namespace Storage { namespace Files { namespace DataLake {
+           vectorElement2.FileSize = var0["contentLength"].is_number_integer()
+               ? var0["contentLength"].get<std::int64_t>()
+               : std::stoll(var0["contentLength"].get<std::string>());
+-          vectorElement2.Owner = var0["owner"].get<std::string>();
+-          vectorElement2.Group = var0["group"].get<std::string>();
+-          vectorElement2.Permissions = var0["permissions"].get<std::string>();
++          // StarRocks patch (issue #74961): owner/group/permissions are POSIX
++          // fields only returned for HNS-enabled accounts. On a flat (non-HNS)
++          // account accessed via the DFS endpoint they are absent; the const
++          // operator[] on a missing key is UB (-> json type_error.302 / SIGSEGV).
++          // Guard them, mirroring the optional fields handled just below.
++          if (var0.count("owner") != 0 && var0["owner"].is_string())
++          {
++            vectorElement2.Owner = var0["owner"].get<std::string>();
++          }
++          if (var0.count("group") != 0 && var0["group"].is_string())
++          {
++            vectorElement2.Group = var0["group"].get<std::string>();
++          }
++          if (var0.count("permissions") != 0 && var0["permissions"].is_string())
++          {
++            vectorElement2.Permissions = var0["permissions"].get<std::string>();
++          }
+           if (var0.count("EncryptionScope") != 0)
+           {
+             vectorElement2.EncryptionScope = var0["EncryptionScope"].get<std::string>();


### PR DESCRIPTION
@kevincai as discussed in #74961, here is the patch

## Why I'm doing:

On a non-HNS account, the `List Paths` response differs from what the DataLake client expects,
and the FE autovacuum (`LakeServiceImpl::vacuum` → `lake::vacuum_txn_log` →
`ADLS2FileSystem::list_dir` → `ListPaths`) hits both:

| Field | HNS (expected) | Non-HNS (actual) | Unguarded result |
|---|---|---|---|
| `owner`/`group`/`permissions` | present (POSIX ACL) | **absent** | const `operator[]` on a missing key is UB → `type_error.302` (`is null`/`is number`/`is binary`) → **SIGSEGV** in `basic_string::_M_assign` |
| `creationTime`/`expiryTime` | FILETIME ticks (numeric) | **RFC1123 date string** | `std::stoll("Wed, 10 Jun 2026 …")` → **`std::invalid_argument`** |

The first issue masks the second in production: `owner` (rest_client.cpp L113) crashes before
`creationTime` is ever reached. So a fix that only guards `owner`/`group`/`permissions` removes
the SIGSEGV but then throws on `creationTime` — the listing still fails. Both guards are needed.

Azure considers the underlying behaviour WONT-FIX (Azure/azure-sdk-for-cpp#3037, closed; guard
PR Azure/azure-sdk-for-cpp#3038 closed, not merged — *"DataLake clients only work for storage
accounts with HNS enabled. Please use blob clients instead."*). StarRocks already vendors a patch
for this exact SDK version, so carrying these guards there is the pragmatic fix and does not
depend on Azure.


## What I'm doing:

Extends the vendored `azure-sdk-for-cpp` patch
(`thirdparty/patches/azure-storage-files-shares_12.12.0.patch`) with **two guards** so that
`DataLakeFileSystemClient::ListPaths` tolerates the response of a **flat-namespace (non-HNS)**
storage account accessed through the DFS endpoint:

1. `src/rest_client.cpp` — read `owner` / `group` / `permissions` only when present and of
   string type (mirroring the existing handling of `isDirectory`, `EncryptionScope`,
   `creationTime`, etc.).
2. `src/datalake_file_system_client.cpp` — convert `creationTime` / `expiryTime` only when the
   value is a numeric FILETIME tick string; otherwise leave it unset.

Fixes #74961

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
