### PR TITLE
[Enhancement] Compute Iceberg foreground row-count from manifests without enumerating files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1676,29 +1676,63 @@ public class IcebergMetadata implements ConnectorMetadata {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 
+        // Default path (column statistics disabled): derive row count from manifest metadata
+        // (O(manifests)) without enumerating DataFiles. This avoids triggering a full planFiles()
+        // in the foreground, so it no longer pre-populates splitTasks and incremental scan range
+        // delivery (getRemoteFilesAsync) stays on its lazy/streaming path.
+        if (!session.getSessionVariable().enableIcebergColumnStatistics()) {
+            try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.calculateCardinality")) {
+                long rowCount = getManifestPrunedRowCount(icebergTable, predicate, version);
+                return statisticProvider.buildRowCountStatistics(columns, rowCount);
+            }
+        }
+
         GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
                 .setPredicate(predicate)
                 .setLimit(limit)
                 .setTableVersionRange(version)
-                .setEnableColumnStats(session.getSessionVariable().enableIcebergColumnStatistics())
+                .setEnableColumnStats(true)
                 .build();
 
         PredicateSearchKey key = PredicateSearchKey.of(
                 icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), params);
         triggerIcebergPlanFilesIfNeeded(key, icebergTable);
+        return statisticProvider.getTableStatistics(icebergTable, columns, session, params);
+    }
 
