### PR TITLE
[BugFix] Lake: preserve segment filenames when dual-writing legacy arrays from un-normalized metadata (backport #75193)

### DIFF
--- a/be/src/runtime/lake_snapshot_loader.cpp
+++ b/be/src/runtime/lake_snapshot_loader.cpp
@@ -21,6 +21,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/snapshot_loader.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/lake_proto_normalizer.h"
 #include "storage/lake/tablet.h"
 #include "util/network_util.h"
 #include "util/raw_container.h"
@@ -307,6 +308,12 @@ Status LakeSnapshotLoader::restore(const ::starrocks::RestoreSnapshotsRequest* r
                 return Status::Corruption(fmt::format("failed to parse tablet meta {}", full_remote_file));
             }
             meta->set_id(restore_info.tablet_id());
+            // The snapshot blob is parsed directly (it never went through a load path), so a backup taken
+            // on a pre-feature BE is legacy-shaped. Normalize it on entry exactly like a disk-loaded one
+            // (after-load back-fills segment_metas from the legacy arrays) so both the cached object and
+            // put_tablet_metadata's dual-write before-save carry the segment filenames. put_tablet_metadata
+            // caches the original object, so this must run here on the cached object, not on a copy inside.
+            lake::normalize_tablet_metadata_after_load(meta.get());
             RETURN_IF_ERROR(_env->lake_tablet_manager()->put_tablet_metadata(meta));
         }
 

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -40,6 +40,7 @@
 #include "storage/lake/async_delta_writer.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/delta_writer_finish_mode.h"
+#include "storage/lake/lake_proto_normalizer.h"
 #include "storage/memtable.h"
 #include "storage/memtable_flush_executor.h"
 #include "storage/storage_engine.h"
@@ -148,7 +149,18 @@ private:
         void add_txn_logs(const std::vector<TxnLogPtr>& logs) {
             _response->mutable_lake_tablet_data()->mutable_txn_logs()->Reserve(logs.size());
             for (auto& log : logs) {
-                _response->mutable_lake_tablet_data()->add_txn_logs()->CopyFrom(*log);
+                // Dual-write the deprecated legacy arrays into the txn log shipped back to the load
+                // coordinator, so a coordinator BE that lacks the segment_metas refactor (mixed-version)
+                // still persists a combined txn log an old reader can resolve. DeltaWriter emits only the
+                // structured segment_metas; before-save adds the legacy dual-write. Mirrors the compaction
+                // worker. On the (practically unreachable) normalize failure, fail the load rather than
+                // ship a non-dual-written log.
+                TxnLogPB normalized(*log);
+                if (auto st = starrocks::lake::normalize_txn_log_before_save(&normalized); st.ok()) {
+                    _response->mutable_lake_tablet_data()->add_txn_logs()->Swap(&normalized);
+                } else {
+                    update_status(st);
+                }
             }
         }
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -33,6 +33,7 @@
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/compaction_task.h"
+#include "storage/lake/lake_proto_normalizer.h"
 #include "storage/lake/local_pk_index_manager.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
@@ -357,6 +358,21 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                         TabletMetadataPB local_metadata;
                         if (skip_write_tablet_metadata) {
                             local_metadata.CopyFrom(*metadata);
+                            // Dual-write the legacy arrays into the RPC payload so an aggregator that
+                            // lacks the segment_metas refactor (a node not yet upgraded, or one rolled
+                            // back below this version) still persists metadata an old BE can read.
+                            // Mirrors the dual-write that every on-disk save performs.
+                            if (auto st = lake::normalize_tablet_metadata_before_save(&local_metadata); !st.ok()) {
+                                g_publish_version_failed_tasks << 1;
+                                LOG(WARNING) << "Fail to normalize aggregate-publish metadata: " << st
+                                             << " tablet_id=" << metadata->id();
+                                std::lock_guard l(response_mtx);
+                                response->mutable_failed_tablets()->Add(
+                                        tablet_info.get_tablet_ids_in_txn_logs().begin(),
+                                        tablet_info.get_tablet_ids_in_txn_logs().end());
+                                st.to_protobuf(response->mutable_status());
+                                return;
+                            }
                         }
                         {
                             std::lock_guard l(response_mtx);
@@ -448,6 +464,21 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                                 std::unordered_map<int64_t, TabletMetadataPB> copied_tablet_metas;
                                 for (auto& pair : tablet_metadatas) {
                                     copied_tablet_metas[pair.first].CopyFrom(*pair.second);
+                                }
+                                // Dual-write the legacy arrays into the RPC payload (see the non-reshard
+                                // publish path above) so an aggregator without the segment_metas refactor
+                                // persists old-readable metadata. If any fails, fail the whole reshard
+                                // task rather than publish a partial tablet_metas map.
+                                for (auto& pair : copied_tablet_metas) {
+                                    if (auto st = lake::normalize_tablet_metadata_before_save(&pair.second); !st.ok()) {
+                                        g_publish_version_failed_tasks << 1;
+                                        LOG(WARNING) << "Fail to normalize aggregate reshard metadata: " << st
+                                                     << " tablet_id=" << pair.first;
+                                        std::lock_guard l(response_mtx);
+                                        add_failed_tablets(response, resharding_tablet_info);
+                                        st.to_protobuf(response->mutable_status());
+                                        return;
+                                    }
                                 }
 
                                 std::lock_guard l(response_mtx);
@@ -1373,6 +1404,9 @@ struct AggregateCompactContext {
             auto* next_txn_log = combined_txn_log.add_txn_logs();
             next_txn_log->CopyFrom(log);
             next_txn_log->set_partition_id(partition_id);
+            // These collected logs are persisted by put_combined_txn_log, which normalizes each received
+            // log on entry (after-load) before its dual-write before-save -- so an old compaction worker's
+            // legacy-shaped op_compaction output rowset keeps its segment names. No need to after-load here.
         }
     }
 
