### PR TITLE
[BugFix] Fix use-after-free of PipelineObserver in global runtime filter receive path

### DIFF
--- a/be/src/exec/runtime/pipeline_driver.cpp
+++ b/be/src/exec/runtime/pipeline_driver.cpp
@@ -233,7 +233,10 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
 #endif
                     auto* observer = this->observer();
                     DCHECK(observer != nullptr || !runtime_state->enable_event_scheduler());
-                    desc->add_observer(_runtime_state, [observer]() { observer->source_trigger(); });
+                    // Key the callback by `observer` so it can be detached in finalize(); the
+                    // descriptor outlives this driver, so a late runtime filter must not invoke a
+                    // callback capturing the destructed observer (use-after-free).
+                    desc->add_observer(_runtime_state, observer, [observer]() { observer->source_trigger(); });
                 }
             }
 
@@ -860,6 +863,20 @@ void PipelineDriver::_try_to_release_buffer(RuntimeState* state, size_t operator
 }
 
 void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
+    // Global runtime filters are delivered asynchronously on the RuntimeFilterWorker thread and
+    // the probe descriptors outlive this driver (they live in the fragment's object pool). This
+    // driver registered a callback capturing its PipelineObserver into each descriptor during
+    // prepare(); detach them before teardown, otherwise a late runtime filter would invoke that
+    // callback over the destructed observer (use-after-free, crashing in set_runtime_filter ->
+    // PipelineObserver::source_trigger -> _do_update). The fragment_prepared() guard only covers
+    // the prepare side and stays true once set, so it does not protect this teardown window. The
+    // matching timer observer is removed via the global RF timer unschedule below.
+    if (runtime_state->enable_event_scheduler()) {
+        for (auto* desc : _global_rf_descriptors) {
+            desc->remove_observer(observer());
+        }
+    }
+
     stop_timers();
     int64_t time_spent = 0;
     // The driver may be destructed after finalizing, so use a temporal driver to record

