### PR TITLE
[BugFix] Fix NPE in OlapScanNode.getBucketNums when selected partition is concurrently removed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -337,7 +337,16 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         int bucketNum = distInfo.getBucketNum();
         if (getSelectedPartitionIds().size() <= 1) {
             for (Long pid : getSelectedPartitionIds()) {
-                bucketNum = olapTable.getPartition(pid).getDistributionInfo().getBucketNum();
+                // The selected partition id is captured at planning time. It may be concurrently
+                // removed (e.g. by INSERT OVERWRITE swapping partitions) before the scheduler
+                // builds the colocate/local-bucket-shuffle assignment, in which case
+                // getPartition() returns null. Fall back to the table's default bucket number
+                // instead of throwing NPE, so the query fails gracefully (or succeeds) rather
+                // than crashing the coordinator preprocessing.
+                Partition partition = olapTable.getPartition(pid);
+                if (partition != null) {
+                    bucketNum = partition.getDistributionInfo().getBucketNum();
+                }
             }
         }
         return bucketNum;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -340,14 +340,23 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 // The selected partition id is captured at planning time. It may be concurrently
                 // removed (e.g. by INSERT OVERWRITE swapping partitions) before the scheduler
                 // builds the colocate/local-bucket-shuffle assignment, in which case
-                // getPartition() returns null. Fall back to the table's default bucket number
-                // instead of throwing NPE, so the query fails gracefully (or succeeds) rather
-                // than crashing the coordinator preprocessing.
+                // getPartition() returns null. Keep the table default here and fall back to the
+                // actual scan-range bucket sequences below, instead of throwing NPE and crashing
+                // the coordinator preprocessing.
                 Partition partition = olapTable.getPartition(pid);
                 if (partition != null) {
                     bucketNum = partition.getDistributionInfo().getBucketNum();
                 }
             }
+        }
+        // The table default can be 0 for inferred distributions (e.g. DISTRIBUTED BY HASH(k)
+        // without an explicit BUCKETS, where inferDistribution() only fills the partition copy).
+        // If the selected partition was concurrently removed we would otherwise return 0, and
+        // ExecutionFragment.getBucketSeqAssignment() would allocate zero-length arrays and fail
+        // with "bucketSeq exceeds bucketNum". Derive a non-zero count from the bucket sequences
+        // already materialized in the scan ranges.
+        if (bucketNum <= 0 && !bucketSeq2locations.isEmpty()) {
+            bucketNum = Collections.max(bucketSeq2locations.keySet()) + 1;
         }
         return bucketNum;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
@@ -105,4 +105,21 @@ public class OlapScanNodeTest {
         Assertions.assertNotNull(msg.lake_scan_node);
         Assertions.assertFalse(msg.lake_scan_node.isSetVector_search_options());
     }
