### PR TITLE
[Enhancement] Enable tablet pre-split for column-list INSERTs that keep all sort keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * INSERT-from-FILES pre-split source. Matches only the strict bare
@@ -106,19 +107,39 @@ final class FilesPreSplitSource implements InsertPreSplitSource {
         if (insertStmt.isColumnMatchByName()) {
             return true;
         }
-        List<Column> targetColumns = targetTable.getBaseSchemaWithoutGeneratedColumn();
+        // The effective target columns are the explicit column list when present
+        // (a partial list omits non-key columns, which are defaulted), otherwise
+        // the full base schema. The load writes FILES column N into effective
+        // target column N by position; requiring name equality at every ordinal
+        // makes the sampler's by-name read of a sort-key column resolve to the
+        // same FILES column the load writes into that key.
+        List<String> targetColumnNames = effectiveTargetColumnNames(insertStmt, targetTable);
         List<Column> sourceColumns = sourceTable.getFullSchema();
-        if (targetColumns.size() != sourceColumns.size()) {
+        if (targetColumnNames.size() != sourceColumns.size()) {
             return false;
         }
-        for (int ordinal = 0; ordinal < targetColumns.size(); ordinal++) {
-            String targetName = targetColumns.get(ordinal).getName();
+        for (int ordinal = 0; ordinal < targetColumnNames.size(); ordinal++) {
+            String targetName = targetColumnNames.get(ordinal);
             String sourceName = sourceColumns.get(ordinal).getName();
             if (!targetName.equalsIgnoreCase(sourceName)) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Target column names in INSERT (by-position) order: the explicit target
+     * column list when present, otherwise the base (non-generated) schema names.
+     */
+    private static List<String> effectiveTargetColumnNames(InsertStmt insertStmt, OlapTable targetTable) {
+        List<String> targetColumnNames = insertStmt.getTargetColumnNames();
+        if (targetColumnNames != null && !targetColumnNames.isEmpty()) {
+            return targetColumnNames;
+        }
+        return targetTable.getBaseSchemaWithoutGeneratedColumn().stream()
+                .map(Column::getName)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -38,7 +39,9 @@ import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Single {@code StmtExecutor} &rarr; {@link PreSplitFlow} bridge for Sample-Based
@@ -109,6 +112,10 @@ public final class InsertPreSplitHook {
         if (resolvedTable == null) {
             return;
         }
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(resolvedTable.olapTable());
+        if (!targetColumnListIsPreSplitSafe(insertStmt, resolvedTable.olapTable(), sortKeyColumns)) {
+            return;
+        }
         authorizeTargetSideEffects(resolvedTable, context);
 
         PreSplitFlow.Prepared prepared = source.prepare(
@@ -121,9 +128,10 @@ public final class InsertPreSplitHook {
     }
 
     private static boolean passesCommonPreFilters(InsertStmt insertStmt, ConnectContext context) {
-        if (insertStmt.getTargetColumnNames() != null) {
-            return false;
-        }
+        // An explicit target column list is validated after target resolution:
+        // the source-agnostic targetColumnListIsPreSplitSafe gate plus each
+        // source's own column/source alignment in prepare(). The sort-key columns
+        // and table schema are not available this early.
         if (insertStmt.isExplain() && !ExplainLevel.ANALYZE.equals(insertStmt.getExplainLevel())) {
             return false;
         }
@@ -138,6 +146,98 @@ public final class InsertPreSplitHook {
         }
         if (insertStmt.getProperties() != null && !insertStmt.getProperties().isEmpty()) {
             return false;
+        }
+        return true;
+    }
+
+    /**
+     * Whether an explicit target column list is safe to pre-split on. Returns true
+     * for a bare INSERT (null/empty list). For an explicit list every check below
+     * must hold, otherwise pre-split is skipped so it never mutates tablet metadata
+     * for a statement the analyzer would reject or that would split degenerately:
+     *
+     * <ul>
+     *   <li>no duplicate names, and every listed name is a real base
+     *       (non-generated) column — rejects the unknown/duplicate/generated lists
+     *       that {@code InsertAnalyzer} fails later;</li>
+     *   <li>every base column omitted from the list is fillable without an explicit
+     *       value (has a default, is nullable, auto-increment, or generated) —
+     *       mirrors InsertAnalyzer's "must be explicitly mentioned" rule, so a list
+     *       missing a required column is skipped rather than resharded;</li>
+     *   <li>every range-distribution (sort) key column is present — an omitted key
+     *       is defaulted for every row, collapsing the data on that key and making
+     *       split boundaries degenerate.</li>
+     * </ul>
+     *
+     * <p>Source-specific column/source alignment is still checked later in each
+     * {@link InsertPreSplitSource#prepare}.
+     *
+     * <p>Package-private (not private) so the unit test can drive it directly
+     * without mocking the full eligibility chain that precedes it.
+     */
+    static boolean targetColumnListIsPreSplitSafe(
+            InsertStmt insertStmt, OlapTable target, List<Column> sortKeyColumns) {
+        List<String> targetColumnNames = insertStmt.getTargetColumnNames();
+        if (targetColumnNames == null || targetColumnNames.isEmpty()) {
+            return true;
+        }
+        Set<String> listed = new HashSet<>();
+        for (String name : targetColumnNames) {
+            if (!listed.add(name.toLowerCase())) {
+                return false;   // duplicate target column
+            }
+        }
+        Set<String> baseNonGenerated = new HashSet<>();
+        for (Column column : target.getBaseSchemaWithoutGeneratedColumn()) {
+            baseNonGenerated.add(column.getName().toLowerCase());
+        }
+        if (!baseNonGenerated.containsAll(listed)) {
+            return false;   // unknown column, or a generated column, named in the list
+        }
+        // Mirror InsertAnalyzer: a column must be mentioned when it has no default,
+        // is not nullable, and is neither auto-increment nor generated.
+        for (Column column : target.getBaseSchema()) {
+            if (column.getDefaultValueType() == Column.DefaultValueType.NULL
+                    && !column.isAllowNull()
+                    && !column.isAutoIncrement()
+                    && !column.isGeneratedColumn()
+                    && !listed.contains(column.getName().toLowerCase())) {
+                return false;   // a required column is missing from the list
+            }
+        }
+        for (Column sortKey : sortKeyColumns) {
+            if (!listed.contains(sortKey.getName().toLowerCase())) {
+                return false;   // a sort-key column is missing -> degenerate split
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether the target column list names every base (non-generated) column
+     * exactly once, in schema order — i.e. it is semantically identical to
+     * omitting the list. Used by the INSERT-from-table source, whose column
+     * mapping assumes the full base schema in order; partial / reordered lists
+     * are not yet supported there.
+     *
+     * <p>Returns true when there is no target column list or when the list is a
+     * full, in-order identity list.
+     *
+     * <p>Package-private (not private) so the unit test can drive it directly.
+     */
+    static boolean targetColumnListIsFullIdentity(InsertStmt insertStmt, OlapTable target) {
+        List<String> targetColumnNames = insertStmt.getTargetColumnNames();
+        if (targetColumnNames == null || targetColumnNames.isEmpty()) {
+            return true;
+        }
+        List<Column> baseColumns = target.getBaseSchemaWithoutGeneratedColumn();
+        if (targetColumnNames.size() != baseColumns.size()) {
+            return false;
+        }
+        for (int i = 0; i < baseColumns.size(); i++) {
+            if (!targetColumnNames.get(i).equalsIgnoreCase(baseColumns.get(i).getName())) {
+                return false;
+            }
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
@@ -75,6 +75,13 @@ final class TablePreSplitSource implements InsertPreSplitSource {
     public PreSplitFlow.Prepared prepare(InsertStmt insertStmt, SelectRelation selectRelation,
                                          OlapTable target, Database database, ConnectContext context)
             throws AccessDeniedException {
+        // The INSERT-from-table column mapping (InsertSelectSourceColumns) assumes
+        // the load writes the full base schema in order, so a partial / reordered
+        // target column list is not yet supported on this path (the common gate
+        // only guarantees all sort keys are present, which is weaker).
+        if (!InsertPreSplitHook.targetColumnListIsFullIdentity(insertStmt, target)) {
+            return null;
+        }
         TableRelation sourceRelation = (TableRelation) selectRelation.getRelation();
         ResolvedSource resolvedSource = resolveSourceTable(sourceRelation, context);
         if (resolvedSource == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookColumnListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookColumnListTest.java
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.ast.InsertStmt;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the two target-column-list gates in {@link InsertPreSplitHook}:
+ * <ul>
+ *   <li>{@code targetColumnListIsPreSplitSafe} — the source-agnostic gate: an
+ *       explicit list must be a valid INSERT permutation (no unknown/duplicate/
+ *       generated names, every required column present) and contain every sort
+ *       key, otherwise pre-split is skipped.</li>
+ *   <li>{@code targetColumnListIsFullIdentity} — the stricter gate used by the
+ *       INSERT-from-table source: the list must be the full base schema in order.</li>
+ * </ul>
+ */
+public class InsertPreSplitHookColumnListTest {
+
+    private static List<Column> requiredColumns(String... names) {
+        // PresplitTestSupport.bigintColumn is NOT NULL with no default => required.
+        return Arrays.stream(names).map(PresplitTestSupport::bigintColumn).collect(Collectors.toList());
+    }
+
+    private static OlapTable tableWithBaseColumns(String... names) {
+        return tableWithSchema(requiredColumns(names));
+    }
+
+    private static OlapTable tableWithSchema(List<Column> baseColumns) {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseSchema()).thenReturn(baseColumns);
+        when(table.getBaseSchemaWithoutGeneratedColumn()).thenReturn(baseColumns);
+        return table;
+    }
+
+    private static InsertStmt insertWithTargetColumns(List<String> targetColumnNames) {
+        InsertStmt stmt = mock(InsertStmt.class);
+        when(stmt.getTargetColumnNames()).thenReturn(targetColumnNames);
+        return stmt;
+    }
+
+    // ---- targetColumnListIsPreSplitSafe (source-agnostic gate) ----
+
+    @Test
+    public void noColumnListIsSafe() {
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(null), tableWithBaseColumns("k", "v"), requiredColumns("k")));
+    }
+
+    @Test
+    public void emptyColumnListIsSafe() {
+        // A mocked InsertStmt yields an empty (not null) list; treat it like a bare INSERT.
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of()), tableWithBaseColumns("k", "v"), requiredColumns("k")));
+    }
+
+    @Test
+    public void fullValidListWithAllSortKeysIsSafe() {
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("k", "v")), tableWithBaseColumns("k", "v"), requiredColumns("k")));
+    }
+
+    @Test
+    public void partialListOmittingOnlyNullableNonKeyIsSafe() {
+        // base: k (required, sort key), v (nullable). Omitting v is allowed.
+        List<Column> base = List.of(PresplitTestSupport.bigintColumn("k"),
+                PresplitTestSupport.nullableBigintColumn("v"));
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("k")), tableWithSchema(base), requiredColumns("k")));
+    }
+
+    @Test
+    public void partialListMissingRequiredColumnIsUnsafe() {
+        // base: k (sort key), v (required, no default, not null). Omitting v would be
+        // rejected by InsertAnalyzer, so pre-split must skip rather than reshard.
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("k")), tableWithBaseColumns("k", "v"), requiredColumns("k")));
+    }
+
+    @Test
+    public void listMissingASortKeyIsUnsafe() {
+        // base: k (nullable, sort key), v (nullable). The list covers required columns
+        // (none) but omits the sort key k -> degenerate split.
+        List<Column> base = List.of(PresplitTestSupport.nullableBigintColumn("k"),
+                PresplitTestSupport.nullableBigintColumn("v"));
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("v")), tableWithSchema(base),
+                List.of(PresplitTestSupport.nullableBigintColumn("k"))));
+    }
+
+    @Test
+    public void unknownColumnInListIsUnsafe() {
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("k", "typo")), tableWithBaseColumns("k"), requiredColumns("k")));
+    }
+
+    @Test
+    public void duplicateColumnInListIsUnsafe() {
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("k", "k")), tableWithBaseColumns("k"), requiredColumns("k")));
+    }
+
+    @Test
+    public void sortKeyMatchIsCaseInsensitive() {
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                insertWithTargetColumns(List.of("K", "V")), tableWithBaseColumns("k", "v"), requiredColumns("k")));
+    }
+
+    // ---- targetColumnListIsFullIdentity (INSERT-from-table gate) ----
+
+    @Test
+    public void noColumnListIsFullIdentity() {
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsFullIdentity(
+                insertWithTargetColumns(null), tableWithBaseColumns("a", "b", "c")));
+    }
+
+    @Test
+    public void fullInOrderListIsIdentity() {
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsFullIdentity(
+                insertWithTargetColumns(List.of("a", "b", "c")), tableWithBaseColumns("a", "b", "c")));
+    }
+
+    @Test
+    public void identityIsCaseInsensitive() {
+        Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsFullIdentity(
+                insertWithTargetColumns(List.of("A", "B", "C")), tableWithBaseColumns("a", "b", "c")));
+    }
+
+    @Test
+    public void reorderedListIsNotIdentity() {
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsFullIdentity(
+                insertWithTargetColumns(List.of("a", "c", "b")), tableWithBaseColumns("a", "b", "c")));
+    }
+
+    @Test
+    public void partialListIsNotIdentity() {
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsFullIdentity(
+                insertWithTargetColumns(List.of("a", "b")), tableWithBaseColumns("a", "b", "c")));
+    }
+
+    @Test
+    public void supersetListIsNotIdentity() {
+        Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsFullIdentity(
+                insertWithTargetColumns(List.of("a", "b", "c", "d")), tableWithBaseColumns("a", "b", "c")));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
@@ -356,19 +356,6 @@ public class InsertPreSplitHookFilesTest {
     }
 
     @Test
