### PR TITLE
[Enhancement] Route comment-only MODIFY COLUMN to comment path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -727,6 +727,42 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
+    // Returns true when the MODIFY COLUMN clause changes nothing but the column comment, so it can take the
+    // lightweight ModifyColumnComment path instead of spawning a schema change job.
+    private boolean isCommentOnlyModification(ModifyColumnClause alterClause, OlapTable olapTable) {
+        // Repositioning the column, targeting a rollup, or carrying column properties is a real change.
+        if (alterClause.getColPos() != null || alterClause.getRollupName() != null
+                || (alterClause.getProperties() != null && !alterClause.getProperties().isEmpty())) {
+            return false;
+        }
+        Column modColumn = buildColumnForModify(alterClause.getColumnDef(), olapTable);
+        Column oriColumn = olapTable.getBaseColumn(modColumn.getName());
+        if (oriColumn == null) {
+            // Leave the "column does not exist" error to processModifyColumn.
+            return false;
+        }
+        // The KEY designation is table-level and is not repeated in the MODIFY COLUMN clause, so a rebuilt
+        // column inherits the stored key flag the same way processModifyColumn does.
+        if (!modColumn.isKey()) {
+            modColumn.setIsKey(oriColumn.isKey());
+        }
+        if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
+            // AlterTableClauseAnalyzer force-injects REPLACE on PK value columns (and keeps key columns as
+            // keys), so modColumn always carries an aggregation type here. Mirror the PK branch in
+            // processModifyColumn, which unconditionally realigns the type + implicit flag from the stored
+            // column, so an explicitly-typed clause still compares as comment-only.
+            modColumn.setAggregationType(oriColumn.getAggregationType(), oriColumn.isAggregationTypeImplicit());
+        } else if (oriColumn.isAggregationTypeImplicit() && modColumn.getAggregationType() == null) {
+            // For DUP/UNIQUE the value column's aggregation (NONE/REPLACE) is implied by the table model and
+            // the user omits it; inherit it as implicit so the comparison matches. If the user *explicitly*
+            // wrote an aggregation method, leave it explicit so the comparison fails and processModifyColumn
+            // raises the proper "Can not assign aggregation method" error instead of being silently dropped
+            // into the lightweight comment path.
+            modColumn.setAggregationType(oriColumn.getAggregationType(), oriColumn.isAggregationTypeImplicit());
+        }
+        return oriColumn.equalsIgnoreComment(modColumn);
+    }
+
     // User can modify column type and column position
     private boolean processModifyColumn(ModifyColumnClause alterClause, OlapTable olapTable,
                                         Map<Long, LinkedList<Column>> indexMetaIdToSchema,
@@ -2304,6 +2340,23 @@ public class SchemaChangeHandler extends AlterHandler {
                                 newIndexes);
             } else if (alterClause instanceof ModifyColumnClause) {
                 ModifyColumnClause modifyColumnClause = (ModifyColumnClause) alterClause;
+
+                // A MODIFY COLUMN that only changes the comment does not need a schema change job; route it to
+                // the lightweight ModifyColumnCommentClause path instead, mirroring the explicit
+                // MODIFY COLUMN COMMENT syntax (including its restriction against batching). This is checked
+                // before processModifyColumn so a comment-only change on a primary key column is not rejected
+                // by the key-column validation there.
+                if (isCommentOnlyModification(modifyColumnClause, olapTable)) {
+                    // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
+                    if (alterClauses.size() > 1) {
+                        throw new DdlException("MODIFY COLUMN COMMENT can not be combined with other alter operations");
+                    }
+                    ColumnDef columnDef = modifyColumnClause.getColumnDef();
+                    ModifyColumnCommentClause commentClause = new ModifyColumnCommentClause(
+                            columnDef.getName(), columnDef.getComment(), modifyColumnClause.getPos());
+                    processModifyColumnComment(commentClause, db, olapTable, indexMetaIdToSchema);
+                    return null;
+                }
 
                 // check relative mvs with the modified column
                 Set<String> modifiedColumns = Set.of(modifyColumnClause.getColumnDef().getName());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -902,6 +902,15 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     @Override
     public boolean equals(Object obj) {
+        if (!equalsIgnoreComment(obj)) {
+            return false;
+        }
+
+        Column other = (Column) obj;
+        return comment == null ? other.comment == null : comment.equals(other.getComment());
+    }
+
+    public boolean equalsIgnoreComment(Object obj) {
         if (obj == this) {
             return true;
         }
@@ -935,18 +944,14 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (!this.isSameDefaultValue(other)) {
             return false;
         }
-        if (this.isGeneratedColumn() && !other.isGeneratedColumn()) {
+        if (this.isGeneratedColumn() != other.isGeneratedColumn()) {
             return false;
         }
         if (this.isGeneratedColumn() &&
                 !this.generatedColumnExpr.equals(other.generatedColumnExpr)) {
             return false;
         }
-        if (this.isHidden != other.isHidden()) {
-            return false;
-        }
-
-        return comment == null ? other.comment == null : comment.equals(other.getComment());
+        return this.isHidden == other.isHidden();
     }
 
     public boolean isSchemaCompatible(Column other) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -1000,6 +1000,137 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     }
 
 
+    @Test
+    public void testModifyColumnCommentOnlyForDuplicateTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_dup (k1 INT, v1 INT) DUPLICATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_dup",
+                "ALTER TABLE test.cmt_dup MODIFY COLUMN v1 INT COMMENT 'dup comment';",
+                "v1", "dup comment");
+    }
+
+    @Test
+    public void testModifyColumnCommentOnlyForAggregateTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_agg (k1 INT, v1 INT SUM) AGGREGATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_agg",
+                "ALTER TABLE test.cmt_agg MODIFY COLUMN v1 INT SUM COMMENT 'agg comment';",
+                "v1", "agg comment");
+    }
+
+    @Test
+    public void testModifyColumnCommentOnlyForUniqueTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_uniq (k1 INT, v1 INT) UNIQUE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_uniq",
+                "ALTER TABLE test.cmt_uniq MODIFY COLUMN v1 INT COMMENT 'uniq comment';",
+                "v1", "uniq comment");
+    }
+
+    // A comment-only MODIFY COLUMN takes the lightweight path even for a primary key table's key column,
+    // which the regular processModifyColumn path rejects ("Can not modify key column ... for primary key table").
+    @Test
+    public void testModifyColumnCommentOnlyForPrimaryKeyTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_pk (k1 INT, v1 INT) PRIMARY KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_pk",
+                "ALTER TABLE test.cmt_pk MODIFY COLUMN k1 INT COMMENT 'pk key comment';",
+                "k1", "pk key comment");
+        assertCommentOnlyModify("cmt_pk",
+                "ALTER TABLE test.cmt_pk MODIFY COLUMN v1 INT COMMENT 'pk value comment';",
+                "v1", "pk value comment");
+    }
+
+    // The KEY designation is table-level and is not repeated in MODIFY COLUMN k1 INT COMMENT '...', so the
+    // rebuilt column comes back with isKey=false; isCommentOnlyModification must inherit the key flag from the
+    // stored column, otherwise a comment-only change on a key column would fall through and be rejected on a
+    // single-key table (leaving no key column) or create an unnecessary schema change job.
+    @Test
+    public void testModifyColumnCommentOnlyForKeyColumnOfDuplicateAndUniqueTables() throws Exception {
+        createTable("CREATE TABLE test.cmt_dup_key (k1 INT, v1 INT) DUPLICATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_dup_key",
+                "ALTER TABLE test.cmt_dup_key MODIFY COLUMN k1 INT COMMENT 'dup key comment';",
+                "k1", "dup key comment");
+
+        createTable("CREATE TABLE test.cmt_uniq_key (k1 INT, v1 INT) UNIQUE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_uniq_key",
+                "ALTER TABLE test.cmt_uniq_key MODIFY COLUMN k1 INT COMMENT 'uniq key comment';",
+                "k1", "uniq key comment");
+    }
+
+    @Test
+    public void testModifyColumnCommentOnlyCannotCombineWithOtherClause() throws Exception {
+        createTable("CREATE TABLE test.cmt_combine (k1 INT, v1 INT) DUPLICATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        String alterSql = "ALTER TABLE test.cmt_combine MODIFY COLUMN v1 INT COMMENT 'x', ADD COLUMN v2 INT;";
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("cmt_combine");
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> handler.process(alterTableStmt.getAlterClauseList(), db, table));
+        Assertions.assertTrue(exception.getMessage()
+                        .contains("MODIFY COLUMN COMMENT can not be combined with other alter operations"),
+                exception.getMessage());
+    }
+
+    @Test
+    public void testModifyColumnRepositionIsNotCommentOnly() throws Exception {
+        createTable("CREATE TABLE test.cmt_reposition (k1 INT, v1 INT, v2 INT) DUPLICATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("cmt_reposition");
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(
+                "ALTER TABLE test.cmt_reposition MODIFY COLUMN v2 INT AFTER k1;");
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        handler.process(alterTableStmt.getAlterClauseList(), db, table);
+
+        List<AlterJobV2> jobs = handler.getUnfinishedAlterJobV2ByTableId(table.getId());
+        Assertions.assertFalse(jobs.isEmpty());
+        waitAlterJobDone(handler.getAlterJobsV2());
+        // Remove the job this test created from the shared global alterJobsV2 map so it does not skew the
+        // absolute job-count assertions in sibling tests
+        jobs.forEach(job -> handler.getAlterJobsV2().remove(job.getJobId()));
+    }
+
+    // Omitting an explicit aggregation type on an AGGREGATE table value column (v INT SUM -> v INT) is a real
+    // schema change, not a comment-only one: the stored SUM is explicit user schema, so isCommentOnlyModification
+    // must NOT inherit it. The clause has to fall through to processModifyColumn, which treats the missing
+    // aggregation as turning the value column into a key column and rejects it on this table.
+    @Test
+    public void testModifyColumnOmittingExplicitAggregationIsNotCommentOnly() throws Exception {
+        createTable("CREATE TABLE test.cmt_agg_omit (k1 INT, v1 INT SUM) AGGREGATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("cmt_agg_omit");
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(
+                "ALTER TABLE test.cmt_agg_omit MODIFY COLUMN v1 INT COMMENT 'agg comment';");
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> handler.process(alterTableStmt.getAlterClauseList(), db, table));
+        // It must not have been silently routed to the comment-only path: the comment stays unchanged.
+        Assertions.assertEquals("", table.getColumn("v1").getComment(), exception.getMessage());
+    }
+
+    private void assertCommentOnlyModify(String tableName, String alterSql, String columnName, String expectedComment)
+            throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Assertions.assertNotNull(table);
+
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        handler.process(alterTableStmt.getAlterClauseList(), db, table);
+
+        // A comment-only MODIFY COLUMN must take the lightweight path: no schema change job is created and
+        // the table stays in NORMAL state, while the column comment is updated in place.
+        Assertions.assertTrue(handler.getUnfinishedAlterJobV2ByTableId(table.getId()).isEmpty());
+        Assertions.assertEquals(OlapTableState.NORMAL, table.getState());
+        Assertions.assertEquals(expectedComment, table.getColumn(columnName).getComment());
+    }
+
     private void assertSortKey(OlapTable tbl, List<Integer> expectedSortKeyIndexes) {
         List<Column> columns = tbl.getBaseSchema();
         MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());

