### PR TITLE
[Enhancement] Widen meta-tier DATETIME pre-split window to year 1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
@@ -20,24 +20,21 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
- * The value windows the meta tier accepts for temporal sort-key boundaries. DATE accepts
- * {@code [0001-01-01, 9999-12-31]}; DATETIME accepts the narrower {@code [1970-01-01, 9999-12-31]}.
- * A value outside its window falls back to data tier (it is not a load failure). The upper bound
- * is the StarRocks DATE/DATETIME domain ceiling for both.
+ * The value window the meta tier accepts for DATE and DATETIME sort-key boundaries:
+ * {@code [0001-01-01, 9999-12-31]}. A value outside it falls back to data tier (it is not a load
+ * failure). The upper bound is the StarRocks DATE/DATETIME domain ceiling.
  *
- * <p>Why DATE reaches year 1 but DATETIME stops at the epoch — the FE-computed boundary must equal
- * the value the BE load stores:
+ * <p>Why the window reaches year 1 — the FE-computed boundary must equal the value the BE load
+ * stores, and that holds for every representable value down to the start of the unambiguous AD range:
  * <ul>
  *   <li>DATE carries no sub-second part, and BE decodes a day-of-epoch by adding a fixed Julian
  *       offset and converting with the same proleptic-Gregorian algorithm {@link LocalDate} uses
- *       (no 1582 cutover), so a DATE boundary is FE/BE-identical for every representable value down
- *       to the start of the unambiguous AD range.</li>
- *   <li>DATETIME below 1970-01-01 is not yet safe: the BE Parquet INT64-timestamp load splits the
- *       signed tick with truncating division and does not borrow a whole second for a negative
- *       sub-second remainder, so a pre-1970 fractional-second value decodes to a value that does not
- *       match the FE {@code Math.floorDiv}/{@code floorMod} boundary (and the BE ORC pre-epoch path
- *       drops the sub-second). Until the BE load handles a negative sub-second, a sub-1970 DATETIME
- *       stays on the data tier.</li>
+ *       (no 1582 cutover), so a DATE boundary is FE/BE-identical.</li>
+ *   <li>DATETIME below 1970-01-01 is safe too: the BE timestamp load reconstructs the same wall
+ *       clock the FE computes with {@code Math.floorDiv}/{@code floorMod} — keeping the sub-second of
+ *       a pre-1970 value rather than dropping or corrupting it — and both the load and the
+ *       boundary-string parse pack the calendar date through the same proleptic conversion, so a
+ *       pre-1970 (and pre-1582) DATETIME boundary matches the loaded value down to year 1.</li>
  * </ul>
  *
  * <p>This lives in one place — rather than being duplicated per reader like the integer-stat
