### PR TITLE
[BugFix] Preserve sub-second when loading pre-1970 ORC TIMESTAMP

### DIFF
--- a/be/src/formats/orc/orc_min_max_decoder.cpp
+++ b/be/src/formats/orc/orc_min_max_decoder.cpp
@@ -137,6 +137,23 @@ static Status decode_datetime_min_max(const orc::Type* orc_type, const orc::prot
             }
             int64_t secs = ms / 1000;
             ns += (ms - secs * 1000) * 1000000L;
+            // orc_ts_to_native_ts now carries the sub-second into the before-epoch result for the
+            // data load path. Pre-1970 stripe-stats sub-second is a separate, pre-existing concern
+            // here (the ORC nanos field is stored with a +1 offset this decoder does not undo, the
+            // remainder above can be negative, and the before-epoch instant branch ignores the
+            // offset). Dropping the min sub-second does not affect pruning, but dropping the max
+            // sub-second understates the max bound; keep dropping it for negative-epoch bounds to
+            // leave pruning byte-for-byte unchanged rather than regress it.
+            //
+            // TODO: decode pre-1970 stripe-stats sub-second correctly in a dedicated stats path:
+            //   - subtract the +1 nanos offset (mirror liborc's reader);
+            //   - floor secs toward -inf (not toward zero) so the ms remainder stays non-negative;
+            //   - apply the instant tz offset on the negative-epoch branch;
+            //   - round conservatively for bounds (floor the min, ceil the max) so [min, max] still
+            //     contains the true value range instead of understating the max.
+            if (secs < 0) {
+                ns = 0;
+            }
             OrcTimestampHelper::orc_ts_to_native_ts(&min, utc_tzinfo, tz_offset_in_seconds, secs, ns, is_instant);
         }
 
@@ -148,6 +165,10 @@ static Status decode_datetime_min_max(const orc::Type* orc_type, const orc::prot
             }
             int64_t secs = ms / 1000;
             ns += (ms - secs * 1000) * 1000000L;
+            // See the minimum branch: keep dropping the sub-second for negative-epoch bounds.
+            if (secs < 0) {
+                ns = 0;
+            }
             OrcTimestampHelper::orc_ts_to_native_ts(&max, utc_tzinfo, tz_offset_in_seconds, secs, ns, is_instant);
         }
 

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -86,7 +86,10 @@ public:
                                                       int64_t nanoseconds) {
         cctz::time_point<cctz::sys_seconds> t = CCTZ_UNIX_EPOCH + cctz::seconds(seconds);
         const auto tp = cctz::convert(t, tz);
-        tv->from_timestamp(tp.year(), tp.month(), tp.day(), tp.hour(), tp.minute(), tp.second(), 0);
+        // Carry the sub-second through as microseconds (it used to be dropped to 0). As on the
+        // after-epoch path, nanoseconds is the floored sub-second in [0, NANOSECS_PER_SEC).
+        tv->from_timestamp(tp.year(), tp.month(), tp.day(), tp.hour(), tp.minute(), tp.second(),
+                           nanoseconds / NANOSECS_PER_USEC);
     }
     static void orc_ts_to_native_ts(TimestampValue* tv, const cctz::time_zone& tz, int64_t tzoffset, int64_t seconds,
                                     int64_t nanoseconds, bool is_instant) {

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -30,6 +30,7 @@
 #include "exprs/is_null_predicate.h"
 #include "formats/orc/memory_stream/MemoryInputStream.hh"
 #include "formats/orc/memory_stream/MemoryOutputStream.hh"
+#include "formats/orc/orc_min_max_decoder.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptor_helper.h"
@@ -848,7 +849,8 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
 
 Buffer<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, ObjectPool* pool,
                                                           const std::string& reader_tz, const std::string& write_tz,
-                                                          const Buffer<int64_t>& values, const bool isInstant) {
+                                                          const Buffer<int64_t>& values, const bool isInstant,
+                                                          const Buffer<int64_t>& nanos = {}) {
     const char* filename = "orc_scanner_test_timestamp.orc";
     std::filesystem::remove(filename);
     ORC_UNIQUE_PTR<orc::OutputStream> outStream = orc::writeLocalFile(filename);
@@ -870,7 +872,7 @@ Buffer<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, O
 
     for (int i = 0; i < values.size(); i++) {
         c0->data[i] = values[i];
-        c0->nanoseconds[i] = 0;
+        c0->nanoseconds[i] = nanos.empty() ? 0 : nanos[i];
     }
 
     root->numElements = values.size();
@@ -972,6 +974,85 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
             EXPECT_EQ(o, exp_values[i]);
         }
     }
