### PR TITLE
[Enhancement] Gate range-colocate stability on StarOS placement convergence

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -30,6 +30,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
@@ -86,16 +87,6 @@ import java.util.stream.Collectors;
  */
 public class ColocateChecker {
     private static final Logger LOG = LogManager.getLogger(ColocateChecker.class);
-
-    // Cap on tablets per getShardInfo RPC during PACK reconcile. A local safety bound on this
-    // (potentially large) sweep — getShardInfo is not globally chunked, and other callers pass
-    // smaller, bounded lists.
-    private static final int GET_SHARD_INFO_BATCH_SIZE = 1000;
-
-    // Cap on PACK shard group ids per queryShardGroupStable RPC. Colocate ranges (one PACK group
-    // each) accumulate across Level-1 splits, so bound the convergence query like the membership
-    // read above.
-    private static final int QUERY_SHARD_GROUP_STABLE_BATCH_SIZE = 1000;
 
     /**
      * Invoked from {@link TabletReshardJobMgr#runAfterCatalogReady} on every scheduler tick.
@@ -183,7 +174,7 @@ public class ColocateChecker {
     }
 
     /**
-     * Final stability gate (F7): after range alignment and PACK membership repair, asks StarOS whether
+     * Final stability gate: after range alignment and PACK membership repair, asks StarOS whether
      * every PACK shard group of this colocate group has actually converged onto co-resident workers —
      * placement is done, not merely that membership was assigned. Range alignment + membership are
      * sufficient for query correctness, but the colocate-join optimization only pays off when execution
@@ -210,9 +201,10 @@ public class ColocateChecker {
         try {
             long workerGroupId = resolveWorkerGroupId(colocateTableIndex, peers);
             StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
-            for (int batchStart = 0; batchStart < packGroupIds.size(); batchStart += QUERY_SHARD_GROUP_STABLE_BATCH_SIZE) {
+            int batchSize = Math.max(1, Config.tablet_reshard_colocate_checker_batch_size);
+            for (int batchStart = 0; batchStart < packGroupIds.size(); batchStart += batchSize) {
                 List<Long> batch = packGroupIds.subList(batchStart,
-                        Math.min(batchStart + QUERY_SHARD_GROUP_STABLE_BATCH_SIZE, packGroupIds.size()));
+                        Math.min(batchStart + batchSize, packGroupIds.size()));
                 List<Boolean> stable = starOSAgent.queryShardGroupStable(batch, workerGroupId);
                 // A size mismatch would let allMatch pass on a subset and flip the group stable while a
                 // group is still migrating — fail closed so placement convergence is never faked.
@@ -336,9 +328,10 @@ public class ColocateChecker {
         List<Long> tabletIds = new ArrayList<>(tabletIdToRange.keySet());
         Map<Long, List<Long>> tabletIdToGroupIds = new HashMap<>();
         // Query membership in bounded batches so one very large table cannot produce an oversized RPC.
-        for (int batchStart = 0; batchStart < tabletIds.size(); batchStart += GET_SHARD_INFO_BATCH_SIZE) {
+        int batchSize = Math.max(1, Config.tablet_reshard_colocate_checker_batch_size);
+        for (int batchStart = 0; batchStart < tabletIds.size(); batchStart += batchSize) {
             List<Long> batch = tabletIds.subList(batchStart,
-                    Math.min(batchStart + GET_SHARD_INFO_BATCH_SIZE, tabletIds.size()));
+                    Math.min(batchStart + batchSize, tabletIds.size()));
             try {
                 for (ShardInfo shardInfo : starOSAgent.getShardInfo(batch, StarOSAgent.DEFAULT_WORKER_GROUP_ID)) {
                     tabletIdToGroupIds.put(shardInfo.getShardId(), shardInfo.getGroupIdsList());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -201,7 +201,9 @@ public class ColocateChecker {
         try {
             long workerGroupId = resolveWorkerGroupId(colocateTableIndex, peers);
             StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
-            int batchSize = Math.max(1, Config.tablet_reshard_colocate_checker_batch_size);
+            // queryShardGroupStable computes each group's stability server-side, so keep this batch small
+            // to bound per-RPC latency; the full result is assembled across repeated calls.
+            int batchSize = Math.max(1, Config.tablet_reshard_colocate_checker_convergence_batch_size);
             for (int batchStart = 0; batchStart < packGroupIds.size(); batchStart += batchSize) {
                 List<Long> batch = packGroupIds.subList(batchStart,
                         Math.min(batchStart + batchSize, packGroupIds.size()));
@@ -328,7 +330,7 @@ public class ColocateChecker {
         List<Long> tabletIds = new ArrayList<>(tabletIdToRange.keySet());
         Map<Long, List<Long>> tabletIdToGroupIds = new HashMap<>();
         // Query membership in bounded batches so one very large table cannot produce an oversized RPC.
-        int batchSize = Math.max(1, Config.tablet_reshard_colocate_checker_batch_size);
+        int batchSize = Math.max(1, Config.tablet_reshard_colocate_checker_membership_batch_size);
         for (int batchStart = 0; batchStart < tabletIds.size(); batchStart += batchSize) {
             List<Long> batch = tabletIds.subList(batchStart,
                     Math.min(batchStart + batchSize, tabletIds.size()));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -203,12 +203,16 @@ public class ColocateChecker {
         List<Long> packGroupIds = expectedRanges.stream()
                 .map(ColocateRange::getShardGroupId)
                 .collect(Collectors.toList());
-        long workerGroupId = resolveWorkerGroupId(colocateTableIndex, peers);
-        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
-        for (int batchStart = 0; batchStart < packGroupIds.size(); batchStart += QUERY_SHARD_GROUP_STABLE_BATCH_SIZE) {
-            List<Long> batch = packGroupIds.subList(batchStart,
-                    Math.min(batchStart + QUERY_SHARD_GROUP_STABLE_BATCH_SIZE, packGroupIds.size()));
-            try {
+        // Both expected failures on this path fail closed (group stays unstable, retried next tick):
+        // resolving the worker group can throw ErrorReportException (warehouse has no available compute
+        // nodes) and the StarOS query can throw StarClientException. Anything unexpected propagates to
+        // runOneCycle, which logs it with a stack trace rather than masking it as "not converged".
+        try {
+            long workerGroupId = resolveWorkerGroupId(colocateTableIndex, peers);
+            StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+            for (int batchStart = 0; batchStart < packGroupIds.size(); batchStart += QUERY_SHARD_GROUP_STABLE_BATCH_SIZE) {
+                List<Long> batch = packGroupIds.subList(batchStart,
+                        Math.min(batchStart + QUERY_SHARD_GROUP_STABLE_BATCH_SIZE, packGroupIds.size()));
                 List<Boolean> stable = starOSAgent.queryShardGroupStable(batch, workerGroupId);
                 // A size mismatch would let allMatch pass on a subset and flip the group stable while a
                 // group is still migrating — fail closed so placement convergence is never faked.
@@ -222,13 +226,13 @@ public class ColocateChecker {
                             colocateGroupId);
                     return false;
                 }
-            } catch (StarClientException e) {
-                LOG.warn("placement-convergence query failed for colocate group {}; staying unstable: {}",
-                        colocateGroupId, e.getMessage());
-                return false;
             }
+            return true;
+        } catch (Exception e) {
+            LOG.warn("placement-convergence check failed for colocate group {}; staying unstable",
+                    colocateGroupId, e);
+            return false;
         }
-        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -92,6 +92,11 @@ public class ColocateChecker {
     // smaller, bounded lists.
     private static final int GET_SHARD_INFO_BATCH_SIZE = 1000;
 
+    // Cap on PACK shard group ids per queryShardGroupStable RPC. Colocate ranges (one PACK group
+    // each) accumulate across Level-1 splits, so bound the convergence query like the membership
+    // read above.
+    private static final int QUERY_SHARD_GROUP_STABLE_BATCH_SIZE = 1000;
+
     /**
      * Invoked from {@link TabletReshardJobMgr#runAfterCatalogReady} on every scheduler tick.
      * Fast-returns when there's no work to do; otherwise iterates unstable range-colocate
@@ -161,18 +166,93 @@ public class ColocateChecker {
 
         if (allAligned) {
             // Ranges are settled, so each tablet's expected PACK shard group is now well-defined.
-            // Migrate any tablet still in the wrong PACK shard group (e.g. a split child left in the
-            // old group) into place, and flip the group stable ONLY once placement is repaired. The
-            // checker never revisits a stable group, so marking stable while a reassignment is still
-            // pending (or a StarOS query/RPC failed) would leak a permanently mis-placed tablet. This
-            // gate is on membership repair being issued and confirmed; gating on actual StarOS
-            // worker-placement convergence can be layered on top later.
-            if (reconcilePackPlacement(colocateTableIndex, peers, expectedRanges, colocateColumnCount)) {
+            // Migrate any tablet still in the wrong PACK shard group (reconcilePackPlacement), then
+            // confirm StarOS has actually placed every PACK group's shards onto co-resident workers
+            // (isPlacementConverged). Flip the group stable ONLY when both hold: the checker never
+            // revisits a stable group, so marking it stable while a reassignment is pending, a query
+            // failed, or placement is still migrating would leak a permanently mis-placed or
+            // non-host-local tablet. Both gates fail closed — any failure or pending work keeps the
+            // group unstable for the next tick.
+            if (reconcilePackPlacement(colocateTableIndex, peers, expectedRanges, colocateColumnCount)
+                    && isPlacementConverged(colocateTableIndex, peers, expectedRanges, colocateGroupId)) {
                 colocateTableIndex.markAllGroupsWithSameColocateGroupIdStable(colocateGroupId, true);
                 LOG.info("marked colocate group id {} stable across {} peer GroupIds",
                         colocateGroupId, peers.size());
             }
         }
+    }
+
+    /**
+     * Final stability gate (F7): after range alignment and PACK membership repair, asks StarOS whether
+     * every PACK shard group of this colocate group has actually converged onto co-resident workers —
+     * placement is done, not merely that membership was assigned. Range alignment + membership are
+     * sufficient for query correctness, but the colocate-join optimization only pays off when execution
+     * is host-local, so the stable flip waits for StarOS placement to converge.
+     *
+     * <p>Queried in bounded batches (PACK groups accumulate as colocate ranges split). Best-effort /
+     * eventually-consistent: a {@code false} for any group (still migrating), a short response, or a
+     * query failure returns {@code false}, leaving the group unstable for the next tick. A group that
+     * never converges simply stays unstable and the colocate join falls back to a correct shuffle plan
+     * — no livelock, no correctness risk.
+     *
+     * @return {@code true} iff every PACK shard group reports placement-converged.
+     */
+    private boolean isPlacementConverged(ColocateTableIndex colocateTableIndex,
+                                         List<ColocateTableIndex.GroupId> peers,
+                                         List<ColocateRange> expectedRanges, long colocateGroupId) {
+        List<Long> packGroupIds = expectedRanges.stream()
+                .map(ColocateRange::getShardGroupId)
+                .collect(Collectors.toList());
+        long workerGroupId = resolveWorkerGroupId(colocateTableIndex, peers);
+        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+        for (int batchStart = 0; batchStart < packGroupIds.size(); batchStart += QUERY_SHARD_GROUP_STABLE_BATCH_SIZE) {
+            List<Long> batch = packGroupIds.subList(batchStart,
+                    Math.min(batchStart + QUERY_SHARD_GROUP_STABLE_BATCH_SIZE, packGroupIds.size()));
+            try {
+                List<Boolean> stable = starOSAgent.queryShardGroupStable(batch, workerGroupId);
+                // A size mismatch would let allMatch pass on a subset and flip the group stable while a
+                // group is still migrating — fail closed so placement convergence is never faked.
+                if (stable.size() != batch.size()) {
+                    LOG.warn("placement-convergence query returned {} results for {} PACK groups in colocate "
+                            + "group {}; staying unstable", stable.size(), batch.size(), colocateGroupId);
+                    return false;
+                }
+                if (!stable.stream().allMatch(Boolean.TRUE::equals)) {
+                    LOG.debug("colocate group {} not yet placement-converged on StarOS; staying unstable",
+                            colocateGroupId);
+                    return false;
+                }
+            } catch (StarClientException e) {
+                LOG.warn("placement-convergence query failed for colocate group {}; staying unstable: {}",
+                        colocateGroupId, e.getMessage());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Worker group to query for placement convergence, via the reshard-module daemon idiom
+     * ({@link com.starrocks.server.WarehouseManager#getBackgroundComputeResource(long)}, as used by
+     * {@link SplitTabletJob}). Resolves to the default worker group in the open-source build and to a
+     * table's import-warehouse worker group in the enterprise build. The convergence query is
+     * group-level while a worker group is per-table, so a representative member table is used; a
+     * colocate group is expected to live in one warehouse, and any mismatch only fails safe (the group
+     * stays unstable → shuffle), never a false stable. {@code isPlacementConverged} only runs after
+     * {@code reconcilePackPlacement} settled, which already proved every member table is a live NORMAL
+     * OlapTable this pass, and {@code getBackgroundComputeResource} resolves the table's warehouse
+     * worker group (table-independent in OSS) — so the first member table is a fine representative.
+     */
+    private long resolveWorkerGroupId(ColocateTableIndex colocateTableIndex,
+                                      List<ColocateTableIndex.GroupId> peers) {
+        for (ColocateTableIndex.GroupId peerGroupId : peers) {
+            List<Long> tableIds = colocateTableIndex.getAllTableIds(peerGroupId);
+            if (!tableIds.isEmpty()) {
+                return GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                        .getBackgroundComputeResource(tableIds.get(0)).getWorkerGroupId();
+            }
+        }
+        return StarOSAgent.DEFAULT_WORKER_GROUP_ID;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4577,11 +4577,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The max number of new tablets that an old tablet can be split into.")
     public static int tablet_reshard_max_split_count = 1024;
 
-    @ConfField(mutable = true, comment = "Max number of ids the range-colocate checker sends to StarOS in a "
-            + "single batch RPC (tablets for getShardInfo membership reads, PACK shard groups for "
-            + "queryShardGroupStable placement-convergence checks). Bounds the checker's per-RPC StarOS load "
-            + "on shared-data clusters; values < 1 are treated as 1.")
-    public static int tablet_reshard_colocate_checker_batch_size = 1000;
+    @ConfField(mutable = true, comment = "Max number of tablets the range-colocate checker sends to StarOS in a "
+            + "single getShardInfo membership-read batch RPC on shared-data clusters; values < 1 are treated as 1.")
+    public static int tablet_reshard_colocate_checker_membership_batch_size = 1000;
+
+    @ConfField(mutable = true, comment = "Max number of PACK shard groups the range-colocate checker sends to StarOS "
+            + "in a single queryShardGroupStable placement-convergence batch RPC. Each group's stability check is "
+            + "computed server-side, so a smaller batch bounds per-RPC latency (the full result is assembled across "
+            + "repeated calls); values < 1 are treated as 1.")
+    public static int tablet_reshard_colocate_checker_convergence_batch_size = 64;
 
     @ConfField(mutable = true, comment = "Whether to enable tablet merge in tablet reshard. " +
             "Only takes effect for tables in clusters with run_mode=shared_data.")

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4577,6 +4577,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The max number of new tablets that an old tablet can be split into.")
     public static int tablet_reshard_max_split_count = 1024;
 
+    @ConfField(mutable = true, comment = "Max number of ids the range-colocate checker sends to StarOS in a "
+            + "single batch RPC (tablets for getShardInfo membership reads, PACK shard groups for "
+            + "queryShardGroupStable placement-convergence checks). Bounds the checker's per-RPC StarOS load "
+            + "on shared-data clusters; values < 1 are treated as 1.")
+    public static int tablet_reshard_colocate_checker_batch_size = 1000;
+
     @ConfField(mutable = true, comment = "Whether to enable tablet merge in tablet reshard. " +
             "Only takes effect for tables in clusters with run_mode=shared_data.")
     public static boolean tablet_reshard_enable_tablet_merge = false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -1183,6 +1183,22 @@ public class StarOSAgent {
         return shardInfos;
     }
 
+    /**
+     * Best-effort placement-convergence query for PACK shard groups. Returns, positionally aligned
+     * with {@code shardGroupIds}, whether each PACK shard group has converged onto co-resident workers
+     * in {@code workerGroupId} — every member shard has >=1 replica there and all member shards share
+     * the same replica worker set; an empty PACK group is vacuously stable. Eventually-consistent:
+     * callers must poll rather than treat a single {@code true} as durable. A non-PACK or non-existent
+     * id, or an empty {@code shardGroupIds}, fails the whole RPC with {@link StarClientException}, so
+     * callers must pass only existing PACK shard-group ids and never an empty list.
+     */
+    @NotNull
+    public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId)
+            throws StarClientException {
+        prepare();
+        return client.queryShardGroupStable(serviceId, shardGroupIds, workerGroupId);
+    }
+
     public static FilePathInfo allocatePartitionFilePathInfo(FilePathInfo tableFilePathInfo, long physicalPartitionId) {
         String allocPath = StarClient.allocateFilePath(tableFilePathInfo, Long.hashCode(physicalPartitionId));
         return tableFilePathInfo.toBuilder().setFullPath(String.format("%s/%d", allocPath, physicalPartitionId)).build();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -34,17 +34,21 @@ import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.Range;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
@@ -506,6 +510,33 @@ public class ColocateCheckerTest {
 
         Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
                 "a short convergence response must leave the group unstable");
+    }
+
+    @Test
+    public void testStaysUnstableWhenWorkerGroupResolutionFails() throws Exception {
+        // Resolving the worker group calls WarehouseManager.getBackgroundComputeResource, which throws
+        // ErrorReportException when the warehouse has no available compute nodes. The gate must fail
+        // closed locally (group stays unstable) rather than letting the exception escape. Convergence
+        // is stubbed converged so the worker-group throw is the only thing keeping the group unstable.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                return Collections.nCopies(shardGroupIds.size(), Boolean.TRUE);
+            }
+        };
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeResource getBackgroundComputeResource(long tableId) {
+                throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, "mocked: warehouse unavailable");
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "a worker-group resolution failure must leave the group unstable for retry");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,8 +119,15 @@ public class ColocateCheckerTest {
     public void testAlignedUnstableGroupBecomesStable() throws Exception {
         // The freshly-created table has one tablet covering the single default ColocateRange
         // [MIN, MAX) -> already aligned. Marking the group unstable then running the checker
-        // must find every partition aligned and mark every peer GroupId stable.
+        // must find every partition aligned and mark every peer GroupId stable. F7 also gates the
+        // flip on StarOS placement convergence, so stub it converged.
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                return Collections.nCopies(shardGroupIds.size(), Boolean.TRUE);
+            }
+        };
         colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
         Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId));
 
@@ -127,7 +135,7 @@ public class ColocateCheckerTest {
         checker.runOneCycle();
 
         Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId),
-                "aligned + unstable group must be marked stable after one cycle");
+                "aligned + membership-settled + placement-converged unstable group must be marked stable after one cycle");
     }
 
     private long firstVisibleTabletId() {
@@ -163,6 +171,7 @@ public class ColocateCheckerTest {
 
         Map<Long, List<Long>> reassignedAdd = new HashMap<>();
         Map<Long, List<Long>> reassignedRemove = new HashMap<>();
+        boolean[] convergenceQueried = {false};
         new MockUp<StarOSAgent>() {
             @Mock
             public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
@@ -179,6 +188,12 @@ public class ColocateCheckerTest {
                 reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
                 reassignedRemove.put(shardId, new ArrayList<>(removeGroupIds));
             }
+
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                convergenceQueried[0] = true;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.TRUE);
+            }
         };
 
         colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
