### PR TITLE
[BugFix] Keep count_combine serialize column non-nullable

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -213,11 +213,9 @@ void AggregatorParams::init() {
         const TExpr& desc = aggregate_functions[i];
         const TFunction& fn = desc.nodes[0].fn;
 
-        if (AggStateUtils::is_count_function(fn.name.function_name) &&
-            fn.name.function_name != FUNCTION_COUNT + AggStateUtils::AGG_STATE_COMBINE_SUFFIX) {
-            // count family output is always non-nullable BIGINT. count_combine is the
-            // exception: it needs the real input nullability so the nested lookup picks
-            // the NULL-skipping CountNullableAggregateFunction (else it counts NULLs too).
+        if (AggStateUtils::is_count_function(fn.name.function_name)) {
+            // count family serializes a non-nullable BIGINT. count_combine's NULL-skipping is
+            // re-derived from the real input nullability in _is_agg_result_nullable, not here.
             agg_fn_types[i] = {TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_BIGINT), {}, false, false};
         } else {
             // whether agg function has nullable child
@@ -595,8 +593,10 @@ Status Aggregator::prepare(RuntimeState* state, RuntimeProfile* runtime_profile)
 
 bool Aggregator::_is_agg_result_nullable(const TExpr& desc, const AggFunctionTypes& agg_func_type) {
     const TFunction& fn = desc.nodes[0].fn;
-    // NOTE: For count, we cannot use agg_func_type since it's only mocked values.
-    if (fn.name.function_name == FUNCTION_COUNT) {
+    // NOTE: count and count_combine carry mocked agg_func_type values (non-nullable fast-path), so
+    // their NULL-skipping choice must come from the real input nullability on the plan node.
+    if (fn.name.function_name == FUNCTION_COUNT ||
+        fn.name.function_name == FUNCTION_COUNT + AggStateUtils::AGG_STATE_COMBINE_SUFFIX) {
         if (fn.arg_types.empty()) {
             return false;
         }

--- a/test/sql/test_agg_state/R/test_count_combine_nullable
+++ b/test/sql/test_agg_state/R/test_count_combine_nullable
@@ -43,6 +43,17 @@ FROM t;
 -- result:
 5	5
 -- !result
+SET streaming_preaggregation_mode = 'force_streaming';
+-- result:
+-- !result
+SELECT region,
+       count_state_merge(count_combine(nullable_score)) AS via_col_streaming,
+       count(nullable_score)                            AS direct
+FROM t GROUP BY region ORDER BY region;
+-- result:
+CN	2	2
+US	1	1
+-- !result
 DROP DATABASE test_count_combine_nullable_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_agg_state/T/test_count_combine_nullable
+++ b/test/sql/test_agg_state/T/test_count_combine_nullable
@@ -30,4 +30,12 @@ SELECT count_state_merge(count_combine(region)) AS via_combine_nonnull,
        COUNT(region) AS direct_nonnull
 FROM t;
 
+-- force_streaming routes count_combine through the streaming serialize path; its
+-- output column must stay non-nullable and still skip NULLs (matches count(col)).
+SET streaming_preaggregation_mode = 'force_streaming';
+SELECT region,
+       count_state_merge(count_combine(nullable_score)) AS via_col_streaming,
+       count(nullable_score)                            AS direct
+FROM t GROUP BY region ORDER BY region;
+
 DROP DATABASE test_count_combine_nullable_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`count_combine` over a nullable column crashes the BE with SIGSEGV in the streaming pre-aggregation pass-through path. This is a regression introduced by #74029.

## What I'm doing:

Fixes #issue: N/A — regression from #74029, found via internal testing; no separate public issue filed.

#74029 excluded `count_combine` from the count-family non-nullable fast-path in `AggregatorParams::init`, so its nested lookup correctly selects the NULL-skipping `CountNullableAggregateFunction`. As an unintended side effect, `has_nullable_child=true` also makes `is_result_nullable<true>()` build a **nullable** serialize column. In the streaming pass-through path (`AggregateStreamingSinkOperator::_push_chunk_by_force_streaming` → `Aggregator::output_chunk_by_streaming` → `convert_to_serialize_format`), the unwrapped `CountNullableAggregateFunction::convert_to_serialize_format` does `down_cast<Int64Column*>(dst)` on that `NullableColumn` and writes through a garbage pointer → SIGSEGV.

Fix: keep `count_combine` in the non-nullable fast-path, and add it to the dedicated `count` branch in `_is_agg_result_nullable` so the NULL-skipping decision is re-derived from the real input nullability on the plan node. This decouples the two roles of `has_nullable_child`: correct nested-function selection (still skips NULL) and a non-nullable serialize column (no crash). `count_combine()` (zero-arg / count(*) form) is unaffected.

The crash only manifests under streaming pass-through (low reduction, or `streaming_preaggregation_mode=force_streaming`), which #74029's small-data test never reached. Extended `test/sql/test_agg_state/test_count_combine_nullable` with a `force_streaming` case.

Repro (before this PR):

```sql
SET streaming_preaggregation_mode='force_streaming';
SELECT region, count_state_merge(count_combine(nullable_col)) FROM t GROUP BY region;
-- SIGSEGV: CountNullableAggregateFunction<false>::convert_to_serialize_format <- _push_chunk_by_force_streaming
```

Verification: built the CN and deployed to a shared-data cluster. Before the fix the query crashed every CN with the stack above; after the fix it returns correct NULL-skipping counts (`count_combine(nullable)` == `count(col)`).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
