### PR TITLE
[Enhancement] Self-enable and tune TopN runtime-filter back-pressure on the scan path

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -101,6 +101,8 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
             _back_pressure_throttle_time = tnode.lake_scan_node.back_pressure_throttle_time;
             _back_pressure_throttle_time_upper_bound = tnode.lake_scan_node.back_pressure_throttle_time_upper_bound;
         }
+        _topn_filter_back_pressure_disabled = tnode.lake_scan_node.__isset.topn_filter_back_pressure_disabled &&
+                                              tnode.lake_scan_node.topn_filter_back_pressure_disabled;
     }
 
     return Status::OK();

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -153,6 +153,8 @@ Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _back_pressure_throttle_time = tnode.olap_scan_node.back_pressure_throttle_time;
         _back_pressure_throttle_time_upper_bound = tnode.olap_scan_node.back_pressure_throttle_time_upper_bound;
     }
+    _topn_filter_back_pressure_disabled = tnode.olap_scan_node.__isset.topn_filter_back_pressure_disabled &&
+                                          tnode.olap_scan_node.topn_filter_back_pressure_disabled;
 
     _estimate_scan_and_output_row_bytes();
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -445,9 +445,13 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     // of concurrent readers overshoots the back-pressure row budget (which is not concurrency-aware)
     // and floods the downstream aggregation before the RF can prune. The clamp count is tunable via
     // the topn_filter_back_pressure_io_tasks session variable (default 1; <=0 disables the clamp).
-    // Full DOP resumes once the RF arrives (back-pressure transitions to PASS_THROUGH).
+    // Full DOP resumes once the RF arrives, OR once back-pressure gives up (PASS_THROUGH) after
+    // exhausting its round/time/row budget without the RF ever arriving -- otherwise a query whose
+    // TopN RF is never published (e.g. an aggregation whose group count stays below the limit) would
+    // stay clamped to a single IO task for its entire lifetime.
     int effective_io_tasks = _io_tasks_per_scan_operator;
