### PR TITLE
[BugFix] Reserve dict size + 1 for NULL-absorbing dict-mapping groupby keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
@@ -177,7 +177,13 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
                         && entry.getValue() instanceof DictMappingOperator mappingOperator) {
                     ColumnRefOperator column = mappingOperator.getDictColumn();
                     if (isNumericOrDate(column) && globalDicts.containsKey(column.getId())) {
-                        infos.put(entry.getKey().getId(), dictMinMax(globalDicts.get(column.getId())));
+                        // A dict-mapping expression maps each input code, including the dict's NULL
+                        // slot, to at most one output value, so the derived result dict can hold up
+                        // to base dict size + 1 codes (a value-adding expression such as
+                        // `case when x is null then '-' ...` grows it by one). Reserve that extra
+                        // code for the compressed group-by key range, otherwise it overflows the
+                        // packed key width and decode fails with "Dict can't take cover all key".
+                        infos.put(entry.getKey().getId(), dictMinMaxForMapping(globalDicts.get(column.getId())));
                     }
                 }
             }
@@ -193,6 +199,11 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
     private static Pair<ConstantOperator, ConstantOperator> dictMinMax(ColumnDict dict) {
         return new Pair<>(ConstantOperator.createVarchar("0"),
                 ConstantOperator.createVarchar("" + dict.getDictSize()));
+    }
+
+    private static Pair<ConstantOperator, ConstantOperator> dictMinMaxForMapping(ColumnDict dict) {
+        return new Pair<>(ConstantOperator.createVarchar("0"),
+                ConstantOperator.createVarchar("" + (dict.getDictSize() + 1)));
     }
 
     private static void putStatsMgrMinMax(ColumnRefOperator column,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1238,6 +1238,27 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testDictMappingGroupByReservesExtraCode() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        try {
+            // A value-adding dict-mapping group-by key (e.g. `case when x is null then '-'`,
+            // ifnull, coalesce) can grow the derived dict to base dict size + 1 codes. The
+            // compressed group-by key range must reserve that extra code, otherwise the code
+            // overflows the packed key width and decode fails with "Dict can't take cover all key".
+            String sql = "select count(*) from supplier group by "
+                    + "case when S_ADDRESS is null then '-' else S_ADDRESS end";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "group by min-max stats:\n" + "  |  - 0:2");
+
+            sql = "select count(*) from supplier group by ifnull(S_ADDRESS, 'x')";
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "group by min-max stats:\n" + "  |  - 0:2");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(0);
+        }
+    }
+
+    @Test
     public void testGroupByWithOrderBy() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         try {
@@ -1279,7 +1300,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                     "result: VARBINARY; args nullable: false; result nullable: false]\n" +
                     "  |  group by: [12: upper, INT, true]\n" +
                     "  |  group by min-max stats:\n" +
-                    "  |  - 0:1\n" +
+                    "  |  - 0:2\n" +
                     "  |  cardinality: 1\n");
             assertContains(plan, "Global Dict Exprs:\n" +
                     "    12: DictDefine(11: S_ADDRESS, [upper(<place-holder>)])");


### PR DESCRIPTION
## Why I'm doing:

A group-by on a low-cardinality dict-mapping column uses the compressed group-by key path, whose key range is sized by ApplyMinMaxStatisticRule as (0, baseDictSize). For a NULL-absorbing mapping expression (IS NULL / ifnull / coalesce / nullif / concat_ws) the dict's NULL slot is mapped to an extra value, so the derived dict can hold baseDictSize + 1 codes. That extra code overflows the packed compressed-key width, the producer emits a code the decode dict cannot cover, and the query fails with "Dict Decode failed, Dict can't take cover all key".

Reserve baseDictSize + 1 for such keys. A single expression maps each input code (including the NULL slot) to at most one output, so the derived dict is always <= baseDictSize + 1, which makes the bound exact. Non NULL-absorbing mappings keep baseDictSize unchanged.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
