### PR TITLE
[BugFix] Fix multi-column NOT IN dropping wrong rows on NULL tuple columns

### DIFF
--- a/be/src/exec/join/join_hash_map.hpp
+++ b/be/src/exec/join/join_hash_map.hpp
@@ -1702,6 +1702,21 @@ void JoinHashMap<LT, CT, MT>::_probe_from_ht_for_null_aware_anti_join_with_other
                 MATCH_RIGHT_TABLE_ROWS()
                 RETURN_IF_CHUNK_FULL_FOR_NULLAWARE_OTHER_CONJUCTS()
             }
+        } else if (!_table_items->build_key_nulls.empty()) {
+            // Multi-column NULL_AWARE_LEFT_ANTI_JOIN: build_key_nulls[j] is the OR of every key
+            // column's null flag for build row j. Pair the probe row with EVERY build row that has
+            // a NULL in ANY key column (not just key_columns[0]) so the null-aware other-conjunct
+            // can apply per-column three-valued logic. Without this, a NULL in a non-first key
+            // column was missed and a multi-column NOT IN wrongly emitted rows it must drop.
+            const auto& null_array = _table_items->build_key_nulls;
+            size_t j = _probe_state->cur_nullaware_build_index;
+            while (j < _table_items->row_count + 1) {
+                j = SIMD::find_nonzero(null_array, j);
+                if (j >= _table_items->row_count + 1) break;
+                MATCH_RIGHT_TABLE_ROWS()
+                RETURN_IF_CHUNK_FULL_FOR_NULLAWARE_OTHER_CONJUCTS()
+                ++j;
+            }
         } else if (_table_items->key_columns[0]->is_nullable()) {
             // when left table col value not hits in hash table needs match all null value rows in right table
             auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.MultiInPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
@@ -40,6 +41,27 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Rewrites an uncorrelated quantified subquery -- {@code IN} / {@code NOT IN} -- from a
+ * {@link LogicalApplyOperator} (the dependent-join representation) into a plain hash join, so it
+ * runs as a set operation instead of a per-row nested loop.
+ *
+ * <p>Transformation flow:
+ * <ol>
+ *   <li>Match a quantified, semi/anti Apply with no correlation (see {@link #check}). The subquery
+ *       predicate is either an {@link InPredicateOperator} (single-column {@code x IN/NOT IN (sub)})
+ *       or a {@link MultiInPredicateOperator} (row-value {@code (a, b) IN/NOT IN (sub)}).</li>
+ *   <li>Build the equi keys: one {@code EQ(left_i, right_i)} per tuple column, ANDed together. They
+ *       become the join's equality predicate and drive the hash join.</li>
+ *   <li>For {@code NOT IN} over nullable columns, additionally build a per-column null-aware check
+ *       {@code (l = r) OR l IS NULL OR r IS NULL}, ANDed across columns, carried as the join's OTHER
+ *       conjunct. The executor's NULL_AWARE_LEFT_ANTI_JOIN applies it to the NULL-containing build
+ *       rows so the result honours SQL three-valued logic.</li>
+ *   <li>Pick the join type: {@code IN -> LEFT_SEMI_JOIN}, {@code NOT IN -> NULL_AWARE_LEFT_ANTI_JOIN};
+ *       attach the correlation conjuncts and the apply predicate to the join ON clause.</li>
+ *   <li>Wrap the join in a {@link LogicalProjectOperator} re-projecting the Apply's output columns.</li>
+ * </ol>
+ */
 public class QuantifiedApply2JoinRule extends TransformationRule {
     public QuantifiedApply2JoinRule() {
         super(RuleType.TF_QUANTIFIED_APPLY_TO_JOIN,
@@ -58,10 +80,19 @@ public class QuantifiedApply2JoinRule extends TransformationRule {
         LogicalApplyOperator apply = (LogicalApplyOperator) input.getOp();
         boolean isNotIn = false;
         ScalarOperator simplifiedPredicate = null;
+        // For a multi-column NOT IN, the equi keys (a=x AND b=y) only find exact (TRUE) matches; the
+        // executor additionally pairs each probe row with the NULL-containing build rows for a
+        // NULL_AWARE_LEFT_ANTI_JOIN. This per-column predicate -- (l=r) OR l IS NULL OR r IS NULL,
+        // ANDed across columns -- is supplied as the join's OTHER conjunct so those null-build pairs
+        // are kept only when the row comparison is TRUE or UNKNOWN (every column equal or NULL on
+        // either side), matching SQL three-valued NOT IN semantics. The equi keys still drive the
+        // hash join, so this keeps hash-join performance.
+        ScalarOperator nullAwareConjunct = null;
         if (apply.getSubqueryOperator() instanceof MultiInPredicateOperator) {
             MultiInPredicateOperator multiIn = (MultiInPredicateOperator) apply.getSubqueryOperator();
             isNotIn = multiIn.isNotIn();
             List<ScalarOperator> conjuncts = Lists.newArrayList();
+            List<ScalarOperator> nullAwareConjuncts = Lists.newArrayList();
             ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
             for (int i = 0; i < multiIn.getTupleSize(); ++i) {
                 ScalarOperator left = multiIn.getChild(i);
@@ -70,8 +101,23 @@ public class QuantifiedApply2JoinRule extends TransformationRule {
                         rewriter.rewrite(new BinaryPredicateOperator(BinaryType.EQ,
                                 left, right), ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
                 conjuncts.add(normalizedConjunct);
+                if (isNotIn && (left.isNullable() || right.isNullable())) {
+                    List<ScalarOperator> ors =
+                            Lists.newArrayList(new BinaryPredicateOperator(BinaryType.EQ, left, right));
+                    if (left.isNullable()) {
+                        ors.add(new IsNullPredicateOperator(false, left));
+                    }
+                    if (right.isNullable()) {
+                        ors.add(new IsNullPredicateOperator(false, right));
+                    }
+                    nullAwareConjuncts.add(rewriter.rewrite(Utils.compoundOr(ors),
+                            ScalarOperatorRewriter.DEFAULT_REWRITE_RULES));
+                }
             }
             simplifiedPredicate = Utils.compoundAnd(conjuncts);
+            if (!nullAwareConjuncts.isEmpty()) {
+                nullAwareConjunct = Utils.compoundAnd(nullAwareConjuncts);
+            }
         } else {
             // IN/NOT IN
             InPredicateOperator ipo = (InPredicateOperator) apply.getSubqueryOperator();
@@ -93,9 +139,16 @@ public class QuantifiedApply2JoinRule extends TransformationRule {
             //@TODO: if will can filter null, use left-anti-join
             List<ScalarOperator> correlatedConjuncts = Utils.extractConjuncts(apply.getCorrelationConjuncts());
             correlatedConjuncts.forEach(conjunct -> conjunct.setCorrelated(true));
+            ScalarOperator joinOnPredicate = Utils.compoundAnd(simplifiedPredicate,
+                    Utils.compoundAnd(Utils.compoundAnd(correlatedConjuncts), apply.getPredicate()));
+            if (nullAwareConjunct != null) {
+                // Carry the per-column null-aware check as an OTHER join conjunct; the executor's
+                // NAAJ filter path applies it to the null-build pairs to honour three-valued logic.
+                nullAwareConjunct.setJoinDerived(true);
+                joinOnPredicate = Utils.compoundAnd(joinOnPredicate, nullAwareConjunct);
+            }
             joinExpression = new OptExpression(new LogicalJoinOperator(JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN,
-                    Utils.compoundAnd(simplifiedPredicate,
-                            Utils.compoundAnd(Utils.compoundAnd(correlatedConjuncts), apply.getPredicate()))));
+                    joinOnPredicate));
         } else {
             joinExpression = new OptExpression(new LogicalJoinOperator(JoinOperator.LEFT_SEMI_JOIN,
                     Utils.compoundAnd(simplifiedPredicate,

--- a/test/sql/test_subquery/R/test_multi_column_not_in_null
+++ b/test/sql/test_subquery/R/test_multi_column_not_in_null
@@ -1,0 +1,83 @@
+-- name: test_multi_column_not_in_null
+CREATE TABLE o2 (a INT, b INT) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE o3 (a INT, b INT, c INT) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE i_null (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE i_null3 (x INT, y INT, z INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE i_nonull (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE i_allnull (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE i_empty (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE nn0 (a INT NOT NULL, b INT NOT NULL) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE nn1 (x INT NOT NULL, y INT NOT NULL) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO o2 VALUES (1,1),(2,2);
+-- result:
+-- !result
+INSERT INTO o3 VALUES (1,1,1),(2,2,2);
+-- result:
+-- !result
+INSERT INTO i_null VALUES (1,NULL);
+-- result:
+-- !result
+INSERT INTO i_null3 VALUES (1,NULL,1);
+-- result:
+-- !result
+INSERT INTO i_nonull VALUES (1,1);
+-- result:
+-- !result
+INSERT INTO i_allnull VALUES (NULL,NULL);
+-- result:
+-- !result
+select a,b from o2 where (a,b) not in (select x,y from i_null) order by a,b;
+-- result:
+2	2
+-- !result
+select a,b,c from o3 where (a,b,c) not in (select x,y,z from i_null3) order by a,b,c;
+-- result:
+2	2	2
+-- !result
+select a,b from o2 where (a,b) not in (select x,y from i_nonull) order by a,b;
+-- result:
+2	2
+-- !result
+select a,b from o2 where (a,b) not in (select x,y from i_allnull) order by a,b;
+-- result:
+-- !result
+select a,b from o2 where (a,b) not in (select x,y from i_empty) order by a,b;
+-- result:
+1	1
+2	2
+-- !result
+select a,b from o2 where (a,b) in (select x,y from i_null) order by a,b;
+-- result:
+-- !result
+select a,b from o2 where (a,b) in (select x,y from i_nonull) order by a,b;
+-- result:
+1	1
+-- !result
+INSERT INTO nn0 VALUES (1,1),(2,2),(3,3);
+-- result:
+-- !result
+INSERT INTO nn1 VALUES (1,1),(2,2);
+-- result:
+-- !result
+select a,b from nn0 where (a,b) not in (select x,y from nn1) order by a,b;
+-- result:
+3	3
+-- !result

--- a/test/sql/test_subquery/T/test_multi_column_not_in_null
+++ b/test/sql/test_subquery/T/test_multi_column_not_in_null
@@ -1,0 +1,52 @@
+-- name: test_multi_column_not_in_null
+
+-- Regression for row-value (multi-column) NOT IN with NULLs in a tuple column.
+-- (a,b) NOT IN (subquery) must apply SQL three-valued logic per column: a NULL on either
+-- side of a column comparison makes that row's tuple comparison UNKNOWN (not a definite
+-- mismatch), so the outer row must be DROPPED, not returned. Previously the multi-column
+-- path lowered to a single multi-key NULL_AWARE_LEFT_ANTI_JOIN that treated a NULL in one
+-- column as "no match" and wrongly returned such rows.
+
+CREATE TABLE o2 (a INT, b INT) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE o3 (a INT, b INT, c INT) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE i_null (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE i_null3 (x INT, y INT, z INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE i_nonull (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE i_allnull (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE i_empty (x INT, y INT) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE nn0 (a INT NOT NULL, b INT NOT NULL) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE nn1 (x INT NOT NULL, y INT NOT NULL) DUPLICATE KEY(x) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+
+INSERT INTO o2 VALUES (1,1),(2,2);
+INSERT INTO o3 VALUES (1,1,1),(2,2,2);
+INSERT INTO i_null VALUES (1,NULL);
+INSERT INTO i_null3 VALUES (1,NULL,1);
+INSERT INTO i_nonull VALUES (1,1);
+INSERT INTO i_allnull VALUES (NULL,NULL);
+
+-- BUG CASE: (1,1) vs (1,NULL) = 1=1 AND 1=NULL = TRUE AND UNKNOWN = UNKNOWN -> drop (1,1);
+-- (2,2) vs (1,NULL): a=x is 2=1 = definite mismatch -> keep. Expected: only (2,2).
+select a,b from o2 where (a,b) not in (select x,y from i_null) order by a,b;
+
+-- 3-column variant: (1,1,1) vs (1,NULL,1) -> UNKNOWN -> drop; (2,2,2) -> keep.
+select a,b,c from o3 where (a,b,c) not in (select x,y,z from i_null3) order by a,b,c;
+
+-- no NULLs in subquery: plain anti-join semantics. (1,1) matches -> drop; (2,2) -> keep.
+select a,b from o2 where (a,b) not in (select x,y from i_nonull) order by a,b;
+
+-- subquery has a (NULL,NULL) row: every outer row's comparison is UNKNOWN -> all dropped (empty).
+select a,b from o2 where (a,b) not in (select x,y from i_allnull) order by a,b;
+
+-- empty subquery: NOT IN (empty) is TRUE for all outer rows -> keep everything.
+select a,b from o2 where (a,b) not in (select x,y from i_empty) order by a,b;
+
+-- positive multi-column IN is unaffected (unchanged path): (1,1) IN (1,NULL) is UNKNOWN -> not selected;
+-- so against i_null both rows are excluded -> empty.
+select a,b from o2 where (a,b) in (select x,y from i_null) order by a,b;
+-- positive IN against a real match: (1,1) IN (1,1) -> selected.
+select a,b from o2 where (a,b) in (select x,y from i_nonull) order by a,b;
+
+-- NOT NULL columns: no NULLs possible, must keep exact anti-join semantics and stay correct.
+INSERT INTO nn0 VALUES (1,1),(2,2),(3,3);
+INSERT INTO nn1 VALUES (1,1),(2,2);
+select a,b from nn0 where (a,b) not in (select x,y from nn1) order by a,b;


### PR DESCRIPTION
## Why I'm doing:

A row-value NOT IN such as (a, b) NOT IN (SELECT x, y FROM t) must follow SQL three-valued logic per column: a NULL on either side of a column comparison makes that tuple comparison UNKNOWN (not a definite mismatch), so the outer row must be dropped, not returned. Previously the multi-column case wrongly returned such rows (e.g. (1,1) NOT IN {(1,NULL)} kept (1,1)), and a (NULL,NULL) build row failed to drop anything. Single-column NOT IN was already correct.

Root cause is in the NULL_AWARE_LEFT_ANTI_JOIN execution. When pairing a probe row with the NULL-containing build rows, the executor only inspected the FIRST key column (key_columns[0]), so a NULL in any non-first tuple column was missed and the probe row was treated as "no match". Multi-column build-side null-awareness was effectively unimplemented.

BE: in _probe_from_ht_for_null_aware_anti_join_with_other_conjunct, pair the probe row with every build row that has a NULL in ANY key column, using build_key_nulls (the per-row OR of all key columns' null flags) instead of only key_columns[0]. Single-key builds, which do not materialize build_key_nulls, keep using the existing first-column path.

FE: in QuantifiedApply2JoinRule, keep the NULL_AWARE_LEFT_ANTI_JOIN and its equi keys (so the join still runs as a hash join), and additionally carry the per-column null-aware check (l = r) OR l IS NULL OR r IS NULL (only for nullable columns) as an OTHER join conjunct. This routes the join through the null-aware filter path and lets it keep/drop the null-build pairs per three-valued logic. Non-nullable columns stay as plain equi keys.

The FE rewrite, by example:

  (x, y) NOT IN (SELECT a, b FROM s)
    => NULL_AWARE_LEFT_ANTI_JOIN
         equi keys:      x = a AND y = b                       (drive the hash join)
         OTHER conjunct: (x = a OR x IS NULL OR a IS NULL)
                     AND (y = b OR y IS NULL OR b IS NULL)     (per-column 3VL on null-build pairs)

Add SQLTest test_subquery/test_multi_column_not_in_null covering NULL in any tuple column, 3-column tuples, (NULL,NULL) build rows, empty subquery, positive IN, and NOT NULL columns.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
