### PR TITLE
[UT] Add @native tag to dict mapping and GIN index test cases

### DIFF
--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -1,4 +1,4 @@
--- name: test_dict_mapping_streamload
+-- name: test_dict_mapping_streamload @native
 CREATE DATABASE test_dict_mapping_streamload;
 -- result:
 -- !result
@@ -59,7 +59,7 @@ DROP TABLE t_dict_mapping_streamload;
 DROP DATABASE test_dict_mapping_streamload;
 -- result:
 -- !result
--- name: test_dictmapping_multiple_column
+-- name: test_dictmapping_multiple_column @native
 CREATE DATABASE test_dictmapping_multiple_column;
 -- result:
 -- !result
@@ -95,7 +95,7 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 DROP DATABASE test_dictmapping_multiple_column;
 -- result:
 -- !result
--- name: test_dictmapping_null_column
+-- name: test_dictmapping_null_column @native
 CREATE DATABASE test_dictmapping_null_column;
 -- result:
 -- !result
@@ -131,7 +131,7 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 DROP DATABASE test_dictmapping_null_column;
 -- result:
 -- !result
--- name: test_dictmapping_DictQueryOperator_bug
+-- name: test_dictmapping_DictQueryOperator_bug @native
 CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
 -- result:
 -- !result
@@ -192,7 +192,7 @@ insert into fact_tbl_2
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;
 -- result:
 -- !result
--- name: test_dictmapping_add_generated_column_with_dict_mapping
+-- name: test_dictmapping_add_generated_column_with_dict_mapping @native
 CREATE DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
 -- result:
 -- !result
@@ -239,7 +239,7 @@ DROP TABLE t_dictmapping_add_generated_column_with_dict_mapping;
 DROP DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
 -- result:
 -- !result
--- name: test_dictmapping_generated_column_in_create_table
+-- name: test_dictmapping_generated_column_in_create_table @native
 CREATE DATABASE test_dictmapping_generated_column_in_create_table;
 -- result:
 -- !result
@@ -264,7 +264,7 @@ E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not exist.
 DROP DATABASE test_dictmapping_generated_column_in_create_table;
 -- result:
 -- !result
--- name: test_dictmapping_null_if_not_found
+-- name: test_dictmapping_null_if_not_found @native
 CREATE DATABASE test_dictmapping_null_if_not_found;
 -- result:
 -- !result
@@ -307,7 +307,7 @@ drop table t_dictmapping_null_if_not_found;
 drop database test_dictmapping_null_if_not_found;
 -- result:
 -- !result
