### PR TITLE
[Enhancement] Cache BinaryPlainPageDecoder::max_value_length

### DIFF
--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -406,7 +406,7 @@ private:
     mutable bool _dict_filter_cache_valid{false};
     mutable std::vector<uint8_t> _dict_filter_cache_selection;
     mutable uint32_t _dict_filter_cache_selected_count{0};
-    
+
     // Lazily-computed cache for max_value_length(); -1 means "not yet computed".
     mutable int64_t _max_value_length_cache = -1;
 };

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -263,6 +263,13 @@ public:
     bool supports_read_by_rowids() const override { return Type == TYPE_VARCHAR; }
 
     uint32_t max_value_length() const {
+        // The max value length is an invariant of the (immutable) dictionary/page, but it is
+        // O(_num_elems) to compute. As a dict decoder this is re-queried on every data page via
+        // BinaryDictPageDecoder::set_dict_decoder, so memoize the first computation. The decoder
+        // object is owned by a single ScalarColumnIterator, so the mutable cache needs no locking.
+        if (_max_value_length_cache >= 0) {
+            return static_cast<uint32_t>(_max_value_length_cache);
+        }
         uint32_t max_length = 0;
         for (int i = 0; i < _num_elems; ++i) {
             uint32_t length = offset(i + 1) - offset_uncheck(i);
@@ -270,6 +277,7 @@ public:
                 max_length = length;
             }
         }
+        _max_value_length_cache = max_length;
         return max_length;
     }
 
@@ -398,6 +406,9 @@ private:
     mutable bool _dict_filter_cache_valid{false};
     mutable std::vector<uint8_t> _dict_filter_cache_selection;
     mutable uint32_t _dict_filter_cache_selected_count{0};
+    
+    // Lazily-computed cache for max_value_length(); -1 means "not yet computed".
+    mutable int64_t _max_value_length_cache = -1;
 };
 
 } // namespace starrocks

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -486,4 +486,40 @@ TEST_F(BinaryPlainPageTest, test_delta_offset_roundtrip) {
     build_and_check(true);  // delta offsets must decode identically
 }
 
+// NOLINTNEXTLINE
+TEST_F(BinaryPlainPageTest, test_max_value_length_is_cached_and_correct) {
+    auto build_decoder = [](const std::vector<Slice>& slices, OwnedSlice* keep_alive) {
+        PageBuilderOptions options;
+        options.data_page_size = 256 * 1024;
+        BinaryPlainPageBuilder builder(options);
+        size_t count = slices.size();
+        builder.add(reinterpret_cast<const uint8_t*>(slices.data()), count);
+        *keep_alive = builder.finish()->build();
+        return BinaryPlainPageDecoder<TYPE_VARCHAR>(keep_alive->slice());
+    };
+
+    // Longest value is "StarRocks" (9 bytes); repeated calls must be stable and equal to the
+    // freshly-recomputed value (memoization must not change the answer).
+    {
+        std::vector<Slice> slices{"Hello", ",", "StarRocks", "ab"};
+        OwnedSlice owned;
+        auto decoder = build_decoder(slices, &owned);
+        ASSERT_OK(decoder.init());
+        EXPECT_EQ(9U, decoder.max_value_length());
+        EXPECT_EQ(9U, decoder.max_value_length());
+        EXPECT_EQ(9U, decoder.max_value_length());
+    }
+
+    // All-empty dictionary: max length is the legitimate value 0; the -1 "not computed" sentinel
+    // must not be confused with a cached 0.
+    {
+        std::vector<Slice> slices{"", "", ""};
+        OwnedSlice owned;
+        auto decoder = build_decoder(slices, &owned);
+        ASSERT_OK(decoder.init());
+        EXPECT_EQ(0U, decoder.max_value_length());
+        EXPECT_EQ(0U, decoder.max_value_length());
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
<img width="1408" height="658" alt="image" src="https://github.com/user-attachments/assets/e2234c75-c8b3-4d9e-8395-c5fcf633aa63" />

max_value_length() is O(dict cardinality) and was recomputed on every data page via BinaryDictPageDecoder::set_dict_decoder, even though the dictionary is immutable for the decoder's lifetime. For scattered vector top-k row fetches over a high-cardinality dict string column this showed up as ~11.7% self time in profiling. Memoize the first computation in a mutable cache field; the decoder is owned by a single ScalarColumnIterator so no locking is needed.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
