### PR TITLE
[BugFix] Fix load spill metrics without query context

### DIFF
--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -24,7 +24,6 @@
 #include "compute_env/workgroup/work_group_manager.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
-#include "runtime/runtime_state_helper.h"
 #include "storage/aggregate_iterator.h"
 #include "storage/base/merge_iterator.h"
 #include "storage/chunk_helper.h"
@@ -163,8 +162,7 @@ Status LoadChunkSpiller::_prepare(const ChunkPtr& chunk_ptr) {
         _spiller = _spiller_factory->create(options);
         RETURN_IF_ERROR(_spiller->prepare(_runtime_state.get()));
         DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
-        spill::SpillProcessMetrics metrics(_profile,
-                                           RuntimeStateHelper::mutable_total_spill_bytes(_runtime_state.get()));
+        spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
         _spiller->set_metrics(metrics);
         // 2. prepare serde
         if (const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->empty()) {

--- a/be/src/storage/load_chunk_spiller.h
+++ b/be/src/storage/load_chunk_spiller.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "column/vectorized_fwd.h"
 #include "common/runtime_profile.h"
 #include "compute_env/spill/block_manager.h"
@@ -126,6 +128,8 @@ private:
     RuntimeProfile* _profile = nullptr;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
+    // Load spilling uses a dummy RuntimeState without QueryContext.
+    std::atomic_int64_t _total_spill_bytes = 0;
     // pipeline merge context for managing merge tasks
     LoadSpillPipelineMergeContext* _pipeline_merge_context = nullptr;
     // used when input profile is nullptr

--- a/be/test/storage/load_spill_pipeline_merge_test.cpp
+++ b/be/test/storage/load_spill_pipeline_merge_test.cpp
@@ -24,6 +24,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/runtime_profile.h"
+#include "compute_env/spill/spiller.h"
 #include "fs/fs.h"
 #include "fs/fs_factory.h"
 #include "storage/chunk_helper.h"
@@ -111,6 +112,16 @@ protected:
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
+
+TEST_F(LoadSpillPipelineMergeTest, test_spill_without_query_context_uses_local_spill_counter) {
+    auto chunk = gen_data(100, 0);
+
+    auto result = _spiller->spill(*chunk, 0);
+    ASSERT_OK(result.status());
+    ASSERT_GT(result.value(), 0);
+    ASSERT_NE(nullptr, _spiller->spiller());
+    ASSERT_NE(nullptr, _spiller->spiller()->metrics().total_spill_bytes);
+}
 
 // Test basic pipeline merge task generation
 TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_basic) {


### PR DESCRIPTION
LoadChunkSpiller creates a dummy RuntimeState for load spilling, and that RuntimeState does not own a QueryContext. Passing
_runtime_state->mutable_total_spill_bytes() or
RuntimeStateHelper::mutable_total_spill_bytes(_runtime_state.get()) can therefore dereference a missing query context.

Use a LoadChunkSpiller-owned local spill byte counter for SpillProcessMetrics instead. This keeps load spilling independent from query-scoped RuntimeState state while preserving the metrics pointer expected by the spiller.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