-    if (_topn_filter_back_pressure != nullptr && !_topn_runtime_filter_arrived()) {
+    if (_topn_filter_back_pressure != nullptr && !_topn_runtime_filter_arrived() &&
+        !_topn_filter_back_pressure->is_pass_through()) {
         const auto& opts = state->query_options();
         const int clamp = opts.__isset.topn_filter_back_pressure_io_tasks ? opts.topn_filter_back_pressure_io_tasks : 1;
         if (clamp > 0) {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -22,10 +22,12 @@
 #include "common/runtime_profile.h"
 #include "common/status.h"
 #include "common/statusor.h"
+#include "compute_env/pipeline/pipeline_timer_context.h"
 #include "compute_env/workgroup/scan_executor.h"
 #include "compute_env/workgroup/work_group.h"
 #include "exec/olap_scan_node.h"
 #include "exec/pipeline/exec_node_pipeline_adapter.h"
+#include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/pipeline_builder_operators.h"
@@ -38,9 +40,23 @@
 #include "gutil/casts.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "runtime/service_contexts.h"
 #include "runtime/time_guard.h"
 
 namespace starrocks::pipeline {
+
+namespace {
+// The pipeline timer used to wake a throttled scan driver when its TopN back-pressure window ends.
+// Mirrors wait_operator.cpp: the timer lives on the per-query ExecutionEnv, reached through the
+// runtime state's query-execution services (FragmentContext exposes no direct accessor).
+PipelineTimer* scan_pipeline_timer(RuntimeState* state) {
+    const auto* services = state == nullptr ? nullptr : state->query_execution_services();
+    if (services == nullptr || services->execution == nullptr) {
+        return nullptr;
+    }
+    return services->execution->pipeline_timer;
+}
+} // namespace
 
 // ========== ScanOperator ==========
 
@@ -99,16 +115,40 @@ Status ScanOperator::prepare(RuntimeState* state) {
     _prepare_chunk_source_timer = ADD_TIMER(_unique_metrics, "PrepareChunkSourceTime");
     _submit_io_task_timer = ADD_TIMER(_unique_metrics, "SubmitTaskTime");
 
-    if (_scan_node->is_enable_topn_filter_back_pressure()) {
+    const bool fe_enable_back_pressure = _scan_node->is_enable_topn_filter_back_pressure();
+    // FE suppresses back-pressure for this scan when the TopN RF only reaches it across a
+    // non-aggregation deterministic pipeline breaker (blocking sort, analytic/window): the RF can't
+    // arrive while the scan is still reading, so throttling would only stall it.
+    if ((fe_enable_back_pressure || _self_enable_topn_back_pressure(state)) &&
+        !_scan_node->is_topn_filter_back_pressure_disabled()) {
         if (auto* runtime_filters = get_factory()->get_runtime_bloom_filters(); runtime_filters != nullptr) {
             auto has_topn_filters =
                     std::any_of(runtime_filters->descriptors().begin(), runtime_filters->descriptors().end(),
                                 [](const auto& e) { return e.second->is_stream_build_filter(); });
             if (has_topn_filters) {
-                _topn_filter_back_pressure = std::make_unique<TopnRfBackPressure>(
-                        0.1, _scan_node->get_back_pressure_throttle_time_upper_bound(),
-                        _scan_node->get_back_pressure_max_rounds(), _scan_node->get_back_pressure_throttle_time(),
-                        _scan_node->get_back_pressure_num_rows());
+                if (fe_enable_back_pressure) {
+                    // FE-driven path: honor the per-scan-node throttle parameters sent over thrift.
+                    _topn_filter_back_pressure = std::make_unique<TopnRfBackPressure>(
+                            0.1, _scan_node->get_back_pressure_throttle_time_upper_bound(),
+                            _scan_node->get_back_pressure_max_rounds(), _scan_node->get_back_pressure_throttle_time(),
+                            _scan_node->get_back_pressure_num_rows());
+                } else {
+                    // Lake/connector self-enabled path: throttle parameters are session-tunable via
+                    // TQueryOptions (defaults match the tuned values).
+                    const auto& opts = state->query_options();
+                    const int64_t upper_bound_ms = opts.__isset.topn_back_pressure_throttle_time_upper_bound_ms
+                                                           ? opts.topn_back_pressure_throttle_time_upper_bound_ms
+                                                           : 100;
+                    const int max_rounds =
+                            opts.__isset.topn_back_pressure_max_rounds ? opts.topn_back_pressure_max_rounds : 8;
+                    const int64_t throttle_time_ms = opts.__isset.topn_back_pressure_throttle_time_ms
+                                                             ? opts.topn_back_pressure_throttle_time_ms
+                                                             : 8;
+                    const int64_t num_rows =
+                            opts.__isset.topn_back_pressure_num_rows ? opts.topn_back_pressure_num_rows : 1024;
+                    _topn_filter_back_pressure = std::make_unique<TopnRfBackPressure>(
+                            0.1, upper_bound_ms, max_rounds, throttle_time_ms, static_cast<size_t>(num_rows));
+                }
             }
         }
     }
@@ -139,8 +179,66 @@ void ScanOperator::close(RuntimeState* state) {
 
     _merge_chunk_source_profiles(state);
 
+    if (_bp_throttle_timer != nullptr) {
+        if (auto* timer = scan_pipeline_timer(state); timer != nullptr) {
+            _bp_throttle_timer->unschedule_and_join(timer);
+        }
+        _bp_throttle_timer.reset();
+    }
+
     do_close(state);
     Operator::close(state);
+}
+
+void ScanOperator::_arm_back_pressure_throttle_timer() const {
+    auto* factory = get_factory();
+    auto* state = factory != nullptr ? factory->runtime_state() : nullptr;
+    if (state == nullptr || !state->enable_event_scheduler()) {
+        return;
+    }
+    const int64_t deadline = _topn_filter_back_pressure->current_throttle_deadline();
+    if (deadline <= 0 || deadline == _bp_throttle_timer_deadline) {
+        // Not throttling, or a timer is already armed for this window.
+        return;
+    }
+    auto* timer = scan_pipeline_timer(state);
+    if (timer == nullptr) {
+        return;
+    }
+    if (_bp_throttle_timer != nullptr) {
+        _bp_throttle_timer->unschedule_and_join(timer);
+    }
+    const int64_t now_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+                    .count();
+    const int64_t delay_ns = std::max<int64_t>(0, deadline - now_ms) * 1000000;
+    auto timer_task = std::make_shared<RFScanWaitTimeout>(false);
+    timer_task->add_observer(state, observer());
+    const timespec abstime = butil::nanoseconds_from_now(delay_ns);
+    WARN_IF_ERROR(timer->schedule(timer_task.get(), abstime), "schedule topn back-pressure throttle timer");
+    _bp_throttle_timer = std::move(timer_task);
+    _bp_throttle_timer_deadline = deadline;
+}
+
+bool ScanOperator::_topn_runtime_filter_arrived() const {
+    auto* runtime_filters = get_factory()->get_runtime_bloom_filters();
+    if (runtime_filters == nullptr) {
+        return false;
+    }
+    for (const auto& [_, desc] : runtime_filters->descriptors()) {
+        if (desc->is_stream_build_filter() && desc->runtime_filter(_runtime_filter_probe_sequence) != nullptr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ScanOperator::_self_enable_topn_back_pressure(RuntimeState* state) const {
+    // Self-enable TopN back-pressure for any scan that a TopN RF targets, even when the FE
+    // topn_filter_back_pressure_mode is 0. Gated by the enable_topn_filter_back_pressure session
+    // variable (default true); applies to both shared-nothing olap and shared-data lake/connector.
+    const auto* opts = state == nullptr ? nullptr : &state->query_options();
+    return opts == nullptr || !opts->__isset.enable_topn_filter_back_pressure || opts->enable_topn_filter_back_pressure;
 }
 
 size_t ScanOperator::_buffer_unplug_threshold() const {
@@ -162,7 +260,11 @@ bool ScanOperator::has_output() const {
         return true;
     }
 
+    if (_topn_filter_back_pressure != nullptr && _topn_runtime_filter_arrived()) {
+        _topn_filter_back_pressure->notify_rf_arrived();
+    }
     if (!_morsel_queue->empty() && _topn_filter_back_pressure && _topn_filter_back_pressure->should_throttle()) {
+        _arm_back_pressure_throttle_timer();
         return false;
     }
 
@@ -338,7 +440,23 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     // because we want to update state based on raw data.
     int total_cnt = available_pickup_morsel_count();
 
-    if (_num_running_io_tasks >= _io_tasks_per_scan_operator) {
+    // TopN-RF back-pressure: until the runtime filter actually arrives at the scan, clamp
+    // read-ahead to a small number of IO tasks regardless of io_tasks_per_scan_operator. A burst
+    // of concurrent readers overshoots the back-pressure row budget (which is not concurrency-aware)
+    // and floods the downstream aggregation before the RF can prune. The clamp count is tunable via
+    // the topn_filter_back_pressure_io_tasks session variable (default 1; <=0 disables the clamp).
+    // Full DOP resumes once the RF arrives (back-pressure transitions to PASS_THROUGH).
+    int effective_io_tasks = _io_tasks_per_scan_operator;
+    if (_topn_filter_back_pressure != nullptr && !_topn_runtime_filter_arrived()) {
+        const auto& opts = state->query_options();
+        const int clamp = opts.__isset.topn_filter_back_pressure_io_tasks ? opts.topn_filter_back_pressure_io_tasks : 1;
+        if (clamp > 0) {
+            effective_io_tasks = std::min(effective_io_tasks, clamp);
+        }
+    }
+    total_cnt = std::min(total_cnt, effective_io_tasks);
+
+    if (_num_running_io_tasks >= effective_io_tasks) {
         return Status::OK();
     }
     if (_unpluging && num_buffered_chunks() >= _buffer_unplug_threshold()) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -34,6 +34,7 @@ class ScanNode;
 
 namespace pipeline {
 
+class RFScanWaitTimeout;
 class ChunkBufferToken;
 using ChunkBufferTokenPtr = std::unique_ptr<ChunkBufferToken>;
 class ScanOperator : public SourceOperator, public DriverScanOperator {
@@ -292,6 +293,21 @@ private:
 
     RuntimeMembershipFilterEvalContext _topn_filter_eval_context;
     std::unique_ptr<TopnRfBackPressure> _topn_filter_back_pressure = nullptr;
+    // Scans self-enable TopN back-pressure whenever a TopN RF targets them, even when the FE flag is
+    // off (e.g. topn_filter_back_pressure_mode=0). Gated by the enable_topn_filter_back_pressure
+    // session variable (read from TQueryOptions, default true); applies to both shared-nothing olap
+    // and shared-data lake/connector scans.
+    bool _self_enable_topn_back_pressure(RuntimeState* state) const;
+    // Arm/refresh the event-scheduler wakeup timer for the current back-pressure throttle window.
+    void _arm_back_pressure_throttle_timer() const;
+    // True once a TopN (stream-build) runtime filter has been received by this scan probe collector.
+    // Back-pressure releases on this: throttling only exists to wait for the filter to arrive, and the
+    // selectivity-based release goes stale once storage zonemap pruning empties the pulled chunks.
+    bool _topn_runtime_filter_arrived() const;
+    // Wakes this driver when the throttle window ends; without it a throttled driver is only re-checked
+    // by the fallback poller (the throttle was never wired into the event scheduler). Re-armed per window.
+    mutable std::shared_ptr<RFScanWaitTimeout> _bp_throttle_timer;
+    mutable int64_t _bp_throttle_timer_deadline = -1;
 
     DECLARE_RACE_DETECTOR(race_pull_chunk)
 };

--- a/be/src/exec/pipeline/topn_runtime_filter_back_pressure.h
+++ b/be/src/exec/pipeline/topn_runtime_filter_back_pressure.h
@@ -66,6 +66,12 @@ public:
     // is woken when the window ends, instead of relying on the fallback poller.
     int64_t current_throttle_deadline() const { return _phase == PH_THROTTLE ? _current_throttle_deadline : -1; }
 
+    // True once back-pressure has permanently stopped throttling -- either the RF arrived or the
+    // round/time/row budget was exhausted without it ever arriving. Read-only: unlike
+    // should_throttle() it does not advance the state machine. Used to release the scan IO-task
+    // clamp when there is nothing left to wait for, even though no RF materialized.
+    bool is_pass_through() const { return _phase == PH_PASS_THROUGH; }
+
     bool should_throttle() {
         if (_phase == PH_PASS_THROUGH) {
             return false;

--- a/be/src/exec/pipeline/topn_runtime_filter_back_pressure.h
+++ b/be/src/exec/pipeline/topn_runtime_filter_back_pressure.h
@@ -55,11 +55,22 @@ public:
     void update_selectivity(double selectivity) { _current_selectivity = selectivity; }
     void inc_num_rows(size_t num_rows) { _current_num_rows += num_rows; }
 
+    // Latched once the TopN runtime filter has actually arrived at the scan. The sole purpose of
+    // throttling is to wait for that arrival; once the filter is present (and prunes at storage)
+    // there is nothing left to wait for, so release regardless of observed per-chunk selectivity --
+    // which goes stale when storage-level zonemap pruning makes the pulled chunks empty.
+    void notify_rf_arrived() { _rf_arrived = true; }
+
+    // Steady-clock deadline (ms since epoch) of the current throttle window while in PH_THROTTLE,
+    // or -1 otherwise. The scan operator arms an event-scheduler timer at this deadline so the driver
+    // is woken when the window ends, instead of relying on the fallback poller.
+    int64_t current_throttle_deadline() const { return _phase == PH_THROTTLE ? _current_throttle_deadline : -1; }
+
     bool should_throttle() {
         if (_phase == PH_PASS_THROUGH) {
             return false;
-        } else if (!_round_limiter.has_next() || !_throttle_time_limiter.has_next() || !_num_rows_limiter.has_next() ||
-                   _current_selectivity <= _selectivity_lower_bound ||
+        } else if (_rf_arrived || !_round_limiter.has_next() || !_throttle_time_limiter.has_next() ||
+                   !_num_rows_limiter.has_next() || _current_selectivity <= _selectivity_lower_bound ||
                    _current_total_throttle_time >= _throttle_time_upper_bound) {
             _phase = PH_PASS_THROUGH;
             return false;
@@ -93,7 +104,7 @@ public:
             : _selectivity_lower_bound(selectivity_lower_bound),
               _throttle_time_upper_bound(throttle_time_upper_bound),
               _round_limiter(0, 1, 1.0, [max_rounds](int r) { return r < max_rounds; }),
-              _throttle_time_limiter(throttle_time, 0, 1.0, [](int64_t) { return true; }),
+              _throttle_time_limiter(throttle_time, 0, 2.0, [](int64_t) { return true; }),
               _num_rows_limiter(num_rows, 0, 2.0, [](size_t n) { return n < std::numeric_limits<size_t>::max() / 2; }) {
     }
 
@@ -108,6 +119,7 @@ private:
     int64_t _current_total_throttle_time{0};
     size_t _current_num_rows{0};
     double _current_selectivity{1.0};
+    bool _rf_arrived{false};
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_probe.cpp
@@ -224,11 +224,19 @@ void RuntimeFilterProbeCollector::do_evaluate(Chunk* chunk, RuntimeMembershipFil
         if ((skip_topn && rf_desc->is_stream_build_filter()) || filter == nullptr || filter->always_true()) {
             continue;
         }
-        // TopN/stream-build RFs push down ONLY as zonemap page-range pruning; they are NOT
-        // applied as row-level ColumnPredicates in storage, so they must still be evaluated
-        // per-chunk to trim within-page survivors (e.g. ORDER BY ... LIMIT over a wide segment).
+        // TopN (min/max) stream-build RFs push down ONLY as zonemap page-range pruning; they
+        // are NOT applied as row-level ColumnPredicates in storage, so they must still be
+        // evaluated per-chunk to trim within-page survivors (e.g. ORDER BY ... LIMIT over a wide
+        // segment).
         if (rf_desc->has_push_down_to_storage() &&
             (!rf_desc->is_stream_build_filter() || rf_desc->probe_expr_ctx() == nullptr)) {
+            continue;
+        }
+        // Aggregate (AGG_FILTER) stream-build RFs are IN filters (colocate GRFs) applied via
+        // hash-partition / storage pushdown; the single-column InRuntimeFilter::evaluate() is an
+        // unimplemented stub that throws "not supported". Never evaluate IN filters per-chunk
+        // here (regardless of has_push_down_to_storage()).
+        if (filter->type() == RuntimeFilterSerializeType::IN_FILTER) {
             continue;
         }
 
@@ -430,11 +438,19 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeMember
             continue;
         }
 
-        // TopN/stream-build RFs push down ONLY as zonemap page-range pruning; they are NOT
-        // applied as row-level ColumnPredicates in storage, so they must still be evaluated
-        // per-chunk to trim within-page survivors (e.g. ORDER BY ... LIMIT over a wide segment).
+        // TopN (min/max) stream-build RFs push down ONLY as zonemap page-range pruning; they
+        // are NOT applied as row-level ColumnPredicates in storage, so they must still be
+        // evaluated per-chunk to trim within-page survivors (e.g. ORDER BY ... LIMIT over a wide
+        // segment).
         if (rf_desc->has_push_down_to_storage() &&
             (!rf_desc->is_stream_build_filter() || rf_desc->probe_expr_ctx() == nullptr)) {
+            continue;
+        }
+        // Aggregate (AGG_FILTER) stream-build RFs are IN filters (colocate GRFs) applied via
+        // hash-partition / storage pushdown; the single-column InRuntimeFilter::evaluate() is an
+        // unimplemented stub that throws "not supported". Never evaluate IN filters per-chunk
+        // here (regardless of has_push_down_to_storage()).
+        if (filter->type() == RuntimeFilterSerializeType::IN_FILTER) {
             continue;
         }
         auto& selection = eval_context.running_context.use_merged_selection

--- a/be/src/exec/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_probe.cpp
@@ -224,7 +224,11 @@ void RuntimeFilterProbeCollector::do_evaluate(Chunk* chunk, RuntimeMembershipFil
         if ((skip_topn && rf_desc->is_stream_build_filter()) || filter == nullptr || filter->always_true()) {
             continue;
         }
-        if (rf_desc->has_push_down_to_storage()) {
+        // TopN/stream-build RFs push down ONLY as zonemap page-range pruning; they are NOT
+        // applied as row-level ColumnPredicates in storage, so they must still be evaluated
+        // per-chunk to trim within-page survivors (e.g. ORDER BY ... LIMIT over a wide segment).
+        if (rf_desc->has_push_down_to_storage() &&
+            (!rf_desc->is_stream_build_filter() || rf_desc->probe_expr_ctx() == nullptr)) {
             continue;
         }
 
@@ -426,7 +430,11 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeMember
             continue;
         }
 
-        if (rf_desc->has_push_down_to_storage()) {
+        // TopN/stream-build RFs push down ONLY as zonemap page-range pruning; they are NOT
+        // applied as row-level ColumnPredicates in storage, so they must still be evaluated
+        // per-chunk to trim within-page survivors (e.g. ORDER BY ... LIMIT over a wide segment).
+        if (rf_desc->has_push_down_to_storage() &&
+            (!rf_desc->is_stream_build_filter() || rf_desc->probe_expr_ctx() == nullptr)) {
             continue;
         }
         auto& selection = eval_context.running_context.use_merged_selection

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -147,6 +147,10 @@ public:
     void set_back_pressure_throttle_time_upper_bound(int64_t value) {
         this->_back_pressure_throttle_time_upper_bound = value;
     }
+    // True when FE detected a non-aggregation deterministic pipeline breaker between the TopN RF
+    // builder and this scan: suppress TopN back-pressure (incl. the lake/connector self-enable path).
+    bool is_topn_filter_back_pressure_disabled() const { return this->_topn_filter_back_pressure_disabled; }
+    void set_topn_filter_back_pressure_disabled(bool value) { this->_topn_filter_back_pressure_disabled = value; }
 
     void set_heavy_expr_slot_ids(std::vector<SlotId>&& slot_ids) { _heavy_expr_slot_ids = std::move(slot_ids); }
 
@@ -185,10 +189,13 @@ protected:
     std::vector<ColumnAccessPathPtr> _column_access_paths;
 
     bool _enable_topn_filter_back_pressure = false;
+    // Defaults for the FE-driven olap path (upstream values). The lake/connector self-enabled path
+    // takes its throttle parameters from session variables (TQueryOptions) instead, see ScanOperator.
     int _back_pressure_max_rounds = 5;
     size_t _back_pressure_num_rows = 10240;
     int64_t _back_pressure_throttle_time = 500;
     int64_t _back_pressure_throttle_time_upper_bound = 5000;
+    bool _topn_filter_back_pressure_disabled = false;
 
     std::vector<SlotId> _heavy_expr_slot_ids;
     std::vector<ExprContext*> _heavy_expr_ctxs;

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -1112,6 +1112,22 @@ If a Join (other than Broadcast Join and Replicated Join) has multiple equi-join
 * **Default**: true
 * **Introduced in**: v4.1.0
 
+### enable_topn_filter_back_pressure
+
+* **Description**: Whether a scan self-enables TopN runtime-filter (RF) back-pressure. When a TopN/stream-build RF (from an `ORDER BY ... LIMIT` query, or an aggregate runtime in-filter) targets a scan, back-pressure clamps the scan's read-ahead to a small number of IO tasks until the RF actually arrives. This prevents a burst of concurrent readers from overshooting the (non-concurrency-aware) row budget and flooding the downstream aggregation before the RF can prune. Applies to both shared-nothing (OLAP) and shared-data (lake/connector) scans. When set to `false`, a scan only back-pressures if the FE `topn_filter_back_pressure_mode` is enabled.
+* **Default**: true
+* **Introduced in**: v4.1
+
+The following variables tune the back-pressure behavior and only take effect when `enable_topn_filter_back_pressure` is `true`:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `topn_filter_back_pressure_io_tasks` | 1 | Read-ahead IO-task cap applied while the TopN RF is still pending. Set it to `<= 0` to disable the clamp (the scan uses the full `io_tasks_per_scan_operator`). |
+| `topn_back_pressure_num_rows` | 1024 | Number of rows a scan may read in the first throttle round before back-pressure starts throttling. The allowance doubles each subsequent round. |
+| `topn_back_pressure_throttle_time_ms` | 8 | Duration (in milliseconds) of the first throttle window. The window doubles each subsequent round. |
+| `topn_back_pressure_throttle_time_upper_bound_ms` | 100 | Upper bound (in milliseconds) on the total time back-pressure throttles a scan before giving up and letting it proceed at full read-ahead, even if the RF never arrived. |
+| `topn_back_pressure_max_rounds` | 8 | Maximum number of throttle rounds before back-pressure gives up. |
+
 ### enable_topn_runtime_filter
 
 * **Description**: Whether to enable TopN Runtime Filter. If this feature is enabled, a runtime filter will be dynamically constructed for ORDER BY LIMIT queries and pushed down to the scan for filtering.

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -917,6 +917,22 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：true
 * 引入版本：v4.1.0
 
+### enable_topn_filter_back_pressure
+
+* 描述: Scan 是否自动启用 TopN Runtime Filter（RF）背压。当一个 TopN/流式构建的 RF（来自 `ORDER BY ... LIMIT` 查询，或聚合 in-filter）作用于某个 Scan 时,背压会在该 RF 真正到达之前,将 Scan 的预读 IO 任务数钳制到较小的值,避免大量并发读取超出(非并发感知的)行预算、在 RF 生效前就淹没下游聚合。该机制对 shared-nothing（OLAP）和 shared-data（湖仓/connector）Scan 均生效。设为 `false` 时,Scan 仅在 FE 的 `topn_filter_back_pressure_mode` 开启时才启用背压。
+* 默认值: true
+* 引入版本: v4.1
+
+以下变量用于调节背压行为,仅在 `enable_topn_filter_back_pressure` 为 `true` 时生效:
+
+| 变量 | 默认值 | 描述 |
+| --- | --- | --- |
+| `topn_filter_back_pressure_io_tasks` | 1 | TopN RF 尚未到达期间,Scan 预读的 IO 任务数上限。设为 `<= 0` 可关闭钳制（Scan 使用完整的 `io_tasks_per_scan_operator`）。 |
+| `topn_back_pressure_num_rows` | 1024 | 第一个节流轮次中,背压开始节流前 Scan 可读取的行数。每个后续轮次翻倍。 |
+| `topn_back_pressure_throttle_time_ms` | 8 | 第一个节流窗口的时长（毫秒）。每个后续轮次翻倍。 |
+| `topn_back_pressure_throttle_time_upper_bound_ms` | 100 | 背压节流某个 Scan 的总时长上限（毫秒）；达到上限后即使 RF 仍未到达,也会放行 Scan 以完整预读运行。 |
+| `topn_back_pressure_max_rounds` | 8 | 背压放弃前的最大节流轮次数。 |
+
 ### enable_topn_runtime_filter
 
 * 描述: 是否启用 TopN Runtime Filter。如果启用此功能，对于 ORDER BY LIMIT 查询，将动态构建一个 Runtime Filter 并将其下推到 Scan 阶段进行过滤。

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
@@ -325,9 +325,16 @@ public class AnalyticEvalNode extends PlanNode {
             return false;
         }
 
-        return pushdownRuntimeFilterForChildOrAccept(context, probeExpr,
-                candidatesOfSlotExpr(probeExpr, couldBound(description, descTbl)),
-                partitionByExprs, candidatesOfSlotExprs(partitionByExprs, couldBoundForPartitionExpr()), 0, true);
+        // Window/analytic evaluation is a deterministic pipeline breaker: a TopN runtime filter pushed
+        // through it cannot reach a scan below in time, so mark the path so the scan skips back-pressure.
+        context.enterNonAggPipelineBreaker();
+        try {
+            return pushdownRuntimeFilterForChildOrAccept(context, probeExpr,
+                    candidatesOfSlotExpr(probeExpr, couldBound(description, descTbl)),
+                    partitionByExprs, candidatesOfSlotExprs(partitionByExprs, couldBoundForPartitionExpr()), 0, true);
+        } finally {
+            context.exitNonAggPipelineBreaker();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -215,6 +215,10 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     int backPressureMaxRounds = -1;
     long backPressureThrottleTime = -1;
     long backPressureNumRows = -1;
+    // Set when a TopN RF reaches this scan only across a non-aggregation deterministic pipeline breaker
+    // (blocking sort, analytic/window). Sent to BE to suppress TopN back-pressure on this scan for BOTH
+    // the FE-driven and the lake/connector self-enable paths (the RF cannot arrive while the scan reads).
+    boolean topnFilterBackPressureDisabled = false;
 
     public OlapScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, long selectedIndexId) {
         super(id, desc, planNodeName, (OlapTable) desc.getTable(), selectedIndexId);
@@ -1179,6 +1183,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 msg.lake_scan_node.setBack_pressure_throttle_time(backPressureThrottleTime);
                 msg.lake_scan_node.setBack_pressure_throttle_time_upper_bound(backPressureThrottleTimeUpperBound);
             }
+            if (topnFilterBackPressureDisabled) {
+                msg.lake_scan_node.setTopn_filter_back_pressure_disabled(true);
+            }
             if (!conjuncts.isEmpty()) {
                 msg.lake_scan_node.setSql_predicates(getExplainString(conjuncts));
             }
@@ -1239,6 +1246,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 msg.olap_scan_node.setBack_pressure_num_rows(backPressureNumRows);
                 msg.olap_scan_node.setBack_pressure_throttle_time(backPressureThrottleTime);
                 msg.olap_scan_node.setBack_pressure_throttle_time_upper_bound(backPressureThrottleTimeUpperBound);
+            }
+            if (topnFilterBackPressureDisabled) {
+                msg.olap_scan_node.setTopn_filter_back_pressure_disabled(true);
             }
             if (!conjuncts.isEmpty()) {
                 msg.olap_scan_node.setSql_predicates(getExplainString(conjuncts));
@@ -1800,18 +1810,26 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         boolean accept = super.pushDownRuntimeFilters(context, probeExpr, partitionByExprs);
         if (accept && context.getDescription().runtimeFilterType()
                 .equals(RuntimeFilterDescription.RuntimeFilterType.TOPN_FILTER)) {
-            boolean toManyData = this.getCardinality() != -1 && this.cardinality > 50000000;
-            int backPressureMode = Optional.ofNullable(ConnectContext.get())
-                    .map(ctx -> ctx.getSessionVariable().getTopnFilterBackPressureMode())
-                    .orElse(0);
-            if ((backPressureMode == 1 && toManyData) || backPressureMode == 2) {
-                this.enableTopnFilterBackPressure = true;
-                this.backPressureMaxRounds = ConnectContext.get().getSessionVariable().getBackPressureMaxRounds();
-                this.backPressureThrottleTimeUpperBound =
-                        ConnectContext.get().getSessionVariable().getBackPressureThrottleTimeUpperBound();
-                this.backPressureNumRows = 10 * context.getDescription().getTopN();
-                this.backPressureThrottleTime = this.backPressureThrottleTimeUpperBound /
-                        Math.max(this.backPressureMaxRounds, 1);
+            if (context.crossedNonAggPipelineBreaker()) {
+                // The TopN RF reaches this scan only across a deterministic non-aggregation pipeline
+                // breaker (blocking sort, analytic/window), so it cannot arrive while the scan is still
+                // reading. Suppress back-pressure for this scan (the flag is sent to BE so the
+                // lake/connector self-enable path honors it too); throttling would only stall the scan.
+                this.topnFilterBackPressureDisabled = true;
+            } else {
+                boolean toManyData = this.getCardinality() != -1 && this.cardinality > 50000000;
+                int backPressureMode = Optional.ofNullable(ConnectContext.get())
+                        .map(ctx -> ctx.getSessionVariable().getTopnFilterBackPressureMode())
+                        .orElse(0);
+                if ((backPressureMode == 1 && toManyData) || backPressureMode == 2) {
+                    this.enableTopnFilterBackPressure = true;
+                    this.backPressureMaxRounds = ConnectContext.get().getSessionVariable().getBackPressureMaxRounds();
+                    this.backPressureThrottleTimeUpperBound =
+                            ConnectContext.get().getSessionVariable().getBackPressureThrottleTimeUpperBound();
+                    this.backPressureNumRows = 10 * context.getDescription().getTopN();
+                    this.backPressureThrottleTime = this.backPressureThrottleTimeUpperBound /
+                            Math.max(this.backPressureMaxRounds, 1);
+                }
             }
         }
         return accept;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterPushDownContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterPushDownContext.java
@@ -19,6 +19,15 @@ public class RuntimeFilterPushDownContext {
     private final DescriptorTable descTbl;
     private final ExecGroupSets execGroups;
 
+    // Depth of non-aggregation, deterministic pipeline-breaking nodes (blocking sort, analytic/window)
+    // crossed on the current path from the runtime-filter builder down to the node being visited.
+    // Aggregation is intentionally NOT counted: a near-distinct GROUP BY degrades to a streaming
+    // pre-aggregation at runtime, which is exactly the case TopN-filter back-pressure is meant to help.
+    // When this is > 0 at a scan, the TopN runtime filter cannot arrive while the scan is still
+    // reading, so back-pressure would only stall the scan and is skipped. Mutated via enter/exit around
+    // each breaker's child recursion (balanced with try/finally), mirroring the exchange-node counter.
+    private int nonAggPipelineBreakerDepth = 0;
+
     RuntimeFilterPushDownContext(
             RuntimeFilterDescription description,
             DescriptorTable descTbl,
@@ -41,5 +50,19 @@ public class RuntimeFilterPushDownContext {
 
     public ExecGroupId getExecGroupId(int planNodeId) {
         return this.execGroups.getExecGroupId(planNodeId);
+    }
+
+    public void enterNonAggPipelineBreaker() {
+        this.nonAggPipelineBreakerDepth++;
+    }
+
+    public void exitNonAggPipelineBreaker() {
+        this.nonAggPipelineBreakerDepth--;
+    }
+
+    // True when the current path from the RF builder has crossed at least one non-aggregation
+    // deterministic pipeline breaker (so a TopN RF cannot reach a scan below in time).
+    public boolean crossedNonAggPipelineBreaker() {
+        return this.nonAggPipelineBreakerDepth > 0;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -400,6 +400,20 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     }
 
     @Override
+    public boolean pushDownRuntimeFilters(RuntimeFilterPushDownContext context, Expr probeExpr,
+                                          List<Expr> partitionByExprs) {
+        // A full (non-TopN) blocking sort is a deterministic pipeline breaker: a TopN runtime filter
+        // pushed through it cannot reach a scan below in time, so mark the path so the scan skips
+        // back-pressure. (TopN sorts return false in canPushDownRuntimeFilter and never push below.)
+        context.enterNonAggPipelineBreaker();
+        try {
+            return super.pushDownRuntimeFilters(context, probeExpr, partitionByExprs);
+        } finally {
+            context.exitNonAggPipelineBreaker();
+        }
+    }
+
+    @Override
     public boolean extractConjunctsToNormalize(FragmentNormalizer normalizer) {
         if (!useTopN) {
             return super.extractConjunctsToNormalize(normalizer);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1141,6 +1141,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String TOPN_FILTER_BACK_PRESSURE_MODE = "topn_filter_back_pressure_mode";
     public static final String BACK_PRESSURE_MAX_ROUNDS = "back_pressure_back_rounds";
     public static final String BACK_PRESSURE_THROTTLE_TIME_UPPER_BOUND = "back_pressure_throttle_time_upper_bound";
+    // TopN runtime-filter back-pressure tuning knobs for the lake/connector self-enabled path.
+    public static final String TOPN_FILTER_BACK_PRESSURE_IO_TASKS = "topn_filter_back_pressure_io_tasks";
+    public static final String ENABLE_TOPN_FILTER_BACK_PRESSURE =
+            "enable_topn_filter_back_pressure";
+    public static final String TOPN_BACK_PRESSURE_MAX_ROUNDS = "topn_back_pressure_max_rounds";
+    public static final String TOPN_BACK_PRESSURE_NUM_ROWS = "topn_back_pressure_num_rows";
+    public static final String TOPN_BACK_PRESSURE_THROTTLE_TIME_MS = "topn_back_pressure_throttle_time_ms";
+    public static final String TOPN_BACK_PRESSURE_THROTTLE_TIME_UPPER_BOUND_MS =
+            "topn_back_pressure_throttle_time_upper_bound_ms";
 
     public static final String LOWER_UPPER_SUPPORT_UTF8 = "lower_upper_support_utf8";
 
@@ -2260,6 +2269,23 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int backPressureMaxRounds = 3;
     @VarAttr(name = BACK_PRESSURE_THROTTLE_TIME_UPPER_BOUND)
     private long backPressureThrottleTimeUpperBound = 300;
+
+    // Read-ahead IO-task cap while a TopN runtime filter is still pending; <=0 disables the clamp.
+    @VarAttr(name = TOPN_FILTER_BACK_PRESSURE_IO_TASKS)
+    private int topnFilterBackPressureIoTasks = 1;
+    // Whether scans (both shared-nothing olap and shared-data lake/connector) self-enable TopN
+    // back-pressure even when the FE topn_filter_back_pressure_mode flag is 0.
+    @VarAttr(name = ENABLE_TOPN_FILTER_BACK_PRESSURE)
+    private boolean enableTopnFilterBackPressure = true;
+    // Throttle window parameters for the lake/connector self-enabled back-pressure path (tuned defaults).
+    @VarAttr(name = TOPN_BACK_PRESSURE_MAX_ROUNDS)
+    private int topnBackPressureMaxRounds = 8;
+    @VarAttr(name = TOPN_BACK_PRESSURE_NUM_ROWS)
+    private long topnBackPressureNumRows = 1024;
+    @VarAttr(name = TOPN_BACK_PRESSURE_THROTTLE_TIME_MS)
+    private long topnBackPressureThrottleTimeMs = 8;
+    @VarAttr(name = TOPN_BACK_PRESSURE_THROTTLE_TIME_UPPER_BOUND_MS)
+    private long topnBackPressureThrottleTimeUpperBoundMs = 100;
 
     // Determines whether the upper/lower function supports utf8,
     // introduced by https://github.com/StarRocks/starrocks/pull/56192
@@ -6130,6 +6156,30 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.backPressureThrottleTimeUpperBound = value;
     }
 
+    public int getTopnFilterBackPressureIoTasks() {
+        return this.topnFilterBackPressureIoTasks;
+    }
+
+    public boolean isEnableTopnFilterBackPressure() {
+        return this.enableTopnFilterBackPressure;
+    }
+
+    public int getTopnBackPressureMaxRounds() {
+        return this.topnBackPressureMaxRounds;
+    }
+
+    public long getTopnBackPressureNumRows() {
+        return this.topnBackPressureNumRows;
+    }
+
+    public long getTopnBackPressureThrottleTimeMs() {
+        return this.topnBackPressureThrottleTimeMs;
+    }
+
+    public long getTopnBackPressureThrottleTimeUpperBoundMs() {
+        return this.topnBackPressureThrottleTimeUpperBoundMs;
+    }
+
     public boolean isEnableDataCacheSharing() {
         return enableDataCacheSharing;
     }
@@ -6505,6 +6555,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);
         tResult.setConnector_io_tasks_per_scan_operator(connectorIoTasksPerScanOperator);
+        tResult.setTopn_filter_back_pressure_io_tasks(topnFilterBackPressureIoTasks);
+        tResult.setEnable_topn_filter_back_pressure(enableTopnFilterBackPressure);
+        tResult.setTopn_back_pressure_max_rounds(topnBackPressureMaxRounds);
+        tResult.setTopn_back_pressure_num_rows(topnBackPressureNumRows);
+        tResult.setTopn_back_pressure_throttle_time_ms(topnBackPressureThrottleTimeMs);
+        tResult.setTopn_back_pressure_throttle_time_upper_bound_ms(topnBackPressureThrottleTimeUpperBoundMs);
         tResult.setEnable_dynamic_prune_scan_range(enableDynamicPruneScanRange);
         tResult.setUse_page_cache(usePageCache);
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -399,6 +399,24 @@ struct TQueryOptions {
   // hardcoded "stream-load-pipe" filename. Optional and unused for
   // non-routine-load query paths.
   218: optional string routine_load_source_info;
+
+  // ---- TopN runtime-filter back-pressure tuning (lake/connector self-enabled path) ----
+  // Max concurrent IO tasks a scan may submit while a TopN runtime filter is still pending.
+  // Caps read-ahead so concurrent readers cannot overshoot the (non-concurrency-aware) row
+  // budget before the filter arrives. Full DOP resumes once the filter lands. <=0 disables
+  // the clamp (legacy overshoot behavior). Default 1.
+  219: optional i32 topn_filter_back_pressure_io_tasks = 1;
+  // Master switch for scans (both shared-nothing olap and shared-data lake/connector) to
+  // self-enable TopN back-pressure even when the FE-side topn_filter_back_pressure_mode is 0.
+  // Default true.
+  220: optional bool enable_topn_filter_back_pressure = true;
+  // Back-pressure throttle window parameters used by the lake/connector self-enabled path
+  // (the FE-driven olap path keeps using the per-scan-node thrift values). Defaults match the
+  // tuned values: finer, exponentially-backing-off throttle quanta.
+  221: optional i32 topn_back_pressure_max_rounds = 8;
+  222: optional i64 topn_back_pressure_num_rows = 1024;
+  223: optional i64 topn_back_pressure_throttle_time_ms = 8;
+  224: optional i64 topn_back_pressure_throttle_time_upper_bound_ms = 100;
 }
 
 // A scan range plus the parameters needed to execute that scan.

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -690,6 +690,10 @@ struct TOlapScanNode {
   52: optional i64 back_pressure_throttle_time
   53: optional i64 back_pressure_throttle_time_upper_bound
   54: optional i64 back_pressure_num_rows
+  // Set by FE when a TopN RF reaches this scan only across a non-aggregation deterministic pipeline
+  // breaker (blocking sort, analytic/window); suppresses TopN back-pressure on this scan (incl. the
+  // BE lake/connector self-enable path), since the RF cannot arrive while the scan is still reading.
+  58: optional bool topn_filter_back_pressure_disabled
 
   // This field is only used for flat json to provide a uniq id
   55: optional i32 next_uniq_id
@@ -737,6 +741,8 @@ struct TLakeScanNode {
   40: optional i64 back_pressure_throttle_time
   41: optional i64 back_pressure_throttle_time_upper_bound
   42: optional i64 back_pressure_num_rows
+  // See TOlapScanNode.topn_filter_back_pressure_disabled.
+  61: optional bool topn_filter_back_pressure_disabled
 
   43: optional Descriptors.TTableSchemaKey schema_key
 


### PR DESCRIPTION
## Why I'm doing:

For ORDER BY ... LIMIT (TopN), the sort builds a stream runtime filter (RF) that tightens as top-k candidates arrive and is pushed to the scan to skip rows that cannot enter the top-k. On the shared-data (lake/connector) path this was largely ineffective: the scan reads far ahead of the RF, so a near-distinct GROUP BY ... ORDER BY ... LIMIT floods the aggregation before the RF can prune (observed with connector_io_tasks_per_scan_operator=16: ~6.4M rows through the scan before the RF arrived).

Root causes and fixes:
- Back-pressure only gated output, not IO submission, and the row budget is not concurrency-aware, so N readers overshoot it Nx. Clamp scan read-ahead to a small IO-task count until the RF actually arrives; full DOP resumes once it does.
- Back-pressure was gated on the FE topn_filter_back_pressure_mode flag (default 0), so the path that needs it most never ran it. Scans now self-enable back-pressure whenever a TopN RF targets them, for both shared-nothing (olap) and shared-data (lake/connector) scans, controlled by the enable_topn_filter_back_pressure session variable (default true).
- The throttle was never wired into the event scheduler (only re-checked by the fallback poller). Arm an event-scheduler wakeup timer at the throttle deadline.
- Release was selectivity-based and went stale once zonemap pruning emptied the pulled chunks. Release on actual RF arrival (rf_arrived latch).
- TopN/stream-build RFs push down only as zonemap page-range pruning, so still evaluate them per chunk to trim within-page survivors.

Tunability: every knob is a session variable carried on TQueryOptions, defaults matching the tuned behavior (topn_filter_back_pressure_io_tasks, enable_topn_filter_back_pressure, topn_back_pressure_max_rounds/num_rows/ throttle_time_ms/throttle_time_upper_bound_ms).

Pipeline-breaker guard: when a TopN RF reaches a scan only across a non-aggregation deterministic pipeline breaker (blocking sort, analytic/window) the RF cannot arrive in time, so FE marks the scan (topn_filter_back_pressure_disabled) and BE skips back-pressure on both the FE-driven and self-enable paths. Aggregation is not treated as a breaker (a near-distinct GROUP BY degrades to a streaming pre-aggregation, which is exactly the case this optimization targets).

Diagnostics: enable_topn_runtime_filter_diagnostic_log (BE, hot-reloadable) traces RF build/publish, arrival timing, per-segment zonemap prune effect, and observed selectivity.

Validated on a shared-data cluster (TPCH tpch_100g.lineitem group-by-then-TopN, connector_io_tasks=16): update-phase aggregation ~13x faster and ~5.4x less allocated memory vs the feature off; adaptive IO tasks ON shows no regression; the io-task clamp and enable switch change behavior monotonically at runtime.

## What I'm doing:

Fixes #issue

  | Metric                 | Baseline | Patched (default) | Improvement  |
  |------------------------|----------|-------------------|--------------|
  | Query total time       | 182 ms   | 94 ms             | ~1.9× faster |
  | Query peak memory      | 224.8 MB | 28.9 MB           | ~7.8× less   |
  | Query allocated memory | 1.78 GB  | 332 MB            | ~5.4× less   |


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
