### PR TITLE
[Enhancement] Widen meta-tier DATE pre-split window to year 1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
@@ -20,29 +20,36 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
- * The value window the meta tier accepts for DATE/DATETIME sort-key boundaries:
- * {@code [1970-01-01, 9999-12-31]}. A value outside it falls back to data tier
- * (it is not a load failure).
+ * The value windows the meta tier accepts for temporal sort-key boundaries. DATE accepts
+ * {@code [0001-01-01, 9999-12-31]}; DATETIME accepts the narrower {@code [1970-01-01, 9999-12-31]}.
+ * A value outside its window falls back to data tier (it is not a load failure). The upper bound
+ * is the StarRocks DATE/DATETIME domain ceiling for both.
  *
- * <p>Why these bounds — render must be unambiguous and the FE-computed boundary must
- * equal the value the BE load stores:
+ * <p>Why DATE reaches year 1 but DATETIME stops at the epoch — the FE-computed boundary must equal
+ * the value the BE load stores:
  * <ul>
- *   <li>Below 1970-01-01 the BE timestamp conversion uses signed C++ division whose
- *       (seconds, nanos) split differs from {@code Math.floorDiv}/{@code floorMod},
- *       and pre-1582 dates raise proleptic-vs-hybrid calendar parity questions.</li>
- *   <li>Year 0 / BCE mis-renders through the {@code yyyy} (year-of-era) formatters.</li>
- *   <li>Above year 9999 leaves the StarRocks DATE/DATETIME domain.</li>
+ *   <li>DATE carries no sub-second part, and BE decodes a day-of-epoch by adding a fixed Julian
+ *       offset and converting with the same proleptic-Gregorian algorithm {@link LocalDate} uses
+ *       (no 1582 cutover), so a DATE boundary is FE/BE-identical for every representable value down
+ *       to the start of the unambiguous AD range.</li>
+ *   <li>DATETIME below 1970-01-01 is not yet safe: the BE Parquet INT64-timestamp load splits the
+ *       signed tick with truncating division and does not borrow a whole second for a negative
+ *       sub-second remainder, so a pre-1970 fractional-second value decodes to a value that does not
+ *       match the FE {@code Math.floorDiv}/{@code floorMod} boundary (and the BE ORC pre-epoch path
+ *       drops the sub-second). Until the BE load handles a negative sub-second, a sub-1970 DATETIME
+ *       stays on the data tier.</li>
  * </ul>
  *
