### PR TITLE
[BugFix] Fix load spill metrics without query context (backport #75236)

### DIFF
--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -157,7 +157,7 @@ Status LoadChunkSpiller::_prepare(const ChunkPtr& chunk_ptr) {
         _spiller = _spiller_factory->create(options);
         RETURN_IF_ERROR(_spiller->prepare(_runtime_state.get()));
         DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
-        spill::SpillProcessMetrics metrics(_profile, _runtime_state->mutable_total_spill_bytes());
+        spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
         _spiller->set_metrics(metrics);
         // 2. prepare serde
         if (const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->empty()) {

--- a/be/src/storage/load_chunk_spiller.h
+++ b/be/src/storage/load_chunk_spiller.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "exec/spill/block_manager.h"
 #include "exec/spill/data_stream.h"
 #include "exec/spill/spiller_factory.h"
@@ -124,6 +126,8 @@ private:
     RuntimeProfile* _profile = nullptr;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
+    // Load spilling uses a dummy RuntimeState without QueryContext.
+    std::atomic_int64_t _total_spill_bytes = 0;
     // pipeline merge context for managing merge tasks
     LoadSpillPipelineMergeContext* _pipeline_merge_context = nullptr;
     // used when input profile is nullptr

--- a/be/test/storage/load_spill_pipeline_merge_test.cpp
+++ b/be/test/storage/load_spill_pipeline_merge_test.cpp
@@ -18,6 +18,7 @@
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "column/vectorized_fwd.h"
+#include "exec/spill/spiller.h"
 #include "fs/fs.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/tablet_metadata.h"
@@ -94,6 +95,16 @@ protected:
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
+
+TEST_F(LoadSpillPipelineMergeTest, test_spill_without_query_context_uses_local_spill_counter) {
+    auto chunk = gen_data(100, 0);
+
+    auto result = _spiller->spill(*chunk, 0);
+    ASSERT_OK(result.status());
+    ASSERT_GT(result.value(), 0);
+    ASSERT_NE(nullptr, _spiller->spiller());
+    ASSERT_NE(nullptr, _spiller->spiller()->metrics().total_spill_bytes);
+}
 
 // Test basic pipeline merge task generation
 TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_basic) {


### PR DESCRIPTION
Signed-off-by: alvin-phoenix-ai <alvin.zhao@phoenixdata.ai>
(cherry picked from commit 5ea37b8832612df055e0ae0d2e6fde0a9c7152a1)

# Conflicts:
#	be/src/storage/load_chunk_spiller.cpp
#	be/src/storage/load_chunk_spiller.h
#	be/test/storage/load_spill_pipeline_merge_test.cpp

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

