### PR TITLE
[BugFix] Enforce query memory limit during table function execution (backport #75179)

### DIFF
--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -14,6 +14,9 @@
 
 #include "table_function_operator.h"
 
+#include "runtime/current_thread.h"
+#include "runtime/runtime_state.h"
+
 namespace starrocks::pipeline {
 void TableFunctionOperator::close(RuntimeState* state) {
     if (_table_function != nullptr && _table_function_state != nullptr) {
@@ -185,7 +188,18 @@ Status TableFunctionOperator::_process_table_function(RuntimeState* state) {
     _next_output_row = 0;
     _next_output_row_offset = 0;
 
-    _table_function_result = _table_function->process(state, _table_function_state);
+    // A table function (e.g. unnest) materializes the whole expansion of the input chunk in
+    // this single call, with no intermediate memory-limit check. For wide arrays this one step
+    // can allocate tens of GB and get the BE OOM-killed before the next pipeline-driver limit
+    // check fires. For implementations whose process() is exception-safe, wrap it in
+    // TRY_CATCH_BAD_ALLOC so allocations are checked against the query/query_pool/process mem
+    // tracker per batch and a runaway query fails with MemoryLimitExceeded instead of crashing
+    // the whole BE; implementations that are not exception-safe keep the original behavior.
+    if (_table_function->is_exception_safe()) {
+        TRY_CATCH_BAD_ALLOC(_table_function_result = _table_function->process(state, _table_function_state));
+    } else {
+        _table_function_result = _table_function->process(state, _table_function_state);
+    }
     return _table_function_state->status();
 }
 

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -109,6 +109,8 @@ public:
         return std::make_pair(std::move(result), std::move(copy_count_column));
     }
 
+    bool is_exception_safe() const override { return true; }
+
     class UnnestState : public TableFunctionState {
         /**
          * Unnest does not need to customize the State,

--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -102,6 +102,12 @@ public:
     virtual std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
                                                           TableFunctionState* state) const = 0;
 
+    // Whether process() is safe to run wrapped in TRY_CATCH_BAD_ALLOC: a std::bad_alloc thrown
+    // by an over-limit allocation can unwind out of process() without leaking memory or leaving
+    // any state corrupted. Default false; override to true only for implementations whose
+    // process() is fully RAII / exception-safe (e.g. Unnest/MultiUnnest).
+    virtual bool is_exception_safe() const { return false; }
+
     //Release the resources constructed in init and prepare
     virtual Status close(RuntimeState* runtime_state, TableFunctionState* context) const = 0;
 };

--- a/be/src/exprs/table_function/unnest.h
+++ b/be/src/exprs/table_function/unnest.h
@@ -83,6 +83,8 @@ public:
         }
     }
 
+    bool is_exception_safe() const override { return true; }
+
     class UnnestState : public TableFunctionState {
         /**
          * Unnest does not need to customize the State,


### PR DESCRIPTION
## Why I'm doing:

A query with `unnest` over array columns can drive BE memory far past `query_mem_limit` and get the **BE OOM-killed**, instead of just failing that one query. Reported on 3.5.18 (shared-nothing).

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/pull/75179.

Wrap the `TableFunction::process()` call in `_process_table_function` with `TRY_CATCH_BAD_ALLOC`, so allocations during the expansion are checked against the query / query_pool / process mem tracker **at allocation granularity**. This mirrors how `ProjectOperator::push_chunk`, `AggregateBlockingSinkOperator::push_chunk`, `ExchangeSinkOperator`, hash/nl-join probes and ~60 other hot paths already guard their per-chunk compute - `TableFunctionOperator` was simply missing it. A runaway table function now returns `MemoryLimitExceeded` instead of crashing the whole BE.

## Backport notes:

- Resolved the release-branch conflict by preserving the existing `TableFunctionOperator` implementation and adding the memory-limit guard plus required includes.
- Validation: `git diff --check` passed for branch-4.1, branch-4.0, and branch-3.5.
- Targeted BE UT was attempted with `run-be-ut.sh --gtest_filter TableFunctionOperatorTest.*`; the build failed before tests in unrelated common compilation because `gutil/port.h` defines `PACKED`, which conflicts with third-party `fmt` template parameters in multiple non-backport files.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature (see Tests note - not unit-testable in `BE_TEST`)
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