- * <p>This lives in one place — rather than being duplicated per reader like the
- * integer-stat conversion — because both responsibilities are format-agnostic: the
- * window check operates on an already-decoded {@link LocalDate}, and the microsecond
- * datetime renderer on an already-decoded {@link LocalDateTime}, identical whether the
- * value came from a Parquet INT32/INT64 stat or an ORC day-of-epoch / timestamp stat.
+ * <p>This lives in one place — rather than being duplicated per reader like the integer-stat
+ * conversion — because both responsibilities are format-agnostic: the window check operates on an
+ * already-decoded {@link LocalDate}, and the microsecond datetime renderer on an already-decoded
+ * {@link LocalDateTime}, identical whether the value came from a Parquet INT32/INT64 stat or an ORC
+ * day-of-epoch / timestamp stat.
  */
 final class MetaTierTemporalWindow {
 
-    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1970, 1, 1);
+    private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1, 1, 1);
+    private static final LocalDate MIN_SUPPORTED_DATETIME_DATE = LocalDate.of(1970, 1, 1);
     private static final LocalDate MAX_SUPPORTED_DATE = LocalDate.of(9999, 12, 31);
 
     private MetaTierTemporalWindow() {
@@ -50,12 +57,26 @@ final class MetaTierTemporalWindow {
 
     /**
      * Throw {@link MetaTierUnavailableException} (the meta-tier-to-data-tier fallback signal)
-     * if {@code date} is outside {@code [1970-01-01, 9999-12-31]}.
+     * if a DATE sort-key boundary is outside {@code [0001-01-01, 9999-12-31]}.
      */
     static void rejectDateOutsideWindow(LocalDate date) throws MetaTierUnavailableException {
         if (date.isBefore(MIN_SUPPORTED_DATE) || date.isAfter(MAX_SUPPORTED_DATE)) {
             throw new MetaTierUnavailableException(
-                    "DATE/DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
+                    "DATE meta tier supports [0001-01-01, 9999-12-31] only; value "
+                            + date + " is outside that window");
+        }
+    }
+
+    /**
+     * Throw {@link MetaTierUnavailableException} if the calendar date of a DATETIME sort-key boundary
+     * is outside {@code [1970-01-01, 9999-12-31]}. The lower bound is the epoch (not year 1 as for
+     * DATE) because the BE timestamp load does not yet decode a pre-1970 sub-second value to a
+     * boundary-matching wall clock — see the class comment.
+     */
+    static void rejectDateTimeOutsideWindow(LocalDate date) throws MetaTierUnavailableException {
+        if (date.isBefore(MIN_SUPPORTED_DATETIME_DATE) || date.isAfter(MAX_SUPPORTED_DATE)) {
+            throw new MetaTierUnavailableException(
+                    "DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
                             + date + " is outside that window");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -55,8 +55,9 @@ import java.util.Objects;
  * <ul>
  *   <li>ORC BYTE/SHORT/INT/LONG → StarRocks TINYINT/SMALLINT/INT/BIGINT</li>
  *   <li>ORC DATE → StarRocks DATE (day-of-epoch, timezone-free), gated to
- *       {@code [1970-01-01, 9999-12-31]} — values outside that window (year &le; 0
- *       rendering, pre-1582 proleptic/hybrid calendar ambiguity) fall back to data tier</li>
+ *       {@code [0001-01-01, 9999-12-31]} (the BE day-of-epoch load is proleptic-Gregorian with no
+ *       sub-second part, so the boundary is FE/BE-identical down to year 1); values outside that
+ *       window fall back to data tier</li>
  *   <li>ORC DECIMAL → StarRocks DECIMAL of the SAME precision and scale (ORC orders decimal
  *       stats correctly, so footer min/max are usable). Non-matching precision/scale → data tier</li>
  *   <li>ORC TIMESTAMP (local, no timezone) → StarRocks DATETIME, using the tz-independent UTC stat,
@@ -318,13 +319,13 @@ public final class OrcStripeStatisticsReader {
             // wrong data or wrong results (and if a conversion ever yields min > max, the downstream
             // ParquetMetadataSampler treats the row group as fallback rather than emitting a boundary).
             // Modern writers (StarRocks unload, Spark, Hive, ORC >= 1.5) emit minimumUtc and are unaffected.
-            // rejectDateOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
+            // rejectDateTimeOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
             // catch(RuntimeException) below (keeping its own message); getMinimumUTC/Variant.of
             // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateStripe.
             LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
-            MetaTierTemporalWindow.rejectDateOutsideWindow(minDateTime.toLocalDate());
-            MetaTierTemporalWindow.rejectDateOutsideWindow(maxDateTime.toLocalDate());
+            MetaTierTemporalWindow.rejectDateTimeOutsideWindow(minDateTime.toLocalDate());
+            MetaTierTemporalWindow.rejectDateTimeOutsideWindow(maxDateTime.toLocalDate());
             minVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(minDateTime));
             maxVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(maxDateTime));
         } catch (RuntimeException conversionFailure) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -84,10 +84,12 @@ import java.util.Objects;
  *       integer sort key (decoded as the true unsigned magnitude and range-checked), but ONLY when
  *       the file's raw footer declares a TypeDefinedOrder column order for that leaf.</li>
  * </ul>
- * <p>DATE/DATETIME values are additionally gated to {@code [1970-01-01, 9999-12-31]}; values
- * outside that window (year &le; 0 mis-renders through the {@code yyyy} formatters, pre-1970
- * has unverified FE/BE timestamp-division parity, pre-1582 has calendar-parity questions)
- * fall back to data tier.
+ * <p>A DATE boundary is gated to {@code [0001-01-01, 9999-12-31]} and a DATETIME boundary to the
+ * narrower {@code [1970-01-01, 9999-12-31]}; a value outside its window falls back to data tier.
+ * DATE reaches year 1 because the BE day-of-epoch load is proleptic-Gregorian with no sub-second
+ * part, so the boundary is FE/BE-identical; DATETIME keeps the epoch lower bound because the BE
+ * timestamp load does not yet decode a pre-1970 sub-second tick to a boundary-matching wall clock
+ * (see {@link MetaTierTemporalWindow}).
  * Anything else (UINT_64, signed INT_8/16/32 annotations, UTC-adjusted/INT96 timestamps, JSON,
  * BSON, UUID, FLOAT, DOUBLE, byte-array DECIMAL without a footer-declared TypeDefinedOrder,
  * raw BINARY for VARBINARY) makes the reader throw
@@ -312,10 +314,10 @@ public final class ParquetRowGroupStatisticsReader {
         if (location.logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
             long ticks = ((Number) parquetValue).longValue();
             LocalDateTime dateTime = epochTicksToUtcDateTime(ticks, timestampAnnotation.getUnit());
-            // A negative (pre-1970) tick lands on a date before the window's lower bound and is
-            // rejected here, which also keeps the floorDiv/floorMod conversion above in the range
-            // where it is provably identical to BE's signed division.
-            MetaTierTemporalWindow.rejectDateOutsideWindow(dateTime.toLocalDate());
+            // A negative (pre-1970) tick lands before the DATETIME window's lower bound and is
+            // rejected here: the BE timestamp load does not yet decode a pre-1970 sub-second tick to
+            // the wall clock this floorDiv/floorMod boundary expects (see MetaTierTemporalWindow).
+            MetaTierTemporalWindow.rejectDateTimeOutsideWindow(dateTime.toLocalDate());
             return Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(dateTime));
         }
         if (location.logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
@@ -17,6 +17,7 @@ package com.starrocks.alter.reshard.presplit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Locale;
@@ -62,5 +63,35 @@ public class MetaTierTemporalWindowTest {
         } finally {
             Locale.setDefault(previous);
         }
+    }
+
+    @Test
+    public void dateWindowAcceptsYearOneThroughNineThousand() throws Exception {
+        // DATE reaches the start of the AD range: pre-1970 and pre-1582 are FE/BE-identical because
+        // the day-of-epoch load is proleptic Gregorian with no sub-second component.
+        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(1, 1, 1));
+        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(1500, 6, 15));
+        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(1969, 12, 31));
+        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(9999, 12, 31));
+    }
+
+    @Test
+    public void dateWindowRejectsYearZeroAndBeyondNineThousand() {
+        Assertions.assertThrows(MetaTierUnavailableException.class,
+                () -> MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(0, 12, 31)));
+        Assertions.assertThrows(MetaTierUnavailableException.class,
+                () -> MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(10000, 1, 1)));
+    }
+
+    @Test
+    public void dateTimeWindowKeepsEpochLowerBound() throws Exception {
+        // DATETIME stays at the epoch: the BE timestamp load does not yet decode a pre-1970
+        // sub-second tick to a boundary-matching wall clock.
+        MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(1970, 1, 1));
+        MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(9999, 12, 31));
+        Assertions.assertThrows(MetaTierUnavailableException.class,
+                () -> MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(1969, 12, 31)));
+        Assertions.assertThrows(MetaTierUnavailableException.class,
+                () -> MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(1500, 6, 15)));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -315,18 +315,40 @@ class OrcStripeStatisticsReaderTest {
     }
 
     @Test
