### PR TITLE
[BugFix] Align null mask to num_rows in array_map empty-array path

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -411,6 +411,11 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
             auto array_col = ArrayColumn::create(std::move(column), std::move(aligned_offsets));
             array_col->check_or_die();
             auto result_null_mut = NullColumn::static_pointer_cast(std::move(*result_null_column).mutate());
+            // result_null_column may be shorter than num_rows when the nullable input is a
+            // const/single-row column that has not been materialized to chunk size; align the
+            // per-row null mask to the empty-array column (padded rows are non-null, since the
+            // all-null case already returned above) so the NullableColumn stays consistent.
+            result_null_mut->resize(chunk->num_rows());
             auto result = NullableColumn::create(std::move(array_col), std::move(result_null_mut));
             result->check_or_die();
             return result;


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #75141. In the all-empty-arrays branch (total_elements_num == 0) with a nullable input, #75141 builds a num_rows-sized empty-array column but pairs it with result_null_column without aligning its length. For a const/single-row nullable input, result_null_column stays at the input row count (< num_rows), so NullableColumn::check_or_die() aborts on the size mismatch (e.g. _null_column->size()=1 vs _data_column->size()=3) and crashes the BE.

Resize the null mask to chunk->num_rows() before building the NullableColumn, mirroring the resize already done in the adjacent all-null branch. Padded rows are non-null because the all-null case returns earlier.

Reproduced by VectorizedLambdaFunctionExprTest.array_map_lambda_test_special_array, which aborts without this change.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
