### PR TITLE
[Enhancement] Expose jemalloc runtime options as be config

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -114,6 +114,17 @@ CONF_String(mem_limit, "90%");
 // Enable the jemalloc tracker, which is responsible for reserving memory
 CONF_Bool(enable_jemalloc_memory_tracker, "true");
 
+// The jemalloc runtime options applied via the JEMALLOC_CONF environment variable when the
+// process is started in the normal mode (i.e. neither --jemalloc_debug nor --check_mem_leak).
+// jemalloc reads JEMALLOC_CONF at process init before BE config parsing, so this config does not
+// reconfigure jemalloc at runtime; it is exported by bin/start_backend.sh and surfaced here purely
+// for observability via information_schema.be_configs. It is ignored under the jemalloc_debug and
+// check_mem_leak modes, which force their own JEMALLOC_CONF.
+// NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
+CONF_String(jemalloc_conf,
+            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
+            "background_thread:true,prof:true,prof_active:false");
+
 // Whether abort the process if a large memory allocation is detected which the requested
 // size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC
 CONF_mBool(abort_on_large_memory_allocation, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -115,7 +115,7 @@ CONF_String(mem_limit, "90%");
 CONF_Bool(enable_jemalloc_memory_tracker, "true");
 
 // The jemalloc runtime options applied via the JEMALLOC_CONF environment variable when the
-// process is started in the normal mode (i.e. neither --jemalloc_debug nor --check_mem_leak).
+// process is started in the normal mode (i.e. neither --jemalloc_debug nor --check_mem_leak) and JEMALLOC_CONF is not already set.
 // jemalloc reads JEMALLOC_CONF at process init before BE config parsing, so this config does not
 // reconfigure jemalloc at runtime; it is exported by bin/start_backend.sh and surfaced here purely
 // for observability via information_schema.be_configs. It is ignored under the jemalloc_debug and

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -162,7 +162,16 @@ if [[ -z "$JEMALLOC_CONF" ]]; then
     elif [ ${RUN_CHECK_MEM_LEAK} -eq 1 ] ; then
         export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:true,prof_leak:true,lg_prof_sample:0,prof_final:true"
     else
-        export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
+        # Normal mode: take the value from the `jemalloc_conf` config in be.conf/cn.conf so it is
+        # observable via information_schema.be_configs. Fall back to the built-in default when unset.
+        # NOTE: keep this default in sync with CONF_String(jemalloc_conf, ...) in be/src/common/config.h.
+        jemalloc_conf="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
+        if [ ${RUN_BE} -eq 1 ]; then
+            read_var_from_conf jemalloc_conf $STARROCKS_HOME/conf/be.conf
+        elif [ ${RUN_CN} -eq 1 ]; then
+            read_var_from_conf jemalloc_conf $STARROCKS_HOME/conf/cn.conf
+        fi
+        export JEMALLOC_CONF="$jemalloc_conf"
     fi
 fi
 


### PR DESCRIPTION
## Why I'm doing this:

The jemalloc runtime options used by BE/CN are currently set only as the `JEMALLOC_CONF` environment variable inside `bin/start_backend.sh`. Because `information_schema.be_configs` is populated purely from `config::list_configs()` (i.e. items declared in `be/src/common/config.h`), this value is invisible there — there is no way to confirm via SQL which jemalloc options a running BE/CN was started with.

## What I'm doing:

- Add a new BE config `jemalloc_conf` (`CONF_String`, immutable) in `be/src/common/config.h`, defaulting to the normal-mode jemalloc option string. This makes the value queryable through `information_schema.be_configs`.
- In `bin/start_backend.sh`, the normal startup path (neither `--jemalloc_debug` nor `--check_mem_leak`) now reads `jemalloc_conf` from `be.conf`/`cn.conf` and exports it as `JEMALLOC_CONF`, falling back to the built-in default when unset. The `--jemalloc_debug` and `--check_mem_leak` modes keep forcing their own `JEMALLOC_CONF` values and ignore the config, as before.

**Note:** jemalloc reads `JEMALLOC_CONF` during process init, before BE config parsing, so this config does not reconfigure jemalloc at runtime — it serves as the single source of truth for the startup script and for observability. The script default and the `config.h` default are kept in sync (commented in both places).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
