### PR TITLE
[BugFix] Emit valid Prometheus # TYPE lines for BE/CN JVM metrics

### DIFF
--- a/be/src/util/jvm_metrics.cpp
+++ b/be/src/util/jvm_metrics.cpp
@@ -106,8 +106,9 @@ void JVMMetrics::install(MetricRegistry* registry) {
         return;
     }
 
-#define REGISTER_JVM_METRIC(name, type) \
-    registry->register_metric("jvm_" #name "_size_bytes{type=\"" #type "\"}", &jvm_##name##_##type##_bytes)
+#define REGISTER_JVM_METRIC(name, type)                                                      \
+    registry->register_metric("jvm_" #name "_size_bytes", MetricLabels().add("type", #type), \
+                              &jvm_##name##_##type##_bytes)
 
     REGISTER_JVM_METRIC(heap, used);
     REGISTER_JVM_METRIC(heap, committed);

--- a/be/test/util/jvm_metrics_test.cpp
+++ b/be/test/util/jvm_metrics_test.cpp
@@ -36,31 +36,40 @@ TEST_F(JVMMetricsTest, normal) {
     ASSERT_TRUE(st.ok());
     jvm_metrics.install(&registry);
 
-    ASSERT_NE(nullptr, registry.get_metric("jvm_heap_size_bytes{type=\"used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_heap_size_bytes{type=\"committed\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_heap_size_bytes{type=\"max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_non_heap_size_bytes{type=\"used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_non_heap_size_bytes{type=\"committed\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes{type=\"used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes{type=\"committed\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes{type=\"max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes{type=\"peak_used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes{type=\"peak_max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes{type=\"used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes{type=\"committed\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes{type=\"max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes{type=\"peak_used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes{type=\"peak_max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes{type=\"used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes{type=\"committed\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes{type=\"max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes{type=\"peak_used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes{type=\"peak_max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes{type=\"used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes{type=\"committed\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes{type=\"max\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes{type=\"peak_used\"}"));
-    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes{type=\"peak_max\"}"));
+    // Each JVM gauge is registered under a bare metric name plus a `type` label, so that the
+    // Prometheus exposition emits one valid `# TYPE <name>` line per name (see issue #75159).
+    auto type_label = [](const std::string& type) { return MetricLabels().add("type", type); };
+
+    ASSERT_NE(nullptr, registry.get_metric("jvm_heap_size_bytes", type_label("used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_heap_size_bytes", type_label("committed")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_heap_size_bytes", type_label("max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_non_heap_size_bytes", type_label("used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_non_heap_size_bytes", type_label("committed")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes", type_label("used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes", type_label("committed")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes", type_label("max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes", type_label("peak_used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_young_size_bytes", type_label("peak_max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes", type_label("used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes", type_label("committed")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes", type_label("max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes", type_label("peak_used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_old_size_bytes", type_label("peak_max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes", type_label("used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes", type_label("committed")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes", type_label("max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes", type_label("peak_used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_survivor_size_bytes", type_label("peak_max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes", type_label("used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes", type_label("committed")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes", type_label("max")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes", type_label("peak_used")));
+    ASSERT_NE(nullptr, registry.get_metric("jvm_perm_size_bytes", type_label("peak_max")));
+
+    // Regression guard for #75159: the label must NOT be baked into the metric name. If it were,
+    // the `# TYPE` line would contain `{...}` and break the entire Prometheus scrape.
+    ASSERT_EQ(nullptr, registry.get_metric("jvm_heap_size_bytes{type=\"used\"}"));
+    ASSERT_EQ(nullptr, registry.get_metric("jvm_perm_size_bytes{type=\"peak_max\"}"));
 
     registry.trigger_hook();
 


### PR DESCRIPTION
## Why I'm doing:

`enable_jvm_metrics = true` makes the BE/CN `/metrics` endpoint emit invalid
Prometheus text. Each JVM gauge is registered with its label baked into the
metric-name string, e.g.:

```cpp
register_metric("jvm_heap_size_bytes{type=\"committed\"}", &gauge);
```

so the exposition prints that string verbatim after `# TYPE `:

```
# TYPE starrocks_be_jvm_heap_size_bytes{type="committed"} gauge   <-- illegal
starrocks_be_jvm_heap_size_bytes{type="committed"} 905969664
```

A `# TYPE` metric name must not contain a label set. Prometheus aborts the
**entire** scrape on the first text-format error, so flipping this flag on
takes the node's whole metric set offline (`up == 0`) — not just the JVM
series. `promtool check metrics` rejects it with `invalid metric name in
comment`. Reproduced on 4.0.10/4.0.11 and `main`; the feature shipped in 4.0.0
(#62210).

## What I'm doing:

Register each JVM gauge under a bare metric name plus a real `type` label via
`MetricLabels`, mirroring the existing `stream_load_metrics` pattern. The
metrics framework then emits one valid `# TYPE <name>` line followed by the
labelled samples:

```
# TYPE starrocks_be_jvm_heap_size_bytes gauge
starrocks_be_jvm_heap_size_bytes{type="committed"} 905969664
starrocks_be_jvm_heap_size_bytes{type="max"} 21474836480
starrocks_be_jvm_heap_size_bytes{type="used"} 256609448
```

The sample lines (name + labels) are **byte-identical** to before, so the
time-series identity is unchanged and existing dashboards/alerts keep working;
only the previously-malformed `# TYPE` comment is corrected. No metric is
renamed, so no docs change is required.

`jvm_metrics_test` is updated to look metrics up by name + label, plus a
regression guard asserting the old braced names no longer resolve (which would
mean the label was still baked into the name).

Fixes #75159

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