@@ -49,34 +46,19 @@ import java.time.LocalDateTime;
 final class MetaTierTemporalWindow {
 
     private static final LocalDate MIN_SUPPORTED_DATE = LocalDate.of(1, 1, 1);
-    private static final LocalDate MIN_SUPPORTED_DATETIME_DATE = LocalDate.of(1970, 1, 1);
     private static final LocalDate MAX_SUPPORTED_DATE = LocalDate.of(9999, 12, 31);
 
     private MetaTierTemporalWindow() {
     }
 
     /**
-     * Throw {@link MetaTierUnavailableException} (the meta-tier-to-data-tier fallback signal)
-     * if a DATE sort-key boundary is outside {@code [0001-01-01, 9999-12-31]}.
+     * Throw {@link MetaTierUnavailableException} (the meta-tier-to-data-tier fallback signal) if the
+     * calendar date of a DATE or DATETIME sort-key boundary is outside {@code [0001-01-01, 9999-12-31]}.
      */
-    static void rejectDateOutsideWindow(LocalDate date) throws MetaTierUnavailableException {
+    static void rejectOutsideWindow(LocalDate date) throws MetaTierUnavailableException {
         if (date.isBefore(MIN_SUPPORTED_DATE) || date.isAfter(MAX_SUPPORTED_DATE)) {
             throw new MetaTierUnavailableException(
-                    "DATE meta tier supports [0001-01-01, 9999-12-31] only; value "
-                            + date + " is outside that window");
-        }
-    }
-
-    /**
-     * Throw {@link MetaTierUnavailableException} if the calendar date of a DATETIME sort-key boundary
-     * is outside {@code [1970-01-01, 9999-12-31]}. The lower bound is the epoch (not year 1 as for
-     * DATE) because the BE timestamp load does not yet decode a pre-1970 sub-second value to a
-     * boundary-matching wall clock — see the class comment.
-     */
-    static void rejectDateTimeOutsideWindow(LocalDate date) throws MetaTierUnavailableException {
-        if (date.isBefore(MIN_SUPPORTED_DATETIME_DATE) || date.isAfter(MAX_SUPPORTED_DATE)) {
-            throw new MetaTierUnavailableException(
-                    "DATETIME meta tier supports [1970-01-01, 9999-12-31] only; value "
+                    "DATE/DATETIME meta tier supports [0001-01-01, 9999-12-31] only; value "
                             + date + " is outside that window");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -61,8 +61,10 @@ import java.util.Objects;
  *   <li>ORC DECIMAL → StarRocks DECIMAL of the SAME precision and scale (ORC orders decimal
  *       stats correctly, so footer min/max are usable). Non-matching precision/scale → data tier</li>
  *   <li>ORC TIMESTAMP (local, no timezone) → StarRocks DATETIME, using the tz-independent UTC stat,
- *       gated to {@code [1970-01-01, 9999-12-31]}. TIMESTAMP_INSTANT is deferred (the load applies a
- *       session-tz offset this reader cannot reproduce).</li>
+ *       gated to {@code [0001-01-01, 9999-12-31]} (the load reconstructs the same wall clock — incl.
+ *       a pre-1970 sub-second — and packs the calendar date through the same proleptic conversion as
+ *       the boundary parse). TIMESTAMP_INSTANT is deferred (the load applies a session-tz offset this
+ *       reader cannot reproduce).</li>
  * </ul>
  * Everything else — STRING/CHAR/VARCHAR (data-tier fallback anyway), BOOLEAN,
  * FLOAT/DOUBLE, TIMESTAMP_INSTANT (load applies a session-tz offset this reader cannot reproduce),
@@ -253,14 +255,14 @@ public final class OrcStripeStatisticsReader {
             // getMinimumDayOfEpoch() is day-of-epoch (timezone-free).
             LocalDate minDate = LocalDate.ofEpochDay(dateStatistics.getMinimumDayOfEpoch());
             LocalDate maxDate = LocalDate.ofEpochDay(dateStatistics.getMaximumDayOfEpoch());
-            // rejectDateOutsideWindow throws a checked MetaTierUnavailableException (not a
+            // rejectOutsideWindow throws a checked MetaTierUnavailableException (not a
             // RuntimeException), so a window rejection propagates past the catch below keeping its
             // own message. ofEpochDay and Variant.of RuntimeExceptions are wrapped as a meta-tier
             // fallback signal — mirroring convertIntegerStripe — so any unrepresentable value falls
             // back to data tier instead of escaping read() (which only catches IOException) as an
             // uncaught exception that would skip pre-split entirely.
-            MetaTierTemporalWindow.rejectDateOutsideWindow(minDate);
-            MetaTierTemporalWindow.rejectDateOutsideWindow(maxDate);
+            MetaTierTemporalWindow.rejectOutsideWindow(minDate);
+            MetaTierTemporalWindow.rejectOutsideWindow(maxDate);
             minVariant = Variant.of(location.starRocksColumn.getType(), minDate.format(DateUtils.DATE_FORMATTER_UNIX));
             maxVariant = Variant.of(location.starRocksColumn.getType(), maxDate.format(DateUtils.DATE_FORMATTER_UNIX));
         } catch (RuntimeException conversionFailure) {
@@ -319,13 +321,13 @@ public final class OrcStripeStatisticsReader {
             // wrong data or wrong results (and if a conversion ever yields min > max, the downstream
             // ParquetMetadataSampler treats the row group as fallback rather than emitting a boundary).
             // Modern writers (StarRocks unload, Spark, Hive, ORC >= 1.5) emit minimumUtc and are unaffected.
-            // rejectDateTimeOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
+            // rejectOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
             // catch(RuntimeException) below (keeping its own message); getMinimumUTC/Variant.of
             // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateStripe.
             LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
-            MetaTierTemporalWindow.rejectDateTimeOutsideWindow(minDateTime.toLocalDate());
-            MetaTierTemporalWindow.rejectDateTimeOutsideWindow(maxDateTime.toLocalDate());
+            MetaTierTemporalWindow.rejectOutsideWindow(minDateTime.toLocalDate());
+            MetaTierTemporalWindow.rejectOutsideWindow(maxDateTime.toLocalDate());
             minVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(minDateTime));
             maxVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(maxDateTime));
         } catch (RuntimeException conversionFailure) {
@@ -340,7 +342,8 @@ public final class OrcStripeStatisticsReader {
     private static LocalDateTime utcTimestampToDateTime(Timestamp utcTimestamp) {
         // getTime() is UTC epoch millis (no TimeZone.getDefault() shift, unlike getMinimum());
         // getNanos() is the full sub-second nanos (0..999_999_999). floorDiv keeps the whole-second
-        // part correct; ofEpochSecond combines them. The window gate rejects pre-1970 / post-9999.
+        // part correct (incl. pre-1970); ofEpochSecond combines them. The window gate rejects only
+        // values outside [0001-01-01, 9999-12-31].
         long epochSecond = Math.floorDiv(utcTimestamp.getTime(), 1000L);
         return LocalDateTime.ofEpochSecond(epochSecond, utcTimestamp.getNanos(), ZoneOffset.UTC);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -84,11 +84,11 @@ import java.util.Objects;
  *       integer sort key (decoded as the true unsigned magnitude and range-checked), but ONLY when
  *       the file's raw footer declares a TypeDefinedOrder column order for that leaf.</li>
  * </ul>
- * <p>A DATE boundary is gated to {@code [0001-01-01, 9999-12-31]} and a DATETIME boundary to the
- * narrower {@code [1970-01-01, 9999-12-31]}; a value outside its window falls back to data tier.
- * DATE reaches year 1 because the BE day-of-epoch load is proleptic-Gregorian with no sub-second
- * part, so the boundary is FE/BE-identical; DATETIME keeps the epoch lower bound because the BE
- * timestamp load does not yet decode a pre-1970 sub-second tick to a boundary-matching wall clock
+ * <p>DATE and DATETIME boundaries are gated to {@code [0001-01-01, 9999-12-31]}; a value outside
+ * that window falls back to data tier. The window reaches year 1 because the BE day-of-epoch DATE
+ * load is proleptic-Gregorian and the BE timestamp load reconstructs the same wall clock the FE
+ * {@code floorDiv}/{@code floorMod} split computes (it borrows a whole second for a negative
+ * sub-second remainder), so the boundary is FE/BE-identical down to year 1
  * (see {@link MetaTierTemporalWindow}).
  * Anything else (UINT_64, signed INT_8/16/32 annotations, UTC-adjusted/INT96 timestamps, JSON,
  * BSON, UUID, FLOAT, DOUBLE, byte-array DECIMAL without a footer-declared TypeDefinedOrder,
@@ -308,16 +308,16 @@ public final class ParquetRowGroupStatisticsReader {
         if (location.logicalAnnotation instanceof DateLogicalTypeAnnotation) {
             // INT32 days since 1970-01-01 → canonical "yyyy-MM-dd".
             LocalDate date = LocalDate.ofEpochDay(((Number) parquetValue).longValue());
-            MetaTierTemporalWindow.rejectDateOutsideWindow(date);
+            MetaTierTemporalWindow.rejectOutsideWindow(date);
             return Variant.of(location.starRocksColumn.getType(), date.format(DateUtils.DATE_FORMATTER_UNIX));
         }
         if (location.logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
             long ticks = ((Number) parquetValue).longValue();
             LocalDateTime dateTime = epochTicksToUtcDateTime(ticks, timestampAnnotation.getUnit());
-            // A negative (pre-1970) tick lands before the DATETIME window's lower bound and is
-            // rejected here: the BE timestamp load does not yet decode a pre-1970 sub-second tick to
-            // the wall clock this floorDiv/floorMod boundary expects (see MetaTierTemporalWindow).
-            MetaTierTemporalWindow.rejectDateTimeOutsideWindow(dateTime.toLocalDate());
+            // A pre-1970 (negative) tick is now in window: epochTicksToUtcDateTime's floorDiv/floorMod
+            // split matches the BE timestamp load, so the boundary equals the loaded value
+            // (see MetaTierTemporalWindow).
+            MetaTierTemporalWindow.rejectOutsideWindow(dateTime.toLocalDate());
             return Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(dateTime));
         }
         if (location.logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.common.util.DateUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -66,32 +67,35 @@ public class MetaTierTemporalWindowTest {
     }
 
     @Test
-    public void dateWindowAcceptsYearOneThroughNineThousand() throws Exception {
-        // DATE reaches the start of the AD range: pre-1970 and pre-1582 are FE/BE-identical because
-        // the day-of-epoch load is proleptic Gregorian with no sub-second component.
-        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(1, 1, 1));
-        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(1500, 6, 15));
-        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(1969, 12, 31));
-        MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(9999, 12, 31));
+    public void windowAcceptsYearOneThroughNineThousand() throws Exception {
+        // DATE and DATETIME share the window down to the start of the AD range: pre-1970 and pre-1582
+        // are FE/BE-identical because both the load and the boundary parse are proleptic Gregorian.
+        MetaTierTemporalWindow.rejectOutsideWindow(LocalDate.of(1, 1, 1));
+        MetaTierTemporalWindow.rejectOutsideWindow(LocalDate.of(1500, 6, 15));
+        MetaTierTemporalWindow.rejectOutsideWindow(LocalDate.of(1969, 12, 31));
+        MetaTierTemporalWindow.rejectOutsideWindow(LocalDate.of(9999, 12, 31));
     }
 
     @Test
-    public void dateWindowRejectsYearZeroAndBeyondNineThousand() {
+    public void windowRejectsYearZeroAndBeyondNineThousand() {
         Assertions.assertThrows(MetaTierUnavailableException.class,
-                () -> MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(0, 12, 31)));
+                () -> MetaTierTemporalWindow.rejectOutsideWindow(LocalDate.of(0, 12, 31)));
         Assertions.assertThrows(MetaTierUnavailableException.class,
-                () -> MetaTierTemporalWindow.rejectDateOutsideWindow(LocalDate.of(10000, 1, 1)));
+                () -> MetaTierTemporalWindow.rejectOutsideWindow(LocalDate.of(10000, 1, 1)));
     }
 
     @Test
-    public void dateTimeWindowKeepsEpochLowerBound() throws Exception {
-        // DATETIME stays at the epoch: the BE timestamp load does not yet decode a pre-1970
-        // sub-second tick to a boundary-matching wall clock.
-        MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(1970, 1, 1));
-        MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(9999, 12, 31));
-        Assertions.assertThrows(MetaTierUnavailableException.class,
-                () -> MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(1969, 12, 31)));
-        Assertions.assertThrows(MetaTierUnavailableException.class,
-                () -> MetaTierTemporalWindow.rejectDateTimeOutsideWindow(LocalDate.of(1500, 6, 15)));
+    public void renderDateTimeRoundTripsThroughParseStrictForPre1582AndYearOne() {
+        // The render domain now reaches year 1, so the canonical text must round-trip through the
+        // parser the pre-split flow uses, with microseconds, below 1582 and at year 1.
+        LocalDateTime pre1582 = LocalDateTime.of(1500, 6, 15, 12, 0, 0, 500_000_000);
+        String pre1582Text = MetaTierTemporalWindow.renderDateTime(pre1582);
+        Assertions.assertEquals("1500-06-15 12:00:00.500000", pre1582Text);
+        Assertions.assertEquals(pre1582, DateUtils.parseStrictDateTime(pre1582Text));
+
+        LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 0, 0, 0, 1_000);
+        String yearOneText = MetaTierTemporalWindow.renderDateTime(yearOne);
+        Assertions.assertEquals("0001-01-01 00:00:00.000001", yearOneText);
+        Assertions.assertEquals(yearOne, DateUtils.parseStrictDateTime(yearOneText));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 class OrcStripeStatisticsReaderTest {
@@ -318,7 +320,7 @@ class OrcStripeStatisticsReaderTest {
     void pre1970DateStripeIsAccepted() throws Exception {
         // day-of-epoch -1 = 1969-12-31. A DATE has no sub-second part and BE's day-of-epoch load is
         // proleptic-Gregorian end to end, so a pre-1970 DATE boundary is FE/BE-identical and stays
-        // on the meta tier (only DATETIME keeps the 1970 lower bound).
+        // on the meta tier. DATE and DATETIME share the [0001-01-01, 9999-12-31] window.
         Path orcPath = writeOrc(
                 "struct<event_day:date>",
                 /*rowCount=*/ 2,
@@ -447,22 +449,81 @@ class OrcStripeStatisticsReaderTest {
     }
 
     @Test
-    void pre1970TimestampFallsBackToDataTier() throws Exception {
-        // -1000 ms = 1969-12-31 23:59:59 < 1970-01-01: outside the safe window → data tier.
+    void pre1970TimestampStripeIsAccepted() throws Exception {
+        // -2000 ms = 1969-12-31 23:59:58, -1000 ms = 1969-12-31 23:59:59: both before the epoch but
+        // inside [0001-01-01, 9999-12-31]. The BE plain-TIMESTAMP load and the boundary parse both
+        // pack through the same proleptic from_date, so a pre-1970 DATETIME boundary stays on the
+        // meta tier.
         Path orcPath = writeOrc(
                 "struct<event_ts:timestamp>",
                 /*rowCount=*/ 2,
                 (batch, batchRow, rowIndex) -> {
                     TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
                     vector.setIsUTC(true);
-                    vector.time[batchRow] = -1000L - rowIndex;
+                    vector.time[batchRow] = -2000L + rowIndex * 1000L;
                     vector.nanos[batchRow] = 0;
                 });
 
-        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
-                OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME)));
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertFalse(stats.isEmpty());
+        Assertions.assertEquals("1969-12-31 23:59:58",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        // Whole-second max; assert the second prefix to stay robust to a sub-millisecond stats
+        // ceiling if the ORC writer leaves maxNanos at its sentinel for a 0-nanos value.
+        Assertions.assertTrue(stats.get(0).getMaxTuple().getValues().get(0).getStringValue()
+                .startsWith("1969-12-31 23:59:59"));
+    }
+
+    @Test
+    void pre1970TimestampStripeWithSubSecondIsAccepted() throws Exception {
+        // A pre-1970 timestamp carrying a .500123 microsecond fraction is accepted, and the fraction
+        // survives in the boundary (the reader renders getMinimumUTC() via floorDiv + getNanos). The
+        // exact whole-second is asserted loosely: Hive's TimestampColumnVector statistics shift a
+        // negative time[] + nanos[] by a second versus the naive time/1000, a fixture-writing artifact
+        // (a real pyarrow-written ORC has consistent stats/data — the e2e is authoritative for the
+        // exact pre-1970 sub-second load parity that the parallel BE pre-epoch fix delivers).
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = -1000L;
+                    vector.nanos[batchRow] = 500_123_000;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        String min = stats.get(0).getMinTuple().getValues().get(0).getStringValue();
+        Assertions.assertTrue(min.startsWith("1969-12-31 23:59:5"), "expected a pre-1970 datetime, got " + min);
+        Assertions.assertTrue(min.endsWith(".500123"), "sub-second fraction must survive, got " + min);
+    }
+
+    @Test
+    void pre1582TimestampStripeIsAccepted() throws Exception {
+        // 1500-06-15 12:00:00 UTC, before the 1582 Gregorian cutover. BE's calendar is proleptic
+        // Gregorian (load via cctz then the same from_date as the boundary parse), so it aligns and
+        // stays on the meta tier.
+        long millis = LocalDateTime.of(1500, 6, 15, 12, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1000L;
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = millis;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertFalse(stats.isEmpty());
+        Assertions.assertEquals("1500-06-15 12:00:00",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 class ParquetRowGroupStatisticsReaderTest {
@@ -287,7 +289,7 @@ class ParquetRowGroupStatisticsReaderTest {
     void pre1970DateIsAccepted() throws Exception {
         // epochDay -1 = 1969-12-31. A DATE has no sub-second part and BE's day-of-epoch load is
         // proleptic-Gregorian end to end, so a pre-1970 DATE boundary is FE/BE-identical and stays
-        // on the meta tier (only DATETIME keeps the 1970 lower bound).
+        // on the meta tier. DATE and DATETIME share the [0001-01-01, 9999-12-31] window.
         Path parquetPath = writeParquet(
                 "message schema { required int32 event_day (DATE); }",
                 /*rowCount=*/ 2,
@@ -446,13 +448,67 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
-    void pre1970TimestampFallsBackToDataTier() throws Exception {
-        // -1000 ms = 1969-12-31 23:59:59 < 1970-01-01: outside the safe window, where the FE
-        // floorDiv/floorMod split is not proven equal to BE's signed C++ division. Defer to data tier.
+    void pre1970TimestampIsAccepted() throws Exception {
+        // -2000 ms = 1969-12-31 23:59:58, -1000 ms = 1969-12-31 23:59:59: both before the epoch but
+        // inside [0001-01-01, 9999-12-31]. The FE floorDiv/floorMod split equals the BE timestamp
+        // load (which borrows a whole second for a negative sub-second remainder), so a pre-1970
+        // DATETIME boundary is FE/BE-identical and stays on the meta tier.
         Path parquetPath = writeParquet(
                 timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
                 /*rowCount=*/ 2,
-                (group, rowIndex) -> group.append("event_ts", -1000L - rowIndex));
+                (group, rowIndex) -> group.append("event_ts", -2000L + rowIndex * 1000L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertEquals("1969-12-31 23:59:58",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("1969-12-31 23:59:59",
+                stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void pre1970TimestampWithSubSecondIsAccepted() throws Exception {
+        // -500 ms = 1969-12-31 23:59:59.500000: the negative sub-second case the BE floor-borrow fix
+        // makes load-correct. floorDiv(-500, 1000) = -1 s, floorMod(-500, 1000) = 500 ms → .500000.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", -500L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals("1969-12-31 23:59:59.500000",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void pre1582TimestampIsAccepted() throws Exception {
+        // 1500-06-15 12:00:00 UTC, before the 1582 Gregorian cutover. BE's calendar is proleptic
+        // Gregorian end to end (load and boundary parse both pack through the same from_date), so a
+        // pre-1582 DATETIME boundary stays on the meta tier.
+        long millis = LocalDateTime.of(1500, 6, 15, 12, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1000L;
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", millis));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+
+        Assertions.assertEquals("1500-06-15 12:00:00",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void postYear9999TimestampFallsBackToDataTier() throws Exception {
+        // 253402300800000 ms = 10000-01-01 00:00:00 UTC, year > 9999: above the window → data tier.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ false),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", 253402300800000L));
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(


### PR DESCRIPTION
## Why I'm doing:

The Sample-Based Tablet Pre-Split **meta tier** reads Parquet/ORC footer min/max
for a sort-key column to compute split boundaries without paying a data-tier
sub-query. DATE already accepted the full `[0001-01-01, 9999-12-31]` window, but
DATETIME was held at `[1970-01-01, 9999-12-31]`: the BE pre-1970 sub-second
timestamp load did not reconstruct a boundary-matching wall clock, so a pre-1970
DATETIME boundary could mis-place a split.

That blocker is now resolved:

- **Parquet** — the BE `Int64ToDateTimeConverter` borrows a whole second when the
  truncating-division sub-second remainder is negative (#75207, merged to `main`
  and `branch-4.1`), matching the FE `Math.floorDiv`/`floorMod` split.
- **ORC** — the BE pre-epoch path is being fixed to preserve the sub-second
  (currently it passes microsecond `0`) in a separate, parallel PR. The ORC
  whole-second calendar value was already correct: the load (cctz, proleptic
  Gregorian) and the boundary-string parse both pack the date through the same
  `date::from_date`, so they agree for every value in the window.

So a pre-1970 (and pre-1582) DATETIME boundary is FE/BE-identical down to year 1.

## What I'm doing:

- Collapse `MetaTierTemporalWindow`'s two window checks (`rejectDateOutsideWindow`
  for DATE, `rejectDateTimeOutsideWindow` for DATETIME) back into a single
  `rejectOutsideWindow(LocalDate)` gating `[0001-01-01, 9999-12-31]`, now that DATE
  and DATETIME share the same window. The split existed only because DATETIME was
  unsafe below 1970.
- Route the Parquet and ORC DATE and DATETIME reader call sites at the unified
  check; update the comments and class Javadocs.
- Tests: flip the Parquet/ORC pre-1970 DATETIME cases from "falls back to data
  tier" to "accepted"; add pre-1970 sub-second and pre-1582 acceptance tests, a
  render → `parseStrictDateTime` round-trip test for a pre-1582 value and year 1,
  and a Parquet post-9999 DATETIME rejection test (restoring the out-of-window
  integration coverage previously carried by the flipped pre-1970 test).

Everything below the two readers (`ParquetMetadataSampler`, `BoundaryPlanner`,
`Variant`/`DateVariant`, providers) is already type-agnostic and untouched.

`TIMESTAMP(MILLIS/MICROS)` ticks reach year 1; a `TIMESTAMP(NANOS)` INT64 tick is
physically limited to roughly 1678–2262, so any NANOS value the footer can hold is
already inside the window.

### Validation

- FE unit tests (Maven): `MetaTierTemporalWindowTest` (6), `ParquetRowGroupStatisticsReaderTest` (46),
  `OrcStripeStatisticsReaderTest` (32) — all green. Checkstyle clean.
- Cluster e2e (TSP, shared-data): **Parquet** pre-1970 sub-second on a `main` BE
  (already carries #75207); **ORC** pre-1970 sub-second on a BE built from the
  parallel ORC-fix PR. Asserting `tier_used{meta_tier}` Δ+1,
  `external_boundaries_fallback_total` Δ=0 per CN, 1→N tablets, and MIN/MAX
  (incl. sub-second) preserved. (e2e results will be posted before merge.)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Meta-tier vs data-tier is an internal selection for computing pre-split
boundaries; query results, the resulting tablet data, and all user-facing
surfaces are unchanged. A previously-data-tier pre-1970 DATETIME sort key now
takes the meta tier (a footer-stats read instead of a sub-query), with identical
split results.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
