### PR TITLE
[BugFix] Avoid BE abort on CAST(json/variant AS struct) with a non-path field name

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1843,6 +1843,18 @@ Expr* VectorizedCastExprFactory::create_json_to_complex_type_cast(ObjectPool* po
     case TYPE_STRUCT: {
         TypeDescriptor cast_to = TypeDescriptor::from_thrift(node.type);
 
+        // Validate that every struct field name is a parseable JSON path before constructing
+        // CastJsonToStruct, whose ctor would otherwise throw an uncaught std::runtime_error.
+        // The throw propagates out of create_expr_tree (no try/catch on that path) and aborts
+        // the BE at fragment prepare. Returning nullptr surfaces a clean Status::NotSupported.
+        for (const auto& field_name : cast_to.field_names) {
+            std::string path_string = "$." + field_name;
+            if (!JsonPath::parse(Slice(path_string)).ok()) {
+                LOG(WARNING) << "Cannot cast json to struct: field name is not a valid JSON path: " << field_name;
+                return nullptr;
+            }
+        }
+
         std::vector<Expr*> field_casts(cast_to.children.size());
         for (int i = 0; i < cast_to.children.size(); ++i) {
             TypeDescriptor json_type = TypeDescriptor::create_json_type();
@@ -1976,6 +1988,18 @@ Expr* VectorizedCastExprFactory::create_variant_to_complex_type_cast(ObjectPool*
     }
     case TYPE_STRUCT: {
         TypeDescriptor expected_type = TypeDescriptor::from_thrift(node.type);
+
+        // Validate that every struct field name is a parseable variant path before constructing
+        // CastVariantToStruct, whose ctor would otherwise throw an uncaught std::runtime_error
+        // that propagates out of create_expr_tree and aborts the BE at fragment prepare.
+        // Returning nullptr surfaces a clean Status::NotSupported instead.
+        for (const auto& field_name : expected_type.field_names) {
+            std::string path_string = "$." + field_name;
+            if (!VariantPathParser::parse(Slice(path_string)).ok()) {
+                LOG(WARNING) << "Cannot cast variant to struct: field name is not a valid variant path: " << field_name;
+                return nullptr;
+            }
+        }
 
         std::vector<Expr*> field_casts(expected_type.children.size());
         for (int i = 0; i < expected_type.children.size(); ++i) {

--- a/test/sql/test_cast/R/test_cast_json_to_struct
+++ b/test/sql/test_cast/R/test_cast_json_to_struct
@@ -47,3 +47,11 @@ select cast(PARSE_JSON('[{"star" : "rocks", "length": 5, "numbers": [1, 4, 7], "
 -- result:
 [{"star":"rocks","length":5,"numbers":[1,4,7],"nest":{"col1":1,"col2":2,"col3":3}},{"star":"rockses","length":33,"numbers":[2,5,9],"nest":{"col1":3,"col2":6,"col3":9}}]
 -- !result
+select cast(PARSE_JSON('{"x":1}') as struct<`a[` int>);
+-- result:
+[REGEX].*Not support cast JSON to STRUCT.*
+-- !result
+select cast(PARSE_JSON('{"a.b":7}') as struct<`a.b` int>);
+-- result:
+{"a.b":null}
+-- !result

--- a/test/sql/test_cast/T/test_cast_json_to_struct
+++ b/test/sql/test_cast/T/test_cast_json_to_struct
@@ -12,3 +12,5 @@ select cast(PARSE_JSON('{"star": "rocks", "number": [1, 2, 3]}') as struct<numbe
 select cast(PARSE_JSON('[1, [{"star": "rocks"}, {"star": "rocks"}]]') as struct<col1 int, col2 array<json>>);
 select cast(PARSE_JSON('{"star" : "rocks", "length": 5, "numbers": [1, 4, 7], "nest": [1, 2, 3]}') as struct<star varchar(10), length int, numbers array<int>, nest struct<col1 int, col2 int, col3 int>>);
 select cast(PARSE_JSON('[{"star" : "rocks", "length": 5, "numbers": [1, 4, 7], "nest": [1, 2, 3]}, {"star" : "rockses", "length": 33, "numbers": [2, 5, 9], "nest": [3, 6, 9]}]') as array<struct<star varchar(10), length int, numbers array<int>, nest struct<col1 int, col2 int, col3 int>>>);
+select cast(PARSE_JSON('{"x":1}') as struct<`a[` int>);
+select cast(PARSE_JSON('{"a.b":7}') as struct<`a.b` int>);


### PR DESCRIPTION
## Why I'm doing:

CastJsonToStruct / CastVariantToStruct ctors parse each struct field name as a JSON/variant path and throw std::runtime_error on failure. The throw escapes VectorizedCastExprFactory::from_thrift -> create_expr_tree (no try/catch) and aborts the BE at fragment prepare. Pre-validate the field-name paths in the json/variant->struct factory branches and return nullptr (clean Status::NotSupported) instead of constructing the throwing expr.

Add a regression case to test_cast_json_to_struct: a struct field name that is not a parseable JSON path (e.g. an unterminated '[') now returns a clean error instead of crashing the BE, while a field name that is a valid quoted path tail ('a.b') still returns null.

## What I'm doing:

Fixes #issue

```
*** SIGABRT (@0x22fd4) received by PID 143316 (TID 0x7efb86399640) LWP(143823) from PID 143316; stack trace: ***
    @         0x31e5dd87 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7efd8a367ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x31e5d586 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7efd8a310520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7efd8a3649fc pthread_kill
    @     0x7efd8a310476 raise
    @     0x7efd8a2f67f3 abort
    @         0x3aa482b0 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @         0x3aa46a3a __cxxabiv1::__terminate(void (*)())
    @         0x3aa46aa1 std::terminate()
    @     0x7efd8a14e4d8 __cxa_throw
    @         0x3ab2759e __wrap___cxa_throw
    @         0x2a889eb0 starrocks::CastJsonToStruct::CastJsonToStruct(starrocks::TExprNode const&, std::vector<starrocks::Expr*, std::allocator<starrocks::Expr*> >)
    @         0x2a82d315 starrocks::VectorizedCastExprFactory::create_json_to_complex_type_cast(starrocks::ObjectPool*, starrocks::TExprNode const&, starrocks::LogicalType, starrocks::LogicalType, bool)
    @         0x2a830a57 starrocks::VectorizedCastExprFactory::create_primitive_cast(starrocks::ObjectPool*, starrocks::TExprNode const&, starrocks::LogicalType, starrocks::LogicalType, bool)
    @         0x2a8454a9 starrocks::VectorizedCastExprFactory::create_cast_expr(starrocks::ObjectPool*, starrocks::TExprNode const&, starrocks::TypeDescriptor const&, starrocks::TypeDescriptor const&, bool)
    @         0x2a846081 starrocks::VectorizedCastExprFactory::from_thrift(starrocks::ObjectPool*, starrocks::TExprNode const&, bool)
    @         0x2c2b9135 starrocks::(anonymous namespace)::create_vectorized_expr(starrocks::ObjectPool*, starrocks::TExprNode const&, starrocks::Expr**, starrocks::RuntimeState*)
    @         0x2c2bb0dc starrocks::(anonymous namespace)::create_tree_from_thrift(starrocks::ObjectPool*, std::vector<starrocks::TExprNode, std::allocator<starrocks::TExprNode> > const&, starrocks::Expr*, int*, starrocks::Expr**, starrocks::RuntimeState*)
    @         0x2c2bbd11 starrocks::(anonymous namespace)::create_tree_from_thrift_with_jit(starrocks::ObjectPool*, std::vector<starrocks::TExprNode, std::allocator<starrocks::TExprNode> > const&, int*, starrocks::Expr**, starrocks::RuntimeState*)
    @         0x2c2bcaa6 starrocks::ExprFactory::create_expr_from_thrift_nodes(starrocks::ObjectPool*, std::vector<starrocks::TExprNode, std::allocator<starrocks::TExprNode> > const&, int*, starrocks::Expr**, starrocks::RuntimeState*, bool)
    @         0x2c2bc2a5 starrocks::ExprFactory::create_expr_tree(starrocks::ObjectPool*, starrocks::TExpr const&, starrocks::Expr**, starrocks::RuntimeState*, bool)
    @         0x2c2bcbef starrocks::ExprFactory::create_expr_tre
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