--- name: test_dictmapping_multiple_open_crash
+-- name: test_dictmapping_multiple_open_crash @native
 CREATE TABLE `t_dictmapping_multiple_open_crash` (
   `k` BIGINT NOT NULL COMMENT "",
   `v` BIGINT AUTO_INCREMENT

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -1,4 +1,4 @@
--- name: test_dict_mapping_streamload
+-- name: test_dict_mapping_streamload @native
 CREATE DATABASE test_dict_mapping_streamload;
 USE test_dict_mapping_streamload;
 CREATE TABLE `t_dict_mapping_streamload` (
@@ -36,7 +36,7 @@ SELECT * FROM test_table;
 DROP TABLE t_dict_mapping_streamload;
 DROP DATABASE test_dict_mapping_streamload;
 
--- name: test_dictmapping_multiple_column
+-- name: test_dictmapping_multiple_column @native
 CREATE DATABASE test_dictmapping_multiple_column;
 use test_dictmapping_multiple_column;
 create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
@@ -61,7 +61,7 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 
 DROP DATABASE test_dictmapping_multiple_column;
 
--- name: test_dictmapping_null_column
+-- name: test_dictmapping_null_column @native
 CREATE DATABASE test_dictmapping_null_column;
 use test_dictmapping_null_column;
 create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
@@ -86,7 +86,7 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 
 DROP DATABASE test_dictmapping_null_column;
 
--- name: test_dictmapping_DictQueryOperator_bug
+-- name: test_dictmapping_DictQueryOperator_bug @native
 CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
 USE test_dictmapping_DictQueryOperator_bug;
 create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
@@ -116,7 +116,7 @@ insert into fact_tbl_2
                 (3, 'Shanghai', Dict_Mapping("dict", 3, "col_4"));
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;
 
--- name: test_dictmapping_add_generated_column_with_dict_mapping
+-- name: test_dictmapping_add_generated_column_with_dict_mapping @native
 CREATE DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
 USE test_dictmapping_add_generated_column_with_dict_mapping;
 
@@ -145,7 +145,7 @@ SELECT * FROM t_dictmapping_add_generated_column_with_dict_mapping;
 DROP TABLE t_dictmapping_add_generated_column_with_dict_mapping;
 DROP DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
 
--- name: test_dictmapping_generated_column_in_create_table
+-- name: test_dictmapping_generated_column_in_create_table @native
 CREATE DATABASE test_dictmapping_generated_column_in_create_table;
 USE test_dictmapping_generated_column_in_create_table;
 
@@ -163,7 +163,7 @@ PROPERTIES (
 
 DROP DATABASE test_dictmapping_generated_column_in_create_table;
 
--- name: test_dictmapping_null_if_not_found
+-- name: test_dictmapping_null_if_not_found @native
 CREATE DATABASE test_dictmapping_null_if_not_found;
 USE test_dictmapping_null_if_not_found;
 
@@ -190,7 +190,7 @@ select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
 drop table t_dictmapping_null_if_not_found;
 drop database test_dictmapping_null_if_not_found;
 
--- name: test_dictmapping_multiple_open_crash
+-- name: test_dictmapping_multiple_open_crash @native
 CREATE TABLE `t_dictmapping_multiple_open_crash` (
   `k` BIGINT NOT NULL COMMENT "",
   `v` BIGINT AUTO_INCREMENT

--- a/test/sql/test_index/R/test_gin_index
+++ b/test/sql/test_index/R/test_gin_index
@@ -1,4 +1,4 @@
--- name: test_gin_index_table
+-- name: test_gin_index_table @native
 create database test_gin_index;
 -- result:
 -- !result

--- a/test/sql/test_index/T/test_gin_index
+++ b/test/sql/test_index/T/test_gin_index
@@ -1,4 +1,4 @@
--- name: test_gin_index_table
+-- name: test_gin_index_table @native
 create database test_gin_index;
 use  test_gin_index;
 

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1,4 +1,4 @@
--- name: test_basic_create_index @slow
+-- name: test_basic_create_index @slow @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -151,7 +151,7 @@ DROP TABLE t_test_basic_create_index_pk;
 DROP TABLE t_test_basic_create_index_dup;
 -- result:
 -- !result
--- name: test_query_gin_index
+-- name: test_query_gin_index @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -227,7 +227,7 @@ select count(*) from t_test_gin_index_query where query_english match_any "hello
 drop table t_test_gin_index_query;
 -- result:
 -- !result
--- name: test_gin_index_single_predicate_none
+-- name: test_gin_index_single_predicate_none @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -347,7 +347,7 @@ SELECT * FROM t_gin_index_single_predicate_none WHERE text_column match_any "ABC
 DROP TABLE t_gin_index_single_predicate_none;
 -- result:
 -- !result
--- name: test_gin_index_single_predicate_english
+-- name: test_gin_index_single_predicate_english @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -447,7 +447,7 @@ SELECT * FROM t_gin_index_single_predicate_english WHERE text_column LIKE "thi%"
 DROP TABLE t_gin_index_single_predicate_english;
 -- result:
 -- !result
--- name: test_gin_index_multiple_predicate_none
+-- name: test_gin_index_multiple_predicate_none @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -570,7 +570,7 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 DROP TABLE t_gin_index_multiple_predicate_none;
 -- result:
 -- !result
--- name: test_gin_index_multiple_predicate_english
+-- name: test_gin_index_multiple_predicate_english @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -633,7 +633,7 @@ SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column LIKE "%th
 DROP TABLE t_gin_index_multiple_predicate_english;
 -- result:
 -- !result
--- name: test_gin_index_compaction
+-- name: test_gin_index_compaction @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -803,7 +803,7 @@ DROP TABLE t_gin_index_compaction_english_base;
 DROP TABLE t_gin_index_compaction_english_cumu;
 -- result:
 -- !result
--- name: test_gin_index_type
+-- name: test_gin_index_type @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -922,7 +922,7 @@ PROPERTIES (
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type..')
 -- !result
--- name: test_clone_for_gin
+-- name: test_clone_for_gin @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -970,7 +970,7 @@ SELECT * FROM t_clone_for_gin ORDER BY id1;
 1	abc	abc	abc	abc
 2	ABC	ABC	ABC	ABC
 -- !result
--- name: test_complex_predicate_for_gin
+-- name: test_complex_predicate_for_gin @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1198,7 +1198,7 @@ DROP TABLE t_complex_predicate_for_gin_none;
 DROP TABLE t_complex_predicate_for_gin_english;
 -- result:
 -- !result
--- name: test_delete_and_column_prune
+-- name: test_delete_and_column_prune @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1237,7 +1237,7 @@ SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
 DROP TABLE t_delete_and_column_prune;
 -- result:
 -- !result
--- name: test_upper_case_column_name
+-- name: test_upper_case_column_name @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1293,7 +1293,7 @@ SELECT id1 FROM t_upper_case_column_name WHERE `text` MATCH_ANY "b";
 DROP TABLE t_upper_case_column_name;
 -- result:
 -- !result
--- name: test_alter_replicated_storage
+-- name: test_alter_replicated_storage @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1335,7 +1335,7 @@ PROPERTIES (
 DROP TABLE t_alter_replicated_storage;
 -- result:
 -- !result
--- name: test_disable_global_dict_rewrite
+-- name: test_disable_global_dict_rewrite @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1450,7 +1450,7 @@ SELECT id FROM t_disable_global_dict_rewrite WHERE v2 MATCH_ANY "abc" ORDER BY v
 DROP TABLE t_disable_global_dict_rewrite;
 -- result:
 -- !result
--- name: test_create_mv_with_match
+-- name: test_create_mv_with_match @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1490,7 +1490,7 @@ None
 DROP TABLE t_create_mv_with_match;
 -- result:
 -- !result
--- name: test_alter_gin_col_into_other_type
+-- name: test_alter_gin_col_into_other_type @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1547,7 +1547,7 @@ DROP TABLE t_alter_gin_col_into_other_type;
 -- result:
 -- !result
 
--- name: test_gin_match_empty
+-- name: test_gin_match_empty @native
 CREATE TABLE `t_gin_match_empty` (
   `k` BIGINT NOT NULL COMMENT "",
   `v1` string COMMENT "",
@@ -1597,7 +1597,7 @@ SELECT count(*) FROM t_gin_match_empty WHERE v3 MATCH_ANY "";
 DROP TABLE t_gin_match_empty;
 -- result:
 -- !result
--- name: test_gin_view
+-- name: test_gin_view @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -1731,7 +1731,7 @@ DROP VIEW test_view;
 DROP TABLE duplicate_table_demo_datatype_not_replicated_all_varchar;
 -- result:
 -- !result
--- name: test_vertical_compaction
+-- name: test_vertical_compaction @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -1,4 +1,4 @@
--- name: test_basic_create_index @slow
+-- name: test_basic_create_index @slow @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -85,7 +85,7 @@ show create table t_test_basic_create_index_replicated;
 DROP TABLE t_test_basic_create_index_pk;
 DROP TABLE t_test_basic_create_index_dup;
 
--- name: test_query_gin_index
+-- name: test_query_gin_index @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -131,7 +131,7 @@ select count(*) from t_test_gin_index_query where query_english match_any "hello
 
 drop table t_test_gin_index_query;
 
--- name: test_gin_index_single_predicate_none
+-- name: test_gin_index_single_predicate_none @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -176,7 +176,7 @@ SELECT * FROM t_gin_index_single_predicate_none WHERE text_column match_any "ABC
 
 DROP TABLE t_gin_index_single_predicate_none;
 
--- name: test_gin_index_single_predicate_english
+-- name: test_gin_index_single_predicate_english @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -219,7 +219,7 @@ SELECT * FROM t_gin_index_single_predicate_english WHERE text_column LIKE "thi%"
 
 DROP TABLE t_gin_index_single_predicate_english;
 
--- name: test_gin_index_multiple_predicate_none
+-- name: test_gin_index_multiple_predicate_none @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -263,7 +263,7 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 
 DROP TABLE t_gin_index_multiple_predicate_none;
 
--- name: test_gin_index_multiple_predicate_english
+-- name: test_gin_index_multiple_predicate_english @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -297,7 +297,7 @@ SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column LIKE "%th
 
 DROP TABLE t_gin_index_multiple_predicate_english;
 
--- name: test_gin_index_compaction
+-- name: test_gin_index_compaction @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -400,7 +400,7 @@ DROP TABLE t_gin_index_compaction_english_base;
 DROP TABLE t_gin_index_compaction_english_cumu;
 
 
--- name: test_gin_index_type
+-- name: test_gin_index_type @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -502,7 +502,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
--- name: test_clone_for_gin
+-- name: test_clone_for_gin @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -533,7 +533,7 @@ function: set_first_tablet_bad_and_recover("t_clone_for_gin")
 
 SELECT * FROM t_clone_for_gin ORDER BY id1;
 
--- name: test_complex_predicate_for_gin
+-- name: test_complex_predicate_for_gin @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -625,7 +625,7 @@ SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match_any NU
 DROP TABLE t_complex_predicate_for_gin_none;
 DROP TABLE t_complex_predicate_for_gin_english;
 
--- name: test_delete_and_column_prune
+-- name: test_delete_and_column_prune @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_delete_and_column_prune` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -648,7 +648,7 @@ SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
 
 DROP TABLE t_delete_and_column_prune;
 
--- name: test_upper_case_column_name
+-- name: test_upper_case_column_name @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
@@ -680,7 +680,7 @@ SELECT id1 FROM t_upper_case_column_name WHERE `text` MATCH_ANY "b";
 
 DROP TABLE t_upper_case_column_name;
 
--- name: test_alter_replicated_storage
+-- name: test_alter_replicated_storage @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_alter_replicated_storage` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -700,7 +700,7 @@ ALTER TABLE t_alter_replicated_storage SET ("replicated_storage" = "true");
 SHOW CREATE TABLE t_alter_replicated_storage;
 DROP TABLE t_alter_replicated_storage;
 
--- name: test_disable_global_dict_rewrite
+-- name: test_disable_global_dict_rewrite @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_disable_global_dict_rewrite` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -752,7 +752,7 @@ SELECT id FROM t_disable_global_dict_rewrite WHERE v2 MATCH_ANY "abc" ORDER BY v
 
 DROP TABLE t_disable_global_dict_rewrite;
 
--- name: test_create_mv_with_match
+-- name: test_create_mv_with_match @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_create_mv_with_match` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -776,7 +776,7 @@ CREATE MATERIALIZED VIEW mv1 AS SELECT id, v1, v2 FROM t_create_mv_with_match WH
 function: wait_materialized_view_cancel()
 DROP TABLE t_create_mv_with_match;
 
--- name: test_alter_gin_col_into_other_type
+-- name: test_alter_gin_col_into_other_type @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_alter_gin_col_into_other_type` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -801,7 +801,7 @@ SHOW CREATE TABLE t_alter_gin_col_into_other_type;
 SELECT * FROM t_alter_gin_col_into_other_type;
 DROP TABLE t_alter_gin_col_into_other_type;
 
--- name: test_gin_var @sequential
+-- name: test_gin_var @sequential @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -870,7 +870,7 @@ PROPERTIES (
 );
 DROP TABLE t_gin_var;
 
--- name: test_gin_match_empty
+-- name: test_gin_match_empty @native
 CREATE TABLE `t_gin_match_empty` (
   `k` BIGINT NOT NULL COMMENT "",
   `v1` string COMMENT "",
@@ -901,7 +901,7 @@ SELECT count(*) FROM t_gin_match_empty WHERE v3 MATCH_ANY "";
 
 DROP TABLE t_gin_match_empty;
 
--- name: test_gin_view
+-- name: test_gin_view @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_gin_view` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -952,7 +952,7 @@ select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 DROP VIEW test_view;
 DROP TABLE duplicate_table_demo_datatype_not_replicated_all_varchar;
 
--- name: test_vertical_compaction
+-- name: test_vertical_compaction @native
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_vertical_compaction` (
   `id1` bigint(20) NOT NULL COMMENT "",


### PR DESCRIPTION
Mark native-only SQL test cases with @native so they run in the native test environment instead of the default CI cluster.

## Why I'm doing:
These SQL test cases depend on features or behaviors that only exist in the shared-nothing (native) deployment mode. By default, sql-tester runs cases in both native and cloud (shared-data) modes, which causes these tests to run in cloud mode where they are not applicable or may fail. Adding the @native tag ensures they only run in the correct environment.

## What I'm doing:
Add the @native tag to native-only SQL test cases in the following test files:
test/sql/test_dict_mapping_function — all dict mapping test cases
test/sql/test_index/test_gin_index — GIN index table creation test
test/sql/test_inverted_index — GIN/inverted index related test cases (including those with existing tags like @slow and @sequential)
Both T (test input) and R (expected result) files are updated to keep case names consistent.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

