### PR TITLE
[BugFix] Fix heap-use-after-free in OrderedPartitionExchanger when previous chunk is mutated downstream

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -25,7 +25,6 @@
 #include "exec/pipeline/exchange/shuffler.h"
 #include "exprs/expr_context.h"
 #include "exprs/expr_executor.h"
-#include "gutil/hash/hash.h"
 
 namespace starrocks::pipeline {
 Status Partitioner::partition_chunk(const ChunkPtr& chunk, int32_t num_partitions,
@@ -229,6 +228,11 @@ void OrderedPartitionExchanger::close(RuntimeState* state) {
 Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_driver_sequence) {
     DCHECK_EQ(sink_driver_sequence, 0);
 
+    // Capture the row count now, before the chunk is handed downstream below. Once published, the chunk
+    // may be mutated on another thread (e.g. AnalyticSinkOperator appends window-function result columns),
+    // so reading chunk->num_rows() afterwards would race on the chunk's column vector.
+    const size_t cur_num_rows = chunk->num_rows();
+
     Columns partition_columns(_partition_exprs.size());
     for (size_t i = 0; i < partition_columns.size(); ++i) {
         ASSIGN_OR_RETURN(partition_columns[i], _partition_exprs[i]->evaluate(chunk.get()));
@@ -243,7 +247,7 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
     std::vector<std::pair<size_t, ChunkPtr>> chunks;
 
     size_t min_channel_id = _find_min_channel_id();
-    if (_previous_chunk == nullptr || _previous_channel_id == min_channel_id) {
+    if (!_has_previous || _previous_channel_id == min_channel_id) {
         chunks.emplace_back(min_channel_id, chunk);
     } else {
         auto is_equal = [](const Columns& columns1, size_t offset1, const Columns& columns2, size_t offset2) {
@@ -255,9 +259,12 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
             }
             return true;
         };
-        // Check if the joint of two consecutive chunks are the same
+        // Check if the joint of two consecutive chunks are the same.
+        // _previous_partition_columns aliases the previous chunk's (read-only) partition-key column objects,
+        // which are never mutated downstream; only the chunk's column vector is, so we use the captured
+        // _previous_num_rows instead of dereferencing the previous chunk to index its last row.
         bool is_joint_equal =
-                is_equal(_previous_partition_columns, _previous_chunk->num_rows() - 1, partition_columns, 0);
+                is_equal(_previous_partition_columns, _previous_num_rows - 1, partition_columns, 0);
 
         if (!is_joint_equal) {
             // The first row of current chunk is the start of a new partition, so
@@ -265,7 +272,7 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
             chunks.emplace_back(min_channel_id, chunk);
         } else {
             bool is_current_of_same_partition =
-                    is_equal(partition_columns, 0, partition_columns, chunk->num_rows() - 1);
+                    is_equal(partition_columns, 0, partition_columns, cur_num_rows - 1);
             if (is_current_of_same_partition) {
                 chunks.emplace_back(_previous_channel_id, chunk);
             } else {
@@ -273,7 +280,7 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
                 // 1. The first part is the rows of the same partition as the last row of previous chunk, and send it to previous channel
                 // 2. The second part is the rows of the different partition, and send it to the channel with the minimum number of rows.
 
-                int64_t end = chunk->num_rows();
+                int64_t end = cur_num_rows;
                 for (auto& column : partition_columns) {
                     end = ColumnHelper::find_first_not_equal(column.get(), 0, 0, end);
                 }
@@ -282,9 +289,9 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
                 first_part->append(*chunk, 0, end);
                 chunks.emplace_back(_previous_channel_id, first_part);
 
-                // Second part: [end, chunk->num_rows())
+                // Second part: [end, cur_num_rows)
                 ChunkPtr second_part = chunk->clone_empty();
-                second_part->append(*chunk, end, chunk->num_rows() - end);
+                second_part->append(*chunk, end, cur_num_rows - end);
                 chunks.emplace_back(min_channel_id, second_part);
             }
         }
@@ -296,8 +303,9 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
     }
 
     _previous_channel_id = chunks.back().first;
-    _previous_chunk = chunk;
+    _previous_num_rows = cur_num_rows;
     _previous_partition_columns = std::move(partition_columns);
+    _has_previous = true;
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -229,6 +229,12 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
     DCHECK_EQ(sink_driver_sequence, 0);
 
     const size_t cur_num_rows = chunk->num_rows();
+    // Drop empty chunks: they carry no rows to route and no partition boundary. This also guards the
+    // `cur_num_rows - 1` boundary-row indexing below from wrapping. Matches the other row-partition
+    // exchangers, which all early-return on empty input.
+    if (cur_num_rows == 0) {
+        return Status::OK();
+    }
 
     Columns partition_columns(_partition_exprs.size());
     for (size_t i = 0; i < partition_columns.size(); ++i) {

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -228,9 +228,6 @@ void OrderedPartitionExchanger::close(RuntimeState* state) {
 Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_driver_sequence) {
     DCHECK_EQ(sink_driver_sequence, 0);
 
-    // Capture the row count now, before the chunk is handed downstream below. Once published, the chunk
-    // may be mutated on another thread (e.g. AnalyticSinkOperator appends window-function result columns),
-    // so reading chunk->num_rows() afterwards would race on the chunk's column vector.
     const size_t cur_num_rows = chunk->num_rows();
 
     Columns partition_columns(_partition_exprs.size());
@@ -260,10 +257,10 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
             return true;
         };
         // Check if the joint of two consecutive chunks are the same.
-        // _previous_partition_columns aliases the previous chunk's (read-only) partition-key column objects,
-        // which are never mutated downstream; only the chunk's column vector is, so we use the captured
-        // _previous_num_rows instead of dereferencing the previous chunk to index its last row.
-        bool is_joint_equal = is_equal(_previous_partition_columns, _previous_num_rows - 1, partition_columns, 0);
+        // _previous_partition_columns is an owned single-row copy of the previous chunk's last row (at
+        // offset 0), so it stays valid even after the previous chunk has been handed to and mutated by
+        // downstream operators.
+        bool is_joint_equal = is_equal(_previous_partition_columns, 0, partition_columns, 0);
 
         if (!is_joint_equal) {
             // The first row of current chunk is the start of a new partition, so
@@ -295,17 +292,33 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
         }
     }
 
+    // Clone the boundary (last) row of the partition key BEFORE publishing the chunk downstream. At this
+    // point the chunk is still owned solely by this driver thread, so reading partition_columns is safe.
+    // After add_chunk() the chunk may be mutated concurrently by downstream operators (AnalyticSinkOperator
+    // appends window result columns and, on the LIMIT path, set_num_rows() resizes columns in place), so we
+    // must not retain any reference that aliases it.
+    Columns boundary_partition_columns = _clone_partition_key_row(partition_columns, cur_num_rows - 1);
+
     for (auto& kv : chunks) {
         _channel_row_nums[kv.first] += kv.second->num_rows();
         _source->get_sources()[kv.first]->add_chunk(kv.second);
     }
 
     _previous_channel_id = chunks.back().first;
-    _previous_num_rows = cur_num_rows;
-    _previous_partition_columns = std::move(partition_columns);
+    _previous_partition_columns = std::move(boundary_partition_columns);
     _has_previous = true;
 
     return Status::OK();
+}
+
+Columns OrderedPartitionExchanger::_clone_partition_key_row(const Columns& partition_columns, size_t row) {
+    Columns result(partition_columns.size());
+    for (size_t i = 0; i < partition_columns.size(); ++i) {
+        auto cloned = partition_columns[i]->clone_empty();
+        cloned->append(*partition_columns[i], row, 1);
+        result[i] = std::move(cloned);
+    }
+    return result;
 }
 
 size_t OrderedPartitionExchanger::_find_min_channel_id() {

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -263,16 +263,14 @@ Status OrderedPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t si
         // _previous_partition_columns aliases the previous chunk's (read-only) partition-key column objects,
         // which are never mutated downstream; only the chunk's column vector is, so we use the captured
         // _previous_num_rows instead of dereferencing the previous chunk to index its last row.
-        bool is_joint_equal =
-                is_equal(_previous_partition_columns, _previous_num_rows - 1, partition_columns, 0);
+        bool is_joint_equal = is_equal(_previous_partition_columns, _previous_num_rows - 1, partition_columns, 0);
 
         if (!is_joint_equal) {
             // The first row of current chunk is the start of a new partition, so
             // send the chunk to the channel with the minimum number of rows.
             chunks.emplace_back(min_channel_id, chunk);
         } else {
-            bool is_current_of_same_partition =
-                    is_equal(partition_columns, 0, partition_columns, cur_num_rows - 1);
+            bool is_current_of_same_partition = is_equal(partition_columns, 0, partition_columns, cur_num_rows - 1);
             if (is_current_of_same_partition) {
                 chunks.emplace_back(_previous_channel_id, chunk);
             } else {

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -48,9 +48,13 @@ public:
     // Send chunk to each source by using `partition_row_indexes`.
     Status send_chunk(const ChunkPtr& chunk, const std::shared_ptr<std::vector<uint32_t>>& partition_row_indexes);
 
-    size_t partition_begin_offset(size_t partition_id) const { return _partition_row_indexes_start_points[partition_id]; }
+    size_t partition_begin_offset(size_t partition_id) const {
+        return _partition_row_indexes_start_points[partition_id];
+    }
 
-    size_t partition_end_offset(size_t partition_id) const { return _partition_row_indexes_start_points[partition_id + 1]; }
+    size_t partition_end_offset(size_t partition_id) const {
+        return _partition_row_indexes_start_points[partition_id + 1];
+    }
 
 protected:
     LocalExchangeSourceOperatorFactory* _source;

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -221,17 +221,19 @@ public:
 
 private:
     size_t _find_min_channel_id();
+    // Deep-copy the partition-key values of a single row (the previous chunk's last row) into freshly owned
+    // columns, so the retained boundary key does not alias any chunk handed downstream.
+    static Columns _clone_partition_key_row(const Columns& partition_columns, size_t row);
 
     std::vector<ExprContext*> _partition_exprs;
     std::vector<size_t> _channel_row_nums;
+    // Owned single-row copy of the previous chunk's last-row partition key (stored at offset 0).
+    // We must NOT retain a reference to the previous chunk (or columns aliasing it): once handed downstream
+    // the chunk may be mutated concurrently (AnalyticSinkOperator appends window-function result columns and,
+    // on the LIMIT path, set_num_rows() resizes columns in place), which would make reading it here a data
+    // race / heap-use-after-free.
     Columns _previous_partition_columns;
     size_t _previous_channel_id = 0;
-    // Row count of the previous chunk, captured before the chunk is handed downstream.
-    // We must NOT keep a pointer to the previous chunk and read num_rows() from it later: once handed
-    // downstream the chunk may be mutated concurrently (e.g. AnalyticSinkOperator appends window-function
-    // result columns, reallocating the chunk's column vector), which would make reading it a data race /
-    // heap-use-after-free.
-    size_t _previous_num_rows = 0;
     bool _has_previous = false;
 };
 

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -48,16 +48,16 @@ public:
     // Send chunk to each source by using `partition_row_indexes`.
     Status send_chunk(const ChunkPtr& chunk, const std::shared_ptr<std::vector<uint32_t>>& partition_row_indexes);
 
-    size_t partition_begin_offset(size_t partition_id) { return _partition_row_indexes_start_points[partition_id]; }
+    size_t partition_begin_offset(size_t partition_id) const { return _partition_row_indexes_start_points[partition_id]; }
 
-    size_t partition_end_offset(size_t partition_id) { return _partition_row_indexes_start_points[partition_id + 1]; }
+    size_t partition_end_offset(size_t partition_id) const { return _partition_row_indexes_start_points[partition_id + 1]; }
 
 protected:
     LocalExchangeSourceOperatorFactory* _source;
 
-    // This array record the channel start point in _row_indexes
+    // This array records the channel start point in _row_indexes
     // And the last item is the number of rows of the current shuffle chunk.
-    // It will easy to get number of rows belong to one channel by doing
+    // It will be easy to get the number of rows belong to one channel by doing
     // _partition_row_indexes_start_points[i + 1] - _partition_row_indexes_start_points[i]
     std::vector<size_t> _partition_row_indexes_start_points;
     std::vector<uint32_t> _shuffle_channel_id;
@@ -221,8 +221,14 @@ private:
     std::vector<ExprContext*> _partition_exprs;
     std::vector<size_t> _channel_row_nums;
     Columns _previous_partition_columns;
-    size_t _previous_channel_id;
-    ChunkPtr _previous_chunk;
+    size_t _previous_channel_id = 0;
+    // Row count of the previous chunk, captured before the chunk is handed downstream.
+    // We must NOT keep a pointer to the previous chunk and read num_rows() from it later: once handed
+    // downstream the chunk may be mutated concurrently (e.g. AnalyticSinkOperator appends window-function
+    // result columns, reallocating the chunk's column vector), which would make reading it a data race /
+    // heap-use-after-free.
+    size_t _previous_num_rows = 0;
+    bool _has_previous = false;
 };
 
 // key partition mainly means that the column value of each partition is the same.

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXEC_FILES
         ./exec/pipeline/enforce_unique_row_locator_operator_test.cpp
         ./exec/pipeline/local_bucket_shuffle_test.cpp
         ./exec/pipeline/local_exchange_memory_test.cpp
+        ./exec/pipeline/ordered_partition_exchanger_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp
         ./exec/pipeline/fragment_executor_test.cpp

--- a/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
+++ b/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
@@ -166,6 +166,19 @@ TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_
     EXPECT_TRUE(_drain(2).empty());
 }
 
+// An empty chunk must be dropped: it carries no rows and no partition boundary, and accepting it must not
+// underflow the boundary-row indexing (cur_num_rows - 1). It also must not disturb routing of later chunks.
+TEST_F(OrderedPartitionExchangerTest, empty_chunk_is_dropped) {
+    ASSERT_OK(_exchanger->accept(_make_chunk({}), 0));        // empty, before any boundary is recorded
+    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7, 7, 7}), 0));
+    ASSERT_OK(_exchanger->accept(_make_chunk({}), 0));        // empty, after a boundary exists
+    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7}), 0));    // continues the same partition
+
+    EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7, 7, 7}));
+    EXPECT_TRUE(_drain(1).empty());
+    EXPECT_TRUE(_drain(2).empty());
+}
+
 // The first row of the next chunk starts a brand-new partition, so it is routed to the
 // least-loaded channel rather than continuing on the previous channel.
 TEST_F(OrderedPartitionExchangerTest, new_partition_goes_to_min_channel) {

--- a/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
+++ b/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
@@ -169,10 +169,10 @@ TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_
 // An empty chunk must be dropped: it carries no rows and no partition boundary, and accepting it must not
 // underflow the boundary-row indexing (cur_num_rows - 1). It also must not disturb routing of later chunks.
 TEST_F(OrderedPartitionExchangerTest, empty_chunk_is_dropped) {
-    ASSERT_OK(_exchanger->accept(_make_chunk({}), 0));        // empty, before any boundary is recorded
+    ASSERT_OK(_exchanger->accept(_make_chunk({}), 0)); // empty, before any boundary is recorded
     ASSERT_OK(_exchanger->accept(_make_chunk({7, 7, 7, 7}), 0));
-    ASSERT_OK(_exchanger->accept(_make_chunk({}), 0));        // empty, after a boundary exists
-    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7}), 0));    // continues the same partition
+    ASSERT_OK(_exchanger->accept(_make_chunk({}), 0));     // empty, after a boundary exists
+    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7}), 0)); // continues the same partition
 
     EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7, 7, 7}));
     EXPECT_TRUE(_drain(1).empty());