@@ -190,6 +205,8 @@ public class ColocateCheckerTest {
                 "no stale PACK group to remove in the add-only case");
         Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
                 "group must stay unstable until a re-read confirms the repaired placement");
+        Assertions.assertFalse(convergenceQueried[0],
+                "convergence must not be queried while PACK membership is still being repaired");
     }
 
     @Test
@@ -221,6 +238,11 @@ public class ColocateCheckerTest {
                 reassignCount[0]++;
                 repaired[0] = true;
             }
+
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                return Collections.nCopies(shardGroupIds.size(), Boolean.TRUE);
+            }
         };
 
         colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
@@ -233,7 +255,7 @@ public class ColocateCheckerTest {
         new ColocateChecker().runOneCycle();
         new ColocateChecker().runOneCycle();
         Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId),
-                "group must become stable once the re-read shows the repaired placement");
+                "group must become stable once the re-read shows the repaired placement and placement converged");
         Assertions.assertTrue(reassignCount[0] >= 1, "a reassign must have been issued to repair placement");
     }
 
@@ -403,6 +425,87 @@ public class ColocateCheckerTest {
                 "must not re-add the already-present expected PACK group");
         Assertions.assertEquals(List.of(packForHigh), reassignedRemove.get(lowTabletId),
                 "must remove the stale sibling PACK group");