--- a/test/sql/test_alter_table/R/test_alter_column_comment_with_type
+++ b/test/sql/test_alter_table/R/test_alter_column_comment_with_type
@@ -1,0 +1,67 @@
+-- name: test_alter_table_column_comment_with_type @native
+create table t(k int, v int) primary key(k);
+-- result:
+-- !result
+show create table t;
+-- result:
+t	CREATE TABLE `t` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "3"
+);
+-- !result
+alter table t modify column v int comment 'v';
+-- result:
+-- !result
+alter table t modify column v int comment 'v';
+-- result:
+-- !result
+alter table t modify column k int comment 'k';
+-- result:
+-- !result
+show create table t;
+-- result:
+t	CREATE TABLE `t` (
+  `k` int(11) NOT NULL COMMENT "k",
+  `v` int(11) NULL COMMENT "v"
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "3"
+);
+-- !result
+create table d(k int, v int) duplicate key(k);
+-- result:
+-- !result
+alter table d modify column v int comment 'v';
+-- result:
+-- !result
+show create table d;
+-- result:
+d	CREATE TABLE `d` (
+  `k` int(11) NULL COMMENT "",
+  `v` int(11) NULL COMMENT "v"
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"bucket_size" = "1073741824",
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "3"
+);
+-- !result

--- a/test/sql/test_alter_table/T/test_alter_column_comment_with_type
+++ b/test/sql/test_alter_table/T/test_alter_column_comment_with_type
@@ -1,0 +1,14 @@
+-- name: test_alter_table_column_comment_with_type @native
+create table t(k int, v int) primary key(k);
+show create table t;
+-- comment-only modify with the column type repeated takes the lightweight ModifyColumnComment path; it
+-- works on a primary key table's value column without a schema change job.
+alter table t modify column v int comment 'v';
+-- re-applying the same comment is idempotent and still succeeds (aligned with MODIFY COLUMN ... COMMENT).
+alter table t modify column v int comment 'v';
+-- the lightweight path also works on a primary key table's key column, which a regular MODIFY COLUMN rejects.
+alter table t modify column k int comment 'k';
+show create table t;
+create table d(k int, v int) duplicate key(k);
+alter table d modify column v int comment 'v';
+show create table d;


