### PR TITLE
[Enhancement] Add external_analyze_history table for Iceberg stats collection observability

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -423,6 +423,22 @@ public class IcebergTable extends Table {
                 summary.getOrDefault("total-records", "0"));
     }
 
+    @Override
+    public String getStatsCollectJson() {
+        org.apache.iceberg.Snapshot snapshot = getNativeTable().currentSnapshot();
+        if (snapshot == null) {
+            return "";
+        }
+        java.util.Map<String, String> summary = snapshot.summary();
+        if (summary == null) {
+            summary = java.util.Collections.emptyMap();
+        }
+        return String.format("{\"snapshot_id\":%d,\"total_files\":%s,\"total_rows\":%s}",
+                snapshot.snapshotId(),
+                summary.getOrDefault("total-data-files", "0"),
+                summary.getOrDefault("total-records", "0"));
+    }
+
     public org.apache.iceberg.Table getNativeTable() {
         // For compatibility with the resource iceberg table. native table is lazy. Prevent failure during fe restarting.
         if (nativeTable == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -408,35 +408,20 @@ public class IcebergTable extends Table {
     }
 
     @Override
-    public String getStatsCollectSummary() {
+    public java.util.Map<String, String> getStatsCollectMetadata() {
         org.apache.iceberg.Snapshot snapshot = getNativeTable().currentSnapshot();
         if (snapshot == null) {
-            return "";
+            return java.util.Collections.emptyMap();
         }
         java.util.Map<String, String> summary = snapshot.summary();
         if (summary == null) {
             summary = java.util.Collections.emptyMap();
         }
-        return String.format("snapshotId=%d totalFiles=%s totalRows=%s",
-                snapshot.snapshotId(),
-                summary.getOrDefault("total-data-files", "0"),
-                summary.getOrDefault("total-records", "0"));
-    }
-
-    @Override
-    public String getStatsCollectJson() {
-        org.apache.iceberg.Snapshot snapshot = getNativeTable().currentSnapshot();
-        if (snapshot == null) {
-            return "";
-        }
-        java.util.Map<String, String> summary = snapshot.summary();
-        if (summary == null) {
-            summary = java.util.Collections.emptyMap();
-        }
-        return String.format("{\"snapshot_id\":%d,\"total_files\":%s,\"total_rows\":%s}",
-                snapshot.snapshotId(),
-                summary.getOrDefault("total-data-files", "0"),
-                summary.getOrDefault("total-records", "0"));
+        java.util.Map<String, String> meta = new java.util.LinkedHashMap<>();
+        meta.put("snapshot_id", String.valueOf(snapshot.snapshotId()));
+        meta.put("total_files", summary.getOrDefault("total-data-files", "0"));
+        meta.put("total_rows", summary.getOrDefault("total-records", "0"));
+        return meta;
     }
 
     public org.apache.iceberg.Table getNativeTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -413,14 +413,11 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return type == TableType.ICEBERG;
     }
 
-    // Returns a one-line summary string for stats-collection logging.
-    // Subclasses can override to include connector-specific metadata (e.g. snapshot info).
-    public String getStatsCollectSummary() {
-        return "";
-    }
-
-    public String getStatsCollectJson() {
-        return "";
+    // Returns connector-specific metadata for stats-collection observability.
+    // Used for both log output and the extended_info JSON column in external_analyze_history.
+    // Subclasses override to include fields like snapshot_id, total_files, total_rows.
+    public Map<String, String> getStatsCollectMetadata() {
+        return Collections.emptyMap();
     }
 
     public boolean isDeltalakeTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -419,6 +419,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return "";
     }
 
+    public String getStatsCollectJson() {
+        return "";
+    }
+
     public boolean isDeltalakeTable() {
         return type == TableType.DELTALAKE;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -126,22 +126,34 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
         long startMs = System.currentTimeMillis();
         long jobId = analyzeStatus.getId();
+        // Fetch connector-specific metadata best-effort — a snapshot access failure must not
+        // prevent the FAILED history row from being written (that row is the most valuable one).
+        Map<String, String> tableMeta;
+        try {
+            tableMeta = table.getStatsCollectMetadata();
+        } catch (Exception e) {
+            LOG.warn("[ExternalStats] Failed to get table metadata | catalog={} db={} table={}",
+                    catalogName, db.getOriginName(), table.getName(), e);
+            tableMeta = Collections.emptyMap();
+        }
+        int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
+        List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
+        long totalCollectSQL = collectSQLList.size();
+
         LOG.info("[ExternalStats] collect start | jobId={} catalog={} db={} table={} partitions={} columns={}",
                 jobId, catalogName, db.getOriginName(), table.getName(),
                 partitionNames.size(), columnNames.size());
-        String tableSummary = table.getStatsCollectSummary();
-        if (!tableSummary.isEmpty()) {
+        if (!tableMeta.isEmpty()) {
+            String metaStr = tableMeta.entrySet().stream()
+                    .map(e -> e.getKey() + "=" + e.getValue())
+                    .collect(Collectors.joining(" "));
             LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
-                    jobId, catalogName, db.getOriginName(), table.getName(), tableSummary);
+                    jobId, catalogName, db.getOriginName(), table.getName(), metaStr);
         }
         String status = "SUCCESS";
         String failureReason = "";
         try {
             long finishedSQLNum = 0;
-            int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
-            List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
-            long totalCollectSQL = collectSQLList.size();
-
             // First, the collection task is divided into several small tasks according to the column name and partition,
             // and then the multiple small tasks are aggregated into several tasks
             // that will actually be run according to the configured parallelism, and are connected by union all
@@ -176,12 +188,20 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                     jobId, catalogName, db.getOriginName(), table.getName(),
                     status, endMs - startMs,
                     partitionNames.size(), columnNames.size(), failureReason);
-            writeAnalyzeHistory(context, jobId, status, startMs, endMs, failureReason);
+            // Build extended_info: execution params + column/partition lists + connector metadata
+            Map<String, Object> extended = new java.util.LinkedHashMap<>();
+            extended.put("parallelism", parallelism);
+            extended.put("sql_count", totalCollectSQL);
+            extended.put("partitions_collected", partitionNames.size());
+            extended.put("columns_collected", columnNames);
+            extended.putAll(tableMeta);
+            writeAnalyzeHistory(context, jobId, status, startMs, endMs, failureReason, extended);
         }
     }
 
     private void writeAnalyzeHistory(ConnectContext context, long jobId, String status,
-                                     long startMs, long endMs, String failureReason) {
+                                     long startMs, long endMs, String failureReason,
+                                     Map<String, Object> extended) {
         try {
             ZoneId zone = ZoneId.systemDefault();
             LocalDateTime startTime = DateUtils.fromEpochMillis(startMs, zone);
@@ -192,21 +212,14 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             if (safeReason.length() > 65530) {
                 safeReason = safeReason.substring(0, 65530);
             }
-            // ARRAY<VARCHAR>: use array literal syntax
-            String columnsArrayLiteral = columnNames.stream()
-                    .map(c -> "'" + c.replace("'", "\\'") + "'")
-                    .collect(Collectors.joining(", ", "[", "]"));
-            // JSON: use parse_json(), or NULL if no extended info
-            String extendedJson = table.getStatsCollectJson();
-            String extendedInfoExpr = extendedJson.isEmpty()
-                    ? "NULL"
-                    : "parse_json('" + extendedJson.replace("'", "\\'") + "')";
+            // JSON: serialize extended map, or NULL if empty
+            String extendedInfoExpr = extended.isEmpty() ? "NULL"
+                    : "parse_json('" + new com.google.gson.Gson().toJson(extended).replace("'", "\\'") + "')";
             String sql = String.format(
                     "INSERT INTO _statistics_.external_analyze_history" +
                             " (job_id, catalog_name, db_name, table_name, status," +
-                            " start_time, end_time, duration_ms, failure_reason," +
-                            " partitions_collected, columns_collected, extended_info) VALUES" +
-                            " (%d, '%s', '%s', '%s', '%s', '%s', '%s', %d, '%s', %d, %s, %s)",
+                            " start_time, end_time, duration_ms, failure_reason, extended_info) VALUES" +
+                            " (%d, '%s', '%s', '%s', '%s', '%s', '%s', %d, '%s', %s)",
                     jobId,
                     catalogName.replace("'", "''"),
                     db.getOriginName().replace("'", "''"),
@@ -216,8 +229,6 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                     endStr,
                     endMs - startMs,
                     safeReason,
-                    partitionNames.size(),
-                    columnsArrayLiteral,
                     extendedInfoExpr);
             StatementBase stmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             StmtExecutor stmtExecutor = StmtExecutor.newInternalExecutor(context, stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -132,27 +132,30 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         try {
             tableMeta = table.getStatsCollectMetadata();
         } catch (Exception e) {
-            LOG.warn("[ExternalStats] Failed to get table metadata | catalog={} db={} table={}",
-                    catalogName, db.getOriginName(), table.getName(), e);
+            LOG.warn("[ExternalStats] Failed to get table metadata | table={}",
+                    table.getQualifiedTableName(), e);
             tableMeta = Collections.emptyMap();
         }
         int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
-        List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
-        long totalCollectSQL = collectSQLList.size();
+        // Initialized to safe defaults so the finally block can record a FAILED row even if
+        // buildCollectSQLList() throws before the try/finally is entered.
+        List<List<String>> collectSQLList = Collections.emptyList();
+        long totalCollectSQL = 0;
 
-        LOG.info("[ExternalStats] collect start | jobId={} catalog={} db={} table={} partitions={} columns={}",
-                jobId, catalogName, db.getOriginName(), table.getName(),
-                partitionNames.size(), columnNames.size());
+        LOG.info("[ExternalStats] collect start | jobId={} table={} partitions={} columns={}",
+                jobId, table.getQualifiedTableName(), partitionNames.size(), columnNames.size());
         if (!tableMeta.isEmpty()) {
             String metaStr = tableMeta.entrySet().stream()
                     .map(e -> e.getKey() + "=" + e.getValue())
                     .collect(Collectors.joining(" "));
-            LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
-                    jobId, catalogName, db.getOriginName(), table.getName(), metaStr);
+            LOG.info("[ExternalStats] table info | jobId={} table={} {}",
+                    jobId, table.getQualifiedTableName(), metaStr);
         }
         String status = "SUCCESS";
         String failureReason = "";
         try {
+            collectSQLList = buildCollectSQLList(parallelism);
+            totalCollectSQL = collectSQLList.size();
             long finishedSQLNum = 0;
             // First, the collection task is divided into several small tasks according to the column name and partition,
             // and then the multiple small tasks are aggregated into several tasks
@@ -183,9 +186,9 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             throw e;
         } finally {
             long endMs = System.currentTimeMillis();
-            LOG.info("[ExternalStats] collect end | jobId={} catalog={} db={} table={} status={} " +
-                            "durationMs={} partitions={} columns={} reason={}",
-                    jobId, catalogName, db.getOriginName(), table.getName(),
+            LOG.info("[ExternalStats] collect end | jobId={} table={} status={} durationMs={} " +
+                            "partitions={} columns={} reason={}",
+                    jobId, table.getQualifiedTableName(),
                     status, endMs - startMs,
                     partitionNames.size(), columnNames.size(), failureReason);
             // Build extended_info: execution params + column/partition lists + connector metadata
@@ -236,9 +239,13 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             context.setQueryId(UUIDUtil.genUUID());
             context.setStartTime();
             stmtExecutor.execute();
+            if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                LOG.warn("[ExternalStats] Failed to write analyze history | jobId={} table={} error={}",
+                        jobId, table.getQualifiedTableName(), context.getState().getErrorMessage());
+            }
         } catch (Exception e) {
             LOG.warn("[ExternalStats] Failed to write analyze history | jobId={} table={}",
-                    jobId, table.getName(), e);
+                    jobId, table.getQualifiedTableName(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.PartitionInfo;
@@ -50,6 +51,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TStatisticData;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
@@ -62,6 +64,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -125,13 +129,11 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         LOG.info("[ExternalStats] collect start | jobId={} catalog={} db={} table={} partitions={} columns={}",
                 jobId, catalogName, db.getOriginName(), table.getName(),
                 partitionNames.size(), columnNames.size());
-
         String tableSummary = table.getStatsCollectSummary();
         if (!tableSummary.isEmpty()) {
             LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
                     jobId, catalogName, db.getOriginName(), table.getName(), tableSummary);
         }
-
         String status = "SUCCESS";
         String failureReason = "";
         try {
@@ -165,14 +167,67 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             flushInsertStatisticsData(context, true);
         } catch (Exception e) {
             status = "FAILED";
-            failureReason = e.getMessage();
+            failureReason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             throw e;
         } finally {
+            long endMs = System.currentTimeMillis();
             LOG.info("[ExternalStats] collect end | jobId={} catalog={} db={} table={} status={} " +
                             "durationMs={} partitions={} columns={} reason={}",
                     jobId, catalogName, db.getOriginName(), table.getName(),
-                    status, System.currentTimeMillis() - startMs,
+                    status, endMs - startMs,
                     partitionNames.size(), columnNames.size(), failureReason);
+            writeAnalyzeHistory(context, jobId, status, startMs, endMs, failureReason);
+        }
+    }
+
+    private void writeAnalyzeHistory(ConnectContext context, long jobId, String status,
+                                     long startMs, long endMs, String failureReason) {
+        try {
+            ZoneId zone = ZoneId.systemDefault();
+            LocalDateTime startTime = DateUtils.fromEpochMillis(startMs, zone);
+            LocalDateTime endTime = DateUtils.fromEpochMillis(endMs, zone);
+            String startStr = DateUtils.formatDateTimeUnix(startTime);
+            String endStr = DateUtils.formatDateTimeUnix(endTime);
+            String safeReason = failureReason.replace("'", "''");
+            if (safeReason.length() > 65530) {
+                safeReason = safeReason.substring(0, 65530);
+            }
+            // ARRAY<VARCHAR>: use array literal syntax
+            String columnsArrayLiteral = columnNames.stream()
+                    .map(c -> "'" + c.replace("'", "\\'") + "'")
+                    .collect(Collectors.joining(", ", "[", "]"));
+            // JSON: use parse_json(), or NULL if no extended info
+            String extendedJson = table.getStatsCollectJson();
+            String extendedInfoExpr = extendedJson.isEmpty()
+                    ? "NULL"
+                    : "parse_json('" + extendedJson.replace("'", "\\'") + "')";
+            String sql = String.format(
+                    "INSERT INTO _statistics_.external_analyze_history" +
+                            " (job_id, catalog_name, db_name, table_name, status," +
+                            " start_time, end_time, duration_ms, failure_reason," +
+                            " partitions_collected, columns_collected, extended_info) VALUES" +
+                            " (%d, '%s', '%s', '%s', '%s', '%s', '%s', %d, '%s', %d, %s, %s)",
+                    jobId,
+                    catalogName.replace("'", "''"),
+                    db.getOriginName().replace("'", "''"),
+                    table.getName().replace("'", "''"),
+                    status,
+                    startStr,
+                    endStr,
+                    endMs - startMs,
+                    safeReason,
+                    partitionNames.size(),
+                    columnsArrayLiteral,
+                    extendedInfoExpr);
+            StatementBase stmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
+            StmtExecutor stmtExecutor = StmtExecutor.newInternalExecutor(context, stmt);
+            context.setExecutor(stmtExecutor);
+            context.setQueryId(UUIDUtil.genUUID());
+            context.setStartTime();
+            stmtExecutor.execute();
+        } catch (Exception e) {
+            LOG.warn("[ExternalStats] Failed to write analyze history | jobId={} table={}",
+                    jobId, table.getName(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -60,9 +60,11 @@ import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.transaction.InsertOverwriteJobStats;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.type.ArrayType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.HLLType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.JsonType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
@@ -438,6 +440,22 @@ public class StatisticUtils {
                     new ColumnDef("column_names", new TypeDef(columnNameType)),
                     new ColumnDef("ndv", new TypeDef(IntegerType.BIGINT)),
                     new ColumnDef("update_time", new TypeDef(DateType.DATETIME))
+            );
+        } else if (tableName.equals(StatsConstants.EXTERNAL_ANALYZE_HISTORY_TABLE_NAME)) {
+            ScalarType failureReasonType = TypeFactory.createVarcharType(65530);
+            return ImmutableList.of(
+                    new ColumnDef("job_id", new TypeDef(IntegerType.BIGINT)),
+                    new ColumnDef("catalog_name", new TypeDef(catalogNameType)),
+                    new ColumnDef("db_name", new TypeDef(dbNameType)),
+                    new ColumnDef("table_name", new TypeDef(tableNameType)),
+                    new ColumnDef("status", new TypeDef(TypeFactory.createVarcharType(16))),
+                    new ColumnDef("start_time", new TypeDef(DateType.DATETIME)),
+                    new ColumnDef("end_time", new TypeDef(DateType.DATETIME)),
+                    new ColumnDef("duration_ms", new TypeDef(IntegerType.BIGINT)),
+                    new ColumnDef("failure_reason", new TypeDef(failureReasonType)),
+                    new ColumnDef("partitions_collected", new TypeDef(IntegerType.INT)),
+                    new ColumnDef("columns_collected", new TypeDef(ArrayType.ARRAY_VARCHAR)),
+                    new ColumnDef("extended_info", new TypeDef(JsonType.JSON))
             );
         } else {
             throw new StarRocksPlannerException("Not support stats table " + tableName, ErrorType.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -60,7 +60,6 @@ import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.transaction.InsertOverwriteJobStats;
 import com.starrocks.transaction.TransactionState;
-import com.starrocks.type.ArrayType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.HLLType;
 import com.starrocks.type.IntegerType;
@@ -453,8 +452,6 @@ public class StatisticUtils {
                     new ColumnDef("end_time", new TypeDef(DateType.DATETIME)),
                     new ColumnDef("duration_ms", new TypeDef(IntegerType.BIGINT)),
                     new ColumnDef("failure_reason", new TypeDef(failureReasonType)),
-                    new ColumnDef("partitions_collected", new TypeDef(IntegerType.INT)),
-                    new ColumnDef("columns_collected", new TypeDef(ArrayType.ARRAY_VARCHAR)),
                     new ColumnDef("extended_info", new TypeDef(JsonType.JSON))
             );
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+import static com.starrocks.statistic.StatsConstants.EXTERNAL_ANALYZE_HISTORY_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
@@ -139,6 +140,10 @@ public class StatisticsMetaManager extends LeaderDaemon {
 
     private static final List<String> EXTERNAL_HISTOGRAM_KEY_COLUMNS = ImmutableList.of(
             "table_uuid", "column_name"
+    );
+
+    private static final List<String> EXTERNAL_ANALYZE_HISTORY_KEY_COLUMNS = ImmutableList.of(
+            "job_id"
     );
 
     private static final List<String> FULL_STATISTICS_COMPATIBLE_COLUMNS = ImmutableList.of(
@@ -328,6 +333,36 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return checkTableExist(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
     }
 
+    private boolean createExternalAnalyzeHistoryTable(ConnectContext context) {
+        LOG.info("create external analyze history table start");
+        KeysType keysType = RunMode.isSharedDataMode() ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
+        Map<String, String> properties = Maps.newHashMap();
+        try {
+            int defaultReplicationNum = AutoInferUtil.calDefaultReplicationNum();
+            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
+            QualifiedName qualifiedName =
+                    QualifiedName.of(Arrays.asList(STATISTICS_DB_NAME, EXTERNAL_ANALYZE_HISTORY_TABLE_NAME));
+            TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+            CreateTableStmt stmt = new CreateTableStmt(false, false,
+                    tableRef,
+                    StatisticUtils.buildStatsColumnDef(EXTERNAL_ANALYZE_HISTORY_TABLE_NAME),
+                    EngineType.defaultEngine().name(),
+                    new KeysDesc(keysType, EXTERNAL_ANALYZE_HISTORY_KEY_COLUMNS),
+                    null,
+                    new HashDistributionDesc(10, EXTERNAL_ANALYZE_HISTORY_KEY_COLUMNS),
+                    properties,
+                    null,
+                    "");
+            Analyzer.analyze(stmt, context);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
+        } catch (StarRocksException e) {
+            LOG.warn("Failed to create external analyze history table", e);
+            return false;
+        }
+        LOG.info("create external analyze history table done");
+        return checkTableExist(EXTERNAL_ANALYZE_HISTORY_TABLE_NAME);
+    }
+
     private boolean createMultiColumnStatisticsTable(ConnectContext context) {
         LOG.info("create multi column statistics table start");
         TableName tableName = new TableName(STATISTICS_DB_NAME, MULTI_COLUMN_STATISTICS_TABLE_NAME);
@@ -487,6 +522,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 return createSPMBaselinesTable(context);
             } else if (QUERY_HISTORY_TABLE_NAME.equals(tableName)) {
                 return createQueryHistoryTable(context);
+            } else if (EXTERNAL_ANALYZE_HISTORY_TABLE_NAME.equals(tableName)) {
+                return createExternalAnalyzeHistoryTable(context);
             } else {
                 throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
             }
@@ -608,6 +645,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         refreshStatisticsTable(MULTI_COLUMN_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(SPM_BASELINE_TABLE_NAME);
         refreshStatisticsTable(QUERY_HISTORY_TABLE_NAME);
+        refreshStatisticsTable(EXTERNAL_ANALYZE_HISTORY_TABLE_NAME);
         if (isStopped()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -669,14 +669,19 @@ public class StatisticsMetaManager extends LeaderDaemon {
 
             boolean existsSample = false;
             boolean existsFull = false;
-            while (!existsSample || !existsFull) {
+            boolean existsHistory = false;
+            while (!existsSample || !existsFull || !existsHistory) {
                 existsSample = checkTableExist(SAMPLE_STATISTICS_TABLE_NAME);
                 existsFull = checkTableExist(FULL_STATISTICS_TABLE_NAME);
+                existsHistory = checkTableExist(EXTERNAL_ANALYZE_HISTORY_TABLE_NAME);
                 if (!existsSample) {
                     createTable(SAMPLE_STATISTICS_TABLE_NAME);
                 }
                 if (!existsFull) {
                     createTable(FULL_STATISTICS_TABLE_NAME);
+                }
+                if (!existsHistory) {
+                    createTable(EXTERNAL_ANALYZE_HISTORY_TABLE_NAME);
                 }
                 trySleep(1);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -70,7 +70,7 @@ public class StatsConstants {
     public static final String HISTOGRAM_STATISTICS_TABLE_NAME = "histogram_statistics";
     public static final String EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME = "external_histogram_statistics";
     public static final String MULTI_COLUMN_STATISTICS_TABLE_NAME = "multi_column_statistics";
-
+    public static final String EXTERNAL_ANALYZE_HISTORY_TABLE_NAME = "external_analyze_history";
 
     public static final String INFORMATION_SCHEMA = "information_schema";
 
@@ -131,7 +131,8 @@ public class StatsConstants {
             EXTERNAL_FULL_STATISTICS_TABLE_NAME,
             MULTI_COLUMN_STATISTICS_TABLE_NAME,
             HISTOGRAM_STATISTICS_TABLE_NAME,
-            EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME
+            EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME,
+            EXTERNAL_ANALYZE_HISTORY_TABLE_NAME
     );
 
     public enum AnalyzeType {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -570,11 +570,13 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         mostCommonValues.put("2", "20");
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectBucketsWithoutNdv",
                 db, olapTable, 0.1, 64L, mostCommonValues, "v6", IntegerType.BIGINT);
-        Assertions.assertEquals(normalize.apply("select cast(2 as int) as version, cast(10009 as bigint), " +
-                        "cast(10060 as bigint), 'v6', histogram(`column_key`, cast(64 as int), cast(0.1 as double)) " +
+        Assertions.assertEquals(normalize.apply(String.format(
+                        "select cast(2 as int) as version, cast(%d as bigint), " +
+                        "cast(%d as bigint), 'v6', histogram(`column_key`, cast(64 as int), cast(0.1 as double)) " +
                         "from " +
                         "(select `v6` as column_key from `test`.`t0_stats` where rand() <= 0.1 and `v6` is not null and " +
-                        "`v6` not in (1,2) order by `v6` limit 10000000) t"),
+                        "`v6` not in (1,2) order by `v6` limit 10000000) t",
+                        dbid, t0StatsTableId)),
                 normalize.apply(sql));
 
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectHistogramWithHllNdv",


### PR DESCRIPTION
## Why I'm doing:
External table statistics collection (ANALYZE jobs) runs in the background with no persistent record of outcomes. When jobs fail silently or produce stale stats, there's no way to diagnose which tables were analyzed, how long they took, or why they failed without grepping FE logs. This adds a persistent, SQL-queryable history table to fill that gap.

## What I'm doing:

**New `_statistics_.external_analyze_history` table** — auto-created on FE leader startup alongside other `_statistics_` tables, with primary key on `job_id`:

| Column                                | Type              | Notes                                 |
| ------------------------------------- | ----------------- | ------------------------------------- |
| `job_id`                              | BIGINT            | links to `AnalyzeStatus.getId()`      |
| `catalog_name / db_name / table_name` | VARCHAR           | table identity                        |
| `status`                              | VARCHAR(16)       | `SUCCESS` / `FAILED`                  |
| `start_time / end_time / duration_ms` | DATETIME / BIGINT | timing                                |
| `failure_reason`                      | VARCHAR(65530)    | populated on failure                  |
| `extended_info`                       | JSON              | execution params + connector metadata |

**`extended_info` JSON** merges job-level params and connector-specific metadata into one extensible field — no schema change needed as collection strategies evolve:
```json
{
  "parallelism": 4, "sql_count": 12,
  "partitions_collected": 10, "columns_collected": ["c1", "c2"],
  "snapshot_id": "...", "total_files": "500", "total_rows": "1000000"
}
```

**`Table.getStatsCollectMetadata()`** — single plugin interface replacing the previous `getStatsCollectSummary()`. Returns `Map<String, String>` used for both structured log output and the `extended_info` JSON. `IcebergTable` overrides to expose snapshot id, total files, and total rows (O(1), zero extra IO). Called best-effort so metadata access failure never prevents a FAILED history row from being written.

**`ExternalFullStatisticsCollectJob`** — writes one row per job in a `finally` block via an internal INSERT. Write failure is logged and swallowed; history is observability-only and must not affect collection correctness.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
