### PR TITLE
[BugFix][CVE] bump jackson-databind to 2.21.4

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -61,7 +61,7 @@ subprojects {
         set("hudi.version", "1.0.2")
         set("iceberg.version", "1.10.0")
         set("io.netty.version", "4.1.135.Final")
-        set("jackson.version", "2.21.1")
+        set("jackson.version", "2.21.4")
         set("jackson-annotations.version", "2.21")
         set("jetty.version", "9.4.57.v20241219")
         set("jprotobuf-starrocks.version", "1.0.0")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -49,8 +49,8 @@ under the License.
         <junit.version>5.8.2</junit.version>
         <jprotobuf-starrocks.version>1.0.0</jprotobuf-starrocks.version>
         <log4j.version>2.19.0</log4j.version>
-        <jackson.version>2.21.1</jackson.version>
-        <!-- jackson-annotations doesn't have 2.21.1 version released -->
+        <jackson.version>2.21.4</jackson.version>
+        <!-- jackson-annotations doesn't have 2.21.4 version released -->
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <spark.version>3.5.7</spark.version>
         <tomcat.version>8.5.70</tomcat.version>

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -47,7 +47,7 @@ under the License.
         <thrift.version>0.23.0</thrift.version>
         <tomcat.version>9.0.118</tomcat.version>
         <log4j.version>2.17.1</log4j.version>
-        <jackson.version>2.21.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <avro.version>1.11.4</avro.version>
         <jetty.version>9.4.58.v20250814</jetty.version>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -49,8 +49,8 @@
         <gcs.connector.version>3.0.13</gcs.connector.version>
         <slf4j.version>1.7.36</slf4j.version>
         <arrow.version>17.0.0</arrow.version>
-        <jackson.version>2.21.1</jackson.version>
-        <!-- jackson-annotations doesn't have 2.21.1 version released -->
+        <jackson.version>2.21.4</jackson.version>
+        <!-- jackson-annotations doesn't have 2.21.4 version released -->
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>32.0.1-jre</guava.version>
         <!-- hadoop-azure requires no more than jetty10+ -->


### PR DESCRIPTION
Bump the jackson family (jackson.version) from 2.21.1 to 2.21.4 across fe/, java-extensions/, and fs_brokers/ to remediate two jackson-databind deserialization vulnerabilities.

- CVE-2026-54512: com.fasterxml.jackson.core:jackson-databind, affected
  >= 2.10.0 < 2.21.4 (2.21.x line), fixed in 2.21.4. A class can be
  smuggled past a PolymorphicTypeValidator allow-list as a generic type argument and instantiated during deserialization (RCE).
- CVE-2026-54513: com.fasterxml.jackson.core:jackson-databind, affected
  >= 2.10.0 < 2.21.4 (2.21.x line), fixed in 2.21.4. CWE-184: the
  BasicPolymorphicTypeValidator.Builder.allowIfSubTypeIsArray() path inadequately validates array component types, bypassing the allow-list.

jackson-databind ships directly in fe/ and is also pulled in transitively via the Hadoop/Hive/Iceberg/Paimon/Kudu/Hudi ecosystem in java-extensions/ and fs_brokers/. All trees route jackson-core / jackson-databind / jackson-dataformat-yaml / jackson-module-jaxb-annotations through the shared ${jackson.version} property in dependencyManagement (Maven) and constraints (Gradle), so the single property bump forces the patched version everywhere, including transitive pulls.

jackson-annotations.version stays at 2.21 (it has no 2.21.4 release and is not affected by these CVEs).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