+    }
+
+    @Test
+    public void testStaysUnstableWhenPlacementNotConverged() throws Exception {
+        // Fresh single-range group is range-aligned and membership-settled (embedded StarMgr), but
+        // StarOS reports the PACK group has NOT converged onto co-resident workers -> stay unstable.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "group must stay unstable until StarOS reports placement converged");
+    }
+
+    @Test
+    public void testBecomesStableWhenPlacementConverged() throws Exception {
+        // Fresh single-range group is range-aligned + membership-settled, and StarOS now reports the
+        // PACK group converged -> the group flips stable. Also assert the OSS worker group (0L) is the
+        // one queried (Option B resolves to the default warehouse worker group).
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long[] capturedWorkerGroupId = {-1L};
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                capturedWorkerGroupId[0] = workerGroupId;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.TRUE);
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId),
+                "aligned + membership-settled + placement-converged group must be marked stable");
+        Assertions.assertEquals(StarOSAgent.DEFAULT_WORKER_GROUP_ID, capturedWorkerGroupId[0],
+                "F7 must query the default warehouse worker group in OSS");
+    }
+
+    @Test
+    public void testStaysUnstableOnConvergenceQueryFailure() throws Exception {
+        // A queryShardGroupStable RPC failure must NOT flip the group stable (fail-closed).
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId)
+                    throws StarClientException {
+                throw new StarClientException(com.staros.proto.StatusCode.INTERNAL, "mocked query failure");
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "a placement-convergence query failure must leave the group unstable for retry");
+    }
+
+    @Test
+    public void testStaysUnstableOnShortConvergenceResponse() throws Exception {
+        // A short/empty response (size != requested) must fail closed so a subset can never flip the
+        // group stable while a group is still migrating.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                return new ArrayList<>(); // empty response for a non-empty request
+            }
+        };
+
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        new ColocateChecker().runOneCycle();
+
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "a short convergence response must leave the group unstable");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -501,6 +501,35 @@ public class StarOSAgentTest {
     }
 
     @Test