### PR DESCRIPTION
## Why I'm doing:
 ALTER TABLE ... MODIFY COLUMN <col> <type> COMMENT '...' previously always spawned a full schema change job, even when the column type was repeated unchanged and only the comment differed. This is wasteful: the only thing that actually changed is metadata. StarRocks already has a lightweight path for MODIFY COLUMN COMMENT (ModifyColumnCommentClause) that updates the comment without a schema change job, but a MODIFY COLUMN that respecifies the type was not routed to it. The regular MODIFY COLUMN path also rejects any change to a primary key column, so even a pure comment change on a PK column failed.

## What I'm doing:
Detect a MODIFY COLUMN clause that changes nothing but the column comment and route it to the existing ModifyColumnCommentClause path, mirroring the explicit MODIFY COLUMN ... COMMENT syntax.
    
  - SchemaChangeHandler:
    - Add isCommentOnlyModification, which returns true only when the clause has no column position, no rollup target, no column properties, the column exists, and the rebuilt column is identical to the existing one apart from its comment. processModifyColumn is left unchanged.
    - The check runs before processModifyColumn, so a comment-only change on a primary key column takes the lightweight path instead of being rejected by the key-column validation there.
    - The rebuilt column is normalized before comparison, the same way processModifyColumn does. buildColumnForModify rebuilds the column from the ColumnDef, which carries no implicit-aggregation flag, so the aggregation type always comes back as explicit. For a primary key table the aggregation is never
  user-specified (AlterTableClauseAnalyzer injects REPLACE for value columns), so it is realigned with the stored column unconditionally; for duplicate/unique tables the inherited aggregation is filled only when the user did not specify one, so a genuine aggregation change (e.g. SUM → MAX) is still treated as a
  real modification.
  - Column: add equalsIgnoreComment, comparing every column attribute except the comment (name, type, aggregation type + implicit flag, agg-state, key flag, nullability, default value, generated-column flag/expr, hidden flag). The generated-column flag is compared in both directions so that converting to/from a
  generated column is treated as a real modification rather than a comment-only change.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
