### PR TITLE
[Enhancement] Support extended BinaryColumn serde format

### DIFF
--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -24,6 +24,7 @@
 
 #include "base/coding.h"
 #include "base/compression/compression_headers.h"
+#include "base/failpoint/fail_point.h"
 #include "base/status.h"
 #include "base/statusor.h"
 #include "column/array_column.h"
@@ -45,6 +46,14 @@
 #include "types/percentile_value.h"
 
 namespace starrocks::serde {
+
+// Test-only seam. The real trigger for the extended BinaryColumn layout is a
+// payload that overflows the legacy u32 format (bytes or offsets > UINT32_MAX),
+// which cannot be allocated in a unit test. When this failpoint is enabled,
+// `_can_use_legacy_u32_format` reports overflow so the extended serialize/size
+// path can be exercised on a small column. Compiled out entirely without
+// FIU_ENABLE, so it has no effect on release builds.
+DEFINE_FAIL_POINT(binary_column_serde_force_extended_format);
 
 static Status check_remaining_size(const uint8_t* current, const uint8_t* end, size_t expected_remains) {
     if (expected_remains > static_cast<size_t>(end - current)) {
@@ -348,6 +357,9 @@ private:
     static constexpr int64_t kExtendedHeaderSize = sizeof(uint32_t) * 2;
 
     static bool _can_use_legacy_u32_format(const BinaryColumnBase<uint32_t>& column) {
+        // Test-only: pretend the payload overflows the legacy u32 layout so the
+        // extended serialize/size path is reachable without a >4GB column.
+        FAIL_POINT_TRIGGER_RETURN(binary_column_serde_force_extended_format, false);
         const auto bytes_size = column.get_immutable_bytes().size();
         const auto offset_bytes_size = static_cast<uint64_t>(column.get_offset().size()) * sizeof(uint32_t);
         return bytes_size <= std::numeric_limits<uint32_t>::max() &&

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -394,8 +394,8 @@ private:
         int64_t size = sizeof(SerializedValue);
         if (is_string_encoding_enabled(encode_level) && bytes.size() >= ENCODE_SIZE_LIMIT &&
             bytes.size() <= LZ4_MAX_INPUT_SIZE) {
-            size += sizeof(uint64_t) + std::max(static_cast<int64_t>(bytes.size()),
-                                                static_cast<int64_t>(LZ4_compressBound(bytes.size())));
+            size += sizeof(uint64_t) +
+                    std::max(static_cast<int64_t>(bytes.size()), static_cast<int64_t>(LZ4_compressBound(bytes.size())));
         } else {
             size += bytes.size();
         }
@@ -404,9 +404,8 @@ private:
         size += sizeof(SerializedValue);
         if (_can_encode_offsets_as_integers(offset_bytes_size, encode_level)) {
             const auto integer_count = upper_int32(offset_bytes_size);
-            size += sizeof(uint64_t) +
-                    std::max(static_cast<int64_t>(offset_bytes_size),
-                             static_cast<int64_t>(streamvbyte_max_compressedbytes(integer_count)));
+            size += sizeof(uint64_t) + std::max(static_cast<int64_t>(offset_bytes_size),
+                                                static_cast<int64_t>(streamvbyte_max_compressedbytes(integer_count)));
         } else {
             size += offset_bytes_size;
         }
@@ -466,8 +465,8 @@ private:
 
     template <typename SerializedValue, typename T>
     static StatusOr<const uint8_t*> _deserialize_bytes_with_size(const uint8_t* buff, const uint8_t* end,
-                                                                 BinaryColumnBase<T>* column, SerializedValue bytes_size,
-                                                                 int encode_level) {
+                                                                 BinaryColumnBase<T>* column,
+                                                                 SerializedValue bytes_size, int encode_level) {
         column->get_bytes().resize(bytes_size);
         auto* bytes_data = column->get_bytes().data();
         if (is_string_encoding_enabled(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT &&
@@ -479,9 +478,9 @@ private:
 
     template <typename SerializedOffset, typename T>
     static StatusOr<const uint8_t*> _deserialize_offsets_with_size(const uint8_t* buff, const uint8_t* end,
-                                                                    BinaryColumnBase<T>* column,
-                                                                    SerializedOffset offset_bytes_size,
-                                                                    int encode_level) {
+                                                                   BinaryColumnBase<T>* column,
+                                                                   SerializedOffset offset_bytes_size,
+                                                                   int encode_level) {
         if (UNLIKELY(offset_bytes_size % sizeof(SerializedOffset) != 0)) {
             return Status::InternalError(fmt::format("invalid binary column offset bytes size {}, offset width {}",
                                                      offset_bytes_size, sizeof(SerializedOffset)));
@@ -516,8 +515,8 @@ private:
     static StatusOr<const uint8_t*> _deserialize_body_with_size(const uint8_t* buff, const uint8_t* end,
                                                                 BinaryColumnBase<T>* column, SerializedValue bytes_size,
                                                                 int encode_level) {
-        ASSIGN_OR_RETURN(
-                buff, _deserialize_bytes_with_size<SerializedValue>(buff, end, column, bytes_size, encode_level));
+        ASSIGN_OR_RETURN(buff,
+                         _deserialize_bytes_with_size<SerializedValue>(buff, end, column, bytes_size, encode_level));
         return _deserialize_offsets<SerializedValue>(buff, end, column, encode_level);
     }
 

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -252,125 +252,269 @@ public:
 };
 
 class BinaryColumnSerde {
+    // ColumnArraySerde has three binary wire layouts.
+    //
+    // 1. Normal BinaryColumn: used when both bytes and offsets payload sizes
+    //    fit in u32. This is the historical layout and remains the default fast
+    //    path. The boundary value bytes_size == UINT32_MAX is still encoded by
+    //    this format for compatibility with existing legacy payloads.
+    //
+    //      u32 bytes_size
+    //      bytes
+    //      u32 offset_bytes_size
+    //      u32 offsets
+    //
+    // 2. Overflow BinaryColumn: used when the legacy u32 layout cannot
+    //    represent the column. It starts with an escape header that a valid
+    //    legacy BinaryColumn payload can never emit: bytes_size == 0 and
+    //    offset_bytes_size == 0. Even an empty legacy BinaryColumn has one
+    //    offset entry, so its legacy offset_bytes_size is at least 4.
+    //
+    //      u32 bytes_size (0)
+    //      u32 offset_bytes_size (0)
+    //      u64 bytes_size
+    //      bytes
+    //      u64 offset_bytes_size
+    //      u64 offsets
+    //
+    // 3. LargeBinaryColumn: keeps the original bare u64 body without the
+    //    BinaryColumn escape prefix.
+    //
+    //      u64 bytes_size
+    //      bytes
+    //      u64 offset_bytes_size
+    //      u64 offsets
+    //
+    // During BE rolling upgrade we rely on the existing operational guarantee
+    // that BinaryColumn chunks do not overflow the legacy u32 layout. Under
+    // that condition new BEs still emit exactly the historical BinaryColumn
+    // format, so old BEs can deserialize exchanged/spilled payloads normally.
+    // After all BEs are upgraded, overflow BinaryColumns can use the extended
+    // escape format. The common non-overflow path keeps the original u32 body,
+    // and the extended escape is structurally disjoint from every valid legacy
+    // payload, so no content collision can make a legacy column ambiguous.
+    // The extended BinaryColumn layout is not readable by old BEs. Rolling
+    // downgrade or mixed-version runtime exchange still relies on the same
+    // no-overflow guarantee; delete-file persistence has a separate legacy
+    // guard in PrimaryKeyEncoder.
 public:
     template <typename T>
     static int64_t max_serialized_size(const BinaryColumnBase<T>& column, const int encode_level) {
-        auto bytes = column.get_immutable_bytes();
-        const auto& offsets = column.get_offset();
-        int64_t res = sizeof(T) * 2;
-        int64_t offsets_size = offsets.size() * sizeof(T);
-        if (is_integer_encoding_enabled(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
-            res += sizeof(uint64_t) +
-                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size)));
-        } else {
-            res += offsets_size;
+        if constexpr (std::is_same_v<T, uint32_t>) {
+            if (!_can_use_legacy_u32_format(column)) {
+                return kExtendedHeaderSize +
+                       _max_body_size<uint64_t>(column.get_immutable_bytes(), column.get_offset(), encode_level);
+            }
         }
-        if (is_string_encoding_enabled(encode_level) && bytes.size() >= ENCODE_SIZE_LIMIT) {
-            res += sizeof(uint64_t) + std::max((int64_t)bytes.size(), (int64_t)LZ4_compressBound(bytes.size()));
-        } else {
-            res += bytes.size();
-        }
-        return res;
+        return _max_body_size<T>(column.get_immutable_bytes(), column.get_offset(), encode_level);
     }
 
     template <typename T>
     static uint8_t* serialize(const BinaryColumnBase<T>& column, uint8_t* buff, const int encode_level) {
-        auto bytes = column.get_immutable_bytes();
-        const auto& offsets = column.get_offset();
-
-        T bytes_size = bytes.size() * sizeof(uint8_t);
         if constexpr (std::is_same_v<T, uint32_t>) {
-            buff = write_little_endian_32(bytes_size, buff);
-        } else {
-            buff = write_little_endian_64(bytes_size, buff);
-        }
-        if (is_string_encoding_enabled(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT &&
-            bytes_size <= LZ4_MAX_INPUT_SIZE) {
-            buff = encode_string_lz4(bytes.data(), bytes_size, buff, encode_level);
-        } else {
-            buff = write_raw(bytes.data(), bytes_size, buff);
-        }
-
-        //TODO: if T is uint32_t, `offsets_size` may be overflow
-        T offsets_size = offsets.size() * sizeof(T);
-        if constexpr (std::is_same_v<T, uint32_t>) {
-            buff = write_little_endian_32(offsets_size, buff);
-        } else {
-            buff = write_little_endian_64(offsets_size, buff);
-        }
-        if (is_integer_encoding_enabled(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
-            if (sizeof(T) == 4) { // only support sorted 32-bit integers
-                buff = offsets.visit_storage([&](const auto& offsets_buf) {
-                    auto offset_data = _get_offsets_data<T>(offsets_buf);
-                    return encode_integers<true>(offset_data.data(), offsets_size, buff, encode_level);
-                });
-            } else {
-                buff = offsets.visit_storage([&](const auto& offsets_buf) {
-                    auto offset_data = _get_offsets_data<T>(offsets_buf);
-                    return encode_integers<false>(offset_data.data(), offsets_size, buff, encode_level);
-                });
+            if (!_can_use_legacy_u32_format(column)) {
+                buff = _write_size<uint32_t>(kExtendedU32Escape, buff);
+                buff = _write_size<uint32_t>(kExtendedU32Escape, buff);
+                return _serialize_body<uint64_t>(column.get_immutable_bytes(), column.get_offset(), buff, encode_level);
             }
-        } else {
-            buff = offsets.visit_storage([&](const auto& offsets_buf) {
-                auto offset_data = _get_offsets_data<T>(offsets_buf);
-                return write_raw(offset_data.data(), offsets_size, buff);
-            });
         }
-        return buff;
+        return _serialize_body<T>(column.get_immutable_bytes(), column.get_offset(), buff, encode_level);
     }
 
     template <typename T>
     static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, BinaryColumnBase<T>* column,
                                                 const int encode_level) {
-        // deserialize bytes
-        T bytes_size = 0;
         if constexpr (std::is_same_v<T, uint32_t>) {
-            ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &bytes_size));
+            uint32_t bytes_size = 0;
+            ASSIGN_OR_RETURN(buff, _read_size<uint32_t>(buff, end, &bytes_size));
+            if (bytes_size == kExtendedU32Escape) {
+                uint32_t offset_bytes_size = 0;
+                ASSIGN_OR_RETURN(buff, _read_size<uint32_t>(buff, end, &offset_bytes_size));
+                if (offset_bytes_size == kExtendedU32Escape) {
+                    return _deserialize_body<uint64_t>(buff, end, column, encode_level);
+                }
+                ASSIGN_OR_RETURN(buff,
+                                 _deserialize_bytes_with_size<uint32_t>(buff, end, column, bytes_size, encode_level));
+                return _deserialize_offsets_with_size<uint32_t>(buff, end, column, offset_bytes_size, encode_level);
+            }
+            return _deserialize_body_with_size<uint32_t>(buff, end, column, bytes_size, encode_level);
         } else {
-            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &bytes_size));
+            return _deserialize_body<uint64_t>(buff, end, column, encode_level);
         }
-        column->get_bytes().resize(bytes_size);
+    }
 
+private:
+    static constexpr uint32_t kExtendedU32Escape = 0;
+    static constexpr int64_t kExtendedHeaderSize = sizeof(uint32_t) * 2;
+
+    static bool _can_use_legacy_u32_format(const BinaryColumnBase<uint32_t>& column) {
+        const auto bytes_size = column.get_immutable_bytes().size();
+        const auto offset_bytes_size = static_cast<uint64_t>(column.get_offset().size()) * sizeof(uint32_t);
+        return bytes_size <= std::numeric_limits<uint32_t>::max() &&
+               offset_bytes_size <= std::numeric_limits<uint32_t>::max();
+    }
+
+    static bool _can_encode_offsets_as_integers(uint64_t offset_bytes_size, int encode_level) {
+        return is_integer_encoding_enabled(encode_level) && offset_bytes_size >= ENCODE_SIZE_LIMIT &&
+               upper_int32(offset_bytes_size) <= std::numeric_limits<uint32_t>::max();
+    }
+
+    template <typename SerializedValue>
+    static uint8_t* _write_size(uint64_t value, uint8_t* buff) {
+        if constexpr (std::is_same_v<SerializedValue, uint32_t>) {
+            DCHECK_LE(value, std::numeric_limits<uint32_t>::max());
+            return write_little_endian_32(static_cast<uint32_t>(value), buff);
+        }
+        return write_little_endian_64(value, buff);
+    }
+
+    template <typename SerializedValue>
+    static StatusOr<const uint8_t*> _read_size(const uint8_t* buff, const uint8_t* end, SerializedValue* value) {
+        if constexpr (std::is_same_v<SerializedValue, uint32_t>) {
+            return read_little_endian_32(buff, end, value);
+        } else {
+            return read_little_endian_64(buff, end, value);
+        }
+    }
+
+    template <typename SerializedValue>
+    static int64_t _max_body_size(ImmBytes bytes, const AdaptiveOffsets& offsets, int encode_level) {
+        int64_t size = sizeof(SerializedValue);
+        if (is_string_encoding_enabled(encode_level) && bytes.size() >= ENCODE_SIZE_LIMIT &&
+            bytes.size() <= LZ4_MAX_INPUT_SIZE) {
+            size += sizeof(uint64_t) + std::max(static_cast<int64_t>(bytes.size()),
+                                                static_cast<int64_t>(LZ4_compressBound(bytes.size())));
+        } else {
+            size += bytes.size();
+        }
+
+        const auto offset_bytes_size = static_cast<uint64_t>(offsets.size()) * sizeof(SerializedValue);
+        size += sizeof(SerializedValue);
+        if (_can_encode_offsets_as_integers(offset_bytes_size, encode_level)) {
+            const auto integer_count = upper_int32(offset_bytes_size);
+            size += sizeof(uint64_t) +
+                    std::max(static_cast<int64_t>(offset_bytes_size),
+                             static_cast<int64_t>(streamvbyte_max_compressedbytes(integer_count)));
+        } else {
+            size += offset_bytes_size;
+        }
+        return size;
+    }
+
+    template <typename SerializedValue>
+    static uint8_t* _serialize_bytes(ImmBytes bytes, uint8_t* buff, int encode_level) {
+        if constexpr (std::is_same_v<SerializedValue, uint32_t>) {
+            DCHECK_LE(bytes.size(), std::numeric_limits<uint32_t>::max());
+        }
+        const SerializedValue bytes_size = static_cast<SerializedValue>(bytes.size());
+        buff = _write_size<SerializedValue>(bytes_size, buff);
+        if (is_string_encoding_enabled(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT &&
+            bytes_size <= LZ4_MAX_INPUT_SIZE) {
+            return encode_string_lz4(bytes.data(), bytes_size, buff, encode_level);
+        }
+        return write_raw(bytes.data(), bytes_size, buff);
+    }
+
+    template <typename SerializedOffset>
+    static uint8_t* _serialize_offsets(const AdaptiveOffsets& offsets, uint8_t* buff, int encode_level) {
+        const auto offset_bytes_size = static_cast<uint64_t>(offsets.size()) * sizeof(SerializedOffset);
+        buff = _write_size<SerializedOffset>(offset_bytes_size, buff);
+        offsets.visit_storage([&](const auto& offsets_buf) {
+            using SrcOffset = typename std::decay_t<decltype(offsets_buf)>::value_type;
+            Buffer<SerializedOffset> converted_offsets;
+            const SerializedOffset* offset_data = nullptr;
+            if constexpr (std::is_same_v<SrcOffset, SerializedOffset>) {
+                offset_data = offsets_buf.data();
+            } else {
+                raw::stl_vector_resize_uninitialized(&converted_offsets, offsets_buf.size());
+                for (size_t i = 0; i < offsets_buf.size(); ++i) {
+                    converted_offsets[i] = static_cast<SerializedOffset>(offsets_buf[i]);
+                }
+                offset_data = converted_offsets.data();
+            }
+
+            if (_can_encode_offsets_as_integers(offset_bytes_size, encode_level)) {
+                if constexpr (std::is_same_v<SerializedOffset, uint32_t>) {
+                    buff = encode_integers<true>(offset_data, offset_bytes_size, buff, encode_level);
+                } else {
+                    buff = encode_integers<false>(offset_data, offset_bytes_size, buff, encode_level);
+                }
+            } else {
+                buff = write_raw(offset_data, offset_bytes_size, buff);
+            }
+        });
+        return buff;
+    }
+
+    template <typename SerializedValue>
+    static uint8_t* _serialize_body(ImmBytes bytes, const AdaptiveOffsets& offsets, uint8_t* buff, int encode_level) {
+        buff = _serialize_bytes<SerializedValue>(bytes, buff, encode_level);
+        return _serialize_offsets<SerializedValue>(offsets, buff, encode_level);
+    }
+
+    template <typename SerializedValue, typename T>
+    static StatusOr<const uint8_t*> _deserialize_bytes_with_size(const uint8_t* buff, const uint8_t* end,
+                                                                 BinaryColumnBase<T>* column, SerializedValue bytes_size,
+                                                                 int encode_level) {
+        column->get_bytes().resize(bytes_size);
         auto* bytes_data = column->get_bytes().data();
         if (is_string_encoding_enabled(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT &&
             bytes_size <= LZ4_MAX_INPUT_SIZE) {
-            ASSIGN_OR_RETURN(buff, decode_string_lz4(buff, end, bytes_data, bytes_size));
-        } else {
-            ASSIGN_OR_RETURN(buff, read_raw(buff, end, bytes_data, bytes_size));
+            return decode_string_lz4(buff, end, bytes_data, bytes_size);
+        }
+        return read_raw(buff, end, bytes_data, bytes_size);
+    }
+
+    template <typename SerializedOffset, typename T>
+    static StatusOr<const uint8_t*> _deserialize_offsets_with_size(const uint8_t* buff, const uint8_t* end,
+                                                                    BinaryColumnBase<T>* column,
+                                                                    SerializedOffset offset_bytes_size,
+                                                                    int encode_level) {
+        if (UNLIKELY(offset_bytes_size % sizeof(SerializedOffset) != 0)) {
+            return Status::InternalError(fmt::format("invalid binary column offset bytes size {}, offset width {}",
+                                                     offset_bytes_size, sizeof(SerializedOffset)));
         }
 
-        T offset_bytes_size = 0;
-        if constexpr (std::is_same_v<T, uint32_t>) {
-            ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &offset_bytes_size));
+        Buffer<SerializedOffset> serialized_offsets;
+        raw::make_room(&serialized_offsets, offset_bytes_size / sizeof(SerializedOffset));
+        if (_can_encode_offsets_as_integers(offset_bytes_size, encode_level)) {
+            constexpr bool is_i32 = std::is_same_v<SerializedOffset, uint32_t>;
+            ASSIGN_OR_RETURN(buff, decode_integers<is_i32>(buff, end, serialized_offsets.data(), offset_bytes_size));
         } else {
-            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &offset_bytes_size));
+            ASSIGN_OR_RETURN(buff, read_raw(buff, end, serialized_offsets.data(), offset_bytes_size));
         }
-        Buffer<T> offsets;
-        raw::make_room(&offsets, offset_bytes_size / sizeof(T));
 
-        if (is_integer_encoding_enabled(encode_level) && offset_bytes_size >= ENCODE_SIZE_LIMIT) {
-            constexpr bool is_i32 = sizeof(T) == 4;
-            ASSIGN_OR_RETURN(buff, decode_integers<is_i32>(buff, end, offsets.data(), offset_bytes_size));
+        if constexpr (std::is_same_v<SerializedOffset, uint32_t>) {
+            column->get_offset().set_small_buffer(std::move(serialized_offsets));
         } else {
-            ASSIGN_OR_RETURN(buff, read_raw(buff, end, offsets.data(), offset_bytes_size));
-        }
-        if constexpr (std::is_same_v<T, uint32_t>) {
-            column->get_offset().set_small_buffer(std::move(offsets));
-        } else {
-            column->get_offset().set_large_buffer(std::move(offsets));
+            column->get_offset().set_large_buffer(std::move(serialized_offsets));
         }
         return buff;
     }
 
-private:
-    template <typename DstOffset, typename SrcOffsets>
-    static Buffer<DstOffset> _get_offsets_data(const SrcOffsets& src_offsets) {
-        Buffer<DstOffset> dst_offsets;
-        raw::stl_vector_resize_uninitialized(&dst_offsets, src_offsets.size());
-        for (size_t i = 0; i < src_offsets.size(); ++i) {
-            dst_offsets[i] = static_cast<DstOffset>(src_offsets[i]);
-        }
-        return dst_offsets;
+    template <typename SerializedOffset, typename T>
+    static StatusOr<const uint8_t*> _deserialize_offsets(const uint8_t* buff, const uint8_t* end,
+                                                         BinaryColumnBase<T>* column, int encode_level) {
+        SerializedOffset offset_bytes_size = 0;
+        ASSIGN_OR_RETURN(buff, _read_size<SerializedOffset>(buff, end, &offset_bytes_size));
+        return _deserialize_offsets_with_size(buff, end, column, offset_bytes_size, encode_level);
+    }
+
+    template <typename SerializedValue, typename T>
+    static StatusOr<const uint8_t*> _deserialize_body_with_size(const uint8_t* buff, const uint8_t* end,
+                                                                BinaryColumnBase<T>* column, SerializedValue bytes_size,
+                                                                int encode_level) {
+        ASSIGN_OR_RETURN(
+                buff, _deserialize_bytes_with_size<SerializedValue>(buff, end, column, bytes_size, encode_level));
+        return _deserialize_offsets<SerializedValue>(buff, end, column, encode_level);
+    }
+
+    template <typename SerializedValue, typename T>
+    static StatusOr<const uint8_t*> _deserialize_body(const uint8_t* buff, const uint8_t* end,
+                                                      BinaryColumnBase<T>* column, int encode_level) {
+        SerializedValue bytes_size = 0;
+        ASSIGN_OR_RETURN(buff, _read_size<SerializedValue>(buff, end, &bytes_size));
+        return _deserialize_body_with_size<SerializedValue>(buff, end, column, bytes_size, encode_level);
     }
 };
 

--- a/be/src/storage/del_file_stream_converter.cpp
+++ b/be/src/storage/del_file_stream_converter.cpp
@@ -119,6 +119,7 @@ Status DelFileStreamConverter::close() {
     PrimaryKeyEncoder::encode(*_pkey_schema, pk_chunk, /*offset=*/0, /*len=*/row_count, dst_col.get(),
                               _target_pk_encoding);
 
+    RETURN_IF_ERROR(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(*dst_col));
     const int64_t output_capacity = serde::ColumnArraySerde::max_serialized_size(*dst_col);
     if (output_capacity <= 0) {
         return Status::InternalError("ColumnArraySerde::max_serialized_size returned 0 for target column");

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -25,6 +25,7 @@
 #include "storage/lake/filenames.h"
 #include "storage/lake/pk_tablet_sst_writer.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/primitive/primary_key_encoder.h"
 #include "storage/rows_mapper.h"
 #include "storage/rowset/segment_writer.h"
 
@@ -73,6 +74,7 @@ Status HorizontalPkTabletWriter::flush_del_file(const Column& deletes) {
         wopts.encryption_info = pair.info;
         encryption_meta.swap(pair.encryption_meta);
     }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(deletes));
     std::unique_ptr<WritableFile> of;
     if (_location_provider && _fs) {
         ASSIGN_OR_RETURN(of, _fs->new_writable_file(_location_provider->del_location(_tablet_id, name)));

--- a/be/src/storage/primitive/primary_key_encoder.cpp
+++ b/be/src/storage/primitive/primary_key_encoder.cpp
@@ -283,10 +283,10 @@ Status PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(
         return Status::OK();
     }
 
-    return Status::CapacityLimitExceed(fmt::format(
-            "primary key encoded BinaryColumn cannot be serialized with legacy u32 format, bytes_size: {}, "
-            "offset_bytes_size: {}, limit: {}",
-            bytes_size, offset_bytes_size, std::numeric_limits<uint32_t>::max()));
+    return Status::CapacityLimitExceed(
+            fmt::format("primary key encoded BinaryColumn cannot be serialized with legacy u32 format, bytes_size: {}, "
+                        "offset_bytes_size: {}, limit: {}",
+                        bytes_size, offset_bytes_size, std::numeric_limits<uint32_t>::max()));
 }
 
 Status PrimaryKeyEncoder::create_column(const Schema& schema, MutableColumnPtr* pcolumn,

--- a/be/src/storage/primitive/primary_key_encoder.cpp
+++ b/be/src/storage/primitive/primary_key_encoder.cpp
@@ -35,8 +35,11 @@
 
 #include "storage/primitive/primary_key_encoder.h"
 
+#include <fmt/format.h>
+
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <type_traits>
@@ -261,6 +264,29 @@ size_t PrimaryKeyEncoder::get_encoded_fixed_size(const Schema& schema, PrimaryKe
         ret += TypeUtils::estimate_field_size(t, 0);
     }
     return ret;
+}
+
+Status PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(const Column& column) {
+    const auto* data_column = ColumnHelper::get_data_column(&column);
+    if (data_column->is_large_binary()) {
+        return Status::NotSupported("LargeBinaryColumn cannot be serialized with legacy BinaryColumn format");
+    }
+    if (!data_column->is_binary()) {
+        return Status::OK();
+    }
+
+    const auto* binary_column = down_cast<const BinaryColumn*>(data_column);
+    const auto bytes_size = binary_column->get_immutable_bytes().size();
+    const auto offset_bytes_size = static_cast<uint64_t>(binary_column->get_offset().size()) * sizeof(uint32_t);
+    if (bytes_size <= std::numeric_limits<uint32_t>::max() &&
+        offset_bytes_size <= std::numeric_limits<uint32_t>::max()) {
+        return Status::OK();
+    }
+
+    return Status::CapacityLimitExceed(fmt::format(
+            "primary key encoded BinaryColumn cannot be serialized with legacy u32 format, bytes_size: {}, "
+            "offset_bytes_size: {}, limit: {}",
+            bytes_size, offset_bytes_size, std::numeric_limits<uint32_t>::max()));
 }
 
 Status PrimaryKeyEncoder::create_column(const Schema& schema, MutableColumnPtr* pcolumn,

--- a/be/src/storage/primitive/primary_key_encoder.h
+++ b/be/src/storage/primitive/primary_key_encoder.h
@@ -162,6 +162,10 @@ public:
     static Status create_column(const Schema& schema, MutableColumnPtr* pcolumn, const std::vector<ColumnId>& key_idxes,
                                 PrimaryKeyEncodingType encoding_type, bool large_column = false);
 
+    // Delete files are persisted with the historical BinaryColumn serde format.
+    // Check that an encoded primary-key column can still be persisted by delete files in that legacy format.
+    static Status check_can_persist_delete_file_as_legacy_binary_format(const Column& column);
+
     static void encode(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest,
                        PrimaryKeyEncodingType encoding_type);
 

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -65,6 +65,7 @@
 #include "storage/index/index_descriptor.h"
 #include "storage/metadata_util.h"
 #include "storage/primitive/empty_iterator.h"
+#include "storage/primitive/primary_key_encoder.h"
 #include "storage/primitive/storage_define.h"
 #include "storage/primitive/type_utils.h"
 #include "storage/rows_mapper.h"
@@ -694,6 +695,7 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const Chunk& upserts, co
             wopts.encryption_info = pair.info;
             encryption_meta = std::move(pair.encryption_meta);
         }
+        RETURN_IF_ERROR(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(deletes));
         auto file_path = Rowset::segment_del_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_delfile);
         ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(wopts, file_path));
         size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);

--- a/be/test/serde/serde_test.cpp
+++ b/be/test/serde/serde_test.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
+#include <limits>
+#include <type_traits>
 
 #include "base/coding.h"
 #include "base/failpoint/fail_point.h"
@@ -37,6 +39,7 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/memory/mem_chunk_allocator.h"
 #include "serde/column_array_serde.h"
+#include "serde/encode_level.h"
 #include "serde/protobuf_serde.h"
 #include "types/hll.h"
 #include "types/json_value.h"
@@ -729,6 +732,63 @@ PARALLEL_TEST(ColumnArraySerdeTest, nullable_int32_column) {
     }
 }
 
+namespace {
+
+template <typename ColumnType>
+void append_binary_serde_test_strings(ColumnType* column) {
+    std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
+    column->append_strings(strings.data(), strings.size());
+}
+
+template <typename ColumnType>
+void force_large_offsets(ColumnType* column) {
+    AdaptiveOffsets::Large large_offsets;
+    large_offsets.resize(column->get_offset().size());
+    for (size_t i = 0; i < column->get_offset().size(); ++i) {
+        large_offsets[i] = column->get_offset()[i];
+    }
+    column->get_offset().set_large_buffer(std::move(large_offsets));
+}
+
+template <typename ColumnType>
+void assert_binary_column_equal(const ColumnType& lhs, const ColumnType& rhs) {
+    ASSERT_EQ(lhs.size(), rhs.size());
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        ASSERT_EQ(lhs.get_slice(i), rhs.get_slice(i));
+    }
+}
+
+bool has_binary_serde_extended_escape(const uint8_t* buffer) {
+    const auto bytes_size = decode_fixed32_le(buffer);
+    return bytes_size == 0 && decode_fixed32_le(buffer + sizeof(uint32_t)) == 0;
+}
+
+template <typename ColumnType>
+void assert_binary_serde_round_trip(const ColumnType& src, ColumnType* dst, int64_t expected_size,
+                                    bool expect_extended_escape, bool expect_dst_large_offsets) {
+    const auto max_size = ColumnArraySerde::max_serialized_size(src);
+    ASSERT_EQ(expected_size, max_size);
+
+    ASSERT_GE(max_size, 0);
+    const auto expected_size_bytes = static_cast<size_t>(expected_size);
+    std::vector<uint8_t> buffer(expected_size_bytes);
+    ASSIGN_OR_ABORT(auto serialized_end, ColumnArraySerde::serialize(src, buffer.data()));
+    ASSERT_EQ(buffer.data() + expected_size_bytes, serialized_end);
+
+    if (expect_extended_escape) {
+        ASSERT_TRUE(has_binary_serde_extended_escape(buffer.data()));
+    } else if constexpr (std::is_same_v<ColumnType, BinaryColumn>) {
+        ASSERT_FALSE(has_binary_serde_extended_escape(buffer.data()));
+    }
+
+    ASSIGN_OR_ABORT(auto deserialized_end, ColumnArraySerde::deserialize(buffer.data(), serialized_end, dst));
+    ASSERT_EQ(serialized_end, deserialized_end);
+    ASSERT_EQ(expect_dst_large_offsets, dst->get_offset().is_large());
+    assert_binary_column_equal(src, *dst);
+}
+
+} // namespace
+
 // NOLINTNEXTLINE
 PARALLEL_TEST(ColumnArraySerdeTest, binary_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
@@ -759,6 +819,167 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column) {
             ASSERT_EQ(c1->get_slice(i), c2->get_slice(i));
         }
     }
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_empty_legacy_format) {
+    auto c1 = BinaryColumn::create();
+    auto c2 = BinaryColumn::create();
+
+    const int64_t expected_size = sizeof(uint32_t) * 3;
+    ASSERT_EQ(expected_size, ColumnArraySerde::max_serialized_size(*c1));
+
+    std::vector<uint8_t> buffer(static_cast<size_t>(expected_size));
+    ASSIGN_OR_ABORT(auto serialized_end, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSERT_EQ(buffer.data() + static_cast<size_t>(expected_size), serialized_end);
+    ASSERT_EQ(0, decode_fixed32_le(buffer.data()));
+    ASSERT_EQ(static_cast<uint32_t>(sizeof(uint32_t)), decode_fixed32_le(buffer.data() + sizeof(uint32_t)));
+    ASSERT_FALSE(has_binary_serde_extended_escape(buffer.data()));
+
+    ASSIGN_OR_ABORT(auto deserialized_end, ColumnArraySerde::deserialize(buffer.data(), serialized_end, c2.get()));
+    ASSERT_EQ(serialized_end, deserialized_end);
+    ASSERT_EQ(0, c2->size());
+    ASSERT_FALSE(c2->get_offset().is_large());
+    ASSERT_EQ(1, c2->get_offset().size());
+    ASSERT_EQ(0, c2->get_offset().back());
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_serde_offset_width_layouts) {
+    {
+        auto c1 = BinaryColumn::create();
+        auto c2 = BinaryColumn::create();
+        append_binary_serde_test_strings(c1.get());
+        ASSERT_FALSE(c1->get_offset().is_large());
+
+        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) +
+                                   sizeof(uint32_t) * 2;
+        assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, false);
+    }
+
+    {
+        auto c1 = BinaryColumn::create();
+        auto c2 = BinaryColumn::create();
+        append_binary_serde_test_strings(c1.get());
+        force_large_offsets(c1.get());
+        ASSERT_TRUE(c1->get_offset().is_large());
+
+        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) +
+                                   sizeof(uint32_t) * 2;
+        assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, false);
+    }
+
+    {
+        auto c1 = LargeBinaryColumn::create();
+        auto c2 = LargeBinaryColumn::create();
+        append_binary_serde_test_strings(c1.get());
+        ASSERT_FALSE(c1->get_offset().is_large());
+
+        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) +
+                                   sizeof(uint64_t) * 2;
+        assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, true);
+    }
+
+    {
+        auto c1 = LargeBinaryColumn::create();
+        auto c2 = LargeBinaryColumn::create();
+        append_binary_serde_test_strings(c1.get());
+        force_large_offsets(c1.get());
+        ASSERT_TRUE(c1->get_offset().is_large());
+
+        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) +
+                                   sizeof(uint64_t) * 2;
+        assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, true);
+    }
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_sticky_large_offsets_integer_encoding) {
+    auto c1 = BinaryColumn::create();
+    auto c2 = BinaryColumn::create();
+
+    std::vector<std::string> values;
+    std::vector<Slice> slices;
+    values.reserve(80);
+    slices.reserve(80);
+    for (int i = 0; i < 80; ++i) {
+        values.emplace_back(strings::Substitute("v$0", i));
+        slices.emplace_back(values.back());
+    }
+    c1->append_strings(slices.data(), slices.size());
+    force_large_offsets(c1.get());
+    ASSERT_TRUE(c1->get_offset().is_large());
+
+    const auto max_size = ColumnArraySerde::max_serialized_size(*c1, ENCODE_INTEGER);
+    ASSERT_GE(max_size, 0);
+    std::vector<uint8_t> buffer(static_cast<size_t>(max_size));
+    ASSIGN_OR_ABORT(auto serialized_end, ColumnArraySerde::serialize(*c1, buffer.data(), false, ENCODE_INTEGER));
+    ASSERT_LE(serialized_end, buffer.data() + buffer.size());
+    ASSERT_FALSE(has_binary_serde_extended_escape(buffer.data()));
+
+    ASSIGN_OR_ABORT(auto deserialized_end,
+                    ColumnArraySerde::deserialize(buffer.data(), serialized_end, c2.get(), false, ENCODE_INTEGER));
+    ASSERT_EQ(serialized_end, deserialized_end);
+    ASSERT_FALSE(c2->get_offset().is_large());
+    assert_binary_column_equal(*c1, *c2);
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, large_binary_column_empty_format) {
+    auto c1 = LargeBinaryColumn::create();
+    auto c2 = LargeBinaryColumn::create();
+
+    const int64_t expected_size = sizeof(uint64_t) * 3;
+    ASSERT_EQ(expected_size, ColumnArraySerde::max_serialized_size(*c1));
+
+    std::vector<uint8_t> buffer(static_cast<size_t>(expected_size));
+    ASSIGN_OR_ABORT(auto serialized_end, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSERT_EQ(buffer.data() + static_cast<size_t>(expected_size), serialized_end);
+    ASSERT_EQ(0, decode_fixed64_le(buffer.data()));
+    ASSERT_EQ(static_cast<uint64_t>(sizeof(uint64_t)), decode_fixed64_le(buffer.data() + sizeof(uint64_t)));
+
+    ASSIGN_OR_ABORT(auto deserialized_end, ColumnArraySerde::deserialize(buffer.data(), serialized_end, c2.get()));
+    ASSERT_EQ(serialized_end, deserialized_end);
+    ASSERT_EQ(0, c2->size());
+    ASSERT_TRUE(c2->get_offset().is_large());
+    ASSERT_EQ(1, c2->get_offset().size());
+    ASSERT_EQ(0, c2->get_offset().back());
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_extended_format_deserialize) {
+    auto append_u32 = [](std::vector<uint8_t>* buffer, uint32_t value) {
+        const auto old_size = buffer->size();
+        buffer->resize(old_size + sizeof(value));
+        encode_fixed32_le(buffer->data() + old_size, value);
+    };
+    auto append_u64 = [](std::vector<uint8_t>* buffer, uint64_t value) {
+        const auto old_size = buffer->size();
+        buffer->resize(old_size + sizeof(value));
+        encode_fixed64_le(buffer->data() + old_size, value);
+    };
+
+    const std::string bytes = "aabbcc";
+    const uint64_t offsets[] = {0, 2, 4, 6};
+
+    std::vector<uint8_t> buffer;
+    append_u32(&buffer, 0);
+    append_u32(&buffer, 0);
+    append_u64(&buffer, bytes.size());
+    buffer.insert(buffer.end(), bytes.begin(), bytes.end());
+    append_u64(&buffer, sizeof(offsets));
+    for (auto offset : offsets) {
+        append_u64(&buffer, offset);
+    }
+
+    auto column = BinaryColumn::create();
+    ASSIGN_OR_ABORT(auto p, ColumnArraySerde::deserialize(buffer.data(), buffer.data() + buffer.size(), column.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p);
+    ASSERT_EQ(3, column->size());
+    ASSERT_TRUE(column->get_offset().is_large());
+    ASSERT_EQ(Slice("aa"), column->get_slice(0));
+    ASSERT_EQ(Slice("bb"), column->get_slice(1));
+    ASSERT_EQ(Slice("cc"), column->get_slice(2));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/serde/serde_test.cpp
+++ b/be/test/serde/serde_test.cpp
@@ -852,8 +852,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_serde_offset_width_layouts) {
         append_binary_serde_test_strings(c1.get());
         ASSERT_FALSE(c1->get_offset().is_large());
 
-        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) +
-                                   sizeof(uint32_t) * 2;
+        const auto expected_size =
+                c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) + sizeof(uint32_t) * 2;
         assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, false);
     }
 