-    public void testTargetColumnListShortCircuits() throws Exception {
-        // INSERT INTO t (a, b) SELECT * FROM FILES(...) — the explicit column
-        // list reorders/subsets the target's columns; the sampler reads source
-        // columns matching the target's sort-key names, so the sampled column
-        // would mismatch what the load writes.
-        InsertStmt stmt = simpleFilesInsertStmt();
-        when(stmt.getTargetColumnNames()).thenReturn(List.of("a", "b"));
-
-        assertHookDoesNotDelegate(() ->
-                InsertPreSplitHook.maybeRunPreSplit(stmt, mockConnectContextWithSessionPreSplit(true)));
-    }
-
-    @Test
     public void testExpressionProjectionShortCircuits() throws Exception {
         // INSERT INTO t SELECT col + 1 FROM FILES(...) — expression projection
         // changes the inserted values; the sampler reads source columns
@@ -570,6 +557,33 @@ public class InsertPreSplitHookFilesTest {
         TableFunctionTable source = tableFunctionTableWithColumns("v", "k");
 
         assertTrue(FilesPreSplitSource.schemasAlignForByPositionInsert(stmt, target, source));
+    }
+
+    @Test
+    public void testSchemasAlignWithPartialColumnListMatchingFiles() {
+        // INSERT INTO t (k) SELECT * FROM FILES(...): target is (k, v) but the parquet
+        // has only column k. The effective target columns are the list (k), which
+        // aligns by position-name with the FILES schema (k).
+        InsertStmt stmt = byPositionInsertStmt();
+        when(stmt.getTargetColumnNames()).thenReturn(List.of("k"));
+        OlapTable target = olapTableWithColumns("k", "v");
+        TableFunctionTable source = tableFunctionTableWithColumns("k");
+
+        assertTrue(FilesPreSplitSource.schemasAlignForByPositionInsert(stmt, target, source));
+    }
+
+    @Test
+    public void testSchemasMisalignedWhenColumnListOrderDiffersFromFiles() {
+        // INSERT INTO t (v, k) SELECT * FROM FILES(k, v): by position the load writes
+        // FILES column k into target v and FILES column v into target k, so the
+        // effective target names (v, k) disagree with the FILES names (k, v) at every
+        // ordinal — the by-name sampler would read the wrong column.
+        InsertStmt stmt = byPositionInsertStmt();
+        when(stmt.getTargetColumnNames()).thenReturn(List.of("v", "k"));
+        OlapTable target = olapTableWithColumns("k", "v");
+        TableFunctionTable source = tableFunctionTableWithColumns("k", "v");
+
+        assertFalse(FilesPreSplitSource.schemasAlignForByPositionInsert(stmt, target, source));
     }
 
     private static InsertStmt byPositionInsertStmt() {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -252,15 +252,6 @@ public class InsertPreSplitHookTableTest {
     }
 
     @Test
-    public void testTargetColumnListShortCircuits() throws Exception {
-        InsertStmt stmt = simpleTableInsertStmt();
-        when(stmt.getTargetColumnNames()).thenReturn(List.of("a", "b"));
-
-        assertHookDoesNotDelegate(() ->
-                InsertPreSplitHook.maybeRunPreSplit(stmt, mockConnectContextWithSessionPreSplit(true)));
-    }
-
-    @Test
     public void testExpressionProjectionShortCircuits() throws Exception {
         // INSERT INTO t SELECT col + 1 FROM src — a non-SlotRef expression item.
         SelectListItem exprItem = mock(SelectListItem.class);


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split silently skips any INSERT that specifies a target column list. `InsertPreSplitHook.passesCommonPreFilters` returns false when `getTargetColumnNames() != null`, so the extremely common shape

```sql
INSERT INTO t (c1, c2, ...) SELECT * FROM FILES(...)
```

never pre-splits — the entire load lands in the single initial range tablet, losing the parallelism pre-split exists to provide. This is a quiet footgun: the same statement without the column list pre-splits fine, and nothing tells the user why one is slow.

## What I'm doing:

Allow a target column list as long as it keeps pre-split well-defined:

- **Source-agnostic gate** (`targetColumnListIncludesAllSortKeys`): the list must name every range-distribution (sort) key column. An omitted key column is written with its default for every row, collapsing the data on that key and making split boundaries degenerate. Non-key columns may be omitted.
- **INSERT-from-FILES**: `schemasAlignForByPositionInsert` is generalized to align the FILES schema against the *effective* target columns (the explicit list when present, else the base schema). With all sort keys present and aligned, the by-name sampler reads exactly the FILES column the by-position load writes into each key — so a full **or partial-but-key-complete** list is correct.
- **INSERT-from-table**: its column mapping (`InsertSelectSourceColumns`) still assumes the full base schema in order, so that path accepts only a full, in-order identity list (`targetColumnListIsFullIdentity`) for now; partial/reordered lists are skipped there (a follow-up can generalize the table mapping).

The blanket `getTargetColumnNames()` reject moves out of `passesCommonPreFilters` (which runs before target resolution) into a resolution-time gate, where the sort-key columns are available.

Tests: the two gates are unit-tested directly (`InsertPreSplitHookColumnListTest`), plus FILES partial-list alignment cases in `InsertPreSplitHookFilesTest`. The two obsolete `testTargetColumnListShortCircuits` cases (premise: any column list skips) are removed.

> Local FE unit tests are not runnable in my environment; relying on CI to execute the added tests.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5