### PR TITLE
[BugFix] Make the spill merge op-aware to preserve upsert/delete order

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -267,6 +267,13 @@ private:
 
     int64_t _max_buffer_size;
 
+    // Snapshot the in-transaction upsert/delete-order feature flag once for the whole load.
+    // lake_enable_pk_preserve_txn_delete_order is a mutable BE config, but it must not change
+    // mid-load: it drives both whether the spill path keeps the __op column (fixing LoadChunkSpiller's
+    // serde/schema from the first chunk) and whether finish() emits the del_op_offsets array. Reading
+    // it live in each place could tear a single load across the legacy and op-aware paths.
+    const bool _preserve_txn_delete_order = config::lake_enable_pk_preserve_txn_delete_order;
+
     std::unique_ptr<TabletWriter> _tablet_writer;
     std::unique_ptr<MemTable> _mem_table;
     std::unique_ptr<MemTableSink> _mem_table_sink;
@@ -440,8 +447,8 @@ Status DeltaWriterImpl::build_schema_and_writer() {
                 RETURN_IF_ERROR(_load_spill_block_mgr->init());
             }
             // Init SpillMemTableSink
-            _mem_table_sink =
-                    std::make_unique<SpillMemTableSink>(_load_spill_block_mgr.get(), _tablet_writer.get(), _profile);
+            _mem_table_sink = std::make_unique<SpillMemTableSink>(_load_spill_block_mgr.get(), _tablet_writer.get(),
+                                                                  _profile, _preserve_txn_delete_order);
             // Use concurrent flush token to improve the flush speed when spilling is enabled.
             // PERFORMANCE: Concurrent mode allows multiple memtables to flush in parallel,
             // which improves throughput when data is spilled to temporary storage before
@@ -843,7 +850,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
         // after all segments" path -- this never writes the new on-disk state that a pre-fix BE
         // (rollback / not-yet-upgraded node / cross-version OpReplication target) would misread into a
         // duplicate primary key. See config::lake_enable_pk_preserve_txn_delete_order.