@@ -864,8 +864,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_serde_offset_width_layouts) {
         force_large_offsets(c1.get());
         ASSERT_TRUE(c1->get_offset().is_large());
 
-        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) +
-                                   sizeof(uint32_t) * 2;
+        const auto expected_size =
+                c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint32_t) + sizeof(uint32_t) * 2;
         assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, false);
     }
 
@@ -875,8 +875,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_serde_offset_width_layouts) {
         append_binary_serde_test_strings(c1.get());
         ASSERT_FALSE(c1->get_offset().is_large());
 
-        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) +
-                                   sizeof(uint64_t) * 2;
+        const auto expected_size =
+                c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) + sizeof(uint64_t) * 2;
         assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, true);
     }
 
@@ -887,8 +887,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_serde_offset_width_layouts) {
         force_large_offsets(c1.get());
         ASSERT_TRUE(c1->get_offset().is_large());
 
-        const auto expected_size = c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) +
-                                   sizeof(uint64_t) * 2;
+        const auto expected_size =
+                c1->get_immutable_bytes().size() + c1->get_offset().size() * sizeof(uint64_t) + sizeof(uint64_t) * 2;
         assert_binary_serde_round_trip(*c1, c2.get(), expected_size, false, true);
     }
 }
@@ -1030,8 +1030,7 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_extended_format_serialize_roun
         if (check_exact_size) {
             // u32 escape + u32 escape + u64 bytes_size + bytes + u64 offset_bytes_size + u64 offsets
             // (small payload, so neither string nor integer encoding kicks in).
-            const auto expected_size = sizeof(uint32_t) * 2 + sizeof(uint64_t) * 2 +
-                                       src->get_immutable_bytes().size() +
+            const auto expected_size = sizeof(uint32_t) * 2 + sizeof(uint64_t) * 2 + src->get_immutable_bytes().size() +
                                        src->get_offset().size() * sizeof(uint64_t);
             ASSERT_EQ(static_cast<int64_t>(expected_size), max_size);
             ASSERT_EQ(buffer.data() + expected_size, serialized_end);

--- a/be/test/serde/serde_test.cpp
+++ b/be/test/serde/serde_test.cpp
@@ -982,6 +982,78 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_extended_format_deserialize) {
     ASSERT_EQ(Slice("cc"), column->get_slice(2));
 }
 