--- a/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
+++ b/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
@@ -1,0 +1,172 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "exec/chunk_buffer_memory_manager.h"
+#include "exec/pipeline/exchange/local_exchange.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exec/pipeline/query_context.h"
+#include "exprs/expr_executor.h"
+#include "exprs/expr_factory.h"
+#include "gen_cpp/Exprs_types.h"
+#include "gutil/casts.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "testutil/column_test_helper.h"
+#include "testutil/exprs_test_helper.h"
+#include "types/datum.h"
+#include "types/logical_type.h"
+
+namespace starrocks::pipeline {
+
+// The partition key lives in slot id 1, matching the SlotRef partition expr below.
+static constexpr SlotId kPartitionSlotId = 1;
+
+class OrderedPartitionExchangerTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+
+        _query_context = std::make_shared<QueryContext>();
+        _query_context->set_query_execution_services(&_exec_env->query_execution_services());
+        _query_context->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
+
+        TQueryOptions query_options;
+        query_options.batch_size = 4096;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(_fragment_id, query_options, query_globals,
+                                                        &_exec_env->query_execution_services(), _exec_env);
+        _query_context->attach_to_runtime_state(_runtime_state.get());
+        _runtime_state->init_instance_mem_tracker();
+
+        _memory_manager = std::make_shared<ChunkBufferMemoryManager>(_dop, 1024 * 1024);
+        _source_op_factory = std::make_unique<LocalExchangeSourceOperatorFactory>(0, 1, _memory_manager);
+        _source_op_factory->set_runtime_state(_runtime_state.get());
+        for (size_t i = 0; i < _dop; i++) {
+            _sources.emplace_back(_source_op_factory->create(_dop, i));
+        }
+
+        _exchanger = std::make_unique<OrderedPartitionExchanger>(_memory_manager, _source_op_factory.get(),
+                                                                 _make_partition_exprs());
+        ASSERT_OK(_exchanger->prepare(_runtime_state.get()));
+    }
+
+    void TearDown() override { _exchanger->close(_runtime_state.get()); }
+
+protected:
+    LocalExchangeSourceOperator* _source(size_t i) const {
+        return down_cast<LocalExchangeSourceOperator*>(_sources[i].get());
+    }
+
+    // A single SlotRef(slot 1, INT) partition expression.
+    std::vector<ExprContext*> _make_partition_exprs() {
+        std::vector<TExpr> t_exprs{
+                ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(kPartitionSlotId, /*is_nullable=*/false)};
+        std::vector<ExprContext*> exprs;
+        CHECK(ExprFactory::create_expr_trees(&_object_pool, t_exprs, &exprs, nullptr).ok());
+        return exprs;
+    }
+
+    // Build a chunk whose only column (slot 1) holds the given partition-key values.
+    static ChunkPtr _make_chunk(const std::vector<int32_t>& keys) {
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(ColumnTestHelper::build_column<int32_t>(keys), kPartitionSlotId);
+        return chunk;
+    }
+
+    // Drain a source channel, returning the partition-key values of every row routed to it, in order.
+    std::vector<int32_t> _drain(size_t channel) const {
+        std::vector<int32_t> keys;
+        while (_source(channel)->has_output()) {
+            auto pulled = _source(channel)->pull_chunk(_runtime_state.get());
+            CHECK(pulled.ok());
+            ChunkPtr chunk = std::move(pulled.value());
+            if (chunk == nullptr) {
+                break;
+            }
+            const auto& col = chunk->get_column_by_index(0);
+            for (size_t i = 0; i < chunk->num_rows(); ++i) {
+                keys.push_back(col->get(i).get_int32());
+            }
+        }
+        return keys;
+    }
+
+    std::shared_ptr<ChunkBufferMemoryManager> _memory_manager;
+    std::unique_ptr<LocalExchangeSourceOperatorFactory> _source_op_factory;
+    std::unique_ptr<OrderedPartitionExchanger> _exchanger;
+    TUniqueId _fragment_id;
+    ExecEnv* _exec_env = nullptr;
+    std::shared_ptr<QueryContext> _query_context;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::vector<OperatorPtr> _sources;
+    ObjectPool _object_pool;
+    size_t _dop = 3;
+};
+
+// Regression for the heap-use-after-free fixed alongside this test: once a chunk is handed downstream,
+// it may be mutated on another thread (AnalyticSinkOperator appends window result columns, reallocating
+// the chunk's column vector). The exchanger must not read the previous chunk on the next accept().
+// Here we deterministically reproduce that hazard by appending a column to the already-accepted chunk
+// between two accept() calls. Under ASAN this would trip on `_previous_chunk->num_rows()` before the fix.
+TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_mutated) {
+    auto chunk_a = _make_chunk({7, 7, 7, 7});
+    ASSERT_OK(_exchanger->accept(chunk_a, 0));
+
+    // Simulate the downstream operator mutating the already-handed-off chunk: appending a column
+    // reallocates chunk_a's `_columns` vector and frees the old storage.
+    chunk_a->append_column(ColumnTestHelper::build_column<int32_t>({0, 0, 0, 0}), /*slot_id=*/2);
+
+    // chunk_b's first row continues chunk_a's last partition (7), so it must stay on the same channel.
+    auto chunk_b = _make_chunk({7, 7, 7, 7});
+    ASSERT_OK(_exchanger->accept(chunk_b, 0));
+
+    // Both chunks land on channel 0 (the first chunk's min-loaded channel); the join is preserved.
+    EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7, 7, 7, 7, 7}));
+    EXPECT_TRUE(_drain(1).empty());
+    EXPECT_TRUE(_drain(2).empty());
+}
+
+// The first row of the next chunk starts a brand-new partition, so it is routed to the
+// least-loaded channel rather than continuing on the previous channel.
+TEST_F(OrderedPartitionExchangerTest, new_partition_goes_to_min_channel) {
+    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7, 7, 7}), 0));
+    ASSERT_OK(_exchanger->accept(_make_chunk({9, 9, 9, 9}), 0));
+
+    EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7}));
+    EXPECT_EQ(_drain(1), (std::vector<int32_t>{9, 9, 9, 9}));
+    EXPECT_TRUE(_drain(2).empty());
+}
+
+// A chunk that begins in the previous partition but switches mid-chunk is split: the leading rows
+// continue on the previous channel, the trailing rows of the new partition go to the min channel.
+TEST_F(OrderedPartitionExchangerTest, chunk_split_across_partition_boundary) {
+    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7, 7, 7}), 0));
+    ASSERT_OK(_exchanger->accept(_make_chunk({7, 7, 9, 9}), 0));
+
+    // channel 0: chunk_a (4 rows of 7) + first split part (2 rows of 7).
+    EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7, 7, 7}));
+    // channel 1 (least loaded at split time): the trailing new-partition rows.
+    EXPECT_EQ(_drain(1), (std::vector<int32_t>{9, 9}));
+    EXPECT_TRUE(_drain(2).empty());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
+++ b/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
@@ -122,11 +122,13 @@ protected:
     size_t _dop = 3;
 };
 
