### PR TITLE
[BugFix] Fix wrong timeout in MaterializedViewHandler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -345,7 +345,7 @@ public class MaterializedViewHandler extends AlterHandler {
         // get short key column count
         short mvShortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(mvColumns, properties);
         // get timeout
-        long timeoutMs = PropertyAnalyzer.analyzeTimeout(properties, Config.alter_table_timeout_second) * 1000;
+        long timeoutSecond = PropertyAnalyzer.analyzeTimeout(properties, Config.alter_table_timeout_second);
 
         // create rollup job
         long dbId = db.getId();
@@ -384,7 +384,7 @@ public class MaterializedViewHandler extends AlterHandler {
             AlterJobV2 mvJob = mvJobBuilder
                     .withJobId(jobId)
                     .withDbId(dbId)
-                    .withTimeoutSeconds(timeoutMs * 1000)
+                    .withTimeoutSeconds(timeoutSecond)
                     .withBaseIndexMetaId(baseIndexMetaId)
                     .withMvIndexMetaId(mvIndexMetaId)
                     .withBaseIndexName(baseIndexName)


### PR DESCRIPTION
## Why I'm doing:

The `Timeout` column shows an abnormally large value `86400000000`, which is the default timeout multiplied by `1000 * 1000` instead of the value in seconds.

```text
mysql> use example_db;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> SHOW ALTER MATERIALIZED VIEW;
+--------+--------------------------+---------------------+---------------------+--------------------------+-----------------+----------+---------------+----------+------+----------+-------------+
| JobId  | TableName                | CreateTime          | FinishedTime        | BaseIndexName            | RollupIndexName | RollupId | TransactionId | State    | Msg  | Progress | Timeout     |
+--------+--------------------------+---------------------+---------------------+--------------------------+-----------------+----------+---------------+----------+------+----------+-------------+
| 120708 | sr_049_materialized_view | 2026-06-19 09:31:42 | 2026-06-19 09:31:58 | sr_049_materialized_view | store_amt       | 120709   | 7139          | FINISHED |      | NULL     | 86400000000 |
+--------+--------------------------+---------------------+---------------------+--------------------------+-----------------+----------+---------------+----------+------+----------+-------------+
1 row in set (0.00 sec)
```

## What I'm doing:

Fixes #75439

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
