### PR TITLE
[Tool] ci-merged: add labels via REST instead of gh pr edit

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           LABEL="${GITHUB_BASE_REF##*-}-merged"
           ORI_PR=$(echo "${PR_TITLE}" | grep -oP '\(backport #\K\d+' | tail -n 1)
-          gh pr edit ${ORI_PR} -R ${GITHUB_REPOSITORY} --add-label "${LABEL}"
+          gh api --method POST "/repos/${GITHUB_REPOSITORY}/issues/${ORI_PR}/labels" -f "labels[]=${LABEL}"
 
       - name: prepare version label
         id: prepare_version_label
@@ -204,7 +204,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_LABEL: ${{ steps.prepare_version_label.outputs.LABEL }}
         run: |
-          gh pr edit ${PR_NUMBER} -R ${GITHUB_REPOSITORY} --add-label "${VERSION_LABEL}"
+          gh api --method POST "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" -f "labels[]=${VERSION_LABEL}"
 
   update_version_label_for_main_feature:
     runs-on: [self-hosted, quick]
@@ -235,7 +235,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_LABEL: ${{ steps.prepare_version_label.outputs.LABEL }}
         run: |
-          gh pr edit ${PR_NUMBER} -R ${GITHUB_REPOSITORY} --add-label "${VERSION_LABEL}"
+          gh api --method POST "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" -f "labels[]=${VERSION_LABEL}"
 
   update_feature_issue:
     runs-on: [self-hosted, quick]


### PR DESCRIPTION
## Why I'm doing:
Since 2026-06-24, backport merges stopped getting their `version:*` and `*-merged` labels: `gh pr edit --add-label` exits non-zero because its GraphQL query still selects the sunset `repository.pullRequest.projectCards` field, which GitHub now rejects ("Projects (classic) is being deprecated").

## What I'm doing:
Replace the three `gh pr edit ... --add-label` calls in `ci-merged.yml` (`update_backport_merged_msg` ×2 and `update_version_label_for_main_feature` ×1) with the REST endpoint `gh api --method POST /repos/{repo}/issues/{n}/labels -f "labels[]=..."`. REST never touches `projectCards`, and is a single request instead of GraphQL lookup+mutation (less rate-limit usage, separate REST bucket).

Evidence: `MERGE PIPELINE` run 28085287916 (PR #75274 → branch-4.1) — `add version label` step failed with `VERSION_LABEL: version:4.1.3` + `GraphQL: ... (repository.pullRequest.projectCards)` exit 1. Same failure on #75281 (branch-4.0.12) and #75278 (branch-3.5.19) on 06-24; the same branches succeeded on 06-23. Not branch-specific — a global regression from GitHub hardening the projectCards GraphQL field.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4