### PR TITLE
[BugFix] Surface isolation property in SHOW FUNCTIONS output

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -452,6 +452,9 @@ public class AggregateFunction extends Function {
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName == null ? "" : symbolName);
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
+        // isolationType defaults to true (isolated); surface it so users can tell whether the
+        // function was created with isolation = "shared".
+        properties.put(CreateFunctionStmt.ISOLATION_KEY, isolationType ? "isolated" : "shared");
         return new Gson().toJson(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -394,7 +394,7 @@ public class AggregateFunction extends Function {
         }
         // Default isolation is isolated (true); only emit when explicitly shared.
         if (!isolationType) {
-            props.put(CreateFunctionStmt.ISOLATION_KEY, "shared");
+            props.put(CreateFunctionStmt.ISOLATION_KEY, CreateFunctionStmt.ISOLATION_SHARED);
         }
         if (isAnalyticFn) {
             props.put(CreateFunctionStmt.IS_ANALYTIC_NAME, "true");
@@ -454,7 +454,8 @@ public class AggregateFunction extends Function {
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
         // isolationType defaults to true (isolated); surface it so users can tell whether the
         // function was created with isolation = "shared".
-        properties.put(CreateFunctionStmt.ISOLATION_KEY, isolationType ? "isolated" : "shared");
+        properties.put(CreateFunctionStmt.ISOLATION_KEY,
+                isolationType ? CreateFunctionStmt.ISOLATION_ISOLATED : CreateFunctionStmt.ISOLATION_SHARED);
         return new Gson().toJson(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -266,7 +266,7 @@ public class ScalarFunction extends Function {
         }
         // Default isolation is isolated (true); only emit the property when explicitly shared.
         if (!isolationType) {
-            props.put(CreateFunctionStmt.ISOLATION_KEY, "shared");
+            props.put(CreateFunctionStmt.ISOLATION_KEY, CreateFunctionStmt.ISOLATION_SHARED);
         }
         return props;
     }
@@ -306,7 +306,8 @@ public class ScalarFunction extends Function {
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
         // isolationType defaults to true (isolated); surface it so users can tell whether the
         // function was created with isolation = "shared".
-        properties.put(CreateFunctionStmt.ISOLATION_KEY, isolationType ? "isolated" : "shared");
+        properties.put(CreateFunctionStmt.ISOLATION_KEY,
+                isolationType ? CreateFunctionStmt.ISOLATION_ISOLATED : CreateFunctionStmt.ISOLATION_SHARED);
         return new Gson().toJson(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -304,6 +304,9 @@ public class ScalarFunction extends Function {
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
+        // isolationType defaults to true (isolated); surface it so users can tell whether the
+        // function was created with isolation = "shared".
+        properties.put(CreateFunctionStmt.ISOLATION_KEY, isolationType ? "isolated" : "shared");
         return new Gson().toJson(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -366,7 +366,8 @@ public class CreateFunctionAnalyzer {
         Function function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
                 returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
-                objectFile, handleClass.getCanonicalName(), "", "", !"shared".equalsIgnoreCase(isolation),
+                objectFile, handleClass.getCanonicalName(), "", "",
+                !CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation),
                 cloudConfiguration);
         function.setChecksum(checksum);
         return function;
@@ -491,7 +492,7 @@ public class CreateFunctionAnalyzer {
                 .isAnalyticFn(isAnalyticFn)
                 .symbolName(mainClass.getCanonicalName())
                 .cloudConfiguration(cloudConfiguration)
-                .setIsolationType(!"shared".equalsIgnoreCase(isolation));
+                .setIsolationType(!CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation));
         Function function = builder.build();
         function.setChecksum(checksum);
         return function;
@@ -1075,7 +1076,7 @@ public class CreateFunctionAnalyzer {
                 objectFile(objectFile).
                 inputType(inputType).
                 symbolName(symbol).
-                isolation(!"shared".equalsIgnoreCase(isolation)).
+                isolation(!CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation)).
                 content(content);
         ScalarFunction function = scalarFunctionBuilder.build();
         function.setChecksum(checksum);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -32,6 +32,8 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String MD5_CHECKSUM = "md5";
     public static final String TYPE_KEY = "type";
     public static final String ISOLATION_KEY = "isolation";
+    public static final String ISOLATION_SHARED = "shared";
+    public static final String ISOLATION_ISOLATED = "isolated";
     public static final String INTERMEDIATE_KEY = "intermediate";
     public static final String TYPE_STARROCKS_JAR = "StarrocksJar";
     public static final String TYPE_STARROCKS_PYTHON = "Python";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowFunctionsIsolationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowFunctionsIsolationTest.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.ast.ShowFunctionsStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+// Regression coverage for SHOW FULL FUNCTIONS exposing the "isolation" property so users can tell
+// whether a UDF/UDAF was created with isolation = "shared".
+public class ShowFunctionsIsolationTest {
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase("test_iso_db").useDatabase("test_iso_db");
+        starRocksAssert.withFunction(
+                "CREATE FUNCTION test_iso_db.shared_udf(int) RETURNS int PROPERTIES " +
+                        "(\"symbol\" = \"Echo\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\", " +
+                        "\"isolation\" = \"shared\");");
+        starRocksAssert.withFunction(
+                "CREATE FUNCTION test_iso_db.isolated_udf(int) RETURNS int PROPERTIES " +
+                        "(\"symbol\" = \"Echo\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+        starRocksAssert.withFunction(
+                "CREATE AGGREGATE FUNCTION test_iso_db.shared_agg(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyShared\", \"type\" = \"StarrocksJar\", " +
+                        "\"file\" = \"xxx\", \"isolation\" = \"shared\");");
+        starRocksAssert.withFunction(
+                "CREATE AGGREGATE FUNCTION test_iso_db.isolated_agg(int) RETURNS bigint PROPERTIES " +
+                        "(\"symbol\" = \"com.example.MyAgg\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+    }
+
+    private static String propertiesOf(String functionName) throws Exception {
+        ShowFunctionsStmt stmt = new ShowFunctionsStmt("test_iso_db", false, false, true, null, null);
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        // Verbose layout: [signature, returnType, functionType, intermediateType, properties]
+        for (var row : rs.getResultRows()) {
+            if (row.get(0).startsWith(functionName + "(")) {
+                return row.get(4);
+            }
+        }
+        throw new AssertionError("function not found in SHOW FULL FUNCTIONS: " + functionName);
+    }
+
+    @Test
+    public void testSharedScalarFunctionShowsIsolation() throws Exception {
+        String props = propertiesOf("shared_udf");
+        Assertions.assertTrue(props.contains("\"isolation\":\"shared\""), props);
+    }
+
+    @Test
+    public void testIsolatedScalarFunctionShowsIsolation() throws Exception {
+        String props = propertiesOf("isolated_udf");
+        Assertions.assertTrue(props.contains("\"isolation\":\"isolated\""), props);
+    }
+
+    @Test
+    public void testSharedAggregateFunctionShowsIsolation() throws Exception {
+        String props = propertiesOf("shared_agg");
+        Assertions.assertTrue(props.contains("\"isolation\":\"shared\""), props);
+    }
+
+    @Test
+    public void testIsolatedAggregateFunctionShowsIsolation() throws Exception {
+        String props = propertiesOf("isolated_agg");
+        Assertions.assertTrue(props.contains("\"isolation\":\"isolated\""), props);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

  `ScalarFunction.getProperties()` and `AggregateFunction.getProperties()`,
  which build the Properties column of `SHOW [FULL] FUNCTIONS`, only emitted
  fid/file/md5/symbol/type and never the isolation flag. A UDF/UDAF
  created with "isolation" = "shared" therefore showed no isolation entry,
  so users could not tell whether the property was set.

## What I'm doing:

  Always emit "isolation" ("shared" or "isolated") in the properties JSON,
  computed from the persisted isolationType field, so the state is visible
  for any function without recreating it.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