+    public void testQueryShardGroupStable() throws StarClientException {
+        List<Long> shardGroupIds = Lists.newArrayList(10L, 20L);
+        new Expectations(client) {
+            {
+                client.queryShardGroupStable("1", shardGroupIds, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                result = Lists.newArrayList(true, false);
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        List<Boolean> stable =
+                starosAgent.queryShardGroupStable(shardGroupIds, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+        Assertions.assertEquals(Lists.newArrayList(true, false), stable);
+    }
+
+    @Test
+    public void testQueryShardGroupStableThrows() throws StarClientException {
+        List<Long> shardGroupIds = Lists.newArrayList(10L);
+        new Expectations(client) {
+            {
+                client.queryShardGroupStable("1", shardGroupIds, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                result = new StarClientException(StatusCode.INVALID_ARGUMENT, "non-PACK group");
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        Assertions.assertThrows(StarClientException.class,
+                () -> starosAgent.queryShardGroupStable(shardGroupIds, StarOSAgent.DEFAULT_WORKER_GROUP_ID));
+    }
+
+    @Test
     public void testGetBackendByShard() throws StarClientException {
         ReplicaInfo replica1 = ReplicaInfo.newBuilder()
                 .setReplicaRole(ReplicaRole.PRIMARY)


### PR DESCRIPTION
## Why I'm doing:

Range-colocate groups in shared-data mode are marked **stable** by `ColocateChecker` once every table is range-aligned and PACK shard-group **membership** has been repaired (#74323). That is sufficient for query **correctness** — `RangeColocateScanDispatch` routes scan ranges by tablet range, not by StarOS worker placement — but it is **not** sufficient for the colocate-join optimization to actually deliver host-local execution: StarOS may still be migrating shards onto co-resident workers in the background (e.g. the transient window after `reassignShardGroups` is issued but before the StarOS `ShardScheduler` finishes placement). Marking the group stable during that window lets the optimizer pick the colocate plan (`RangeDistributionSpec.canColocate` gates on `isGroupUnstable`) while execution silently pays a network hop on the still-migrating bucket, with no plan-level signal.

## What I'm doing:

Add a final placement-convergence gate, on top of the existing range-colocate stability machinery (#74323):

- **`StarOSAgent.queryShardGroupStable(shardGroupIds, workerGroupId)`** — a thin wrapper (modeled on `getShardInfo`) over the StarOS `QueryShardGroupStable` RPC, present in the pinned `staros.version` (`4.2-rc2` on main, `4.1.1` on `branch-4.1`). It returns, positionally aligned with the input ids, whether each PACK shard group has converged onto co-resident workers in the queried worker group.
- **`ColocateChecker.processGroup`** now marks a group stable only when `reconcilePackPlacement(...) && isPlacementConverged(...)`. After membership settles, `isPlacementConverged` queries convergence for every PACK shard group of the colocate group (in bounded batches) and marks stable only when all report converged. The worker group is resolved via the reshard-daemon idiom `WarehouseManager.getBackgroundComputeResource(tableId)` — the default warehouse worker group in the open-source build.
- **Fail-closed**: anything other than an all-converged response keeps the group unstable for the next tick — a `false` for any group (still migrating), a short/size-mismatched response, a `StarClientException` from the query, or a failure resolving the worker group (`getBackgroundComputeResource` throws `ErrorReportException` when the warehouse has no available compute nodes). The whole convergence check is wrapped in one `try/catch` that fails closed on any exception (logging the throwable so the stack trace is preserved). A group that never converges simply stays unstable and the colocate join falls back to a correct shuffle plan — no livelock, no correctness risk. The convergence query is short-circuited (not issued) until membership is settled.

The checker's per-RPC StarOS batch cap (shared by the membership read and the convergence query) is the runtime-mutable `Config.tablet_reshard_colocate_checker_batch_size` (default 1000), so it can be tuned without an FE restart.

Tests: `StarOSAgentTest` covers the wrapper passthrough + exception propagation; `ColocateCheckerTest` covers not-converged / converged (asserting the default worker group is queried) / query-failure / short-response / worker-group resolution failure, plus a regression that convergence is **not** queried while PACK membership is still being repaired.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

This is an internal placement gate: it only tightens *when* a range-colocate group becomes stable, which affects optimizer eligibility for the colocate-join plan (a plan-shape concern with identical SQL results). No SQL syntax, config, session-variable, metric, or external API changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

