### PR TITLE
[Refactor] Refactoring struct handling in dictification to a new class

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -91,7 +91,6 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -170,17 +169,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     private final Map<Integer, ScalarOperator> stringRefToDefineExprMap = Maps.newHashMap();
 
-    // Maintains a mapping from structs operators to field columnRefs to use for encoded fields. Currently only fields
-    // which correspond to a column ref can be encoded. All field ColumnRefOperators should have STRING or ARRAY<STRING>
-    // types. Nested structs are not supported.
-    private final Map<ScalarOperator, Map<String, ColumnRefOperator>> structOpToFieldUseStringRef =
-            Maps.newIdentityHashMap();
-
-    // Maintains a mapping from structs ColumnRefs to field columnRefs to use for encoded fields. Currently only fields
-    // which correspond to a column ref can be encoded. All field ColumnRefOperators should have STRING or ARRAY<STRING>
-    // types. Nested structs are not supported.
-    private final Map<Integer, Map<String, ColumnRefOperator>> structRefToFieldUseStringRef = Maps.newHashMap();
-
     // string column use counter, 0 meanings decoded immediately after it was generated.
     // for compute global dict define expressions
     private final Map<Integer, Integer> expressionStringRefCounter = Maps.newHashMap();
@@ -202,6 +190,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     private final ColumnRefSet scanColumnRefSet = new ColumnRefSet();
 
+    private final StructManager structManager;
+
     // check if there is a blocking node in plan
     private boolean canBlockingOutput = false;
 
@@ -210,6 +200,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         this.isQuery = isQuery;
         unionDictionaryManager = new UnionDictionaryManager(
                 sessionVariable, stringRefToDefineExprMap, globalDicts, joinEqColumnGroupIds);
+        structManager = new StructManager(sessionVariable.isEnableStructLowCardinalityOptimize());
     }
 
     public void collect(OptExpression root, DecodeContext context) {
@@ -436,29 +427,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 }
             }
         }
-        // Filling context's structOpToFieldUseStringRefMap and structRefToFieldUseStringRefMap with fields in
-        // context.allStringColumns.
-        context.structOpToFieldUseStringRefMap = structOpToFieldUseStringRef.entrySet().stream()
-                .map(e -> new Pair<>(
-                        e.getKey(),
-                        e.getValue().entrySet().stream()
-                                .filter(e2 -> context.allStringColumns.contains(e2.getValue().getId()))
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))))
-                .filter(k -> !k.second.isEmpty())
-                .collect(Collectors.toMap(
-                        p -> p.first,
-                        p -> p.second,
-                        (oldVal, newVal) -> oldVal,
-                        IdentityHashMap::new));
-
-        context.structRefToFieldUseStringRefMap = structRefToFieldUseStringRef.entrySet().stream()
-                .map(e -> new Pair<>(
-                        e.getKey(),
-                        e.getValue().entrySet().stream()
-                                .filter(e2 -> context.allStringColumns.contains(e2.getValue().getId()))
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))))
-                .filter(k -> !k.second.isEmpty())
-                .collect(Collectors.toMap(p -> p.first, p -> p.second));
+        structManager.finalize(context.allStringColumns);
+        context.structManager = structManager;
     }
 
     // For SubfieldOperators, we just need to get the field column refs, not the whole columns in the struct.
