### PR TITLE
[Enhancement] Estimate NDV for Iceberg columns when Puffin stats are unavailable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -344,7 +344,9 @@ public class IcebergStatisticProvider {
         Optional<Double> minVal = icebergStats.getMinValue(fieldId);
         Optional<Double> maxVal = icebergStats.getMaxValue(fieldId);
         if (minVal.isPresent() && maxVal.isPresent() && isRangeEstimableType(fieldId, icebergStats)) {
-            long range = Math.max(0L, (long) (maxVal.get() - minVal.get())) + 1;
+            double diff = maxVal.get() - minVal.get();
+            // Guard against overflow: very wide BIGINT ranges may exceed Long.MAX_VALUE as a double
+            long range = (diff >= (double) Long.MAX_VALUE) ? Long.MAX_VALUE : Math.max(0L, (long) diff) + 1;
             double rangeNdv = Math.min(rowCount, range);
             // Take min with size-based to stay conservative when range >> actual NDV
             double sizeNdv = estimateSizeBasedNdv(fieldId, icebergStats, rowCount);
@@ -365,8 +367,13 @@ public class IcebergStatisticProvider {
             return Math.max(1.0, Math.min(rowCount, sizeNdv));
         }
         // Tier 3: type-fraction last resort
+        Map<Integer, Type.PrimitiveType> typeMapping = icebergStats.getIdToTypeMapping();
+        Type.PrimitiveType type = typeMapping != null ? typeMapping.get(fieldId) : null;
+        if (type instanceof Types.BooleanType) {
+            return Math.min(2.0, rowCount);  // BOOLEAN has at most 2 distinct values
+        }
         double fraction = typeNdvFraction(fieldId, icebergStats);
-        return Math.max(2.0, rowCount * fraction);
+        return Math.max(1.0, Math.min(rowCount, rowCount * fraction));
     }
 
     private boolean isRangeEstimableType(Integer fieldId, IcebergFileStats icebergStats) {
@@ -375,7 +382,8 @@ public class IcebergStatisticProvider {
             return false;
         }
         Type.PrimitiveType type = typeMapping.get(fieldId);
-        return type instanceof Types.IntegerType
+        return type instanceof Types.BooleanType
+                || type instanceof Types.IntegerType
                 || type instanceof Types.LongType
                 || type instanceof Types.DateType
                 || type instanceof Types.TimestampType

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -322,11 +322,98 @@ public class IcebergStatisticProvider {
             builder.setDistinctValuesCount(Math.max(Math.min(ndv, icebergStats.getRecordCount()), 1));
             builder.setType(ColumnStatistic.StatisticType.ESTIMATE);
         } else {
-            builder.setDistinctValuesCount(1);
-            builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
+            double estimatedNdv = estimateNdvFallback(fieldId, icebergStats);
+            builder.setDistinctValuesCount(estimatedNdv);
+            builder.setType(ColumnStatistic.StatisticType.ESTIMATE);
         }
 
         return builder.build();
+    }
+
+    // Estimate NDV when Puffin stats are unavailable.
+    // Uses min/max range when present (zero extra IO — already in IcebergFileStats),
+    // falls back to column-size heuristic, then type-fraction as last resort.
+    private double estimateNdvFallback(Integer fieldId, IcebergFileStats icebergStats) {
+        long rowCount = icebergStats.getRecordCount();
+        if (rowCount <= 0) {
+            return 1.0;
+        }
+
+        // Tier 1: range-based for integer/date/timestamp types.
+        // min/max come from IcebergFileStats if column stats were computed — no new IO.
+        Optional<Double> minVal = icebergStats.getMinValue(fieldId);
+        Optional<Double> maxVal = icebergStats.getMaxValue(fieldId);
+        if (minVal.isPresent() && maxVal.isPresent() && isRangeEstimableType(fieldId, icebergStats)) {
+            long range = Math.max(0L, (long) (maxVal.get() - minVal.get())) + 1;
+            double rangeNdv = Math.min(rowCount, range);
+            // Take min with size-based to stay conservative when range >> actual NDV
+            double sizeNdv = estimateSizeBasedNdv(fieldId, icebergStats, rowCount);
+            return Math.max(1.0, Math.min(rangeNdv, sizeNdv));
+        }
+
+        return estimateSizeBasedNdv(fieldId, icebergStats, rowCount);
+    }
+
+    private double estimateSizeBasedNdv(Integer fieldId, IcebergFileStats icebergStats, long rowCount) {
+        // Tier 2: column physical size / min-bytes-per-distinct-value
+        Map<Integer, Long> columnSizes = icebergStats.getColumnSizes();
+        long columnSizeRcnt = icebergStats.getColumnSizeRecordCount(fieldId);
+        if (columnSizes != null && columnSizes.containsKey(fieldId) && columnSizeRcnt > 0) {
+            long colSizeBytes = columnSizes.get(fieldId);
+            int minBytesPerValue = minBytesPerDistinctValue(fieldId, icebergStats);
+            double sizeNdv = (double) colSizeBytes / minBytesPerValue;
+            return Math.max(1.0, Math.min(rowCount, sizeNdv));
+        }
+        // Tier 3: type-fraction last resort
+        double fraction = typeNdvFraction(fieldId, icebergStats);
+        return Math.max(2.0, rowCount * fraction);
+    }
+
+    private boolean isRangeEstimableType(Integer fieldId, IcebergFileStats icebergStats) {
+        Map<Integer, Type.PrimitiveType> typeMapping = icebergStats.getIdToTypeMapping();
+        if (typeMapping == null) {
+            return false;
+        }
+        Type.PrimitiveType type = typeMapping.get(fieldId);
+        return type instanceof Types.IntegerType
+                || type instanceof Types.LongType
+                || type instanceof Types.DateType
+                || type instanceof Types.TimestampType
+                || type instanceof Types.TimeType;
+    }
+
+    private int minBytesPerDistinctValue(Integer fieldId, IcebergFileStats icebergStats) {
+        Map<Integer, Type.PrimitiveType> typeMapping = icebergStats.getIdToTypeMapping();
+        if (typeMapping == null) {
+            return 4;
+        }
+        Type.PrimitiveType type = typeMapping.get(fieldId);
+        if (type instanceof Types.BooleanType) {
+            return 1;
+        } else if (type instanceof Types.IntegerType || type instanceof Types.FloatType
+                || type instanceof Types.DateType) {
+            return 4;
+        } else if (type instanceof Types.LongType || type instanceof Types.DoubleType
+                || type instanceof Types.TimestampType || type instanceof Types.TimeType) {
+            return 8;
+        } else {
+            return 4; // STRING/BINARY: assume dictionary encoding ~4 bytes per index
+        }
+    }
+
+    private double typeNdvFraction(Integer fieldId, IcebergFileStats icebergStats) {
+        Map<Integer, Type.PrimitiveType> typeMapping = icebergStats.getIdToTypeMapping();
+        if (typeMapping == null) {
+            return 0.3;
+        }
+        Type.PrimitiveType type = typeMapping.get(fieldId);
+        if (type instanceof Types.BooleanType) {
+            return 0.01;
+        } else if (type instanceof Types.IntegerType || type instanceof Types.LongType) {
+            return 0.3;
+        } else {
+            return 0.5;
+        }
     }
 
     public void updateColumnSizes(IcebergFileStats icebergFileStats, Map<Integer, Long> addedColumnSizes,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1544,7 +1544,7 @@ public class IcebergMetadataTest extends TableTestBase {
                 icebergTable, colRefToColumnMetaMap, null, null, -1, versionRange);
         Assertions.assertEquals(4.0, statistics.getOutputRowCount(), 0.001);
         Assertions.assertEquals(2, statistics.getColumnStatistics().size());
-        Assertions.assertTrue(statistics.getColumnStatistic(columnRefOperator1).isUnknown());
+        Assertions.assertFalse(statistics.getColumnStatistic(columnRefOperator1).isUnknown());
         ColumnStatistic columnStatistic = statistics.getColumnStatistic(columnRefOperator1);
         Assertions.assertEquals(1.0, columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(2.0, columnStatistic.getMaxValue(), 0.001);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -125,6 +125,115 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         Assertions.assertEquals(1.0, statistics.getOutputRowCount(), 0.001);
     }
 
+    // --- NDV fallback estimation tests (改动 C) ---
+
+    @Test
+    public void testNdvFallback_noPuffinNoStats_usesTypeFraction() {
+        // IcebergFileStats with only recordCount: no type mapping, no min/max, no column sizes.
+        // Expects type-fraction fallback: max(2, 10000 * 0.3) = 3000
+        IcebergFileStats fileStats = new IcebergFileStats(10000);
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().setTableVersionRange(version).build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+
+        Assertions.assertTrue(k1Stat.getDistinctValuesCount() > 1.0,
+                "NDV must be > 1 even without Puffin or column stats");
+        Assertions.assertEquals(ColumnStatistic.StatisticType.ESTIMATE, k1Stat.getType());
+        Assertions.assertEquals(3000.0, k1Stat.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testNdvFallback_rangeBased_integerSmallRange() {
+        // k1 (fieldId=1, INT): min=1, max=100 → range=100; columnSizes huge → sizeNdv >> 100.
+        // Expects range-based NDV = min(rowCount=10000, range=100) = 100.
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = getIdToTypeMappingB();
+        List<Types.NestedField> nonPartitionCols = getNonPartitionColumnsB();
+
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, nonPartitionCols,
+                10000, 100000,
+                ImmutableMap.of(1, 1, 2, 0),
+                ImmutableMap.of(1, 100, 2, 999),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                ImmutableMap.of(1, 10000000L, 2, 10000000L));
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().setTableVersionRange(version).build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+
+        // rangeNdv = min(10000, 100)=100; sizeNdv = min(10000, 10000000/4)=10000; result = min(100,10000) = 100
+        Assertions.assertEquals(100.0, k1Stat.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(ColumnStatistic.StatisticType.ESTIMATE, k1Stat.getType());
+    }
+
+    @Test
+    public void testNdvFallback_sizeBasedWinsWhenRangeLarge() {
+        // k1 (fieldId=1, INT): min=1, max=1000000 (large range > rowCount); columnSizes small.
+        // rangeNdv = min(10000, 1000000)=10000; sizeNdv = min(10000, 2000/4)=500 → size wins.
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = getIdToTypeMappingB();
+        List<Types.NestedField> nonPartitionCols = getNonPartitionColumnsB();
+
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, nonPartitionCols,
+                10000, 100000,
+                ImmutableMap.of(1, 1, 2, 0),
+                ImmutableMap.of(1, 1000000, 2, 999),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                ImmutableMap.of(1, 2000L, 2, 2000L));
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().setTableVersionRange(version).build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+
+        // sizeNdv = 2000/4 = 500 < rangeNdv=10000 → result = 500
+        Assertions.assertEquals(500.0, k1Stat.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(ColumnStatistic.StatisticType.ESTIMATE, k1Stat.getType());
+    }
+
     @Test
     public void testDoubleValue() {
         Assertions.assertEquals(1.0, convertObjectToOptionalDouble(Types.BooleanType.get(), true).get(), 0.001);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -155,7 +155,36 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         Assertions.assertTrue(k1Stat.getDistinctValuesCount() > 1.0,
                 "NDV must be > 1 even without Puffin or column stats");
         Assertions.assertEquals(ColumnStatistic.StatisticType.ESTIMATE, k1Stat.getType());
+        // type-fraction for INT: max(1, min(10000, 10000 * 0.3)) = 3000
         Assertions.assertEquals(3000.0, k1Stat.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testNdvFallback_singleRowTable_ndvNotExceedsRowCount() {
+        // rowCount=1: type-fraction gives max(1, min(1, 1*0.3))=1, not 2 (the old Math.max(2.0,...) bug)
+        IcebergFileStats fileStats = new IcebergFileStats(1);
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().setTableVersionRange(version).build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+
+        Assertions.assertTrue(k1Stat.getDistinctValuesCount() <= 1.0,
+                "NDV must not exceed rowCount=1");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
When querying Iceberg external tables without Puffin statistics files, the CBO optimizer hardcodes `distinctValuesCount = 1` for every column. This causes catastrophically wrong query plans: JOIN selectivity is estimated as 1.0 (full cross-join), and GROUP BY output cardinality is wildly overestimated. The result is that the optimizer routinely picks the wrong join strategy (broadcast vs. shuffle) and misestimates aggregation output size, regardless of the actual data distribution.

## What I'm doing:
Replace the hardcoded `NDV = 1` fallback with a three-tier estimation strategy in `IcebergStatisticProvider.buildColumnStatistic()`. The Puffin path is untouched — this only affects the `else` branch when Puffin is absent.

```
NDV source priority (unchanged):
  1. Puffin sketch  ← no change
  2. [NEW] estimateNdvFallback()
       Tier 1 — range-based (integer/date/timestamp, min/max already in IcebergFileStats → zero extra IO)
                NDV ≤ min(rowCount, max − min + 1)
       Tier 2 — column-size-based (compressed bytes / min-bytes-per-distinct-value)
                NDV ≤ min(rowCount, columnSizeBytes / typeMinBytes)
       Tier 3 — type-fraction last resort (rowCount × fraction, fraction = 0.3 for INT, 0.5 for STRING, 0.01 for BOOL)
```

The key design point for Tier 1: `IcebergFileStats` already carries `minValues`/`maxValues` from DataFile metadata when column stats are enabled. The estimation reads them with zero additional IO — if they're absent (fast path with `IcebergFileStats(recordCount)` only), `getMinValue()` returns empty and the code falls through to Tier 2/3 automatically. No parameter signature changes.

When both Tier 1 and Tier 2 are available, the code takes `min(rangeNdv, sizeNdv)` to stay conservative: range gives a tight upper bound for low-cardinality columns (e.g. a status column with values 1–5 gives NDV ≤ 5), while size-based caps the estimate when the range is too wide to be informative.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
