### PR TITLE
[BugFix] Fix combined ALTER TABLE on external Iceberg re-executing queued actions (backport #74036)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorAlterTableExecutor.java
@@ -45,6 +45,11 @@ public class ConnectorAlterTableExecutor implements AstVisitorExtendInterface<Vo
             for (AlterClause c : alterClauses) {
                 visit(c, null);
             }
+            // Run queued actions only after every clause is visited; running inside the
+            // loop above would re-execute every previously queued action on each pass.
+            for (Runnable r : actions) {
+                r.run();
+            }
         } catch (StarRocksConnectorException e) {
             throw new DdlException(e.getMessage(), e.getCause());
         }
@@ -53,15 +58,6 @@ public class ConnectorAlterTableExecutor implements AstVisitorExtendInterface<Vo
     public ShowResultSet execute() throws DdlException {
         applyClauses();
         return resultSet;
-    }
-
-    @Override
-    public Void visit(ParseNode node, ConnectContext context) {
-        node.accept(this, context);
-        for (Runnable r : actions) {
-            r.run();
-        }
-        return null;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
@@ -282,6 +282,48 @@ public class AlterTableTest extends TableTestBase {
     }
 
     @Test
+    public void testCombinedAddAndDropColumn() throws Exception {
+        // Regression test for StarRocksTest issue #11315: a single ALTER carrying multiple
+        // schema clauses (e.g. ADD a, ADD b, DROP c) previously failed with
+        // "Cannot add column, name already exists: ..." because the executor re-ran every
+        // previously appended action on each subsequent visit() call.
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, "db");
+            }
+
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableH;
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        // Use a unique table name so we don't share the IcebergMetadata.tables cache
+        // with the other tests in this class (which all reuse "srTableName" backed by
+        // mockedNativeTableB).
+        String sql = "alter table iceberg_catalog.db.combinedAlterTestTable "
+                + "add column multi_col_a varchar(32), "
+                + "add column multi_col_b int, "
+                + "drop column k5";
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        Assertions.assertEquals(3, stmt.getAlterClauseList().size());
+
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
+
+        mockedNativeTableH.refresh();
+        org.apache.iceberg.Schema schema = mockedNativeTableH.schema();
+        Assertions.assertNotNull(schema.findField("multi_col_a"));
+        Assertions.assertNotNull(schema.findField("multi_col_b"));
+        Assertions.assertNull(schema.findField("k5"));
+    }
+
+    @Test
     public void testAlterView() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock


### PR DESCRIPTION
## Why I'm doing:

A single `ALTER TABLE` on an external Iceberg table that carries more than one schema clause (e.g. `ADD COLUMN a, ADD COLUMN b, DROP COLUMN c`) fails with a misleading error such as:

```
ERROR 1064 (HY000): Cannot add column, name already exists: multi_col_a
```

Root cause is in `ConnectorAlterTableExecutor`. Each `visitXxxClause` only queues a deferred action into the `actions` list, but the overridden `visit(ParseNode, ConnectContext)` re-ran the **entire** `actions` list on every clause dispatch without ever clearing it. So for N clauses, action #1 runs N times, action #2 runs N-1 times, etc. The second time an `addColumn` action runs against the same Iceberg transaction, Iceberg's `SchemaUpdate` rejects it with `name already exists`.

This affects external **Iceberg** catalogs only (the sole subclass of `ConnectorAlterTableExecutor`). Internal/OLAP tables use a separate `AlterJobExecutor` path and are unaffected. The defect has existed since the class was introduced, so all maintained branches are impacted.

Reported in StarRocksTest issue #11315.

## What I'm doing:

- Collect the deferred actions while visiting all clauses, then run each queued action exactly once after the loop completes, inside `applyClauses()`.
- Remove the redundant `visit(ParseNode, ConnectContext)` override and fall back to the default `AstVisitor` dispatch.
- Add a regression test `AlterTableTest#testCombinedAddAndDropColumn` covering a combined add/drop-column ALTER against an Iceberg table. The existing `IcebergMetadataTest.testAlterTable` could not catch this because it uses a fully mocked catalog that swallows the duplicate `addColumn` calls.

Verified end-to-end on a TSP cluster: the same combined ALTER fails on the baseline build and succeeds after applying this fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