+
+    @Test
+    public void testGetBucketNumsWhenSelectedPartitionConcurrentlyRemoved() {
+        // Regression test for the coordinator-preprocessing NPE on colocate / local-bucket-shuffle
+        // joins. The selected partition id is captured at planning time; a concurrent
+        // INSERT OVERWRITE can swap/remove that partition before the scheduler builds the
+        // colocate assignment, so OlapTable.getPartition(pid) returns null.
+        // getBucketNums() must fall back to the table's default bucket number rather than
+        // dereferencing null and throwing NullPointerException.
+        OlapScanNode scanNode = createOlapScanNode(Table.TableType.OLAP);
+        // 999L is a partition id that does not exist in the table (concurrently removed).
+        scanNode.setSelectedPartitionIds(Collections.singletonList(999L));
+
+        int bucketNum = Assertions.assertDoesNotThrow(scanNode::getBucketNums);
+        // Falls back to the default distribution bucket number (3, see createOlapScanNode).
+        Assertions.assertEquals(3, bucketNum);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
@@ -22,6 +22,7 @@ import com.starrocks.common.VectorSearchOptions;
 import com.starrocks.type.IntegerType;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TStorageType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,10 @@ import java.util.Collections;
 public class OlapScanNodeTest {
 
     private OlapScanNode createOlapScanNode(Table.TableType tableType) {
+        return createOlapScanNode(tableType, 3);
+    }
+
+    private OlapScanNode createOlapScanNode(Table.TableType tableType, int defaultBucketNum) {
         OlapTable table = new OlapTable(tableType);
         table.maySetDatabaseId(1L);
         table.setBaseIndexMetaId(1L);
@@ -39,7 +44,7 @@ public class OlapScanNodeTest {
                 Collections.singletonList(new Column("c0", IntegerType.INT)),
                 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(
-                new HashDistributionInfo(3, Collections.emptyList()));
+                new HashDistributionInfo(defaultBucketNum, Collections.emptyList()));
 
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
@@ -120,6 +125,24 @@ public class OlapScanNodeTest {
 
         int bucketNum = Assertions.assertDoesNotThrow(scanNode::getBucketNums);
         // Falls back to the default distribution bucket number (3, see createOlapScanNode).
+        Assertions.assertEquals(3, bucketNum);
+    }
+
+    @Test
+    public void testGetBucketNumsFallsBackToScanRangesWhenDefaultIsZero() {
+        // Same concurrent-removal race, but for an inferred distribution where the table default
+        // bucket number is 0 (DISTRIBUTED BY HASH(k) without explicit BUCKETS). Returning 0 would
+        // later make ExecutionFragment.getBucketSeqAssignment() allocate zero-length arrays and
+        // fail with "bucketSeq exceeds bucketNum". getBucketNums() must instead derive a non-zero
+        // count from the bucket sequences already materialized in the scan ranges.
+        OlapScanNode scanNode = createOlapScanNode(Table.TableType.OLAP, 0);
+        scanNode.setSelectedPartitionIds(Collections.singletonList(999L)); // concurrently removed
+        // Scan ranges already carry bucket sequences 0, 1, 2 -> expected bucket count = max + 1 = 3.
+        scanNode.bucketSeq2locations.put(0, new TScanRangeLocations());
+        scanNode.bucketSeq2locations.put(1, new TScanRangeLocations());
+        scanNode.bucketSeq2locations.put(2, new TScanRangeLocations());
+
+        int bucketNum = Assertions.assertDoesNotThrow(scanNode::getBucketNums);
         Assertions.assertEquals(3, bucketNum);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`OlapScanNode.getBucketNums()` dereferences `olapTable.getPartition(pid)` without a null check on the HASH-distribution path:

```java
for (Long pid : getSelectedPartitionIds()) {
    bucketNum = olapTable.getPartition(pid).getDistributionInfo().getBucketNum(); // NPE if getPartition() == null
}
```

The selected partition ids are captured at **planning** time. When the scheduler later builds the colocate / local-bucket-shuffle assignment (`ExecutionFragment.getOrCreateColocatedAssignment` -> `ColocatedBackendSelector.Assignment`), it calls `getBucketNums()`. If a concurrent **INSERT OVERWRITE** has swapped/removed that partition in between (INSERT OVERWRITE atomically replaces partitions, so the old partition id no longer exists on the live `OlapTable`), `getPartition(pid)` returns `null` and the coordinator preprocessing crashes with an NPE. The query is then cancelled.

**Steps to reproduce (observed on a customer cluster, 3.3.x):**
- A bucketed/colocate-eligible table is queried by a multi-join SQL whose predicate prunes to a single partition (e.g. `WHERE year=2023 AND term='...'`).
- The same table is being rewritten by a periodic `INSERT OVERWRITE`.
- When the query's scheduling phase races with the partition swap, it fails intermittently.

**Stack trace (3.3.x line numbers):**
```
java.lang.NullPointerException: null
    at com.starrocks.qe.ColocatedBackendSelector$Assignment.<init>(ColocatedBackendSelector.java:186)
    at com.starrocks.qe.scheduler.dag.ExecutionFragment.getOrCreateColocatedAssignment(ExecutionFragment.java:170)
    at com.starrocks.qe.scheduler.assignment.BackendSelectorFactory.create(BackendSelectorFactory.java:82)
    at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignScanRangesToWorker(...)
    at com.starrocks.qe.CoordinatorPreprocessor.computeFragmentInstances(CoordinatorPreprocessor.java:248)
    ...
    at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:646)
```

**Frequency:** intermittent — only when query scheduling races with the partition swap of the pruned partition.

Note: setting `disable_colocate_join = true` does **not** avoid this. With colocate disabled the planner falls back to a **local bucket-shuffle join** (`ChildOutputPropertyGuarantor.transToBucketShuffleJoin`), which goes through the exact same `getOrCreateColocatedAssignment` -> `Assignment` path and hits the same NPE.

## What I'm doing:

Add a null guard in `OlapScanNode.getBucketNums()`: if the selected partition was concurrently removed, fall back to the table's default distribution bucket number instead of dereferencing `null`. This turns a hard coordinator crash into graceful behavior.

**Scope / honesty note:** this is a **defensive fix at the symptom layer**, not a root-cause fix. The underlying issue is that the live `OlapTable` referenced by an in-flight query can have its partition metadata mutated by a concurrent `INSERT OVERWRITE` (the query does not operate on a fully consistent partition snapshot for this code path). The same root cause has surfaced at other call sites of `olapTable.getPartition(id)` in the scheduler/statistics paths. Fixing the snapshot/locking model is a larger change tracked separately; this PR removes one concrete, customer-impacting crash.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
