### PR TITLE
[BugFix] Cache Iceberg REST vended-credential tables and keep their credentials fresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -77,6 +77,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     // Only emit the partition-load INFO line when a refresh exceeds this many partitions, so the log
     // remains useful for diagnosing slow loads on large tables without flooding for normal-sized ones.
     private static final int PARTITION_LOAD_LOG_THRESHOLD = 10000;
+    // REST tables embed short-lived vended credentials (~1h) in their FileIO; cap the table-cache TTL so an
+    // idle entry can't outlive its token. Provider-agnostic: bounds cache lifetime, no per-cloud expiry parse.
+    private static final long REST_TABLE_CACHE_MAX_TTL_SEC = 3000;
     private static final ThreadLocal<ConnectContext> TABLE_LOAD_CONTEXT = new ThreadLocal<>();
     private final String catalogName;
     private final IcebergCatalog delegate;
@@ -107,8 +110,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         this.databases = newCacheBuilderWithMaximumSize(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
                 NEVER_CACHE, DEFAULT_CACHE_NUM).build();
+        long tableCacheTtlSec = icebergProperties.getIcebergMetaCacheTtlSec();
+        if (delegate instanceof IcebergRESTCatalog) {
+            tableCacheTtlSec = Math.min(tableCacheTtlSec, REST_TABLE_CACHE_MAX_TTL_SEC);
+        }
         this.tables = newCacheBuilder(
-                icebergProperties.getIcebergMetaCacheTtlSec(),
+                tableCacheTtlSec,
                 icebergProperties.getIcebergTableCacheRefreshIntervalSec())
                 .executor(executorService)
                 .maximumWeight(tableCacheSize)
@@ -133,14 +140,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     @Override
                     public Table reload(IcebergTableName key, Table oldValue) {
                         try {
-                            BaseTable updateTable = 
-                                    (BaseTable) delegate.getTable(new ConnectContext(), key.dbName, key.tableName);
-                            TableOperations newOps = updateTable.operations();
-                            TableOperations oldOps = ((BaseTable) oldValue).operations();
-                            if (oldOps.current().metadataFileLocation().equals(newOps.current().metadataFileLocation())) {
-                                return oldValue;
-                            }
-                            return updateTable;
+                            return delegate.getTable(new ConnectContext(), key.dbName, key.tableName);
                         } catch (Exception e) {
                             LOG.warn("refresh table {}.{} failed", key.dbName, key.tableName, e);
                             return oldValue;
@@ -264,10 +264,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
 
         // do not cache if jwt or oauth2 is used AND it is a REST Catalog.
-        // do not cache if vended credentials are enabled, because credentials may expire before cache TTL.
         boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
-                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog)) &&
-                !delegate.isVendedCredentialsEnabled();
+                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog));
         if (!cacheAllowed) {
             return delegate.getTable(connectContext, dbName, tableName);
         }
@@ -435,6 +433,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                         dbName, tableName, currentLocation, updateLocation);
                 refreshTable(currentTable, updateTable, dbName, tableName, ctx, executorService);
                 LOG.info("Finished to refresh iceberg table {}.{}", dbName, tableName);