@@ -468,7 +438,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
         if (op instanceof SubfieldOperator) {
             SubfieldOperator subfieldOp = op.cast();
-            Map<String, ColumnRefOperator> fields = getFieldUseStringRefMap(subfieldOp.getChild((0)));
+            Map<String, ColumnRefOperator> fields = structManager.getFieldStringRefMap(subfieldOp.getChild((0)));
             if (fields != null
                     && subfieldOp.getFieldNames().size() == 1
                     && fields.containsKey(subfieldOp.getFieldNames().get(0))) {
@@ -495,7 +465,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                     checkDependOnExpr(((ColumnRefOperator) define.getChild(0)).getId(), checkList);
         }
         if (define.getType().isStructType()) {
-            Map<String, ColumnRefOperator> fieldsMap = getFieldUseStringRefMap(define);
+            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(define);
             if (fieldsMap == null) {
                 return false;
             }
@@ -504,7 +474,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
         if (define instanceof SubfieldOperator) {
             SubfieldOperator subfieldOperator = define.cast();
-            Map<String, ColumnRefOperator> fieldsMap = getFieldUseStringRefMap(subfieldOperator.getChild(0));
+            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(subfieldOperator.getChild(0));
             if (fieldsMap == null || subfieldOperator.getFieldNames().size() != 1) {
                 return false;
             }
@@ -522,19 +492,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return true;
     }
 
-    Map<String, ColumnRefOperator> getFieldUseStringRefMap(ScalarOperator op) {
-        if (op.isColumnRef()) {
-            return structRefToFieldUseStringRef.get(((ColumnRefOperator) op).getId());
-        }
-        return structOpToFieldUseStringRef.get(op);
-    }
-
     void setDefineExpr(ColumnRefOperator col, ScalarOperator define, int counter) {
         stringRefToDefineExprMap.putIfAbsent(col.getId(), define);
-        Map<String, ColumnRefOperator> fieldsMap = getFieldUseStringRefMap(define);
-        if (fieldsMap != null) {
-            structRefToFieldUseStringRef.putIfAbsent(col.getId(), fieldsMap);
-        }
+        structManager.addIfStruct(col, define);
         expressionStringRefCounter.put(col.getId(), counter);
     }
 
@@ -571,8 +531,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         });
         info.inputStringColumns.getStream().forEach(c -> {
             // For structs, we increase the counter of all of its encoded fields
-            List<Integer> columns = structRefToFieldUseStringRef.containsKey(c)
-                    ? structRefToFieldUseStringRef.get(c).values().stream().map(ColumnRefOperator::getId).toList()
+            List<Integer> columns = structManager.contains(c)
+                    ? structManager.getFieldStringRefMap(c).values().stream().map(ColumnRefOperator::getId).toList()
                     : List.of(c);
             columns.forEach(id -> {
                 if (expressionStringRefCounter.containsKey(id)) {
@@ -1048,16 +1008,16 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             // aggregate ref -> aggregate expr
             stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
             AggregateFunction aggFn = (AggregateFunction) value.getFunction();
-            if (aggFn.getReturnType().isStructType() && !structRefToFieldUseStringRef.containsKey(key.getId())) {
+            if (aggFn.getReturnType().isStructType() && !structManager.contains(key.getId())) {
                 final Map<String, ColumnRefOperator> fieldsData;
                 if (FunctionSet.ANY_VALUE.equals(aggFn.functionName())) {
-                    fieldsData = getFieldUseStringRefMap(value.getArguments().get(0));
+                    fieldsData = structManager.getFieldStringRefMap(value.getArguments().get(0));
                 } else {
                     throw new UnsupportedOperationException(
                             String.format("Unsupported function: %s with Struct Type", aggFn.functionName()));
                 }
                 Preconditions.checkNotNull(fieldsData);
-                structOpToFieldUseStringRef.put(value, fieldsData);
+                structManager.setFieldMapping(value, fieldsData);
             }
             if (supportLowCardinality(aggFn.getReturnType())) {
                 setDefineExpr(key, value, 1);
@@ -1376,8 +1336,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             return;
         }
         DictExpressionCollector dictExpressionCollector = new DictExpressionCollector(info.outputStringColumns,
-                structOpToFieldUseStringRef, this::getFieldUseStringRefMap,
-                sessionVariable.isEnableStructLowCardinalityOptimize());
+                structManager);
         dictExpressionCollector.collect(operator.getPredicate());
 
         info.outputStringColumns.getStream().forEach(c -> {
@@ -1398,8 +1357,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         ColumnRefSet decodeInput = new ColumnRefSet();
         decodeInput.union(info.outputStringColumns);
-        info.outputStringColumns.getStream().filter(structRefToFieldUseStringRef::containsKey).forEach(
-                c -> decodeInput.union(structRefToFieldUseStringRef.get(c).values())
+        info.outputStringColumns.getStream().filter(structManager::contains).forEach(
+                c -> decodeInput.union(structManager.getFieldStringRefMap(c).values())
         );
         info.outputStringColumns = new ColumnRefSet();
         for (ColumnRefOperator key : operator.getProjection().getColumnRefMap().keySet()) {
@@ -1408,9 +1367,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 continue;
             }
 
-            DictExpressionCollector dictExpressionCollector = new DictExpressionCollector(decodeInput,
-                    structOpToFieldUseStringRef, this::getFieldUseStringRefMap,
-                    sessionVariable.isEnableStructLowCardinalityOptimize());
+            DictExpressionCollector dictExpressionCollector = new DictExpressionCollector(decodeInput, structManager);
 
             ScalarOperator value = operator.getProjection().getColumnRefMap().get(key);
             dictExpressionCollector.collect(value);
@@ -1431,7 +1388,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 }
                 info.usedStringColumns.union(c);
             });
-            if (structOpToFieldUseStringRef.containsKey(value)) {
+            if (structManager.contains(value)) {
                 setDefineExpr(key, value, 0);
                 info.outputStringColumns.union(key.getId());
             }
@@ -1475,19 +1432,12 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         private final ColumnRefSet matchChildren = new ColumnRefSet();
 
-        private final Map<ScalarOperator, Map<String, ColumnRefOperator>> structOpToFieldUseStringRef;
-        private final java.util.function.Function<ScalarOperator, Map<String, ColumnRefOperator>> getFieldsUseStringRef;
-        private final boolean isEnableStructLowCardinalityOptimize;
+        private final StructManager structManager;
 
         public DictExpressionCollector(ColumnRefSet allDictColumnRefs,
-                                       Map<ScalarOperator, Map<String, ColumnRefOperator>> structOpToFieldUseStringRef,
-                                       java.util.function.Function<ScalarOperator, Map<String, ColumnRefOperator>>
-                                               getFieldsUseStringRef,
-                                       boolean isEnableStructLowCardinalityOptimize) {
+                                       StructManager structManager) {
             this.allDictColumnRefs = allDictColumnRefs;
-            this.structOpToFieldUseStringRef = structOpToFieldUseStringRef;
-            this.getFieldsUseStringRef = getFieldsUseStringRef;
-            this.isEnableStructLowCardinalityOptimize = isEnableStructLowCardinalityOptimize;
+            this.structManager = structManager;
         }
 
         public void collect(ScalarOperator scalarOperator) {
@@ -1610,7 +1560,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             if (LOW_CARD_STRING_FUNCTIONS.contains(call.getFnName())) {
                 return merge(visitChildren(call, context), call);
             }
-            if (isEnableStructLowCardinalityOptimize && LOW_CARD_STRUCT_FUNCTIONS.contains(call.getFnName())
+            if (structManager.isEnableStructLowCardinalityOptimize()
+                    && LOW_CARD_STRUCT_FUNCTIONS.contains(call.getFnName())
                     && call.getChildren().stream().allMatch(
                             c -> (c.isColumnRef() || c.isConstantRef()) && !c.getType().isStructType())) {
                 Map<String, ColumnRefOperator> fieldMap = Maps.newHashMap();
@@ -1629,7 +1580,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                     }
                 }
                 if (!fieldMap.isEmpty()) {
-                    structOpToFieldUseStringRef.put(call, fieldMap);
+                    structManager.setFieldMapping(call, fieldMap);
                     return call;
                 }
                 return VARIABLES;
@@ -1663,7 +1614,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 return result;
             }
             ScalarOperator child = op.getChild(0);
-            Map<String, ColumnRefOperator> fieldsUseStringRef = getFieldsUseStringRef.apply(child);
+            Map<String, ColumnRefOperator> fieldsUseStringRef = structManager.getFieldStringRefMap(child);
             if (op.getFieldNames().size() == 1 && fieldsUseStringRef != null
                     && fieldsUseStringRef.containsKey(op.getFieldNames().get(0))) {
                 return fieldsUseStringRef.get(op.getFieldNames().get(0));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -107,16 +107,7 @@ class DecodeContext {
 
     Map<ScalarOperator, ScalarOperator> stringExprToDictExprMap = Maps.newHashMap();
 
-    // Maintains a mapping from struct ColumnRefs to field ColumnRefs to use for encoded fields.
-    // Currently only fields which correspond to a ColumnRef can be encoded. All field ColumnRefOperators should have
-    // STRING or ARRAY<STRING> types. Nested structs are not supported.
-    Map<Integer, Map<String, ColumnRefOperator>> structRefToFieldUseStringRefMap = Maps.newHashMap();
-
-    // Maintains a mapping from struct operators to field ColumnRefs to use for encoded fields.
-    // Currently only fields which correspond to a ColumnRef can be encoded. All field ColumnRefOperators should have
-    // STRING or ARRAY<STRING> types. Nested structs are not supported.
-    Map<ScalarOperator, Map<String, ColumnRefOperator>> structOpToFieldUseStringRefMap =
-            Maps.newIdentityHashMap();
+    StructManager structManager;
 
     UnionDictionaryManager unionDictionaryManager;
 
@@ -131,22 +122,14 @@ class DecodeContext {
         rewriteStringAggregations();
     }
 
-    Map<String, ColumnRefOperator> getFieldUseStringRefMap(ScalarOperator operator) {
-        if (operator.isColumnRef()) {
-            ColumnRefOperator c = operator.cast();
-            return structRefToFieldUseStringRefMap.get(c.getId());
-        }
-        return structOpToFieldUseStringRefMap.get(operator);
-
-    }
-
     ColumnRefOperator getUseStringRef(ScalarOperator operator) {
         if (operator.isColumnRef()) {
             return (ColumnRefOperator) operator;
         }
         if (operator instanceof SubfieldOperator) {
             SubfieldOperator subfieldOperator = operator.cast();
-            Map<String, ColumnRefOperator> fieldsUseRefMap = getFieldUseStringRefMap(subfieldOperator.getChild(0));
+            Map<String, ColumnRefOperator> fieldsUseRefMap = structManager.getFieldStringRefMap(
+                    subfieldOperator.getChild(0));
             Preconditions.checkNotNull(fieldsUseRefMap);
             Preconditions.checkState(subfieldOperator.getFieldNames().size() == 1
                     && fieldsUseRefMap.containsKey(subfieldOperator.getFieldNames().get(0)));
@@ -298,7 +281,7 @@ class DecodeContext {
         } else if (column.getType().isStringType()) {
             return factory.create(column.getName(), IntegerType.INT, column.isNullable());
         } else if (column.getType().isStructType()) {
-            Map<String, ColumnRefOperator> fieldsData = getFieldUseStringRefMap(column);
+            Map<String, ColumnRefOperator> fieldsData = structManager.getFieldStringRefMap(column);
             Preconditions.checkNotNull(fieldsData);
             List<StructField> structFields = Lists.newArrayList();
             StructType type = (StructType) column.getType();
@@ -351,7 +334,7 @@ class DecodeContext {
             StructType exprType =  (StructType) expression.getType();
             StructType dictType = (StructType) dictExpression.getType();
             List<ScalarOperator> newFields = Lists.newArrayList();
-            Map<String, ColumnRefOperator> fieldsStringRefMap = getFieldUseStringRefMap(useStringRef);
+            Map<String, ColumnRefOperator> fieldsStringRefMap = structManager.getFieldStringRefMap(useStringRef);
             Preconditions.checkNotNull(fieldsStringRefMap);
             for (int i = 0; i < exprType.getFields().size(); ++i) {
                 String fieldName = exprType.getField(i).getName();
@@ -408,7 +391,7 @@ class DecodeContext {
                 Preconditions.checkState(expression instanceof SubfieldOperator);
                 SubfieldOperator subfieldOperator = expression.cast();
                 if (subfieldOperator.getFieldNames().size() != 1 ||
-                        !getFieldUseStringRefMap(expression.getChild(0))
+                        !structManager.getFieldStringRefMap(expression.getChild(0))
                                 .containsKey(subfieldOperator.getFieldNames().get(0))) {
                     // Getting non dictified field from a struct
                     return result;
@@ -495,7 +478,8 @@ class DecodeContext {
                     operator.getCopyFlag());
             if (!originalType.getField(operator.getFieldNames().get(0)).getType().matchesType(
                     newType.getField(operator.getFieldNames().get(0)).getType())) {
-                Map<String, ColumnRefOperator> useFieldRefMap = getFieldUseStringRefMap(operator.getChild(0));
+                Map<String, ColumnRefOperator> useFieldRefMap = structManager.getFieldStringRefMap(
+                        operator.getChild(0));
                 Preconditions.checkNotNull(useFieldRefMap);
                 ColumnRefOperator fieldUseStringRef = useFieldRefMap.get(operator.getFieldNames().get(0));
                 Preconditions.checkNotNull(fieldUseStringRef);
@@ -653,7 +637,7 @@ class DecodeContext {
         @Override
         public ScalarOperator visitSubfield(SubfieldOperator operator, Void context) {
             Preconditions.checkState(operator.getFieldNames().size() == 1);
-            Map<String, ColumnRefOperator> fieldData = getFieldUseStringRefMap(operator.getChild(0));
+            Map<String, ColumnRefOperator> fieldData = structManager.getFieldStringRefMap(operator.getChild(0));
             Preconditions.checkNotNull(fieldData);
             ColumnRefOperator useStringRef = fieldData.get(operator.getFieldNames().get(0));
             Preconditions.checkNotNull(useStringRef);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -95,7 +95,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         if (scalarOperator.isColumnRef()) {
             return new ColumnRefSet(((ColumnRefOperator) scalarOperator).getId());
         }
-        Map<String, ColumnRefOperator> structFieldsData = context.getFieldUseStringRefMap(scalarOperator);
+        Map<String, ColumnRefOperator> structFieldsData = context.structManager.getFieldStringRefMap(scalarOperator);
         if (structFieldsData != null) {
             return new ColumnRefSet(structFieldsData.values());
         }
@@ -494,7 +494,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         inputColumns.union(inputColumns.getStream()
                 .map(factory::getColumnRef)
                 .filter(c -> c.getType().isStructType())
-                .map(context::getFieldUseStringRefMap)
+                .map(context.structManager::getFieldStringRefMap)
                 .filter(Objects::nonNull)
                 .flatMap(k -> k.values().stream())
                 .toList());
@@ -767,7 +767,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         for (int sid : fragmentUseDictExprs.getColumnIds()) {
             ColumnRefOperator strRef = factory.getColumnRef(sid);
             if (strRef.getType().isStructType()) {
-                Map<String, ColumnRefOperator> subFields = context.getFieldUseStringRefMap(strRef);
+                Map<String, ColumnRefOperator> subFields = context.structManager.getFieldStringRefMap(strRef);
                 if (subFields != null) {
                     useDictExprs.union(subFields.values());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/StructManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/StructManager.java
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
+
+import com.google.common.collect.Maps;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class StructManager {
+    // Maintains a mapping from struct ColumnRefs to field ColumnRefs to use for encoded fields.
+    // Currently only fields which correspond to a ColumnRef can be encoded. All field ColumnRefOperators should have
+    // STRING or ARRAY<STRING> types. Nested structs are not supported.
+    private Map<Integer, Map<String, ColumnRefOperator>> structRefToFieldStringRefMap = Maps.newHashMap();
+
+    // Maintains a mapping from struct operators to field ColumnRefs to use for encoded fields.
+    // Currently only fields which correspond to a ColumnRef can be encoded. All field ColumnRefOperators should have
+    // STRING or ARRAY<STRING> types. Nested structs are not supported.
+    private Map<ScalarOperator, Map<String, ColumnRefOperator>> structOpToFieldStringRefMap =
+            Maps.newIdentityHashMap();
+
+    private final boolean enableStructLowCardinalityOptimize;
+
+    public StructManager(boolean enableStructLowCardinalityOptimize) {
+        this.enableStructLowCardinalityOptimize = enableStructLowCardinalityOptimize;
+    }
+
+    public boolean isEnableStructLowCardinalityOptimize() {
+        return enableStructLowCardinalityOptimize;
+    }
+
+    public Map<String, ColumnRefOperator> getFieldStringRefMap(ScalarOperator operator) {
+        if (operator.isColumnRef()) {
+            ColumnRefOperator c = operator.cast();
+            return structRefToFieldStringRefMap.get(c.getId());
+        }
+        return structOpToFieldStringRefMap.get(operator);
+    }
+
+    public Map<String, ColumnRefOperator> getFieldStringRefMap(Integer c) {
+        return structRefToFieldStringRefMap.get(c);
+    }
+
+    boolean contains(Integer cid) {
+        return structRefToFieldStringRefMap.containsKey(cid);
+    }
+
+    boolean contains(ScalarOperator op) {
+        return structOpToFieldStringRefMap.containsKey(op) ||
+                op.isColumnRef() && structRefToFieldStringRefMap.containsKey(((ColumnRefOperator) op).getId());
+    }
+
+    public void setFieldMapping(CallOperator call, Map<String, ColumnRefOperator> fieldMap) {
+        structOpToFieldStringRefMap.put(call, fieldMap);
+    }
+
+    public void addIfStruct(ColumnRefOperator col, ScalarOperator define) {
+        Map<String, ColumnRefOperator> fieldsMap = getFieldStringRefMap(define);
+        if (fieldsMap != null) {
+            structRefToFieldStringRefMap.putIfAbsent(col.getId(), fieldsMap);
+        }
+    }
+
+    public void finalize(Set<Integer> allStringColumns) {
+        structOpToFieldStringRefMap = structOpToFieldStringRefMap.entrySet().stream()
+                .map(e -> Map.entry(
+                        e.getKey(),
+                        e.getValue().entrySet().stream()
+                                .filter(e2 -> allStringColumns.contains(e2.getValue().getId()))
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                ))
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (oldVal, newVal) -> oldVal,
+                        IdentityHashMap::new));
+
+        structRefToFieldStringRefMap = structRefToFieldStringRefMap.entrySet().stream()
+                .map(e -> Map.entry(
+                        e.getKey(),
+                        e.getValue().entrySet().stream()
+                                .filter(e2 -> allStringColumns.contains(e2.getValue().getId()))
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                ))
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Currently, processing of structs is handled using two separate maps in `DecodeCollector` and `DecodeContext`. This leads to fragmented logic and code duplication across multiple parts of the codebase, making it harder to maintain.

## What I'm doing:
Introduced a new `StructManager` class and refactored the code to delegate all struct processing logic to it. This consolidates the duplicate map usage into a single, clean interface.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
