### PR TITLE
[Enhancement] Round pre-split tablet count up to a multiple of the compute-node count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -474,11 +474,14 @@ public final class TabletPreSplitCoordinator {
     /**
      * Choose how many tablets to pre-split a load into.
      *
-     * <p>Picks the larger of two lower bounds — the cluster's active compute-node
-     * count (so every compute node gets at least one tablet) and the byte-volume
-     * estimate ({@code ceil(estimatedTotalBytes / tablet_reshard_target_size)})
-     * — then clamps to {@code [2, tablet_reshard_max_split_count]}. Two is the
+     * <p>Takes the byte-volume estimate
+     * ({@code ceil(estimatedTotalBytes / tablet_reshard_target_size)}), rounds it up
+     * to a whole multiple of the active compute-node count so tablets spread evenly
+     * across nodes, floors it at the node count (so every node gets at least one
+     * tablet), and clamps to {@code [2, tablet_reshard_max_split_count]}. Two is the
      * minimum because a single-tablet result is equivalent to skipping pre-split.
+     * The {@code max_split_count} cap takes precedence, so a clamped result is not
+     * necessarily a multiple of the node count.
      *
      * @param estimates              full-input estimates from the sampler. Only
      *                               {@link Estimates#totalBytes} is read.
@@ -501,7 +504,20 @@ public final class TabletPreSplitCoordinator {
         // does not overflow when totalBytes is near Long.MAX_VALUE.
         long totalBytes = estimates.totalBytes();
         long byteTargetTabletCount = totalBytes == 0L ? 0L : ((totalBytes - 1) / targetSize) + 1;
-        long proposed = Math.max(activeComputeNodeCount, byteTargetTabletCount);
+        // Clamp to maxSplitCount before the node-count rounding. The final result is
+        // capped at maxSplitCount anyway, and clamping first keeps the rounding
+        // arithmetic (+ activeComputeNodeCount) from overflowing on a near-
+        // Long.MAX_VALUE estimate (tiny target_size + huge input).
+        long boundedByteTarget = Math.min(byteTargetTabletCount, maxSplitCount);
+        // Round the byte-volume estimate up to a whole multiple of the compute-node
+        // count so the tablets distribute evenly. A count that is not a multiple of
+        // the node count leaves some nodes owning one more tablet than the rest (e.g.
+        // 4 tablets on 3 nodes -> 2/1/1), skewing load-write and scan parallelism
+        // toward the heavier nodes.
+        long nodeAlignedCount =
+                ((boundedByteTarget + activeComputeNodeCount - 1) / activeComputeNodeCount)
+                        * activeComputeNodeCount;
+        long proposed = Math.max(activeComputeNodeCount, nodeAlignedCount);
         long clamped = Math.max(2L, Math.min(proposed, maxSplitCount));
         return (int) clamped;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -350,10 +350,10 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
     public void selectsPerPartitionKIndependently() throws Exception {
         // Two existing partitions with different estimatedBytes -> selector picks K_i
         // independently for each. With 12 CNs and target_size=50MB:
-        //   p1: 1000MB -> max(12, ceil(1000/50)=20) = 20 (byte target dominates)
-        //   p2:   10MB -> max(12, ceil(10/50)=1)   = 12 (CN floor dominates)
+        //   p1: 1000MB -> ceil(1000/50)=20, rounded up to a multiple of 12 -> 24
+        //   p2:   10MB -> ceil(10/50)=1,  rounded up / CN floor -> 12
         // A bug that ignored estimatedBytes would pick K=12 for both, so the differing
-        // K_1=20 vs K_2=12 catches it. Provide 100 distinct ascending samples (max
+        // K_1=24 vs K_2=12 catches it. Provide 100 distinct ascending samples (max
         // useful cuts ~=99) so the planner does not duplicate-collapse below the
         // requested counts.
         installExistingPartition("p1", 11_001L, 21_001L, 0L);
@@ -376,12 +376,12 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, /*activeComputeNodeCount*/ 12, freshConnectContext());
 
             Map<Long, List<TabletRange>> map = mapCaptor.getValue();
