### PR TITLE
[BugFix] Unregister txn-state callback when removing multi-statement stream load task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -582,6 +582,19 @@ public class StreamLoadMgr implements MemoryTrackable {
             }
         }
 
+        // Unregister the txn-state callback that was registered in addLoadTask(), otherwise the task
+        // leaks in TxnStateCallbackFactory forever.
+        // - For an ordinary StreamLoadTask the callback is already removed in afterVisible/afterAborted,
+        //   so this is an idempotent no-op.
+        // - For a StreamLoadMultiStmtTask the explicit transaction carries no callback id, so the parent
+        //   task's afterCommitted/afterVisible/afterAborted are never dispatched and its callback is never
+        //   removed. Without this call every multi-statement stream load would leave one dangling entry
+        //   (and the StreamLoadTask sub-task shells it references) in the callback map permanently.
+        // This is only reached after the task has reached a final state (see checkNeedRemove /
+        // isFinalState in the callers), so the callback is guaranteed to be unneeded here.
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory()
+                .removeCallback(streamLoadTask.getId());
+
         if (streamLoadTask instanceof StreamLoadTask) {
             warehouseLoadStatusInfoBuilder.withRemovedJob((StreamLoadTask) streamLoadTask);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.backup.CatalogMocker;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -33,6 +34,7 @@ import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.transaction.TxnStateCallbackFactory;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -340,6 +342,40 @@ public class StreamLoadManagerTest {
 
         streamLoadManager.cleanSyncStreamLoadTasks();
         Assertions.assertNull(streamLoadManager.getTaskByLabel("sync_label"));
+    }
+
+    // ---- Regression: a multi-statement parent task must unregister its txn-state callback when it
+    // is cleaned up. The explicit transaction carries no callback id, so the parent's
+    // afterCommitted/afterVisible/afterAborted are never dispatched and never remove the callback;
+    // without removal in unprotectedRemoveTaskFromDb every multi-statement stream load leaks one
+    // entry (and the sub-task shells it references) in TxnStateCallbackFactory forever. ----
+    @Test
+    public void testMultiStmtTaskRemovesTxnCallbackOnCleanup() throws StarRocksException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+        TxnStateCallbackFactory callbackFactory = globalTransactionMgr.getCallbackFactory();
+
+        TransactionResult beginResp = new TransactionResult();
+        streamLoadManager.beginMultiStatementLoadTask(
+                CatalogMocker.TEST_DB_NAME, "leak_label", "", "127.0.0.1",
+                100000L, beginResp, WarehouseManager.DEFAULT_RESOURCE);
+
+        AbstractStreamLoadTask task = streamLoadManager.getTaskByLabel("leak_label");
+        Assertions.assertNotNull(task);
+        long taskId = task.getId();
+        // The parent task is registered as a txn-state callback when it is created.
+        Assertions.assertNotNull(callbackFactory.getCallback(taskId));
+
+        // Drive the task to a final state so cleanup is allowed to remove it.
+        Deencapsulation.setField(task, "state", StreamLoadMultiStmtTask.State.COMMITED);
+        Deencapsulation.setField(task, "endTimeMs",
+                System.currentTimeMillis() - (Config.stream_load_task_keep_max_second * 1000L + 10000));
+
+        streamLoadManager.cleanOldStreamLoadTasks(true);
+
+        // The task is removed from the manager...
+        Assertions.assertNull(streamLoadManager.getTaskByLabel("leak_label"));
+        // ...and crucially its txn-state callback must be unregistered too (this is the leak fix).
+        Assertions.assertNull(callbackFactory.getCallback(taskId));
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

Multi-statement stream load leaks one entry in `TxnStateCallbackFactory` per transaction, growing without bound until the FE runs out of heap.

The parent `StreamLoadMultiStmtTask` is registered as a transaction-state callback in `StreamLoadMgr.addLoadTask` → `getCallbackFactory().addCallback(task)`. But the explicit transaction created by `TransactionStmtExecutor.beginStmt` carries **no callback id** (only the per-statement `InsertLoadJob` jobIds are added via `addCallbackId`). Therefore `TransactionState.afterStateTransform` never dispatches to the parent — its `afterCommitted` / `afterVisible` / `afterAborted` (which only delegate to sub-tasks) are never invoked, and the parent's callback is **never removed**.

`TxnStateCallbackFactory` is a plain `HashMap` with no expiry/sweep, and `unprotectedRemoveTaskFromDb` (the place every final-state task removal goes through) did not remove the callback. So:

- `idToStreamLoadTask` is bounded by `stream_load_task_keep_max_num`, but the callback map is **not** — it grows monotonically, one entry per multi-statement transaction, forever.
- Each leaked entry pins the parent task, its `ConnectContext` (which holds a full `SessionVariable`, ~520 fields — never nulled) and the sub-task `StreamLoadTask` shells. ~10–25 KB per leak in the common case, unbounded in count.
- The `TxnCallbackCount` memory-tracker metric was observed climbing past 46k entries (~GB-level retained heap) and rising with throughput/uptime.

Ordinary (single-table / sync) stream load is **not** affected — it removes its callback in `afterVisible`/`afterAborted`. Sub-task coordinator memory is already released on current code via `markCommittedByParent(visible) → gcObject()`; this PR only fixes the dangling callback entry.

## What I'm doing:

Remove the callback in `StreamLoadMgr.unprotectedRemoveTaskFromDb`:

```java
GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory()
        .removeCallback(streamLoadTask.getId());
```

`unprotectedRemoveTaskFromDb` is called only from `cleanOldStreamLoadTasks` and `cleanSyncStreamLoadTasks`, both of which only remove tasks that have reached a **final state** (`checkNeedRemove` / `isFinalState`). So the callback is guaranteed to be unneeded at this point. For an ordinary `StreamLoadTask` the callback was already removed at terminal state, so this is an idempotent no-op (`removeCallback` is a guarded `Map.remove`). For the multi-statement parent task it is the actual fix. Callback ids are globally unique (`getNextId`), so there is no risk of evicting a different live object's callback.

This caps the callback map at roughly the number of live stream-load tasks (≤ `stream_load_task_keep_max_num`), turning an unbounded leak into a bounded footprint.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

It only stops an internal memory leak. The removed callback was never dispatched, so no user-observable behavior (load semantics, results, SHOW STREAM LOAD / information_schema.loads display) changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Added `StreamLoadManagerTest#testMultiStmtTaskRemovesTxnCallbackOnCleanup` — a true red/green regression (fails without the fix: `expected <null> but was <StreamLoadMultiStmtTask@...>`; passes with it). All 59 stream-load FE unit tests pass; checkstyle clean.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
