### PR TITLE
[BugFix] Support creating multiple physical partitions in one addPhysicalPartition call

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1888,6 +1888,25 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
      */
     public void addPhysicalPartition(String dbName, String tableName, String partitionName,
                                      int bucketNum) throws DdlException {
+        addPhysicalPartition(dbName, tableName, partitionName, bucketNum, 1);
+    }
+
+    /**
+     * Add {@code count} new physical partitions to an existing logical partition, each with the
+     * given bucket number, persisted in a single batch. Calling this with {@code count == 1} is
+     * equivalent to the 4-argument overload. Designed to be called via admin execute script for
+     * cross-cluster data replication scenarios that need to backfill many physical partitions on a
+     * random-distribution table in one call instead of one per scheduling cycle.
+     *
+     * @param dbName        the database name
+     * @param tableName     the table name
+     * @param partitionName the partition name (null for non-partitioned table)
+     * @param bucketNum     the bucket number (0 to use system default)
+     * @param count         the number of physical partitions to add (must be {@code >= 1} and
+     *                      {@code <= Config.max_partitions_in_one_batch})
+     */
+    public void addPhysicalPartition(String dbName, String tableName, String partitionName,
+                                     int bucketNum, int count) throws DdlException {
         Database db = getDb(dbName);
         if (db == null) {
             throw new DdlException("Database '" + dbName + "' does not exist");
@@ -1940,6 +1959,17 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             throw new DdlException("Bucket number exceeds maximum allowed: " + Config.max_bucket_number_per_partition);
         }
 
+        if (count < 1) {
+            throw new DdlException("Count must be at least 1");
+        }
+
+        if (count > Config.max_partitions_in_one_batch) {
+            throw new DdlException(String.format(
+                    "Count %d exceeds the maximum number of physical partitions allowed in one batch: %d. " +
+                            "You can modify this restriction by setting max_partitions_in_one_batch larger.",
+                    count, Config.max_partitions_in_one_batch));
+        }
+
         // Get compute resource
         long warehouseId = ConnectContext.get() != null
                 ? ConnectContext.get().getCurrentWarehouseId()
@@ -1948,13 +1978,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         final CRAcquireContext acquireContext = CRAcquireContext.of(warehouseId);
         final ComputeResource computeResource = warehouseManager.acquireComputeResource(acquireContext);
 
-        // Add one physical partition with the specified bucket number.
+        // Add `count` physical partitions with the specified bucket number, persisted in one batch.
         // The bucketNum is set on the shadow-copied table inside addSubPartitions,
         // so there is no concurrent safety issue with the original table object.
-        addSubPartitions(db, olapTable, partition, 1, bucketNum, computeResource);
+        addSubPartitions(db, olapTable, partition, count, bucketNum, computeResource);
 
-        LOG.info("Successfully added physical partition to partition '{}' in table '{}'",
-                partition.getName(), olapTable.getName());
+        LOG.info("Successfully added {} physical partition(s) to partition '{}' in table '{}'",
+                count, partition.getName(), olapTable.getName());
     }
 
     public void replayAddSubPartition(PhysicalPartitionPersistInfoV2 info) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -566,4 +566,95 @@ public class LocalMetaStoreTest {
 
         starRocksAssert.dropTable("test.add_pp_err");
     }
