### PR TITLE
[Enhancement] Add structured logging to ExternalFullStatisticsCollectJob for observability

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -414,6 +414,9 @@ public class IcebergTable extends Table {
             return "";
         }
         java.util.Map<String, String> summary = snapshot.summary();
+        if (summary == null) {
+            summary = java.util.Collections.emptyMap();
+        }
         return String.format("snapshotId=%d totalFiles=%s totalRows=%s",
                 snapshot.snapshotId(),
                 summary.getOrDefault("total-data-files", "0"),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -407,6 +407,19 @@ public class IcebergTable extends Table {
         return columnType.isInt() || columnType.isBigint() || columnType.isBinaryType() || columnType.isVarchar();
     }
 
+    @Override
+    public String getStatsCollectSummary() {
+        org.apache.iceberg.Snapshot snapshot = getNativeTable().currentSnapshot();
+        if (snapshot == null) {
+            return "";
+        }
+        java.util.Map<String, String> summary = snapshot.summary();
+        return String.format("snapshotId=%d totalFiles=%s totalRows=%s",
+                snapshot.snapshotId(),
+                summary.getOrDefault("total-data-files", "0"),
+                summary.getOrDefault("total-records", "0"));
+    }
+
     public org.apache.iceberg.Table getNativeTable() {
         // For compatibility with the resource iceberg table. native table is lazy. Prevent failure during fe restarting.
         if (nativeTable == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -403,6 +403,12 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return type == TableType.ICEBERG;
     }
 
+    // Returns a one-line summary string for stats-collection logging.
+    // Subclasses can override to include connector-specific metadata (e.g. snapshot info).
+    public String getStatsCollectSummary() {
+        return "";
+    }
+
     public boolean isDeltalakeTable() {
         return type == TableType.DELTALAKE;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.statistic;
 
 import com.google.common.base.Joiner;
@@ -169,7 +168,8 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             failureReason = e.getMessage();
             throw e;
         } finally {
-            LOG.info("[ExternalStats] collect end | jobId={} catalog={} db={} table={} status={} durationMs={} partitions={} columns={} reason={}",
+            LOG.info("[ExternalStats] collect end | jobId={} catalog={} db={} table={} status={} " +
+                            "durationMs={} partitions={} columns={} reason={}",
                     jobId, catalogName, db.getOriginName(), table.getName(),
                     status, System.currentTimeMillis() - startMs,
                     partitionNames.size(), columnNames.size(), failureReason);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -121,34 +121,59 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
     @Override
     public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
-        long finishedSQLNum = 0;
-        int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
-        List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
-        long totalCollectSQL = collectSQLList.size();
+        long startMs = System.currentTimeMillis();
+        long jobId = analyzeStatus.getId();
+        LOG.info("[ExternalStats] collect start | jobId={} catalog={} db={} table={} partitions={} columns={}",
+                jobId, catalogName, db.getOriginName(), table.getName(),
+                partitionNames.size(), columnNames.size());
 
-        // First, the collection task is divided into several small tasks according to the column name and partition,
-        // and then the multiple small tasks are aggregated into several tasks
-        // that will actually be run according to the configured parallelism, and are connected by union all
-        // Because each union will run independently, if the number of unions is greater than the degree of parallelism,
-        // dop will be set to 1 to meet the requirements of the degree of parallelism.
-        // If the number of unions is less than the degree of parallelism,
-        // dop should be adjusted appropriately to use enough cpu cores
-        for (List<String> sqlUnion : collectSQLList) {
-            if (sqlUnion.size() < parallelism) {
-                context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
-            } else {
-                context.getSessionVariable().setPipelineDop(1);
-            }
-
-            String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
-
-            collectStatisticSync(sql, context, analyzeStatus);
-            finishedSQLNum++;
-            analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
-            GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
+        String tableSummary = table.getStatsCollectSummary();
+        if (!tableSummary.isEmpty()) {
+            LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
+                    jobId, catalogName, db.getOriginName(), table.getName(), tableSummary);
         }
 
-        flushInsertStatisticsData(context, true);
+        String status = "SUCCESS";
+        String failureReason = "";
+        try {
+            long finishedSQLNum = 0;
+            int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
+            List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
+            long totalCollectSQL = collectSQLList.size();
+
+            // First, the collection task is divided into several small tasks according to the column name and partition,
+            // and then the multiple small tasks are aggregated into several tasks
+            // that will actually be run according to the configured parallelism, and are connected by union all
+            // Because each union will run independently, if the number of unions is greater than the degree of parallelism,
+            // dop will be set to 1 to meet the requirements of the degree of parallelism.
+            // If the number of unions is less than the degree of parallelism,
+            // dop should be adjusted appropriately to use enough cpu cores
+            for (List<String> sqlUnion : collectSQLList) {
+                if (sqlUnion.size() < parallelism) {
+                    context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
+                } else {
+                    context.getSessionVariable().setPipelineDop(1);
+                }
+
+                String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
+
+                collectStatisticSync(sql, context, analyzeStatus);
+                finishedSQLNum++;
+                analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
+                GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
+            }
+
+            flushInsertStatisticsData(context, true);
+        } catch (Exception e) {
+            status = "FAILED";
+            failureReason = e.getMessage();
+            throw e;
+        } finally {
+            LOG.info("[ExternalStats] collect end | jobId={} catalog={} db={} table={} status={} durationMs={} partitions={} columns={} reason={}",
+                    jobId, catalogName, db.getOriginName(), table.getName(),
+                    status, System.currentTimeMillis() - startMs,
+                    partitionNames.size(), columnNames.size(), failureReason);
+        }
     }
 
     protected List<List<String>> buildCollectSQLList(int parallelism) {


### PR DESCRIPTION
## Why I'm doing:
Background statistics collection for external tables (Iceberg, Hive, Paimon, etc.) currently produces no structured log output — you can only tell whether a job started or failed from high-level scheduler logs, with no visibility into which table was collected, how long it took, how many partitions/columns were involved, or why it failed. This makes it impossible to establish a performance baseline or diagnose collection issues in production.

## What I'm doing:
Add structured `[ExternalStats]` log lines around the `collect()` lifecycle in `ExternalFullStatisticsCollectJob`, covering start, optional connector metadata summary, and end (with status/duration/failure reason). All log lines carry a `jobId` (reusing `analyzeStatus.getId()`) so concurrent multi-table jobs can be correlated across interleaved output.

Connector-specific metadata (e.g. Iceberg snapshot info) is kept out of the job class via a new overridable `Table.getStatsCollectSummary()` hook — `IcebergTable` overrides it to emit `snapshotId/totalFiles/totalRows` from the current snapshot summary (zero extra IO). Other connectors can opt in by overriding the same method.

Log format:
```
[ExternalStats] collect start | jobId=42 catalog=ice db=tpch table=lineitem partitions=365 columns=16
[ExternalStats] table info    | jobId=42 catalog=ice db=tpch table=lineitem snapshotId=123 totalFiles=52000 totalRows=6000000000
[ExternalStats] collect end   | jobId=42 catalog=ice db=tpch table=lineitem status=SUCCESS durationMs=45320 partitions=365 columns=16 reason=
```

Grep to see all collection activity at a glance:
```bash
grep "\[ExternalStats\]" fe/log/fe.log
grep "\[ExternalStats\].*jobId=42" fe/log/fe.log   # single job
grep "\[ExternalStats\].*FAILED" fe/log/fe.log      # failures only
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
