### PR TITLE
[Enhancement] Support native MAP/STRUCT target columns for Avro routine load (backport #74901)

### DIFF
--- a/be/src/exec/file_scanner/avro_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_scanner.cpp
@@ -160,11 +160,15 @@ Status AvroScanner::open() {
     }
     ++_counter->num_files_read;
 
-    for (const auto& desc : _src_slot_descriptors) {
+    for (size_t i = 0; i < _src_slot_descriptors.size(); ++i) {
+        const auto& desc = _src_slot_descriptors[i];
         if (desc == nullptr) {
             continue;
         }
         _slot_desc_dict.emplace(desc->col_name(), desc);
+        // Remember the intermediate avro type per slot so the no-jsonpath path can dispatch
+        // _construct_column on the source column's type rather than the destination type.
+        _slot_id_to_avro_type.emplace(desc->id(), _avro_types[i]);
     }
     _init_data_idx_to_slot_once = false;
     return Status::OK();
@@ -216,8 +220,13 @@ Status AvroScanner::_construct_row(const avro_value_t& avro_value, Chunk* chunk)
         avro_value_t output_value;
         auto st = _extract_field(avro_value, _json_paths[i], &output_value);
         if (LIKELY(st.ok())) {
-            RETURN_IF_ERROR(_construct_column(output_value, column, _src_slot_descriptors[i]->type(),
-                                              _src_slot_descriptors[i]->col_name()));
+            // Dispatch on the intermediate avro type (which matches the source column created in
+            // _create_src_chunk), not the destination type. Otherwise a complex column whose
+            // intermediate type differs from the destination (e.g. MAP<VARCHAR,VARCHAR> vs
+            // MAP<VARCHAR,DATE>) would be written by a writer chosen for the destination and crash
+            // on down_cast. The cast stage converts the intermediate column to the destination type.
+            RETURN_IF_ERROR(
+                    _construct_column(output_value, column, _avro_types[i], _src_slot_descriptors[i]->col_name()));
         } else if (st.is_not_found()) {
             column->append_nulls(1);
         } else {
@@ -354,7 +363,9 @@ Status AvroScanner::_construct_row_without_jsonpath(const avro_value_t& avro_val
             }
             auto slot_desc = itr->second;
             slot_info.id = slot_desc->id();
-            slot_info.type = slot_desc->type();
+            // Store the intermediate avro type (not the destination type) so _construct_column
+            // dispatches on the type the source column was built with. See _construct_row.
+            slot_info.type = _slot_id_to_avro_type[slot_desc->id()];
             slot_info.key = key;
             int column_index = chunk->get_index_by_slot_id(slot_info.id);
             _found_columns[column_index] = true;
@@ -459,6 +470,66 @@ Status AvroScanner::_construct_cast_exprs() {
     return Status::OK();
 }
 
+// Build the intermediate avro load type for a destination slot type. Complex types (ARRAY / MAP /
+// STRUCT) recurse so they are loaded natively; directly-representable scalars are kept as-is and
+// everything else is loaded as VARCHAR(MAX), with the cast stage converting to the destination type
+// (the cast factory supports recursive ARRAY/MAP/STRUCT casts). This mirrors
+// JsonUtils::construct_json_type. Avro map keys are always strings, so a map's intermediate key
+// type is forced to a string type regardless of the destination key type.
+static TypeDescriptor construct_avro_type(const TypeDescriptor& slot_type) {
+    switch (slot_type.type) {
+    case TYPE_ARRAY: {
+        TypeDescriptor avro_type(TYPE_ARRAY);
+        avro_type.children.emplace_back(construct_avro_type(slot_type.children[0]));
+        return avro_type;
+    }
+    case TYPE_MAP: {
+        TypeDescriptor avro_type(TYPE_MAP);
+        const auto& key_type = slot_type.children[0];
+        if (key_type.type == TYPE_CHAR) {
+            avro_type.children.emplace_back(TypeDescriptor::create_char_type(key_type.len));
+        } else if (key_type.type == TYPE_VARCHAR) {
+            avro_type.children.emplace_back(TypeDescriptor::create_varchar_type(key_type.len));
+        } else {
+            avro_type.children.emplace_back(TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH));
+        }
+        avro_type.children.emplace_back(construct_avro_type(slot_type.children[1]));
+        return avro_type;
+    }
+    case TYPE_STRUCT: {
+        TypeDescriptor avro_type(TYPE_STRUCT);
+        avro_type.field_names = slot_type.field_names;
+        for (const auto& child : slot_type.children) {
+            avro_type.children.emplace_back(construct_avro_type(child));
+        }
+        return avro_type;
+    }
+
+    // Treat these types as what they are.
+    case TYPE_FLOAT:
+    case TYPE_DOUBLE:
+    case TYPE_BIGINT:
+    case TYPE_INT:
+    case TYPE_BOOLEAN:
+    case TYPE_SMALLINT:
+    case TYPE_TINYINT:
+        return TypeDescriptor{slot_type.type};
+
+    case TYPE_CHAR:
+        return TypeDescriptor::create_char_type(slot_type.len);
+
+    case TYPE_VARCHAR:
+        return TypeDescriptor::create_varchar_type(slot_type.len);
+
+    case TYPE_JSON:
+        return TypeDescriptor::create_json_type();
+
+    // Treat other types as VARCHAR.
+    default:
+        return TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    }
+}
+
 Status AvroScanner::_construct_avro_types() {
     size_t slot_size = _src_slot_descriptors.size();
     _avro_types.resize(slot_size);
@@ -467,79 +538,7 @@ Status AvroScanner::_construct_avro_types() {
         if (slot_desc == nullptr) {
             continue;
         }
-
-        switch (slot_desc->type().type) {
-        case TYPE_ARRAY: {
-            TypeDescriptor json_type(TYPE_ARRAY);
-            TypeDescriptor* child_type = &json_type;
-
-            const TypeDescriptor* slot_type = &(slot_desc->type().children[0]);
-            while (slot_type->type == TYPE_ARRAY) {
-                slot_type = &(slot_type->children[0]);
-
-                child_type->children.emplace_back(TYPE_ARRAY);
-                child_type = &(child_type->children[0]);
-            }
-
-            // the json lib don't support get_int128_t(), so we load with BinaryColumn and then convert to LargeIntColumn
-            if (slot_type->type == TYPE_FLOAT || slot_type->type == TYPE_DOUBLE || slot_type->type == TYPE_BIGINT ||
-                slot_type->type == TYPE_INT || slot_type->type == TYPE_SMALLINT || slot_type->type == TYPE_TINYINT) {
-                // Treat these types as what they are.
-                child_type->children.emplace_back(slot_type->type);
-            } else if (slot_type->type == TYPE_VARCHAR) {
-                auto varchar_type = TypeDescriptor::create_varchar_type(slot_type->len);
-                child_type->children.emplace_back(varchar_type);
-            } else if (slot_type->type == TYPE_CHAR) {
-                auto char_type = TypeDescriptor::create_char_type(slot_type->len);
-                child_type->children.emplace_back(char_type);
-            } else if (slot_type->type == TYPE_JSON) {
-                child_type->children.emplace_back(TypeDescriptor::create_json_type());
-            } else {
-                // Treat other types as VARCHAR.
-                auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
-                child_type->children.emplace_back(varchar_type);
-            }
-
-            _avro_types[column_pos] = std::move(json_type);
-            break;
-        }
-
-        // Treat these types as what they are.
-        case TYPE_FLOAT:
-        case TYPE_DOUBLE:
-        case TYPE_BIGINT:
-        case TYPE_INT:
-        case TYPE_BOOLEAN:
-        case TYPE_SMALLINT:
-        case TYPE_TINYINT: {
-            _avro_types[column_pos] = TypeDescriptor{slot_desc->type().type};
-            break;
-        }
-
-        case TYPE_CHAR: {
-            auto char_type = TypeDescriptor::create_char_type(slot_desc->type().len);
-            _avro_types[column_pos] = std::move(char_type);
-            break;
-        }
-
-        case TYPE_VARCHAR: {
-            auto varchar_type = TypeDescriptor::create_varchar_type(slot_desc->type().len);
-            _avro_types[column_pos] = std::move(varchar_type);
-            break;
-        }
-
-        case TYPE_JSON: {
-            _avro_types[column_pos] = TypeDescriptor::create_json_type();
-            break;
-        }
-
-        // Treat other types as VARCHAR.
-        default: {
-            auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
-            _avro_types[column_pos] = std::move(varchar_type);
-            break;
-        }
-        }
+        _avro_types[column_pos] = construct_avro_type(slot_desc->type());
     }
     return Status::OK();
 }

--- a/be/src/exec/file_scanner/avro_scanner.h
+++ b/be/src/exec/file_scanner/avro_scanner.h
@@ -97,6 +97,8 @@ private:
     ObjectPool _pool;
     std::shared_ptr<SequentialFile> _file;
     std::unordered_map<std::string_view, SlotDescriptor*> _slot_desc_dict;
+    // Maps each source slot id to its intermediate avro load type (see AvroScanner::_construct_avro_types).
+    std::unordered_map<SlotId, TypeDescriptor> _slot_id_to_avro_type;
     std::vector<bool> _found_columns;
     std::vector<SlotInfo> _data_idx_to_slot;
     std::vector<std::string> _data_idx_to_fieldname;

--- a/be/src/formats/avro/nullable_column.cpp
+++ b/be/src/formats/avro/nullable_column.cpp
@@ -14,14 +14,97 @@
 
 #include "nullable_column.h"
 
+#include <cstring>
+
 #include "column/adaptive_nullable_column.h"
 #include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/map_column.h"
 #include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "formats/json/binary_column.h"
 #include "gutil/strings/substitute.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
+
+// Resolve an avro union to its currently selected branch. Mirrors AvroScanner::_handle_union:
+// loops to peel nested unions; the resolved value may be AVRO_NULL.
+static Status resolve_union(avro_value_t* value) {
+    while (avro_value_get_type(value) == AVRO_UNION) {
+        avro_value_t branch;
+        if (avro_value_get_current_branch(value, &branch) != 0) {
+            return Status::InvalidArgument(strings::Substitute("Cannot get union branch: $0", avro_strerror()));
+        }
+        *value = branch;
+    }
+    return Status::OK();
+}
+
+// Recursive (non-adaptive) value writer used by complex types; defined below.
+static Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                  const avro_value_t& value);
+
+// Populate a MapColumn (the data column of a nullable map) from an avro map value.
+// Avro map keys are always strings, so they are written directly into the key column with a
+// length check; values recurse through add_nullable_column, which unwraps inner unions/nulls.
+static Status add_map_column(MapColumn* map_column, const TypeDescriptor& type_desc, const std::string& name,
+                             const avro_value_t& value) {
+    if (avro_value_get_type(&value) != AVRO_MAP) {
+        return Status::InvalidArgument(strings::Substitute("Failed to parse value as map, column=$0", name));
+    }
+    auto* keys_column = down_cast<NullableColumn*>(map_column->keys_column_raw_ptr());
+    auto* keys_null = keys_column->null_column_raw_ptr();
+    auto* keys_data = down_cast<BinaryColumn*>(keys_column->data_column_raw_ptr());
+    auto* values_column = map_column->values_column_raw_ptr();
+    auto* offsets = map_column->offsets_column_raw_ptr();
+
+    size_t n = 0;
+    if (avro_value_get_size(&value, &n) != 0) {
+        return Status::InvalidArgument(strings::Substitute("Failed to get map size, column=$0", name));
+    }
+
+    const auto& key_type = type_desc.children[0];
+    for (size_t i = 0; i < n; ++i) {
+        const char* key = nullptr;
+        avro_value_t element;
+        if (avro_value_get_by_index(&value, i, &element, &key) != 0) {
+            return Status::InvalidArgument(strings::Substitute("Failed to get map entry, column=$0", name));
+        }
+        size_t key_len = (key == nullptr) ? 0 : strlen(key);
+        if (key_type.len >= 0 && key_len > static_cast<size_t>(key_type.len)) {
+            return Status::DataQualityError(strings::Substitute(
+                    "Map key length is beyond the capacity. column=$0, capacity=$1", name, key_type.len));
+        }
+        keys_data->append(Slice(key, key_len));
+        keys_null->append(0);
+        RETURN_IF_ERROR(add_nullable_column(values_column, type_desc.children[1], name, element));
+    }
+    uint32_t sz = offsets->immutable_data().back() + n;
+    offsets->append_numbers(&sz, sizeof(sz));
+    return Status::OK();
+}
+
+// Populate a StructColumn (the data column of a nullable struct) from an avro record value.
+// Fields are matched by name; a field absent from the record becomes NULL. Each present field
+// recurses through add_nullable_column, which unwraps inner unions/nulls.
+static Status add_struct_column(StructColumn* struct_column, const TypeDescriptor& type_desc, const std::string& name,
+                                const avro_value_t& value) {
+    if (avro_value_get_type(&value) != AVRO_RECORD) {
+        return Status::InvalidArgument(strings::Substitute("Failed to parse value as struct, column=$0", name));
+    }
+    for (size_t i = 0; i < type_desc.children.size(); ++i) {
+        auto* field_column = struct_column->field_column_raw_ptr(i);
+        const std::string& field_name = type_desc.field_names[i];
+        avro_value_t field_value;
+        if (avro_value_get_by_name(&value, field_name.c_str(), &field_value, nullptr) == 0) {
+            RETURN_IF_ERROR(add_nullable_column(field_column, type_desc.children[i], name, field_value));
+        } else {
+            field_column->append_nulls(1);
+        }
+    }
+    return Status::OK();
+}
 
 template <typename T>
 static Status add_adaptive_nullable_numeric_column(Column* column, const TypeDescriptor& type_desc,
@@ -142,25 +225,34 @@ static Status add_nullable_native_json_column(Column* column, const TypeDescript
 
 static Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                                   const avro_value_t& value) {
+    // Unwrap nullable unions so nested fields/elements/values dispatch on their real type,
+    // and route avro nulls to a column null regardless of the destination type.
+    avro_value_t resolved = value;
+    RETURN_IF_ERROR(resolve_union(&resolved));
+    if (avro_value_get_type(&resolved) == AVRO_NULL) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+
     switch (type_desc.type) {
     case TYPE_BOOLEAN:
-        return add_nullable_numeric_column<int8_t>(column, type_desc, name, value);
+        return add_nullable_numeric_column<int8_t>(column, type_desc, name, resolved);
     case TYPE_BIGINT:
-        return add_nullable_numeric_column<int64_t>(column, type_desc, name, value);
+        return add_nullable_numeric_column<int64_t>(column, type_desc, name, resolved);
     case TYPE_INT:
-        return add_nullable_numeric_column<int32_t>(column, type_desc, name, value);
+        return add_nullable_numeric_column<int32_t>(column, type_desc, name, resolved);
     case TYPE_SMALLINT:
-        return add_nullable_numeric_column<int16_t>(column, type_desc, name, value);
+        return add_nullable_numeric_column<int16_t>(column, type_desc, name, resolved);
     case TYPE_TINYINT:
-        return add_nullable_numeric_column<int8_t>(column, type_desc, name, value);
+        return add_nullable_numeric_column<int8_t>(column, type_desc, name, resolved);
     case TYPE_DOUBLE:
-        return add_nullable_numeric_column<double>(column, type_desc, name, value);
+        return add_nullable_numeric_column<double>(column, type_desc, name, resolved);
     case TYPE_FLOAT:
-        return add_nullable_numeric_column<float>(column, type_desc, name, value);
+        return add_nullable_numeric_column<float>(column, type_desc, name, resolved);
     case TYPE_JSON:
-        return add_nullable_native_json_column(column, type_desc, name, value);
+        return add_nullable_native_json_column(column, type_desc, name, resolved);
     case TYPE_ARRAY: {
-        if (avro_value_get_type(&value) == AVRO_ARRAY) {
+        if (avro_value_get_type(&resolved) == AVRO_ARRAY) {
             auto nullable_column = down_cast<NullableColumn*>(column);
 
             auto array_column = down_cast<ArrayColumn*>(nullable_column->data_column_raw_ptr());
@@ -168,13 +260,13 @@ static Status add_nullable_column(Column* column, const TypeDescriptor& type_des
 
             auto* elems_column = array_column->elements_column_raw_ptr();
             size_t n = 0;
-            if (avro_value_get_size(&value, &n) != 0) {
+            if (avro_value_get_size(&resolved, &n) != 0) {
                 auto err_msg = strings::Substitute("Failed to get array size, column=$0", name);
                 return Status::InvalidArgument(err_msg);
             }
             for (int i = 0; i < n; i++) {
                 avro_value_t element;
-                if (avro_value_get_by_index(&value, i, &element, nullptr) != 0) {
+                if (avro_value_get_by_index(&resolved, i, &element, nullptr) != 0) {
                     auto err_msg = strings::Substitute("Failed to get array element, column=$0", name);
                     return Status::InvalidArgument(err_msg);
                 }
@@ -192,9 +284,23 @@ static Status add_nullable_column(Column* column, const TypeDescriptor& type_des
             return Status::InvalidArgument(err_msg);
         }
     }
+    case TYPE_MAP: {
+        auto nullable_column = down_cast<NullableColumn*>(column);
+        auto* map_column = down_cast<MapColumn*>(nullable_column->data_column_raw_ptr());
+        RETURN_IF_ERROR(add_map_column(map_column, type_desc, name, resolved));
+        nullable_column->null_column_raw_ptr()->append(0);
+        return Status::OK();
+    }
+    case TYPE_STRUCT: {
+        auto nullable_column = down_cast<NullableColumn*>(column);
+        auto* struct_column = down_cast<StructColumn*>(nullable_column->data_column_raw_ptr());
+        RETURN_IF_ERROR(add_struct_column(struct_column, type_desc, name, resolved));
+        nullable_column->null_column_raw_ptr()->append(0);
+        return Status::OK();
+    }
 
     default:
-        return add_nullable_binary_column(column, type_desc, name, value);
+        return add_nullable_binary_column(column, type_desc, name, resolved);
     }
 }
 
@@ -250,6 +356,20 @@ static Status add_adpative_nullable_column(Column* column, const TypeDescriptor&
             return Status::InvalidArgument(err_msg);
         }
     }
+    case TYPE_MAP: {
+        auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+        auto* map_column = down_cast<MapColumn*>(nullable_column->begin_append_not_default_value());
+        RETURN_IF_ERROR(add_map_column(map_column, type_desc, name, value));
+        nullable_column->finish_append_one_not_default_value();
+        return Status::OK();
+    }
+    case TYPE_STRUCT: {
+        auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+        auto* struct_column = down_cast<StructColumn*>(nullable_column->begin_append_not_default_value());
+        RETURN_IF_ERROR(add_struct_column(struct_column, type_desc, name, value));
+        nullable_column->finish_append_one_not_default_value();
+        return Status::OK();
+    }
     default:
         return add_adpative_nullable_binary_column(column, type_desc, name, value);
     }
@@ -257,30 +377,42 @@ static Status add_adpative_nullable_column(Column* column, const TypeDescriptor&
 
 Status add_adaptive_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                                     const avro_value_t& value, bool invalid_as_null) {
+    // Snapshot so a partial nested append (Map/Struct/Array child column) can be rewound on error.
+    // Column::resize cascades to leaf storage, dropping orphan keys/values/elements.
+    const size_t snapshot = column->size();
     if (avro_value_get_type(&value) == AVRO_NULL) {
         column->append_nulls(1);
         return Status::OK();
     }
 
     auto st = add_adpative_nullable_column(column, type_desc, name, value);
-    if (UNLIKELY(!st.ok() && invalid_as_null)) {
-        column->append_nulls(1);
-        return Status::OK();
+    if (!st.ok()) {
+        column->resize(snapshot);
+        if (invalid_as_null) {
+            column->append_nulls(1);
+            return Status::OK();
+        }
     }
     return st;
 }
 
 Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                            const avro_value_t& value, bool invalid_as_null) {
+    // Snapshot so a partial nested append (Map/Struct/Array child column) can be rewound on error.
+    // Column::resize cascades to leaf storage, dropping orphan keys/values/elements.
+    const size_t snapshot = column->size();
     if (avro_value_get_type(&value) == AVRO_NULL) {
         column->append_nulls(1);
         return Status::OK();
     }
 
     auto st = add_nullable_column(column, type_desc, name, value);
-    if (!st.ok() && invalid_as_null) {
-        column->append_nulls(1);
-        return Status::OK();
+    if (!st.ok()) {
+        column->resize(snapshot);
+        if (invalid_as_null) {
+            column->append_nulls(1);
+            return Status::OK();
+        }
     }
     return st;
 }

--- a/be/test/exec/file_scanner/avro_scanner_test.cpp
+++ b/be/test/exec/file_scanner/avro_scanner_test.cpp
@@ -1358,6 +1358,587 @@ TEST_F(AvroScannerTest, test_map_to_json) {
     }
 }
 
+TEST_F(AvroScannerTest, test_map_type) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_map_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t map_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "maptype", &map_value, NULL) == 0) {
+        avro_value_t ele1;
+        avro_value_add(&map_value, "ele1", &ele1, NULL, NULL);
+        avro_value_set_long(&ele1, 4294967297);
+
+        avro_value_t ele2;
+        avro_value_add(&map_value, "ele2", &ele2, NULL, NULL);
+        avro_value_set_long(&ele2, 4294967298);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_map_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    // load avro map natively into a MAP<VARCHAR, BIGINT> column (no jsonpaths)
+    {
+        std::vector<TypeDescriptor> types;
+        types.emplace_back(TYPE_BOOLEAN);
+        types.emplace_back(TYPE_BIGINT);
+        types.emplace_back(TYPE_DOUBLE);
+        types.emplace_back(TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(65533),
+                                                           TypeDescriptor(TYPE_BIGINT)));
+
+        std::vector<TBrokerRangeDesc> ranges;
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_AVRO;
+        range.__set_path(data_path);
+        ranges.emplace_back(range);
+
+        auto scanner = create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "maptype"},
+                                           avro_helper.schema_text);
+        Status st = scanner->open();
+        ASSERT_TRUE(st.ok()) << st;
+
+        auto st2 = scanner->get_next();
+        ASSERT_TRUE(st2.ok()) << st2.status();
+
+        ChunkPtr chunk = st2.value();
+        EXPECT_EQ(4, chunk->num_columns());
+        EXPECT_EQ(1, chunk->num_rows());
+        EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+        EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+        EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+        EXPECT_EQ("{'ele1':4294967297,'ele2':4294967298}", chunk->get_column_by_index(3)->debug_item(0));
+    }
+
+    // load avro map natively into a MAP<VARCHAR, BIGINT> column selected via jsonpaths
+    {
+        std::vector<TypeDescriptor> types;
+        types.emplace_back(TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(65533),
+                                                           TypeDescriptor(TYPE_BIGINT)));
+
+        std::vector<TBrokerRangeDesc> ranges;
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_AVRO;
+        range.__set_path(data_path);
+        range.__isset.jsonpaths = true;
+        range.jsonpaths = R"(["$.maptype"])";
+        ranges.emplace_back(range);
+
+        auto scanner = create_avro_scanner(types, ranges, {"maptype"}, avro_helper.schema_text);
+        Status st = scanner->open();
+        ASSERT_TRUE(st.ok()) << st;
+
+        auto st2 = scanner->get_next();
+        ASSERT_TRUE(st2.ok()) << st2.status();
+
+        ChunkPtr chunk = st2.value();
+        EXPECT_EQ(1, chunk->num_columns());
+        EXPECT_EQ(1, chunk->num_rows());
+        EXPECT_EQ("{'ele1':4294967297,'ele2':4294967298}", chunk->get_column_by_index(0)->debug_item(0));
+    }
+}
+
+TEST_F(AvroScannerTest, test_struct_type) {
+    // record root { record s { int f_int; string f_str; union{ null, string } f_opt; } }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"s","type":{"type":"record","name":"inner","fields":[{"name":"f_int","type":"int"},{"name":"f_str","type":"string"},{"name":"f_opt","type":["null","string"]}]}}]})";
+
+    // build one avro record, scan it into a native STRUCT column, return the struct's debug_item.
+    // opt_value == nullptr selects the null branch of f_opt.
+    auto build_and_scan = [&](const char* opt_value) -> std::string {
+        AvroHelper avro_helper;
+        init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+        DeferOp avro_helper_deleter([&] {
+            avro_schema_decref(avro_helper.schema);
+            avro_value_iface_decref(avro_helper.iface);
+            avro_value_decref(&avro_helper.avro_val);
+        });
+
+        avro_value_t s_value;
+        EXPECT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "s", &s_value, NULL));
+
+        avro_value_t f_int;
+        if (avro_value_get_by_name(&s_value, "f_int", &f_int, NULL) == 0) {
+            avro_value_set_int(&f_int, 42);
+        }
+        avro_value_t f_str;
+        if (avro_value_get_by_name(&s_value, "f_str", &f_str, NULL) == 0) {
+            avro_value_set_string(&f_str, "hello");
+        }
+        avro_value_t f_opt;
+        if (avro_value_get_by_name(&s_value, "f_opt", &f_opt, NULL) == 0) {
+            avro_value_t branch;
+            if (opt_value == nullptr) {
+                avro_value_set_branch(&f_opt, 0, &branch);
+                avro_value_set_null(&branch);
+            } else {
+                avro_value_set_branch(&f_opt, 1, &branch);
+                avro_value_set_string(&branch, opt_value);
+            }
+        }
+
+        std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_struct_data.avro";
+        EXPECT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+        std::vector<TypeDescriptor> types;
+        types.emplace_back(TypeDescriptor::create_struct_type(
+                {"f_int", "f_str", "f_opt"}, {TypeDescriptor(TYPE_INT), TypeDescriptor::create_varchar_type(50),
+                                              TypeDescriptor::create_varchar_type(50)}));
+
+        std::vector<TBrokerRangeDesc> ranges;
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_AVRO;
+        range.__set_path(data_path);
+        ranges.emplace_back(range);
+
+        auto scanner = create_avro_scanner(types, ranges, {"s"}, avro_helper.schema_text);
+        Status st = scanner->open();
+        EXPECT_TRUE(st.ok()) << st;
+        if (!st.ok()) {
+            return std::string("open failed: ") + st.to_string();
+        }
+
+        auto st2 = scanner->get_next();
+        EXPECT_TRUE(st2.ok()) << st2.status();
+        if (!st2.ok()) {
+            return std::string("get_next failed: ") + st2.status().to_string();
+        }
+
+        ChunkPtr chunk = st2.value();
+        EXPECT_EQ(1, chunk->num_columns());
+        EXPECT_EQ(1, chunk->num_rows());
+        return chunk->get_column_by_index(0)->debug_item(0);
+    };
+
+    // Native struct parsing must be independent of avro_ignore_union_type_tag (that config only
+    // affects the JSON-string serialization path, not the native readers).
+    for (bool ignore_tag : {false, true}) {
+        config::avro_ignore_union_type_tag = ignore_tag;
+        // non-null union branch is unwrapped
+        EXPECT_EQ("{f_int:42,f_str:'hello',f_opt:'world'}", build_and_scan("world"));
+        // null union branch becomes a NULL struct field
+        EXPECT_EQ("{f_int:42,f_str:'hello',f_opt:NULL}", build_and_scan(nullptr));
+    }
+}
+
+TEST_F(AvroScannerTest, test_array_of_nullable_string) {
+    // record root { array< union{ null, string } > a }
+    // Regression guard for the codex review (PR #74901): an ARRAY<VARCHAR> whose elements are avro
+    // unions produces identical output under both avro_ignore_union_type_tag values. Array elements
+    // are delivered to the column writer already unwrapped, so the union wrapper never reaches the
+    // serializer and the config (which only governs union-tag serialization) is a no-op here. A
+    // null union element becomes a SQL NULL. This refutes the claim that the PR changed
+    // ARRAY<VARCHAR>/ARRAY<JSON> union-element serialization.
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"a","type":{"type":"array","items":["null","string"]}}]})";
+
+    // Build one avro record holding the array ["x", null, "y"] (each element a union branch) and
+    // scan it into a native ARRAY<VARCHAR> column.
+    auto build_and_scan = [&]() -> ChunkPtr {
+        AvroHelper avro_helper;
+        init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+        DeferOp avro_helper_deleter([&] {
+            avro_schema_decref(avro_helper.schema);
+            avro_value_iface_decref(avro_helper.iface);
+            avro_value_decref(&avro_helper.avro_val);
+        });
+
+        avro_value_t array_value;
+        EXPECT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "a", &array_value, NULL));
+        // element 0: union -> "x"
+        avro_value_t ele0, branch0;
+        avro_value_append(&array_value, &ele0, NULL);
+        avro_value_set_branch(&ele0, 1, &branch0);
+        avro_value_set_string(&branch0, "x");
+        // element 1: union -> null
+        avro_value_t ele1, branch1;
+        avro_value_append(&array_value, &ele1, NULL);
+        avro_value_set_branch(&ele1, 0, &branch1);
+        avro_value_set_null(&branch1);
+        // element 2: union -> "y"
+        avro_value_t ele2, branch2;
+        avro_value_append(&array_value, &ele2, NULL);
+        avro_value_set_branch(&ele2, 1, &branch2);
+        avro_value_set_string(&branch2, "y");
+
+        std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_array_nullable_string_data.avro";
+        EXPECT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+        std::vector<TypeDescriptor> types;
+        TypeDescriptor t(TYPE_ARRAY);
+        t.children.emplace_back(TypeDescriptor::create_varchar_type(50));
+        types.emplace_back(t);
+
+        std::vector<TBrokerRangeDesc> ranges;
+        TBrokerRangeDesc range;
+        range.format_type = TFileFormatType::FORMAT_AVRO;
+        range.__isset.jsonpaths = false;
+        range.__set_path(data_path);
+        ranges.emplace_back(range);
+
+        auto scanner = create_avro_scanner(types, ranges, {"a"}, avro_helper.schema_text);
+        Status st = scanner->open();
+        EXPECT_TRUE(st.ok()) << st;
+        auto st2 = scanner->get_next();
+        EXPECT_TRUE(st2.ok()) << st2.status();
+        return st2.value();
+    };
+
+    // Elements arrive unwrapped: clean string values, the null union element is a SQL NULL.
+    {
+        config::avro_ignore_union_type_tag = true;
+        ChunkPtr chunk = build_and_scan();
+        ASSERT_EQ(1, chunk->num_columns());
+        ASSERT_EQ(1, chunk->num_rows());
+        auto array = chunk->get(0)[0].get_array();
+        ASSERT_EQ(3, array.size());
+        EXPECT_EQ("x", array[0].get_slice());
+        EXPECT_TRUE(array[1].is_null());
+        EXPECT_EQ("y", array[2].get_slice());
+    }
+    // =false produces the byte-identical result: the config does not reach array-element handling.
+    {
+        config::avro_ignore_union_type_tag = false;
+        ChunkPtr chunk = build_and_scan();
+        ASSERT_EQ(1, chunk->num_columns());
+        ASSERT_EQ(1, chunk->num_rows());
+        auto array = chunk->get(0)[0].get_array();
+        ASSERT_EQ(3, array.size());
+        EXPECT_EQ("x", array[0].get_slice());
+        EXPECT_TRUE(array[1].is_null());
+        EXPECT_EQ("y", array[2].get_slice());
+    }
+}
+
+TEST_F(AvroScannerTest, test_array_of_map) {
+    // record root { array< map<int> > am }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"am","type":{"type":"array","items":{"type":"map","values":"int"}}}]})";
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t am_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "am", &am_value, NULL));
+    {
+        avro_value_t m1;
+        ASSERT_EQ(0, avro_value_append(&am_value, &m1, NULL));
+        avro_value_t a;
+        avro_value_add(&m1, "a", &a, NULL, NULL);
+        avro_value_set_int(&a, 1);
+        avro_value_t b;
+        avro_value_add(&m1, "b", &b, NULL, NULL);
+        avro_value_set_int(&b, 2);
+    }
+    {
+        avro_value_t m2;
+        ASSERT_EQ(0, avro_value_append(&am_value, &m2, NULL));
+        avro_value_t c;
+        avro_value_add(&m2, "c", &c, NULL, NULL);
+        avro_value_set_int(&c, 3);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_array_of_map_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_array_type(
+            TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(20), TypeDescriptor(TYPE_INT))));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"am"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("[{'a':1,'b':2},{'c':3}]", chunk->get_column_by_index(0)->debug_item(0));
+}
+
+TEST_F(AvroScannerTest, test_map_of_array) {
+    // record root { map< array<int> > ma }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"ma","type":{"type":"map","values":{"type":"array","items":"int"}}}]})";
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t ma_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "ma", &ma_value, NULL));
+    {
+        avro_value_t arr_x;
+        avro_value_add(&ma_value, "x", &arr_x, NULL, NULL);
+        avro_value_t e1;
+        avro_value_append(&arr_x, &e1, NULL);
+        avro_value_set_int(&e1, 1);
+        avro_value_t e2;
+        avro_value_append(&arr_x, &e2, NULL);
+        avro_value_set_int(&e2, 2);
+    }
+    {
+        avro_value_t arr_y;
+        avro_value_add(&ma_value, "y", &arr_y, NULL, NULL);
+        avro_value_t e3;
+        avro_value_append(&arr_y, &e3, NULL);
+        avro_value_set_int(&e3, 3);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_map_of_array_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(20),
+                                                       TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT))));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"ma"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("{'x':[1,2],'y':[3]}", chunk->get_column_by_index(0)->debug_item(0));
+}
+
+TEST_F(AvroScannerTest, test_array_of_struct) {
+    // record root { array< record{ int a; string b; } > as }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"as","type":{"type":"array","items":{"type":"record","name":"item","fields":[{"name":"a","type":"int"},{"name":"b","type":"string"}]}}}]})";
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t as_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "as", &as_value, NULL));
+    {
+        avro_value_t rec;
+        ASSERT_EQ(0, avro_value_append(&as_value, &rec, NULL));
+        avro_value_t a;
+        avro_value_get_by_name(&rec, "a", &a, NULL);
+        avro_value_set_int(&a, 1);
+        avro_value_t b;
+        avro_value_get_by_name(&rec, "b", &b, NULL);
+        avro_value_set_string(&b, "x");
+    }
+    {
+        avro_value_t rec;
+        ASSERT_EQ(0, avro_value_append(&as_value, &rec, NULL));
+        avro_value_t a;
+        avro_value_get_by_name(&rec, "a", &a, NULL);
+        avro_value_set_int(&a, 2);
+        avro_value_t b;
+        avro_value_get_by_name(&rec, "b", &b, NULL);
+        avro_value_set_string(&b, "y");
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_array_of_struct_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_array_type(TypeDescriptor::create_struct_type(
+            {"a", "b"}, {TypeDescriptor(TYPE_INT), TypeDescriptor::create_varchar_type(20)})));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"as"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("[{a:1,b:'x'},{a:2,b:'y'}]", chunk->get_column_by_index(0)->debug_item(0));
+}
+
+TEST_F(AvroScannerTest, test_struct_with_map) {
+    // record root { record s { int id; map<int> m; } }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"s","type":{"type":"record","name":"inner","fields":[{"name":"id","type":"int"},{"name":"m","type":{"type":"map","values":"int"}}]}}]})";
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t s_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "s", &s_value, NULL));
+    avro_value_t id_value;
+    avro_value_get_by_name(&s_value, "id", &id_value, NULL);
+    avro_value_set_int(&id_value, 7);
+    avro_value_t m_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&s_value, "m", &m_value, NULL));
+    {
+        avro_value_t k1;
+        avro_value_add(&m_value, "k1", &k1, NULL, NULL);
+        avro_value_set_int(&k1, 10);
+        avro_value_t k2;
+        avro_value_add(&m_value, "k2", &k2, NULL, NULL);
+        avro_value_set_int(&k2, 20);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_struct_with_map_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_struct_type(
+            {"id", "m"},
+            {TypeDescriptor(TYPE_INT),
+             TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(20), TypeDescriptor(TYPE_INT))}));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"s"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("{id:7,m:{'k1':10,'k2':20}}", chunk->get_column_by_index(0)->debug_item(0));
+}
+
+TEST_F(AvroScannerTest, test_deep_nested) {
+    // record root { array< record item{ string k; map< array<int> > m; } > data }
+    //   => destination ARRAY< STRUCT< k VARCHAR, m MAP<VARCHAR, ARRAY<INT>> > >
+    // Crosses all three container kinds in one chain: array -> struct -> map -> array.
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"data","type":{"type":"array","items":{"type":"record","name":"item","fields":[{"name":"k","type":"string"},{"name":"m","type":{"type":"map","values":{"type":"array","items":"int"}}}]}}}]})";
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    auto add_int_array = [](avro_value_t* map_value, const char* key, const std::vector<int>& vals) {
+        avro_value_t arr;
+        avro_value_add(map_value, key, &arr, NULL, NULL);
+        for (int v : vals) {
+            avro_value_t e;
+            avro_value_append(&arr, &e, NULL);
+            avro_value_set_int(&e, v);
+        }
+    };
+
+    avro_value_t data_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "data", &data_value, NULL));
+    {
+        avro_value_t item;
+        ASSERT_EQ(0, avro_value_append(&data_value, &item, NULL));
+        avro_value_t k;
+        avro_value_get_by_name(&item, "k", &k, NULL);
+        avro_value_set_string(&k, "a");
+        avro_value_t m;
+        avro_value_get_by_name(&item, "m", &m, NULL);
+        add_int_array(&m, "x", {1, 2});
+        add_int_array(&m, "y", {3});
+    }
+    {
+        avro_value_t item;
+        ASSERT_EQ(0, avro_value_append(&data_value, &item, NULL));
+        avro_value_t k;
+        avro_value_get_by_name(&item, "k", &k, NULL);
+        avro_value_set_string(&k, "b");
+        avro_value_t m;
+        avro_value_get_by_name(&item, "m", &m, NULL);
+        add_int_array(&m, "z", {4});
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_deep_nested_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_array_type(TypeDescriptor::create_struct_type(
+            {"k", "m"},
+            {TypeDescriptor::create_varchar_type(20),
+             TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(20),
+                                             TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT)))})));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"data"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("[{k:'a',m:{'x':[1,2],'y':[3]}},{k:'b',m:{'z':[4]}}]", chunk->get_column_by_index(0)->debug_item(0));
+}
+
 void AvroScannerTest::test_map_nested_struct() {
     // protocol request {
     //     record cookie {

--- a/docs/en/loading/RoutineLoad.md
+++ b/docs/en/loading/RoutineLoad.md
@@ -407,10 +407,10 @@ The data type mapping between the Avro data fields you want to load and the Star
 
 | Avro           | StarRocks                                                    |
 | -------------- | ------------------------------------------------------------ |
-| record         | Load the entire RECORD or its subfields into StarRocks as JSON. |
+| record         | STRUCT, or load the entire RECORD or its subfields into StarRocks as JSON. |
 | enums          | STRING                                                       |
 | arrays         | ARRAY                                                        |
-| maps           | JSON                                                         |
+| maps           | MAP or JSON                                                  |
 | union(T, null) | NULLABLE(T)                                                  |
 | fixed          | STRING                                                       |
 

--- a/docs/ja/loading/RoutineLoad.md
+++ b/docs/ja/loading/RoutineLoad.md
@@ -407,10 +407,10 @@ FROM KAFKA
 
 | Avro           | StarRocks                                                    |
 | -------------- | ------------------------------------------------------------ |
-| record         | RECORD 全体またはそのサブフィールドを JSON として StarRocks にロードします。 |
+| record         | STRUCT、または RECORD 全体やそのサブフィールドを JSON として StarRocks にロードします。 |
 | enums          | STRING                                                       |
 | arrays         | ARRAY                                                        |
-| maps           | JSON                                                         |
+| maps           | MAP または JSON                                                         |
 | union(T, null) | NULLABLE(T)                                                  |
 | fixed          | STRING                                                       |
 

--- a/docs/zh/loading/RoutineLoad.md
+++ b/docs/zh/loading/RoutineLoad.md
@@ -393,10 +393,10 @@ StarRocks 支持导入所有类型的 Avro 数据。导入 Avro 数据至 StarRo
 
 | Avro           |StarRocks                                        |
 | -------------- | ------------------------------------------------ |
-| record         | 将 RECORD 类型的字段或者其子字段中作为 JSON 导入 |
+| record         | STRUCT，或将 RECORD 类型的字段或者其子字段中作为 JSON 导入 |
 | enums          | STRING                                           |
 | arrays         | ARRAY                                            |
-| maps           | JSON                                             |
+| maps           | MAP 或 JSON                                             |
 | union(T, null) | NULLABE(T)                                       |
 | fixed          | STRING                                           |
 


### PR DESCRIPTION
## Why I'm doing:

Routine Load with `format="avro"` (Confluent Schema Registry) aborts at the BE
scanner `open()` when a destination column is `MAP` or `STRUCT`, failing with:

```
Not support cast VARCHAR(1048576) to MAP<VARCHAR(65533), INT>.
```

`AvroScanner::_construct_avro_types()` only had a native branch for `ARRAY`;
`MAP`/`STRUCT` fell through to `VARCHAR(MAX)`, and the subsequent
`VARCHAR -> MAP/STRUCT` cast does not exist, so the task fails before reading any
data. Scalars, `ARRAY`, and nullable unions already worked; only `MAP`/`STRUCT`
(and nesting that contains them) were broken.

## What I'm doing:

Load avro `MAP`/`STRUCT` natively, with no JSON intermediary:

- **`avro_scanner.cpp`** — replace the ARRAY-only switch in
  `_construct_avro_types` with a recursive `construct_avro_type()` that builds
  native `ARRAY`/`MAP`/`STRUCT` intermediate load types (mirrors
  `JsonUtils::construct_json_type`). Avro map keys are always strings, so the
  intermediate map key is forced to `VARCHAR`/`CHAR`; the cast stage converts it
  to the declared key type.
- **Dispatch fix** — `_construct_column` now dispatches the column writer on the
  *intermediate* (`_avro_types`) type, which is what the source column was built
  with, instead of the destination type. Otherwise a complex column whose
  intermediate type differs from the destination (e.g. `MAP<VARCHAR,VARCHAR>` vs
  `MAP<VARCHAR,DATE>`) is written by a writer chosen for the destination and
  crashes on `down_cast`. Both call sites are fixed: the jsonpath path uses
  `_avro_types[i]`; the no-jsonpath path stores the intermediate type via a new
  slot-id -> type map.
- **`formats/avro/nullable_column.cpp`** — native `add_map_column` /
  `add_struct_column`, mirroring the avro-cpp `MapColumnReader`/`StructColumnReader`:
  map key written with a length check + value recurses; struct fields matched by
  name, missing fields become `NULL`. Inner unions in nested map values / struct
  fields / array elements are unwrapped, and a partial nested append is rewound
  (snapshot + `resize`) on error before deciding `NULL` vs. propagate.

The existing avro -> JSON path (`TYPE_JSON` columns) and scalar/array handling are
unchanged. The cast factory already supports recursive `MAP->MAP` /
`STRUCT->STRUCT` / `ARRAY->ARRAY` casts, so e.g. `MAP<VARCHAR,DATE>` works without
any JSON round-trip.

### Tests

- BE UT (`AvroScannerTest`, `AvroAddNullableColumnTest`): native `MAP` (with and
  without jsonpaths), `STRUCT` (nullable-union field, null and non-null, both
  `avro_ignore_union_type_tag` values), nested `ARRAY<MAP>`, `MAP<ARRAY>`,
  `ARRAY<STRUCT>`, `STRUCT`-with-`MAP`, and a 4-level-deep
  `ARRAY<STRUCT<VARCHAR, MAP<VARCHAR, ARRAY<INT>>>>`; the `test_map_to_json`
  regression is preserved.
- End-to-end: routine load from Kafka + Confluent Schema Registry into a
  `MAP<VARCHAR(65533), INT>` column loads native maps (`map['k']`, `map_size`,
  `map_keys`, `map_values` all work); previously it aborted at `open()`.
- `python3 build-support/check_be_module_boundaries.py --mode full` clean.

### Docs

Updated the Avro → StarRocks complex-type mapping table in `loading/RoutineLoad.md`
(en/zh/ja): `maps` → `MAP or JSON`, `record` → `STRUCT, or ... JSON`.

Fixes #70928

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

> No currently-working behavior changes: avro routine load into a `MAP`/`STRUCT`
> destination column previously always failed at the BE scanner `open()`
> (`Not support cast VARCHAR to MAP`), so this only enables a path that always
> errored. Scalar / `ARRAY` / `TYPE_JSON` columns and the `parse_json` workaround
> are unaffected.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
 <hr>This is an automatic backport of pull request #74901 done by [Mergify](https://mergify.com).