### PR TITLE
[BugFix] Try to drop redundant partition column predicate when bucket prune is not available

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
@@ -295,7 +296,10 @@ public class OptOlapPartitionPruner {
             return null;
         }
 
-        if (!table.getDistributionColumnNames().contains(columnName)) {
+        Set<String> distributionColumnNames = table.getDistributionColumnNames();
+        boolean shouldRemovePrunedPartitionPredicates = !distributionColumnNames.contains(columnName)
+                || !areAllDistributionColumnsInFilter(logicalOlapScanOperator, distributionColumnNames);
+        if (shouldRemovePrunedPartitionPredicates) {
             scanPredicates.removeAll(prunedPartitionPredicates);
         }
 
@@ -461,6 +465,30 @@ public class OptOlapPartitionPruner {
                     && !tmpIdToRange.containsKey(candidatePartitions.get(0));
         }
         return false;
+    }
+
+    private static boolean areAllDistributionColumnsInFilter(LogicalOlapScanOperator operator,
+                                                            Set<String> distributionColumnNames) {
+        if (distributionColumnNames.isEmpty()) {
+            return true;
+        }
+
+        ScalarOperator predicate = operator.getPredicate();
+        if (predicate == null) {
+            return false;
+        }
+        ColumnRefSet usedColumns = predicate.getUsedColumns();
+        if (usedColumns.isEmpty()) {
+            return false;
+        }
+
+        for (Map.Entry<Column, ColumnRefOperator> entry : operator.getColumnMetaToColRefMap().entrySet()) {
+            String name = entry.getKey().getName();
+            if (distributionColumnNames.contains(name) && !usedColumns.contains(entry.getValue().getId())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean containsNullValue(PartitionKey minRange) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HashDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HashDistributionPrunerTest.java
@@ -230,4 +230,65 @@ public class HashDistributionPrunerTest extends PlanTestBase {
         starRocksAssert.query("select * from test_bucket_prune where dim_dt = '2024-12-29' and dim_class_id = 1")
                 .explainContains("tabletRatio=1/8");
     }
+
+    @Test
+    public void testPruneTabletWithCompleteFilter() throws Exception {
+        new MockUp<Partition>() {
+            @Mock
+            public boolean hasData() {
+                return true;
+            }
+        };
+
+        starRocksAssert.withTable("CREATE TABLE `test_bucket_prune_full` (\n" +
+                "  `dim_dt` date NOT NULL COMMENT \"\",\n" +
+                "  `dim_class_id` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `dim_week_id` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `deleted` int(11) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "PRIMARY KEY(`dim_dt`, `dim_class_id`, `dim_week_id`)\n" +
+                "PARTITION BY RANGE(`dim_dt`)\n" +
+                "(PARTITION p20241229 VALUES [(\"2024-12-29\"), (\"2024-12-30\")))\n" +
+                "DISTRIBUTED BY HASH(`dim_dt`, `dim_class_id`, `dim_week_id`) BUCKETS 8 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        // All bucket columns are filtered: bucket prune is effective, the partition
+        // column predicate should be retained.
+        starRocksAssert.query("select * from test_bucket_prune_full " +
+                "where dim_dt = '2024-12-29' and dim_class_id = 1 and dim_week_id = 5")
+                .explainContains("tabletRatio=1/8", "PREDICATES: 1: dim_dt = '2024-12-29'");
+    }
+
+    @Test
+    public void testPruneTabletWithIncompleteFilter() throws Exception {
+        new MockUp<Partition>() {
+            @Mock
+            public boolean hasData() {
+                return true;
+            }
+        };
+
+        starRocksAssert.withTable("CREATE TABLE `test_bucket_prune_partial` (\n" +
+                "  `dim_dt` date NOT NULL COMMENT \"\",\n" +
+                "  `dim_class_id` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `dim_week_id` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `deleted` int(11) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "PRIMARY KEY(`dim_dt`, `dim_class_id`, `dim_week_id`)\n" +
+                "PARTITION BY RANGE(`dim_dt`)\n" +
+                "(PARTITION p20241229 VALUES [(\"2024-12-29\"), (\"2024-12-30\")))\n" +
+                "DISTRIBUTED BY HASH(`dim_dt`, `dim_class_id`, `dim_week_id`) BUCKETS 8 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        // Without a filter on dim_week_id, bucket prune falls back to scanning all 8
+        // buckets (tabletRatio=8/8) and the partition column predicate should be dropped.
+        String plan = starRocksAssert.query("select * from test_bucket_prune_partial " +
+                "where dim_dt = '2024-12-29' and dim_class_id = 1").explainQuery();
+        PlanTestBase.assertContains(plan, "tabletRatio=8/8");
+        PlanTestBase.assertNotContains(plan, "PREDICATES: 1: dim_dt = '2024-12-29'");
+    }
 }


### PR DESCRIPTION

## Why I'm doing:
In #54679 when table is `PARTITION BY RANGE(dim_dt)` and `DISTRIBUTED BY HASH(dim_dt, dim_class_id)`, for a sql `where dim_dt = '2024-12-05'`, the `dim_dt = '2024-12-05'` will be remained in `PREDICATES`, you can see it when explain.



## What I'm doing:

#54679 should only be applied when columns in where condition are exactly match the columns in distributed by columns.   
When columns in where condition are less than distributed by columns, in this situation, bucket prune doesn't really happen, thus the partition column should be removed like the old behavior.

This is a lightweight heuristic rather than a definitive check that hash bucket pruning will succeed. 
Determining actual pruning capability requires duplicating or depending on HashDistributionPruner's predicate analysis, which is intentionally avoided here. A false positive only keeps a redundant partition predicate and does not affect query correctness.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
