### PR TITLE
[Refactor] Remove obsolete config-name prefix compatibility in BE config parsing

### DIFF
--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <regex>
 #include <set>
 #include <string>
 
@@ -125,7 +124,6 @@ inline bool parse_key_value_pairs(std::istream& input) {
     std::string line;
     std::string key;
     std::string value;
-    std::regex doris_start("^doris_");
     line.reserve(512);
     std::set<Field*> assigned_fields;
     while (input) {
@@ -144,9 +142,6 @@ inline bool parse_key_value_pairs(std::istream& input) {
         std::pair<std::string, std::string> kv = strings::Split(line, strings::delimiter::Limit("=", 1));
         StripWhiteSpace(&kv.first);
 
-        // compatible with doris_config
-        kv.first = std::regex_replace(kv.first, doris_start, "");
-
         auto op_field = Field::get(kv.first);
         if (!op_field.has_value()) {
             // A valid env var name should be: [A-Z_][A-Z0-9_]*
@@ -158,7 +153,7 @@ inline bool parse_key_value_pairs(std::istream& input) {
             continue;
         }
         auto field = op_field.value();
-        if (assigned_fields.count(field) > 0) {
+        if (assigned_fields.contains(field)) {
             std::cerr << fmt::format("Duplicate assignment to config '{}', previous assignment will be ignored\n",
                                      field->name());
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

It's introduced in this pr: https://github.com/StarRocks/starrocks/pull/8406

The BE config parser (`parse_key_value_pairs`) carried legacy compatibility logic that stripped an obsolete name prefix from every config key before looking it up. The configs that relied on this prefix were renamed many versions ago and no longer exist in `config.h`, so the special-casing is dead code that adds a regex compile and a per-line `regex_replace` to config loading for no benefit.

This PR removes the obsolete prefix-stripping logic so the parser looks up each key by its real name directly. It also drops the now-unused `<regex>` include.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
