### PR TITLE
[BugFix] Fix load spill metrics without query context (backport #75236)

### DIFF
--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -139,7 +139,7 @@ Status LoadChunkSpiller::_prepare(const ChunkPtr& chunk_ptr) {
         _spiller = _spiller_factory->create(options);
         RETURN_IF_ERROR(_spiller->prepare(_runtime_state.get()));
         DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
-        spill::SpillProcessMetrics metrics(_profile, _runtime_state->mutable_total_spill_bytes());
+        spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
         _spiller->set_metrics(metrics);
         // 2. prepare serde
         if (const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->empty()) {

--- a/be/src/storage/load_chunk_spiller.h
+++ b/be/src/storage/load_chunk_spiller.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "exec/spill/block_manager.h"
 #include "exec/spill/data_stream.h"
 #include "exec/spill/spiller_factory.h"
@@ -79,6 +81,8 @@ private:
     LoadSpillBlockManager* _block_manager = nullptr;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
+    // Load spilling uses a dummy RuntimeState without QueryContext.
+    std::atomic_int64_t _total_spill_bytes = 0;
     // used when input profile is nullptr
     std::unique_ptr<RuntimeProfile> _dummy_profile;
     RuntimeProfile* _profile = nullptr;

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -84,6 +84,24 @@ protected:
     RuntimeProfile _dummy_runtime_profile{"dummy"};
 };
 
+TEST_F(SpillMemTableSinkTest, test_flush_chunk_without_query_context_uses_local_spill_counter) {
+    int64_t tablet_id = 1;
+    int64_t txn_id = 1;
+    std::unique_ptr<LoadSpillBlockManager> block_manager = std::make_unique<LoadSpillBlockManager>(
+            TUniqueId(), UniqueId(tablet_id, txn_id).to_thrift(), kTestDir, nullptr);
+    ASSERT_OK(block_manager->init());
+    std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+
+    auto chunk = gen_data(kChunkSize, 0);
+    starrocks::SegmentPB segment;
+    ASSERT_OK(sink.flush_chunk(*chunk, &segment, false));
+
+    ASSERT_NE(nullptr, sink.get_spiller());
+    ASSERT_NE(nullptr, sink.get_spiller()->metrics().total_spill_bytes);
+}
+
 TEST_F(SpillMemTableSinkTest, test_flush_chunk) {
     int64_t tablet_id = 1;
     int64_t txn_id = 1;


### PR DESCRIPTION
Signed-off-by: alvin-phoenix-ai <alvin.zhao@phoenixdata.ai>
(cherry picked from commit 5ea37b8832612df055e0ae0d2e6fde0a9c7152a1)

# Conflicts:
#	be/src/storage/load_chunk_spiller.cpp
#	be/src/storage/load_chunk_spiller.h
#	be/test/storage/load_spill_pipeline_merge_test.cpp

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