-        if (config::lake_enable_pk_preserve_txn_delete_order) {
+        if (_preserve_txn_delete_order) {
             for (size_t i = 0; i < del_idx; ++i) {
                 op_write->add_del_op_offsets(i < del_op_offsets.size() ? del_op_offsets[i] : kUnknownDelOpOffset);
             }

--- a/be/src/storage/lake/load_spill_pipeline_merge_iterator.cpp
+++ b/be/src/storage/lake/load_spill_pipeline_merge_iterator.cpp
@@ -24,8 +24,13 @@ namespace starrocks {
 
 LoadSpillPipelineMergeIterator::LoadSpillPipelineMergeIterator(LoadChunkSpiller* spiller,
                                                                lake::TabletWriter* parent_writer,
-                                                               std::atomic<bool>* quit_flag, bool final_round)
-        : _spiller(spiller), _parent_writer(parent_writer), _quit_flag(quit_flag), _final_round(final_round) {
+                                                               std::atomic<bool>* quit_flag, bool final_round,
+                                                               bool op_aware)
+        : _spiller(spiller),
+          _parent_writer(parent_writer),
+          _quit_flag(quit_flag),
+          _final_round(final_round),
+          _op_aware(op_aware) {
     SchemaPtr schema = _spiller->schema();
 
     // PERFORMANCE OPTIMIZATION: DUP_KEYS tables don't require sorting or aggregation
@@ -79,7 +84,7 @@ Status LoadSpillPipelineMergeIterator::_generate_next_task() {
         auto task = std::make_unique<LoadSpillMergeInputBatch>(std::move(batch));
         _current_task = std::make_shared<lake::TabletInternalParallelMergeTask>(
                 std::move(writer), std::move(task), _spiller->schema().get(), _quit_flag,
-                _spiller->spiller()->metrics().write_io_timer);
+                _spiller->spiller()->metrics().write_io_timer, _op_aware);
     } else {
         // No more data to merge - signal iteration completion by returning nullptr.
         // Pipeline operators check has_more() which tests for nullptr to know when to stop.

--- a/be/src/storage/lake/load_spill_pipeline_merge_iterator.h
+++ b/be/src/storage/lake/load_spill_pipeline_merge_iterator.h
@@ -51,8 +51,10 @@ public:
      * @param quit_flag - Shared cancellation flag for all generated tasks
      * @param final_round - If true, merge directly to tablet; if false, merge to intermediate blocks
      */
+    // @param op_aware - forwarded to each TabletInternalParallelMergeTask: whether the merge input carries
+    //                   a trailing hidden __op column (set by the sink, not inferred from the schema).
     LoadSpillPipelineMergeIterator(LoadChunkSpiller* spiller, lake::TabletWriter* parent_writer,
-                                   std::atomic<bool>* quit_flag, bool final_round);
+                                   std::atomic<bool>* quit_flag, bool final_round, bool op_aware);
     ~LoadSpillPipelineMergeIterator() = default;
 
     // Returns current merge task, or nullptr if iteration exhausted
@@ -91,6 +93,9 @@ private:
     // If true, this is the final merge round writing to tablet. If false, intermediate
     // round writing back to spill blocks for next iteration.
     bool _final_round = false;
+
+    // Whether the merge input carries a trailing hidden __op column (forwarded to each task).
+    bool _op_aware = false;
 
     // WHY NEEDED: Determines merge iterator type. DUP_KEYS tables use union iterator
     // (simple concatenation), while AGG/UNIQUE keys use merge iterator (sorted merge

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -29,8 +29,9 @@
 namespace starrocks::lake {
 
 SpillMemTableSink::SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer,
-                                     RuntimeProfile* profile)
+                                     RuntimeProfile* profile, bool keep_op_column)
         : _writer(writer),
+          _keep_op_column(keep_op_column),
           _pipeline_merge_context(std::make_unique<LoadSpillPipelineMergeContext>(_writer)),
           _load_chunk_spiller(
                   std::make_unique<LoadChunkSpiller>(block_manager, profile, _pipeline_merge_context.get())) {
@@ -53,7 +54,7 @@ SpillMemTableSink::~SpillMemTableSink() {
 }
 
 bool SpillMemTableSink::keep_op_column() const {
-    return config::lake_enable_pk_preserve_txn_delete_order;
+    return _keep_op_column;
 }
 
 Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos,

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -65,7 +65,19 @@ Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* 
         RETURN_IF_ERROR(_writer->write(chunk, segment, eos));
         return _writer->flush(segment);
     }
+    return _spill_and_maybe_eager_merge(chunk, slot_idx, flush_data_size);
+}
 
+Status SpillMemTableSink::flush_chunk_with_op(const Chunk& chunk_with_op, starrocks::SegmentPB* segment, bool eos,
+                                              int64_t* flush_data_size, int64_t slot_idx) {
+    // The chunk still carries the trailing __op column. Always spill (skip the single-flush
+    // direct-write shortcut, which cannot handle __op): the op-aware merge resolves upsert/delete
+    // order per key by slot, then splits the merged output into segments + del files (see
+    // TabletInternalParallelMergeTask). __op is REPLACE-aggregated through the merge.
+    return _spill_and_maybe_eager_merge(chunk_with_op, slot_idx, flush_data_size);
+}
+
+Status SpillMemTableSink::_spill_and_maybe_eager_merge(const Chunk& chunk, int64_t slot_idx, int64_t* flush_data_size) {
     // Spill chunk to temporary storage with slot_idx for ordering
     auto res = _load_chunk_spiller->spill(chunk, slot_idx);
     RETURN_IF_ERROR(res.status());

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -74,6 +74,9 @@ Status SpillMemTableSink::flush_chunk_with_op(const Chunk& chunk_with_op, starro
     // direct-write shortcut, which cannot handle __op): the op-aware merge resolves upsert/delete
     // order per key by slot, then splits the merged output into segments + del files (see
     // TabletInternalParallelMergeTask). __op is REPLACE-aggregated through the merge.
+    // The memtable only calls this when it actually kept the hidden __op column, so this is the
+    // authoritative op-aware signal handed to the merge tasks (see _op_aware).
+    _op_aware = true;
     return _spill_and_maybe_eager_merge(chunk_with_op, slot_idx, flush_data_size);
 }
 
@@ -108,7 +111,8 @@ Status SpillMemTableSink::_spill_and_maybe_eager_merge(const Chunk& chunk, int64
         // rather than all upfront which would consume excessive memory.
         // final_round=false means this merges to intermediate blocks, not final tablet.
         LoadSpillPipelineMergeIterator task_iterator(_load_chunk_spiller.get(), _writer,
-                                                     _pipeline_merge_context->quit_flag(), false /* final_round */);
+                                                     _pipeline_merge_context->quit_flag(), false /* final_round */,
+                                                     _op_aware);
         task_iterator.init();
         if (task_iterator.has_more()) {
             auto current_task = task_iterator.current_task();
@@ -172,7 +176,8 @@ Status SpillMemTableSink::merge_blocks_to_segments() {
     // This iterator generates tasks lazily - one at a time as we iterate, enabling
     // dynamic load balancing and memory control.
     LoadSpillPipelineMergeIterator task_iterator(_load_chunk_spiller.get(), _writer,
-                                                 _pipeline_merge_context->quit_flag(), true /* final_round */);
+                                                 _pipeline_merge_context->quit_flag(), true /* final_round */,
+                                                 _op_aware);
 
     // PIPELINE EXECUTION MODEL: Generate tasks on-demand and submit for parallel execution.
     // Each task processes a batch of block groups (up to load_spill_max_merge_bytes).

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -52,6 +52,10 @@ SpillMemTableSink::~SpillMemTableSink() {
     _load_chunk_spiller.reset();
 }
 
+bool SpillMemTableSink::keep_op_column() const {
+    return config::lake_enable_pk_preserve_txn_delete_order;
+}
+
 Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos,
                                       int64_t* flush_data_size, int64_t slot_idx) {
     if (eos && _load_chunk_spiller->empty() && slot_idx == 0) {

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -48,6 +48,18 @@ public:
                                     starrocks::SegmentPB* segment = nullptr, bool eos = false,
                                     int64_t* flush_data_size = nullptr, int64_t slot_idx = -1) override;
 
+    // The spill sink keeps the __op column so the merge resolves upsert/delete order by slot.
+    // Keep the __op column (drive the op-aware merge) only when the in-transaction upsert/delete order
+    // feature is enabled. When it is off (the default), return false so the memtable takes the legacy
+    // _split_upserts_deletes path (deletes split into a del file, applied after all segments) -- keeping
+    // the spill path's behavior, del-file layout, and delete-with-merge-condition rejection identical to
+    // before this feature. Gated by config::lake_enable_pk_preserve_txn_delete_order.
+    bool keep_op_column() const override;
+
+    // Spill a chunk that still carries the trailing __op column (see keep_op_column()).
+    Status flush_chunk_with_op(const Chunk& chunk_with_op, starrocks::SegmentPB* segment = nullptr, bool eos = false,
+                               int64_t* flush_data_size = nullptr, int64_t slot_idx = -1) override;
+
     Status merge_blocks_to_segments();
 
     spill::Spiller* get_spiller() { return _load_chunk_spiller->spiller().get(); }

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -73,6 +73,10 @@ public:
     int64_t tablet_id() override;
 
 private:
+    // Spill a chunk and, if the spill threshold is reached, kick off an eager merge task. Shared by
+    // flush_chunk() (after the single-flush shortcut) and flush_chunk_with_op().
+    Status _spill_and_maybe_eager_merge(const Chunk& chunk, int64_t slot_idx, int64_t* flush_data_size);
+
     TabletWriter* _writer;
 
     // Per-load snapshot of config::lake_enable_pk_preserve_txn_delete_order (see keep_op_column()).

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -34,7 +34,10 @@ class TabletWriter;
 // The slot_idx parameter is used to track the original flush order for correct merging.
 class SpillMemTableSink : public MemTableSink {
 public:
-    SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer, RuntimeProfile* profile);
+    // @param keep_op_column: snapshot of config::lake_enable_pk_preserve_txn_delete_order taken once by
+    // the DeltaWriter for the whole load, so the __op-keeping decision cannot change mid-load (see below).
+    SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer, RuntimeProfile* profile,
+                      bool keep_op_column);
     ~SpillMemTableSink() override;
 
     // Spill chunk to temporary storage or write directly if eos and no prior spills
@@ -53,7 +56,9 @@ public:
     // feature is enabled. When it is off (the default), return false so the memtable takes the legacy
     // _split_upserts_deletes path (deletes split into a del file, applied after all segments) -- keeping
     // the spill path's behavior, del-file layout, and delete-with-merge-condition rejection identical to
-    // before this feature. Gated by config::lake_enable_pk_preserve_txn_delete_order.
+    // before this feature. Backed by _keep_op_column, a per-load snapshot of
+    // config::lake_enable_pk_preserve_txn_delete_order taken by the DeltaWriter, so the decision is
+    // stable for the whole load even if the mutable config is flipped mid-load.
     bool keep_op_column() const override;
 
     // Spill a chunk that still carries the trailing __op column (see keep_op_column()).
@@ -69,6 +74,9 @@ public:
 
 private:
     TabletWriter* _writer;
+
+    // Per-load snapshot of config::lake_enable_pk_preserve_txn_delete_order (see keep_op_column()).
+    const bool _keep_op_column;
 
     // Memory tracker for merge operations, parent is compaction tracker.
     // RATIONALE: Merge phase uses separate memory budget from normal load operations

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -82,6 +82,12 @@ private:
     // Per-load snapshot of config::lake_enable_pk_preserve_txn_delete_order (see keep_op_column()).
     const bool _keep_op_column;
 
+    // Set once when flush_chunk_with_op() is first called, i.e. the memtable actually kept a hidden __op
+    // column (PK load with an op slot + _keep_op_column). This is the authoritative op-aware signal
+    // forwarded to the merge tasks -- distinct from _keep_op_column, which is true for any load while the
+    // config is on (including non-PK loads that never produce a hidden __op).
+    bool _op_aware = false;
+
     // Memory tracker for merge operations, parent is compaction tracker.
     // RATIONALE: Merge phase uses separate memory budget from normal load operations
     // to prevent OOM. Parent is compaction tracker since merge is similar to compaction.

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -84,11 +84,16 @@ Status write_one_merged_chunk(TabletWriter* writer, Chunk* chunk, bool has_op, c
         PrimaryKeyEncoder::encode_selective(merge_schema, *chunk, del_idx.data(), del_idx.size(), deletes->get(),
                                             pk_enc);
     }
-    // Write upsert rows as a chunk without __op.
+    // Write upsert rows as a chunk without __op. Copy the upsert rows into a temp chunk (Chunk-level
+    // append_selective handles the immutable columns), then repackage its leading data columns into a
+    // segment chunk backed by a FRESH copy of write_schema. Do NOT clone-then-remove_column_by_index:
+    // clone_empty_with_schema shares the SchemaPtr and remove_column_by_index mutates it in place, which
+    // would shrink the reused loop chunk's shared schema and corrupt the next iteration's op split.
     if (!up_idx.empty()) {
-        auto up_chunk = chunk->clone_empty_with_schema(up_idx.size());
-        up_chunk->append_selective(*chunk, up_idx.data(), 0, up_idx.size());
-        up_chunk->remove_column_by_index(up_chunk->num_columns() - 1); // drop __op
+        auto tmp = chunk->clone_empty_with_schema(up_idx.size());
+        tmp->append_selective(*chunk, up_idx.data(), 0, up_idx.size());
+        Columns up_cols(tmp->columns().begin(), tmp->columns().begin() + write_schema.num_fields()); // drop __op
+        auto up_chunk = std::make_shared<Chunk>(std::move(up_cols), std::make_shared<Schema>(write_schema));
         ChunkHelper::padding_char_columns(char_field_indexes, write_schema, writer->tablet_schema(), up_chunk.get());
         RETURN_IF_ERROR(writer->write(*up_chunk, nullptr));
         *wrote_upsert = true;

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -35,12 +35,13 @@ namespace starrocks::lake {
 TabletInternalParallelMergeTask::TabletInternalParallelMergeTask(std::unique_ptr<TabletWriter> writer,
                                                                  std::unique_ptr<LoadSpillMergeInputBatch> task,
                                                                  const Schema* schema, std::atomic<bool>* quit_flag,
-                                                                 RuntimeProfile::Counter* write_io_timer)
+                                                                 RuntimeProfile::Counter* write_io_timer, bool op_aware)
         : _writer(std::move(writer)),
           _task(std::move(task)),
           _schema(schema),
           _quit_flag(quit_flag),
-          _write_io_timer(write_io_timer) {
+          _write_io_timer(write_io_timer),
+          _op_aware(op_aware) {
     std::string tracker_label =
             "LoadSpillMerge-" + std::to_string(_writer->tablet_id()) + "-" + std::to_string(_writer->txn_id());
     _merge_mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, std::move(tracker_label),
@@ -166,8 +167,11 @@ void TabletInternalParallelMergeTask::run() {
     // (-> a del file); see write_one_merged_chunk / finalize_merged_batch. The del file's op_offset is
     // assigned at result consolidation (TabletWriter::merge_other_writer) so it follows this batch's
     // segments and a later batch's re-upsert of the same key correctly wins.
-    const auto& field_names = _schema->field_names();
-    const bool has_op = !field_names.empty() && field_names.back() == "__op";
+    // op_aware is set by the sink only when the memtable actually kept a hidden __op column (PK load with
+    // an op slot + preserve-order feature on). It is NOT inferred from the last column name, so a real user
+    // column happening to be named "__op" (e.g. allow_system_reserved_names) is never mistaken for it.
+    const bool has_op = _op_aware;
+    DCHECK(!has_op || (!_schema->field_names().empty() && _schema->field_names().back() == "__op"));
     // Schema used to write segments (drops the trailing __op when present).
     std::vector<ColumnId> write_cids;
     for (size_t i = 0; i + (has_op ? 1 : 0) < _schema->num_fields(); i++) {

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -50,69 +50,164 @@ TabletInternalParallelMergeTask::~TabletInternalParallelMergeTask() {
     }
 }
 
+namespace {
+
+// Write one merged chunk. Plain (no __op) merge: write the chunk as a segment. Op-aware merge
+// (trailing __op column, REPLACE-aggregated so the latest op per key wins): split into upsert rows
+// (-> a segment, __op dropped) and net-deleted keys (accumulated into `deletes` for this batch's del
+// file); set `wrote_upsert` when an upsert segment was produced. `merge_schema` carries __op (used by
+// the PK encoder, which reads only the leading key columns); `write_schema` is the segment schema.
+Status write_one_merged_chunk(TabletWriter* writer, Chunk* chunk, bool has_op, const Schema& merge_schema,
+                              const Schema& write_schema, const std::vector<size_t>& char_field_indexes,
+                              PrimaryKeyEncodingType pk_enc, MutableColumnPtr* deletes, bool* wrote_upsert) {
+    if (!has_op) {
+        ChunkHelper::padding_char_columns(char_field_indexes, write_schema, writer->tablet_schema(), chunk);
+        return writer->write(*chunk, nullptr);
+    }
+    // Split the merged chunk by __op (last column).
+    const size_t op_idx = chunk->num_columns() - 1;
+    RawDataVisitor visitor;
+    RETURN_IF_ERROR(chunk->get_column_by_index(op_idx)->accept(&visitor));
+    const auto* ops = visitor.result();
+    const size_t nrows = chunk->num_rows();
+    std::vector<uint32_t> up_idx;
+    std::vector<uint32_t> del_idx;
+    up_idx.reserve(nrows);
+    for (uint32_t i = 0; i < nrows; i++) {
+        (ops[i] == TOpType::UPSERT ? up_idx : del_idx).push_back(i);
+    }
+    // Encode net-deleted keys.
+    if (!del_idx.empty()) {
+        if (*deletes == nullptr) {
+            RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(merge_schema, deletes, pk_enc));
+        }
+        PrimaryKeyEncoder::encode_selective(merge_schema, *chunk, del_idx.data(), del_idx.size(), deletes->get(),
+                                            pk_enc);
+    }
+    // Write upsert rows as a chunk without __op.
+    if (!up_idx.empty()) {
+        auto up_chunk = chunk->clone_empty_with_schema(up_idx.size());
+        up_chunk->append_selective(*chunk, up_idx.data(), 0, up_idx.size());
+        up_chunk->remove_column_by_index(up_chunk->num_columns() - 1); // drop __op
+        ChunkHelper::padding_char_columns(char_field_indexes, write_schema, writer->tablet_schema(), up_chunk.get());
+        RETURN_IF_ERROR(writer->write(*up_chunk, nullptr));
+        *wrote_upsert = true;
+    }
+    return Status::OK();
+}
+
+// After the merge loop: flush this batch's segments and (for an op-aware batch with net-deletes) its del
+// file, then finish the writer. A net-delete-only batch (deletes but no upsert segment) first writes a
+// 0-row segment so its del file anchors at a real segment index (assigned in merge_other_writer) instead
+// of colliding with a later batch's segment 0 -- which would let the delete (reserved UINT32_MAX rowid)
+// sort after, and wrongly erase, a key re-upserted in that later segment. Mirrors the serial path, which
+// writes a 0-row segment for a delete-only flush.
+Status finalize_merged_batch(TabletWriter* writer, bool has_op, const Schema& write_schema,
+                             const MutableColumnPtr& deletes, bool wrote_upsert,
+                             RuntimeProfile::Counter* write_io_timer) {
+    const bool has_deletes = has_op && deletes != nullptr && deletes->size() > 0;
+    if (has_deletes && !wrote_upsert) {
+        SCOPED_TIMER(write_io_timer);
+        auto empty_chunk = ChunkFactory::new_chunk(write_schema, 0);
+        RETURN_IF_ERROR(writer->write(*empty_chunk, nullptr));
+    }
+    {
+        SCOPED_TIMER(write_io_timer);
+        RETURN_IF_ERROR(writer->flush());
+    }
+    if (has_deletes) {
+        SCOPED_TIMER(write_io_timer);
+        // op_offset is a placeholder here; the real (global) value is assigned in merge_other_writer when
+        // this batch's writer is consolidated into the parent, based on the cumulative segment count.
+        RETURN_IF_ERROR(writer->flush_del_file(*deletes, kUnknownDelOpOffset));
+    }
+    SCOPED_TIMER(write_io_timer);
+    return writer->finish();
+}
+
+// Proactively batch-delete the merged-and-committed spill files: under flat layout their per-block dtors
+// are no-ops (skip_file_deletion = true). Only FileBlocks under flat layout return a non-empty path;
+// LogBlock and legacy FileBlock return nullopt and are skipped. MUST run before release_block_groups()
+// clears the vector. Callers invoke this only on merge success -- failed-merge files are reclaimed by the
+// offline vacuum_full job once the txn is inactive, avoiding races with files still in use upstream.
+void hot_delete_merged_spill_files(TabletWriter* writer, LoadSpillMergeInputBatch* task) {
+    std::vector<std::string> spill_paths;
+    for (const auto& bg : task->block_groups) {
+        if (bg == nullptr) continue;
+        for (const auto& block : bg->blocks()) {
+            if (block == nullptr) continue;
+            if (auto p = block->path(); p.has_value() && !p->empty()) {
+                spill_paths.emplace_back(std::move(*p));
+            }
+        }
+    }
+    if (!spill_paths.empty()) {
+        VLOG(2) << "load spill hot delete: " << spill_paths.size() << " files for txn " << writer->txn_id();
+        delete_files_async(std::move(spill_paths));
+    }
+}
+
+} // namespace
+
 void TabletInternalParallelMergeTask::run() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_merge_mem_tracker.get(), false);
     MonotonicStopWatch timer;
     timer.start();
-    auto char_field_indexes = ChunkSchemaHelper::get_char_field_indexes(*_schema);
+    // Op-aware spill: when the merged schema's last column is __op (REPLACE-aggregated, so per key the
+    // latest op by slot wins), each merged chunk is split into upsert rows (-> segments) and deleted keys
+    // (-> a del file); see write_one_merged_chunk / finalize_merged_batch. The del file's op_offset is
+    // assigned at result consolidation (TabletWriter::merge_other_writer) so it follows this batch's
+    // segments and a later batch's re-upsert of the same key correctly wins.
+    const auto& field_names = _schema->field_names();
+    const bool has_op = !field_names.empty() && field_names.back() == "__op";
+    // Schema used to write segments (drops the trailing __op when present).
+    std::vector<ColumnId> write_cids;
+    for (size_t i = 0; i + (has_op ? 1 : 0) < _schema->num_fields(); i++) {
+        write_cids.push_back(static_cast<ColumnId>(i));
+    }
+    Schema write_schema(const_cast<Schema*>(_schema), write_cids);
+    auto char_field_indexes = ChunkSchemaHelper::get_char_field_indexes(write_schema);
+    PrimaryKeyEncodingType pk_enc = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+    if (has_op) {
+        auto enc_or = _writer->tablet_schema()->primary_key_encoding_type_or_error();
+        if (!enc_or.ok()) {
+            update_status(enc_or.status());
+            return;
+        }
+        pk_enc = enc_or.value();
+    }
+
     auto chunk_shared_ptr = ChunkFactory::new_chunk(*_schema, config::vector_chunk_size);
     auto chunk = chunk_shared_ptr.get();
     auto st = Status::OK();
-
-    // CANCELLATION CHECK: Loop while quit flag is not set. The condition "_quit_flag == nullptr ||"
-    // handles the case where quit_flag is nullptr (cancellation not supported). When nullptr,
-    // we skip the quit check entirely and run to completion. When non-null, we check the
-    // atomic flag on each iteration to support early termination on error or user cancellation.
+    MutableColumnPtr deletes;  // accumulates net-deleted keys for this batch's del file
+    bool wrote_upsert = false; // whether this batch produced any upsert segment
+    // Read and write each merged chunk. _quit_flag (when non-null) lets a sibling task's error abort the
+    // loop early; when nullptr, cancellation is unsupported and we run to completion.
     while (_quit_flag == nullptr || !_quit_flag->load()) {
         chunk->reset();
         auto itr_st = _task->merge_itr->get_next(chunk);
         if (itr_st.is_end_of_file()) {
             break;
-        } else if (itr_st.ok()) {
-            SCOPED_TIMER(_write_io_timer);
-            ChunkHelper::padding_char_columns(char_field_indexes, *_schema, _writer->tablet_schema(), chunk);
-            st = _writer->write(*chunk, nullptr);
-            if (!st.ok()) {
-                break;
-            }
-        } else {
+        }
+        if (!itr_st.ok()) {
             st = itr_st;
+            break;
+        }
+        SCOPED_TIMER(_write_io_timer);
+        st = write_one_merged_chunk(_writer.get(), chunk, has_op, *_schema, write_schema, char_field_indexes, pk_enc,
+                                    &deletes, &wrote_upsert);
+        if (!st.ok()) {
             break;
         }
     }
     if (st.ok()) {
-        SCOPED_TIMER(_write_io_timer);
-        st = _writer->flush();
+        st = finalize_merged_batch(_writer.get(), has_op, write_schema, deletes, wrote_upsert, _write_io_timer);
     }
     if (st.ok()) {
-        SCOPED_TIMER(_write_io_timer);
-        st = _writer->finish();
+        hot_delete_merged_spill_files(_writer.get(), _task.get());
     }
-    // Hot-delete spill files written under flat layout: their per-block dtors are no-ops
-    // (skip_file_deletion = true), so we proactively batch-delete the merged-and-committed
-    // files here. Only collect when:
-    //   1. Merge succeeded — failed-merge files are reclaimed by the offline vacuum_full job
-    //      once the txn becomes inactive, avoiding races with files still in use upstream.
-    //   2. Block::path() returns a non-empty value — i.e. it is a FileBlock under flat layout.
-    //      LogBlock and legacy FileBlock return nullopt and are filtered out (no-op).
-    // MUST run BEFORE release_block_groups() because that call clears the vector.
-    if (st.ok()) {
-        std::vector<std::string> spill_paths;
-        for (const auto& bg : _task->block_groups) {
-            if (bg == nullptr) continue;
-            for (const auto& block : bg->blocks()) {
-                if (block == nullptr) continue;
-                if (auto p = block->path(); p.has_value() && !p->empty()) {
-                    spill_paths.emplace_back(std::move(*p));
-                }
-            }
-        }
-        if (!spill_paths.empty()) {
-            VLOG(2) << "load spill hot delete: " << spill_paths.size() << " files for txn " << _writer->txn_id();
-            delete_files_async(std::move(spill_paths));
-        }
-    }
-    // Release block groups to free up spill disk space
+    // Release block groups to free up spill disk space.
     _task->release_block_groups();
     timer.stop();
     LOG(INFO) << fmt::format(

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -16,16 +16,19 @@
 
 #include "column/chunk_factory.h"
 #include "column/chunk_schema_helper.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_exec_fwd.h"
 #include "common/runtime_profile.h"
 #include "compute_env/load_spill/load_spill_merge_input_batch.h"
 #include "compute_env/spill/block_group.h"
+#include "gen_cpp/Types_types.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/vacuum.h"
 #include "storage_primitive/chunk_iterator.h"
+#include "storage_primitive/primary_key_encoder.h"
 
 namespace starrocks::lake {
 

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -54,10 +54,16 @@ public:
      * @param schema - Table schema (borrowed, outlives task)
      * @param quit_flag - Shared cancellation flag (nullptr or points to context's atomic)
      * @param write_io_timer - Shared I/O metrics counter (borrowed)
+     * @param op_aware - Whether the merge input carries a trailing hidden __op column (set by the sink
+     *                   only when the memtable actually kept it, i.e. a PK load with an op slot and the
+     *                   preserve-order feature on). When true, run() splits each merged chunk into upsert
+     *                   rows and net-deleted keys. Passed explicitly rather than inferred from the last
+     *                   column name, so a real user column named "__op" is never mistaken for the op column.
      */
     TabletInternalParallelMergeTask(std::unique_ptr<TabletWriter> writer,
                                     std::unique_ptr<LoadSpillMergeInputBatch> task, const Schema* schema,
-                                    std::atomic<bool>* quit_flag, RuntimeProfile::Counter* write_io_timer);
+                                    std::atomic<bool>* quit_flag, RuntimeProfile::Counter* write_io_timer,
+                                    bool op_aware);
 
     ~TabletInternalParallelMergeTask() override;
 
@@ -110,6 +116,10 @@ private:
 
     // Shared I/O metrics counter (borrowed)
     RuntimeProfile::Counter* _write_io_timer = nullptr;
+
+    // Whether the merge input carries a trailing hidden __op column (see ctor). Drives the op-aware
+    // upsert/delete split in run(); never inferred from the last column name.
+    const bool _op_aware = false;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -78,7 +78,18 @@ Status TabletWriter::merge_other_writers(const std::vector<std::unique_ptr<Table
 Status TabletWriter::merge_other_writer(const TabletWriter* other_writer) {
     // merge other writer's files into current writer
     _segments.insert(_segments.end(), other_writer->_segments.begin(), other_writer->_segments.end());
-    _dels.insert(_dels.end(), other_writer->_dels.begin(), other_writer->_dels.end());
+    // Assign each consolidated del file an op_offset that places it right after THIS batch's segments
+    // in the merged rowset. merge_other_writer() is called once per merge batch in slot order, so after
+    // appending this batch's segments above, _segments.size()-1 is the global index of this batch's
+    // last segment. A delete therefore (a) wins over equal keys upserted by this or earlier batches and
+    // (b) loses to a re-upsert in a later batch (higher segment index) -- preserving the in-transaction
+    // upsert/delete order across the parallel/batched spill merge (publish interleaves by op_offset).
+    // _del_op_offsets must stay positionally aligned with _dels.
+    const uint32_t del_op_offset = _segments.empty() ? 0 : static_cast<uint32_t>(_segments.size() - 1);
+    for (const auto& del : other_writer->_dels) {
+        _dels.push_back(del);
+        _del_op_offsets.push_back(del_op_offset);
+    }
     _ssts.insert(_ssts.end(), other_writer->_ssts.begin(), other_writer->_ssts.end());
     _sst_ranges.insert(_sst_ranges.end(), other_writer->_sst_ranges.begin(), other_writer->_sst_ranges.end());
     _num_rows += other_writer->_num_rows;

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -315,6 +315,20 @@ Status MemTable::finalize() {
                 if (_result_chunk != upserts) {
                     _result_chunk = upserts;
                 }
+            } else if (_has_op_slot && !_merge_condition.empty()) {
+                // The op-aware spill path (keep_op_column) skips _split_upserts_deletes, which is where a
+                // DELETE combined with a merge condition is rejected. Enforce the same rejection here so
+                // such a load fails consistently instead of the spill merge silently applying the delete.
+                size_t op_column_id = _result_chunk->num_columns() - 1;
+                RawDataVisitor visitor;
+                RETURN_IF_ERROR(_result_chunk->get_column_by_index(op_column_id)->accept(&visitor));
+                const auto* ops = visitor.result();
+                for (size_t i = 0; i < _result_chunk->num_rows(); i++) {
+                    if (ops[i] == TOpType::DELETE) {
+                        return Status::InternalError(fmt::format(
+                                "memtable of tablet {} delete with condition column {}", _tablet_id, _merge_condition));
+                    }
+                }
             }
             if (_keys_type == KeysType::PRIMARY_KEYS) {
                 std::vector<ColumnId> primary_key_idxes(_vectorized_schema->num_key_fields());

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -308,7 +308,7 @@ Status MemTable::finalize() {
                 _aggregator_bytes_usage = 0;
                 return Status::Cancelled(kPrimaryKeySizeExceedError);
             }
-            if (_has_op_slot) {
+            if (_has_op_slot && !_sink->keep_op_column()) {
                 // TODO(cbl): mem_tracker
                 ChunkPtr upserts;
                 RETURN_IF_ERROR(_split_upserts_deletes(_result_chunk, &upserts, &_deletes));
@@ -330,6 +330,8 @@ Status MemTable::finalize() {
                     }
                 }
             }
+            // When the sink keeps the __op column (spill path), _result_chunk retains __op and is not
+            // split here; the sink resolves the upsert/delete order during its merge (see flush()).
             if (_keys_type == KeysType::PRIMARY_KEYS) {
                 std::vector<ColumnId> primary_key_idxes(_vectorized_schema->num_key_fields());
                 for (ColumnId i = 0; i < _vectorized_schema->num_key_fields(); ++i) {
@@ -383,6 +385,10 @@ Status MemTable::flush(SegmentPB* seg_info, bool eos, int64_t* flush_data_size, 
         if (_deletes) {
             RETURN_IF_ERROR(_sink->flush_chunk_with_deletes(*_result_chunk, *_deletes, seg_info, eos, flush_data_size,
                                                             slot_idx));
+        } else if (_has_op_slot && _sink->keep_op_column()) {
+            // Spill path: _result_chunk still carries the trailing __op column; the sink spills it and
+            // resolves upsert/delete order during the merge.
+            RETURN_IF_ERROR(_sink->flush_chunk_with_op(*_result_chunk, seg_info, eos, flush_data_size, slot_idx));
         } else {
             RETURN_IF_ERROR(_sink->flush_chunk(*_result_chunk, seg_info, eos, flush_data_size, slot_idx));
         }

--- a/be/src/storage/memtable_sink.h
+++ b/be/src/storage/memtable_sink.h
@@ -46,6 +46,18 @@ public:
                                             bool eos = false, int64_t* flush_data_size = nullptr,
                                             int64_t slot_idx = -1) = 0;
 
+    // If true, the memtable does NOT split upserts/deletes; it keeps the trailing __op column in the
+    // flushed chunk and hands the whole chunk to flush_chunk_with_op(). The sink then resolves the
+    // upsert/delete order across flushes during its (spill) merge. Only the spill sink overrides this.
+    virtual bool keep_op_column() const { return false; }
+
+    // Flush a chunk whose last column is __op (TINYINT, REPLACE-aggregated). Only called when
+    // keep_op_column() is true. Default: not supported.
+    virtual Status flush_chunk_with_op(const Chunk& chunk_with_op, starrocks::SegmentPB* seg_info = nullptr,
+                                       bool eos = false, int64_t* flush_data_size = nullptr, int64_t slot_idx = -1) {
+        return Status::NotSupported("flush_chunk_with_op not supported");
+    }
+
     virtual int64_t txn_id() = 0;
     virtual int64_t tablet_id() = 0;
 };

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -772,6 +772,61 @@ TEST_P(LakePrimaryKeyPublishTest, test_spill_delete_only_removes_keys) {
     ASSERT_EQ(0, read_rows(tablet_id, 3));
 }
 
+// Spill path regression (kevincai review on #75366): when a single op-aware merge task emits more than one
+// upsert chunk (merged upsert rows > config::vector_chunk_size), write_one_merged_chunk must not corrupt
+// the reused merge chunk's schema. The old clone_empty_with_schema + remove_column_by_index shared then
+// shrank the SchemaPtr, so the second chunk cloned a K-column chunk against a now K-1-field schema and
+// tripped Schema::remove's bounds (DCHECK in debug, out-of-range erase / UB in release). Load more than
+// vector_chunk_size distinct upsert keys through the op-aware spill merge and assert they all read back.
+TEST_P(LakePrimaryKeyPublishTest, test_spill_upsert_spanning_multiple_merge_chunks) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    // Exceed the merge get_next chunk size so run() calls write_one_merged_chunk for more than one chunk.
+    const int n = config::vector_chunk_size + 128;
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto tablet_id = _tablet_metadata->id();
+    const int64_t old_size = config::write_buffer_size;
+    const bool old_spill = config::enable_load_spill;
+    const bool old_parallel = config::enable_load_spill_parallel_merge;
+    const bool old_preserve = config::lake_enable_pk_preserve_txn_delete_order;
+    // write_buffer_size=1 forces spilling (blocks flushed before eos, skipping the single-flush shortcut);
+    // serial merge then consolidates them in one task whose merged stream exceeds vector_chunk_size.
+    config::write_buffer_size = 1;
+    config::enable_load_spill = true;
+    config::enable_load_spill_parallel_merge = false;
+    config::lake_enable_pk_preserve_txn_delete_order = true;
+    DeferOp reset_cfg([&]() {
+        config::write_buffer_size = old_size;
+        config::enable_load_spill = old_spill;
+        config::enable_load_spill_parallel_merge = old_parallel;
+        config::lake_enable_pk_preserve_txn_delete_order = old_preserve;
+    });
+    int64_t txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*make_op_chunk(n, /*value_shift=*/0, /*upsert=*/true, _slot_cid_map),
+                                      indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+    ASSERT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+    ASSERT_EQ(n, read_rows(tablet_id, 2));
+}
+
 TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
     auto txns = std::vector<int64_t>();

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -628,6 +628,150 @@ TEST_P(LakePrimaryKeyPublishTest, test_delete_only_first_flush_creates_segment) 
     EXPECT_EQ(0u, v3_del_op_offset);
 }
 
+// Build a 3-column chunk (c0=key, c1=value, __op) for keys [0, n). op: true=UPSERT, false=DELETE.
+static ChunkPtr make_op_chunk(int n, int value_shift, bool upsert, const Chunk::SlotHashMap& slot_cid_map) {
+    std::vector<int> keys(n), vals(n);
+    std::vector<uint8_t> ops(n);
+    for (int i = 0; i < n; i++) {
+        keys[i] = i;
+        vals[i] = i + value_shift;
+        ops[i] = upsert ? TOpType::UPSERT : TOpType::DELETE;
+    }
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int8Column::create();
+    c0->append_numbers(keys.data(), keys.size() * sizeof(int));
+    c1->append_numbers(vals.data(), vals.size() * sizeof(int));
+    c2->append_numbers(ops.data(), ops.size() * sizeof(uint8_t));
+    return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, slot_cid_map);
+}
+
+// Spill path: the op-aware parallel merge must preserve in-transaction upsert/delete order. Drive the
+// default spill path (enable_load_spill=true) with parallel merge and tiny merge batches so a key that is
+// deleted and then re-upserted across flushes resolves across merge batches; the re-upsert (higher global
+// segment index, assigned in TabletWriter::merge_other_writer) must win. This exercises
+// write_one_merged_chunk (upsert + delete split) and finalize_merged_batch. Asserts data only -- the spill
+// segment/del layout is not what this test pins.
+TEST_P(LakePrimaryKeyPublishTest, test_spill_interleaved_delete_then_reupsert) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    const int n = kChunkSize;
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto upsert_first = make_op_chunk(n, /*value_shift=*/0, /*upsert=*/true, _slot_cid_map);
+    auto delete_keys = make_op_chunk(n, /*value_shift=*/0, /*upsert=*/false, _slot_cid_map);
+    auto upsert_last = make_op_chunk(n, /*value_shift=*/1000, /*upsert=*/true, _slot_cid_map);
+
+    auto tablet_id = _tablet_metadata->id();
+    const int64_t old_size = config::write_buffer_size;
+    const bool old_spill = config::enable_load_spill;
+    const bool old_parallel = config::enable_load_spill_parallel_merge;
+    const int64_t old_merge_bytes = config::load_spill_max_merge_bytes;
+    const bool old_preserve = config::lake_enable_pk_preserve_txn_delete_order;
+    // write_buffer_size=1: each write() flushes to its own spilled block. parallel merge + tiny
+    // load_spill_max_merge_bytes: each block becomes its own merge batch, so the delete and the re-upsert
+    // land in different batches and their global order is decided at consolidation.
+    config::write_buffer_size = 1;
+    config::enable_load_spill = true;
+    config::enable_load_spill_parallel_merge = true;
+    config::load_spill_max_merge_bytes = 1;
+    config::lake_enable_pk_preserve_txn_delete_order = true;
+    DeferOp reset_cfg([&]() {
+        config::write_buffer_size = old_size;
+        config::enable_load_spill = old_spill;
+        config::enable_load_spill_parallel_merge = old_parallel;
+        config::load_spill_max_merge_bytes = old_merge_bytes;
+        config::lake_enable_pk_preserve_txn_delete_order = old_preserve;
+    });
+    int64_t txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*upsert_first, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->write(*delete_keys, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->write(*upsert_last, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+    ASSERT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+
+    // All keys survive (the trailing upsert wins) with the re-upserted value.
+    ASSIGN_OR_ABORT(auto chunk, read(tablet_id, 2));
+    ASSERT_EQ(n, chunk->num_rows());
+    std::map<int, int> kv;
+    for (size_t i = 0; i < chunk->num_rows(); i++) {
+        kv[chunk->get(i)[0].get_int32()] = chunk->get(i)[1].get_int32();
+    }
+    ASSERT_EQ(static_cast<size_t>(n), kv.size());
+    for (int i = 0; i < n; i++) {
+        ASSERT_TRUE(kv.count(i) > 0) << "key " << i << " missing";
+        EXPECT_EQ(i + 1000, kv[i]) << "key " << i << " has stale value";
+    }
+}
+
+// Spill path: a delete-only transaction (a net-delete-only merge batch) must still erase its keys.
+// Exercises finalize_merged_batch's empty-segment anchor + del-file write on the op-aware spill merge.
+TEST_P(LakePrimaryKeyPublishTest, test_spill_delete_only_removes_keys) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    const int n = kChunkSize;
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto tablet_id = _tablet_metadata->id();
+    const int64_t old_size = config::write_buffer_size;
+    const bool old_spill = config::enable_load_spill;
+    const bool old_parallel = config::enable_load_spill_parallel_merge;
+    const bool old_preserve = config::lake_enable_pk_preserve_txn_delete_order;
+    config::write_buffer_size = 1;
+    config::enable_load_spill = true;
+    config::enable_load_spill_parallel_merge = true;
+    config::lake_enable_pk_preserve_txn_delete_order = true;
+    DeferOp reset_cfg([&]() {
+        config::write_buffer_size = old_size;
+        config::enable_load_spill = old_spill;
+        config::enable_load_spill_parallel_merge = old_parallel;
+        config::lake_enable_pk_preserve_txn_delete_order = old_preserve;
+    });
+    auto write_one_txn = [&](int64_t version, const ChunkPtr& chunk) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version, txn_id).status());
+    };
+    // v2: populate n keys; v3: delete them all (net-delete-only) on the spill path.
+    write_one_txn(2, make_op_chunk(n, /*value_shift=*/0, /*upsert=*/true, _slot_cid_map));
+    ASSERT_EQ(n, read_rows(tablet_id, 2));
+    write_one_txn(3, make_op_chunk(n, /*value_shift=*/0, /*upsert=*/false, _slot_cid_map));
+    ASSERT_EQ(0, read_rows(tablet_id, 3));
+}
+
 TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
     auto txns = std::vector<int64_t>();

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -129,7 +129,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     for (int i = 0; i < 3; i++) {
         // 3 times
         auto chunk = gen_data(kChunkSize, i);
@@ -169,7 +170,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk_with_deletes) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     for (int i = 0; i < 3; i++) {
         // 3 times
         auto chunk = gen_data(kChunkSize, i);
@@ -207,7 +209,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk2) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment;
     ASSERT_OK(sink.flush_chunk(*chunk, &segment, true, nullptr, 0));
@@ -222,7 +225,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk_with_delete2) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment;
     ASSERT_OK(sink.flush_chunk_with_deletes(*chunk, *(chunk->columns()[0]), &segment, true, nullptr, 0));
@@ -238,7 +242,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk_with_limit) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     for (int i = 0; i < 3; i++) {
         int64_t old_val = config::load_spill_max_chunk_bytes;
         config::load_spill_max_chunk_bytes = 1;
@@ -281,7 +286,8 @@ TEST_P(SpillMemTableSinkTest, test_merge) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment0;
     ASSERT_OK(sink.flush_chunk(*chunk, &segment0, false));
@@ -306,7 +312,8 @@ TEST_P(SpillMemTableSinkTest, test_out_of_disk_space) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment0;
     ASSERT_OK(sink.flush_chunk(*chunk, &segment0, false));
@@ -324,7 +331,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk_with_slot_idx) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
 
     // Flush chunks with different slot_idx
     for (int i = 0; i < 3; i++) {
@@ -353,7 +361,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_chunk_with_deletes_and_slot_idx) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
 
     // Flush chunks with deletes and different slot_idx
     for (int i = 0; i < 3; i++) {
@@ -379,7 +388,8 @@ TEST_P(SpillMemTableSinkTest, test_slot_idx_ordering_after_merge) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
 
     // Flush chunks in non-sequential slot_idx order
     auto chunk0 = gen_data(kChunkSize, 0);
@@ -417,7 +427,8 @@ TEST_P(SpillMemTableSinkTest, test_flush_data_size_with_slot_idx) {
     ASSERT_OK(block_manager->init());
     std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
             _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
 
     auto chunk = gen_data(kChunkSize, 0);
     starrocks::SegmentPB segment;
@@ -451,7 +462,8 @@ TEST_P(SpillMemTableSinkTest, test_merge_blocks_after_eager_merge_consumed_all) 
     ASSERT_OK(block_manager->init());
     auto tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr.get(), tablet_id, _tablet_schema,
                                                                          txn_id, false);
-    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get(), &_dummy_runtime_profile,
+                           /*keep_op_column=*/false);
 
     // Flush 2 chunks normally (no eager merge, threshold is high by default)
     auto chunk0 = gen_data(kChunkSize, 0);

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -516,7 +516,8 @@ TEST_P(SpillMemTableSinkTest, test_merge_task_results_orders_by_slot) {
         auto batch = std::make_unique<LoadSpillMergeInputBatch>();
         batch->slot_idx = slot;
         auto task = std::make_shared<TabletInternalParallelMergeTask>(std::move(writer), std::move(batch),
-                                                                      _schema.get(), nullptr, nullptr);
+                                                                      _schema.get(), nullptr, nullptr,
+                                                                      /*op_aware=*/false);
         context.add_merge_task(task);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Primary Key tables must preserve the in-transaction order of `UPSERT` and `DELETE`
for the same key. Shared-nothing (local) PK tables already do this; shared-data
(lake) PK tables did not.

#75338 fixed the **serial** flush path. But lake PK loads use the **spill** path by
default (`config::enable_load_spill=true`), where the parallel/batched merge dropped
the `__op` column and applied all deletes after the merged upsert segments — so a key
that is `DELETE`d and then re-`UPSERT`ed across flushes in one transaction was wrongly
erased.

Cluster repro (1 FE + 3 CN, small `write_buffer_size` to force multi-flush; one stream
load = upsert id→A, delete id, re-upsert id→B):
- serial (`enable_load_spill=false`): all keys present with value B — correct (from #75338).
- spill (default), **before this PR**: every re-upsert erased.
- spill (default), **with this PR**: all keys present with value B — correct.

## What I'm doing:

This PR contains #75338 (the serial-path fix) **plus** the spill-path fix, making the
spill merge op-aware so a delete and a later re-upsert of the same key resolve by slot
order.

- **spill merge**: `TabletInternalParallelMergeTask` keeps the `__op` column through the
  merge (REPLACE-aggregated, so the latest op per key wins) and splits each merged chunk
  into upsert rows (→ segments) and net-deleted keys (→ a del file). A net-delete-only
  batch writes a 0-row segment so its del file anchors at a real segment index. The del
  file's `op_offset` is assigned at result consolidation (`TabletWriter::merge_other_writer`)
  as the cumulative segment index, so it follows this batch's segments and a later batch's
  re-upsert (higher segment index) correctly wins.
- **op_offset transport/persist/apply/rebuild** (from #75338): the per-del `op_offset`
  is carried on `OpWrite.del_op_offsets` (parallel to `dels_meta`), resolved once via
  `del_op_offset_or_unset` / `resolve_del_op_offset`, and interleaved at apply and at
  index rebuild/recover.
- **downgrade safety**: persisting `op_offset` is gated behind
  `config::lake_enable_pk_preserve_txn_delete_order` (**default false**). While disabled,
  no new on-disk state is written and the whole chain falls back to the legacy "delete
  after all segments" behavior, so a rollback to a pre-fix BE stays safe. Multi-statement
  txns snapshotted via `publish_log_version` also fall back (a `TODO` records the full fix).
- **column-mode partial update** keeps the max segment id (its deletes apply after all
  column upserts, never interleaved). Cross-flush delete→re-update ordering for partial
  update is a pre-existing limitation in both shared-nothing and shared-data and is out of
  scope here.

Validated end-to-end on a shared-data TSP cluster (build from this branch): the exact
user repro, a 200k phased upsert→delete→re-upsert load, and a leading-delete case all
pass on the default spill path with multi-flush forced.

Fixes the shared-data half of the PK in-transaction upsert/delete ordering gap
(companion to #75338).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