+            } else {
+                // Metadata unchanged keeps the partition/file caches valid; still swap in the reloaded
+                // table so the cache stops serving the old (expiring) vended FileIO token.
+                tables.put(icebergTableName, updateTable);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -278,17 +278,6 @@ public interface IcebergCatalog extends MemoryTrackable {
         return new HashMap<>();
     }
 
-    /**
-     * Check if this catalog uses vended credentials for table access.
-     * When vended credentials are used, caching tables may cause issues
-     * because credentials expire before the cache TTL.
-     *
-     * @return true if vended credentials are enabled
-     */
-    default boolean isVendedCredentialsEnabled() {
-        return false;
-    }
-
     default String defaultTableLocation(ConnectContext context, Namespace ns, String tableName) {
         Map<String, String> properties = loadNamespaceMetadata(context, ns);
         String databaseLocation = properties.get(LOCATION_PROPERTY);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -87,7 +87,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
-    private final boolean enableVendedCredentials;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
@@ -105,7 +104,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         restCatalogProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         restCatalogProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
-        this.enableVendedCredentials =
+        boolean enableVendedCredentials =
                 Boolean.parseBoolean(restCatalogProperties.getOrDefault(KEY_VENDED_CREDENTIALS_ENABLED, "true"));
         if (enableVendedCredentials) {
             restCatalogProperties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
@@ -140,7 +139,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         this.nestedNamespaceEnabled = false;
         this.viewEndpointsEnabled = true;
         this.restCatalogProperties = Maps.newHashMap();
-        this.enableVendedCredentials = false;
     }
 
     @Override
@@ -466,10 +464,5 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         return new SessionCatalog.SessionContext(sessionId, context.getQualifiedUser(), credentials, ImmutableMap.of(),
                 context.getCurrentUserIdentity());
-    }
-
-    @Override
-    public boolean isVendedCredentialsEnabled() {
-        return enableVendedCredentials;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -464,63 +464,114 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testGetTableBypassCacheWhenVendedCredentialsEnabled(@Mocked IcebergRESTCatalog restCatalog) {
-        // When vended credentials is enabled, caching should be bypassed to avoid
-        // using expired credentials.
+    public void testRestCatalogWithoutAuthTokenUsesCache(@Mocked IcebergRESTCatalog restCatalog) {
+        // A REST catalog (including one with vended credentials) is served from the cache: the delegate
+        // is hit once and the second getTable() is a cache hit. Guards the revert of the #69434 bypass.
         ConnectContext ctx = new ConnectContext();
-        Table nativeTable1 = createBaseTableWithManifests(1, 1);
-        Table nativeTable2 = createBaseTableWithManifests(1, 1);
-
+        Table nativeTable = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
-                restCatalog.isVendedCredentialsEnabled();
-                result = true;
-                minTimes = 0;
-
                 restCatalog.getTable(ctx, "db4", "tbl4");
-                result = nativeTable1;
-                result = nativeTable2;
+                result = nativeTable;
+                times = 1;
             }
         };
 
         CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
                 DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
 
-        Table result1 = cachingIcebergCatalog.getTable(ctx, "db4", "tbl4");
-        Table result2 = cachingIcebergCatalog.getTable(ctx, "db4", "tbl4");
-
-        // Should return different instances (no caching)
-        Assertions.assertSame(nativeTable1, result1);
-        Assertions.assertSame(nativeTable2, result2);
+        Assertions.assertSame(nativeTable, cachingIcebergCatalog.getTable(ctx, "db4", "tbl4"));
+        Assertions.assertSame(nativeTable, cachingIcebergCatalog.getTable(ctx, "db4", "tbl4"));
     }
 
     @Test
-    public void testGetTableWithCacheWhenVendedCredentialsDisabled(@Mocked IcebergRESTCatalog restCatalog) {
-        // When vended credentials is disabled, normal caching should work.
+    public void testReloadReturnsFreshTableWhenMetadataUnchanged(@Mocked IcebergCatalog delegate) throws Exception {
         ConnectContext ctx = new ConnectContext();
-        Table nativeTable = createBaseTableWithManifests(1, 1);
+        Table oldTable = createBaseTableWithManifests(1, 1);
+        Table freshTable = createBaseTableWithManifests(1, 1);
+        // Identical metadata location on both: the removed short-circuit would have returned oldValue here,
+        // so this asserts the fresh (renewed-credential) table is installed regardless of metadata equality.
+        String sharedLocation = "s3://bucket/metadata/v1.metadata.json";
+        Mockito.when(((BaseTable) oldTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
+        Mockito.when(((BaseTable) freshTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
 
+        AtomicInteger calls = new AtomicInteger();
         new Expectations() {
             {
-                restCatalog.isVendedCredentialsEnabled();
-                result = false;
-                minTimes = 0;
-
-                restCatalog.getTable(ctx, "db5", "tbl5");
-                result = nativeTable;
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table get(ConnectContext c, String db, String tbl) {
+                        return calls.getAndIncrement() == 0 ? oldTable : freshTable;
+                    }
+                };
             }
         };
 
-        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        CachingIcebergCatalog catalog = new CachingIcebergCatalog(CATALOG_NAME, delegate,
+                DEFAULT_CATALOG_PROPERTIES, refreshExecutor);
+        LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+        IcebergTableName key = new IcebergTableName("db1", "t1");
+
+        Assertions.assertSame(oldTable, catalog.getTable(ctx, "db1", "t1"));
+        tableCache.refresh(key);
+        // refresh dispatches reload() onto refreshExecutor; this FIFO barrier returns once it has run.
+        refreshExecutor.submit(() -> { }).get();
+        Assertions.assertSame(freshTable, tableCache.getIfPresent(key));
+    }
+
+    @Test
+    public void testRefreshTableRenewsCredentialsWhenMetadataUnchanged(@Mocked IcebergCatalog delegate) {
+        ConnectContext ctx = new ConnectContext();
+        Table cachedTable = createBaseTableWithManifests(1, 1);
+        Table reloadedTable = createBaseTableWithManifests(1, 1);
+        // Identical metadata location: no snapshot change, so the background refresh keeps the
+        // partition/file caches but must still swap in the reloaded table to pick up renewed credentials.
+        String sharedLocation = "s3://bucket/metadata/v1.metadata.json";
+        Mockito.when(((BaseTable) cachedTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
+        Mockito.when(((BaseTable) reloadedTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
+
+        AtomicInteger calls = new AtomicInteger();
+        new Expectations() {
+            {
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table get(ConnectContext c, String db, String tbl) {
+                        return calls.getAndIncrement() == 0 ? cachedTable : reloadedTable;
+                    }
+                };
+            }
+        };
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CachingIcebergCatalog catalog = new CachingIcebergCatalog(CATALOG_NAME, delegate,
+                DEFAULT_CATALOG_PROPERTIES, executor);
+        LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+        IcebergTableName key = new IcebergTableName("db1", "t1");
+
+        Assertions.assertSame(cachedTable, catalog.getTable(ctx, "db1", "t1"));
+        catalog.refreshTable("db1", "t1", ctx, executor);
+        Assertions.assertSame(reloadedTable, tableCache.getIfPresent(key));
+    }
+
+    @Test
+    public void testRestTableCacheTtlIsCapped(@Mocked IcebergRESTCatalog restCatalog,
+                                              @Mocked IcebergCatalog hiveCatalog) {
+        // REST catalog: the table cache hard-expiry is capped regardless of the (default 24h) meta cache
+        // TTL, so an idle vended-credential entry cannot outlive its token.
+        CachingIcebergCatalog restCaching = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
                 DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        LoadingCache<IcebergTableName, Table> restCache = Deencapsulation.getField(restCaching, "tables");
+        long restTtl = restCache.policy().expireAfterWrite().get().getExpiresAfter(TimeUnit.SECONDS);
+        Assertions.assertTrue(restTtl <= 3000, "REST table cache TTL must be capped, was " + restTtl);
 
-        Table result1 = cachingIcebergCatalog.getTable(ctx, "db5", "tbl5");
-        Table result2 = cachingIcebergCatalog.getTable(ctx, "db5", "tbl5");
-
-        // Should return the same instance (cached)
-        Assertions.assertSame(nativeTable, result1);
-        Assertions.assertSame(nativeTable, result2);
-        Assertions.assertSame(result1, result2);
+        // Non-REST catalog: TTL stays at the configured meta cache TTL (no credential to protect).
+        CachingIcebergCatalog hiveCaching = new CachingIcebergCatalog(CATALOG_NAME, hiveCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        LoadingCache<IcebergTableName, Table> hiveCache = Deencapsulation.getField(hiveCaching, "tables");
+        long hiveTtl = hiveCache.policy().expireAfterWrite().get().getExpiresAfter(TimeUnit.SECONDS);
+        Assertions.assertEquals(DEFAULT_CATALOG_PROPERTIES.getIcebergMetaCacheTtlSec(), hiveTtl,
+                "non-REST table cache TTL must equal the configured meta cache TTL");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

PR #69434 introduced a cache bypass for Iceberg REST catalogs with vended credentials to avoid serving stale STS tokens. It fixed the expiry symptom but made **every `getTable()` hit the REST catalog and Lake Formation directly**, generating hundreds of `GetDataAccess` requests per minute and triggering AWS `Rate exceeded` failures (reported on #70988 by multiple users running AWS Glue / S3 Tables + Lake Formation).

The underlying problem is in `CachingIcebergCatalog`: credential-bearing `Table` objects were discarded on refresh instead of being kept current. This PR fixes that at the source and restores caching, using only **provider-agnostic** mechanisms.

This builds on and supersedes #70988: it keeps that PR's core `reload()` fix, adds a fix for the background-refresh path, and replaces the timing-based test with deterministic ones.

## What I'm doing:

Fixes #issue: N/A — connector caching regression introduced by #69434; tracked via #70988, no separate GitHub issue.

1. **`reload()` always returns the freshly loaded table.** The removed `metadataFileLocation` comparison returned the *old* cached `Table` (carrying its expiring FileIO/STS token) whenever metadata was unchanged — the common case — even though `delegate.getTable()` had already fetched a fresh one. The comparison saved no remote round-trip; it only threw away fresh credentials.

2. **Background `refreshTableUnderLock()` renews credentials when metadata is unchanged.** Previously it loaded a fresh table every cycle but discarded it unless the snapshot changed, so a frequently-refreshed-but-unchanged table kept its expiring credentials. The snapshot-delta partition/file caches stay valid when metadata is unchanged, so we keep gating the expensive delta maintenance on the metadata comparison, but now swap the already-loaded table into the cache so its renewed credentials replace the expiring ones (no extra remote cost — the `getTable()` call already happened).

3. **Revert the cache bypass from #69434.** Remove the `!delegate.isVendedCredentialsEnabled()` condition from `getTable()`, and delete the now-unused `isVendedCredentialsEnabled()` from `IcebergCatalog` and `IcebergRESTCatalog`.

4. **Cap the table-cache TTL for REST catalogs (default-safe, provider-agnostic).** Under the long default `iceberg_meta_cache_ttl_sec` (24h), an *idle* entry can be served past its ~1h token before `refreshAfterWrite` replaces it (Caffeine returns the stale value on the access that triggers the async reload). To make the default safe without operator tuning, the **`tables`** cache hard-expiry is capped at `3000s` when the delegate is a REST catalog. This bounds only the table cache (the partition/file caches keep the full TTL) and only for REST catalogs.

We deliberately do **not** parse per-cloud token-expiry properties to decide this: the markers differ per provider (`s3.session-token-expires-at-ms`, `gcs.oauth2.token-expires-at`, others for Azure/OSS/etc.) and are incomplete/version-dependent, so a hardcoded check would silently fail to protect unlisted providers. The cap is a coarse, provider-agnostic bound instead. Deployments with tokens shorter than the cap should still lower `iceberg_meta_cache_ttl_sec` to match.

Tests: `CachingIcebergCatalogTest` now covers (a) a REST catalog served from the cache across calls, (b) `reload()` installing the fresh table even when `metadataFileLocation` is identical, (c) `refreshTableUnderLock()` swapping in the reloaded table (renewing credentials) when metadata is unchanged, and (d) the REST table-cache TTL being capped while a non-REST catalog keeps the configured TTL. The reload/refresh tests drive the cache executor deterministically (no `Thread.sleep`).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior change**: Iceberg REST catalogs with vended credentials use the Caffeine table cache again (as before #69434); cached `Table` objects are refreshed with current credentials on every refresh cycle, including the background refresh path. For REST catalogs, the table cache's hard-expiry is additionally capped at 3000s (the partition/file caches and non-REST catalogs are unaffected).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