@@ -2043,7 +2077,14 @@ void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* 
             auto task = std::make_shared<CancellableRunnable>(
                     [&, metadata_pb, repair_status] {
                         DeferOp defer([&] { latch.count_down(); });
-                        auto metadata_ptr = std::make_shared<const TabletMetadataPB>(metadata_pb);
+                        // The repaired metadata arrives over RPC and may be legacy-shaped (produced by a
+                        // pre-feature BE during a mixed-version upgrade); normalize it on entry like every
+                        // other foreign-metadata persist path (after-load extends + back-fills segment_metas
+                        // from the legacy arrays) so put_tablet_metadata's no-extend dual-write before-save
+                        // cannot drop segment names. (The bundling branch above gets this via
+                        // put_bundle_tablet_metadata.)
+                        auto metadata_ptr = std::make_shared<TabletMetadataPB>(metadata_pb);
+                        lake::normalize_tablet_metadata_after_load(metadata_ptr.get());
                         auto st = _tablet_mgr->put_tablet_metadata(metadata_ptr);
                         st.to_protobuf(repair_status->mutable_status());
                     },

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -33,6 +33,7 @@
 #include "runtime/exec_env.h"
 #include "service/service_be/lake_service.h"
 #include "storage/lake/compaction_task.h"
+#include "storage/lake/lake_proto_normalizer.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_parallel_compaction_manager.h"
 #include "storage/memtable_flush_executor.h"
@@ -130,7 +131,18 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     compact_stat->set_total_compact_input_file_size(context->stats->input_file_size);
     if (context->skip_write_txnlog && context->txn_log != nullptr) {
         // context->txn_log could be nullptr if the task is failed before writing txn log.
-        _response->add_txn_logs()->CopyFrom(*context->txn_log);
+        // Dual-write the legacy arrays into the RPC payload so an aggregator without the segment_metas
+        // refactor (not-yet-upgraded or rolled-back) persists old-readable metadata. Normalize a temp
+        // copy and only return it on success; never put a non-dual-written / bad txn log in the response.
+        TxnLogPB normalized(*context->txn_log);
+        if (auto st = normalize_txn_log_before_save(&normalized); st.ok()) {
+            _response->add_txn_logs()->Swap(&normalized);
+        } else {
+            LOG(WARNING) << "Fail to normalize aggregate-compact txn log: " << st
+                         << " tablet_id=" << context->tablet_id;
+            _response->add_failed_tablets(context->tablet_id);
+            _status.update(st);
+        }
     }
     DCHECK(_request != nullptr);
     _status.update(context->status);

--- a/be/src/storage/lake/lake_proto_normalizer.cpp
+++ b/be/src/storage/lake/lake_proto_normalizer.cpp
@@ -16,27 +16,31 @@
 
 #include <algorithm>
 
+#include "common/logging.h"
 #include "common/status.h"
 #include "fmt/format.h"
 
 namespace starrocks::lake {
 
-// ---- AFTER LOAD ---------------------------------------------------------------------------------
-// Back-fill the structured fields from the deprecated legacy parallel arrays for data written by a
-// pre-feature BE. `segment_metas` may ALREADY exist on an old rowset (it predates this refactor and
-// carried sort_key/num_rows/segment_idx/vector_index_ids), but WITHOUT the new file-attr fields
-// (filename/size/encryption_meta/shared/bundle_file_offset). So we merge per-index: only set a file
-// attribute on segment_metas[i] when it is absent there and present in the legacy array.
-//
-// Once the back-fill is done, segment_metas is the sole canonical source in memory and nothing reads
-// the legacy arrays again, so we CLEAR them: it avoids caching two copies of every segment's file
-// attributes (filenames especially) for the lifetime of the cached metadata, and it keeps the legacy
-// arrays from going stale relative to segment_metas (before-save rebuilds them from segment_metas on
-// a throwaway copy, so disk dual-write for rollback is unaffected).
+namespace {
 
-void normalize_rowset_after_load(RowsetMetadataPB* rowset_metadata) {
+// Back-fill the canonical structured per-segment file attrs from the deprecated legacy parallel arrays.
+// Shared by after-load (back-fill old on-disk data into segment_metas) and before-save (complete
+// segment_metas before rebuilding the legacy arrays from it, so un-normalized legacy-shaped input does
+// not lose its filenames). Merge per-index: only set a file attribute when it is absent on
+// segment_metas[i] and present in the legacy array (structured wins; never overwrites).
+//
+// allow_extend: after-load passes true so segment_metas grows to cover every legacy entry (the legacy
+// arrays are the source of truth for pre-feature data). before-save passes false: there segment_metas
+// is authoritative and may have intentionally dropped a segment (e.g. partial-compaction trim) while
+// the legacy arrays are momentarily stale-longer; extending would resurrect the dropped segment. The
+// before-save no-extend is only safe because its input is always already extended -- in-memory metadata
+// is after-loaded on read, and RPC/disk-shaped legacy input is after-loaded on entry at the aggregate
+// receive points; a never-after-loaded sparse rowset reaching before-save is reported loudly there.
+void backfill_segment_metas_from_legacy(RowsetMetadataPB* rowset_metadata, bool allow_extend) {
     const int segment_count =
-            std::max(rowset_metadata->deprecated_segments_size(), rowset_metadata->segment_metas_size());
+            allow_extend ? std::max(rowset_metadata->deprecated_segments_size(), rowset_metadata->segment_metas_size())
+                         : rowset_metadata->segment_metas_size();
     while (rowset_metadata->segment_metas_size() < segment_count) {
         rowset_metadata->add_segment_metas();
     }
@@ -63,20 +67,14 @@ void normalize_rowset_after_load(RowsetMetadataPB* rowset_metadata) {
             segment_metadata->set_bundle_file_offset(rowset_metadata->deprecated_bundle_file_offsets(i));
         }
     }
-    // segment_metas is now canonical; drop the legacy arrays so they aren't cached unread (or left stale).
-    rowset_metadata->clear_deprecated_segments();
-    rowset_metadata->clear_deprecated_segment_size();
-    rowset_metadata->clear_deprecated_segment_encryption_metas();
-    rowset_metadata->clear_deprecated_shared_segments();
-    rowset_metadata->clear_deprecated_bundle_file_offsets();
 }
 
-void normalize_op_write_after_load(TxnLogPB::OpWrite* op_write) {
-    if (op_write->has_rowset()) {
-        normalize_rowset_after_load(op_write->mutable_rowset());
-    }
+// dels_meta / rewrite_segments_meta analog of backfill_segment_metas_from_legacy (same allow_extend
+// contract). Does not touch the rowset.
+void backfill_op_write_metas_from_legacy(TxnLogPB::OpWrite* op_write, bool allow_extend) {
     // dels_meta <- deprecated_dels / deprecated_del_encryption_metas / deprecated_shared_dels
-    const int del_file_count = std::max(op_write->deprecated_dels_size(), op_write->dels_meta_size());
+    const int del_file_count = allow_extend ? std::max(op_write->deprecated_dels_size(), op_write->dels_meta_size())
+                                            : op_write->dels_meta_size();
     while (op_write->dels_meta_size() < del_file_count) {
         op_write->add_dels_meta();
     }
@@ -93,8 +91,9 @@ void normalize_op_write_after_load(TxnLogPB::OpWrite* op_write) {
         }
     }
     // rewrite_segments_meta <- deprecated_rewrite_segments
-    const int rewrite_segment_count =
-            std::max(op_write->deprecated_rewrite_segments_size(), op_write->rewrite_segments_meta_size());
+    const int rewrite_segment_count = allow_extend ? std::max(op_write->deprecated_rewrite_segments_size(),
+                                                              op_write->rewrite_segments_meta_size())
+                                                   : op_write->rewrite_segments_meta_size();
     while (op_write->rewrite_segments_meta_size() < rewrite_segment_count) {
         op_write->add_rewrite_segments_meta();
     }
@@ -104,6 +103,33 @@ void normalize_op_write_after_load(TxnLogPB::OpWrite* op_write) {
             rewrite_segment_metadata->set_name(op_write->deprecated_rewrite_segments(i));
         }
     }
+}
+
+} // namespace
+
+// ---- AFTER LOAD ---------------------------------------------------------------------------------
+// Back-fill segment_metas from the deprecated legacy parallel arrays for data written by a pre-feature
+// BE (see backfill_segment_metas_from_legacy for the per-index merge), then CLEAR the legacy arrays:
+// segment_metas is the sole canonical source in memory afterward, so keeping the legacy copies would
+// only waste cache space and risk going stale relative to segment_metas (before-save rebuilds them
+// from segment_metas on a throwaway copy, so disk dual-write for rollback is unaffected).
+
+void normalize_rowset_after_load(RowsetMetadataPB* rowset_metadata) {
+    // Back-fill (and extend) segment_metas from the legacy arrays for data written by a pre-feature BE.
+    backfill_segment_metas_from_legacy(rowset_metadata, /*allow_extend=*/true);
+    // segment_metas is now canonical; drop the legacy arrays so they aren't cached unread (or left stale).
+    rowset_metadata->clear_deprecated_segments();
+    rowset_metadata->clear_deprecated_segment_size();
+    rowset_metadata->clear_deprecated_segment_encryption_metas();
+    rowset_metadata->clear_deprecated_shared_segments();
+    rowset_metadata->clear_deprecated_bundle_file_offsets();
+}
+
+void normalize_op_write_after_load(TxnLogPB::OpWrite* op_write) {
+    if (op_write->has_rowset()) {
+        normalize_rowset_after_load(op_write->mutable_rowset());
+    }
+    backfill_op_write_metas_from_legacy(op_write, /*allow_extend=*/true);
     // dels_meta / rewrite_segments_meta are now canonical; drop the legacy arrays (the rowset's own
     // legacy arrays were already cleared by normalize_rowset_after_load above).
     op_write->clear_deprecated_dels();
@@ -126,6 +152,26 @@ Status normalize_rowset_before_save(RowsetMetadataPB* rowset_metadata) {
     if (rowset_metadata->segment_metas_size() == 0) {
         return Status::OK();
     }
+    // Fail-closed would-truncate guard: more legacy names than authoritative segment_metas slots means
+    // an un-normalized (never after-loaded) legacy rowset reached before-save; the no-extend back-fill +
+    // rebuild below would DROP the tail segment names and silently make the tablet unreadable. This must
+    // not happen in practice -- in-memory metadata is after-loaded on read (which clears the legacy
+    // arrays) and RPC/disk-shaped legacy input is after-loaded at the save choke points
+    // (put_bundle_tablet_metadata / put_combined_txn_log) -- so refuse to persist truncated metadata
+    // rather than lose data, surfacing the missing after-load loudly.
+    if (rowset_metadata->deprecated_segments_size() > rowset_metadata->segment_metas_size()) {
+        return Status::Corruption(fmt::format(
+                "lake rowset reached before-save un-normalized (rowset {} version {}): {} deprecated_segments "
+                "but only {} segment_metas; refusing to persist truncated metadata. after-load must run first.",
+                rowset_metadata->id(), rowset_metadata->version(), rowset_metadata->deprecated_segments_size(),
+                rowset_metadata->segment_metas_size()));
+    }
+    // Complete segment_metas from the legacy arrays before rebuilding those arrays from it, so an
+    // un-normalized legacy-shaped rowset keeps its real filenames instead of being rebuilt from an empty
+    // segment_metas[].filename(). No-extend: never resurrect a segment intentionally dropped from
+    // segment_metas (e.g. partial-compaction trim). Idempotent on already-normalized input.
+    backfill_segment_metas_from_legacy(rowset_metadata, /*allow_extend=*/false);
+
     rowset_metadata->clear_deprecated_segments();
     rowset_metadata->clear_deprecated_segment_size();
     rowset_metadata->clear_deprecated_segment_encryption_metas();
@@ -154,7 +200,9 @@ Status normalize_rowset_before_save(RowsetMetadataPB* rowset_metadata) {
     const bool all_have_bundle_file_offset = bundle_file_offset_count == rowset_metadata->segment_metas_size();
     // Rebuild each legacy array from segment_metas. The all_*/has_any_* flags keep every optional array
     // all-or-nothing (size 0 or == segment count), matching what the legacy readers expect.
+    int empty_filename_count = 0;
     for (const auto& segment_metadata : rowset_metadata->segment_metas()) {
+        empty_filename_count += segment_metadata.filename().empty() ? 1 : 0;
         rowset_metadata->add_deprecated_segments(segment_metadata.filename());
         if (all_have_size) {
             rowset_metadata->add_deprecated_segment_size(segment_metadata.size());
@@ -169,12 +217,44 @@ Status normalize_rowset_before_save(RowsetMetadataPB* rowset_metadata) {
             rowset_metadata->add_deprecated_bundle_file_offsets(segment_metadata.bundle_file_offset());
         }
     }
+    // A segment whose name is absent from BOTH segment_metas and the legacy arrays is genuinely lost;
+    // an empty name resolves to ".../data/" and makes the tablet unreadable. We cannot fabricate a name,
+    // but never emit one silently -- log loudly (once per rowset) so it is diagnosable.
+    if (empty_filename_count > 0) {
+        LOG(ERROR) << "lake metadata: rowset " << rowset_metadata->id() << " (version " << rowset_metadata->version()
+                   << ") has " << empty_filename_count << " of " << rowset_metadata->segment_metas_size()
+                   << " segments with an empty filename in both segment_metas and deprecated_segments; "
+                   << "persisting an empty segment name will make the tablet unreadable.";
+    }
     return Status::OK();
 }
 
 Status normalize_op_write_before_save(TxnLogPB::OpWrite* op_write) {
     if (op_write->has_rowset()) {
         RETURN_IF_ERROR(normalize_rowset_before_save(op_write->mutable_rowset()));
+    }
+
+    // Complete dels_meta / rewrite_segments_meta from the legacy arrays before rebuilding those arrays
+    // from them (same rationale and no-extend contract as normalize_rowset_before_save). Idempotent.
+    backfill_op_write_metas_from_legacy(op_write, /*allow_extend=*/false);
+
+    // Fail-closed would-truncate guards (same rationale as normalize_rowset_before_save): when the
+    // structured array is non-empty but shorter than its legacy array, the rebuild below would drop the
+    // tail names. The `*_meta_size() > 0` qualifier preserves the legitimate "old producer wrote only the
+    // legacy array" case (structured empty -> rebuild skipped, legacy left intact). In production the
+    // structured arrays are always after-loaded first, so these never fire.
+    if (op_write->dels_meta_size() > 0 && op_write->deprecated_dels_size() > op_write->dels_meta_size()) {
+        return Status::Corruption(fmt::format(
+                "lake op_write reached before-save un-normalized: {} deprecated_dels but only {} dels_meta; "
+                "refusing to persist truncated del-file names. after-load must run first.",
+                op_write->deprecated_dels_size(), op_write->dels_meta_size()));
+    }
+    if (op_write->rewrite_segments_meta_size() > 0 &&
+        op_write->deprecated_rewrite_segments_size() > op_write->rewrite_segments_meta_size()) {
+        return Status::Corruption(fmt::format(
+                "lake op_write reached before-save un-normalized: {} deprecated_rewrite_segments but only {} "
+                "rewrite_segments_meta; refusing to persist truncated names. after-load must run first.",
+                op_write->deprecated_rewrite_segments_size(), op_write->rewrite_segments_meta_size()));
     }
 
     // Only rebuild a legacy array group when its structured source is non-empty; otherwise leave the

--- a/be/src/storage/lake/lake_proto_normalizer.h
+++ b/be/src/storage/lake/lake_proto_normalizer.h
@@ -35,7 +35,9 @@ namespace starrocks::lake {
 // Walk every nested RowsetMetadataPB / OpWrite carrier in a TabletMetadataPB or TxnLogPB
 // and normalize it. After-load merges the legacy arrays into the structured fields (structured
 // wins; never errors). Before-save rebuilds the legacy arrays from the structured fields; it
-// returns Status only to propagate failures and currently always succeeds.
+// returns an error if it cannot do so without losing data: Corruption on a mix of bundled and
+// standalone segments, or when un-normalized input (legacy arrays longer than the structured
+// fields, i.e. after-load was skipped) would otherwise be silently truncated.
 void normalize_tablet_metadata_after_load(TabletMetadataPB* tablet_metadata);
 Status normalize_tablet_metadata_before_save(TabletMetadataPB* tablet_metadata);
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -588,6 +588,12 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
     // tablet page and the footer use the same decision, even if the flag is flipped concurrently.
     const bool enable_checksum = config::lake_enable_protobuf_file_checksum;
     for (auto& [tablet_id, meta] : tablet_metas) {
+        // Normalize RPC-received metadata on entry exactly like S3-loaded metadata: after-load
+        // (extend + back-fill segment_metas from the legacy arrays) BEFORE before-save rebuilds those
+        // arrays. During a mixed-version upgrade an old worker can send legacy-shaped metadata whose
+        // segment names live only in deprecated_segments; without this after-load the no-extend
+        // before-save would drop them. Idempotent for already-normalized (new-worker) metadata.
+        normalize_tablet_metadata_after_load(&meta);
         RETURN_IF_ERROR(normalize_tablet_metadata_before_save(&meta));
         meta.clear_schema();
         meta.mutable_historical_schemas()->clear();
@@ -1224,9 +1230,15 @@ Status TabletManager::put_combined_txn_log(const starrocks::CombinedTxnLogPB& lo
     }
 #endif
     auto path = _location_provider->combined_txn_log_location(tablet_id, txn_id);
-    // Dual-write the deprecated legacy parallel arrays from the structured fields for rollback compat.
+    // put_combined_txn_log persists txn logs COLLECTED FROM OTHER NODES over RPC (aggregate compaction
+    // and the normal combined-txn write path), so a log can be legacy-shaped if produced by a pre-feature
+    // BE during a mixed-version upgrade. Normalize each received log on entry exactly like a disk-loaded
+    // one (after-load extends + back-fills segment_metas from the legacy arrays), which also makes the
+    // subsequent no-extend before-save safe; before-save then dual-writes the legacy arrays back from the
+    // structured fields for version-rollback compat.
     CombinedTxnLogPB normalized_logs = logs;
     for (auto& log : *normalized_logs.mutable_txn_logs()) {
+        normalize_txn_log_after_load(&log);
         RETURN_IF_ERROR(normalize_txn_log_before_save(&log));
     }
     return save_lake_protobuf(path, normalized_logs);

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -1317,6 +1317,18 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
                     << finish_response.status().error_msgs(0);
             ASSERT_TRUE(finish_response.has_lake_tablet_data());
             ASSERT_EQ(4, finish_response.lake_tablet_data().txn_logs_size());
+            // The txn logs shipped back to the coordinator must be dual-written (the deprecated legacy
+            // arrays rebuilt from segment_metas), so a mixed-version coordinator that lacks the
+            // segment_metas refactor still persists a combined txn log an old reader can resolve.
+            for (const auto& txn_log : finish_response.lake_tablet_data().txn_logs()) {
+                const auto& rowset = txn_log.op_write().rowset();
+                ASSERT_GT(rowset.segment_metas_size(), 0);
+                ASSERT_EQ(rowset.segment_metas_size(), rowset.deprecated_segments_size());
+                for (int i = 0; i < rowset.segment_metas_size(); i++) {
+                    EXPECT_FALSE(rowset.segment_metas(i).filename().empty());
+                    EXPECT_EQ(rowset.segment_metas(i).filename(), rowset.deprecated_segments(i));
+                }
+            }
             auto metacache = _tablet_manager->metacache();
             for (auto tablet_id : {10086, 10087, 10088, 10089}) {
                 auto txn_log_path = _tablet_manager->txn_log_location(tablet_id, kTxnId);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -42,6 +42,9 @@
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/test_util.h"
 #include "storage/lake/txn_log.h"
+#include "storage/protobuf_file.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/storage_env.h"
 #include "storage/variant_tuple.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
@@ -2313,6 +2316,176 @@ TEST_F(LakeServiceTest, test_aggregate_compact_success) {
 
     server.Stop(0);
     server.Join();
+}
+
+// Layer C (aggregate-compaction receive): an OLD compaction worker sends an op_compaction output rowset
+// whose segment_metas is SPARSE (1 entry, no filename) with the real segment names only in the legacy
+// deprecated_segments array. put_combined_txn_log must run normalize_*_after_load on each received log so
+// segment_metas is extended/back-filled before its no-extend before-save persists it. Without Layer C the
+// before-save would back-fill only the single segment_metas slot and drop "s1.dat".
+TEST_F(LakeServiceTest, test_aggregate_compact_sparse_legacy_segments_preserved) {
+    brpc::Server server;
+    MockLakeServiceImpl mock_service;
+    int port = 0;
+    init_server_with_mock(&mock_service, &server, &port);
+
+    EXPECT_CALL(mock_service, compact(_, _, _, _))
+            .WillRepeatedly(Invoke([&](::google::protobuf::RpcController*, const CompactRequest*, CompactResponse* resp,
+                                       ::google::protobuf::Closure* done) {
+                TxnLogPB txnlog;
+                txnlog.set_tablet_id(100);
+                txnlog.set_txn_id(100);
+                auto* rs = txnlog.mutable_op_compaction()->mutable_output_rowset();
+                rs->add_segment_metas()->set_num_rows(10); // ONE segment_metas, NO filename
+                rs->add_deprecated_segments("s0.dat");     // TWO real segment names
+                rs->add_deprecated_segments("s1.dat");
+                resp->add_txn_logs()->CopyFrom(txnlog);
+                resp->add_compact_stats();
+                resp->mutable_status()->set_status_code(0);
+                done->Run();
+            }));
+
+    auto txn_id = next_id();
+    {
+        brpc::Controller cntl;
+        AggregateCompactRequest agg_request;
+        CompactRequest request;
+        ComputeNodePB cn;
+        cn.set_host("127.0.0.1");
+        cn.set_brpc_port(port);
+        cn.set_id(1);
+        CompactResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_txn_id(txn_id);
+        request.set_version(1);
+        request.set_timeout_ms(3000);
+        agg_request.add_requests()->CopyFrom(request);
+        agg_request.add_compute_nodes()->CopyFrom(cn);
+        agg_request.set_partition_id(99);
+        run_aggregate_compact(&cntl, &agg_request, &response);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    }
+
+    // Load back the persisted combined txn log. put_combined_txn_log picks the anchor via
+    // pick_local_anchor_tablet_id over the txn-log tablet ids and uses logs.txn_logs(0).txn_id().
+    auto anchor_tablet_id = _tablet_mgr->pick_local_anchor_tablet_id({100});
+    int64_t persisted_txn_id = 100;
+    auto path = _tablet_mgr->combined_txn_log_location(anchor_tablet_id, persisted_txn_id);
+    ASSIGN_OR_ABORT(auto combined_log, _tablet_mgr->get_combined_txn_log(path, false));
+    ASSERT_EQ(1, combined_log->txn_logs_size());
+    const auto& out_rs = combined_log->txn_logs(0).op_compaction().output_rowset();
+    // After-load extended segment_metas to 2 and back-filled both names from deprecated_segments; both
+    // survived the round-trip through the no-extend before-save in put_combined_txn_log.
+    ASSERT_EQ(2, out_rs.segment_metas_size());
+    EXPECT_EQ("s0.dat", out_rs.segment_metas(0).filename());
+    EXPECT_EQ("s1.dat", out_rs.segment_metas(1).filename());
+
+    server.Stop(0);
+    server.Join();
+}
+
+// Layer B/C (aggregate-compaction dual-write on disk): a NEW worker sends a CANONICAL op_compaction
+// output rowset (segment_metas carries filename, no legacy arrays). collect_txnlogs after-load +
+// put_combined_txn_log before-save must rebuild the deprecated legacy arrays so a BE rolled back below
+// this version can still read the persisted combined txn log. Inspect the raw on-disk bytes (a normalized
+// load would clear deprecated_segments), so read with ProtobufFileWithHeader to bypass normalization.
+TEST_F(LakeServiceTest, test_aggregate_compact_persisted_log_is_dual_written) {
+    brpc::Server server;
+    MockLakeServiceImpl mock_service;
+    int port = 0;
+    init_server_with_mock(&mock_service, &server, &port);
+
+    EXPECT_CALL(mock_service, compact(_, _, _, _))
+            .WillRepeatedly(Invoke([&](::google::protobuf::RpcController*, const CompactRequest*, CompactResponse* resp,
+                                       ::google::protobuf::Closure* done) {
+                TxnLogPB txnlog;
+                txnlog.set_tablet_id(100);
+                txnlog.set_txn_id(100);
+                auto* rs = txnlog.mutable_op_compaction()->mutable_output_rowset();
+                auto* seg = rs->add_segment_metas(); // CANONICAL: filename set, no deprecated_segments
+                seg->set_filename("c0.dat");
+                seg->set_num_rows(10);
+                resp->add_txn_logs()->CopyFrom(txnlog);
+                resp->add_compact_stats();
+                resp->mutable_status()->set_status_code(0);
+                done->Run();
+            }));
+
+    auto txn_id = next_id();
+    {
+        brpc::Controller cntl;
+        AggregateCompactRequest agg_request;
+        CompactRequest request;
+        ComputeNodePB cn;
+        cn.set_host("127.0.0.1");
+        cn.set_brpc_port(port);
+        cn.set_id(1);
+        CompactResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_txn_id(txn_id);
+        request.set_version(1);
+        request.set_timeout_ms(3000);
+        agg_request.add_requests()->CopyFrom(request);
+        agg_request.add_compute_nodes()->CopyFrom(cn);
+        agg_request.set_partition_id(99);
+        run_aggregate_compact(&cntl, &agg_request, &response);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    }
+
+    auto anchor_tablet_id = _tablet_mgr->pick_local_anchor_tablet_id({100});
+    int64_t persisted_txn_id = 100;
+    auto path = _tablet_mgr->combined_txn_log_location(anchor_tablet_id, persisted_txn_id);
+    // Read the raw persisted bytes without normalization (load_combined_txn_log/get_combined_txn_log run
+    // after-load, which clears the legacy arrays). This mirrors how save_lake_protobuf wrote the file.
+    CombinedTxnLogPB on_disk;
+    ProtobufFileWithHeader file(path, LAKE_META_HEADER_MAGIC_NUMBER, /*allow_plain_protobuf_fallback=*/true);
+    ASSERT_OK(file.load(&on_disk, /*fill_cache=*/false));
+    ASSERT_EQ(1, on_disk.txn_logs_size());
+    const auto& out_rs = on_disk.txn_logs(0).op_compaction().output_rowset();
+    // The structured segment_metas is preserved, and the dual-write rebuilt the legacy array from it.
+    ASSERT_EQ(1, out_rs.segment_metas_size());
+    EXPECT_EQ("c0.dat", out_rs.segment_metas(0).filename());
+    ASSERT_EQ(1, out_rs.deprecated_segments_size());
+    EXPECT_EQ("c0.dat", out_rs.deprecated_segments(0));
+
+    server.Stop(0);
+    server.Join();
+}
+
+// Layer B (aggregate-publish payload dual-write): the worker runs normalize_*_before_save on the
+// metadata it returns over RPC (response->tablet_metas) so an OLD aggregator persists old-readable
+// bytes. After a real write + single-node aggregate publish that yields a segment-bearing rowset, the
+// returned tablet_metas rowset must carry a NON-EMPTY deprecated_segments rebuilt from segment_metas.
+TEST_F(LakeServiceTest, test_aggregate_publish_payload_is_dual_written) {
+    auto txn_log = generate_write_txn_log(1, 100, 100);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    PublishVersionRequest publish_request;
+    publish_request.set_base_version(1);
+    publish_request.set_new_version(2);
+    publish_request.add_tablet_ids(_tablet_id);
+    publish_request.add_txn_ids(txn_log.txn_id());
+    publish_request.set_enable_aggregate_publish(true);
+
+    PublishVersionResponse response;
+    _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+    ASSERT_EQ(0, response.failed_tablets_size());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    ASSERT_EQ(1, response.tablet_metas_size());
+    ASSERT_TRUE(response.tablet_metas().contains(_tablet_id));
+
+    const auto& meta = response.tablet_metas().at(_tablet_id);
+    ASSERT_EQ(1, meta.rowsets_size());
+    const auto& rs = meta.rowsets(0);
+    ASSERT_EQ(1, rs.segment_metas_size());
+    // Layer B dual-write rebuilt the legacy array from segment_metas in the RPC payload.
+    ASSERT_EQ(1, rs.deprecated_segments_size());
+    EXPECT_EQ(rs.segment_metas(0).filename(), rs.deprecated_segments(0));
+    EXPECT_FALSE(rs.deprecated_segments(0).empty());
 }
 
 TEST_F(LakeServiceTest, test_aggregate_compact_with_error) {
@@ -5200,6 +5373,47 @@ TEST_F(LakeServiceTest, test_check_missing_files_across_versions) {
             }
         }
     }
+}
+
+// The non-bundling repair path receives tablet metadata over RPC and persists it via put_tablet_metadata.
+// An old BE's metadata can be legacy-shaped (sparse segment_metas without filename; real names only in
+// deprecated_segments). repair must after-load it on entry, or the no-extend before-save would refuse it
+// (fail-closed) / drop the tail segment name. Verify all segment names survive a non-bundling repair.
+TEST_F(LakeServiceTest, test_repair_non_bundling_preserves_legacy_segment_filenames) {
+    brpc::Controller cntl;
+    RepairTabletMetadataRequest request;
+    RepairTabletMetadataResponse response;
+
+    TabletMetadataPB metadata_to_repair;
+    auto tablet_id = next_id();
+    metadata_to_repair.set_id(tablet_id);
+    metadata_to_repair.set_version(100);
+    metadata_to_repair.mutable_schema()->set_id(next_id());
+    metadata_to_repair.mutable_schema()->set_keys_type(DUP_KEYS);
+    metadata_to_repair.mutable_schema()->set_num_short_key_columns(1);
+    metadata_to_repair.mutable_schema()->set_num_rows_per_row_block(65535);
+    // Legacy-shaped rowset: only 1 segment_metas (no filename), 2 real names in deprecated_segments.
+    auto* rs = metadata_to_repair.add_rowsets();
+    rs->set_id(1);
+    rs->add_segment_metas()->set_num_rows(10);
+    rs->add_deprecated_segments("s0.dat");
+    rs->add_deprecated_segments("s1.dat");
+
+    request.add_tablet_metadatas()->CopyFrom(metadata_to_repair);
+    request.set_enable_file_bundling(false);
+
+    _lake_service.repair_tablet_metadata(&cntl, &request, &response, nullptr);
+    ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+    ASSERT_EQ(TStatusCode::OK, response.status().status_code()) << response.status().error_msgs(0);
+    ASSERT_EQ(1, response.tablet_repair_statuses_size());
+    ASSERT_EQ(TStatusCode::OK, response.tablet_repair_statuses(0).status().status_code());
+
+    ASSIGN_OR_ABORT(auto tablet_read, _tablet_mgr->get_tablet(tablet_id));
+    ASSIGN_OR_ABORT(auto got, tablet_read.get_metadata(100));
+    ASSERT_EQ(1, got->rowsets_size());
+    ASSERT_EQ(2, got->rowsets(0).segment_metas_size());
+    EXPECT_EQ("s0.dat", got->rowsets(0).segment_metas(0).filename());
+    EXPECT_EQ("s1.dat", got->rowsets(0).segment_metas(1).filename());
 }
 
 TEST_F(LakeServiceTest, test_repair_tablet_metadata) {

--- a/be/test/storage/lake/lake_proto_normalizer_test.cpp
+++ b/be/test/storage/lake/lake_proto_normalizer_test.cpp
@@ -169,8 +169,9 @@ TEST(LakeProtoNormalizerTest, round_trip_save_then_load_is_consistent) {
     EXPECT_EQ(0, reloaded.deprecated_segment_size_size());
 }
 
-// A segment removed from segment_metas (e.g. partial-compaction trim) must NOT be resurrected from
-// the stale legacy arrays at save time: before_save rebuilds legacy from segment_metas.
+// A segment removed from segment_metas (e.g. partial-compaction trim) must NOT be resurrected from the
+// legacy arrays at save time. In production the metadata is after-loaded first (legacy arrays cleared),
+// so the trim leaves deprecated_segments empty and before_save rebuilds it from the trimmed segment_metas.
 TEST(LakeProtoNormalizerTest, before_save_does_not_resurrect_removed_segment) {
     RowsetMetadataPB rs;
     for (int i = 0; i < 3; ++i) {
@@ -178,19 +179,50 @@ TEST(LakeProtoNormalizerTest, before_save_does_not_resurrect_removed_segment) {
         s->set_filename("seg" + std::to_string(i) + ".dat");
         s->set_size(100);
     }
-    ASSERT_OK(normalize_rowset_before_save(&rs));
-    ASSERT_EQ(3, rs.deprecated_segments_size());
-
-    // Now drop the middle segment from the canonical list, leaving legacy stale.
+    // Canonical in-memory state: after-load has cleared the legacy arrays. Now trim the middle segment.
     rs.mutable_segment_metas()->erase(rs.mutable_segment_metas()->begin() + 1);
     ASSERT_EQ(2, rs.segment_metas_size());
-    ASSERT_EQ(3, rs.deprecated_segments_size()); // legacy still stale here
+    ASSERT_EQ(0, rs.deprecated_segments_size());
 
     ASSERT_OK(normalize_rowset_before_save(&rs));
-    // Legacy rebuilt to exactly match segment_metas; the removed segment is gone.
+    // Legacy rebuilt to exactly match segment_metas; the removed segment is gone, none resurrected.
     ASSERT_EQ(2, rs.deprecated_segments_size());
     EXPECT_EQ("seg0.dat", rs.deprecated_segments(0));
     EXPECT_EQ("seg2.dat", rs.deprecated_segments(1));
+}
+
+// Fail-closed: an un-normalized legacy-shaped rowset (more legacy names than segment_metas slots, i.e.
+// after-load was skipped) must be REFUSED at before-save rather than silently truncated -- the no-extend
+// rebuild would otherwise drop the tail names and make the tablet unreadable.
+TEST(LakeProtoNormalizerTest, before_save_rejects_unnormalized_legacy_longer_than_segment_metas) {
+    RowsetMetadataPB rs;
+    rs.add_segment_metas()->set_num_rows(10); // 1 segment_metas, no filename
+    rs.add_deprecated_segments("s0.dat");     // 2 real legacy names -> longer than segment_metas
+    rs.add_deprecated_segments("s1.dat");
+
+    auto status = normalize_rowset_before_save(&rs);
+    EXPECT_TRUE(status.is_corruption()) << status.to_string();
+    // Refused before mutating anything: the real names are intact, not truncated.
+    ASSERT_EQ(2, rs.deprecated_segments_size());
+    EXPECT_EQ("s0.dat", rs.deprecated_segments(0));
+    EXPECT_EQ("s1.dat", rs.deprecated_segments(1));
+}
+
+// Fail-closed analog for op_write dels / rewrite_segments: legacy arrays longer than the structured
+// arrays are refused rather than truncated. (The `*_meta_size() > 0` qualifier still lets the legitimate
+// "old producer wrote only the legacy array" case through -- see before_save_preserves_legacy_when_segment_metas_empty.)
+TEST(LakeProtoNormalizerTest, before_save_rejects_unnormalized_op_write_legacy_longer_than_meta) {
+    TxnLogPB::OpWrite del_op;
+    del_op.add_dels_meta(); // 1 dels_meta, no name
+    del_op.add_deprecated_dels("d0");
+    del_op.add_deprecated_dels("d1"); // 2 legacy del names -> longer
+    EXPECT_TRUE(normalize_op_write_before_save(&del_op).is_corruption());
+
+    TxnLogPB::OpWrite rewrite_op;
+    rewrite_op.add_rewrite_segments_meta(); // 1 rewrite_segments_meta, no name
+    rewrite_op.add_deprecated_rewrite_segments("rw0");
+    rewrite_op.add_deprecated_rewrite_segments("rw1"); // 2 legacy -> longer
+    EXPECT_TRUE(normalize_op_write_before_save(&rewrite_op).is_corruption());
 }
 
 // A rowset must be either fully bundled or fully standalone. before_save rejects a mixed state,
@@ -280,6 +312,101 @@ TEST(LakeProtoNormalizerTest, opwrite_dels_and_rewrite_segments_round_trip) {
     EXPECT_EQ(0, old_op.deprecated_dels_size());
     EXPECT_EQ(0, old_op.deprecated_del_encryption_metas_size());
     EXPECT_EQ(0, old_op.deprecated_rewrite_segments_size());
+}
+
+// ---- before_save: non-destructive on un-normalized (legacy-shaped) input ------------------------
+
+// The bug: an old worker (pre-refactor proto) sends a rowset whose segment_metas carry sort-key fields
+// but NO filename, with the real names only in deprecated_segments. A destructive before_save would
+// clear deprecated_segments and rebuild it from the empty filename() -> [""]. before_save must back-fill
+// filename from the legacy arrays first, so BOTH the legacy arrays and segment_metas keep the real names.
+TEST(LakeProtoNormalizerTest, before_save_backfills_filename_from_legacy_when_segment_metas_lacks_file_attrs) {
+    RowsetMetadataPB rs;
+    auto* s0 = rs.add_segment_metas();
+    s0->set_num_rows(10);
+    s0->set_segment_idx(0);
+    auto* s1 = rs.add_segment_metas();
+    s1->set_num_rows(20);
+    s1->set_segment_idx(1);
+    rs.add_deprecated_segments("seg0.dat");
+    rs.add_deprecated_segments("seg1.dat");
+    rs.add_deprecated_segment_size(100);
+    rs.add_deprecated_segment_size(200);
+
+    ASSERT_OK(normalize_rowset_before_save(&rs));
+
+    // Legacy arrays preserved (NOT emptied / not [""]).
+    ASSERT_EQ(2, rs.deprecated_segments_size());
+    EXPECT_EQ("seg0.dat", rs.deprecated_segments(0));
+    EXPECT_EQ("seg1.dat", rs.deprecated_segments(1));
+    // segment_metas back-filled with the real file attrs; pre-existing fields preserved.
+    ASSERT_EQ(2, rs.segment_metas_size());
+    EXPECT_EQ("seg0.dat", rs.segment_metas(0).filename());
+    EXPECT_EQ(100, rs.segment_metas(0).size());
+    EXPECT_EQ(10, rs.segment_metas(0).num_rows());
+    EXPECT_EQ("seg1.dat", rs.segment_metas(1).filename());
+    EXPECT_EQ(200, rs.segment_metas(1).size());
+}
+
+// after_load -> before_save -> after_load is stable; filenames survive every hop even when the first
+// save sees un-normalized legacy-shaped input.
+TEST(LakeProtoNormalizerTest, before_save_after_load_round_trip_is_stable_for_legacy_shaped_input) {
+    RowsetMetadataPB rs;
+    rs.add_segment_metas()->set_num_rows(10); // sort-key-only, no filename
+    rs.add_segment_metas()->set_num_rows(20);
+    rs.add_deprecated_segments("seg0.dat");
+    rs.add_deprecated_segments("seg1.dat");
+
+    ASSERT_OK(normalize_rowset_before_save(&rs));
+    ASSERT_EQ(2, rs.deprecated_segments_size());
+    EXPECT_EQ("seg0.dat", rs.deprecated_segments(0));
+
+    normalize_rowset_after_load(&rs);
+    EXPECT_EQ(0, rs.deprecated_segments_size()); // canonical in memory
+    EXPECT_EQ("seg0.dat", rs.segment_metas(0).filename());
+
+    ASSERT_OK(normalize_rowset_before_save(&rs));
+    ASSERT_EQ(2, rs.deprecated_segments_size());
+    EXPECT_EQ("seg0.dat", rs.deprecated_segments(0));
+    EXPECT_EQ("seg1.dat", rs.deprecated_segments(1));
+}
+
+// When a segment's name is absent from BOTH segment_metas and deprecated_segments, before_save must not
+// crash and must not fabricate a name (it can only emit the empty value; the loud log is the signal).
+TEST(LakeProtoNormalizerTest, before_save_empty_filename_in_both_does_not_fabricate) {
+    RowsetMetadataPB rs;
+    rs.add_segment_metas()->set_num_rows(10); // no filename, and no deprecated_segments either
+
+    ASSERT_OK(normalize_rowset_before_save(&rs));
+
+    ASSERT_EQ(1, rs.segment_metas_size());
+    EXPECT_TRUE(rs.segment_metas(0).filename().empty());
+    ASSERT_EQ(1, rs.deprecated_segments_size());
+    EXPECT_EQ("", rs.deprecated_segments(0)); // emitted, not fabricated
+}
+
+// op_write dels / rewrite_segments: before_save back-fills names from the legacy arrays for
+// un-normalized input (mirrors the rowset path), preserving the legacy arrays.
+TEST(LakeProtoNormalizerTest, before_save_backfills_op_write_dels_and_rewrite_from_legacy) {
+    TxnLogPB::OpWrite op;
+    // dels_meta / rewrite_segments_meta entries exist but lack names; real names in the legacy arrays.
+    op.add_dels_meta();
+    op.add_dels_meta();
+    op.add_deprecated_dels("del0");
+    op.add_deprecated_dels("del1");
+    op.add_rewrite_segments_meta();
+    op.add_deprecated_rewrite_segments("rw0");
+
+    ASSERT_OK(normalize_op_write_before_save(&op));
+
+    ASSERT_EQ(2, op.deprecated_dels_size());
+    EXPECT_EQ("del0", op.deprecated_dels(0));
+    EXPECT_EQ("del1", op.deprecated_dels(1));
+    EXPECT_EQ("del0", op.dels_meta(0).name());
+    EXPECT_EQ("del1", op.dels_meta(1).name());
+    ASSERT_EQ(1, op.deprecated_rewrite_segments_size());
+    EXPECT_EQ("rw0", op.deprecated_rewrite_segments(0));
+    EXPECT_EQ("rw0", op.rewrite_segments_meta(0).name());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1147,6 +1147,90 @@ TEST_F(LakeTabletManagerTest, parse_bundle_tablet_metadata_with_zero_size) {
     EXPECT_TRUE(res.status().is_corruption());
 }
 
+// Regression for the aggregate-publish data-loss bug: an old worker sends a rowset whose segment_metas
+// lack filename, with the real names only in deprecated_segments. put_bundle_tablet_metadata must
+// persist metadata whose segment filename survives (reproduces old-worker -> new-aggregator).
+TEST_F(LakeTabletManagerTest, put_bundle_preserves_legacy_segment_filenames) {
+    auto tablet_id = next_id();
+    std::map<int64_t, TabletMetadataPB> metadatas;
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    {
+        auto* schema = metadata.mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        c0->set_unique_id(0);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+    }
+    // Legacy-shaped rowset: segment_metas carries only sort-key fields (no filename); the real name
+    // lives only in deprecated_segments.
+    auto* rs = metadata.add_rowsets();
+    rs->set_id(2);
+    rs->set_overlapped(false);
+    rs->set_num_rows(5);
+    rs->add_segment_metas()->set_num_rows(5);
+    rs->add_deprecated_segments("real_seg.dat");
+    metadatas.emplace(tablet_id, metadata);
+
+    ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
+
+    auto res = _tablet_manager->get_tablet_metadata(tablet_id, 2);
+    ASSERT_TRUE(res.ok()) << res.status().to_string();
+    auto got = std::move(res).value();
+    ASSERT_EQ(1, got->rowsets_size());
+    ASSERT_EQ(1, got->rowsets(0).segment_metas_size());
+    EXPECT_EQ("real_seg.dat", got->rowsets(0).segment_metas(0).filename());
+}
+
+// Layer C (after_load extend) on the aggregate receive path: a sparse legacy rowset
+// (segment_metas_size() < deprecated_segments_size()) must keep ALL segment names. Without the
+// after_load in put_bundle_tablet_metadata, the no-extend before_save would truncate the tail.
+TEST_F(LakeTabletManagerTest, put_bundle_extends_then_preserves_mismatched_legacy_counts) {
+    auto tablet_id = next_id();
+    std::map<int64_t, TabletMetadataPB> metadatas;
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    {
+        auto* schema = metadata.mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        c0->set_unique_id(0);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+    }
+    auto* rs = metadata.add_rowsets();
+    rs->set_id(2);
+    rs->set_overlapped(false);
+    rs->set_num_rows(10);
+    rs->add_segment_metas()->set_num_rows(10); // only 1 segment_metas...
+    rs->add_deprecated_segments("s0.dat");     // ...but 2 real segment names
+    rs->add_deprecated_segments("s1.dat");
+    metadatas.emplace(tablet_id, metadata);
+
+    ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
+
+    auto res = _tablet_manager->get_tablet_metadata(tablet_id, 2);
+    ASSERT_TRUE(res.ok()) << res.status().to_string();
+    auto got = std::move(res).value();
+    ASSERT_EQ(1, got->rowsets_size());
+    ASSERT_EQ(2, got->rowsets(0).segment_metas_size());
+    EXPECT_EQ("s0.dat", got->rowsets(0).segment_metas(0).filename());
+    EXPECT_EQ("s1.dat", got->rowsets(0).segment_metas(1).filename());
+}
+
 TEST_F(LakeTabletManagerTest, get_single_tablet_metadata_parse_failure) {
     // First, create a valid bundle metadata to get the file path
     auto tablet_id = next_id();


### PR DESCRIPTION
DRAFT — backport of #75193 to branch-4.1, opened to enable a mixed-version (4.1.1 ↔ 4.1.x+fix) end-to-end build/validation on the test platform. Will be finalized / reconciled with the auto-backport once the main PR #75193 merges.

Cherry-pick of the main fix (commit on main branch of #75193). Backport target: branch-4.1 (the release line that carries the #74107 segment_metas refactor).

Fixes the shared-data metadata data-loss where, during a mixed-version aggregate publish, `RowsetMetadataPB.deprecated_segments` could be dual-written empty (segment filenames lost) from un-normalized metadata produced by a pre-#74107 BE.