### PR TITLE
[Enhancement] Surface stats source (TABLE_METADATA / ANALYZE / NONE) per-table in query runtime profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -299,6 +299,16 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return name;
     }
 
+    // Display-friendly qualified name: catalog.db.table for external tables,
+    // short name for internal tables.
+    public String getQualifiedTableName() {
+        try {
+            return getCatalogName() + "." + getCatalogDBName() + "." + getCatalogTableName();
+        } catch (NotImplementedException e) {
+            return getName();
+        }
+    }
+
     // Table name is the name written in native table.
     // but catalog table name is name defined in catalog.
     // If we use resource mapping, they are probably different.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -29,7 +29,6 @@ import com.starrocks.planner.DataStreamSink;
 import com.starrocks.planner.ExchangeNode;
 import com.starrocks.planner.JoinNode;
 import com.starrocks.planner.MultiCastDataSink;
-import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
@@ -101,6 +100,7 @@ public class ProfilingExecPlan {
 
         private String displayName;
         private Statistics statistics;
+        private Statistics.StatsSource statsSource;
         private CostEstimate costEstimate;
         private double totalCost;
 
@@ -162,6 +162,10 @@ public class ProfilingExecPlan {
             return statistics;
         }
 
+        public Statistics.StatsSource getStatsSource() {
+            return statsSource;
+        }
+
         public CostEstimate getCostEstimate() {
             return costEstimate;
         }
@@ -194,6 +198,7 @@ public class ProfilingExecPlan {
 
         private void setEstimation(Statistics statistics, CostEstimate costEstimate, double totalCost) {
             this.statistics = statistics;
+            this.statsSource = statistics != null ? statistics.getStatsSource() : Statistics.StatsSource.NONE;
             this.costEstimate = costEstimate;
             this.totalCost = totalCost;
         }
@@ -404,9 +409,8 @@ public class ProfilingExecPlan {
             }
         } else if (node instanceof ScanNode) {
             ScanNode scanNode = (ScanNode) node;
-            if (scanNode instanceof OlapScanNode) {
-                OlapScanNode olapScanNode = (OlapScanNode) scanNode;
-                element.addInfo("Table: ", olapScanNode.getOlapTable().getName());
+            if (scanNode.getDesc().getTable() != null) {
+                element.addInfo("Table", scanNode.getDesc().getTable().getQualifiedTableName());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -102,7 +102,8 @@ public class ElasticsearchMetadata
                                          ScalarOperator predicate,
                                          long limit,
                                          TvrVersionRange tableVersionRange) {
-        Statistics.Builder builder = Statistics.builder();
+        Statistics.Builder builder = Statistics.builder()
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         for (ColumnRefOperator col : columns.keySet()) {
             builder.addColumnStatistic(col, ColumnStatistic.unknown());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStatisticsProvider.java
@@ -71,7 +71,7 @@ public class HiveStatisticsProvider {
             Table table,
             List<ColumnRefOperator> columns,
             List<PartitionKey> partitionKeys) {
-        Statistics.Builder builder = Statistics.builder();
+        Statistics.Builder builder = Statistics.builder().setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         if (table.isUnPartitioned()) {
             HivePartitionStats tableStats = hmsOps.getTableStatistics(table.getCatalogDBName(), table.getCatalogTableName());
             return createUnpartitionedStats(tableStats, columns, builder, table);
@@ -171,7 +171,8 @@ public class HiveStatisticsProvider {
             List<ColumnRefOperator> columns,
             List<PartitionKey> partitionKeys,
             double presentRowNums) {
-        Statistics.Builder builder = Statistics.builder();
+        Statistics.Builder builder = Statistics.builder()
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         for (ColumnRefOperator columnRefOperator : columns) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -94,6 +94,7 @@ public class IcebergStatisticProvider {
 
         statisticsBuilder.setOutputRowCount(cardinality);
         statisticsBuilder.addColumnStatistics(buildUnknownColumnStatistics(colRefToColumnMetaMap.keySet()));
+        statisticsBuilder.setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         return statisticsBuilder.build();
     }
 
@@ -138,6 +139,7 @@ public class IcebergStatisticProvider {
             statisticsBuilder.setOutputRowCount(icebergFileStats.getRecordCount());
             statisticsBuilder.addColumnStatistics(buildColumnStatistics(
                     nativeTable, colRefToColumnMetaMap, icebergFileStats, colIdToNdvs));
+            statisticsBuilder.setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         } else {
             // empty table
             statisticsBuilder.setOutputRowCount(1);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -527,6 +527,7 @@ public class JDBCMetadata implements ConnectorMetadata {
         JDBCTableName key = new JDBCTableName(null, jdbcTable.getCatalogDBName(), jdbcTable.getName());
 
         long rowCount = Config.default_statistics_output_row_count;
+        boolean hasRealRowCount = false;
         CompletableFuture<Long> future = rowCountCache.getIfPresent(key);
         if (future == null) {
             // Cold start: fire async load, return default for this planning round.
@@ -534,13 +535,17 @@ public class JDBCMetadata implements ConnectorMetadata {
         } else if (future.isDone() && !future.isCompletedExceptionally()) {
             try {
                 rowCount = future.getNow(Config.default_statistics_output_row_count);
+                hasRealRowCount = true;
             } catch (Exception e) {
                 LOG.warn("Unexpected error reading row count for {}.{}", key.getDatabaseName(), key.getTableName(), e);
             }
         }
         // Future in-flight or completed exceptionally: fall through to default.
-        return Statistics.builder().setOutputRowCount(rowCount)
-                .setStatsSource(Statistics.StatsSource.TABLE_METADATA).build();
+        Statistics.Builder builder = Statistics.builder().setOutputRowCount(rowCount);
+        if (hasRealRowCount) {
+            builder.setStatsSource(Statistics.StatsSource.TABLE_METADATA);
+        }
+        return builder.build();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -539,7 +539,8 @@ public class JDBCMetadata implements ConnectorMetadata {
             }
         }
         // Future in-flight or completed exceptionally: fall through to default.
-        return Statistics.builder().setOutputRowCount(rowCount).build();
+        return Statistics.builder().setOutputRowCount(rowCount)
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA).build();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -310,7 +310,8 @@ public class KuduMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TvrVersionRange versionRange) {
-        Statistics.Builder builder = Statistics.builder();
+        Statistics.Builder builder = Statistics.builder()
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         for (ColumnRefOperator columnRefOperator : columns.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -729,7 +729,8 @@ public class PaimonMetadata implements ConnectorMetadata {
                 return StatisticsUtils.buildDefaultStatistics(columns.keySet());
             }
 
-            Statistics.Builder builder = Statistics.builder();
+            Statistics.Builder builder = Statistics.builder()
+                    .setStatsSource(Statistics.StatsSource.TABLE_METADATA);
             if (!session.getSessionVariable().enablePaimonColumnStatistics()) {
                 return defaultStatistics(columns, table, predicate, limit, versionRange);
             }
@@ -751,7 +752,8 @@ public class PaimonMetadata implements ConnectorMetadata {
 
     private Statistics defaultStatistics(Map<ColumnRefOperator, Column> columns, Table table, ScalarOperator predicate,
                                          long limit, TvrVersionRange versionRange) {
-        Statistics.Builder builder = Statistics.builder();
+        Statistics.Builder builder = Statistics.builder()
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         for (ColumnRefOperator columnRefOperator : columns.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
@@ -83,6 +83,7 @@ public class StatisticsUtils {
         statisticsBuilder.setOutputRowCount(Config.default_statistics_output_row_count);
         statisticsBuilder.addColumnStatistics(
                 columns.stream().collect(Collectors.toMap(column -> column, column -> ColumnStatistic.unknown())));
+        statisticsBuilder.setStatsSource(Statistics.StatsSource.NONE);
         return statisticsBuilder.build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1593,6 +1593,7 @@ public class StmtExecutor {
         // Otherwise, the context may be changed, for example, containing the wrong query id.
         profile = buildTopLevelProfile();
         maybeEmbedExplainPlanInProfile(profile, plan);
+        appendStatsSourceToProfile(profile, plan);
         // Capture the session timezone now so that the async profile task uses the same zone
         // as START_TIME (the context may change before the async task runs).
         java.time.ZoneId profileZoneForAsync = TimeUtils.getTimeZone().toZoneId();
@@ -1646,6 +1647,40 @@ public class StmtExecutor {
             }
         };
         return coord.tryProcessProfileAsync(task);
+    }
+
+    /**
+     * Traverse scan operators in the profiled plan and record per-table StatsSource
+     * into a dedicated section of the runtime profile.
+     */
+    private void appendStatsSourceToProfile(RuntimeProfile profile, ExecPlan plan) {
+        if (plan == null) {
+            return;
+        }
+        ProfilingExecPlan profilingPlan = plan.getProfilingPlan();
+        if (profilingPlan == null) {
+            return;
+        }
+        RuntimeProfile statsSourceProfile = new RuntimeProfile("StatsSource");
+        for (ProfilingExecPlan.ProfilingFragment fragment : profilingPlan.getFragments()) {
+            collectStatsSource(fragment.getRoot(), statsSourceProfile);
+        }
+        profile.addChild(statsSourceProfile);
+    }
+
+    private static void collectStatsSource(ProfilingExecPlan.ProfilingElement element,
+                                           RuntimeProfile statsSourceProfile) {
+        if (element == null) {
+            return;
+        }
+        if (element.instanceOf(ScanNode.class)) {
+            String tableName = element.getUniqueInfos().get("Table");
+            String label = tableName != null ? tableName : String.valueOf(element.getId());
+            statsSourceProfile.addInfoString(label, element.getStatsSource().name());
+        }
+        for (ProfilingExecPlan.ProfilingElement child : element.getChildren()) {
+            collectStatsSource(child, statsSourceProfile);
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -751,7 +751,7 @@ public class MetadataMgr {
                 }
             }
         }
-        return statistics.build();
+        return statistics.setStatsSource(Statistics.StatsSource.ANALYZE).build();
     }
 
     public Statistics getTableStatistics(OptimizerContext session,
@@ -796,7 +796,8 @@ public class MetadataMgr {
                     });
 
                     return Statistics.builder().addColumnStatistics(combinedColumnStatsMap).
-                            setOutputRowCount(connectorBasicStats.getOutputRowCount()).build();
+                            setOutputRowCount(connectorBasicStats.getOutputRowCount())
+                            .setStatsSource(Statistics.StatsSource.TABLE_METADATA).build();
                 } else {
                     return connectorBasicStats;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -32,6 +32,12 @@ import java.util.Set;
 import static java.lang.Double.NaN;
 
 public class Statistics {
+    public enum StatsSource {
+        NONE,
+        TABLE_METADATA,
+        ANALYZE
+    }
+
     private final double outputRowCount;
     private final Map<ColumnRefOperator, ColumnStatistic> columnStatistics;
     // This flag set true if get table row count from GlobalStateMgr LE 1
@@ -39,6 +45,7 @@ public class Statistics {
     // this causes the table row count stored in FE to be inaccurate.
     private final boolean tableRowCountMayInaccurate;
     private final Collection<ColumnRefOperator> shadowColumns;
+    private final StatsSource statsSource;
 
     private final Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats;
 
@@ -58,6 +65,7 @@ public class Statistics {
         this.columnStatistics = Collections.unmodifiableMap(builder.columnStatistics);
         this.tableRowCountMayInaccurate = builder.tableRowCountMayInaccurate;
         this.shadowColumns = Collections.unmodifiableCollection(builder.shadowColumns);
+        this.statsSource = builder.statsSource;
         this.multiColumnCombinedStats = Collections.unmodifiableMap(builder.multiColumnCombinedStats);
     }
 
@@ -65,11 +73,13 @@ public class Statistics {
                        Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
                        boolean tableRowCountMayInaccurate,
                        Collection<ColumnRefOperator> shadowColumns,
+                       StatsSource statsSource,
                        Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats) {
         this.outputRowCount = outputRowCount;
         this.columnStatistics = Collections.unmodifiableMap(columnStatistics);
         this.tableRowCountMayInaccurate = tableRowCountMayInaccurate;
         this.shadowColumns = Collections.unmodifiableCollection(shadowColumns);
+        this.statsSource = statsSource;
         this.multiColumnCombinedStats = Collections.unmodifiableMap(multiColumnCombinedStats);
     }
 
@@ -82,7 +92,8 @@ public class Statistics {
         if (Double.compare(this.outputRowCount, clamped) == 0) {
             return this;
         }
-        return new Statistics(clamped, columnStatistics, tableRowCountMayInaccurate, shadowColumns, multiColumnCombinedStats);
+        return new Statistics(clamped, columnStatistics, tableRowCountMayInaccurate, shadowColumns, statsSource,
+                multiColumnCombinedStats);
     }
 
     public double getOutputSize(ColumnRefSet outputColumns) {
@@ -151,6 +162,10 @@ public class Statistics {
 
     public boolean isTableRowCountMayInaccurate() {
         return this.tableRowCountMayInaccurate;
+    }
+
+    public StatsSource getStatsSource() {
+        return statsSource;
     }
 
     public ColumnRefSet getUsedColumns() {
@@ -226,6 +241,7 @@ public class Statistics {
                 other.columnStatistics,
                 other.tableRowCountMayInaccurate,
                 other.shadowColumns,
+                other.statsSource,
                 other.multiColumnCombinedStats);
     }
 
@@ -240,6 +256,7 @@ public class Statistics {
         // columns not used to compute costs
         // which is used by mv rewrite to make the cost accurate
         private Collection<ColumnRefOperator> shadowColumns;
+        private StatsSource statsSource = StatsSource.NONE;
         private final Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats;
 
 
@@ -249,18 +266,21 @@ public class Statistics {
 
         private Builder(double outputRowCount, Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
                         boolean tableRowCountMayInaccurate, Collection<ColumnRefOperator> shadowColumns,
+                        StatsSource statsSource,
                         Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats) {
             this.outputRowCount = outputRowCount;
             this.columnStatistics = new HashMap<>(columnStatistics);
             this.tableRowCountMayInaccurate = tableRowCountMayInaccurate;
             this.shadowColumns = shadowColumns;
+            this.statsSource = statsSource;
             this.multiColumnCombinedStats = (multiColumnCombinedStats == null || multiColumnCombinedStats.isEmpty()) ?
                     new HashMap<>() : new HashMap<>(multiColumnCombinedStats);
         }
 
         private Builder(double outputRowCount, Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
                         boolean tableRowCountMayInaccurate) {
-            this(outputRowCount, columnStatistics, tableRowCountMayInaccurate, Lists.newArrayList(), new HashMap<>());
+            this(outputRowCount, columnStatistics, tableRowCountMayInaccurate, Lists.newArrayList(),
+                    StatsSource.NONE, new HashMap<>());
         }
 
         public Builder setOutputRowCount(double outputRowCount) {
@@ -317,6 +337,11 @@ public class Statistics {
 
         public Builder setShadowColumns(Collection<ColumnRefOperator> shadowColumns) {
             this.shadowColumns = shadowColumns;
+            return this;
+        }
+
+        public Builder setStatsSource(StatsSource statsSource) {
+            this.statsSource = statsSource;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -62,8 +62,8 @@ public class StatisticsCalcUtils {
     }
 
     public static Statistics.Builder estimateScanColumns(Table table,
-                                                         Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
-                                                         OptimizerContext optimizerContext) {
+                                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                          OptimizerContext optimizerContext) {
         Statistics.Builder builder = Statistics.builder();
         List<ColumnRefOperator> requiredColumnRefs = new ArrayList<>(colRefToColumnMetaMap.keySet());
         List<String> columns = new ArrayList<>(colRefToColumnMetaMap.values())

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -393,6 +393,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         long tableRowCount = StatisticsCalcUtils.getTableRowCount(table, node, optimizerContext);
         // 2. get required columns statistics
         Statistics.Builder builder = StatisticsCalcUtils.estimateScanColumns(table, colRefToColumnMetaMap, optimizerContext);
+        builder.setStatsSource(Statistics.StatsSource.ANALYZE);
         if (tableRowCount <= 1) {
             builder.setTableRowCountMayInaccurate(true);
         }
@@ -789,19 +790,21 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private Void computeKuduScanNode(Operator node, ExpressionContext context, Table table,
-                                     Map<ColumnRefOperator, Column> columnRefOperatorColumnMap) {
+                                      Map<ColumnRefOperator, Column> columnRefOperatorColumnMap) {
         long rowCount = Config.default_statistics_output_row_count;
+        Statistics.StatsSource source = Statistics.StatsSource.NONE;
         try {
             Statistics connectorStats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
                     optimizerContext, table.getCatalogName(), table, columnRefOperatorColumnMap,
                     Collections.emptyList(), null);
             if (connectorStats != null) {
                 rowCount = (long) connectorStats.getOutputRowCount();
+                source = connectorStats.getStatsSource();
             }
         } catch (Exception e) {
             LOG.warn("Failed to get Kudu table statistics for {}: {}", table.getName(), e.getMessage());
         }
-        return computeNormalExternalTableScanNode(node, context, table, columnRefOperatorColumnMap, rowCount);
+        return computeNormalExternalTableScanNode(node, context, table, columnRefOperatorColumnMap, rowCount, source);
     }
 
     public Void visitLogicalHudiScan(LogicalHudiScanOperator node, ExpressionContext context) {
@@ -864,8 +867,16 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     private Void computeNormalExternalTableScanNode(Operator node, ExpressionContext context, Table table,
                                                     Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
                                                     long outputRowCount) {
+        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, outputRowCount,
+                Statistics.StatsSource.NONE);
+    }
+
+    private Void computeNormalExternalTableScanNode(Operator node, ExpressionContext context, Table table,
+                                                    Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                    long outputRowCount, Statistics.StatsSource statsSource) {
         Statistics.Builder builder = StatisticsCalcUtils.estimateScanColumns(table, colRefToColumnMetaMap, optimizerContext);
         builder.setOutputRowCount(outputRowCount);
+        builder.setStatsSource(statsSource);
 
         context.setStatistics(builder.build());
         return visitOperator(node, context);
@@ -918,14 +929,16 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private Void computeEsScanNode(Operator node, ExpressionContext context, Table table,
-                                   Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+                                    Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
         long rowCount = Config.default_statistics_output_row_count;
+        Statistics.StatsSource source = Statistics.StatsSource.NONE;
         try {
             Statistics connectorStats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
                     optimizerContext, table.getCatalogName(), table, colRefToColumnMetaMap,
                     Collections.emptyList(), null);
             if (connectorStats != null) {
                 double cnt = connectorStats.getOutputRowCount();
+                source = connectorStats.getStatsSource();
                 if (!Double.isNaN(cnt) && cnt > 0) {
                     rowCount = (long) cnt;
                 }
@@ -933,7 +946,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         } catch (Exception e) {
             LOG.warn("Failed to get ES table statistics for {}: {}", table.getName(), e.getMessage());
         }
-        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, rowCount);
+        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, rowCount, source);
     }
 
     @Override
@@ -1000,19 +1013,21 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private Void computeJDBCScanNode(Operator node, ExpressionContext context, Table table,
-                                     Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+                                      Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
         long rowCount = Config.default_statistics_output_row_count;
+        Statistics.StatsSource source = Statistics.StatsSource.NONE;
         try {
             String catalogName = table.getCatalogName();
             Statistics connectorStats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
                     optimizerContext, catalogName, table, colRefToColumnMetaMap, null, null);
             if (connectorStats != null) {
                 rowCount = (long) connectorStats.getOutputRowCount();
+                source = connectorStats.getStatsSource();
             }
         } catch (Exception e) {
             LOG.warn("Failed to get JDBC table statistics for {}: {}", table.getName(), e.getMessage());
         }
-        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, rowCount);
+        return computeNormalExternalTableScanNode(node, context, table, colRefToColumnMetaMap, rowCount, source);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -1248,4 +1248,136 @@ public class StatisticsCalculatorTest {
         calculator.estimatorStats();
         Assertions.assertEquals(888_000D, expressionContext.getStatistics().getOutputRowCount(), 0.01);
     }
+
+    @Test
+    public void testExternalScanPreservesConnectorForegroundSource(@Mocked KuduTable kuduTable) {
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        LogicalKuduScanOperator scanOperator =
+                new LogicalKuduScanOperator(kuduTable, refToColumn, columnToRef, -1, null);
+        GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+        groupExpression.setGroup(new Group(0));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Statistics getTableStatistics(OptimizerContext session, String catalogName, Table table,
+                                                 Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                                                 ScalarOperator predicate) {
+                return Statistics.builder().setOutputRowCount(100)
+                        .setStatsSource(Statistics.StatsSource.TABLE_METADATA).build();
+            }
+        };
+        new MockUp<StatisticsCalcUtils>() {
+            @Mock
+            public Statistics.Builder estimateScanColumns(Table table,
+                                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                          OptimizerContext ctx) {
+                return Statistics.builder();
+            }
+        };
+
+        StatisticsCalculator calculator = new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext);
+        calculator.estimatorStats();
+        Assertions.assertEquals(Statistics.StatsSource.TABLE_METADATA,
+                expressionContext.getStatistics().getStatsSource());
+    }
+
+    @Test
+    public void testExternalScanDefaultUnknown(@Mocked KuduTable kuduTable) {
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        LogicalKuduScanOperator scanOperator =
+                new LogicalKuduScanOperator(kuduTable, refToColumn, columnToRef, -1, null);
+        GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+        groupExpression.setGroup(new Group(0));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+        // getTableStatistics returns null, triggering catch -> computeNormalExternalTableScanNode with UNKNOWN
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Statistics getTableStatistics(OptimizerContext session, String catalogName, Table table,
+                                                 Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                                                 ScalarOperator predicate) {
+                return null;
+            }
+        };
+        new MockUp<StatisticsCalcUtils>() {
+            @Mock
+            public Statistics.Builder estimateScanColumns(Table table,
+                                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                          OptimizerContext ctx) {
+                return Statistics.builder();
+            }
+        };
+
+        StatisticsCalculator calculator = new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext);
+        calculator.estimatorStats();
+        Assertions.assertEquals(Statistics.StatsSource.NONE,
+                expressionContext.getStatistics().getStatsSource());
+    }
+
+    @Test
+    public void testStatsSourceDefaults() {
+        // Default Builder produces UNKNOWN
+        Statistics stats = Statistics.builder().setOutputRowCount(100).build();
+        Assertions.assertEquals(Statistics.StatsSource.NONE, stats.getStatsSource());
+
+        // Explicit set works
+        Statistics foreground = Statistics.builder().setOutputRowCount(100)
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA).build();
+        Assertions.assertEquals(Statistics.StatsSource.TABLE_METADATA, foreground.getStatsSource());
+
+        Statistics background = Statistics.builder().setOutputRowCount(100)
+                .setStatsSource(Statistics.StatsSource.ANALYZE).build();
+        Assertions.assertEquals(Statistics.StatsSource.ANALYZE, background.getStatsSource());
+    }
+
+    @Test
+    public void testStatsSourceBuildFromPreservesSource() {
+        Statistics original = Statistics.builder().setOutputRowCount(100)
+                .setStatsSource(Statistics.StatsSource.TABLE_METADATA).build();
+        Statistics rebuilt = Statistics.buildFrom(original).setOutputRowCount(200).build();
+        Assertions.assertEquals(Statistics.StatsSource.TABLE_METADATA, rebuilt.getStatsSource());
+        Assertions.assertEquals(200, rebuilt.getOutputRowCount(), 0.001);
+    }
+
+    @Test
+    public void testStatsSourceWithOutputRowCountPreservesSource() {
+        Statistics original = Statistics.builder().setOutputRowCount(100)
+                .setStatsSource(Statistics.StatsSource.ANALYZE).build();
+        Statistics adjusted = original.withOutputRowCount(200);
+        Assertions.assertEquals(Statistics.StatsSource.ANALYZE, adjusted.getStatsSource());
+        Assertions.assertEquals(200, adjusted.getOutputRowCount(), 0.001);
+    }
+
+    @Test
+    public void testOlapScanGetsBackground() {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test")
+                .getTable("test_all_type");
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        for (Column col : table.getBaseSchema()) {
+            ColumnRefOperator ref = columnRefFactory.create(col.getName(), col.getType(), col.isAllowNull());
+            colRefToColumnMetaMap.put(ref, col);
+            columnToRef.put(col, ref);
+        }
+        List<Long> partitionIds = table.getPartitions().stream()
+                .mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+
+        LogicalOlapScanOperator scanOperator = new LogicalOlapScanOperator(table, colRefToColumnMetaMap,
+                columnToRef, null, -1, null, table.getBaseIndexMetaId(),
+                partitionIds, null, false, Lists.newArrayList(),
+                Lists.newArrayList(), Lists.newArrayList(), false);
+
+        GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+        groupExpression.setGroup(new Group(0));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+        StatisticsCalculator calculator = new StatisticsCalculator(expressionContext,
+                columnRefFactory, optimizerContext);
+        calculator.estimatorStats();
+        Assertions.assertEquals(Statistics.StatsSource.ANALYZE, expressionContext.getStatistics().getStatsSource());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Users have no way to tell from a query profile whether the CBO used connector metadata
(e.g. Iceberg manifest row counts, Hive HMS stats, Paimon native stats), internal ANALYZE
results, or pure defaults. This makes it impossible to diagnose plan-quality issues caused
by missing or stale statistics on external tables.

## What I'm doing:

Add a table-level `StatsSource` flag to the `Statistics` object and surface it in the
runtime profile as a dedicated `StatsSource` section.

### Three-tier source classification

| Source | Meaning | Examples |
|--------|---------|----------|
| `TABLE_METADATA` | Any information from the table provider or connector (metadata, row counts, file-size estimates) | Iceberg manifest row count, Hive HMS stats, Paimon native stats, Kudu/ES/JDBC row counts, file-size-based estimates |
| `ANALYZE` | StarRocks internal `ANALYZE TABLE` statistics | Internal Olap tables, external tables with completed ANALYZE |
| `NONE` | No statistics available | `buildDefaultStatistics()` fallback (row count = 1, all columns unknown) |

### Flow

```
MetadataMgr.getTableStatistics()
  ├─ getTableStatisticsFromInternalStatistics()  → ANALYZE    (external ANALYZE data exists)
  └─ connectorMetadata.getTableStatistics()       → TABLE_METADATA   (connector's own source)

StatisticsCalcUtils (Olap internal)
  └─ computeOlapScanNode()                       → ANALYZE    (internal ANALYZE storage)

Connectors (Iceberg / Hive / Paimon / Kudu / ES / JDBC)
  └─ Every meaningful stats builder              → TABLE_METADATA
```

The value flows through `Statistics` → `ProfilingExecPlan.ProfilingElement` → `StmtExecutor`,
which collects per-table info strings using `Table.getQualifiedTableName()` (producing
`catalog.db.table` display names for external tables) and writes them to the runtime profile.

### Runtime profile output

```
Query:
  Summary:
    - ...
  StatsSource:
    - iceberg_catalog.tpch_sf100.orders:     ANALYZE
    - iceberg_catalog.tpch_sf100.lineitem:   TABLE_METADATA
    - kudu_catalog.default.t1:              TABLE_METADATA
    - test.t0:                               ANALYZE
```

### Why not FOREGROUND/BACKGROUND

`TABLE_METADATA` and `ANALYZE` are self-documenting — users immediately understand the
distinction without knowing StarRocks internals. `NONE` is reserved for true blind-guess
fallbacks (`row_count = 1`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
