### PR TITLE
[BugFix] Fix NLJoin crash from build-side column nullability mismatch (backport #75343)

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -272,11 +272,15 @@ ChunkPtr NLJoinProbeOperator::_init_output_chunk(size_t chunk_size) const {
         MutableColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
         chunk->append_column(std::move(new_col), slot->id());
     }
+    // A null _curr_build_chunk means the previous round just consumed all build chunks, so use the
+    // first build chunk to decide column nullability.
+    // NOTE: this can still be wrong if column info differs between build chunks.
+    Chunk* ref_build_chunk = _num_build_chunks() > 0 ? _cross_join_context->get_build_chunk(0) : _curr_build_chunk;
     for (size_t i = _probe_column_count; i < _col_types.size(); i++) {
         SlotDescriptor* slot = _col_types[i];
         bool nullable = right_to_nullable | _col_types[i]->is_nullable();
-        if (_curr_build_chunk) {
-            nullable |= _curr_build_chunk->is_column_nullable(slot->id());
+        if (ref_build_chunk) {
+            nullable |= ref_build_chunk->is_column_nullable(slot->id());
         }
         MutableColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
         chunk->append_column(std::move(new_col), slot->id());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -70,6 +70,7 @@ set(EXEC_FILES
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
+        ./exec/pipeline/nljoin_probe_operator_test.cpp
         ./exec/pipeline/ordered_partition_exchanger_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp

--- a/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
+++ b/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/nljoin/nljoin_probe_operator.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "exec/pipeline/nljoin/nljoin_context.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/descriptors.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+// The test object library is compiled with -fno-access-control, so the test can reach the
+// private members (_init_output_chunk, _curr_build_chunk, NLJoinContext::_build_chunks) directly.
+
+namespace starrocks::pipeline {
+
+class NLJoinProbeOperatorTest : public testing::Test {
+protected:
+    // Build a single INT SlotDescriptor with a controlled nullable flag (the direct
+    // (id, name, type) ctor always marks the slot nullable, so go through TSlotDescriptor).
+    SlotDescriptor* make_int_slot(int id, bool nullable) {
+        TSlotDescriptor t;
+        t.id = id;
+        t.parent = 0;
+        TTypeDesc type;
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::INT);
+        node.__set_scalar_type(scalar_type);
+        type.types.push_back(node);
+        t.__set_slotType(type);
+        t.__set_colName("c" + std::to_string(id));
+        t.__set_slotIdx(id);
+        t.__set_isMaterialized(true);
+        t.__set_isNullable(nullable);
+        return _pool.add(new SlotDescriptor(t));
+    }
+
+    ChunkPtr make_one_int_column_chunk(SlotId slot_id, bool nullable) {
+        auto chunk = std::make_shared<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), nullable);
+        col->append_default();
+        chunk->append_column(std::move(col), slot_id);
+        return chunk;
+    }
+
+    std::shared_ptr<NLJoinContext> make_context() {
+        NLJoinContextParams params;
+        params.plan_node_id = 1;
+        params.rf_hub = nullptr;
+        return std::make_shared<NLJoinContext>(std::move(params));
+    }
+
+    // A factory is only needed because the Operator base ctor uses the factory as its
+    // OperatorRuntimeAccess (DCHECK'd non-null). _init_output_chunk never touches it.
+    std::unique_ptr<NLJoinProbeOperatorFactory> make_factory(const std::shared_ptr<NLJoinContext>& ctx,
+                                                             TJoinOp::type join_op) {
+        return std::make_unique<NLJoinProbeOperatorFactory>(0, 1, _empty_row_desc, _empty_row_desc, _empty_row_desc, "",
+                                                            std::vector<ExprContext*>{}, std::vector<ExprContext*>{},
+                                                            std::map<SlotId, ExprContext*>{},
+                                                            std::shared_ptr<NLJoinContext>(ctx), join_op);
+    }
+
+    ObjectPool _pool;
+    RowDescriptor _empty_row_desc;
+    std::vector<ExprContext*> _no_exprs;
+    std::map<SlotId, ExprContext*> _no_common_exprs;
+    std::string _no_sql;
+};
+
+// Regression for the NLJoin build-side nullability crash: when the build chunk's runtime
+// column is nullable but its slot descriptor is non-nullable, _init_output_chunk must create
+// the build-side output column as nullable so the later append does not mismatch -- even when
+// _curr_build_chunk has already advanced to nullptr after the last build chunk is consumed.
+// It must read the nullability from a stable build chunk (get_build_chunk(0)), not from the
+// transient _curr_build_chunk.
+TEST_F(NLJoinProbeOperatorTest, BuildColumnFollowsRuntimeNullabilityOnReentry) {
+    // probe slot (id=0) and build slot (id=1), both DECLARED non-nullable.
+    SlotDescriptor* probe_slot = make_int_slot(0, /*nullable=*/false);
+    SlotDescriptor* build_slot = make_int_slot(1, /*nullable=*/false);
+    std::vector<SlotDescriptor*> col_types = {probe_slot, build_slot};
+
+    auto ctx = make_context();
+    // The build chunk's runtime column is nullable (more nullable than the slot descriptor).
+    ctx->_build_chunks.push_back(make_one_int_column_chunk(build_slot->id(), /*nullable=*/true));
+
+    auto factory = make_factory(ctx, TJoinOp::RIGHT_OUTER_JOIN);
+    NLJoinProbeOperator op(factory.get(), /*id=*/0, /*plan_node_id=*/1, /*driver_sequence=*/0,
+                           TJoinOp::RIGHT_OUTER_JOIN, _no_sql, _no_exprs, _no_exprs, _no_common_exprs, col_types,
+                           /*probe_column_count=*/1, ctx);
+
+    // Reproduce the crash-trigger state: the last build chunk was just consumed.
+    op._curr_build_chunk = nullptr;
+    op._probe_chunk = nullptr;
+
+    ChunkPtr out = op._init_output_chunk(4096);
+
+    // Build-side output column follows the actual (nullable) build data, not the non-nullable slot.
+    EXPECT_TRUE(out->is_column_nullable(build_slot->id()));
+}
+
+// When no build chunk exists, the build-column nullability falls back to the slot descriptor.
+TEST_F(NLJoinProbeOperatorTest, BuildColumnFollowsSlotWhenNoBuildChunk) {
+    SlotDescriptor* probe_slot = make_int_slot(0, /*nullable=*/false);
+    SlotDescriptor* build_slot = make_int_slot(1, /*nullable=*/false);
+    std::vector<SlotDescriptor*> col_types = {probe_slot, build_slot};
+
+    auto ctx = make_context(); // no build chunks
+
+    auto factory = make_factory(ctx, TJoinOp::INNER_JOIN);
+    NLJoinProbeOperator op(factory.get(), /*id=*/0, /*plan_node_id=*/1, /*driver_sequence=*/0, TJoinOp::INNER_JOIN,
+                           _no_sql, _no_exprs, _no_exprs, _no_common_exprs, col_types,
+                           /*probe_column_count=*/1, ctx);
+    op._curr_build_chunk = nullptr;
+    op._probe_chunk = nullptr;
+
+    ChunkPtr out = op._init_output_chunk(4096);
+
+    // Non-nullable slot, no build chunk, inner join -> non-nullable build-side output column.
+    EXPECT_FALSE(out->is_column_nullable(build_slot->id()));
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
+++ b/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
@@ -56,6 +56,13 @@ protected:
         t.__set_slotIdx(id);
         t.__set_isMaterialized(true);
         t.__set_isNullable(nullable);
+        // On branch-3.5/4.0/4.1 SlotDescriptor::is_nullable() is derived from the legacy
+        // null-indicator offset (nullIndicatorBit), not from the isNullable field, and their
+        // thrift declares nullIndicatorBit without a default (so it defaults to 0 => a non-zero
+        // bit_mask => nullable). Set it explicitly so the requested nullability is honored on
+        // these branches too: bit == -1 yields bit_mask 0 (non-nullable).
+        t.__set_nullIndicatorByte(0);
+        t.__set_nullIndicatorBit(nullable ? 0 : -1);
         return _pool.add(new SlotDescriptor(t));
     }
 

--- a/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
+++ b/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
@@ -28,8 +28,8 @@
 #include "gen_cpp/PlanNodes_types.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/descriptors.h"
+#include "runtime/types.h"
 #include "types/logical_type.h"
-#include "types/type_descriptor.h"
 
 // The test object library is compiled with -fno-access-control, so the test can reach the
 // private members (_init_output_chunk, _curr_build_chunk, NLJoinContext::_build_chunks) directly.

--- a/test/sql/test_nest_loop_join/R/test_nest_loop_join
+++ b/test/sql/test_nest_loop_join/R/test_nest_loop_join
@@ -499,3 +499,23 @@ with L as ( select  c1 lk from  t1),R as ( select  c1 rk from  t1),DIM as ( sele
 -- result:
 2
 -- !result
+create table t5 (x int null, v double null)
+duplicate key(x) distributed by hash(x) buckets 4 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t5 select g%100000, cast(g%500 as double)
+from table(generate_series(1,20000)) t(g);
+-- result:
+-- !result
+with scd as (select 'test' as type, 0 as lo, 100000 as hi)
+select a.*, b.v from scd a
+left join t5 b on b.x between a.lo and a.hi
+left join t5 c on c.x between a.lo and a.hi
+order by b.v limit 5;
+-- result:
+test	0	100000	0.0
+test	0	100000	0.0
+test	0	100000	0.0
+test	0	100000	0.0
+test	0	100000	0.0
+-- !result

--- a/test/sql/test_nest_loop_join/T/test_nest_loop_join
+++ b/test/sql/test_nest_loop_join/T/test_nest_loop_join
@@ -174,3 +174,15 @@ insert into t2 select generate_series, generate_series from table(generate_serie
 select t1.c1 from t1 join t2 on t1.c1 <= t2.c1;
 -- apply to exchange
 with L as ( select  c1 lk from  t1),R as ( select  c1 rk from  t1),DIM as ( select 1000000 as mx_lo_orderkey, 999999 as mn_lo_orderkey)select count(*)from  L join [shuffle] R on lk = rk join DIM where rk >= mn_lo_orderkey and rk <= mx_lo_orderkey;
+
+
+-- nestloop join with nullable build-side data under a non-nullable slot
+create table t5 (x int null, v double null)
+duplicate key(x) distributed by hash(x) buckets 4 properties("replication_num"="1");
+insert into t5 select g%100000, cast(g%500 as double)
+from table(generate_series(1,20000)) t(g);
+with scd as (select 'test' as type, 0 as lo, 100000 as hi)
+select a.*, b.v from scd a
+left join t5 b on b.x between a.lo and a.hi
+left join t5 c on c.x between a.lo and a.hi
+order by b.v limit 5;


### PR DESCRIPTION
## Why I'm doing:

The query will crash when the query has following case:
- use NL-join
- build-side's rows less than normal chunk size
- the slot-descriptor is not nullable and the runtime-status is nullable

Then the query will append a nullable column-value into a not nullable column of output chunk.

Like this SQL case:
```
create table t5 (x int null, v double null)
duplicate key(x) distributed by hash(x) buckets 4 properties("replication_num"="1");

insert into t5 select g%100000, cast(g%500 as double)
from table(generate_series(1,20000)) t(g);

with scd as (select 'test' as type, 0 as lo, 100000 as hi)
select a.*, b.v from scd a
left join t5 b on b.x between a.lo and a.hi
left join t5 c on c.x between a.lo and a.hi
order by b.v limit 5;
```
A middle-layer TopN between of the double-layer NL-join with a not nullable column. Because the TopN has a outer-join as sub-node, Optimizer will let the TopN sets the runtime-status as nullable. Then StarRocks get a diff-status between slot-descriptor and runtime-status. Then BE builds the output chunk's nullability from a transient build-chunk pointer that has already gone null after the only chunk is consumed, so the column is created as non-nullable while the build data is nullable, and appending it crashes the BE.

crash stack in main:
```
*** Aborted at 1782453455 (unix time) try "date -d @1782453455" if you are using GNU date ***
PC: @     0x74d8626819fc pthread_kill
*** SIGABRT (@0x57c82) received by PID 359554 (TID 0x74d6d41e6640) LWP(360386) from PID 359554; stack trace: ***
    @         0x203382d2 starrocks::BinaryColumnBase::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x19318be4 starrocks::Column::append(starrocks::Column const&)
    @         0x1a2b49d5 starrocks::pipeline::NLJoinProbeOperator::_permute_probe_row(std::shared_ptr const&)
    @         0x1a2b44f4 starrocks::pipeline::NLJoinProbeOperator::_permute_chunk_for_other_join(unsigned long)
    @         0x1a2b60c7 starrocks::pipeline::NLJoinProbeOperator::_pull_chunk_for_other_join(unsigned long)
    @         0x1a2b5afc starrocks::pipeline::NLJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x1c8e9093 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1b104227 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

crash stack in 3.5:
```
*** SIGABRT (@0x175c5) received by PID 95685 (TID 0x716673be4640) LWP(96543) from PID 95685; stack trace: ***
    @     0x716810024e96 __assert_fail
    @         0x15480806 starrocks::BinaryColumnBase const& down_cast const&, starrocks::Column const>(starrocks::Column const&)
    @         0x15468a1c starrocks::BinaryColumnBase::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x1531bc9e starrocks::Column::append(starrocks::Column const&)
    @         0x19980bf0 starrocks::pipeline::NLJoinProbeOperator::_permute_probe_row(std::shared_ptr const&)
    @         0x199806af starrocks::pipeline::NLJoinProbeOperator::_permute_chunk_for_other_join(unsigned long)
    @         0x1998245c starrocks::pipeline::NLJoinProbeOperator::_pull_chunk_for_other_join(unsigned long)
    @         0x19981fe7 starrocks::pipeline::NLJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
```

## What I'm doing:

The fix reads nullability from a stable build chunk instead.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

> Backport of #75343 to branch-3.5.