+}
+
+// A pre-1970 ORC TIMESTAMP carries a sub-second component: liborc hands the reader a floored
+// seconds plus nanoseconds in [0, 1e9). The before-epoch conversion used to drop it (passed 0
+// microseconds); verify it is now preserved on both the plain and the instant (timestamp with
+// local time zone) read paths, while whole-second negatives and post-1970 values are unchanged.
+TEST_F(OrcChunkReaderTest, TestTimestampPreEpochSubSecond) {
+    // clang-format off
+    const Buffer<int64_t> orc_values = {
+            -152539200,  // 1965-03-02 12:00:00 UTC (pre-1970), half-second
+            -152539200,  // 1965-03-02 12:00:00 UTC (pre-1970), microsecond precision
+            -8444232248, // 1702-05-31 19:55:52 UTC (pre-1970), whole second
+            1621905520,  // 2021-05-25 01:18:40 UTC (post-1970, after-epoch path)
+    };
+    const Buffer<int64_t> orc_nanos = {500000000, 123456000, 0, 123456000};
+    // clang-format on
+    {
+        // Plain TIMESTAMP; reader == writer == UTC for a deterministic wall clock.
+        const Buffer<std::string> exp_values = {
+                "1965-03-02 12:00:00.500000",
+                "1965-03-02 12:00:00.123456",
+                "1702-05-31 19:55:52",
+                "2021-05-25 01:18:40.123456",
+        };
+        ObjectPool pool;
+        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "UTC", "UTC", orc_values, false,
+                                                      orc_nanos);
+        EXPECT_EQ(res.size(), orc_values.size());
+        for (size_t i = 0; i < res.size(); i++) {
+            EXPECT_EQ(res[i].to_string(), exp_values[i]) << "index " << i;
+        }
+    }
+    {
+        // INSTANT (timestamp with local time zone): the reader-tz shift must compose with the
+        // preserved sub-second. Reuses the wall clock from TestTimestamp's instant case.
+        const Buffer<int64_t> instant_values = {-8444232248};
+        const Buffer<int64_t> instant_nanos = {500000000};
+        const Buffer<std::string> exp_values = {"1702-06-01 04:01:35.500000"};
+        ObjectPool pool;
+        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC",
+                                                      instant_values, true, instant_nanos);
+        EXPECT_EQ(res.size(), instant_values.size());
+        for (size_t i = 0; i < res.size(); i++) {
+            EXPECT_EQ(res[i].to_string(), exp_values[i]) << "index " << i;
+        }
+    }
+}
+
+// The ORC stripe min/max statistics decoder shares the conversion helper with the data load path.
+// For a pre-1970 (negative-epoch) bound it intentionally drops the sub-second, keeping predicate
+// pushdown bounds identical to before the load-path sub-second fix. Verify a pre-1970 timestamp
+// stat with a sub-second decodes to its whole second.
+TEST_F(OrcChunkReaderTest, OrcMinMaxDecoderPreEpochTimestampDropsSubSecond) {
+    ORC_UNIQUE_PTR<orc::Type> orc_type = orc::createPrimitiveType(orc::TypeKind::TIMESTAMP);
+    orc::proto::ColumnStatistics stats;
+    auto* ts = stats.mutable_timestampstatistics();
+    ts->set_minimumutc(-152539200000); // 1965-03-02 12:00:00.000 UTC (pre-1970), whole second
+    ts->set_maximumutc(-152539200000);
+    ts->set_minimumnanos(500000); // 500us sub-second that the before-epoch bound must drop
+    ts->set_maximumnanos(500000);
+
+    TypeDescriptor type(TYPE_DATETIME);
+    TDescriptorTableBuilder builder;
+    TTupleDescriptorBuilder tuple;
+    TSlotDescriptorBuilder slot_builder;
+    slot_builder.column_name("c0").type(type).id(0).nullable(false);
+    tuple.add_slot(slot_builder.build());
+    tuple.build(&builder);
+    DescriptorTbl* tbl = nullptr;
+    ASSERT_TRUE(DescriptorTbl::create(_runtime_state.get(), &_pool, builder.desc_tbl(), &tbl, config::vector_chunk_size)
+                        .ok());
+    SlotDescriptor* slot = tbl->get_slot_descriptor(0);
+
+    auto min_col = ColumnHelper::create_column(type, false);
+    auto max_col = ColumnHelper::create_column(type, false);
+    ASSERT_TRUE(OrcMinMaxDecoder::decode(slot, orc_type.get(), stats, min_col.get(), max_col.get(), 0).ok());
+
+    EXPECT_EQ(down_cast<TimestampColumn*>(min_col.get())->get_data()[0].to_string(), "1965-03-02 12:00:00");
+    EXPECT_EQ(down_cast<TimestampColumn*>(max_col.get())->get_data()[0].to_string(), "1965-03-02 12:00:00");
 }
 
 /**


### PR DESCRIPTION
## Why I'm doing:

`OrcTimestampHelper::orc_ts_to_native_ts_before_unix_epoch` (`be/src/formats/orc/utils.h`) hardcoded the microsecond argument to `0`, so loading **any pre-1970 ORC `TIMESTAMP` with a non-zero sub-second** dropped the fraction, e.g. `1965-03-02 12:00:00.500000` was loaded as `1965-03-02 12:00:00.000000`. It affects both the plain `TIMESTAMP` and the `TIMESTAMP WITH LOCAL TIME ZONE` (instant) read paths and is independent of tablet pre-split.

The `after_unix_epoch` path already carries the sub-second through (`nanoseconds / 1000`); only the `before_unix_epoch` branch threw it away. liborc hands the load path a clean, floored `(seconds, nanoseconds)` pair (`nanoseconds` in `[0, 1e9)`, `instant = data + nanoseconds/1e9`): the writer's `+1` (`ColumnWriter.cc`) and reader's `-1` (`ColumnReader.cc`) for negative sub-second values cancel.

## What I'm doing:

`be/src/formats/orc/utils.h`, in `orc_ts_to_native_ts_before_unix_epoch`: pass `nanoseconds / NANOSECS_PER_USEC` as the microsecond instead of `0`, mirroring the unguarded `after_unix_epoch` sibling. The row load path always supplies a non-negative `nanoseconds`, so this simply restores the sub-second. The dispatcher and the `after_unix_epoch` path are untouched, so timezone composition, whole-second negatives, and post-1970 values are unchanged.

This helper is also shared by the ORC stripe min/max statistics decoder (`orc_min_max_decoder.cpp`), whose pre-1970 sub-second handling has separate, pre-existing quirks (the ORC nanos field is stored with a `+1` offset the decoder does not undo; its truncating-division remainder can be negative; the before-epoch instant branch ignores the reader offset). To keep this change scoped to the data load path and leave predicate-pushdown bounds **byte-for-byte unchanged**, the decoder now explicitly drops the sub-second for negative-epoch bounds (its prior behavior) rather than letting the now-sub-second-preserving helper expose those quirks. Correctly decoding pre-1970 stripe-stats sub-second is left as a follow-up.

BE-only; FE and the pre-split pipeline are not touched.

**Behavior change: No** — values only, correcting a lossy result (the old output was a bug, not intended behavior); no SQL syntax / config / interface change. Same rationale as the companion Parquet fix #75207.

### Tests

`be/test/formats/orc/orc_chunk_reader_test.cpp` — `TestTimestampPreEpochSubSecond` drives the real `OrcChunkReader` load path: pre-1970 sub-second on the plain (`.500000`, `.123456`) and instant (`.500000`) paths, plus whole-second-negative and post-1970 sub-second as no-regression guards. Verified RED→GREEN on a real build (before the fix the sub-second cases dropped to `.000000` and the instant case dropped its fraction; after the fix all pass and the pre-existing `TestTimestamp` still passes). `OrcMinMaxDecoderPreEpochTimestampDropsSubSecond` covers the decoder guard: a pre-1970 stripe-stats bound decodes to its whole second (sub-second dropped, pruning unchanged). BE module-boundary check clean.

Companion to the merged Parquet fix #75207; together they cover pre-1970 sub-second temporal loads.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