-// Regression coverage for OrderedPartitionExchanger state tracking: after a chunk is handed downstream,
-// it may be mutated (e.g. AnalyticSinkOperator appends window result columns, changing the chunk's
-// internal column vector). This test mutates the previously accepted chunk before the next accept()
-// and verifies routing decisions don't require dereferencing the previous chunk object.
-TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_mutated) {
+// Regression for the heap-use-after-free fixed alongside this test: once a chunk is handed downstream, it
+// may be mutated on another thread (AnalyticSinkOperator appends window result columns, reallocating the
+// chunk's column vector). The exchanger must retain only an owned copy of the previous boundary key, never
+// a reference into the handed-off chunk. We deterministically reproduce that hazard by appending a column
+// to the already-accepted chunk between two accept() calls; under ASAN this would trip on
+// `_previous_chunk->num_rows()` before the fix.
+TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_appended) {
     auto chunk_a = _make_chunk({7, 7, 7, 7});
     ASSERT_OK(_exchanger->accept(chunk_a, 0));
 
@@ -140,6 +142,26 @@ TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_
 
     // Both chunks land on channel 0 (the first chunk's min-loaded channel); the join is preserved.
     EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7, 7, 7, 7, 7}));
+    EXPECT_TRUE(_drain(1).empty());
+    EXPECT_TRUE(_drain(2).empty());
+}
+
+// Same hazard via the other downstream mutation: the analytic LIMIT path calls Chunk::set_num_rows(), which
+// resizes every column in place -- including the partition-key column the exchanger used to alias. Caching
+// the previous row count (rather than cloning the boundary row) would index past the shrunk column here;
+// the owned single-row copy must remain valid and the routing decision must still be correct.
+TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_truncated) {
+    auto chunk_a = _make_chunk({7, 7, 7, 7});
+    ASSERT_OK(_exchanger->accept(chunk_a, 0));
+
+    // Simulate the LIMIT path shrinking the already-handed-off chunk in place.
+    chunk_a->set_num_rows(2);
+
+    // chunk_b continues chunk_a's partition (7); the boundary key copy (7) must still drive the decision.
+    auto chunk_b = _make_chunk({7, 7, 7, 7});
+    ASSERT_OK(_exchanger->accept(chunk_b, 0));
+
+    EXPECT_EQ(_drain(0), (std::vector<int32_t>{7, 7, 7, 7, 7, 7}));
     EXPECT_TRUE(_drain(1).empty());
     EXPECT_TRUE(_drain(2).empty());
 }

