### PR TITLE
[UT] Fix chunk_helper_test convert_field after ChunkHelper refactor (#75184)

### DIFF
--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -32,6 +32,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
+#include "storage/primitive/schema_helper.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -223,7 +224,7 @@ TEST_F(ChunkHelperTest, Accumulator) {
 
 TEST_F(ChunkHelperTest, PaddingNullableCharColumnSkipsNullRowsWhenNullsAreDense) {
     auto tablet_schema = create_char_tablet_schema(4);
-    Field field = ChunkHelper::convert_field(0, tablet_schema->column(0));
+    Field field = StorageSchemaHelper::convert_field(0, tablet_schema->column(0));
     auto column = make_nullable_binary_column({"ab", "null", "wxyzq", "skip", "defg", "hi", "null", ""},
                                               {0, 1, 0, 1, 0, 0, 1, 0});
 
@@ -248,7 +249,7 @@ TEST_F(ChunkHelperTest, PaddingNullableCharColumnSkipsNullRowsWhenNullsAreDense)
 
 TEST_F(ChunkHelperTest, PaddingNullableCharColumnCopiesAllRowsWhenNullsAreSparse) {
     auto tablet_schema = create_char_tablet_schema(4);
-    Field field = ChunkHelper::convert_field(0, tablet_schema->column(0));
+    Field field = StorageSchemaHelper::convert_field(0, tablet_schema->column(0));
     auto column = make_nullable_binary_column({"a", "bc", "def", "nullv", "wxyzq", "m", "no", "pqrs"},
                                               {0, 0, 0, 1, 0, 0, 0, 0});
 


### PR DESCRIPTION
## Why I'm doing:

Two PRs that each passed CI independently created a logical merge conflict on `main`, breaking BE UT compilation for every open PR:

- **#75184** *(Refactor: move dictionary cache manager to compute env)* removed `ChunkHelper::convert_field` and migrated every caller to `StorageSchemaHelper::convert_field` (the implementation moved to `be/src/storage/primitive/schema_helper.{h,cpp}`). It did **not** touch `be/test/storage/chunk_helper_test.cpp` — that file did not exist on its base.
- **#74838** *(Enhancement: replace offset implementation in BinaryColumn by AdaptiveOffsets)* added two tests in `be/test/storage/chunk_helper_test.cpp` that call `ChunkHelper::convert_field`.

Each PR was green against its own base; combined on `main` the test file fails to compile:

```
error: 'convert_field' is not a member of 'starrocks::ChunkHelper'
```

## What I'm doing:

Mirror #75184's caller migration at the two test call sites (`ChunkHelperTest.PaddingNullableCharColumnSkipsNullRowsWhenNullsAreDense` and `...CopiesAllRowsWhenNullsAreSparse`):

- `ChunkHelper::convert_field(0, tablet_schema->column(0))` → `StorageSchemaHelper::convert_field(0, tablet_schema->column(0))`
- add `#include "storage/primitive/schema_helper.h"`

`StorageSchemaHelper::convert_field` has the identical signature, so the test intent is unchanged (build a `Field` for column 0 from the tablet schema). The diff is 3 lines and touches only the test file. This is a main-only, unreleased breakage, so no backport is needed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