--- a/be/src/exec/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_probe.cpp
@@ -147,10 +147,18 @@ std::string RuntimeFilterProbeDescriptor::debug_string() const {
 
 RuntimeFilterProbeDescriptor::~RuntimeFilterProbeDescriptor() = default;
 
-void RuntimeFilterProbeDescriptor::add_observer(RuntimeState* state, ReadyObserver observer) {
+void RuntimeFilterProbeDescriptor::add_observer(RuntimeState* state, const void* owner, ReadyObserver observer) {
     if (state != nullptr && state->enable_event_scheduler() && observer) {
-        _ready_observers.emplace_back(std::move(observer));
+        std::lock_guard<std::mutex> l(_observer_mutex);
+        _ready_observers.emplace_back(owner, std::move(observer));
     }
+}
+
+void RuntimeFilterProbeDescriptor::remove_observer(const void* owner) {
+    std::lock_guard<std::mutex> l(_observer_mutex);
+    auto it = std::remove_if(_ready_observers.begin(), _ready_observers.end(),
+                             [owner](const auto& entry) { return entry.first == owner; });
+    _ready_observers.erase(it, _ready_observers.end());
 }
 
 static const int default_runtime_filter_wait_timeout_ms = 1000;
@@ -544,8 +552,9 @@ void RuntimeFilterProbeDescriptor::set_runtime_filter(const RuntimeFilter* rf) {
     auto notify = DeferOp([this]() {
         FAIL_POINT_TRIGGER_EXECUTE(global_runtime_filter_sync_B, { this->barrier.arrive_B(); });
         if (_runtime_state && _runtime_state->fragment_prepared()) {
-            for (auto& observer : _ready_observers) {
-                observer();
+            std::lock_guard<std::mutex> l(_observer_mutex);
+            for (auto& entry : _ready_observers) {
+                entry.second();
             }
         }
     });

--- a/be/src/exec/runtime_filter/runtime_filter_probe.h
+++ b/be/src/exec/runtime_filter/runtime_filter_probe.h
@@ -20,7 +20,9 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "base/failpoint/fail_point.h"
@@ -103,7 +105,14 @@ public:
     }
     void set_runtime_filter(const RuntimeFilter* rf);
     void set_shared_runtime_filter(const std::shared_ptr<const RuntimeFilter>& rf);
-    void add_observer(RuntimeState* state, ReadyObserver observer);
+    // `owner` identifies the registrant (e.g. the PipelineDriver's observer) so it can be
+    // detached again via remove_observer(). Thread-safe.
+    void add_observer(RuntimeState* state, const void* owner, ReadyObserver observer);
+    // Detach the observer previously registered with `owner`. Idempotent (no-op when absent).
+    // MUST be called when the registrant is torn down (PipelineDriver::finalize), otherwise a
+    // runtime filter delivered asynchronously on the RuntimeFilterWorker thread would invoke a
+    // callback that captured the now-destructed observer (use-after-free).
+    void remove_observer(const void* owner);
 
     void set_has_push_down_to_storage(bool v) { _has_push_down_to_storage = v; }
     bool has_push_down_to_storage() const { return _has_push_down_to_storage; }
@@ -138,7 +147,12 @@ private:
     std::atomic<const RuntimeFilter*> _runtime_filter = nullptr;
     std::shared_ptr<const RuntimeFilter> _shared_runtime_filter = nullptr;
     RuntimeState* _runtime_state = nullptr;
-    std::vector<ReadyObserver> _ready_observers;
+    // Guards _ready_observers: set_runtime_filter() notifies on the RuntimeFilterWorker thread
+    // while remove_observer() runs on the driver-executor thread during finalize; the lock
+    // serializes them so a notify never invokes a callback whose owner was just detached.
+    mutable std::mutex _observer_mutex;
+    // {owner, callback}. owner is an opaque key used by remove_observer().
+    std::vector<std::pair<const void*, ReadyObserver>> _ready_observers;
     bool _has_push_down_to_storage = false;
     // Exchange hash function version: 0 for FNV (for backward compatibility), 1 for XXH3
     int32_t _exchange_hash_function_version = 0;


### PR DESCRIPTION
## Why I'm doing:

A global RuntimeFilter delivered asynchronously on the `RuntimeFilterWorker` thread can dereference a **destructed `PipelineObserver`**, crashing the BE/CN process:

```
*** SIGSEGV received by PID ... ; stack trace: ***
PC: RuntimeFilterProbeDescriptor::set_runtime_filter(RuntimeFilter const*)
    RuntimeFilterProbeDescriptor::set_shared_runtime_filter(...)
    RuntimeFilterPort::receive_shared_runtime_filter(...)
    RuntimeFilterWorker::_receive_total_runtime_filter(...)
    RuntimeFilterWorker::execute()
```
(observed as a crash inside `set_runtime_filter` / `PipelineObserver::source_trigger -> _do_update`, signal address `@0x0` or a small offset.)

### Root cause
During `PipelineDriver::prepare()` the driver registers a ready-observer callback that **captures its own `PipelineObserver*`** into every global-RF `RuntimeFilterProbeDescriptor`:

```cpp
auto* observer = this->observer();
desc->add_observer(_runtime_state, [observer]() { observer->source_trigger(); });
```

The descriptor lives in the fragment's object pool and **outlives the driver**, but the callback is **never detached** when the driver is torn down. When a query finishes, the driver (and its `PipelineObserver`, owned via `unique_ptr`) is destroyed while the descriptor keeps the stale callback. A late RF delivered on the `RuntimeFilterWorker` thread then iterates `_ready_observers` and invokes the callback over the freed observer → use-after-free.

The existing `fragment_prepared()` guard only covers the *prepare* side — it is a one-way latch that stays `true` after prepare — so it does **not** protect this *teardown* window.

This is reliably reproducible under concurrent query finish + late global RF delivery, independent of host load, and is not OOM/liveness related.

## What I'm doing:

- Key each ready-observer by its `owner` (the `PipelineObserver*`) and add `RuntimeFilterProbeDescriptor::remove_observer(owner)`.
- `PipelineDriver::finalize()` detaches its observer from every global-RF descriptor before teardown.
- Guard `_ready_observers` with a mutex: `set_runtime_filter()` notifies on the `RuntimeFilterWorker` thread while `remove_observer()` runs on the driver-executor thread; the lock serializes them, so an in-flight notify keeps the observer alive until it finishes, and any notify after detach sees no stale callback.

The matching pipeline timer observer is already removed via the global-RF timer `unschedule` in `finalize()`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

> Affected since the event-scheduler runtime-filter integration (#54691). 3.3.x does not have the event scheduler observer path and is not affected.