-            // K_1 = 20 (byte target dominates over CN floor of 12) -> 20 ranges.
+            // K_1 = 24 (ceil(1000MB/50MB)=20 rounded up to a multiple of 12) -> 24 ranges.
             // K_2 = 12 (CN floor dominates over byte target of 1) -> 12 ranges.
             // The two are intentionally different: equal K's would mask a bug that
             // ignores estimatedBytes and just uses activeComputeNodeCount everywhere.
-            Assertions.assertEquals(20, map.get(21_001L).size(),
-                    "p1 should pick K_1=20 from ceil(1000MB/50MB) > CN floor of 12");
+            Assertions.assertEquals(24, map.get(21_001L).size(),
+                    "p1 should pick K_1=24 from ceil(1000MB/50MB)=20 rounded up to a multiple of 12 CNs");
             Assertions.assertEquals(12, map.get(21_002L).size(),
                     "p2 should pick K_2=12 from CN floor > byte target of 1");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorTest.java
@@ -297,8 +297,22 @@ public class TabletPreSplitCoordinatorTest {
 
     @Test
     public void testTabletCountLargeLoadOnThreeComputeNodes() {
-        // 100 GB / 10 GB target = 10 tablets by bytes; beats the compute-node floor of 3.
-        Assertions.assertEquals(10, selectTabletCount(100L * DebugUtil.GIGABYTE, 3));
+        // 100 GB / 10 GB target = 10 tablets by bytes; rounded up to the next multiple
+        // of the 3 compute nodes -> 12, so each node owns exactly 4 tablets.
+        Assertions.assertEquals(12, selectTabletCount(100L * DebugUtil.GIGABYTE, 3));
+    }
+
+    @Test
+    public void testTabletCountRoundsUpToComputeNodeMultiple() {
+        // 70 GB / 10 GB target = 7 tablets by bytes; rounded up to the next multiple
+        // of 3 -> 9 (avoids an uneven 3/2/2 spread across the nodes).
+        Assertions.assertEquals(9, selectTabletCount(70L * DebugUtil.GIGABYTE, 3));
+    }
+
+    @Test
+    public void testTabletCountAlreadyComputeNodeMultipleIsUnchanged() {
+        // 60 GB / 10 GB target = 6 tablets by bytes, already a multiple of 3 -> 6.
+        Assertions.assertEquals(6, selectTabletCount(60L * DebugUtil.GIGABYTE, 3));
     }
 
     @Test
@@ -317,6 +331,16 @@ public class TabletPreSplitCoordinatorTest {
         // 10 PB / 10 GB target ≈ 1M tablets by bytes; clamps to tablet_reshard_max_split_count.
         Assertions.assertEquals(Config.tablet_reshard_max_split_count,
                 selectTabletCount(10L * 1024L * DebugUtil.TERABYTE, 1));
+    }
+
+    @Test
+    public void testTabletCountHugeEstimateSaturatesWithoutOverflow() {
+        // Tiny target_size + near-Long.MAX_VALUE estimate: the node-count rounding
+        // must not overflow (which would collapse the count to the node floor).
+        // The estimate is clamped before alignment, so it saturates at max_split_count.
+        Config.tablet_reshard_target_size = 1L;
+        Assertions.assertEquals(Config.tablet_reshard_max_split_count,
+                selectTabletCount(Long.MAX_VALUE, 3));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`TabletPreSplitCoordinator.selectTabletCount` floors the byte-volume estimate at the active compute-node count (so every node gets at least one tablet), but it does **not** align the count to a *multiple* of the node count. When `ceil(bytes / tablet_reshard_target_size)` is not a multiple of the node count, the resulting tablets spread unevenly across nodes:

- 4 tablets on 3 nodes → **2 / 1 / 1**
- 7 tablets on 3 nodes → **3 / 2 / 2**

The heavier nodes then bottleneck both the load write path (more tablet writers + persistent-index work per node) and later scans, partially defeating the point of pre-splitting. Observed in practice: an INSERT-from-FILES load pre-split to 4 tablets on a 3-CN cluster ran almost entirely on a single CN.

## What I'm doing:

Round the byte-volume estimate **up to the next whole multiple of the active compute-node count** before applying the existing node-count floor and `[2, max_split_count]` clamp:

```
4 → 6, 7 → 9   (on 3 nodes; each node then owns the same number of tablets)
```

`tablet_reshard_max_split_count` still takes precedence, so a saturated result need not be a multiple of the node count (documented in the javadoc).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
