### PR TITLE
[BugFix] Fix GLM deserialize column failed on cross-side outer-join expressions

### DIFF
--- a/be/src/exec/pipeline/fetch_task.cpp
+++ b/be/src/exec/pipeline/fetch_task.cpp
@@ -23,6 +23,7 @@
 #include "base/status_fmt.hpp"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
+#include "column/column_helper.h"
 #include "common/brpc/brpc_stub_cache.h"
 #include "exec/pipeline/fetch_processor.h"
 #include "gen_cpp/internal_service.pb.h"
@@ -156,8 +157,34 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
     request.set_request_tuple_id(_ctx->request_tuple_id);
     {
         SCOPED_TIMER(processor->_serialize_timer);
+
+        // The remote LookUp receiver rebuilds every request column purely from its slot descriptor via
+        // ColumnHelper::create_column(type, slot_desc->is_nullable()) and then deserializes the raw,
+        // non-self-describing ColumnArraySerde bytes into it. So the bytes serialized here must match
+        // the receiver's descriptor-driven layout. A projection above the FETCH may conservatively
+        // widen a preserved-side row-position column's descriptor to nullable while the column produced
+        // here is still non-nullable; serializing the non-nullable layout then overruns the receiver's
+        // nullable column (issue #75222). Reconcile each column to its declared descriptor nullability
+        // before serializing. These are row-position columns built only for non-null source rows, so a
+        // nullable descriptor only ever wraps a null-free column (the receiver asserts no nulls).
+        std::vector<std::pair<SlotId, ColumnPtr>> serialize_columns;
+        serialize_columns.reserve(request_chunk->get_slot_id_to_index_map().size());
+        for (const auto& [slot_id, idx] : request_chunk->get_slot_id_to_index_map()) {
+            if (slot_id == FetchProcessor::kPositionColumnSlotId) {
+                // we don't need to send position column to remote node
+                continue;
+            }
+            ColumnPtr column = request_chunk->get_column_by_index(idx);
+            auto* slot_desc = state->desc_tbl().get_slot_descriptor(slot_id);
+            if (slot_desc != nullptr && slot_desc->is_nullable() != column->is_nullable()) {
+                size_t num_rows = column->size();
+                column = ColumnHelper::update_column_nullable(slot_desc->is_nullable(), std::move(column), num_rows);
+            }
+            serialize_columns.emplace_back(slot_id, std::move(column));
+        }
+
         size_t max_serialize_size = 0;
-        for (const auto& column : request_chunk->columns()) {
+        for (const auto& [_, column] : serialize_columns) {
             max_serialize_size += serde::ColumnArraySerde::max_serialized_size(*column);
         }
 
@@ -166,14 +193,9 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
 
         uint8_t* buff = reinterpret_cast<uint8_t*>(processor->_serialize_buffer.data());
         uint8_t* begin = buff;
-        for (const auto& [slot_id, idx] : request_chunk->get_slot_id_to_index_map()) {
-            if (slot_id == FetchProcessor::kPositionColumnSlotId) {
-                // we don't need to send position column to remote node
-                continue;
-            }
+        for (const auto& [slot_id, column] : serialize_columns) {
             auto p_column = request.add_request_columns();
             p_column->set_slot_id(slot_id);
-            const auto& column = request_chunk->get_column_by_index(idx);
             uint8_t* start = buff;
             ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column, buff));
             p_column->set_data_size(buff - start);

--- a/be/src/exec/pipeline/lookup_operator.cpp
+++ b/be/src/exec/pipeline/lookup_operator.cpp
@@ -87,14 +87,20 @@ Status LookUpProcessor::_collect_input_columns(RuntimeState* state, const ChunkP
         auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
         request_chunk->append_column(std::move(col), slot_desc->id());
     }
+    // Build the row-source column from its descriptor like every other request column, so the
+    // sender and receiver agree on the serialized layout (the sender reconciles each column to the
+    // descriptor before serializing). The fetch node only emits row-position columns for non-null
+    // source rows, so the deserialized column must carry no nulls even when the descriptor is
+    // nullable -- assert that invariant below instead of forcing the type non-nullable here.
     auto slot_desc = state->desc_tbl().get_slot_descriptor(row_pos_desc->get_row_source_slot_id());
-    // row source column from fetch node won't be nullable
-    auto row_source_col = ColumnHelper::create_column(slot_desc->type(), false);
+    auto row_source_col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
     request_chunk->append_column(std::move(row_source_col), slot_desc->id());
 
     for (auto& request_ctx : _ctx->request_ctxs) {
         RETURN_IF_ERROR(request_ctx->collect_input_columns(request_chunk));
     }
+    DCHECK(!request_chunk->get_column_by_slot_id(row_pos_desc->get_row_source_slot_id())->has_null())
+            << "row source column from fetch node must not contain nulls";
     return Status::OK();
 }
 

--- a/test/sql/test_global_late_mterialization/R/test_glm_outer_join_mixed_expr
+++ b/test/sql/test_global_late_mterialization/R/test_glm_outer_join_mixed_expr
@@ -1,0 +1,62 @@
+-- name: test_glm_outer_join_mixed_expr
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+set enable_global_late_materialization_cost_based = false;
+-- result:
+-- !result
+set enable_global_late_materialization = true;
+-- result:
+-- !result
+CREATE TABLE t (txid VARCHAR(20), s1 VARCHAR(20), s2 VARCHAR(20), s3 VARCHAR(20), amt DOUBLE, mref VARCHAR(20))
+  ENGINE=OLAP DUPLICATE KEY(txid) DISTRIBUTED BY HASH(txid) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE mk (mid VARCHAR(20), rate DOUBLE)
+  ENGINE=OLAP DUPLICATE KEY(mid) DISTRIBUTED BY HASH(mid) BUCKETS 1 PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+insert into t values ('TX1','a','x','p',1000,'M1'),('TX2','b','y','q',2000,'M2'),('TX3','c','z','r',3000,'M9');
+-- result:
+-- !result
+insert into mk values ('M1',10),('M2',20),('M3',30);
+-- result:
+-- !result
+alter table t set ('unique_constraints'='txid');
+-- result:
+-- !result
+alter table mk set ('unique_constraints'='mid');
+-- result:
+-- !result
+select txid, tas from (
+  select t.txid AS txid, CAST(t.amt * (1.0 - mk.rate/100.0) AS DECIMAL(38,10)) AS tas
+  FROM mk right outer join [bucket] t ON t.mref = mk.mid) w1 order by txid;
+-- result:
+TX1	900.0000000000
+TX2	1600.0000000000
+TX3	None
+-- !result
+select t.txid, t.amt + mk.rate as x from mk right outer join [bucket] t on t.mref = mk.mid order by t.txid;
+-- result:
+TX1	1010.0
+TX2	2020.0
+TX3	None
+-- !result
+select mk.mid, t.amt + mk.rate as x from mk left outer join [bucket] t on t.mref = mk.mid order by mk.mid;
+-- result:
+M1	1010.0
+M2	2020.0
+M3	None
+-- !result
+select mk.mid, t.txid, t.amt + mk.rate as x from mk full outer join t on t.mref = mk.mid order by mk.mid, t.txid;
+-- result:
+None	TX3	None
+M1	TX1	1010.0
+M2	TX2	2020.0
+M3	None	None
+-- !result
+select t.txid, t.amt + mk.rate as x from mk inner join [bucket] t on t.mref = mk.mid order by t.txid;
+-- result:
+TX1	1010.0
+TX2	2020.0
+-- !result

--- a/test/sql/test_global_late_mterialization/T/test_glm_outer_join_mixed_expr
+++ b/test/sql/test_global_late_mterialization/T/test_glm_outer_join_mixed_expr
@@ -1,0 +1,36 @@
+-- name: test_glm_outer_join_mixed_expr
+-- Regression for issue #75222: a deferred expression that mixes columns from BOTH
+-- sides of an outer join used to fail with "deserialize column failed, slot_id ..."
+-- under global late materialization. The split projection above the join blanket
+-- widened the preserved side's row-position (row-id) columns to nullable in the
+-- shared slot descriptor, so the GLM FETCH receiver built a nullable column while
+-- the sender serialized non-nullable data.
+set cbo_enable_low_cardinality_optimize = false;
+set enable_global_late_materialization_cost_based = false;
+set enable_global_late_materialization = true;
+
+CREATE TABLE t (txid VARCHAR(20), s1 VARCHAR(20), s2 VARCHAR(20), s3 VARCHAR(20), amt DOUBLE, mref VARCHAR(20))
+  ENGINE=OLAP DUPLICATE KEY(txid) DISTRIBUTED BY HASH(txid) BUCKETS 1 PROPERTIES("replication_num"="1");
+CREATE TABLE mk (mid VARCHAR(20), rate DOUBLE)
+  ENGINE=OLAP DUPLICATE KEY(mid) DISTRIBUTED BY HASH(mid) BUCKETS 1 PROPERTIES("replication_num"="1");
+insert into t values ('TX1','a','x','p',1000,'M1'),('TX2','b','y','q',2000,'M2'),('TX3','c','z','r',3000,'M9');
+insert into mk values ('M1',10),('M2',20),('M3',30);
+alter table t set ('unique_constraints'='txid');
+alter table mk set ('unique_constraints'='mid');
+
+-- the original issue query: CAST over an expression mixing both join sides
+select txid, tas from (
+  select t.txid AS txid, CAST(t.amt * (1.0 - mk.rate/100.0) AS DECIMAL(38,10)) AS tas
+  FROM mk right outer join [bucket] t ON t.mref = mk.mid) w1 order by txid;
+
+-- minimal mixed expression, right outer join (t preserved, mk nullable)
+select t.txid, t.amt + mk.rate as x from mk right outer join [bucket] t on t.mref = mk.mid order by t.txid;
+
+-- left outer join (mk preserved, t nullable)
+select mk.mid, t.amt + mk.rate as x from mk left outer join [bucket] t on t.mref = mk.mid order by mk.mid;
+
+-- full outer join (both sides nullable)
+select mk.mid, t.txid, t.amt + mk.rate as x from mk full outer join t on t.mref = mk.mid order by mk.mid, t.txid;
+
+-- inner join sanity
+select t.txid, t.amt + mk.rate as x from mk inner join [bucket] t on t.mref = mk.mid order by t.txid;


### PR DESCRIPTION
## Why I'm doing:

Under global late materialization, a query whose deferred expression references columns from BOTH sides of an outer join (e.g. t.amt + mk.rate over mk RIGHT JOIN [bucket] t) failed with
"deserialize column failed, slot_id: NN, data_size: NN".

Root cause: a projection above the FETCH conservatively widens all of its outputs to nullable when an outer join exists below it (ProjectNode.hasNullableGenerateChild). This also widens the preserved side's row-position (row-id) virtual columns in the shared slot descriptor, even though the runtime column stays non-nullable. The GLM FETCH request path is the only consumer that rebuilds a column purely from the slot descriptor over the non-self-describing ColumnArraySerde format, so the sender serialized a non-nullable layout while the remote LookUp receiver built a nullable column and overran the buffer.

Make the FETCH request path conform to the slot descriptor on both ends:
- fetch_task: reconcile every request column to its descriptor nullability before serializing (ColumnHelper::update_column_nullable).
- lookup_operator: build the row-source column from its descriptor like the other request columns, and assert it carries no nulls, instead of forcing it non-nullable.

Add a SQL regression test covering RIGHT/LEFT/FULL/INNER joins with unmatched (null-producing) rows under global late materialization.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
