### PR TITLE
[BugFix] Surface isolation property in SHOW FUNCTIONS output (backport #75255)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -430,6 +430,10 @@ public class AggregateFunction extends Function {
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName == null ? "" : symbolName);
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
+        // isolationType defaults to true (isolated); surface it so users can tell whether the
+        // function was created with isolation = "shared".
+        properties.put(CreateFunctionStmt.ISOLATION_KEY,
+                isolationType ? CreateFunctionStmt.ISOLATION_ISOLATED : CreateFunctionStmt.ISOLATION_SHARED);
         return new Gson().toJson(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -276,6 +276,10 @@ public class ScalarFunction extends Function {
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
+        // isolationType defaults to true (isolated); surface it so users can tell whether the
+        // function was created with isolation = "shared".
+        properties.put(CreateFunctionStmt.ISOLATION_KEY,
+                isolationType ? CreateFunctionStmt.ISOLATION_ISOLATED : CreateFunctionStmt.ISOLATION_SHARED);
         return new Gson().toJson(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -357,7 +357,8 @@ public class CreateFunctionAnalyzer {
         Function function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
                 returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
-                objectFile, handleClass.getCanonicalName(), "", "", !"shared".equalsIgnoreCase(isolation),
+                objectFile, handleClass.getCanonicalName(), "", "",
+                !CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation),
                 cloudConfiguration);
         function.setChecksum(checksum);
         return function;
@@ -478,7 +479,7 @@ public class CreateFunctionAnalyzer {
                 .isAnalyticFn(isAnalyticFn)
                 .symbolName(mainClass.getCanonicalName())
                 .cloudConfiguration(cloudConfiguration)
-                .setIsolationType(!"shared".equalsIgnoreCase(isolation));
+                .setIsolationType(!CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation));
         Function function = builder.build();
         function.setChecksum(checksum);
         return function;
@@ -1058,7 +1059,7 @@ public class CreateFunctionAnalyzer {
                 objectFile(objectFile).
                 inputType(inputType).
                 symbolName(symbol).
-                isolation(!"shared".equalsIgnoreCase(isolation)).
+                isolation(!CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation)).
                 content(content);
         ScalarFunction function = scalarFunctionBuilder.build();
         function.setChecksum(checksum);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -34,6 +34,8 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String MD5_CHECKSUM = "md5";
     public static final String TYPE_KEY = "type";
     public static final String ISOLATION_KEY = "isolation";
+    public static final String ISOLATION_SHARED = "shared";
+    public static final String ISOLATION_ISOLATED = "isolated";
     public static final String TYPE_STARROCKS_JAR = "StarrocksJar";
     public static final String TYPE_STARROCKS_PYTHON = "Python";
     public static final String EVAL_METHOD_NAME = "evaluate";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowFunctionsIsolationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowFunctionsIsolationTest.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TFunctionBinaryType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+// Regression coverage for the Properties shown by SHOW [FULL] FUNCTIONS (Function#getProperties)
+// exposing the "isolation" entry so users can tell whether a UDF/UDAF was created with
+// isolation = "shared". isolationType == false means shared; true (default) means isolated.
+public class ShowFunctionsIsolationTest {
+
+    private static ScalarFunction scalarUdf(boolean isolationType) {
+        Type[] args = new Type[] {Type.INT};
+        return ScalarFunction.createUdf(new FunctionName("db", "my_udf"), args, Type.INT,
+                false, TFunctionBinaryType.SRJAR, "objectFile", "symbol", "", "", isolationType, null);
+    }
+
+    private static AggregateFunction aggregateUdf(boolean isolationType) {
+        AggregateFunction fn = new AggregateFunction(new FunctionName("db", "my_agg"),
+                Lists.newArrayList(Type.INT), Type.INT, Type.INT, false);
+        fn.setBinaryType(TFunctionBinaryType.SRJAR);
+        fn.setIsolationType(isolationType);
+        return fn;
+    }
+
+    @Test
+    public void testSharedScalarFunctionShowsIsolation() {
+        String props = scalarUdf(false).getProperties();
+        Assertions.assertTrue(props.contains("\"isolation\":\"shared\""), props);
+    }
+
+    @Test
+    public void testIsolatedScalarFunctionShowsIsolation() {
+        String props = scalarUdf(true).getProperties();
+        Assertions.assertTrue(props.contains("\"isolation\":\"isolated\""), props);
+    }
+
+    @Test
+    public void testSharedAggregateFunctionShowsIsolation() {
+        String props = aggregateUdf(false).getProperties();
+        Assertions.assertTrue(props.contains("\"isolation\":\"shared\""), props);
+    }
+
+    @Test
+    public void testIsolatedAggregateFunctionShowsIsolation() {
+        String props = aggregateUdf(true).getProperties();
+        Assertions.assertTrue(props.contains("\"isolation\":\"isolated\""), props);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Backport of #75255 to branch-4.0.

When a UDF/UDAF is created with `"isolation" = "shared"`, the `isolation` setting was not shown in the `SHOW [FULL] FUNCTIONS` Properties column, so users could not tell whether a function was created with shared isolation.

## What I'm doing:

Surface the `isolation` entry in `Function#getProperties()` (the source of the `SHOW [FULL] FUNCTIONS` Properties column) for scalar and aggregate Java UDFs — emitting `"shared"` when the function is shared and `"isolated"` otherwise. The value is computed from the persisted `isolationType` field, so existing functions display correctly after upgrade without needing to be recreated.

Backport notes (differences from the original #75255 on main):
- Dropped the `synthesizePropertiesFromFields` changes — that helper belongs to `SHOW CREATE FUNCTION` (#73519), which is not present on this branch.
- The regression test is written as a direct `Function#getProperties()` unit test, because this branch's `StarRocksAssert.withFunction` test helper does not apply the `isolation` property (it constructs a mock function with default isolation), so an end-to-end `SHOW FULL FUNCTIONS` assertion cannot exercise the shared path here.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