+
+    @Test
+    public void testAddPhysicalPartitionBatch() throws Exception {
+        // Create a non-partitioned table with random distribution
+        starRocksAssert.useDatabase("test").withTable(
+                "CREATE TABLE test.add_pp_batch(k1 INT, k2 VARCHAR(50), v1 INT) " +
+                        "ENGINE=olap DUPLICATE KEY(k1) DISTRIBUTED BY RANDOM BUCKETS 8 " +
+                        "PROPERTIES ('replication_num' = '1')");
+
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = metastore.getDb("test");
+        OlapTable table = (OlapTable) db.getTable("add_pp_batch");
+        Assertions.assertEquals(1, table.getPhysicalPartitions().size());
+
+        long originalMutableBucketNum = table.getMutableBucketNum();
+        Partition partition = table.getPartitions().iterator().next();
+
+        // Batch-add 3 physical partitions, each with bucketNum = 4, in a single call
+        metastore.addPhysicalPartition("test", "add_pp_batch", null, 4, 3);
+        Assertions.assertEquals(4, table.getPhysicalPartitions().size());
+        Assertions.assertEquals(4, partition.getSubPartitions().size());
+
+        // The 3 newly added (non-default) physical partitions should each have bucketNum = 4
+        int newPartitionCount = 0;
+        for (PhysicalPartition p : partition.getSubPartitions()) {
+            if (p.getId() != partition.getDefaultPhysicalPartition().getId()) {
+                newPartitionCount++;
+                Assertions.assertEquals(4, p.getBucketNum());
+            }
+        }
+        Assertions.assertEquals(3, newPartitionCount);
+
+        // The original table's mutableBucketNum must not be modified (concurrency-safe)
+        Assertions.assertEquals(originalMutableBucketNum, table.getMutableBucketNum());
+
+        starRocksAssert.dropTable("test.add_pp_batch");
+    }
+
+    @Test
+    public void testAddPhysicalPartitionBatchCountOne() throws Exception {
+        // The 5-arg overload with count = 1 must behave exactly like the 4-arg form
+        starRocksAssert.useDatabase("test").withTable(
+                "CREATE TABLE test.add_pp_one(k1 INT, v1 INT) " +
+                        "ENGINE=olap DUPLICATE KEY(k1) DISTRIBUTED BY RANDOM BUCKETS 8 " +
+                        "PROPERTIES ('replication_num' = '1')");
+
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = metastore.getDb("test");
+        OlapTable table = (OlapTable) db.getTable("add_pp_one");
+        Partition partition = table.getPartitions().iterator().next();
+
+        metastore.addPhysicalPartition("test", "add_pp_one", null, 6, 1);
+        Assertions.assertEquals(2, table.getPhysicalPartitions().size());
+
+        PhysicalPartition newPartition = partition.getSubPartitions().stream()
+                .filter(p -> p.getId() != partition.getDefaultPhysicalPartition().getId())
+                .findFirst().orElseThrow();
+        Assertions.assertEquals(6, newPartition.getBucketNum());
+
+        starRocksAssert.dropTable("test.add_pp_one");
+    }
+
+    @Test
+    public void testAddPhysicalPartitionBatchCountValidation() throws Exception {
+        starRocksAssert.useDatabase("test").withTable(
+                "CREATE TABLE test.add_pp_count(k1 INT, v1 INT) " +
+                        "ENGINE=olap DUPLICATE KEY(k1) DISTRIBUTED BY RANDOM BUCKETS 4 " +
+                        "PROPERTIES ('replication_num' = '1')");
+
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+
+        // count < 1 is rejected
+        DdlException zeroEx = Assertions.assertThrows(DdlException.class, () ->
+                metastore.addPhysicalPartition("test", "add_pp_count", null, 0, 0));
+        Assertions.assertTrue(zeroEx.getMessage().contains("at least 1"));
+        Assertions.assertThrows(DdlException.class, () ->
+                metastore.addPhysicalPartition("test", "add_pp_count", null, 0, -1));
+
+        // count > max_partitions_in_one_batch is rejected; the message names the config and value
+        long originalLimit = Config.max_partitions_in_one_batch;
+        try {
+            Config.max_partitions_in_one_batch = 2;
+            DdlException overEx = Assertions.assertThrows(DdlException.class, () ->
+                    metastore.addPhysicalPartition("test", "add_pp_count", null, 0, 3));
+            Assertions.assertTrue(overEx.getMessage().contains("max_partitions_in_one_batch"));
+        } finally {
+            Config.max_partitions_in_one_batch = originalLimit;
+        }
+
+        starRocksAssert.dropTable("test.add_pp_count");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

The string entry point `LocalMetastore.addPhysicalPartition(db, table, partition, bucketNum)`
— reachable through `ADMIN EXECUTE ON FRONTEND` Groovy scripts and used by cross-cluster data
migration tooling to backfill physical partitions on `DISTRIBUTED BY RANDOM` tables —
hard-codes the sub-partition count to `1`. A random table that needs hundreds of physical
partitions therefore has to be backfilled one partition per scheduling cycle, making
provisioning extremely slow, even though the underlying mechanism already supports batching.

## What I'm doing:

Add an **additive** 5-argument overload:

```java
public void addPhysicalPartition(String dbName, String tableName, String partitionName,
                                 int bucketNum, int count) throws DdlException
```

callable as `metastore.addPhysicalPartition("db","tbl","part", <bucketNum>, <count>)`. It
creates `count` physical partitions in a single batch by passing `count` through to the existing
`addSubPartitions(...)` path, which already loops `count` times and persists all of them in one
`AddSubPartitionsInfoV2` edit-log record (replay is unchanged).

- The existing 4-argument method is **preserved** and simply delegates with `count = 1`, so
  existing callers and older clients are unaffected. Groovy resolves the new overload by argument
  count, so a 4-arg call still reaches the 4-arg method.
- `count` is validated: `count >= 1` and `count <= Config.max_partitions_in_one_batch` (the
  existing per-batch partition-creation limit, default 4096, already used by MULTI RANGE
  partition creation and batch/expression-partition load). This prevents a typo from trying to
  allocate an unbounded number of tablets. `bucketNum` validation is unchanged.
- Failure atomicity and the table-global automatic-bucketing flag are pre-existing behaviors of
  `addSubPartitions` and are unchanged by this PR (the call only swaps the literal `1` for `count`).

No new config, SQL syntax, or metric is added; no edit-log / replay changes.

**Behavior-change classification:** marked **No** — this is an additive overload reachable only
via the privileged `ADMIN EXECUTE` admin escape hatch; it changes no SQL syntax, no config
default/name/semantics, and no external REST/CLI interface, and the existing 4-arg behavior is
identical. (Happy to flip to Yes + Miscellaneous if a maintainer prefers.)

## Test:

- Added 3 unit tests in `LocalMetaStoreTest`:
  - `testAddPhysicalPartitionBatch` — `count = 3` creates exactly 3 new physical partitions, each
    with the requested `bucketNum`; the table's `mutableBucketNum` is unchanged.
  - `testAddPhysicalPartitionBatchCountOne` — the 5-arg form with `count = 1` behaves like the 4-arg form.
  - `testAddPhysicalPartitionBatchCountValidation` — `count < 1` and `count > max_partitions_in_one_batch` throw `DdlException`.
- `mvn test -pl fe-core -Dtest=LocalMetaStoreTest`: **Tests run: 18, Failures: 0, Errors: 0, Skipped: 0**.
- `./gradlew :fe-core:checkstyleMain :fe-core:checkstyleTest`: **BUILD SUCCESSFUL**.

No cluster e2e: this widens an already-tested internal batch path (`addSubPartitions` is exercised
with `numSubPartition > 1` by existing `AlterTest` cases); the new validation and batch wiring are
covered by the unit tests above.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
