### PR TITLE
[BugFix] Narrow UNNEST result struct type consistently with its input array element

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -188,11 +188,33 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
             for (int i = 0; i < operator.getFnResultColRefs().size(); i++) {
                 ColumnRefOperator output = operator.getFnResultColRefs().get(i);
                 if (output.getType().isComplexType() && context.hasUnnestColRefMapKey(output)) {
-                    pruneForComplexType(output, context);
+                    // The unnest input array element type is narrowed via the access group that
+                    // setUnnest() propagated from this output to the input array. The output element
+                    // type must be narrowed by that SAME access group, otherwise the unnest emits rows
+                    // whose struct width differs from its (narrowed) input element -> StructColumn::append
+                    // field-count mismatch (BE abort under DCHECK, silent under-read in release). The
+                    // unnest output is not a scan ref, so the scanRefs-gated pruneForComplexType() skips
+                    // it; narrow it directly by its access group instead.
+                    pruneUnnestResultType(output, context);
                     operator.getFn().getTableFnReturnTypes().set(i, output.getType());
                 }
             }
             return visit(optExpression, context);
+        }
+
+        // Narrow an unnest result column by its visited access group, ignoring the scanRefs gate that
+        // pruneForComplexType() applies (the unnest output is never a scan ref). The access group is the
+        // same one setUnnest() copied to the input array, so input and output element types stay in sync.
+        private static void pruneUnnestResultType(ColumnRefOperator columnRefOperator,
+                                                  PruneComplexTypeUtil.Context context) {
+            ComplexTypeAccessGroup accessGroup = context.getVisitedAccessGroup(columnRefOperator);
+            if (accessGroup == null) {
+                return;
+            }
+            Type cloneType = columnRefOperator.getType().clone();
+            PruneComplexTypeUtil.setAccessGroup(cloneType, accessGroup);
+            cloneType.pruneUnusedSubfields();
+            columnRefOperator.setType(cloneType);
         }
 
         private static void pruneForColumnRefMap(Map<ColumnRefOperator, ScalarOperator> map,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -321,6 +321,31 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     }
 
     @Test