-        if (!session.getSessionVariable().enableIcebergColumnStatistics()) {
-            List<FileScanTask> icebergScanTasks = splitTasks.get(key);
-            if (icebergScanTasks == null) {
-                throw new StarRocksConnectorException("Missing iceberg split task for table:[{}.{}]. predicate:[{}]",
-                        icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), predicate);
-            }
-            try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.calculateCardinality" + key)) {
-                return statisticProvider.getCardinalityStats(columns, icebergScanTasks);
-            }
-        } else {
-            return statisticProvider.getTableStatistics(icebergTable, columns, session, params);
+    // Estimate row count from manifest metadata with partition-aware manifest pruning, in O(manifests).
+    // It reads only the manifest list (one file) plus in-memory manifest evaluation; it does NOT open
+    // manifest files or enumerate DataFiles, so it never populates splitTasks and keeps incremental
+    // scan range delivery intact. Manifest-level pruning is coarser than file-level: a matching manifest
+    // contributes its full row count, yielding a partition-aware over-estimate (never an undercount),
+    // which is the safe direction for CBO. Delete files are ignored, consistent with getCardinalityStats.
+    private long getManifestPrunedRowCount(IcebergTable icebergTable, ScalarOperator predicate, TvrVersionRange version) {
+        org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        if (!version.end().isPresent()) {
+            return 1;
         }
+        Snapshot snapshot = nativeTbl.snapshot(version.end().get());
+        if (snapshot == null) {
+            return 1;
+        }
+
+        List<ScalarOperator> scalarOperators = Utils.extractConjuncts(predicate);
+        ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
+                new ScalarOperatorToIcebergExpr.IcebergContext(nativeTbl.schema().asStruct());
+        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+
+        List<ManifestFile> dataManifests = snapshot.dataManifests(nativeTbl.io());
+        List<ManifestFile> matchingManifests = filterManifests(dataManifests, nativeTbl, icebergPredicate);
+
+        long rowCount = 0;
+        for (ManifestFile manifest : matchingManifests) {
+            rowCount += orZeroRows(manifest.addedRowsCount()) + orZeroRows(manifest.existingRowsCount());
+        }
+        return Math.max(rowCount, 1);
+    }
+
+    private static long orZeroRows(Long value) {
+        return value == null ? 0L : value;
     }
 
     private IcebergSplitScanTask buildIcebergSplitScanTask(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1697,17 +1697,19 @@ public class IcebergMetadata implements ConnectorMetadata {
         //    / existingRows unreliable for a snapshot range. Delta files are few by definition,
         //    so O(files) plan cost is acceptable; accuracy is required.
         if (isIncrementalDelta) {
-            return getIncrementalCardinalityFromPlanFiles(icebergTable, columns, predicate, limit, version);
+            return getCardinalityFromPlanFiles(icebergTable, columns, predicate, limit, version);
         }
         //
         // C. Whole-table snapshot (default, column-stats off, non-delta):
         //    Manifest addedRows+existingRows is PROVABLY exact for total live files regardless of
-        //    write style (fastAppend / MergeAppend / compaction / MOR).  partition-aware pruning
-        //    via filterManifests at manifest-granularity yields a safe over-estimate (typically
-        //    <5x vs 100x for snapshot total-records).  Cost: O(manifests), ZERO manifest-file opens,
-        //    ZERO DataFile enumeration — splitTasks never populated, incremental scan range delivery
-        //    stays unlocked.
-        return getStatisticsFromManifest(icebergTable, columns, predicate, version);
+        //    write style.  In the vast majority of cases (all modern Iceberg writers: StarRocks,
+        //    Spark, Trino, Flink) manifests carry the row-count fields needed; partition-aware
+        //    pruning via filterManifests at manifest-granularity yields a safe over-estimate.
+        //    Cost: O(manifests), ZERO manifest-file opens, ZERO DataFile enumeration — splitTasks
+        //    never populated, incremental scan range delivery stays unlocked.
+        //    Rare fallback: if a matching manifest is missing row-count metadata (v1 manifest list
+        //    or pre-0.10 Iceberg), we fall through to Path B for exact cardinality via planFiles.
+        return getStatisticsFromManifest(icebergTable, columns, predicate, limit, version);
     }
 
     // -------------------------------------------------------------------------
@@ -1718,25 +1720,38 @@ public class IcebergMetadata implements ConnectorMetadata {
     // every file within it. Typical over-estimate: <5x (safe direction for CBO).  Cost is
     // O(manifests) with ZERO manifest-file opens and ZERO DataFile enumeration, so splitTasks is
     // never populated and incremental scan range delivery stays lazy/streaming.
+    //
+    // Fallback: if any matching manifest has files but is missing both addedRowsCount and
+    // existingRowsCount (e.g. older or upgraded Iceberg metadata with v1 manifest list), the
+    // manifest-pruned count would be incomplete — fall back to planFiles for exact cardinality.
     private Statistics getStatisticsFromManifest(IcebergTable icebergTable,
                                                   Map<ColumnRefOperator, Column> columns,
                                                   ScalarOperator predicate,
+                                                  long limit,
                                                   TvrVersionRange version) {
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.calculateCardinality")) {
             long rowCount = getManifestPrunedRowCount(icebergTable, predicate, version);
+            if (rowCount < 0) {
+                // Manifest row-count metadata incomplete → fall back to planFiles.
+                return getCardinalityFromPlanFiles(icebergTable, columns, predicate, limit, version);
+            }
             return statisticProvider.buildRowCountStatistics(columns, rowCount);
         }
     }
 
     // -------------------------------------------------------------------------
-    // Path B: incremental delta (append-only), column-stats off.
+    // Path B: incremental delta (append-only) and fallback — column-stats off.
     //
-    // Trade-off: delta requires datafile-level precision (added_snapshot_id on each DataFile)
-    // because MergeAppend/compaction rewrites manifests, merging old and new records into the
-    // same manifest — manifest-level addedRows/existingRows becomes unreliable for ranges.
-    // Only DataFile-level added_snapshot_id (read via IncrementalAppendScan / planFiles entry
-    // iteration) correctly isolates the delta.  Delta files are few, so O(files) is acceptable.
-    private Statistics getIncrementalCardinalityFromPlanFiles(IcebergTable icebergTable,
+    // Used for two cases:
+    //   1. Incremental delta: requires datafile-level precision (added_snapshot_id on each DataFile)
+    //      because MergeAppend/compaction merges old + new records into the same manifest, making
+    //      manifest-level addedRows/existingRows unreliable for snapshot ranges. Delta files are
+    //      few, so O(files) is acceptable; accuracy is required.
+    //   2. Fallback from manifest-pruned: when a matching manifest has live files but is missing
+    //      addedRowsCount / existingRowsCount (e.g. v1 manifest list or pre-0.10 Iceberg metadata),
+    //      the manifest-pruned count would be incomplete. planFiles gets exact cardinality every
+    //      time because DataFile.recordCount() is a required field.
+    private Statistics getCardinalityFromPlanFiles(IcebergTable icebergTable,
                                                                Map<ColumnRefOperator, Column> columns,
                                                                ScalarOperator predicate, long limit,
                                                                TvrVersionRange version) {
@@ -1799,8 +1814,11 @@ public class IcebergMetadata implements ConnectorMetadata {
     // its FULL row count — resulting in a partition-aware over-estimate (safe for CBO).
     //
     // NOT SAFE for incremental versions (TvrTableDelta with start present): MergeAppend/compaction
-    // makes manifest-level added/existing unreliable for ranges. Use getIncrementalCardinality
-    // instead for delta cardinality.
+    // makes manifest-level added/existing unreliable for ranges. Use Path B instead for delta.
+    //
+    // Returns a negative value when any matching manifest has files but is missing both
+    // addedRowsCount and existingRowsCount (e.g. v1 manifest list or upgraded metadata) —
+    // callers must fall back to planFiles for exact cardinality.
     private long getManifestPrunedRowCount(IcebergTable icebergTable, ScalarOperator predicate, TvrVersionRange version) {
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
         if (!version.end().isPresent()) {
@@ -1821,6 +1839,9 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         long rowCount = 0;
         for (ManifestFile manifest : matchingManifests) {
+            if (!canCountRowsFromManifest(manifest)) {
+                return -1;
+            }
             rowCount += orZeroRows(manifest.addedRowsCount()) + orZeroRows(manifest.existingRowsCount());
         }
         return Math.max(rowCount, 1);
@@ -1828,6 +1849,23 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     private static long orZeroRows(Long value) {
         return value == null ? 0L : value;
+    }
+
+    // A manifest can only be counted via addedRowsCount / existingRowsCount when the
+    // manifest-list entry carries those row-count fields. They were added in Iceberg v2
+    // manifest-list format (~0.10, 2021); v1 manifest lists and pre-0.10 metadata lack them.
+    // All modern writers (StarRocks, Spark, Trino, Flink, etc.) write v2+ manifest lists
+    // that include these fields, so normal tables always pass this check. It only rejects
+    // manifests from very old or non-standard Iceberg metadata — and even then, only when
+    // the manifest actually contains live files (added / existing / deleted).
+    private static boolean canCountRowsFromManifest(ManifestFile manifest) {
+        // At least one non-null row count → safe to estimate from manifest metadata.
+        if (manifest.addedRowsCount() != null || manifest.existingRowsCount() != null) {
+            return true;
+        }
+        // Both row counts are null. If the manifest has any live files, the count would be
+        // a severe under-estimate → caller must fall back to planFiles for exact cardinality.
+        return !manifest.hasAddedFiles() && !manifest.hasExistingFiles() && !manifest.hasDeletedFiles();
     }
 
     private IcebergSplitScanTask buildIcebergSplitScanTask(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1676,36 +1676,131 @@ public class IcebergMetadata implements ConnectorMetadata {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 
-        // Default path (column statistics disabled): derive row count from manifest metadata
-        // (O(manifests)) without enumerating DataFiles. This avoids triggering a full planFiles()
-        // in the foreground, so it no longer pre-populates splitTasks and incremental scan range
-        // delivery (getRemoteFilesAsync) stays on its lazy/streaming path.
-        if (!session.getSessionVariable().enableIcebergColumnStatistics()) {
-            try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.calculateCardinality")) {
-                long rowCount = getManifestPrunedRowCount(icebergTable, predicate, version);
-                return statisticProvider.buildRowCountStatistics(columns, rowCount);
-            }
-        }
+        boolean enableColumnStats = session.getSessionVariable().enableIcebergColumnStatistics();
+        boolean isIncrementalDelta = version instanceof TvrTableDelta &&
+                version.start() != null && version.start().isPresent();
 
+        // -------- path selection --------
+        // Three paths with different accuracy/cost trade-offs:
+        //
+        // A. Column-statistics enabled (opt-in, default OFF):
+        //    Must scan files for per-column bounds and Puffin NDV. buildFileScanTaskIterator
+        //    handles both full-table and delta internally.  Cost: O(files) planFiles + per-column
+        //    metadata collection.  Accuracy: best (NDV + min/max).
+        if (enableColumnStats) {
+            return getFullTableStatisticsFromPlanFiles(icebergTable, columns, session, predicate, limit, version);
+        }
+        //
+        // B. Incremental delta (append-only, column-stats off):
+        //    Requires datafile-level precision (added_snapshot_id) because MergeAppend/compaction
+        //    rewrites manifests and merges old + new records, making manifest-level addedRows
+        //    / existingRows unreliable for a snapshot range. Delta files are few by definition,
+        //    so O(files) plan cost is acceptable; accuracy is required.
+        if (isIncrementalDelta) {
+            return getIncrementalCardinalityFromPlanFiles(icebergTable, columns, predicate, limit, version);
+        }
+        //
+        // C. Whole-table snapshot (default, column-stats off, non-delta):
+        //    Manifest addedRows+existingRows is PROVABLY exact for total live files regardless of
+        //    write style (fastAppend / MergeAppend / compaction / MOR).  partition-aware pruning
+        //    via filterManifests at manifest-granularity yields a safe over-estimate (typically
+        //    <5x vs 100x for snapshot total-records).  Cost: O(manifests), ZERO manifest-file opens,
+        //    ZERO DataFile enumeration — splitTasks never populated, incremental scan range delivery
+        //    stays unlocked.
+        return getStatisticsFromManifest(icebergTable, columns, predicate, version);
+    }
+
+    // -------------------------------------------------------------------------
+    // Path A: whole-table snapshot, manifest-pruned (default, column-stats off, non-delta).
+    //
+    // Trade-off: manifest-level partition pruning (filterManifests) is coarser than file-level
+    // — a matching manifest contributes its FULL row count even if the predicate doesn't match
+    // every file within it. Typical over-estimate: <5x (safe direction for CBO).  Cost is
+    // O(manifests) with ZERO manifest-file opens and ZERO DataFile enumeration, so splitTasks is
+    // never populated and incremental scan range delivery stays lazy/streaming.
+    private Statistics getStatisticsFromManifest(IcebergTable icebergTable,
+                                                  Map<ColumnRefOperator, Column> columns,
+                                                  ScalarOperator predicate,
+                                                  TvrVersionRange version) {
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.calculateCardinality")) {
+            long rowCount = getManifestPrunedRowCount(icebergTable, predicate, version);
+            return statisticProvider.buildRowCountStatistics(columns, rowCount);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Path B: incremental delta (append-only), column-stats off.
+    //
+    // Trade-off: delta requires datafile-level precision (added_snapshot_id on each DataFile)
+    // because MergeAppend/compaction rewrites manifests, merging old and new records into the
+    // same manifest — manifest-level addedRows/existingRows becomes unreliable for ranges.
+    // Only DataFile-level added_snapshot_id (read via IncrementalAppendScan / planFiles entry
+    // iteration) correctly isolates the delta.  Delta files are few, so O(files) is acceptable.
+    private Statistics getIncrementalCardinalityFromPlanFiles(IcebergTable icebergTable,
+                                                               Map<ColumnRefOperator, Column> columns,
+                                                               ScalarOperator predicate, long limit,
+                                                               TvrVersionRange version) {
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(predicate)
+                .setLimit(limit)
+                .setTableVersionRange(version)
+                .setEnableColumnStats(false)
+                .build();
+        PredicateSearchKey key = PredicateSearchKey.of(
+                icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), params);
+        triggerIcebergPlanFilesIfNeeded(key, icebergTable);
+        // buildFileScanTaskIterator detects TvrTableDelta internally → IncrementalAppendScan.
+        List<FileScanTask> icebergScanTasks = splitTasks.get(key);
+        if (icebergScanTasks == null) {
+            throw new StarRocksConnectorException("Missing iceberg split task for table:[{}.{}]. predicate:[{}]",
+                    icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), predicate);
+        }
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.calculateCardinality" + key)) {
+            return statisticProvider.getCardinalityStats(columns, icebergScanTasks);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Path C: column-statistics enabled (opt-in, default OFF).
+    //
+    // Trade-off: full file enumeration to collect per-column lowerBounds / upperBounds /
+    // nullCounts / columnSizes and (when available) Puffin NDV.  Highest front-end cost
+    // (O(files) planFiles + per-column metadata) but richest statistics (NDV + min/max).
+    // buildFileScanTaskIterator handles both full-table and delta internally.
+    private Statistics getFullTableStatisticsFromPlanFiles(IcebergTable icebergTable,
+                                                            Map<ColumnRefOperator, Column> columns,
+                                                            OptimizerContext session,
+                                                            ScalarOperator predicate, long limit,
+                                                            TvrVersionRange version) {
         GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
                 .setPredicate(predicate)
                 .setLimit(limit)
                 .setTableVersionRange(version)
                 .setEnableColumnStats(true)
                 .build();
-
         PredicateSearchKey key = PredicateSearchKey.of(
                 icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), params);
         triggerIcebergPlanFilesIfNeeded(key, icebergTable);
         return statisticProvider.getTableStatistics(icebergTable, columns, session, params);
     }
 
-    // Estimate row count from manifest metadata with partition-aware manifest pruning, in O(manifests).
-    // It reads only the manifest list (one file) plus in-memory manifest evaluation; it does NOT open
-    // manifest files or enumerate DataFiles, so it never populates splitTasks and keeps incremental
-    // scan range delivery intact. Manifest-level pruning is coarser than file-level: a matching manifest
-    // contributes its full row count, yielding a partition-aware over-estimate (never an undercount),
-    // which is the safe direction for CBO. Delete files are ignored, consistent with getCardinalityStats.
+    // -------------------------------------------------------------------------
+    // Whole-table row count from manifest metadata with partition-aware manifest pruning.
+    // O(manifests), ZERO manifest-file opens, ZERO DataFile enumeration.
+    //
+    // Accuracy: for a whole-table snapshot, the sum of (addedRowsCount + existingRowsCount)
+    // across all matching data manifests is EXACTLY the total live file row count — regardless
+    // of write style (fastAppend / MergeAppend / compaction / MOR). The manifest list is a
+    // complete, consistent catalogue of all live data files at that snapshot. Delete files are
+    // ignored (over-count not undercount; consistent with getCardinalityStats).
+    //
+    // Partition pruning: filterManifests uses ManifestEvaluator against inline manifest partition
+    // summaries (from the manifest LIST; no manifest-file open). A matching manifest contributes
+    // its FULL row count — resulting in a partition-aware over-estimate (safe for CBO).
+    //
+    // NOT SAFE for incremental versions (TvrTableDelta with start present): MergeAppend/compaction
+    // makes manifest-level added/existing unreliable for ranges. Use getIncrementalCardinality
+    // instead for delta cardinality.
     private long getManifestPrunedRowCount(IcebergTable icebergTable, ScalarOperator predicate, TvrVersionRange version) {
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
         if (!version.end().isPresent()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -97,6 +97,17 @@ public class IcebergStatisticProvider {
         return statisticsBuilder.build();
     }
 
+    // Build row-count-only statistics from a pre-computed cardinality (e.g. manifest-pruned row count),
+    // without enumerating DataFiles. Column statistics are left UNKNOWN here; NDV estimation is handled
+    // separately by the column-statistics path.
+    public Statistics buildRowCountStatistics(
+            Map<ColumnRefOperator, Column> colRefToColumnMetaMap, long rowCount) {
+        Statistics.Builder statisticsBuilder = Statistics.builder();
+        statisticsBuilder.setOutputRowCount(Math.max(rowCount, 1));
+        statisticsBuilder.addColumnStatistics(buildUnknownColumnStatistics(colRefToColumnMetaMap.keySet()));
+        return statisticsBuilder.build();
+    }
+
     public Statistics getTableStatistics(IcebergTable icebergTable,
                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
                                          OptimizerContext session,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1454,6 +1454,40 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testGetTableStatisticsManifestPrunedKeepsIncrementalDelivery() throws Exception {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                new ConnectorProperties(ConnectorType.ICEBERG,
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")), null);
+        // Two separate commits => two data manifests. Manifest-pruned row count must sum across manifests
+        // (FILE_A=2 + FILE_A_2=2 = 4).
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A_2).commit();
+        mockedNativeTableA.refresh();
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<ColumnRefOperator, Column>();
+        ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(3, IntegerType.INT, "id", true);
+        colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", IntegerType.INT));
+        OptimizerContext context = OptimizerFactory.mockContext(new ColumnRefFactory());
+        Assertions.assertFalse(context.getSessionVariable().enableIcebergColumnStatistics());
+        TvrVersionRange versionRange = TvrTableSnapshot.of(Optional.of(
+                mockedNativeTableA.currentSnapshot().snapshotId()));
+        Statistics statistics = metadata.getTableStatistics(
+                context, icebergTable, colRefToColumnMetaMap, null, null, -1, versionRange);
+        Assertions.assertEquals(4.0, statistics.getOutputRowCount(), 0.001);
+
+        // The default (manifest-pruned) path must NOT enumerate DataFiles, i.e. it must not pre-populate
+        // splitTasks. Otherwise getRemoteFilesAsync would replay an eager full list and incremental scan
+        // range delivery would be defeated.
+        java.lang.reflect.Field splitTasksField = IcebergMetadata.class.getDeclaredField("splitTasks");
+        splitTasksField.setAccessible(true);
+        Map<?, ?> splitTasks = (Map<?, ?>) splitTasksField.get(metadata);
+        Assertions.assertTrue(splitTasks.isEmpty());
+    }
+
+    @Test
     public void testGetTableStatisticsWithColumnStats() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1488,6 +1488,36 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testGetTableStatisticsIncrementalDeltaCostsDeltaOnly() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                new ConnectorProperties(ConnectorType.ICEBERG,
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")), null);
+        // snap1: FILE_A (2 rows). snap2: FILE_A_1 (2 rows). Full table at snap2 = 4 rows.
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A_1).commit();
+        mockedNativeTableA.refresh();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<ColumnRefOperator, Column>();
+        ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(3, IntegerType.INT, "id", true);
+        colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", IntegerType.INT));
+        OptimizerContext context = OptimizerFactory.mockContext(new ColumnRefFactory());
+        Assertions.assertFalse(context.getSessionVariable().enableIcebergColumnStatistics());
+
+        // Append-only delta snap1(exclusive) -> snap2(inclusive) must be costed on the delta only
+        // (FILE_A_1 = 2 rows), NOT the full-table manifest-pruned count (4 rows).
+        TvrTableDelta delta = TvrTableDelta.of(TvrVersion.of(snap1.snapshotId()), TvrVersion.of(snap2.snapshotId()));
+        Statistics statistics = metadata.getTableStatistics(
+                context, icebergTable, colRefToColumnMetaMap, null, null, -1, delta);
+        Assertions.assertEquals(2.0, statistics.getOutputRowCount(), 0.001);
+    }
+
+    @Test
     public void testGetTableStatisticsWithColumnStats() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));


### PR DESCRIPTION
## Why I'm doing:
The CBO front-end statistics entry `IcebergMetadata#getTableStatistics()` always called `triggerIcebergPlanFilesIfNeeded()`, which runs a full `planFiles()` (opens every matching data manifest and deserializes every DataFile entry, O(files)) just to obtain a row count.

This has two costs:
- FE planning is blocked on a full O(files) plan even when only a row count is needed — expensive and memory-heavy for million-file tables.
- It eagerly materializes the per-query `splitTasks` cache, which forces the execution-time `getRemoteFilesAsync()` path to replay one giant pre-built list instead of streaming, effectively defeating incremental scan range delivery.

## What I'm doing:
`getTableStatistics()` is restructured into three explicit paths, each with a clear accuracy/cost trade-off:

```text
                ┌── Path A: column-stats enabled (opt-in, default OFF)
                │   → planFiles ⟶ per-column bounds + Puffin NDV
                │   Cost: O(files) + per-column metadata. Accuracy: best (NDV + min/max).
                │
getTableStatistics
                ├── Path B: incremental delta + fallback, column-stats off
                │   → planFiles via IncrementalAppendScan ⟶ delta-only/exact cardinality
                │   Cost: O(delta-files), cheap. Accuracy: exact.
                │
                └── Path C: whole-table snapshot (default, column-stats off, non-delta)
                    → filterManifests (O(manifests), in-memory) ⟶ sum addedRows+existingRows
                    Cost: O(manifests), ZERO manifest-file opens, ZERO DataFile enumeration.
                    Accuracy: manifest addedRows+existingRows is EXACT for total live files
                    regardless of write style. Partition-aware pruning at manifest-granularity
                    yields a safe over-estimate (typically <5x vs 100x for snapshot total-records).
```

### Key trade-off

| | manifest-pruned (Path C) | planFiles (Path A/B) |
|---|---|---|
| Row count for whole table | **exact** (manifest list = complete live-file catalogue) | exact |
| Row count for delta range | unreliable (MergeAppend/compaction rewrites manifests) | **exact** (added_snapshot_id on DataFile) |
| Partition pruning | manifest-granularity (over-estimate, safe) | file-granularity (precise) |
| File enumeration | **none** | O(matching-files) |
| Incremental delivery | **unlocked** (splitTasks never populated) | defeated (eagerly materializes splitTasks) |

### Manifest row-count guard (`canCountRowsFromManifest`)
Path C checks that every matching manifest carries `addedRowsCount` / `existingRowsCount`
before summing. These fields were added in Iceberg's v2 manifest-list format (~0.10, 2021);
all modern writers (StarRocks, Spark, Trino, Flink) write them, so this guard passes for
essentially all real tables. If it fails (v1 manifest list or pre-0.10 metadata), Path C
transparently falls back to Path B for exact cardinality via planFiles. The guard is
extracted into `canCountRowsFromManifest(ManifestFile)` for explicit readability.

### Benefits
- Foreground statistics cost drops from `O(files) + O(manifest opens)` to `O(1 manifest-list read) + O(manifests)` for the default path.
- Incremental scan range delivery is genuinely unlocked: file planning is deferred to the delivery phase and streamed instead of eagerly materialized in the front-end.

### Limitations
- Partition-pruned row count is a manifest-granularity over-estimate (safe direction for CBO).
- This fully unlocks incremental delivery for the common single-table / `prepareMetadata`-off case. When `enable_parallel_prepare_metadata` is ON (multi-table joins), `prepareMetadata` still eagerly runs `planFiles()` and pre-fills the same `splitTasks` cache key, so delivery is defeated there.

### Follow-up: can we drop `prepareMetadata`?
`prepareMetadata` (gated by `enable_parallel_prepare_metadata`, default OFF) only runs for multi-table joins and exists to parallel-warm connector metadata. It is the last remaining front-end path that eagerly runs `planFiles()` and pre-fills `splitTasks` under the same cache key the delivery path reads.

Two incremental options for a future PR (kept out of this one to limit blast radius):
1. Make `prepareMetadata` warm only manifest-level metadata (or a lazy source) instead of a full file enumeration — keeping the parallel-prefetch benefit without eager materialization.
2. Decouple incremental delivery from the `splitTasks` cache entirely, so `getRemoteFilesAsync` always takes the lazy/streaming iterator regardless of front-end warming; the `splitTasks` cache then only serves the non-incremental sync `getRemoteFiles` path.

Note: `PredicateSearchKey` equality only considers `{db, table, version, predicate, enableColumnStats}` and ignores fieldNames/MOR, which is exactly why stats/prepareMetadata entries collide with the delivery key.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