+#ifdef FIU_ENABLE
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_extended_format_serialize_round_trip) {
+    // The real overflow trigger (bytes/offsets payload > UINT32_MAX) cannot be
+    // allocated in a unit test, so force the extended layout via a failpoint and
+    // verify the serialize + max_serialized_size + round-trip path end to end.
+    auto* fp = failpoint::FailPointRegistry::GetInstance()->get("binary_column_serde_force_extended_format");
+    ASSERT_NE(fp, nullptr);
+    PFailPointTriggerMode enable_mode;
+    enable_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    PFailPointTriggerMode disable_mode;
+    disable_mode.set_mode(FailPointTriggerModeType::DISABLE);
+
+    auto run_case = [&](int num_strings, int encode_level, bool check_exact_size) {
+        auto src = BinaryColumn::create();
+        std::vector<std::string> values;
+        std::vector<Slice> slices;
+        values.reserve(num_strings);
+        slices.reserve(num_strings);
+        for (int i = 0; i < num_strings; ++i) {
+            values.emplace_back(strings::Substitute("payload-value-$0", i));
+            slices.emplace_back(values.back());
+        }
+        src->append_strings(slices.data(), slices.size());
+        // A normal small BinaryColumn: only the failpoint, not the real payload,
+        // makes it take the extended path.
+        ASSERT_FALSE(src->get_offset().is_large());
+
+        // Keep the failpoint scoped to size-computation + serialization only, so a
+        // later assertion failure cannot leak the forced-extended state into other
+        // tests. Deserialization auto-detects the escape from the wire and needs
+        // no failpoint.
+        fp->setMode(enable_mode);
+        const auto max_size = ColumnArraySerde::max_serialized_size(*src, encode_level);
+        std::vector<uint8_t> buffer(max_size > 0 ? static_cast<size_t>(max_size) : 0);
+        auto serialize_result = ColumnArraySerde::serialize(*src, buffer.data(), false, encode_level);
+        fp->setMode(disable_mode);
+
+        ASSERT_GT(max_size, 0);
+        ASSERT_TRUE(serialize_result.ok()) << serialize_result.status();
+        auto* serialized_end = serialize_result.value();
+        ASSERT_LE(serialized_end, buffer.data() + buffer.size());
+        // The extended layout always begins with the u32 0 / u32 0 escape header.
+        ASSERT_TRUE(has_binary_serde_extended_escape(buffer.data()));
+
+        if (check_exact_size) {
+            // u32 escape + u32 escape + u64 bytes_size + bytes + u64 offset_bytes_size + u64 offsets
+            // (small payload, so neither string nor integer encoding kicks in).
+            const auto expected_size = sizeof(uint32_t) * 2 + sizeof(uint64_t) * 2 +
+                                       src->get_immutable_bytes().size() +
+                                       src->get_offset().size() * sizeof(uint64_t);
+            ASSERT_EQ(static_cast<int64_t>(expected_size), max_size);
+            ASSERT_EQ(buffer.data() + expected_size, serialized_end);
+        }
+
+        auto dst = BinaryColumn::create();
+        ASSIGN_OR_ABORT(auto deserialized_end,
+                        ColumnArraySerde::deserialize(buffer.data(), serialized_end, dst.get(), false, encode_level));
+        ASSERT_EQ(serialized_end, deserialized_end);
+        // An extended payload encodes offsets as u64, so it always decodes into large offsets.
+        ASSERT_TRUE(dst->get_offset().is_large());
+        assert_binary_column_equal(*src, *dst);
+    };
+
+    // Plain layout: assert the exact extended size and escape header.
+    run_case(3, 0, /*check_exact_size=*/true);
+    // Larger payload with encoding enabled: exercises LZ4 string encoding and
+    // streamvbyte integer encoding of u64 offsets through the extended path.
+    run_case(80, ENCODE_INTEGER | ENCODE_STRING, /*check_exact_size=*/false);
+}
+#endif
+
 // NOLINTNEXTLINE
 PARALLEL_TEST(ColumnArraySerdeTest, large_binary_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -22,6 +22,8 @@
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
 #include "column/schema.h"
 #include "gutil/stringprintf.h"
 #include "storage/chunk_helper.h"
@@ -295,6 +297,39 @@ TEST(PrimaryKeyEncoderTest, testSingleIntV2EncodingRoundTripAndColumnType) {
         ASSERT_EQ(pchunk->get_column_by_index(0)->get(i).get_int32(),
                   decoded->get_column_by_index(0)->get(i).get_int32());
     }
+}
+
+TEST(PrimaryKeyEncoderTest, testDeleteFileLegacyBinaryFormatCheck) {
+    std::vector<Slice> strings{{"a"}, {"bb"}, {"ccc"}};
+
+    auto binary = BinaryColumn::create();
+    binary->append_strings(strings.data(), strings.size());
+    ASSERT_TRUE(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(*binary).ok());
+
+    auto sticky_large = BinaryColumn::create();
+    sticky_large->append_strings(strings.data(), strings.size());
+    AdaptiveOffsets::Large large_offsets;
+    large_offsets.resize(sticky_large->get_offset().size());
+    for (size_t i = 0; i < sticky_large->get_offset().size(); ++i) {
+        large_offsets[i] = sticky_large->get_offset()[i];
+    }
+    sticky_large->get_offset().set_large_buffer(std::move(large_offsets));
+    ASSERT_TRUE(sticky_large->get_offset().is_large());
+    ASSERT_TRUE(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(*sticky_large).ok());
+
+    auto nullable_data = BinaryColumn::create();
+    nullable_data->append_strings(strings.data(), strings.size());
+    auto nullable = NullableColumn::create(std::move(nullable_data), NullColumn::create(strings.size(), 0));
+    ASSERT_TRUE(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(*nullable).ok());
+
+    auto large_binary = LargeBinaryColumn::create();
+    large_binary->append_strings(strings.data(), strings.size());
+    ASSERT_FALSE(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(*large_binary).ok());
+
+    auto fixed = Int32Column::create();
+    int32_t value = 1;
+    fixed->append_numbers(&value, sizeof(value));
+    ASSERT_TRUE(PrimaryKeyEncoder::check_can_persist_delete_file_as_legacy_binary_format(*fixed).ok());
 }
 
 TEST(PrimaryKeyEncoderTest, testEncodedTypeAndFixedSizeByEncodingType) {


### PR DESCRIPTION
## What I'm doing:
Keep the existing serde layouts unchanged for normal BinaryColumn and LargeBinaryColumn:

  BinaryColumn legacy layout:
    u32 bytes_size
    bytes
    u32 offset_bytes_size
    u32 offsets

  LargeBinaryColumn layout:
    u64 bytes_size
    bytes
    u64 offset_bytes_size
    u64 offsets

When a BinaryColumn payload cannot be represented by the legacy u32 layout, use a new extended layout:

  BinaryColumn extended layout:
    u32 bytes_size = 0
    u32 offset_bytes_size = 0
    u64 bytes_size
    bytes
    u64 offset_bytes_size
    u64 offsets

The 0/0 prefix is a structurally impossible legacy BinaryColumn payload because even an empty legacy BinaryColumn still has one offset entry, so its offset_bytes_size is sizeof(uint32_t), not 0. This makes the extended layout unambiguous without relying on a UUID/content marker.

This remains compatible during BE rolling upgrade because non-overflow BinaryColumn payloads, including the UINT32_MAX boundary, are still serialized with the original u32 format. Under the rolling-upgrade guarantee that
BinaryColumn chunks do not overflow the legacy layout, old and new BEs continue to exchange the same wire format. After all BEs are upgraded, overflow BinaryColumn payloads can use the extended format safely.

Also keep delete-file persistence pinned to the legacy BinaryColumn layout. Delete files are generated from primary-key encoded columns and must remain readable by older BEs after downgrade. Before writing local/lake delete files,
and before writing V1->V2 transcoded delete files, reject encoded BinaryColumn payloads that cannot be represented by the historical u32 layout. LargeBinaryColumn is rejected for delete-file persistence for the same reason.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