+    public void testUnnestResultTypeNarrowedConsistently() throws Exception {
+        FeConstants.runningUnitTest = true;
+        // When only one subfield of the unnest output struct is used, both the unnest INPUT array
+        // element AND the unnest OUTPUT (returnTypes) must be narrowed to the same width. Previously
+        // the input was narrowed while the output kept full width, so the emitted struct width
+        // differed from its input element -> StructColumn::append field-count mismatch in the BE.
+        String sql = "select c2_struct.c2_sub1 from array_struct_nest, unnest(c2) as t(c2_struct);";
+        // input array element narrowed ...
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
+        // ... and the unnest result type narrowed in sync (this is the fix).
+        assertVerbosePlanContains(sql, "returnTypes: [struct<`c2_sub1` int(11)>]");
+
+        // Nested case: unnest over an array nested inside a struct.
+        sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
+        assertVerbosePlanContains(sql, "returnTypes: [struct<`c3_sub1_sub1` int(11)>]");
+
+        // All subfields used: nothing to prune, output keeps full width (still consistent).
+        sql = "select c2_struct.c2_sub1, c2_struct.c2_sub2 from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
+        assertVerbosePlanContains(sql, "returnTypes: [struct<`c2_sub1` int(11), `c2_sub2` int(11)>]");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
     public void testSubfieldNoCopy() throws Exception {
         String sql = "select c3.c.a, c3.c.b, c3.a, c3.b, c3.d, c2.a, c1.a, c1.b[1].a from test";
         assertPlanContains(sql, "c3.c.a[false]", "c3.c.b[false]", "c3.a[false]", "c3.b[false]",

--- a/test/sql/test_unnest/R/test_unnest
+++ b/test/sql/test_unnest/R/test_unnest
@@ -85,6 +85,24 @@ select c_struct.c1 from TABLE(unnest(array<struct<c1 int>>[named_struct('c1', 10
 10
 20
 -- !result
+-- name: test_array_of_struct_prune_first_subfield
+select c_struct.c1 from TABLE(unnest(array<struct<c1 int, c2 int>>[named_struct('c1', 10, 'c2', 1), named_struct('c1', 20, 'c2', 2)])) t(c_struct);
+-- result:
+10
+20
+-- !result
+-- name: test_array_of_struct_prune_second_subfield
+select c_struct.c2 from TABLE(unnest(array<struct<c1 int, c2 int>>[named_struct('c1', 10, 'c2', 1), named_struct('c1', 20, 'c2', 2)])) t(c_struct);
+-- result:
+1
+2
+-- !result
+-- name: test_array_of_struct_no_prune_all_subfields
+select c_struct.c1, c_struct.c2 from TABLE(unnest(array<struct<c1 int, c2 int>>[named_struct('c1', 10, 'c2', 1), named_struct('c1', 20, 'c2', 2)])) t(c_struct);
+-- result:
+10	1
+20	2
+-- !result
 -- name: test_array_of_map
 select c_map['a'], c_map['b'] from TABLE(unnest(array<map<string, int>>[map{'a':1,'b':2}, map{'a':2, 'b':3}])) t(c_map);
 -- result:

--- a/test/sql/test_unnest/R/test_unnest_struct_subfield_prune
+++ b/test/sql/test_unnest/R/test_unnest_struct_subfield_prune
@@ -1,0 +1,67 @@
+-- name: test_unnest_struct_subfield_prune
+-- Coverage for PR #75445: PruneSubfieldsForComplexType.pruneUnnestResultType narrows the
+-- UNNEST output struct to match its (narrowed) input array element. The PR's own SQL cases
+-- use array<struct> LITERALS, which trip the global setEnablePruneComplexTypes(false) guard
+-- (a struct-construct scalar disables the whole prune pass) and therefore never exercise the
+-- narrowing. These cases use a SCAN-backed array<struct> column so the prune actually fires,
+-- plus non-scan (UNION) inputs to check the result stays correct when the scan is not narrowed.
+drop database if exists test_unnest_struct_subfield_prune;
+-- result:
+-- !result
+create database test_unnest_struct_subfield_prune;
+-- result:
+-- !result
+use test_unnest_struct_subfield_prune;
+-- result:
+-- !result
+create table ts_arr(id int, arr array<struct<c1 int, c2 int>>)
+  duplicate key(id) distributed by hash(id) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into ts_arr values (1, [row(10,1),row(20,2)]), (2, [row(30,3)]);
+-- result:
+-- !result
+set enable_prune_complex_types_in_unnest = true;
+-- result:
+-- !result
+select s.c1 from ts_arr, unnest(arr) as t(s) order by s.c1;
+-- result:
+10
+20
+30
+-- !result
+select s.c2 from ts_arr, unnest(arr) as t(s) order by s.c2;
+-- result:
+1
+2
+3
+-- !result
+select s.c1, s.c2 from ts_arr, unnest(arr) as t(s) order by s.c1, s.c2;
+-- result:
+10	1
+20	2
+30	3
+-- !result
+select s.c2 from (select arr from ts_arr union all select arr from ts_arr) u,
+  unnest(u.arr) as t(s) order by s.c2;
+-- result:
+1
+1
+2
+2
+3
+3
+-- !result
+select s.c1 from (select arr from ts_arr union all select arr from ts_arr) u,
+  unnest(u.arr) as t(s) order by s.c1;
+-- result:
+10
+10
+20
+20
+30
+30
+-- !result
+drop database test_unnest_struct_subfield_prune;
+-- result:
+-- !result

--- a/test/sql/test_unnest/T/test_unnest
+++ b/test/sql/test_unnest/T/test_unnest
@@ -23,6 +23,12 @@ create view v_unnest_subquery as select x + y from (select * from TABLE(unnest(A
 select * from v_unnest_subquery;
 -- name: test_array_of_struct
 select c_struct.c1 from TABLE(unnest(array<struct<c1 int>>[named_struct('c1', 10), named_struct('c1', 20)])) t(c_struct);
+-- name: test_array_of_struct_prune_first_subfield
+select c_struct.c1 from TABLE(unnest(array<struct<c1 int, c2 int>>[named_struct('c1', 10, 'c2', 1), named_struct('c1', 20, 'c2', 2)])) t(c_struct);
+-- name: test_array_of_struct_prune_second_subfield
+select c_struct.c2 from TABLE(unnest(array<struct<c1 int, c2 int>>[named_struct('c1', 10, 'c2', 1), named_struct('c1', 20, 'c2', 2)])) t(c_struct);
+-- name: test_array_of_struct_no_prune_all_subfields
+select c_struct.c1, c_struct.c2 from TABLE(unnest(array<struct<c1 int, c2 int>>[named_struct('c1', 10, 'c2', 1), named_struct('c1', 20, 'c2', 2)])) t(c_struct);
 -- name: test_array_of_map
 select c_map['a'], c_map['b'] from TABLE(unnest(array<map<string, int>>[map{'a':1,'b':2}, map{'a':2, 'b':3}])) t(c_map);
 -- name: test_array_of_json

--- a/test/sql/test_unnest/T/test_unnest_struct_subfield_prune
+++ b/test/sql/test_unnest/T/test_unnest_struct_subfield_prune
@@ -1,0 +1,33 @@
+-- name: test_unnest_struct_subfield_prune
+-- Coverage for PR #75445: PruneSubfieldsForComplexType.pruneUnnestResultType narrows the
+-- UNNEST output struct to match its (narrowed) input array element. The PR's own SQL cases
+-- use array<struct> LITERALS, which trip the global setEnablePruneComplexTypes(false) guard
+-- (a struct-construct scalar disables the whole prune pass) and therefore never exercise the
+-- narrowing. These cases use a SCAN-backed array<struct> column so the prune actually fires,
+-- plus non-scan (UNION) inputs to check the result stays correct when the scan is not narrowed.
+drop database if exists test_unnest_struct_subfield_prune;
+create database test_unnest_struct_subfield_prune;
+use test_unnest_struct_subfield_prune;
+
+create table ts_arr(id int, arr array<struct<c1 int, c2 int>>)
+  duplicate key(id) distributed by hash(id) buckets 1 properties("replication_num"="1");
+insert into ts_arr values (1, [row(10,1),row(20,2)]), (2, [row(30,3)]);
+
+set enable_prune_complex_types_in_unnest = true;
+
+-- Use only the FIRST subfield -> output narrows to struct<c1>.
+select s.c1 from ts_arr, unnest(arr) as t(s) order by s.c1;
+-- Use only the SECOND subfield -> output narrows to struct<c2>. Guards against a by-position
+-- read of the narrowed struct returning c1's values (10/20/30) instead of c2's (1/2/3).
+select s.c2 from ts_arr, unnest(arr) as t(s) order by s.c2;
+-- Use BOTH subfields -> nothing to prune, full width.
+select s.c1, s.c2 from ts_arr, unnest(arr) as t(s) order by s.c1, s.c2;
+
+-- Non-scan (UNION) array source: the access path does not reach the scans, so they stay full
+-- width while the output narrows. Result must still be correct.
+select s.c2 from (select arr from ts_arr union all select arr from ts_arr) u,
+  unnest(u.arr) as t(s) order by s.c2;
+select s.c1 from (select arr from ts_arr union all select arr from ts_arr) u,
+  unnest(u.arr) as t(s) order by s.c1;
+
+drop database test_unnest_struct_subfield_prune;


### PR DESCRIPTION
## Why I'm doing:

PruneSubfieldsForComplexType.visitPhysicalTableFunction narrows the unnest input
array element type (via the access group setUnnest() propagates output->input) but
the matching narrow of the unnest OUTPUT column is gated by pruneForComplexType's
scanRefs check, which an unnest result column never satisfies. So the input element
became struct<...> with fewer fields while the output/returnTypes kept the original
width, and the unnest emitted rows whose struct width differed from its input
element -> StructColumn::append field-count mismatch (BE abort under DCHECK; silent
under-read of the unguarded struct serde in release). Narrow the unnest result
column directly by its own visited access group so input and output stay in sync.

## What I'm doing:

run case:

```
139976525506112 struct_column.cpp:169] Check failed: _fields.size() == struct_column.fields().size() (1 vs. 2) F20260623 07:51:15.003372 139976565671488 
struct_column.cpp:169] Check failed: _fields.size() == struct_column.fields().size() (1 vs. 2) F20260623 07:51:15.003516 139976364844608 struct_column.cpp:169
] Check failed: _fields.size() == struct_column.fields().size() (1 vs. 2) 
F00000000 00:00:00.000000 139976565671488 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\
n' failed: 
[1782201075.3][thread: 139976585754176] je_mallctl execute purge success
[1782201075.3][thread: 139976585754176] je_mallctl execute dontdump success
*** Aborted at 1782201074 (unix time) try "date -d @1782201074" if you are using GNU date ***
[1782201075.3][thread: 139976525506112] je_mallctl execute purge success
[1782201075.3][thread: 139976525506112] je_mallctl execute dontdump success
[1782201075.3][thread: 139978091955776] je_mallctl execute purge success
[1782201075.3][thread: 139978091955776] je_mallctl execute dontdump success
[1782201075.3][thread: 139976565671488] je_mallctl execute purge success
[1782201075.3][thread: 139976565671488] je_mallctl execute dontdump success
PC: @     0x7f525e3909fc pthread_kill
*** SIGABRT (@0x2117f) received by PID 135551 (TID 0x7f4ed6abb640) LWP(136379) from PID 135551; stack trace: ***
    @         0x31e5dd87 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f525e393ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x31e5d586 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f525e33c520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f525e3909fc pthread_kill
    @     0x7f525e33c476 raise
    @     0x7f525e3227f3 abort
    @         0x29368d99 starrocks::failure_function()
    @         0x31e515dd google::LogMessage::Fail()
    @         0x31e526c4 google::LogMessageFatal::~LogMessageFatal()
    @         0x2cb75db1 starrocks::StructColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x2cd716e9 starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x2cb282b2 starrocks::ArrayColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x2cb285ca starrocks::ArrayColumn::append_selective(starrocks::Column const&, unsigned int const*, unsigned int, unsigned int)
    @         0x2cd727a0 starrocks::NullableColumn::append_selective(starrocks::Column const&, unsigned int const*, unsigned int, unsigned int)
    @         0x358bedf7 starrocks::JoinHashMap<(starrocks::LogicalType)5, (starrocks::JoinKeyConstructorType)1, (starrocks::JoinHashMapMethodType)5>::_copy_p
robe_nullable_column(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>&, std::shared_ptr<starrocks::Chunk>*, s@
    @         0x356048d0 void starrocks::JoinHashMap<(starrocks::LogicalType)5, (starrocks::JoinKeyConstructorType)1, (starrocks::JoinHashMapMethodType)5>::_p
robe_output<false>(std::shared_ptr<starrocks::Chunk>*, std::shared_ptr<starrocks::Chunk>*)
    @         0x354f9463 starrocks::JoinHashMap<(starrocks::LogicalType)5, (starrocks::JoinKeyConstructorType)1, (starrocks::JoinHashMapMethodType)5>::probe(s
tarrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starroc@
    @         0x34f9f2ea auto starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Col
umn>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&, std::shared_ptr<starrocks::@
    @         0x34fba6ed void std::__invoke_impl<void, starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>
::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&, st@
    @         0x34fb32b7 std::__invoke_result<starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPt
r<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&, std::shared@
    @         0x34fa4b36 (unknown)
    @         0x34fa5f1a (unknown)
    @         0x34fa5f78 (unknown)
    @         0x34f6f9c2 auto starrocks::JoinHashTable::visit<starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::
Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > con@
    @         0x34f6fbd9 starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>,
 std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&, std::shared_ptr<starrocks::Chunk@
    @         0x1e86045d starrocks::SingleHashJoinProberImpl::probe_chunk(starrocks::RuntimeState*)
    @         0x1e8014b2 starrocks::HashJoinProber::probe_chunk(starrocks::RuntimeState*)
    @         0x1e7f77c7 starrocks::HashJoiner::_pull_probe_output_chunk(starrocks::RuntimeState*)
    @         0x1e7f73e2 starrocks::HashJoiner::pull_chunk(starrocks::RuntimeState*)
    @         0x1f5fe3e0 starrocks::pipeline::HashJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x2980d52d starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