-    void pre1970DateStripeFallsBackToDataTier() throws Exception {
-        // day-of-epoch -1 = 1969-12-31 < 1970-01-01: outside the safe window → data tier.
+    void pre1970DateStripeIsAccepted() throws Exception {
+        // day-of-epoch -1 = 1969-12-31. A DATE has no sub-second part and BE's day-of-epoch load is
+        // proleptic-Gregorian end to end, so a pre-1970 DATE boundary is FE/BE-identical and stays
+        // on the meta tier (only DATETIME keeps the 1970 lower bound).
         Path orcPath = writeOrc(
                 "struct<event_day:date>",
                 /*rowCount=*/ 2,
                 (batch, batchRow, rowIndex) ->
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = -1 - rowIndex);
 
-        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
-                OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_day", DateType.DATE)));
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertFalse(stats.isEmpty());
+        Assertions.assertEquals("1969-12-31",
+                stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void pre1582DateStripeIsAccepted() throws Exception {
+        // day-of-epoch -171499 = 1500-06-15, before the 1582 Gregorian cutover. BE's calendar is
+        // proleptic Gregorian (no Julian switch), so this still aligns and stays on the meta tier.
+        Path orcPath = writeOrc(
+                "struct<event_day:date>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) ->
+                        ((LongColumnVector) batch.cols[0]).vector[batchRow] = -171499);
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertFalse(stats.isEmpty());
+        Assertions.assertEquals("1500-06-15",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -284,13 +284,63 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
-    void pre1970DateFallsBackToDataTier() throws Exception {
-        // epochDay -1 = 1969-12-31 < 1970-01-01: outside the safe window (pre-1970 +
-        // pre-1582 + year-0 parity traps). Meta tier must defer to data tier.
+    void pre1970DateIsAccepted() throws Exception {
+        // epochDay -1 = 1969-12-31. A DATE has no sub-second part and BE's day-of-epoch load is
+        // proleptic-Gregorian end to end, so a pre-1970 DATE boundary is FE/BE-identical and stays
+        // on the meta tier (only DATETIME keeps the 1970 lower bound).
         Path parquetPath = writeParquet(
                 "message schema { required int32 event_day (DATE); }",
                 /*rowCount=*/ 2,
                 (group, rowIndex) -> group.append("event_day", -1 - rowIndex));
+
+        List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertEquals(1, rowGroupStatistics.size());
+        Assertions.assertEquals("1969-12-31",
+                rowGroupStatistics.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void pre1582DateIsAccepted() throws Exception {
+        // epochDay -171499 = 1500-06-15, before the 1582 Gregorian cutover. BE's calendar is
+        // proleptic Gregorian (no Julian switch), so this still aligns and stays on the meta tier.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_day", -171499));
+
+        List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertEquals(1, rowGroupStatistics.size());
+        Assertions.assertEquals("1500-06-15",
+                rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void minSupportedDateIsAccepted() throws Exception {
+        // epochDay -719162 = 0001-01-01, the lower edge of the DATE window — accepted.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_day", -719162));
+
+        List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+
+        Assertions.assertEquals(1, rowGroupStatistics.size());
+        Assertions.assertEquals("0001-01-01",
+                rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void belowMinSupportedDateFallsBackToDataTier() throws Exception {
+        // epochDay -719163 = 0000-12-31, below 0001-01-01: outside the DATE window → data tier.
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); }",
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_day", -719163));
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(


### PR DESCRIPTION
## Why I'm doing:

The meta-tier footer-stats sampler gated both DATE and DATETIME sort-key boundaries to a single `[1970-01-01, 9999-12-31]` window, so a pre-1970 / pre-1582 DATE sort key always paid a data-tier sub-query even though its boundary is exactly representable.

A DATE boundary has no sub-second component, and BE decodes a Parquet/ORC day-of-epoch with the same proleptic-Gregorian algorithm `java.time` uses (a fixed Julian offset, no 1582 cutover), so a pre-1970 / pre-1582 DATE boundary is FE/BE-identical for every representable value down to year 1.

## What I'm doing:

Split the single window into a DATE window `[0001-01-01, 9999-12-31]` and a DATETIME window `[1970-01-01, 9999-12-31]`. Both readers' DATE-decode paths use the widened DATE check (`rejectDateOutsideWindow`); the DATETIME-decode paths keep the epoch lower bound (`rejectDateTimeOutsideWindow`).

DATETIME keeps the 1970 lower bound because the BE timestamp load does not yet decode a pre-1970 sub-second tick to a boundary-matching wall clock; a sub-1970 DATETIME continues to fall back to the data tier (no behavior change for DATETIME).

A pre-1970 / pre-1582 DATE sort key now pre-splits via the meta tier instead of paying a data-tier sub-query.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5