--- a/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
+++ b/be/test/exec/pipeline/ordered_partition_exchanger_test.cpp
@@ -122,11 +122,10 @@ protected:
     size_t _dop = 3;
 };
 
-// Regression for the heap-use-after-free fixed alongside this test: once a chunk is handed downstream,
-// it may be mutated on another thread (AnalyticSinkOperator appends window result columns, reallocating
-// the chunk's column vector). The exchanger must not read the previous chunk on the next accept().
-// Here we deterministically reproduce that hazard by appending a column to the already-accepted chunk
-// between two accept() calls. Under ASAN this would trip on `_previous_chunk->num_rows()` before the fix.
+// Regression coverage for OrderedPartitionExchanger state tracking: after a chunk is handed downstream,
+// it may be mutated (e.g. AnalyticSinkOperator appends window result columns, changing the chunk's
+// internal column vector). This test mutates the previously accepted chunk before the next accept()
+// and verifies routing decisions don't require dereferencing the previous chunk object.
 TEST_F(OrderedPartitionExchangerTest, same_partition_continues_after_prev_chunk_mutated) {
     auto chunk_a = _make_chunk({7, 7, 7, 7});
     ASSERT_OK(_exchanger->accept(chunk_a, 0));


### PR DESCRIPTION
## Why I'm doing this

Fix: https://github.com/StarRocks/StarRocksTest/issues/11482

## Why I'm doing this

A heap-use-after-free (caught by ASAN) can crash the BE when a window function with a skew hint on `PARTITION BY` runs at DOP>1:

```
heap-use-after-free in Cow<Column>::ImmutPtr::operator->()
  READ  : Chunk::num_rows()      <- OrderedPartitionExchanger::accept()     (thread T296)
  FREED : Chunk::append_column() <- Analytor::_output_result_chunk()        (thread T295)
```

**Root cause:** `OrderedPartitionExchanger::accept()` hands a chunk to the downstream sources (`add_chunk`) and then retains references into that same chunk — `_previous_chunk` and `_previous_partition_columns` (which alias the chunk's partition-key columns for `SlotRef` keys). On the next `accept()`, it reads `_previous_chunk->num_rows()` and `compare_at()` on those columns to test the partition join between consecutive chunks. But the chunk has already been consumed by the downstream `AnalyticSinkOperator`, whose `_output_result_chunk()` reuses the input chunk as its output and mutates it on another thread:

- `append_column()` reallocates the chunk's `_columns` vector → the reported UAF on `num_rows()`.
- On the LIMIT path, `set_num_rows()` → `as_mutable_raw_ptr()->resize()` resizes every column in place (bypassing COW) → races with `compare_at()` and can index out of bounds.

The exchanger violates the pipeline contract that a chunk handed downstream is owned by the consumer. The bug has existed since `OrderedPartitionExchanger` was introduced (#35486); the analytic operator already reused and mutated the input chunk by then (#34312). It only triggers with a window skew hint + `PARTITION BY` + DOP>1, which is why it escaped routine testing.

## What I'm doing

Stop retaining anything that aliases a chunk handed downstream. `accept()` only needs the previous chunk's last-row partition key to compare against the next chunk's first row, so:

- Replace `ChunkPtr _previous_chunk` / `Columns _previous_partition_columns` (aliasing the chunk) with an owned single-row copy of the boundary key, plus a `bool _has_previous` sentinel.
- Add `_clone_partition_key_row()` which deep-copies just the last row of each partition-key column.
- Clone the boundary row before the chunk is published via `add_chunk()` — i.e. while it is still exclusively owned by the current driver thread — so the clone itself is race-free without locks. After publishing, the exchanger only ever reads its own copy.

The clone is one row × a few key columns per chunk (negligible vs. the sort+window work), and is robust against any downstream in-place chunk mutation, not just the two known today.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
